### PR TITLE
fix(site): guard coi-serviceworker against an undefined registration — firefox nightly cross-browser (sq-bx1zv) [FABLE-5]

### DIFF
--- a/site/public/coi-serviceworker.js
+++ b/site/public/coi-serviceworker.js
@@ -153,6 +153,23 @@ if (typeof window === 'undefined') {
             (window.coiServiceWorkerPath || "/sparq/coi-serviceworker.js");
         n.serviceWorker.register(swPath).then(
             (registration) => {
+                // [FABLE-5] sq-bx1zv — Firefox can FULFIL register() with `registration === undefined`
+                // when service-worker registration is disallowed for the context (e.g. the Playwright
+                // `serviceWorkers: "block"` setting, some private-browsing / policy configs). Chromium
+                // rejects that case and takes the (err) branch below, but Firefox lands here with no
+                // registration object, so the original `registration.scope` read threw
+                // `TypeError: can't access property "scope", registration is undefined` — a real console
+                // error surfaced in the nightly cross-browser (firefox) lane. Treat a missing
+                // registration as a benign no-op: isolation headers simply are not applied (the same
+                // graceful-degradation posture as the (err) reject branch), and the page keeps working
+                // single-threaded. No `?.` — this vendored file must parse in the oldest SW-capable
+                // engines, so an explicit guard is used.
+                if (!registration) {
+                    !coi.quiet && console.log(
+                        "COOP/COEP Service Worker registration unavailable in this context; continuing without cross-origin isolation."
+                    );
+                    return;
+                }
                 !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
 
                 registration.addEventListener("updatefound", () => {


### PR DESCRIPTION
> 🤖 **SPARQ agent** (site lane). Self-identifying: this PR was prepared by an automated agent.

Fixes the firefox-specific red in the **nightly cross-browser** lane (`e2e/download-app.spec.ts`), bead **sq-bx1zv** (a `sq-0rbfn` follow-up).

## Root cause (a real Firefox robustness gap, not a test artifact)

The download-app specs run with Playwright's `serviceWorkers: "block"`. In **Firefox**, `navigator.serviceWorker.register()` *fulfils* its promise with `registration === undefined` when SW registration is disallowed for the context, rather than rejecting. The vendored `coi-serviceworker.js` fulfilment handler then read `registration.scope`, throwing:

```
TypeError: can't access property "scope", registration is undefined
```

**Chromium** rejects that same case and takes the existing `(err)` branch, so the error only surfaced in the nightly firefox lane (first seen run 28853194264). The same `undefined`-registration fulfilment can be hit by a real firefox user in private-browsing / policy configs — so this is a genuine (if minor) UX/robustness defect, not something to paper over in the spec allowlist.

## Fix

In `site/public/coi-serviceworker.js`, guard the fulfilment handler: if `registration` is falsy, log once and return — the isolation headers simply are not applied and the page keeps working single-threaded. This is the **same graceful-degradation posture as the existing reject branch**, so no real behaviour is hidden. An explicit `!registration` guard (not `?.`) is used so this vendored file still parses in the oldest SW-capable engines.

I did **not** touch the spec's console-error allowlist: hardening the source removes the throw in *both* browsers, so the error is no longer produced at all (the correct fix per the bead — "do NOT blanket-ignore all console errors").

## Gates (all green)

- `cd js && build:wasm` prereq satisfied (bundle present); `cd site && npm run build` static export ✅ (`out/coi-serviceworker.js` emitted with the guard)
- `npm run lint` — 0 warnings/errors ✅
- `tsc --noEmit` ✅
- basePath `/sparq` unchanged; no route touched; no axe rule / visual threshold weakened.

**Not armed** — leaving for review.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)