### PR TITLE
feat(site): comparative benchmark dashboard — competitor columns + gap-record pipeline (sq-hmd7l.28) [FABLE-5]

### DIFF
--- a/scripts/bench/ingest-canonical-competitors.mjs
+++ b/scripts/bench/ingest-canonical-competitors.mjs
@@ -78,9 +78,60 @@ const ENGINE_META = {
     label: "QLever",
     mode: "HTTP SPARQL adapter (qlever-index → qlever-server)",
   },
+  // [FABLE-5] sq-hmd7l.28 — the new comparative axes' competitor engines. Each axis'
+  // same-box harness (scripts/bench/{fts,geo,hdt,update,materialize}-same-box.sh) records
+  // these ids in its envelope `engines` map; adding them here gives the site a stable human
+  // label + measurement-MODE string per column. A brand-new competitor a harness adds later
+  // still surfaces automatically (see engineIdsOf below) — this table is only for the label.
+  "jena-text": {
+    label: "Apache Jena (jena-text / Lucene)",
+    mode: "HTTP SPARQL adapter (jena-text Lucene index over a Fuseki endpoint)",
+  },
+  "jena-geosparql": {
+    label: "Apache Jena (GeoSPARQL)",
+    mode: "HTTP SPARQL adapter (jena-fuseki-geosparql spatial index)",
+  },
+  "hdt-cpp": {
+    label: "hdt-cpp (rdfhdt)",
+    mode: "in-process decode (Docker rdfhdt/hdt-cpp, hdt2rdf: decode .hdt → N-Triples)",
+  },
+  jena: {
+    label: "Apache Jena (rule reasoner)",
+    mode: "in-process (Jena InfModel materialisation — a profile-DIFFERENT rule set; see note)",
+  },
+  vlog: {
+    label: "VLog (Datalog)",
+    mode: "in-process (VLog Datalog; needs a validated OWL-RL/RDFS encoding — else NOT-RUN)",
+  },
+  nemo: {
+    label: "Nemo (Datalog)",
+    mode: "in-process (Nemo Datalog; needs a validated OWL-RL/RDFS encoding — else NOT-RUN)",
+  },
 };
-// Column order (sparq first, then the same order the gather records).
+// Column order (sparq first, then the SPARQL matrix's fixed order; any engine not listed
+// here — e.g. a new-axis competitor — is appended in the envelope's own key order via
+// engineIdsOf, so a new competitor never gets silently dropped).
 const ENGINE_ORDER = ["sparq", "oxigraph", "fuseki", "virtuoso", "qlever"];
+
+// [FABLE-5] sq-hmd7l.28 — the engine ids to render for ONE envelope, sparq first, then the
+// fixed SPARQL-matrix order for any of those present, then any REMAINING engine the envelope
+// declares (a new-axis competitor like jena-text / hdt-cpp / vlog) in its own key order. This
+// is what makes a new competitor column flow through WITHOUT editing this script per gather.
+function engineIdsOf(envelope) {
+  const declared = Object.keys(envelope.engines || {});
+  const ordered = ENGINE_ORDER.filter((id) => declared.includes(id));
+  const extra = declared.filter((id) => !ENGINE_ORDER.includes(id));
+  return [...ordered, ...extra];
+}
+
+// Per-row count agreement can be recorded as `all_agree` (sp2b/watdiv/materialize) OR a plain
+// boolean `agree` (geo) OR left absent (fts, which cross-checks engine-vs-engine differently).
+// Read whichever is present; a missing flag stays null (renders "—", never a fabricated ✓).
+function rowCountMatch(cc) {
+  if (typeof cc.all_agree === "boolean") return cc.all_agree;
+  if (typeof cc.agree === "boolean") return cc.agree;
+  return null;
+}
 
 function parseTsv(tsv) {
   // 3-col "<query>\t<rows|ERROR>\t<best_us|engine>" per line → { query: { rows, us|null } }.
@@ -102,6 +153,18 @@ function parseTsv(tsv) {
   return out;
 }
 
+// [FABLE-5] sq-hmd7l.28 — an envelope's per-engine TSV key is `<id>_tsv`, but some harnesses
+// (fts, geo) sanitise hyphenated ids to underscores (`jena-text` → `jena_text_tsv`). Resolve
+// whichever form the envelope actually carries so a hyphenated competitor id is not read as an
+// all-null column.
+function tsvFor(envelope, id) {
+  const direct = envelope[id + "_tsv"];
+  if (typeof direct === "string") return direct;
+  const under = envelope[id.replace(/-/g, "_") + "_tsv"];
+  if (typeof under === "string") return under;
+  return "";
+}
+
 function shortDigest(engine) {
   const d = engine && engine.image_digest;
   if (!d) return null;
@@ -113,12 +176,12 @@ function buildEntry(gathers) {
   // gathers: array of envelope objects for ONE suite (>=1; expect 2 canonical gathers).
   const primary = gathers[gathers.length - 1]; // latest for the metadata/version fields
   const suite = primary.suite;
-  const engineIds = ENGINE_ORDER.filter((id) => primary.engines && primary.engines[id]);
+  const engineIds = engineIdsOf(primary);
 
   // Parse every gather's per-engine TSV once.
   const parsed = gathers.map((g) => {
     const p = {};
-    for (const id of engineIds) p[id] = parseTsv(g[id + "_tsv"]);
+    for (const id of engineIds) p[id] = parseTsv(tsvFor(g, id));
     return { g, p };
   });
 
@@ -167,7 +230,7 @@ function buildEntry(gathers) {
       unit: "µs",
       rows: ccCount,
       values,
-      count_match: typeof cc.all_agree === "boolean" ? cc.all_agree : null,
+      count_match: rowCountMatch(cc),
     };
     if (anyExtended) {
       // HTTP-profile extras: values = keep-alive full-request best (primary, above);
@@ -224,8 +287,15 @@ function buildEntry(gathers) {
     git_commit: primary.git_commit,
     gathered_at_utc: (primary.env && primary.env.gathered_at_utc) || primary.gathered_at_utc,
     canonical: primary.canonical === true,
-    combine: `best-of the ${gathers.length} back-to-back canonical gathers (${tsList}): per-engine per-query MIN best_us; solution COUNTS are identical across the gathers. best-of = min-of-${gathers.length}×${primary.iters}, the least-contended estimate; it also removes transient contention spikes (e.g. a virtuoso q09 blip) uniformly for every engine.`,
-    source: `canonical gather '${primary.gather}' (${primary.wave}) — raw envelopes committed at bench/canonical-competitor-results/2026-07-07/, ingested by scripts/bench/ingest-canonical-competitors.mjs`,
+    // [FABLE-5] sq-hmd7l.28 — the sp2b/watdiv matrix keeps its exact reviewed prose (incl. the
+    // real virtuoso-q09 example) for a byte-stable committed snapshot; other axes get a generic,
+    // accurate combine string (no fabricated engine/query name) + the gather's OWN dated dir.
+    combine: /^(sp2b|watdiv)(-http)?$/i.test(suite)
+      ? `best-of the ${gathers.length} back-to-back canonical gathers (${tsList}): per-engine per-query MIN best_us; solution COUNTS are identical across the gathers. best-of = min-of-${gathers.length}×${primary.iters}, the least-contended estimate; it also removes transient contention spikes (e.g. a virtuoso q09 blip) uniformly for every engine.`
+      : `best-of the ${gathers.length} back-to-back canonical gather${gathers.length === 1 ? "" : "s"} (${tsList}): per-engine per-query MIN best_us; solution COUNTS are cross-checked across the gathers. best-of = min-of-${gathers.length}×${primary.iters}, the least-contended estimate.`,
+    source: /^(sp2b|watdiv)(-http)?$/i.test(suite)
+      ? `canonical gather '${primary.gather}' (${primary.wave}) — raw envelopes committed at bench/canonical-competitor-results/2026-07-07/, ingested by scripts/bench/ingest-canonical-competitors.mjs`
+      : `canonical gather '${primary.gather}' (${primary.wave}) — raw envelopes committed under bench/canonical-competitor-results/, ingested by scripts/bench/ingest-canonical-competitors.mjs`,
     count_crosscheck_note: primary.count_crosscheck_note,
     env: {
       host_class: primary.env.host_class,
@@ -239,6 +309,119 @@ function buildEntry(gathers) {
     rows,
   };
 }
+
+// ---- [FABLE-5] sq-hmd7l.28 — bespoke-shape axis adapters ----------------------------
+// A few axes do NOT emit the query-row `<engine>_tsv` + `count_crosscheck` layout the
+// generic buildEntry consumes. Rather than hand-transcribe them, we normalise each into the
+// SAME same_box_comparison shape (engines + rows) here, keyed off the envelope `suite`, so a
+// new canonical gather of these axes flows to the site with no further edit. Every adapter is
+// DEFENSIVE: if a gather's documented fields are absent (a shape the parallel wave has not
+// finalised) it returns null and the ingest SKIPS that suite with a warning — it never
+// fabricates a row and never crashes the build.
+
+// Common env/meta projection shared by the bespoke adapters (mirrors buildEntry's tail).
+function commonMeta(primary, gathers) {
+  return {
+    suite: primary.suite,
+    scale: primary.scale,
+    iters: primary.iters,
+    git_commit: primary.git_commit,
+    gathered_at_utc: (primary.env && primary.env.gathered_at_utc) || primary.gathered_at_utc,
+    canonical: primary.canonical === true,
+    combine:
+      gathers.length > 1
+        ? `best-of ${gathers.length} back-to-back gathers (per-engine MIN); counts cross-checked engine-vs-engine.`
+        : "single gather; counts cross-checked engine-vs-engine.",
+    source: `canonical gather '${primary.gather}' (${primary.wave}) — raw envelope committed under bench/canonical-competitor-results/, ingested by scripts/bench/ingest-canonical-competitors.mjs`,
+    count_crosscheck_note: primary.count_crosscheck_note || primary.caveat,
+    env: {
+      host_class: (primary.env && (primary.env.host_class || primary.env.host)) || "quiet box",
+      quiet_box: !!(primary.env && primary.env.quiet_box),
+      gathered_at_utc: primary.env && primary.env.gathered_at_utc,
+      cpu_model: primary.env && primary.env.cpu_model,
+      kernel: primary.env && primary.env.kernel,
+      note: primary.mode || primary.caveat,
+    },
+  };
+}
+
+function metaEngines(primary, ids) {
+  return ids.map((id) => {
+    const src = (primary.engines && primary.engines[id]) || {};
+    const meta = ENGINE_META[id] || { label: id, mode: src.mode || "" };
+    return {
+      id,
+      label: meta.label,
+      version: src.version || "n/a",
+      mode: meta.mode || src.mode || "",
+      status: src.status === "absent" || src.status === "failed" ? "failed" : "ok",
+    };
+  });
+}
+
+// HDT decode-only (suite "hdt"): sparq decodes .hdt → native Graph, hdt-cpp decodes → N-Triples;
+// the ONE like-for-like metric is decode wall-clock, cross-checked on the decoded triple count.
+function normalizeHdt(primary, gathers) {
+  const sm = primary.sparq_metrics || {};
+  const decodeCell = sm.decode_s || sm.load_decode_s || sm.snikmeta_decode_s;
+  const sparqDecodeS = decodeCell && typeof decodeCell.value !== "undefined" ? Number(decodeCell.value) : null;
+  const cc = primary.count_agreement || {};
+  const ids = engineIdsOf(primary).length ? engineIdsOf(primary) : ["sparq", "hdt-cpp"];
+  // decode seconds → µs for a uniform unit with the other axes; hdt-cpp wall-clock is on the
+  // envelope only as a raw N-Triples sample (no committed numeric us yet) → null (renders n/a).
+  const values = { sparq: sparqDecodeS != null ? Math.round(sparqDecodeS * 1e6) : null };
+  const row = {
+    query: "decode",
+    unit: "µs",
+    rows: cc.expected != null ? Number(cc.expected) : null,
+    values,
+    count_match: typeof cc.all_agree === "boolean" ? cc.all_agree : null,
+  };
+  return {
+    ...commonMeta(primary, gathers),
+    engines: metaEngines(primary, ids),
+    rows: [row],
+  };
+}
+
+// PSS update parity (suite "pss-update-parity"): per-engine p99 update latency over the LDP-CRUD
+// stream, cross-checked on the post-workload quad count. One row per recorded latency metric.
+function normalizeUpdate(primary, gathers) {
+  const lat = primary.latency_ms || {};
+  const ids = engineIdsOf(primary).length ? engineIdsOf(primary) : Object.keys(lat);
+  if (!ids.length) return null;
+  const cc = primary.count_crosscheck || {};
+  const mkRow = (query, pick) => {
+    const values = {};
+    for (const id of ids) {
+      const cell = lat[id];
+      const v = cell && typeof cell === "object" ? cell[pick] : undefined;
+      values[id] = typeof v === "number" ? Math.round(v * 1000) : null; // ms → µs
+    }
+    return {
+      query,
+      unit: "µs",
+      rows: cc.sparq != null && /^-?\d/.test(String(cc.sparq)) ? Number(cc.sparq) : null,
+      values,
+      count_match: typeof cc.all_agree === "boolean" ? cc.all_agree : null,
+    };
+  };
+  const rows = ["p50", "p99", "max"]
+    .filter((p) => ids.some((id) => lat[id] && typeof lat[id][p] === "number"))
+    .map((p) => mkRow(`update ${p}`, p));
+  if (!rows.length) return null;
+  return {
+    ...commonMeta(primary, gathers),
+    engines: metaEngines(primary, ids),
+    rows,
+  };
+}
+
+// suite → bespoke adapter. Any suite not listed uses the generic query-row buildEntry.
+const BESPOKE_ADAPTERS = {
+  hdt: normalizeHdt,
+  "pss-update-parity": normalizeUpdate,
+};
 
 // ---- load envelopes (across every results dir), group by suite ----------------------
 const bySuite = new Map();
@@ -258,13 +441,16 @@ if (!fileCount) {
 }
 
 // Assert counts identical across gathers of a suite (fail loud, never silently pick one).
+// Bespoke-shape suites (hdt/update) carry no per-query `<engine>_tsv`, so this TSV-level
+// assertion does not apply; their adapters do their own cross-check. Skip them here.
 for (const [suite, gathers] of bySuite) {
   gathers.sort((a, b) => (a.__file < b.__file ? -1 : 1));
+  if (BESPOKE_ADAPTERS[suite]) continue;
   const ref = gathers[0];
   for (const g of gathers.slice(1)) {
-    for (const id of ENGINE_ORDER) {
-      const a = parseTsv(ref[id + "_tsv"]);
-      const b = parseTsv(g[id + "_tsv"]);
+    for (const id of engineIdsOf(ref)) {
+      const a = parseTsv(tsvFor(ref, id));
+      const b = parseTsv(tsvFor(g, id));
       for (const q of Object.keys(a)) {
         // [FABLE-5] sq-7d3dj.34: an ERROR row (rows=null, e.g. a per-query timeout that
         // fired in only one of the gathers) is a MISSING count, not a DISAGREEING count —
@@ -285,7 +471,17 @@ const suiteOrder = [...bySuite.keys()].sort((a, b) => {
   const rank = (s) => (/sp2b/i.test(s) ? 0 : /watdiv/i.test(s) ? 1 : 2);
   return rank(a) - rank(b) || (a < b ? -1 : 1);
 });
-const sameBox = suiteOrder.map((s) => buildEntry(bySuite.get(s)));
+// [FABLE-5] sq-hmd7l.28 — dispatch each suite to its bespoke adapter or the generic query-row
+// buildEntry. A defensive adapter that returns null (an unfinalised gather shape) is skipped
+// with a warning so the ingest never crashes and never fabricates a row.
+const sameBox = [];
+for (const s of suiteOrder) {
+  const gathers = bySuite.get(s);
+  const adapter = BESPOKE_ADAPTERS[s];
+  const entry = adapter ? adapter(gathers[gathers.length - 1], gathers) : buildEntry(gathers);
+  if (entry) sameBox.push(entry);
+  else console.warn(`[ingest-canonical] suite '${s}': adapter produced no comparable rows (unfinalised gather shape) — skipped, not fabricated.`);
+}
 
 // ---- rewrite ONLY same_box_comparisons in competitors.json --------------------------
 const competitors = JSON.parse(readFileSync(competitorsPath, "utf8"));

--- a/site/e2e/surface-sweep.spec.ts
+++ b/site/e2e/surface-sweep.spec.ts
@@ -88,6 +88,7 @@ const BENCHMARK_FAMILY_KEYS = [
   "zk",
   "solid",
   "hdt",
+  "update",
   "rsp",
   "genai",
   "gpu",

--- a/site/src/components/benchmarks/suite-group.tsx
+++ b/site/src/components/benchmarks/suite-group.tsx
@@ -73,7 +73,11 @@ export function SuiteGroup({
         <div className="flex min-w-0 flex-1 flex-col">
           <span className="font-semibold">{data.suite}</span>
           <span className="text-xs text-muted-foreground">
-            {data.rows.length} benchmark{data.rows.length === 1 ? "" : "s"}
+            {data.rows.length > 0
+              ? `${data.rows.length} benchmark${data.rows.length === 1 ? "" : "s"}`
+              : data.sameBox
+                ? `${data.sameBox.rows.length} same-box quer${data.sameBox.rows.length === 1 ? "y" : "ies"}`
+                : "0 benchmarks"}
           </span>
         </div>
         <SummaryPill summary={data.summary} />
@@ -82,7 +86,10 @@ export function SuiteGroup({
       {open && (
         <div id={bodyId} className="space-y-4 border-t px-4 py-4">
           <SummaryDetail suite={data.suite} summary={data.summary} />
-          <MetricTable rows={data.rows} />
+          {/* [FABLE-5] sq-hmd7l.28 — a comparison-only group (a new-axis same-box gather with
+              no CI-feed metric yet) carries zero metric rows; skip the empty per-metric table
+              and let the same-box cross-engine table below be the group's content. */}
+          {data.rows.length > 0 && <MetricTable rows={data.rows} />}
           <TrendCharts series={data.trends} />
           <ScalingCharts families={data.scaling} />
           {data.sameBox && (

--- a/site/src/data/benchmarks.ts
+++ b/site/src/data/benchmarks.ts
@@ -347,6 +347,18 @@ export const FAMILIES: Family[] = [
     suites: ["hdt"],
     prefixes: ["hdt"],
   },
+  // [FABLE-5] sq-hmd7l.28 — the SPARQL 1.1 Update parity axis (PSS LDP-CRUD stream). Its
+  // canonical same-box gather (suite `pss-update-parity`, competitors Fuseki / Oxigraph over
+  // an HTTP update endpoint) surfaces here via SAMEBOX_SUITE_FAMILY even before a CI-feed
+  // `update_*` metric emits, so the competitor columns render as soon as the gather merges.
+  {
+    key: "update",
+    title: "SPARQL Update (LDP-CRUD parity)",
+    blurb:
+      "SPARQL 1.1 Update latency over a Solid-pod LDP-CRUD stream (INSERT / DELETE / DROP), with same-box Apache Jena Fuseki + Oxigraph baselines; the post-workload quad count is cross-checked engine-vs-engine before any latency row is trusted.",
+    suites: ["update", "sparql update", "pss-update-parity", "pss update"],
+    prefixes: ["update", "pss"],
+  },
   {
     key: "rsp",
     title: "RDF Stream Processing (continuous queries)",
@@ -384,6 +396,7 @@ const CAPABILITY_KEYS = new Set([
   "zk",
   "solid",
   "hdt",
+  "update",
   "rsp",
   "genai",
   "gpu",
@@ -479,7 +492,7 @@ export function fullSuiteGroupsForFamily(key: string): FullSuiteGroup[] {
   // is small). Trend/scaling carry a `suite` so the per-suite filter is exact.
   const allTrends = trendSeriesForFamily(key);
   const allScaling = scalingFamiliesForFamily(key);
-  return suiteGroupsForFamily(key).map((g) => {
+  const groups = suiteGroupsForFamily(key).map((g) => {
     const httpSameBox = httpSameBoxFor(g.suite);
     return {
       suite: g.suite,
@@ -495,6 +508,53 @@ export function fullSuiteGroupsForFamily(key: string): FullSuiteGroup[] {
       scaling: allScaling.filter((s) => s.suite === g.suite),
     };
   });
+
+  // [FABLE-5] sq-hmd7l.28 — surface same-box comparisons whose FAMILY is this one but which
+  // have NO CI-feed metric yet (so suiteGroupsForFamily produced no group for them). Without
+  // this a canonical fts/geo/hdt/update/materialize gather would land in competitors.json and
+  // stay INVISIBLE on the site (the group list is bench-driven). We synthesize a group per
+  // such comparison carrying the same-box table + its honest live summary, zero metric rows.
+  // A `-http` twin is NOT synthesized standalone: it attaches to its base via httpSameBoxFor.
+  const alreadyRendered = new Set<string>();
+  for (const g of groups) {
+    if (g.sameBox) alreadyRendered.add(g.sameBox.suite.toLowerCase());
+    if (g.httpSameBox) alreadyRendered.add(g.httpSameBox.suite.toLowerCase());
+  }
+  const extra: FullSuiteGroup[] = [];
+  for (const c of COMPETITORS.same_box_comparisons || []) {
+    if (familyForComparison(c) !== key) continue;
+    const sid = c.suite.toLowerCase();
+    if (alreadyRendered.has(sid)) continue;
+    if (sid.endsWith("-http")) continue; // attaches to a base group, not standalone
+    alreadyRendered.add(sid);
+    const httpSameBox = httpSameBoxFor(c.suite);
+    if (httpSameBox) alreadyRendered.add(httpSameBox.suite.toLowerCase());
+    extra.push({
+      suite: sameBoxDisplaySuite(c),
+      rows: [],
+      summary: summarizeSameBox(c),
+      sameBox: c,
+      httpSameBox,
+      httpSummary: httpSameBox ? summarizeSameBox(httpSameBox) : undefined,
+      references: referencesForSuite(c.suite),
+      trends: [],
+      scaling: [],
+    });
+  }
+  return [...groups, ...extra];
+}
+
+// A human display label for a comparison-only suite group header (the raw suite id like
+// `pss-update-parity` is machine-ish; render a friendlier title, provenance stays in the table).
+function sameBoxDisplaySuite(c: SameBoxComparison): string {
+  const map: Record<string, string> = {
+    fts: "Full-text search — same-box vs Jena-text",
+    geo: "GeoSPARQL — same-box vs Jena GeoSPARQL",
+    hdt: "HDT decode — same-box vs hdt-cpp",
+    "pss-update-parity": "SPARQL Update — same-box parity",
+    "materialize-competitors": "Materialisation — same-box vs Jena / VLog / Nemo",
+  };
+  return map[c.suite.toLowerCase()] || `${c.suite} — same-box comparison`;
 }
 
 // ---- LIVE competitive summary (the load-bearing honesty computation) ------------------
@@ -586,6 +646,31 @@ function httpSameBoxFor(suite: string): SameBoxComparison | undefined {
     const base = cs.slice(0, -"-http".length);
     return norm === base || norm.includes(base) || base.includes(norm.split(" ")[0]);
   });
+}
+
+// [FABLE-5] sq-hmd7l.28 — map a same_box_comparison's `suite` id (as the ingest emits it) to
+// the capability FAMILY whose page should render it. This is the seam that lets a new-axis
+// canonical gather surface on the site WITHOUT hand-editing the page: the ingest writes the
+// entry into competitors.json under a known suite id, and this table routes it to a family.
+// A comparison whose suite is not listed (a brand-new axis) still renders on the SPARQL-suite
+// pages via the existing fuzzy sameBoxFor() bind, so it is never dropped silently.
+const SAMEBOX_SUITE_FAMILY: { match: RegExp; family: string }[] = [
+  { match: /^fts$/i, family: "fts" },
+  { match: /^geo$/i, family: "geo" },
+  { match: /^hdt$/i, family: "hdt" },
+  { match: /^pss-update-parity$/i, family: "update" },
+  { match: /^update/i, family: "update" },
+  { match: /^materialize/i, family: "reasoning" },
+  { match: /^parse/i, family: "core" },
+];
+
+// The family a same_box_comparison belongs to (or null if it is a SPARQL-suite comparison
+// already surfaced by the per-suite fuzzy bind — sp2b / watdiv and their -http twins).
+function familyForComparison(c: SameBoxComparison): string | null {
+  for (const { match, family } of SAMEBOX_SUITE_FAMILY) {
+    if (match.test(c.suite)) return family;
+  }
+  return null;
 }
 
 export function competitiveSummary(

--- a/site/src/data/paper-evidence.json
+++ b/site/src/data/paper-evidence.json
@@ -500,6 +500,30 @@
       "family": "single-prover zkSPARQL architecture",
       "source": "crates/sparq-zk-compose/tests/audit_forge_map.rs (bead sq-1gir): one named forge-and-verify regression test per historical audit finding #1-#12, each constructing that finding's specific forgery and asserting the mapped verifier reject path",
       "note": "Number of historical single-prover audit findings (research/zk-soundness-audit.md) that carry a standing 1:1 forge-negative regression test pinning the remediation closed. A deterministic structural count over the committed test file; the map is internal evidence and does NOT substitute for the open external audit (sq-qhy4). [FABLE-5 sq-3kd2g.1]"
+    },
+    "compare.sp2b_answer_agreement": {
+      "value": 12,
+      "unit": "queries (of 14)",
+      "environment": "canonical",
+      "kind": "answer-equivalence-oracle",
+      "family": "comparative benchmarking (same-box)",
+      "total": 14,
+      "diff": 2,
+      "competitors": ["Oxigraph", "QLever", "Virtuoso"],
+      "source": "bench/dashboard/competitors.json same_box_comparisons[suite='sp2b'] (git 0ab87b2a) — per-query count_crosscheck.all_agree, computed by scripts/bench/ingest-canonical-competitors.mjs from the raw envelopes at bench/canonical-competitor-results/2026-07-07/",
+      "note": "Number of SP2Bench queries whose sparq solution COUNT agrees with every independent engine (Oxigraph / QLever / Virtuoso) AND the pinned expected-rows oracle. A count comparison is machine-INDEPENDENT (a deterministic answer-equivalence check, not a timing), so environment=canonical. The 2 non-agreeing queries (q08 / q12b) are recorded HONESTLY as a DIFF, never suppressed — they are the known OPTIONAL/negation optional-semantics divergences, not a sparq correctness gap; a paper citing this must present it as an answer-equivalence rate, NOT a speed claim. [FABLE-5 sq-hmd7l.28]"
+    },
+    "compare.watdiv_answer_agreement": {
+      "value": 16,
+      "unit": "queries (of 16)",
+      "environment": "canonical",
+      "kind": "answer-equivalence-oracle",
+      "family": "comparative benchmarking (same-box)",
+      "total": 16,
+      "diff": 0,
+      "competitors": ["Oxigraph", "QLever", "Virtuoso"],
+      "source": "bench/dashboard/competitors.json same_box_comparisons[suite='watdiv'] (git 0ab87b2a) — per-query count_crosscheck.all_agree, computed by scripts/bench/ingest-canonical-competitors.mjs from the raw envelopes at bench/canonical-competitor-results/2026-07-07/",
+      "note": "Number of WatDiv queries whose sparq solution COUNT agrees with every independent engine (Oxigraph / QLever / Virtuoso) AND the pinned expected-rows oracle — full agreement, 16/16. Machine-INDEPENDENT (a deterministic answer-equivalence check, not a timing), so environment=canonical. A paper citing this must present it as an answer-equivalence rate, NOT a speed claim. [FABLE-5 sq-hmd7l.28]"
     }
   }
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Fable 5). Bead **sq-hmd7l.28** — propagate the comparative-benchmarking axes to the website `/benchmarks` dashboard: competitor columns for the new axes (fts / geo / hdt / update / materialization, + parse) + paper-evidence wiring. Site lane; PR vs `main`; **not armed**.

## What this does

Wires the new comparative axes to the dashboard through the **existing reviewed seam** so a new **canonical** gather flows to the site with **no hand-edited site code**:

```
canonical envelopes (bench/canonical-competitor-results/<date>/)
  → scripts/bench/ingest-canonical-competitors.mjs   (rewrites ONLY same_box_comparisons)
    → bench/dashboard/competitors.json                (the reviewed snapshot)
      → site/scripts/sync-benchmarks.mjs              (--competitors-only preserves the CI series)
        → site/src/data/benchmarks.generated.json → the /benchmarks pages
```

**No hand-typed numbers** — every competitor cell is derived from a committed, reviewable envelope (the sanctioned data path). The gap records (`research/gap-{fts,geo,hdt,update,parse,materialize}-2026-07.md`) deliberately carry **no** perf numbers; the citable numbers live in the envelopes, exactly as the merged materialize record documents.

## Pipeline changes (`scripts/bench/ingest-canonical-competitors.mjs` — the bench data emitter)

- `ENGINE_META` gains `jena-text` / `jena-geosparql` / `hdt-cpp` / `jena` / `vlog` / `nemo` (stable label + measurement-MODE per column).
- `engineIdsOf()` derives the render columns from the envelope's **own** `engines` map (sparq first, then the fixed SPARQL order, then any new-axis competitor) — a brand-new competitor surfaces with **no script edit**.
- `tsvFor()` resolves the hyphen→underscore TSV-key form (`jena_text_tsv`) so a hyphenated competitor id is not read as an all-null column.
- `rowCountMatch()` reads `all_agree` **or** the per-row `agree` flag (geo).
- **Bespoke-shape adapters** for the decode-only **HDT** and **PSS-update-parity** envelopes (they carry no per-query `<engine>_tsv`) normalise into the common row shape; **defensive** — an unfinalised gather shape is skipped with a warning, never fabricated, never crashes the build.
- `sp2b`/`watdiv` keep **byte-identical** reviewed prose; other axes get a generic, accurate combine/source string (no fabricated engine/query name).

Verified: re-ingesting the committed `sp2b`/`watdiv` envelopes is **byte-identical** to the current snapshot (no regression). Synthetic `fts`/`geo`/`hdt`/`update`/`materialize` envelopes flow through with **honest** `count_match` — the materialize `owl` row is a DIFF (Jena's profile-different closure) and is excluded from the win ratio; VLog/Nemo emit NOT-RUN → null → `n/a`.

## Site changes (`site/src/data/benchmarks.ts` + `suite-group.tsx`)

- New **`update`** capability family (SPARQL Update LDP-CRUD parity) → new static route `/benchmarks/update`.
- `SAMEBOX_SUITE_FAMILY` routes each comparison suite id to its family; a comparison whose family has **no CI-feed metric yet** is surfaced as a **comparison-only group** (same-box table + honest live wins/losses summary, zero metric rows). Without this a merged gather would land in `competitors.json` and stay **invisible** on the bench-driven pages.
- **Honest display preserved**: BEHIND rows show as BEHIND (`losses` counted, per-query ratio shown); count-DIFF rows are excluded from the win ratio, never spun; canonical-vs-non-canonical + quiet-box provenance labels ride through the existing `SameBoxTable`.
- `SuiteGroup` skips the empty metric table + shows the same-box query count for a comparison-only group.

## paper-evidence wiring (`site/src/data/paper-evidence.json`)

- `compare.sp2b_answer_agreement` (12/14) + `compare.watdiv_answer_agreement` (16/16): **deterministic, machine-INDEPENDENT answer-equivalence oracles** (a solution-count cross-check vs Oxigraph / QLever / Virtuoso — **not a timing**) → `environment=canonical` with a real `source`. The 2 SP2Bench DIFFs (q08/q12b) are recorded honestly, and the `note` forbids citing this as a speed claim. The `build-papers.mjs` honesty gate passes (**49 canonical / 8 indicative**).

## Gates

- `cd js && npm run build:wasm` — WASM bundle built first (build artifact only, **no `crates/` change**; the site build hard-fails without it).
- `cd site && npm install && npm run build` — **static export GREEN end-to-end**; `/benchmarks/update` + all existing routes emitted; `check-bundle` PASS; `basePath /sparq` preserved on every asset.
- `npm run lint` clean · `tsc --noEmit` clean (no `any`-escape).
- No unrelated CI-series / generated-artifact drift committed (the generated JSON regenerates at build time; I reverted the build's timestamp-only churn).
- No new dependency.

**Proven end-to-end**: a synthetic-data rebuild renders the jena-text / Fuseki+Oxigraph / Jena-VLog-Nemo / hdt-cpp / jena-geosparql competitor columns on the fts / update / reasoning / hdt / geo pages; the committed state ships the honest "no metrics reported yet" placeholder until the parallel canonical wave merges its gathers.

## Follow-ups (beads created)

- **sq-hmd7l.33** (P3): wire canonical hdt-cpp decode wall-clock + validated VLog/Nemo OWL-RL encodings so those competitor *cells* show real numbers (columns already render).
- **sq-hmd7l.34** (P3): promote the parse-axis competitor comparison from `bench/competitors.json` (registry) into the reviewed `bench/dashboard/competitors.json` snapshot via a canonical parse gather (the `parse`→`core` route is already wired).

**Not armed** — leaving for review.