### PR TITLE
chore(roborev): pin repo default model to gpt-5.6-sol

### DIFF
--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,7 +1,7 @@
 # Default agent for this repo when no workflow-specific agent is set.
 agent = ''
 # Default model for this repo when no workflow-specific model is set.
-model = ''
+model = 'gpt-5.6-sol'
 # Backup agent for this repo if the primary agent fails.
 backup_agent = ''
 # Backup model for this repo if the primary model fails.


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Maintainer-requested: update roborev to use **GPT-5.6 Sol** (`gpt-5.6-sol`, GA 2026-07-09). Sets the repo-level default model in `.roborev.toml` so all roborev workflows (review/refine/fix, agent=codex) use Sol. The global `~/.roborev/config.toml` `default_model` on the work box was updated in place (untracked).

Note: codex auth on the work box is currently expired (refresh token already used) — roborev jobs will fail until an interactive `codex login` re-auth; flagged to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)