### PR TITLE
fix(site): mask the live-reasoner status region on /surface/inference (data-vr-mask) (sq-2av3s) [FABLE-5]

### DIFF
--- a/site/src/components/inference-playground.tsx
+++ b/site/src/components/inference-playground.tsx
@@ -188,7 +188,17 @@ export function InferencePlayground() {
           <Brain className="size-4 text-primary" />
           Live reasoner
         </CardTitle>
-        <EngineIndicator engine={engine} />
+        {/* [FABLE-5] sq-2av3s — the live-reasoner status badge reflects the W-reason wasm
+            bundle load outcome (cold → warming → ready | error). In the lean-wasm VISUAL lane
+            the reason bundle genuinely cannot load, so this region renders the
+            "Reasoner failed — retries on reason" state and the load-error toast baked into the
+            baseline, making the surface-inference screenshot drift. Mask this load-driven region
+            at capture ("mask, don't chase", cf. the benchmarks provenance strip in #1801) so the
+            baseline guards the static playground layout, not the runtime load outcome. The
+            vrMasks() helper in e2e/visual/*.spec.ts masks every [data-vr-mask] node. */}
+        <span data-vr-mask className="inline-flex">
+          <EngineIndicator engine={engine} />
+        </span>
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex flex-wrap gap-1.5">


### PR DESCRIPTION
> 🤖 **SPARQ agent** (site lane). Self-identifying: this PR was prepared by an automated agent.

Bead **sq-2av3s**: stop the `surface-inference` visual baseline from baking the lean-wasm reasoner load-error toast.

## Problem

The `/surface/inference` live-reasoner status badge (`EngineIndicator`) reflects the **W-reason wasm bundle load outcome** (`cold → warming → ready | error`). In the lean-wasm **visual** lane the reason bundle genuinely cannot load, so that region renders the *"Reasoner failed — retries on reason"* state (plus a load-error toast), and those runtime-dependent pixels were baked into `e2e/visual/baselines/visual-{desktop,mobile}/surface-inference.png` — a recurring source of screenshot drift.

## Fix

Wrap the `EngineIndicator` status region in a `data-vr-mask` span — the same **"mask, don't chase"** convention the benchmarks provenance strip adopted in #1801. The `vrMasks()` helper in `e2e/visual/*.spec.ts` (`page.locator("[data-vr-mask]")`) already masks every such node, in **both** the live capture and the stored baseline at comparison time, so the region is no longer compared. The baseline now guards the **static playground layout**, not the runtime bundle-load outcome.

**No baseline re-mint required**: adding a mask only *removes* a region from comparison (Playwright overlays the mask colour on the masked bounding box in both images), and the wrapping span keeps the badge in the same flex position — so the existing baseline stays valid. No axe rule or visual threshold weakened.

## Gates (all green)

- `build:wasm` prereq satisfied; `cd site && npm run build` static export ✅ — `data-vr-mask` verified present in exported `out/surface/inference/index.html`
- `npm run lint` — 0 warnings/errors ✅
- `tsc --noEmit` ✅
- basePath `/sparq` unchanged; no other route touched.

**Not armed** — leaving for review.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)