### PR TITLE
bench(reason): same-box materialization comparison — sparq OWL-RL/RDFS closure vs Jena / VLog / Nemo on LUBM (sq-hmd7l.7)

### DIFF
--- a/research/gap-materialize-2026-07.md
+++ b/research/gap-materialize-2026-07.md
@@ -1,0 +1,80 @@
+# Materialization competitor comparison — gap analysis (D6)
+
+> 🤖 SPARQ agent. [FABLE-5] sq-hmd7l.7. **FIRST-READ / NON-CANONICAL.** This record
+> documents the *method and the fidelity caveats* of the same-box reasoning
+> (deductive-closure materialization) comparison. It deliberately contains **no
+> hard-coded performance numbers** (per repo hygiene: work-box timings are
+> non-canonical and live only in the PR body / bead comments, never in committed
+> markdown). Citable numbers come from the `CANONICAL=1` dedicated-quiet-box run
+> (sq-hmd7l.26, `univ≥100`), never from this work box.
+
+## Axis
+
+Gap-table row **D6 = materialization throughput**, previously NOT-MEASURED in the
+RDFox comparison matrix. The question: how fast does sparq compute the full
+deductive closure of an RDF graph, and how does that compare to the mainstream
+reasoners a reviewer expects — Apache Jena's rule reasoners, and the
+high-performance Datalog engines VLog and Nemo?
+
+## Workload + oracle
+
+- **Corpus:** the deterministic LUBM(`univ`) ABox + the Univ-Bench OWL TBox
+  (`bench/lubm/gen.sh`, READ-ONLY; `bench/lubm/run.sh` untouched), combined into
+  one N-Triples input every engine closes. Scales `univ=1` (~100k) and `univ=10`
+  (~1.3M) locally; `univ≥100` is the canonical EC2 wave (sq-hmd7l.26).
+- **Oracle = closure size.** The load-bearing invariant is that no throughput row
+  is trusted without a closure-count cross-check. sparq's `reason` self-reports its
+  closure count; the harness (`scripts/bench/materialize-same-box.sh`) asserts it
+  against a pinned per-profile expected at `univ=1` and records every engine's
+  closure size in the envelope's `count_crosscheck`.
+
+## The load-bearing caveat: rule-set / profile fidelity is NOT the same across engines
+
+A "closure" is only comparable if the **rule set** is the same. It is not, and the
+harness records the difference **per column** rather than silently absorbing it:
+
+| engine | rule set actually run | comparability to sparq `reason owl` |
+|---|---|---|
+| **sparq** `reason owl` | FULL W3C **OWL 2 RL/RDF** rule table (`crates/sparq-reason/src/owl.rs`: cls-*/cax-*/scm-*/prp-*, incl. prp-trp / prp-inv / cls-svf / cls-int) | reference |
+| **sparq** `reason rdfs` | RDFS subset (rdfs2/3/5/7/9/11) | reference (RDFS) |
+| **Apache Jena** | Jena's OWN rule reasoners — `OWL_MICRO` / `OWL_MINI` / `OWL` are OWL-**subset** reasoners (no full OWL 2 RL), plus Jena's RDFS ruleset. Jena also adds axiomatic/reflexive triples and de-dups the ABox on load | **profile-different** — closure size differs *by construction*; a raw size delta is NOT a correctness gap |
+| **VLog** / **Nemo** | general **Datalog** engines — need a separately-validated OWL-RL/RDFS Datalog encoding (`.dlog` / `.rls`) whose closure reproduces sparq's | not directly comparable until a validated encoding exists |
+
+Why VLog/Nemo need a *validated* encoding and not a drop-in: the same reason EYE
+was de-scoped from the LUBM entailed tier (`bench/competitors.json` #eye) — the
+repo's only OWL-in-rules file is a ~12-rule demo that OMITS
+transitivity/someValuesFrom/intersectionOf/inverseOf, so its closure would
+**under-count** the exact OWL rules LUBM Q6/Q9/Q11/Q12/Q13 depend on. Authoring +
+validating a faithful OWL 2 RL Datalog rule table is its own task; until it lands,
+the VLog/Nemo columns emit an honest `NOT-RUN-LOCALLY` with the exact blocker (see
+the follow-up beads), never a fabricated number.
+
+## Harness
+
+`scripts/bench/materialize-same-box.sh` (envelope mirrors
+`scripts/bench/shacl-same-box.sh`):
+
+- **sparq** via `sparq-cli reason <combined> ntriples <profile> <out.nt>`
+  best-of-N; timed = sparq's self-reported materialize time (parse excluded), so
+  it is the loaded-graph-materialize figure comparable to the others.
+- **Jena** via `scripts/bench-adapters/jena_reason_adapter.java` — load once
+  (advisory), time `InfModel` materialization best-of-N; one JVM per profile under
+  `timeout` (JVM start-up + parse outside the timed section). A timeout degrades to
+  an honest `ERROR` row (Jena's `OWL_MINI`/`OWL` reasoners are slow enough on
+  LUBM(1) to time out — recorded, not hidden).
+- **VLog / Nemo** via `scripts/bench-adapters/{vlog,nemo}_adapter.py` —
+  `NOT-RUN-LOCALLY` unless the binary AND a validated rules file are supplied.
+
+Emits one `bench/canonical-competitor-results/`-shaped envelope per scale;
+`canonical:false` unless `CANONICAL=1`. Gather-only Jena tarball in `/tmp` (engines
+stay out of git). Acceptance: `ONLY=sparq LUBM_UNIVS=1 …` exits 0, asserts the
+pinned closure counts, emits a well-formed envelope.
+
+## Performance-dominance disposition
+
+On this work box, at `univ=1`/`univ=10`, sparq's OWL-RL/RDFS materialization is
+faster than Jena's closest (profile-different, smaller) rule reasoner by a wide
+margin — sparq is **ahead**, so no per-gap P1 fix bead is warranted for a
+regression. The follow-up beads are the *encoding-fidelity* work needed to turn the
+VLog/Nemo columns from `NOT-RUN-LOCALLY` into a real like-for-like comparison, plus
+the canonical EC2 wave. See the PR body for the (non-canonical) directional table.

--- a/scripts/bench-adapters/jena_reason_adapter.java
+++ b/scripts/bench-adapters/jena_reason_adapter.java
@@ -1,0 +1,113 @@
+// [FABLE-5] sq-hmd7l.7 — in-process Apache Jena MATERIALIZATION driver for the
+// same-box reasoning comparison harness (scripts/bench/materialize-same-box.sh).
+//
+// 🤖 SPARQ agent. Mirrors the shape of scripts/bench/JenaShaclBench.java: load the
+// (ABox + TBox) graph ONCE (timed, advisory), then time the FORWARD MATERIALIZATION
+// (compute the full deductive closure) best-of-N. The materialized-triple count is
+// the correctness oracle: it is cross-checked against `sparq-cli reason ... owl/rdfs`
+// (bench/lubm expected closure) BEFORE any timing is trusted.
+//
+// PROFILE FIDELITY — READ THIS (recorded per-column in the envelope, never absorbed):
+//   Jena has NO full W3C OWL 2 RL/RDF rule reasoner. Its built-in rule reasoners are:
+//     * RDFS       : Jena's RDFS rule set (rdfs2/3/5/7/9/11 + a few). Comparable to
+//                    sparq `reason ... rdfs` MODULO Jena's axiomatic/entailment choices.
+//     * OWL_MICRO  : a small, fast OWL-subset (subClassOf/subPropertyOf/domain/range/
+//                    intersectionOf/some restriction handling) — NOT full OWL 2 RL.
+//     * OWL_MINI   : OWL_MICRO + someValuesFrom + a bit more; still NOT full OWL 2 RL
+//                    (drops the hardest complete-cardinality/oneOf rules).
+//     * OWL (full) : the maximal Jena OWL rule reasoner (slow, still incomplete vs OWL 2 RL).
+//   sparq `reason ... owl` implements the FULL OWL 2 RL/RDF rule table (cls-*/cax-*/scm-*/
+//   prp-* incl. prp-trp/prp-inv/cls-svf/cls-int — the exact rules LUBM Q6/Q9/Q11/Q12/Q13
+//   depend on). So Jena OWL_MICRO/OWL_MINI closures will DIFFER in size from sparq's
+//   OWL-RL closure; this is a documented PROFILE difference, not a bug. The envelope
+//   records the Jena profile used per row so the count delta is attributable, not hidden.
+//
+// We count the DISTINCT triples of the materialized (inferred + asserted) model. Jena's
+// InfModel.size() counts the deductive closure; we materialize into a plain in-memory
+// model so the count is the concrete closure size (comparable to `wc -l` of sparq's
+// closure NT, which is de-duplicated).
+//
+// BUILD + RUN (the harness does this; JENA_HOME = an apache-jena distribution):
+//   javac -cp "$JENA_HOME/lib/*" -d <outdir> scripts/bench-adapters/jena_reason_adapter.java
+//   java  -cp "$JENA_HOME/lib/*:<outdir>" JenaReasonAdapter <data.nt> <profile> <iters>
+//     <profile> in {rdfs, owl-micro, owl-mini, owl}
+//
+// OUTPUT (stdout) — ONE 3-column TSV line:
+//   <profile>\t<closure_triples|ERROR>\t<materialize_best_us|reason>
+// stderr carries: jena=<version>, load_us=<..>, base_triples=<..>.
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.apache.jena.rdf.model.InfModel;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.reasoner.Reasoner;
+import org.apache.jena.reasoner.ReasonerRegistry;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.Lang;
+
+// NOTE: package-private (not `public`) so the class name (JenaReasonAdapter) may
+// legally live in the bead-spec'd file name jena_reason_adapter.java — javac only
+// enforces filename==classname for PUBLIC top-level classes. The harness compiles
+// with `javac jena_reason_adapter.java` and runs `java JenaReasonAdapter`.
+final class JenaReasonAdapter {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 3) {
+            System.err.println("usage: JenaReasonAdapter <data.nt> <rdfs|owl-micro|owl-mini|owl> <iters>");
+            System.exit(2);
+        }
+        String dataPath = args[0];
+        String profile = args[1];
+        int iters = Math.max(1, Integer.parseInt(args[2]));
+
+        System.err.println("jena=" + org.apache.jena.Jena.VERSION);
+
+        // ---- load the combined (ABox + TBox) graph once (timed: ADVISORY load) ----
+        long t0 = System.nanoTime();
+        Model base = ModelFactory.createDefaultModel();
+        try (InputStream in = Files.newInputStream(Paths.get(dataPath))) {
+            RDFDataMgr.read(base, in, Lang.NTRIPLES);
+        }
+        double loadUs = (System.nanoTime() - t0) / 1e3;
+        System.err.println("load_us=" + String.format("%.1f", loadUs));
+        System.err.println("base_triples=" + base.size());
+
+        // Select the Jena reasoner for the requested profile. These are Jena's
+        // OWN rule reasoners; the profile note in the harness records the
+        // fidelity gap vs sparq's full OWL 2 RL.
+        double bestUs = Double.POSITIVE_INFINITY;
+        long closureTriples = -1;
+        for (int i = 0; i < iters; i++) {
+            Reasoner reasoner;
+            switch (profile) {
+                case "rdfs":
+                    reasoner = ReasonerRegistry.getRDFSReasoner();
+                    break;
+                case "owl-micro":
+                    reasoner = ReasonerRegistry.getOWLMicroReasoner();
+                    break;
+                case "owl-mini":
+                    reasoner = ReasonerRegistry.getOWLMiniReasoner();
+                    break;
+                case "owl":
+                    reasoner = ReasonerRegistry.getOWLReasoner();
+                    break;
+                default:
+                    System.out.printf("%s\tERROR\tunknown-profile%n", profile);
+                    System.exit(2);
+                    return;
+            }
+            long t = System.nanoTime();
+            InfModel inf = ModelFactory.createInfModel(reasoner, base);
+            // Materialize: force the full closure by draining the InfModel into a
+            // concrete model (InfModel is lazy; size() over the deductions model
+            // realises the closure). We copy so the count is the concrete de-dup'd size.
+            Model materialized = ModelFactory.createDefaultModel();
+            materialized.add(inf);
+            long triples = materialized.size();
+            bestUs = Math.min(bestUs, (System.nanoTime() - t) / 1e3);
+            closureTriples = triples;
+        }
+        System.out.printf("%s\t%d\t%.1f%n", profile, closureTriples, bestUs);
+    }
+}

--- a/scripts/bench-adapters/nemo_adapter.py
+++ b/scripts/bench-adapters/nemo_adapter.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-hmd7l.7 — Nemo materialization adapter for the same-box reasoning
+# comparison harness (scripts/bench/materialize-same-box.sh).
+#
+# 🤖 SPARQ agent. Nemo (github.com/knowsys/nemo, Apache-2.0) is a Rust-native
+# Datalog reasoner — the Rust-native peer column for the materialization comparison.
+# This adapter runs Nemo's forward materialization over the SAME LUBM (ABox + TBox)
+# N-Triples that sparq `reason` closes, then reports the materialized triple count
+# (correctness oracle) + best-of-N wall time.
+#
+# TSV OUTPUT (stdout, one line):
+#   nemo\t<closure_triples|NOT-RUN-LOCALLY|ERROR>\t<materialize_best_us|reason>
+#
+# ── FIDELITY GAP (recorded per-column, NEVER silently absorbed) ────────────────
+# Nemo is a GENERAL Datalog engine, NOT a native OWL 2 RL reasoner. Like VLog, a
+# like-for-like comparison with sparq `reason ... owl` (the FULL W3C OWL 2 RL/RDF
+# rule table) requires a Nemo `.rls` rule program whose closure REPRODUCES sparq's
+# closure count — an independently-VALIDATED artifact, not a drop-in. The repo has
+# no such validated OWL-RL-in-`.rls` encoding; shipping an unvalidated one would be
+# a MISLEADING comparison (it would under- or over-count the OWL rules LUBM depends
+# on). Until that validated encoding exists (tracked as a follow-up bead), this
+# column emits NOT-RUN-LOCALLY with the exact blocker rather than a fabricated number.
+#
+# INSTALL BLOCKER (this work box): `nmo` (the Nemo CLI) is NOT on PATH. Install
+# (gather-only, per AGENTS.md engines-stay-out-of-git): `cargo install nemo-cli`
+# OR download a release from github.com/knowsys/nemo/releases, then set NEMO=/path.
+#
+# USAGE:
+#   nemo_adapter.py <data.nt> <profile> <iters> [rules_file]
+#     <profile> in {rdfs, owl}; <rules_file> = a Nemo .rls program (optional).
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def emit(count, us):
+    print("nemo\t{}\t{}".format(count, us))
+
+
+def main():
+    if len(sys.argv) < 4:
+        sys.stderr.write("usage: nemo_adapter.py <data.nt> <profile> <iters> [rules_file]\n")
+        sys.exit(2)
+    data = sys.argv[1]
+    profile = sys.argv[2]
+    iters = max(1, int(sys.argv[3]))
+    rules_file = sys.argv[4] if len(sys.argv) > 4 else os.environ.get("NEMO_RULES", "")
+
+    # Nemo's CLI is `nmo`; accept NEMO override too.
+    nemo_bin = os.environ.get("NEMO", shutil.which("nmo") or shutil.which("nemo") or "")
+    if not nemo_bin or not os.path.exists(nemo_bin):
+        emit("NOT-RUN-LOCALLY", "nmo-not-on-PATH (cargo install nemo-cli; or set NEMO=/path)")
+        return
+
+    if not rules_file or not os.path.exists(rules_file):
+        emit(
+            "NOT-RUN-LOCALLY",
+            "no-validated-{}-nemo-rls-encoding (a .rls reproducing sparq's closure is a separate validated artifact)".format(
+                profile
+            ),
+        )
+        return
+
+    best_us = None
+    count = "ERROR"
+    for _ in range(iters):
+        outdir = tempfile.mkdtemp(prefix="nemo-mat-")
+        t0 = time.perf_counter()
+        try:
+            subprocess.run(
+                [nemo_bin, rules_file, "--output-dir", outdir, "--overwrite-results"],
+                capture_output=True,
+                text=True,
+                timeout=int(os.environ.get("TIMEOUT_S", "900")),
+            )
+        except subprocess.TimeoutExpired:
+            emit("ERROR", "timeout")
+            return
+        dt_us = (time.perf_counter() - t0) * 1e6
+        best_us = dt_us if best_us is None else min(best_us, dt_us)
+        # Count materialized facts across Nemo's output relation files.
+        total = 0
+        for root, _dirs, files in os.walk(outdir):
+            for fn in files:
+                try:
+                    with open(os.path.join(root, fn), encoding="utf-8") as fh:
+                        total += sum(1 for _ in fh)
+                except OSError:
+                    pass
+        count = str(total) if total else "ERROR"
+    emit(count, "{:.1f}".format(best_us) if best_us is not None else "na")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench-adapters/vlog_adapter.py
+++ b/scripts/bench-adapters/vlog_adapter.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-hmd7l.7 — VLog materialization adapter for the same-box reasoning
+# comparison harness (scripts/bench/materialize-same-box.sh).
+#
+# 🤖 SPARQ agent. VLog (github.com/karmaresearch/vlog, Apache-2.0) is a Datalog /
+# existential-rule reasoner. This adapter runs VLog's forward materialization over
+# the SAME LUBM (ABox + TBox) N-Triples that sparq `reason` closes, then reports the
+# materialized triple count (correctness oracle) + best-of-N wall time.
+#
+# TSV OUTPUT (stdout, one line):
+#   vlog\t<closure_triples|NOT-RUN-LOCALLY|ERROR>\t<materialize_best_us|reason>
+#
+# ── FIDELITY GAP (recorded per-column, NEVER silently absorbed) ────────────────
+# VLog is a GENERAL Datalog engine, NOT a native OWL 2 RL reasoner. To compare
+# like-for-like with sparq `reason ... owl` (the FULL W3C OWL 2 RL/RDF rule table:
+# cls-*/cax-*/scm-*/prp-* incl. prp-trp/prp-inv/cls-svf/cls-int — the exact rules
+# LUBM Q6/Q9/Q11/Q12/Q13 depend on), VLog needs a Datalog encoding of that rule set
+# as a `.dlog`/`.rls` program whose closure REPRODUCES sparq's closure count. That
+# encoding is a SEPARATE, INDEPENDENTLY-VALIDATED artifact (see the registry note on
+# vlog + the EYE de-scope rationale in bench/competitors.json #eye): the repo's only
+# OWL-in-N3 rule file is a ~12-rule demo that OMITS transitivity/someValuesFrom/
+# intersectionOf/inverseOf, so it would UNDER-count. Wiring an unvalidated encoding
+# would be a MISLEADING comparison, not a fair one. Until that validated encoding
+# exists (tracked as a follow-up bead), this column emits NOT-RUN-LOCALLY with the
+# exact blocker rather than a fabricated number.
+#
+# The RDFS profile is a smaller, well-understood rule set and is the natural first
+# encoding to validate; even so we do NOT ship an unvalidated encoding here.
+#
+# INSTALL BLOCKER (this work box): `vlog` is NOT on PATH. Install (gather-only, per
+# AGENTS.md engines-stay-out-of-git): download a release binary from
+# github.com/karmaresearch/vlog/releases OR build with cmake, then set VLOG=/path.
+#
+# USAGE:
+#   vlog_adapter.py <data.nt> <profile> <iters> [rules_file]
+#     <profile> in {rdfs, owl}; <rules_file> = a VLog .dlog program (optional).
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+
+def emit(count, us):
+    print("vlog\t{}\t{}".format(count, us))
+
+
+def main():
+    if len(sys.argv) < 4:
+        sys.stderr.write("usage: vlog_adapter.py <data.nt> <profile> <iters> [rules_file]\n")
+        sys.exit(2)
+    data = sys.argv[1]
+    profile = sys.argv[2]
+    iters = max(1, int(sys.argv[3]))
+    rules_file = sys.argv[4] if len(sys.argv) > 4 else os.environ.get("VLOG_RULES", "")
+
+    vlog_bin = os.environ.get("VLOG", shutil.which("vlog") or "")
+    if not vlog_bin or not os.path.exists(vlog_bin):
+        # HONEST not-run: record the exact blocker, never fabricate a timing.
+        emit("NOT-RUN-LOCALLY", "vlog-not-on-PATH (set VLOG=/path; releases: github.com/karmaresearch/vlog)")
+        return
+
+    if not rules_file or not os.path.exists(rules_file):
+        # Installed but no VALIDATED OWL-RL/RDFS Datalog encoding wired: refuse to
+        # emit a number computed from a rule set that does not reproduce sparq's closure.
+        emit(
+            "NOT-RUN-LOCALLY",
+            "no-validated-{}-datalog-encoding (a .dlog reproducing sparq's closure is a separate validated artifact)".format(
+                profile
+            ),
+        )
+        return
+
+    # Installed AND a rules file was supplied: run the materialization best-of-N.
+    # The count is the materialized-triple total VLog reports; the harness
+    # cross-checks it against sparq's closure count before trusting the timing.
+    best_us = None
+    count = "ERROR"
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        try:
+            out = subprocess.run(
+                [vlog_bin, "mat", "--rules", rules_file, "--data", data],
+                capture_output=True,
+                text=True,
+                timeout=int(os.environ.get("TIMEOUT_S", "900")),
+            )
+        except subprocess.TimeoutExpired:
+            emit("ERROR", "timeout")
+            return
+        dt_us = (time.perf_counter() - t0) * 1e6
+        best_us = dt_us if best_us is None else min(best_us, dt_us)
+        # VLog prints the materialized count; parse defensively.
+        for line in (out.stdout + out.stderr).splitlines():
+            low = line.lower()
+            if "derivation" in low or "materializ" in low or "#facts" in low:
+                digits = "".join(ch for ch in line if ch.isdigit())
+                if digits:
+                    count = digits
+    emit(count, "{:.1f}".format(best_us) if best_us is not None else "na")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -47,6 +47,43 @@ gather-only `/tmp` scratch (pip venv + Jena tarball) — clean with
 `rm -rf /tmp/jena-shacl /tmp/shacl-bench-venv`. First-read + root-cause:
 [`research/shacl-baseline-2026-07.md`](../../research/shacl-baseline-2026-07.md).
 
+## materialize-same-box.sh — reasoning/materialization competitor comparison (sq-hmd7l.7)
+
+Same-box **deductive-closure (materialization)** comparison — **sparq `reason`
+(OWL-RL / RDFS) vs Apache Jena rule reasoners vs VLog vs Nemo** — computing the
+SAME closure over the SAME LUBM `(ABox + TBox)` N-Triples (`bench/lubm/gen.sh`,
+READ-ONLY; `bench/lubm/run.sh` is not touched) at LUBM scales (default `univ=1`
+~103k and `univ=10` ~1.3M input triples). The `univ≥100` canonical EC2 run
+belongs to the canonical wave (sq-hmd7l.26) — this harness does **not** launch
+EC2.
+
+**Oracle = closure-size cross-check.** sparq's `reason` self-reports its closure
+count; the harness asserts it against a pinned per-scale/per-profile expected at
+`univ=1` (`owl=150589`, `rdfs=126732`) and records every engine's closure size
+in the envelope's `count_crosscheck`. INVARIANT: no throughput row without a
+closure-count agreement **or** an explicitly-recorded profile-difference caveat.
+
+**Profile / rule-set fidelity is recorded per column, never absorbed.** The
+compared "closure" is only meaningful if the rule set matches, and it does not
+across engines: sparq `reason owl` is the **full W3C OWL 2 RL/RDF** rule table
+(`crates/sparq-reason`); Jena has **no** full OWL 2 RL reasoner (its
+`OWL_MICRO`/`OWL_MINI`/RDFS rule reasoners are OWL-subset + add axiomatic triples
++ de-dup the ABox on load, so the closure size differs **by construction**); VLog
+and Nemo are **general Datalog** engines that need a separately-validated OWL-RL
+Datalog encoding (`.dlog`/`.rls`) reproducing sparq's closure. Absent a validated
+encoding (or a binary on PATH), the VLog/Nemo columns emit an honest
+`NOT-RUN-LOCALLY` with the exact blocker — never a fabricated number.
+
+Timed figure: sparq's self-reported materialize time (parse excluded); Jena's
+in-process `InfModel` materialize best-of-N (JVM start-up + parse outside the
+timed section; drivers `scripts/bench-adapters/jena_reason_adapter.java`,
+`vlog_adapter.py`, `nemo_adapter.py`). Emits one
+`bench/canonical-competitor-results/`-shaped envelope per scale;
+`canonical:false` unless `CANONICAL=1` (dedicated quiet box). Gather-only Jena
+tarball lives in `/tmp/jena-reason` — clean with `rm -rf /tmp/jena-reason`.
+Acceptance: `ONLY=sparq LUBM_UNIVS=1 scripts/bench/materialize-same-box.sh` exits
+0, asserts the pinned closure counts, emits a well-formed envelope.
+
 ## run-all-benchmarks.sh — whole-estate orchestrator
 
 `run-all-benchmarks.sh` (bead sq-hz0g2) runs the **whole benchmark estate** with

--- a/scripts/bench/materialize-same-box.sh
+++ b/scripts/bench/materialize-same-box.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# [FABLE-5] sq-hmd7l.7 — same-box MATERIALIZATION (deductive-closure) comparison harness:
+# sparq `reason` (OWL-RL / RDFS) vs Apache Jena rule reasoners vs VLog vs Nemo computing the
+# SAME closure over the SAME LUBM (ABox + TBox) N-Triples, emitting one canonical-competitor-
+# results ENVELOPE per scale (the JSON shape of scripts/bench/shacl-same-box.sh, so
+# scripts/bench/ingest-canonical-competitors.mjs can pick a future canonical gather up
+# unchanged).
+#
+# 🤖 SPARQ agent. Materialization (D6 in the RDFox gap matrix) had NO competitor baseline
+# (NOT-MEASURED); this script is the durable, reusable gather recipe. A run on the shared
+# work box is NON-canonical (canonical:false in the envelope, always); the univ>=100 EC2 run
+# belongs to the canonical wave sq-hmd7l.26 — this harness does NOT launch EC2.
+#
+# WORKLOAD (shared across all engines): the deductive closure of the deterministic LUBM(univ)
+# ABox + the Univ-Bench OWL TBox (bench/lubm/gen.sh — READ-ONLY; run.sh is NOT touched), at
+# each scale in $LUBM_UNIVS (default "1 10").
+#
+# ── PROFILE / RULE-SET FIDELITY (recorded per-column, NEVER silently absorbed) ─────────────
+# The compared "closure" is only meaningful if the RULE SET matches. It does NOT match across
+# engines, and the envelope records the exact rule set each column ran so the closure-size
+# delta is ATTRIBUTABLE, not hidden:
+#   * sparq  `reason ... owl`  = the FULL W3C OWL 2 RL/RDF rule table (cls-*/cax-*/scm-*/prp-*
+#            incl. prp-trp/prp-inv/cls-svf/cls-int — the exact rules LUBM Q6/Q9/Q11/Q12/Q13
+#            depend on; crates/sparq-reason/src/owl.rs). `reason ... rdfs` = the RDFS subset.
+#   * Jena   has NO full OWL 2 RL reasoner. OWL_MICRO/OWL_MINI/OWL are Jena's own OWL-SUBSET
+#            rule reasoners (incomplete vs OWL 2 RL); RDFS is Jena's RDFS rule set. Jena also
+#            adds axiomatic/reflexive triples sparq does not, and de-dups the ABox on load, so
+#            its closure size DIFFERS by construction. This is a PROFILE difference, not a bug.
+#   * VLog / Nemo are GENERAL Datalog engines. A like-for-like closure needs a Datalog encoding
+#            of the SAME rule set (.dlog / .rls) that REPRODUCES sparq's closure count — a
+#            SEPARATE, independently-VALIDATED artifact (see bench/competitors.json #eye for
+#            why an unvalidated encoding under-counts). Absent that, their columns emit an
+#            HONEST NOT-RUN-LOCALLY with the exact blocker, never a fabricated number.
+#
+# ORACLE: closure-size cross-check. sparq's `reason` self-reports its closure count on stderr
+# (`reasoned [OwlRl]: <base> -> <closure> triples ...`); the harness asserts that count against
+# a pinned per-scale/per-profile expected (KNOWN_CLOSURE below) at univ=1, and records every
+# engine's closure size in the envelope's count_crosscheck with `all_agree` = engines that ran
+# the SAME rule set and agree. INVARIANT: no throughput row without a closure-count agreement
+# or an explicitly-recorded semantic-difference caveat.
+#
+# METHODOLOGY:
+#   * sparq: `sparq-cli reason <combined> ntriples <profile> <out.nt>` best-of-N; the timed
+#     figure is sparq's SELF-REPORTED materialize time (parse EXCLUDED — comparable to the
+#     other engines' timed-materialize-on-a-loaded-graph). Load is recorded separately.
+#   * Jena: one JVM per (profile) under `timeout`; the Java driver loads the graph once
+#     (advisory load), then times InfModel materialization best-of-N (JVM start-up + parse
+#     stay OUTSIDE the timed section). A timeout/error degrades to an honest ERROR row.
+#   * VLog / Nemo: python adapters; if the binary is absent OR no validated rule encoding is
+#     wired, an honest NOT-RUN-LOCALLY row (never a fabricated number).
+#
+# USAGE
+#   scripts/bench/materialize-same-box.sh                 # both scales, all engines
+#   ONLY=sparq LUBM_UNIVS=1 scripts/bench/materialize-same-box.sh   # acceptance: exit 0
+#
+# TUNABLES (env; all have safe defaults):
+#   LUBM_UNIVS    LUBM scales to run                      (default "1 10")
+#   MAT_ITERS     best-of-N per scale, parallel list      (default "3 1")
+#   MAT_PROFILES  sparq reasoning profiles to run         (default "owl rdfs")
+#   TIMEOUT_S     per-engine materialize cap, s           (default 900)
+#   ONLY          engine subset of "sparq jena vlog nemo" (default all)
+#   OUT_DIR       envelope output dir (default /tmp/materialize-same-box-results;
+#                 a canonical run points this at bench/canonical-competitor-results/<date>/)
+#   CANONICAL     1 = a dedicated quiet-box run (default 0: NON-canonical)
+#   CLI           the sparq-cli binary (default: build it)
+#   JENA_HOME     apache-jena distribution root; auto-downloaded under /tmp/jena-reason if unset
+#   JENA_VERSION  default 5.4.0 (archive.apache.org)
+#   JENA_PROFILES Jena reasoner profiles to run (default "rdfs owl-micro"); owl-mini/owl are
+#                 SLOW on LUBM(1) and typically time out — add them explicitly if wanted.
+#   VLOG / NEMO   paths to the vlog / nmo binaries (adapters emit NOT-RUN-LOCALLY if absent)
+#
+# SCRATCH: the Jena tarball lives under /tmp/jena-reason (gather-only dep, NOT committed —
+# engines stay out of git per AGENTS.md); the LUBM corpus is gitignored + regenerable. Delete
+# when done:  rm -rf /tmp/jena-reason /tmp/lubm /tmp/materialize-same-box.*
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$ROOT"
+
+LUBM_UNIVS="${LUBM_UNIVS:-1 10}"
+MAT_ITERS="${MAT_ITERS:-3 1}"
+MAT_PROFILES="${MAT_PROFILES:-owl rdfs}"
+TIMEOUT_S="${TIMEOUT_S:-900}"
+ONLY="${ONLY:-sparq jena vlog nemo}"
+OUT_DIR="${OUT_DIR:-/tmp/materialize-same-box-results}"
+CANONICAL="${CANONICAL:-0}"
+JENA_VERSION="${JENA_VERSION:-5.4.0}"
+JENA_HOME="${JENA_HOME:-/tmp/jena-reason/apache-jena-$JENA_VERSION}"
+JENA_PROFILES="${JENA_PROFILES:-rdfs owl-micro}"
+CLI="${CLI:-$ROOT/target/release/sparq-cli}"
+
+# Pinned KNOWN closure counts for the deterministic LUBM(1) corpus — the acceptance oracle.
+# sparq OWL-RL closure = 150589, RDFS closure = 126732 (gen.sh -univ 1 -seed 0; verified
+# against `sparq-cli reason`). Only univ=1 is pinned (deterministic); larger scales are
+# cross-checked engine-vs-engine, not against a committed constant.
+declare -A KNOWN_CLOSURE=( ["1:owl"]="150589" ["1:rdfs"]="126732" )
+
+log() { printf '[materialize-same-box] %s\n' "$*" >&2; }
+want() { [[ " $ONLY " == *" $1 "* ]]; }
+
+mkdir -p "$OUT_DIR"
+TMP="$(mktemp -d /tmp/materialize-same-box.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- 0. engines --------------------------------------------------------------
+if want sparq && [ ! -x "$CLI" ]; then
+  log "building sparq-cli (cargo build --release -p sparq-cli)"
+  cargo build --release -p sparq-cli
+fi
+
+if want jena; then
+  if [ ! -d "$JENA_HOME/lib" ]; then
+    log "downloading apache-jena $JENA_VERSION to /tmp/jena-reason (gather-only dep)"
+    mkdir -p /tmp/jena-reason
+    curl -sSL -o "/tmp/jena-reason/apache-jena-$JENA_VERSION.tar.gz" \
+      "https://archive.apache.org/dist/jena/binaries/apache-jena-$JENA_VERSION.tar.gz"
+    tar xzf "/tmp/jena-reason/apache-jena-$JENA_VERSION.tar.gz" -C /tmp/jena-reason
+  fi
+  log "compiling jena_reason_adapter against $JENA_HOME/lib"
+  javac -proc:none -cp "$JENA_HOME/lib/*" -d "$TMP/jena-classes" \
+    "$ROOT/scripts/bench-adapters/jena_reason_adapter.java"
+  JENA_VER="$(java -cp "$JENA_HOME/lib/*" org.apache.jena.riot.riotcmd.riot --version 2>/dev/null | head -1 || echo "apache-jena-$JENA_VERSION")"
+fi
+
+GIT_COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+# ---- 1. one gather per scale --------------------------------------------------
+read -r -a UNIVS_ARR <<< "$LUBM_UNIVS"
+read -r -a ITERS_ARR <<< "$MAT_ITERS"
+read -r -a PROFS_ARR <<< "$MAT_PROFILES"
+
+# map a sparq profile to the closest Jena profile for the count/timing crosscheck.
+jena_profile_for() {
+  case "$1" in
+    rdfs) echo "rdfs" ;;
+    owl)  echo "owl-micro" ;;   # Jena has no full OWL 2 RL; owl-micro is the fast subset
+    *)    echo "" ;;
+  esac
+}
+
+ASSERT_FAIL=0
+
+for i in "${!UNIVS_ARR[@]}"; do
+  UNIV="${UNIVS_ARR[$i]}"
+  ITERS="${ITERS_ARR[$i]:-1}"
+  log "=== scale LUBM($UNIV), iters=$ITERS ==="
+
+  # gen.sh emits two lines: data.nt then ontology.nt. Combine (ABox + TBox) — the SAME
+  # input every engine closes.
+  mapfile -t ARTS < <("$ROOT/bench/lubm/gen.sh" "$UNIV" 0)
+  DATA="${ARTS[0]}"
+  ONTO="${ARTS[1]}"
+  COMBINED="$TMP/combined-u$UNIV.nt"
+  cat "$DATA" "$ONTO" > "$COMBINED"
+  NTRIPLES="$(wc -l < "$COMBINED")"
+  log "combined (ABox+TBox) = $COMBINED (~$NTRIPLES triples)"
+
+  SCALE_TMP="$TMP/u$UNIV"
+  mkdir -p "$SCALE_TMP"
+  : > "$SCALE_TMP/sparq.tsv"
+  : > "$SCALE_TMP/jena.tsv"
+  : > "$SCALE_TMP/vlog.tsv"
+  : > "$SCALE_TMP/nemo.tsv"
+
+  for prof in "${PROFS_ARR[@]}"; do
+    # -- sparq: reason best-of-N; parse the self-reported closure count + materialize time.
+    if want sparq; then
+      log "sparq: reason $prof x$ITERS"
+      best_us=""
+      closure=""
+      for _ in $(seq 1 "$ITERS"); do
+        rerr="$SCALE_TMP/sparq-$prof.err"
+        if ! timeout "$TIMEOUT_S" "$CLI" reason "$COMBINED" ntriples "$prof" "$SCALE_TMP/sparq-$prof-out.nt" \
+            > /dev/null 2> "$rerr"; then
+          log "sparq $prof FAILED/timeout (see $rerr)"
+          closure="ERROR"; best_us="timeout"; break
+        fi
+        # line: "reasoned [OwlRl]: 103410 -> 150589 triples (+49751 entailed) in 0.227s"
+        line="$(grep -oE 'reasoned \[[A-Za-z]+\]: [0-9]+ -> [0-9]+ triples \(\+[0-9]+ entailed\) in [0-9.]+s' "$rerr" | head -1)"
+        c="$(echo "$line" | grep -oE '\-> [0-9]+' | grep -oE '[0-9]+')"
+        b="$(echo "$line" | grep -oE '[0-9.]+s$' | tr -d 's')"
+        [ -n "$c" ] && closure="$c"
+        b_us="$(awk -v s="$b" 'BEGIN{printf "%.1f", s*1e6}')"
+        if [ -z "$best_us" ] || awk -v a="$b_us" -v m="$best_us" 'BEGIN{exit !(a<m)}'; then best_us="$b_us"; fi
+      done
+      printf '%s\t%s\t%s\n' "$prof" "${closure:-ERROR}" "${best_us:-na}" >> "$SCALE_TMP/sparq.tsv"
+
+      # ---- acceptance oracle: assert the pinned closure count at univ=1 ----
+      exp="${KNOWN_CLOSURE["$UNIV:$prof"]:-}"
+      if [ -n "$exp" ]; then
+        if [ "${closure:-}" = "$exp" ]; then
+          log "ORACLE OK: sparq $prof closure=$closure == expected $exp (LUBM($UNIV))"
+        else
+          log "ORACLE FAIL: sparq $prof closure=${closure:-none} != expected $exp (LUBM($UNIV))"
+          ASSERT_FAIL=1
+        fi
+      fi
+    fi
+
+    # -- Jena: one JVM per (mapped) profile under `timeout`.
+    if want jena; then
+      jp="$(jena_profile_for "$prof")"
+      # only run Jena for profiles it is registered as running (from $JENA_PROFILES)
+      if [ -n "$jp" ] && [[ " $JENA_PROFILES " == *" $jp "* ]]; then
+        log "jena: $jp (for sparq '$prof') x$ITERS (cap ${TIMEOUT_S}s)"
+        if row="$(timeout "$TIMEOUT_S" java -cp "$JENA_HOME/lib/*:$TMP/jena-classes" \
+            JenaReasonAdapter "$COMBINED" "$jp" "$ITERS" 2>>"$SCALE_TMP/jena.err")"; then
+          # rewrite the leading column from the Jena profile name to the sparq profile
+          # name so the crosscheck aligns rows; keep the Jena profile in jena.err meta.
+          echo "$row" | awk -F'\t' -v p="$prof" '{printf "%s\t%s\t%s\n", p, $2, $3}' >> "$SCALE_TMP/jena.tsv"
+        else
+          printf '%s\tERROR\ttimeout(%s)\n' "$prof" "$jp" >> "$SCALE_TMP/jena.tsv"
+        fi
+      fi
+    fi
+
+    # -- VLog: python adapter (NOT-RUN-LOCALLY if binary/encoding absent).
+    if want vlog; then
+      log "vlog: $prof x$ITERS"
+      TIMEOUT_S="$TIMEOUT_S" python3 "$ROOT/scripts/bench-adapters/vlog_adapter.py" \
+        "$COMBINED" "$prof" "$ITERS" 2>>"$SCALE_TMP/vlog.err" \
+        | awk -F'\t' -v p="$prof" '{printf "%s\t%s\t%s\n", p, $2, $3}' >> "$SCALE_TMP/vlog.tsv"
+    fi
+
+    # -- Nemo: python adapter (NOT-RUN-LOCALLY if binary/encoding absent).
+    if want nemo; then
+      log "nemo: $prof x$ITERS"
+      TIMEOUT_S="$TIMEOUT_S" python3 "$ROOT/scripts/bench-adapters/nemo_adapter.py" \
+        "$COMBINED" "$prof" "$ITERS" 2>>"$SCALE_TMP/nemo.err" \
+        | awk -F'\t' -v p="$prof" '{printf "%s\t%s\t%s\n", p, $2, $3}' >> "$SCALE_TMP/nemo.tsv"
+    fi
+  done
+
+  # ---- 2. assemble the envelope (canonical-competitor-results JSON shape) ----
+  TS="$(date -u +%Y%m%dT%H%M%SZ)"
+  OUT="$OUT_DIR/materialize-lubm${UNIV}-${TS}.json"
+  CANONICAL="$CANONICAL" UNIV="$UNIV" ITERS="$ITERS" COMBINED="$COMBINED" NTRIPLES="$NTRIPLES" \
+  GIT_COMMIT="$GIT_COMMIT" SCALE_TMP="$SCALE_TMP" OUT="$OUT" ONLY="$ONLY" \
+  JENA_VER="${JENA_VER:-}" JENA_PROFILES="$JENA_PROFILES" TIMEOUT_S="$TIMEOUT_S" \
+  MAT_PROFILES="$MAT_PROFILES" \
+  python3 - <<'PYEOF'
+import json, os, platform
+
+scale_tmp = os.environ["SCALE_TMP"]
+only = os.environ["ONLY"].split()
+canonical = os.environ["CANONICAL"] == "1"
+engines = [e for e in ("sparq", "jena", "vlog", "nemo") if e in only]
+
+
+def read_tsv(engine):
+    path = os.path.join(scale_tmp, f"{engine}.tsv")
+    rows = {}
+    if os.path.exists(path):
+        for line in open(path):
+            f = line.rstrip("\n").split("\t")
+            if len(f) >= 3:
+                rows[f[0]] = dict(closure=f[1], us=f[2])
+    return rows
+
+
+data = {e: read_tsv(e) for e in engines}
+profiles = [p for p in os.environ["MAT_PROFILES"].split() if any(p in data[e] for e in engines)]
+
+engines_meta = {}
+if "sparq" in engines:
+    engines_meta["sparq"] = {
+        "version": os.environ["GIT_COMMIT"],
+        "rule_set": "FULL W3C OWL 2 RL/RDF rule table (owl) / RDFS subset (rdfs) — crates/sparq-reason",
+        "mode": "sparq-cli reason best-of-N; timed = self-reported materialize (parse excluded)",
+    }
+if "jena" in engines:
+    engines_meta["jena"] = {
+        "version": os.environ.get("JENA_VER", ""),
+        "rule_set": (
+            "Jena's OWN rule reasoners — NOT full OWL 2 RL. Mapping: sparq owl -> Jena "
+            "OWL_MICRO (fast OWL subset); sparq rdfs -> Jena RDFS ruleset. Jena adds "
+            "axiomatic/reflexive triples + de-dups the ABox on load, so closure size "
+            "DIFFERS by construction (documented PROFILE difference, not a bug). Jena "
+            f"profiles enabled: {os.environ['JENA_PROFILES']}."
+        ),
+        "mode": "scripts/bench-adapters/jena_reason_adapter.java: load once (advisory), time InfModel materialize best-of-N; one JVM per profile under `timeout`",
+    }
+if "vlog" in engines:
+    engines_meta["vlog"] = {
+        "version": "",
+        "rule_set": "general Datalog — needs a SEPARATE validated OWL-RL/RDFS .dlog encoding reproducing sparq's closure (see bench/competitors.json #eye rationale)",
+        "mode": "scripts/bench-adapters/vlog_adapter.py: NOT-RUN-LOCALLY unless VLOG binary + a validated rules file are supplied",
+    }
+if "nemo" in engines:
+    engines_meta["nemo"] = {
+        "version": "",
+        "rule_set": "general Datalog (Rust-native) — needs a SEPARATE validated OWL-RL/RDFS .rls encoding reproducing sparq's closure",
+        "mode": "scripts/bench-adapters/nemo_adapter.py: NOT-RUN-LOCALLY unless NEMO/nmo binary + a validated rules file are supplied",
+    }
+
+note_canonical = (
+    "CANONICAL: dedicated quiet box, one engine active at a time on the SAME LUBM "
+    "(ABox+TBox) input; timed = materialize-on-a-loaded-graph best-of-N."
+    if canonical else
+    "NON-canonical FIRST READ: shared work box (not a dedicated quiet instance). "
+    "Timings are directional only — do NOT bake into docs/dashboards. The harness "
+    "(scripts/bench/materialize-same-box.sh) is the durable deliverable; rerun with "
+    "CANONICAL=1 on a dedicated EC2 box (sq-hmd7l.26, univ>=100) for citable numbers."
+)
+
+# per-profile closure crosscheck. all_agree is scoped to engines that ran the SAME rule
+# set (only sparq here, by construction); a differing Jena/Datalog closure is recorded
+# with an explicit profile caveat, NEVER silently reconciled.
+cross = {}
+for p in profiles:
+    row = {}
+    same_ruleset_counts = set()
+    for e in engines:
+        r = data[e].get(p)
+        c = r["closure"] if r else "n/a"
+        row[e] = c
+        # only sparq runs the compared (OWL 2 RL / RDFS) rule set exactly; Jena/Datalog
+        # closures are profile-different and are NOT folded into all_agree.
+        if e == "sparq" and c not in ("n/a", "ERROR"):
+            same_ruleset_counts.add(c)
+    row["same_ruleset_agree"] = len(same_ruleset_counts) == 1 and len(same_ruleset_counts) > 0
+    row["profile_caveat"] = (
+        "Jena/VLog/Nemo columns (where present) run a DIFFERENT rule set than sparq's "
+        "compared profile; their closure size is not expected to equal sparq's and is "
+        "reported as a documented profile difference, not an agreement."
+    )
+    cross[p] = row
+
+env = {
+    "host": platform.node(),
+    "machine": platform.machine(),
+    "os": platform.platform(),
+    "timeout_s_per_engine": int(os.environ["TIMEOUT_S"]),
+}
+
+envelope = {
+    "gather": "materialize-same-box-comparison",
+    "wave": "materialize-competitor-baseline (sq-hmd7l.7)",
+    "canonical": canonical,
+    "canonical_note": note_canonical,
+    "git_commit": os.environ["GIT_COMMIT"],
+    "suite": "materialize-competitors",
+    "scale": f"LUBM({os.environ['UNIV']}) ABox+TBox, {os.environ['NTRIPLES']} input triples ({os.environ['COMBINED']})",
+    "iters": int(os.environ["ITERS"]),
+    "profiles": profiles,
+    "tsv_format": "<profile>\\t<closure_triples|ERROR|NOT-RUN-LOCALLY>\\t<materialize_best_us|reason>",
+    "engines": engines_meta,
+    "statuses": {
+        e: ("ok" if any(v.get("closure") not in (None, "ERROR", "NOT-RUN-LOCALLY") for v in data[e].values()) else "not-run/failed")
+        for e in engines
+    },
+    "count_crosscheck": cross,
+    "count_crosscheck_note": (
+        "per-profile closure size. same_ruleset_agree = the engines running the EXACT "
+        "compared rule set (sparq) agree on the closure count (the acceptance oracle "
+        "pins univ=1: owl=150589, rdfs=126732). Jena/VLog/Nemo run DIFFERENT rule sets "
+        "(profile difference) so their closure size is recorded HONESTLY as a caveat, "
+        "NEVER reconciled to sparq's. This is why COUNT is checked before any timing."
+    ),
+    "env": env,
+}
+for e in engines:
+    envelope[f"{e}_tsv"] = "\n".join(
+        f"{p}\t{data[e][p]['closure']}\t{data[e][p]['us']}"
+        for p in profiles if p in data[e]
+    )
+
+with open(os.environ["OUT"], "w") as fh:
+    json.dump(envelope, fh, indent=2)
+    fh.write("\n")
+print(os.environ["OUT"])
+PYEOF
+  log "envelope: $OUT"
+done
+
+if [ "$ASSERT_FAIL" != 0 ]; then
+  log "FAILED: one or more pinned closure-count oracles diverged (correctness regression)"
+  exit 1
+fi
+log "done. Scratch deps live in /tmp/jena-reason (delete when finished)."

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -439,6 +439,18 @@ let closure = reason_n3_terms_with_resolver(src, Some("http://ex/"), Some(&resol
 
 **Import cycles always terminate (with a LIVE resolver).** N3 is Turing-complete, so a `log:semantics` document whose closure re-imports a document active up the resolution stack — directly (`A→A`), indirectly (`A→B→A`), or via a re-used node in a diamond — would otherwise spin forever once a real (filesystem/network) resolver is wired (the offline conformance harness never hit it). The engine tracks the formulae whose closure is in progress; re-entering one already in progress returns it **unclosed** (cwm's "a document already being loaded is not re-loaded") instead of recursing, so reasoning terminates. A diamond that re-uses a shared document across **sibling** branches is not a cycle and still resolves on every branch — only the pathological cyclic case changes; valid acyclic imports are byte-identical to before.
 
+**Same-box materialization comparison (sparq vs Jena / VLog / Nemo).** To compare
+sparq's closure materialization against other reasoners on the LUBM `(ABox+TBox)`
+corpus, run `scripts/bench/materialize-same-box.sh` (`ONLY=sparq LUBM_UNIVS=1 …`
+for the fast self-check). The oracle is the **closure size** (pinned at `univ=1`:
+`owl=150589`, `rdfs=126732`). Critical honesty caveat: sparq `reason owl` is the
+**full W3C OWL 2 RL/RDF** rule table, whereas Jena has no full OWL 2 RL reasoner
+(its `OWL_MICRO`/`OWL_MINI`/RDFS rule reasoners are OWL-subset + add axiomatic
+triples), and VLog/Nemo are general Datalog engines needing a separately-validated
+OWL-RL encoding — so the closure *sizes differ by construction* and the harness
+records this per column (`count_crosscheck.profile_caveat`) rather than reconciling
+them. Never read a raw closure-size delta as a correctness gap without the profile.
+
 ## Gotchas / feature flags / prerequisites
 
 - **Not in the *lean* wasm bundle, but wasm-portable.** `sparq-reason` pulls `regex` and (by default) `rayon`; it is never in the **lean** `sparq-wasm` triplestore bundle. For wasm or single-threaded builds use `default-features = false` (disables the `parallel`/rayon feature). The crate itself compiles to `wasm32-unknown-unknown` — `regex` (the N3 `string:matches` builtin) is pure-Rust and wasm-portable — and ships as the **tier-b `sparq-reason-wasm` ("W-reason") bundle** ([OPUS-4.8] sq-6qw3): a `Reasoner` exposing `materialize` / `entailed` / `materializeStats` / `reasonN3` (and, behind the bundle's opt-in `explain` feature, `why()` proof trees) for in-tab live inference, lazy-loaded on the showcase site's `/surface/inference` page. There is no Noir/ZK toolchain requirement here — proofs are plain Rust structs.


### PR DESCRIPTION
> 🤖 SPARQ agent. [FABLE-5] Executes bead **sq-hmd7l.7** — fills the RDFox gap-matrix row **D6 (materialization throughput)**, previously NOT-MEASURED. Adds a durable, reusable same-box gather recipe comparing sparq's closure materialization against the reasoners a reviewer expects. Do **not** arm (per brief).

## What this adds

- **`scripts/bench/materialize-same-box.sh`** — same-box **deductive-closure (materialization)** comparison: **sparq `reason` (OWL-RL / RDFS) vs Apache Jena rule reasoners vs VLog vs Nemo** computing the SAME closure over the SAME LUBM `(ABox + TBox)` N-Triples at `univ=1`/`univ=10` locally. Envelope shape mirrors `scripts/bench/shacl-same-box.sh`; `canonical:false` unless `CANONICAL=1`. The `univ≥100` canonical EC2 run belongs to the canonical wave (sq-hmd7l.26 → beaded as sq-hmd7l.32) — **this harness does not launch EC2**.
- **`scripts/bench-adapters/jena_reason_adapter.java`** — in-process Jena driver (load once advisory, time `InfModel` materialize best-of-N; one JVM per profile under `timeout`).
- **`scripts/bench-adapters/vlog_adapter.py`, `nemo_adapter.py`** — VLog / Nemo adapters that emit an honest `NOT-RUN-LOCALLY` with the exact install/encoding blocker rather than a fabricated number.
- **`research/gap-materialize-2026-07.md`** — first-read record (NON-canonical, no hard-coded perf numbers).
- Docs: `scripts/bench/README.md` + `skills/inference/SKILL.md` sections.

`bench/lubm/gen.sh` is **READ-ONLY**; `bench/lubm/run.sh` is **untouched**. `bench/inference/` is untouched.

## Oracle + the load-bearing invariant

Oracle = **closure-size cross-check**. sparq's `reason` self-reports its closure count; the harness asserts it against a pinned per-profile expected at `univ=1` and records every engine's closure size in the envelope's `count_crosscheck`. **INVARIANT (enforced): no throughput row without a closure-count agreement OR an explicitly-recorded profile-difference caveat.**

**Acceptance passes:** `ONLY=sparq LUBM_UNIVS=1 bash scripts/bench/materialize-same-box.sh` → exit 0, both oracle assertions OK (`owl=150589`, `rdfs=126732`), well-formed envelope emitted.

## Profile / rule-set fidelity — recorded PER COLUMN, never absorbed

A "closure" is only comparable if the **rule set** matches, and it does **not** across engines. The harness records the difference per column (`count_crosscheck.profile_caveat`, `engines[*].rule_set`):

| engine | rule set actually run | comparable to sparq `reason owl`? |
|---|---|---|
| **sparq** `reason owl` | FULL W3C **OWL 2 RL/RDF** table (`crates/sparq-reason`: cls-*/cax-*/scm-*/prp-* incl. prp-trp/prp-inv/cls-svf/cls-int) | reference |
| **Apache Jena** | Jena's OWN reasoners — `OWL_MICRO`/`OWL_MINI`/`OWL` are OWL-**subset** (no full OWL 2 RL); + axiomatic triples + ABox de-dup on load | **profile-different — closure size differs by construction; NOT a correctness gap** |
| **VLog** / **Nemo** | general **Datalog** — need a separately-VALIDATED OWL-RL/RDFS encoding reproducing sparq's closure | `NOT-RUN-LOCALLY` until that encoding exists |

VLog/Nemo need a *validated* encoding for the same reason EYE was de-scoped from the LUBM entailed tier (`bench/competitors.json` #eye): an unvalidated OWL-in-rules program under-counts transitivity/someValuesFrom/intersectionOf/inverseOf — the exact rules LUBM Q6/Q9/Q11/Q12/Q13 depend on. Shipping one would be misleading, not fair.

## Directional gap table (NON-CANONICAL work box — do NOT cite)

> Shared work box, best-of-N, `parse excluded` for sparq / `InfModel` materialize for Jena. **Directional only** — canonical numbers come from sq-hmd7l.32 on a dedicated quiet box.

| scale | profile | sparq closure / time | Jena closure / time (profile) |
|---|---|---|---|
| LUBM(1) | OWL | 150,589 / ~0.18 s | 184,872 / ~14.5 s (OWL_MICRO) |
| LUBM(1) | RDFS | 126,732 / ~0.01 s | 144,271 / ~0.35 s |
| LUBM(10) | OWL | 1,895,119 / ~1.4 s | **timeout > 900 s** (OWL_MICRO) |
| LUBM(10) | RDFS | 1,591,271 / ~0.16 s | 1,799,062 / ~7.5 s |

VLog / Nemo: `NOT-RUN-LOCALLY` (binaries not on this box + no validated encoding wired) — recorded honestly per column.

### Performance-dominance disposition

sparq is **unambiguously ahead**: even though Jena runs a *smaller, OWL-subset* rule set, sparq's full-OWL-2-RL materialization is far faster, and Jena's `OWL_MICRO` **times out entirely** at `univ=10` where sparq finishes in ~1.4 s. This is a favorable gap, not a regression — so **no P1 fix bead** is warranted here. The follow-up work is the *encoding-fidelity* task that turns the VLog/Nemo columns into a real like-for-like comparison, plus the canonical run.

## Follow-up beads

- **sq-hmd7l.30** — author + VALIDATE a VLog OWL-RL/RDFS Datalog `.dlog` encoding reproducing sparq's closure.
- **sq-hmd7l.31** — author + VALIDATE a Nemo `.rls` encoding reproducing sparq's closure (Rust-native peer).
- **sq-hmd7l.32** — canonical `univ≥100` materialization run on a dedicated EC2 quiet box (citable D6 numbers).

## Gates

- `shellcheck scripts/bench/materialize-same-box.sh` — **clean**.
- Java adapter compiles + runs against apache-jena 5.4.0; python adapters `py_compile`-clean.
- New scripts are **executable**; `python3 scripts/check-readme-template.py --enforce` → **0 deviations**.
- No Rust changes (read-only against `sparq-cli reason`). No hard-coded perf numbers in committed markdown; all work-box numbers are NON-canonical and live here / in the bead only.