### PR TITLE
bench(run): canonical wave-1 rows — fts/geo/hdt/update/parse (sq-hmd7l.26) [FABLE-5]

### DIFF
--- a/bench/parse/Cargo.lock
+++ b/bench/parse/Cargo.lock
@@ -1106,6 +1106,7 @@ dependencies = [
 name = "sparq-substrate"
 version = "0.1.0"
 dependencies = [
+ "hashbrown 0.17.1",
  "oxrdf",
  "rustc-hash",
  "smallvec",

--- a/bench/parse/src/main.rs
+++ b/bench/parse/src/main.rs
@@ -1222,6 +1222,23 @@ fn ext_row(dataset: &str, task: &str, secs: f64, bytes: usize, triples: usize) {
     ]);
 }
 
+/// Extract the triple count from `riot --count` output: `"<file> : Triples = N"`
+/// (field name padding varies by version, and riot 5.x prints the count WITH
+/// grouping separators — `"Triples = 2,560,000"` observed from riot 5.4.0 on the
+/// wave-1 canonical box, which wrongly suppressed the row until the commas were
+/// stripped).
+fn parse_riot_count(output: &str) -> Option<usize> {
+    output.lines().find_map(|line| {
+        let pos = line.find("Triples")?;
+        let after = &line[pos..];
+        let eq = after.find('=')?;
+        after[eq + 1..]
+            .split_whitespace()
+            .next()
+            .and_then(|s| s.replace(',', "").parse::<usize>().ok())
+    })
+}
+
 /// External parser competitor measurements (`bench-ext <file>`).
 ///
 /// Detects format from the file extension (`.nt` → N-Triples, `.ttl` /
@@ -1395,16 +1412,7 @@ fn bench_ext(path: &str) {
         );
         match subprocess_time_and_output(&["riot", "--count", abs_str]) {
             Some((secs, output)) => {
-                // "Triples = N" or "Triples      = N" (riot pads the field name)
-                let parsed_count = output.lines().find_map(|line| {
-                    let pos = line.find("Triples")?;
-                    let after = &line[pos..];
-                    let eq = after.find('=')?;
-                    after[eq + 1..]
-                        .split_whitespace()
-                        .next()
-                        .and_then(|s| s.parse::<usize>().ok())
-                });
+                let parsed_count = parse_riot_count(&output);
                 match parsed_count {
                     Some(c) if c == expected => {
                         ext_row(name, &task, secs, nbytes, expected);
@@ -1444,6 +1452,23 @@ fn bench_ext(path: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: riot 5.4.0 prints grouping separators ("Triples = 2,560,000",
+    /// verbatim wave-1 canonical-box output) — the count must parse, or the riot
+    /// row is wrongly suppressed. Plain and padded forms must keep working.
+    #[test]
+    fn riot_count_parses_grouping_separators() {
+        assert_eq!(
+            parse_riot_count("/root/sparq/bench/parse/data/synthetic.nt : Triples = 2,560,000\n"),
+            Some(2_560_000)
+        );
+        assert_eq!(parse_riot_count("Triples = 400000"), Some(400_000));
+        assert_eq!(
+            parse_riot_count("INFO  riot  :: Triples      = 328"),
+            Some(328)
+        );
+        assert_eq!(parse_riot_count("no count here"), None);
+    }
 
     /// `--json <path>` is stripped from the positional argv (so the subcommands'
     /// positional indexing is unaffected) and its value is returned; the escaper

--- a/research/gap-fts-2026-07.md
+++ b/research/gap-fts-2026-07.md
@@ -1,12 +1,11 @@
-<!-- [FABLE-5] sq-hmd7l.2 — per-axis gap record: full-text search. PROTOCOL/SKELETON
-ONLY at this stage: no measured numbers may appear here until the canonical wave-1
-EC2 run (sq-hmd7l.26) fills the tables from quiet-box envelopes with provenance.
+<!-- [FABLE-5] sq-hmd7l.2 — per-axis gap record: full-text search. §3 filled by the
+canonical wave-1 EC2 run (sq-hmd7l.26) from quiet-box envelopes with provenance.
 Work-box readings are NON-canonical by construction and are never transcribed here. -->
 
 # Gap record — full-text search (2026-07)
 
 **Axis:** #13 in `research/comparative-benchmarking-everything.md` §5 (epic `sq-hmd7l`).
-**Status:** protocol + skeleton — **awaiting the canonical wave-1 run (`sq-hmd7l.26`)**.
+**Status:** latency axis MEASURED (canonical wave-1 run `sq-hmd7l.26`); BEIR quality axis still NOT-RUN (see §4).
 **Harness:** `scripts/bench/fts-same-box.sh` (this bead's deliverable, sq-hmd7l.2).
 **Feeds:** the master table in `research/perf-dominance-gap-2026-07.md` (via `sq-hmd7l.27`).
 
@@ -59,25 +58,37 @@ competitors and stay off the table entirely.
 
 ## 3. Results — latency axis (per-workload, best-of-N µs/query)
 
-> NOT-MEASURED — to be filled by `sq-hmd7l.26` from canonical envelopes only.
+**CANONICAL — wave-1 run (`sq-hmd7l.26`).** Provenance: dedicated quiet box
+`i-01a735e27b1764317` (c6i.4xlarge, eu-west-2, tag `sparq-bench`, self-terminated,
+orphan-check clean), commit `cb1fc98c` (= `origin/main` `343aee547` + wave-1
+runner-only fixes), envelope UTC `2026-07-10T00:44:50Z`, `CANONICAL=1`, N=100000
+seed=0 corpus, 200 pinned pairs, best-of-3. Statuses: sparq ok, jena-text ok;
+`pairs_pinned_check` ok; `doc_count_check` ok (100000 == N). Envelope:
+`axis-results/fts/fts-n100000-20260710T004450Z.json` (launcher SSH pull + console).
 
 | Workload | count crosscheck | sparq-text | jena-text | Verdict |
 |---|---|---|---|---|
-| `and_terms` | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
-| `or_terms` | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
-| `prefix4` | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
-| `phrase` | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
-| `near_slop2` | n/a | NOT-MEASURED | NOT-COMPARABLE (untranslated — semantics mismatch) | NOT-COMPARABLE |
-| index build / corpus load | n/a (advisory) | NOT-MEASURED | NOT-MEASURED | advisory only |
+| `and_terms` | agree (52 = 52) | 11.9 µs | 3 177.9 µs | CLEARLY-AHEAD (~267×) |
+| `or_terms` | agree (71 643 = 71 643) | 20.3 µs | 7 008.7 µs | CLEARLY-AHEAD (~345×) |
+| `prefix4` | agree (6 727 493 = 6 727 493) | 3 414.5 µs | 254 655.0 µs | CLEARLY-AHEAD (~75×) |
+| `phrase` | agree (6 = 6) | 1.4 µs | 2 735.3 µs | CLEARLY-AHEAD (~1954×, HTTP-floor caveat) |
+| `near_slop2` | n/a (sparq 21 hits) | 1.4 µs | NOT-COMPARABLE (untranslated — semantics mismatch) | NOT-COMPARABLE |
+| index build / corpus load | n/a (advisory) | 0.531 s | 2.1 s (GSP POST incl. Lucene indexing) | advisory only |
+
+Mode-asymmetry caveat (recorded in the envelope, never adjusted): jena-text timings
+include loopback HTTP round-trip (its deployed surface) — a few hundred µs floor. On
+`phrase`/`and_terms` that floor is a visible share of the jena-text figure; even
+subtracting a generous 500 µs floor the verdicts stay CLEARLY-AHEAD on every
+translated workload. `prefix4`/`or_terms` are dominated by real result-set work.
 
 ## 4. Results — IR-quality axis (BEIR deficits, smaller is better)
 
-> NOT-RUN on the shared work box: `pyserini` and `beir` are not installed
-> (`python3 -c 'import pyserini, beir'` fails). This is the expected state for a
-> gather-only dependency — the BEIR axis is reserved for the quiet EC2 gather box
-> (`sq-hmd7l.26`), where `pip install pyserini beir` is part of the provisioning
-> step. Blocking reason recorded per bead spec; values to be filled from the canonical
-> run envelopes only.
+> STILL NOT-RUN after wave-1. The bin-packed wave-1 runner
+> (`scripts/bench/multi-axis-box.sh`) executes `fts-same-box.sh` — the latency axis
+> only. The BEIR quality axis is a separate download-step gather
+> (`scripts/gather-competitors.sh --only lucene-anserini`, sq-1fz0) whose heavy
+> `pyserini`/`beir` provisioning was not part of the wave-1 box. Honest gap, noted
+> for the consolidation bead `sq-hmd7l.27`; scheduling bead filed: **sq-tvzyi**.
 
 | Cut | Metric | sparq-text deficit | Lucene/Anserini (oracle) deficit | Verdict |
 |---|---|---|---|---|
@@ -86,7 +97,13 @@ competitors and stay off the table entirely.
 
 ## 5. Verdict + fix plan
 
-Pending the canonical run. Verdicts use the fixed vocabulary (CLEARLY-AHEAD /
-AHEAD-BUT-NOT-OOM / PARITY / BEHIND / NOT-MEASURED / NOT-COMPARABLE); per the
-dominance mandate, every BEHIND or PARITY row filed here must carry a root cause and
-an immediate P1 profiling-first fix bead (consolidated by `sq-hmd7l.27`).
+**Latency axis: CLEARLY-AHEAD on all four translated workloads** (~75× to ~1954×,
+count crosscheck green on every row) — no BEHIND/PARITY rows, nothing for the
+dominance fix queue from this axis. `near_slop2` stays NOT-COMPARABLE by design.
+
+Remaining gap for `sq-hmd7l.27`: the BEIR IR-quality axis (§4) is unmeasured — a
+quality (not latency) claim cannot be made either way until that gather runs.
+Verdicts use the fixed vocabulary (CLEARLY-AHEAD / AHEAD-BUT-NOT-OOM / PARITY /
+BEHIND / NOT-MEASURED / NOT-COMPARABLE); per the dominance mandate, every BEHIND or
+PARITY row filed here must carry a root cause and an immediate P1 profiling-first
+fix bead (consolidated by `sq-hmd7l.27`).

--- a/research/gap-geo-2026-07.md
+++ b/research/gap-geo-2026-07.md
@@ -148,6 +148,60 @@ the canonical wave runs.
 
 ---
 
+## 6b. CANONICAL wave-1 results (`sq-hmd7l.26`)
+
+Provenance: dedicated quiet box `i-01a735e27b1764317` (c6i.4xlarge, eu-west-2, tag
+`sparq-bench`, self-terminated, orphan-check clean), commit `cb1fc98c`
+(= `origin/main` `343aee547` + wave-1 runner-only fixes), envelope UTC
+`2026-07-10T00:45:36Z`, `CANONICAL=1`, fixed CRS84 100 000-point corpus, best-of-3.
+Statuses: sparq ok, jena-geosparql ok (jena-fuseki-geosparql-5.4.0, jar sha256
+`a2ef5e6f…`, openjdk 21). Envelope: `axis-results/geo/geo-points100k-20260710T004536Z.json`.
+sparq counts additionally passed the `bench/geo/expected.tsv` hard gate.
+
+| Workload | count crosscheck | sparq | jena-geosparql | Verdict |
+|---|---|---|---|---|
+| `within10km` | **DISAGREE** (sparq 51, jena 0) | 7.2 µs | WITHHELD (count-disagree) | NOT-MEASURED (crosscheck red — see below) |
+| `within50km` | **DISAGREE** (sparq 1547, jena 0) | 150.2 µs | WITHHELD (count-disagree) | NOT-MEASURED (crosscheck red — see below) |
+| `nearest_k10` | agree (10 = 10) | 6.1 µs | 1 517 437 µs | CLEARLY-AHEAD (~2.5 × 10⁵×, caveats below) |
+| `nearest_k100` | agree (100 = 100) | 70.0 µs | 1 635 714 µs | CLEARLY-AHEAD (~2.3 × 10⁴×, caveats below) |
+| `geof_within` | agree (1526 = 1526) | 90 458.9 µs | 137 888 µs | **AHEAD-BUT-NOT-OOM (~1.5×)** — dominance-gap row |
+
+Honest findings, for the consolidation bead `sq-hmd7l.27`:
+
+1. **`within*` crosscheck is RED — jena returned 0 hits on both radius workloads.**
+   Zero (vs sparq's 51/1547) is NOT the documented spherical-vs-ellipsoidal
+   boundary-margin effect (§3) — that would move a handful of edge points, not all
+   of them. This looks like a translation/units semantic gap in the pinned jena
+   rendering of the `geof:distance ≤ radius` filter (jena executed the query fine:
+   0 hits in ~0.61 s). Per the invariant the jena timings are withheld and NO
+   comparative verdict is drawn. Harness root-cause bead filed (see §6c).
+2. **`nearest_k*` CLEARLY-AHEAD carries two caveats** (recorded in the envelope,
+   never adjusted): (a) mode asymmetry — jena is a full HTTP SPARQL round-trip vs
+   sparq's in-process index surface (the HTTP floor is negligible at the observed
+   1.5 s scale); (b) the jena rendering is the standard-visible
+   `ORDER BY ASC(geof:distance(...)) LIMIT k` full scan-and-sort, since standard
+   GeoSPARQL has no k-NN function — any engine is free to optimise it, jena does not.
+3. **`geof_within` is AHEAD-BUT-NOT-OOM (~1.5×) — a dominance-mandate gap row.**
+   sparq's own 90.5 ms is ~600× slower than its `within50km` (150 µs) on the same
+   corpus for a similar-cardinality result (1526 vs 1547) — root-cause hypothesis:
+   the `geof:sfWithin` FILTER path evaluates as a full scan (per-point WKT
+   parse/geometry test) instead of using the spatial index that serves `within*`.
+   Engine-side profiling-first fix bead to be filed by `sq-hmd7l.27`.
+
+---
+
+## 6c. Harness follow-up (filed from wave-1)
+
+- **sq-a8anf** — jena `within*` zero-hit translation/units root-cause — the pinned
+  `bench/geo/queries-jena/within*.rq` renderings need semantic validation against
+  jena-geosparql (units of `geof:distance` / `uom:metre` handling, and axis order:
+  bare `geo:wktLiteral` defaults to CRS84 lon-lat, but a lat-lon interpretation of
+  `POINT(0 51)` puts the query centre ~5000 km from the corpus window — exactly the
+  observed all-zero shape) before the radius workloads can carry a canonical
+  comparative verdict.
+
+---
+
 ## 7. Geographica (deferred)
 
 The reviewer-recognised Geographica real-world benchmark suite is **not wired into

--- a/research/gap-hdt-2026-07.md
+++ b/research/gap-hdt-2026-07.md
@@ -39,6 +39,41 @@ A query-over-HDT head-to-head (e.g., `hdtSearch` / triple-pattern resolution ove
 3. `shellcheck scripts/bench/hdt-same-box.sh` passes.
 4. `markdownlint-cli2 research/gap-hdt-2026-07.md` passes.
 
+## CANONICAL wave-1 results (`sq-hmd7l.26`)
+
+Provenance: dedicated quiet box `i-0d42a7d98f84e0a0d` (c6i.4xlarge, eu-west-2, tag
+`sparq-bench`, self-terminated, orphan-check clean), commit `4324828b`
+(= `origin/main` `343aee547` + wave-1 runner/harness-only fixes), envelope UTC
+`2026-07-10T01:07:20Z`, `CANONICAL=1`, Docker available. Envelope:
+`axis-results/hdt/hdt-snikmeta-20260710T010720Z.json`. Statuses: sparq ok,
+hdt-cpp ok (`rdfhdt/hdt-cpp@sha256:36682e1d…`).
+
+**Count crosscheck: GREEN** — the hard gate this axis exists for:
+
+| engine | decoded snikmeta triples | agree |
+|---|---|---|
+| sparq-hdt (bench_oracle, decode-to-native) | 328 | ✓ |
+| hdt-cpp (`hdt2rdf`, decode-to-N-Triples) | 328 | ✓ |
+
+`all_agree: true` (both equal the 328 ground truth); the five sparq deterministic
+metrics (triples / terms / predicates / rdf:type / direct==upstream) all matched
+`bench/hdt/expected.tsv`.
+
+Advisory timings (recorded, NOT a comparative verdict): sparq `hdt_load_s` 0.0898 s
+in-process; hdt-cpp wall 8.56 s **including `docker run` container spawn + tool
+init** — a different measurement boundary that dominates a 328-triple fixture, so
+no decode-throughput verdict is drawn on this axis at this scale (an OOM-scale
+archive gather would be needed for a meaningful throughput comparison — noted for
+`sq-hmd7l.27`).
+
+Wave-1 execution notes (fixed in this wave's PR): the registered hdt-cpp recipe had
+never actually run — `hdt2rdf` requires an explicit output operand (`ERROR: You
+must supply an input and output`), so the stdout-piped invocation failed on the
+first wave-1 box (`i-01a735e27b1764317`); the error only became visible after the
+harness started surfacing `hdt-cpp.err` into the run log (the /tmp pointer was
+pruned by between-axis cleanup on box `i-06efda08048633f55`). The fixed invocation
+decodes into a rw-mounted scratch file.
+
 ## First-read results (NON-canonical, shared work box)
 
 Smoke run on snikmeta.hdt (328 triples) from the shared work box (not a dedicated quiet instance):

--- a/research/gap-parse-2026-07.md
+++ b/research/gap-parse-2026-07.md
@@ -1,13 +1,15 @@
-<!-- [SONNET-4.6] sq-hmd7l.6 first-read gap record. All rows are NON-CANONICAL
-(measured on the shared work box, not a quiet EC2 instance). Canonical numbers
-ride sq-hmd7l.26. -->
+<!-- [SONNET-4.6] sq-hmd7l.6 first-read gap record. The 2026-07-07 rows are
+NON-CANONICAL (shared work box). CANONICAL wave-1 rows (sq-hmd7l.26) are in the
+canonical section below and supersede them. -->
 
 # RDF parse competitor gap — first-read record (2026-07-07)
 
-**Status:** NON-CANONICAL first-read. Canonical execution: sq-hmd7l.26 (quiet EC2).
+**Status:** CANONICAL wave-1 rows recorded (sq-hmd7l.26, quiet EC2 — see the
+canonical section below). Headline: NT CLEARLY-AHEAD only with chunk-parallelism;
+**Turtle single-thread is BEHIND serd (~2×)** — dominance gap row for `sq-hmd7l.27`.
 **Bead:** sq-hmd7l.6. **Epic:** sq-hmd7l.
-**Box:** shared work box (EC2 work instance, not a dedicated bench box — numbers are
-load-dependent and not suitable for publication).
+**Box (first-read sections):** shared work box (EC2 work instance, not a dedicated
+bench box — numbers are load-dependent and not suitable for publication).
 
 ## Harness
 
@@ -86,9 +88,62 @@ In-process reference (from `bench-nt` on the same box, same file):
 3. **Jena riot**: not available on this box. The canonical run (sq-hmd7l.26) must
    have riot installed and should use `riot --count` mode.
 
+## CANONICAL wave-1 rows (`sq-hmd7l.26`)
+
+Provenance: dedicated quiet box `i-06efda08048633f55` (c6i.4xlarge, eu-west-2, tag
+`sparq-bench`, self-terminated, orphan-check clean), commit `a1bf9b48`
+(= `origin/main` `343aee547` + wave-1 runner/harness-only fixes), UTC
+`2026-07-10T00:58:43Z`, `CANONICAL=1`. Corpus: deterministic synthetic
+320 000-entity graph, **2 560 000 triples**; NT 169 964 508 B (~170 MB — clears the
+≥100 MB canonical floor from note 1 above), TTL 60 022 305 B. All external columns
+min-of-3, count crosschecked against the authoritative oxttl count (**count-ok yes
+on every row**; riot required the grouping-separator fix, see below). Raw rows:
+`axis-results/parse/parse-rows.txt`. Cross-read: a first canonical read on box
+`i-01a735e27b1764317` (00:53Z, same commit base; riot rows suppressed there by the
+comma bug, which is why box-2 is transcribed) reproduces the subprocess competitor
+rows to within ~0.5 % and the 16-thread rows to within ~5 %, but the single-thread
+in-process rows ran up to ~28 % FASTER on box-1 (custom NT 1T 0.921 s / 2.78 Mt/s
+vs 1.278 s / 2.00 Mt/s here) — real between-box single-thread variance on the same
+instance type. The verdicts below hold under either reading (NT 1T lead vs serd is
+1.2–1.7×, still not OOM; Turtle 1T stays BEHIND serd ~1.8–2.0×).
+
+### N-Triples (170 MB, 2.56 M triples)
+
+| task | threads | s | MB/s | Mtriples/s |
+|---|---|---|---|---|
+| sparq custom NT parse+intern (in-process) | 1 | 1.278 | 133 | 2.00 |
+| sparq custom NT parse+intern (in-process) | 16 | 0.164 | 1033 | 15.56 |
+| oxttl NT parse-only (in-process reference, not sparq's parser) | 1 | 1.435 | 118 | 1.78 |
+| serdi/serd (subprocess, parse+serialize-to-sink) | 1 | 1.520 | 112 | 1.68 |
+| rapper/raptor2 (subprocess, count-only) | 1 | 2.551 | 67 | 1.00 |
+| Jena riot (subprocess, `--count`) | 1 | 4.896 | 35 | 0.52 |
+
+### Turtle (60 MB, 2.56 M triples)
+
+| task | threads | s | MB/s | Mtriples/s |
+|---|---|---|---|---|
+| sparq Turtle parse+intern (incumbent chunked, in-process) | 1 | 3.153 | 19 | 0.81 |
+| sparq Turtle parse+intern (incumbent chunked, in-process) | 16 | 0.490 | 122 | 5.22 |
+| serdi/serd (subprocess, parse+serialize-to-sink) | 1 | 1.547 | 39 | 1.65 |
+| rapper/raptor2 (subprocess, count-only) | 1 | 2.194 | 27 | 1.17 |
+| Jena riot (subprocess, `--count`) | 1 | 4.913 | 12 | 0.52 |
+
+### Verdicts (fixed vocabulary; regime caveats from the section above apply)
+
+| axis | verdict |
+|---|---|
+| NT, 1 thread | AHEAD-BUT-NOT-OOM vs serd (~1.2× Mt/s; and serd is doing extra serialize work); ~2× vs rapper; ~3.8× vs riot |
+| NT, 16 threads | CLEARLY-AHEAD (~9.3× vs serd — chunk-parallelism is the lever; the external tools are single-threaded by design) |
+| Turtle, 1 thread | **BEHIND serd (~2.0×) and rapper (~1.4×)** — sparq 0.81 Mt/s vs serd 1.65 / rapper 1.17, and serd additionally serializes. Honest dominance-gap row for `sq-hmd7l.27`: single-thread Turtle parse throughput (the incumbent chunked parser sits at oxttl speed, ~0.8 Mt/s) needs a profiling-first fix bead |
+| Turtle, 16 threads | AHEAD-BUT-NOT-OOM (~3.2× vs serd) — parallelism recovers the lead but not by an order of magnitude |
+
+Wave-1 execution notes: (a) riot 5.4.0 prints `Triples = 2,560,000` — the
+grouping-separator count-parse fix (this wave's PR) un-suppressed the riot rows;
+(b) subprocess spawn overhead is ~1–2 % at this corpus size (note 1 satisfied);
+(c) the serdi-faster-than-rapper regime question from the first read reproduces
+canonically on both formats.
+
 ## Pending
 
-- Canonical EC2 run with riot installed: sq-hmd7l.26.
 - suite-id registration (`parse-competitors`): sq-hmd7l.1 (dep, not yet landed).
-- Regime investigation: serdi faster than rapper despite serialize step — profile
-  on canonical box.
+- Turtle single-thread BEHIND row → root-cause fix bead via `sq-hmd7l.27`.

--- a/research/gap-update-2026-07.md
+++ b/research/gap-update-2026-07.md
@@ -6,9 +6,11 @@ Part of the comparative-benchmarking-everything program
 
 ## Status
 
-**NON-canonical first read.** The harness (`scripts/bench/update-same-box.sh`) is the
-durable deliverable. Numbers from the shared work box are directional only — do not bake
-into docs or dashboards. Canonical numbers ride sq-hmd7l.26 (quiet EC2 run).
+**CANONICAL wave-1 rows recorded** (sq-hmd7l.26, quiet EC2 box — see the canonical
+section below). Headline: **sparq is BEHIND oxigraph** on the PSS interactive-CRUD
+update set (p99 ~6.6×, throughput ~8.2×); fuseki column absent (container readiness
+failure, harness bead filed). The harness (`scripts/bench/update-same-box.sh`)
+remains the durable deliverable.
 
 ## Harness
 
@@ -61,10 +63,47 @@ exercises only the sparq loopback path.
 
 ## First-read rows
 
-**NON-canonical — work box, not a quiet EC2 instance.** All numbers below are
-directional only.
+No first-read rows were recorded; the canonical wave-1 rows below are the first
+measured numbers in this record.
 
-No canonical rows yet. See sq-hmd7l.26 for the scheduled quiet-box harvest.
+## CANONICAL wave-1 rows (`sq-hmd7l.26`)
+
+Provenance: dedicated quiet box `i-01a735e27b1764317` (c6i.4xlarge, eu-west-2, tag
+`sparq-bench`, self-terminated, orphan-check clean), commit `cb1fc98c`
+(= `origin/main` `343aee547` + wave-1 runner-only fixes), envelope UTC
+`2026-07-10T00:47:07Z`, `CANONICAL=1`, 200 interactive PSS LDP-CRUD updates,
+loopback HTTP for every engine (symmetric surface). Count crosscheck: **green** —
+post-workload named-graph quad COUNT sparq 350 = oxigraph 350, `all_agree: True`.
+Rows transcribed from the harness `compare.py` table in
+`axis-results/update/run.log` (the envelope's row-ingest dropped them on the
+parity-gate failure exit — harness bug, bead filed below; the log rows carry the
+same provenance as the envelope in the same pulled directory).
+
+| engine | p50 (ms) | p99 (ms) | max (ms) | throughput (/s) | status |
+|---|---|---|---|---|---|
+| sparq | 3.50 | 4.01 | 24.91 | 275 | ok |
+| oxigraph | 0.45 | 0.61 | 0.84 | 2245 | ok |
+| fuseki | — | — | — | — | absent (container never became ready — bead filed below) |
+
+**Verdict: BEHIND.** sparq p99 4.01 ms vs oxigraph p99 0.61 ms (~6.6× behind); p50
+3.50 ms vs 0.45 ms (~7.8×); throughput 275/s vs 2245/s (~8.2×). The harness parity
+gate (`sparq p99 ≤ competitor p99 × 1.0`) FAILED. This is an honest engine-side gap:
+both engines were measured over the same loopback HTTP POST surface, so server
+framing does not explain it. Root-cause is unprofiled as of this record — plausible
+directions for the profiling-first fix bead (to be filed by `sq-hmd7l.27`): per-update
+parse/plan overhead, index maintenance on small interleaved DELETE/INSERT/DROP ops,
+or allocation churn in the update path; max 24.91 ms also shows a long-tail outlier
+absent in oxigraph (0.84 ms max). No spin: sparq loses this axis today.
+
+Harness follow-ups filed from wave-1:
+
+- **sq-do5fx** — `update-same-box.sh` envelope drops `latency_ms` /
+  `count_crosscheck` when `compare.py` exits non-zero on a parity-gate FAIL — a
+  measured FAIL is a valid result and must still be ingested into the envelope.
+- **sq-l7diu** — the `stain/jena-fuseki` container did not become ready within the
+  30 s window on a fresh box, leaving the fuseki column absent; switch the leg to
+  the direct `apache-jena-fuseki` 5.4.0 distribution already proven by
+  `fts-same-box.sh` on the same box (or extend readiness + surface the container log).
 
 ## BSBM Explore-and-Update
 

--- a/scripts/bench/hdt-same-box.sh
+++ b/scripts/bench/hdt-same-box.sh
@@ -117,6 +117,12 @@ if want hdt-cpp && [ "$HDT_CPP_AVAILABLE" -eq 1 ]; then
       rdfhdt/hdt-cpp:latest hdt2rdf "$HDT_ARCHIVE" \
       > "$SCALE_TMP/hdt-cpp.nt" 2> "$SCALE_TMP/hdt-cpp.err"; then
     log "hdt-cpp FAILED/timeout (see $SCALE_TMP/hdt-cpp.err)"; : > "$SCALE_TMP/hdt-cpp.nt"
+    # Surface the failure reason into the run log itself: $SCALE_TMP is /tmp
+    # scratch that between-axis cleanup prunes, so "see the err file" is a
+    # dead pointer on a self-terminating gather box (bit sq-hmd7l.26 wave-1).
+    head -5 "$SCALE_TMP/hdt-cpp.err" 2>/dev/null | while IFS= read -r ln; do
+      log "hdt-cpp.err: $ln"
+    done
   fi
 elif want hdt-cpp; then
   log "hdt-cpp: SKIPPED (Docker not available or image not found)"

--- a/scripts/bench/hdt-same-box.sh
+++ b/scripts/bench/hdt-same-box.sh
@@ -20,7 +20,7 @@
 #     328 triples, hdt-cpp/java-shaped FourSectionDictionary+BitmapTriples)
 #
 # METHODOLOGY:
-#   * ALL engines are timed in-process, decode-only (hdt2rdf <in.hdt> → N-Triples on stdout),
+#   * ALL engines are timed in-process, decode-only (hdt2rdf <in.hdt> <out.nt> → N-Triples file),
 #     best-of-N on the same archive: sparq-hdt via examples/bench_oracle, hdt-cpp via the
 #     registered Docker recipe (scripts/bench-adapters/report_cli_adapter.py +
 #     bench/competitors.json). Parse is OUTSIDE the timed section.
@@ -110,12 +110,19 @@ if want sparq; then
   fi
 fi
 
-# -- hdt-cpp: hdt2rdf <in.hdt> → N-Triples on stdout
+# -- hdt-cpp: hdt2rdf <in.hdt> <out.nt> — the tool REQUIRES an explicit output
+# operand ("ERROR: You must supply an input and output" observed verbatim on the
+# wave-1 canonical box when stdout-piping was attempted, sq-hmd7l.26); decode into
+# a rw-mounted scratch file instead. Wall-clock is recorded as ADVISORY only: it
+# includes docker container spawn overhead, which dominates on a tiny fixture.
+HDT_CPP_WALL_S="n/a"
 if want hdt-cpp && [ "$HDT_CPP_AVAILABLE" -eq 1 ]; then
   log "hdt-cpp: hdt2rdf decode"
+  T0="$(date +%s.%N)"
   if ! timeout "$TIMEOUT_S" docker run --rm -v "$HDT_ARCHIVE:$HDT_ARCHIVE:ro" \
-      rdfhdt/hdt-cpp:latest hdt2rdf "$HDT_ARCHIVE" \
-      > "$SCALE_TMP/hdt-cpp.nt" 2> "$SCALE_TMP/hdt-cpp.err"; then
+      -v "$SCALE_TMP:/hdt-out" \
+      rdfhdt/hdt-cpp:latest hdt2rdf "$HDT_ARCHIVE" /hdt-out/hdt-cpp.nt \
+      > "$SCALE_TMP/hdt-cpp.out" 2> "$SCALE_TMP/hdt-cpp.err"; then
     log "hdt-cpp FAILED/timeout (see $SCALE_TMP/hdt-cpp.err)"; : > "$SCALE_TMP/hdt-cpp.nt"
     # Surface the failure reason into the run log itself: $SCALE_TMP is /tmp
     # scratch that between-axis cleanup prunes, so "see the err file" is a
@@ -123,6 +130,9 @@ if want hdt-cpp && [ "$HDT_CPP_AVAILABLE" -eq 1 ]; then
     head -5 "$SCALE_TMP/hdt-cpp.err" 2>/dev/null | while IFS= read -r ln; do
       log "hdt-cpp.err: $ln"
     done
+  else
+    HDT_CPP_WALL_S="$(awk -v t0="$T0" -v t1="$(date +%s.%N)" 'BEGIN{printf "%.3f", t1-t0}')"
+    log "hdt-cpp decode ok: wall ${HDT_CPP_WALL_S}s ADVISORY (includes container spawn)"
   fi
 elif want hdt-cpp; then
   log "hdt-cpp: SKIPPED (Docker not available or image not found)"
@@ -135,7 +145,7 @@ OUT="$OUT_DIR/hdt-snikmeta-${TS}.json"
 CANONICAL="$CANONICAL" HDT_ARCHIVE="$HDT_ARCHIVE" NTRIPLES="328" \
 GIT_COMMIT="$GIT_COMMIT" SCALE_TMP="$SCALE_TMP" OUT="$OUT" ONLY="$ONLY" \
 TIMEOUT_S="$TIMEOUT_S" HDT_CPP_AVAILABLE="$HDT_CPP_AVAILABLE" \
-HDT_CPP_DIGEST="${HDT_CPP_DIGEST:-}" \
+HDT_CPP_DIGEST="${HDT_CPP_DIGEST:-}" HDT_CPP_WALL_S="$HDT_CPP_WALL_S" \
 python3 - <<'PYEOF'
 import json, os, platform
 
@@ -175,7 +185,7 @@ if "sparq" in only:
 if "hdt-cpp" in only:
     engines_meta["hdt-cpp"] = {
         "version": os.environ.get("HDT_CPP_DIGEST", "not-available"),
-        "mode": "Docker container (rdfhdt/hdt-cpp:latest, hdt2rdf <archive>: decode .hdt to N-Triples on stdout, wall-clock decode_s)" if hdt_cpp_available else "status:absent (Docker not available)",
+        "mode": "Docker container (rdfhdt/hdt-cpp:latest, hdt2rdf <archive> <out.nt>: decode .hdt to an N-Triples file in a rw scratch mount; wall-clock advisory)" if hdt_cpp_available else "status:absent (Docker not available)",
     }
 
 note_canonical = (
@@ -228,7 +238,7 @@ envelope = {
     "iters": 1,
     "mode": "decode-only (load+decode wall-clock); query-over-HDT is OUT OF SCOPE (not like-for-like)",
     "caveat": "HARD COMPARABILITY CAVEAT: load-and-decode-to-native is the ONLY like-for-like axis. sparq-hdt decodes HDT into sparq's own Dict/Graph (HDT as an ingest format) then queries its own permutation indexes. hdt-cpp/java query the compressed BitmapTriples IN PLACE (HDT as a queryable store). A query-over-HDT head-to-head (hdtSearch) is NOT like-for-like and is OUT OF SCOPE.",
-    "tsv_format": "sparq: <metric>\\t<value>\\t<unit> (from bench_oracle); hdt-cpp: N-Triples lines on stdout",
+    "tsv_format": "sparq: <metric>\\t<value>\\t<unit> (from bench_oracle); hdt-cpp: decoded N-Triples file line count",
     "engines": engines_meta,
     "decode_triple_count_crosscheck": count_check,
     "count_agreement": {
@@ -243,6 +253,15 @@ envelope = {
 # Add metric data from sparq
 if sparq_data:
     envelope["sparq_metrics"] = sparq_data
+
+# hdt-cpp decode wall-clock — ADVISORY ONLY (includes docker container spawn
+# overhead, which dominates on the tiny snikmeta fixture; never a headline).
+if os.environ.get("HDT_CPP_WALL_S", "n/a") != "n/a":
+    envelope["hdt_cpp_decode_wall_s_advisory"] = {
+        "value": os.environ["HDT_CPP_WALL_S"],
+        "unit": "s",
+        "note": "includes docker run container spawn; advisory only",
+    }
 
 # Add raw hdt-cpp output snippet (first 5 lines, last 5 lines for visibility)
 if os.path.exists(hdt_cpp_path) and os.path.getsize(hdt_cpp_path) > 0:

--- a/scripts/bench/multi-axis-box.sh
+++ b/scripts/bench/multi-axis-box.sh
@@ -88,7 +88,9 @@ CONSOLE_CAP_B="${CONSOLE_CAP_B:-6000}"
 PARSE_GEN_N="${PARSE_GEN_N:-320000}"         # registered bench/parse synthetic dataset size (~162MB NT)
 PREBUILD_ALLOW_S="${PREBUILD_ALLOW_S:-900}"  # budget line item for the one-off workspace release build
 EXTRA_INSTANCE_ENV="${EXTRA_INSTANCE_ENV:-}"
-RESULTS_LOCAL="${RESULTS_LOCAL:-$HOME/sparq-bench-results/multi-axis-$(date -u +%Y%m%dT%H%M%SZ)}"
+# ${HOME:-/root}: cloud-init user-data runs with HOME unset — a bare $HOME under
+# `set -u` killed --instance at this line on the first real launch (rc=1).
+RESULTS_LOCAL="${RESULTS_LOCAL:-${HOME:-/root}/sparq-bench-results/multi-axis-$(date -u +%Y%m%dT%H%M%SZ)}"
 
 # HARD never-touch instance ids (prod + dev) — same list as scripts/orphan-check-bench.sh.
 readonly PROD_INSTANCE="i-090531b4ede8f2d3f"
@@ -393,6 +395,9 @@ set -x
 exec > >(tee /var/log/gather.log) 2>&1
 
 step() { echo "[STEP \$(date -u +%Y-%m-%dT%H:%M:%SZ)] \$*" | tee -a /root/GATHER_STEP >&2; }
+# cloud-init runs user-data WITHOUT HOME: rustup/cargo/git and every \$HOME expansion
+# (e.g. .cargo/env's PATH prepend, which produced "/.cargo/bin") misroute without this.
+export HOME=/root
 export DEBIAN_FRONTEND=noninteractive
 step "apt update+install"
 apt-get update -qq

--- a/scripts/bench/multi-axis-box.sh
+++ b/scripts/bench/multi-axis-box.sh
@@ -149,7 +149,7 @@ print_plan() {
     if [ -e "$root/$harness" ]; then present="present"; else present="ABSENT on this checkout -> honest skip"; fi
     bead="$(axis_bead "$axis")"
     if [ "$axis" = parse ]; then
-      echo "    $n_axes. $axis    bench/parse harness (gen ${PARSE_GEN_N} synthetic triples -> bench-nt/-ttl/-zip)"
+      echo "    $n_axes. $axis    bench/parse harness (gen ${PARSE_GEN_N} synthetic triples -> bench-nt/-ttl/-zip/-ext)"
       echo "         [$present; envelope wrapper pending $bead — raw rows to console until then]"
     else
       echo "    $n_axes. $axis    $harness  (TIMEOUT_S=$TIMEOUT_S CANONICAL=1 OUT_DIR=/root/axis-results/$axis)"
@@ -298,6 +298,10 @@ run_instance() {
         ./target/release/parse-baseline bench-nt  data/synthetic.nt
         ./target/release/parse-baseline bench-ttl data/synthetic.ttl
         ./target/release/parse-baseline bench-zip data/synthetic.nt
+        # External competitor columns (sq-hmd7l.6): serdi / rapper / riot
+        # subprocess rows over the SAME corpus files; absent tool => absent column.
+        ./target/release/parse-baseline bench-ext data/synthetic.nt
+        ./target/release/parse-baseline bench-ext data/synthetic.ttl
       ' "$PARSE_GEN_N" > "$out_dir/parse-rows.txt" 2>&1 || rc=$?
       t1=$(date +%s); wall=$((t1 - t0))
       con "status: $([ "$rc" -eq 0 ] && echo ok || echo failed) rc=${rc} wall_s=${wall}"

--- a/scripts/bench/multi-axis-box.sh
+++ b/scripts/bench/multi-axis-box.sh
@@ -392,9 +392,15 @@ step() { echo "[STEP \$(date -u +%Y-%m-%dT%H:%M:%SZ)] \$*" | tee -a /root/GATHER
 export DEBIAN_FRONTEND=noninteractive
 step "apt update+install"
 apt-get update -qq
-# libboost-all-dev: corpus generators; jre: Fuseki-backed axes; raptor2-utils: the
-# parse axis rapper column (absent tool => absent column, never a fake number).
-apt-get install -y -qq build-essential g++ pkg-config git curl jq python3 python3-venv python3-pip unzip docker.io openjdk-21-jre-headless libboost-all-dev bc raptor2-utils || true
+# libboost-all-dev: corpus generators; jre: Fuseki-backed axes; raptor2-utils +
+# serdi: the parse axis rapper/serd columns (absent tool => absent column, never a
+# fake number — but the canonical box provisions all three registered columns).
+apt-get install -y -qq build-essential g++ pkg-config git curl jq python3 python3-venv python3-pip unzip docker.io openjdk-21-jre-headless libboost-all-dev bc raptor2-utils serdi || true
+# Jena riot: the parse axis third competitor column (gap-parse-2026-07 requires it
+# on the canonical box; apt has no package — pinned apache-jena dist, best-effort).
+step "jena riot install"
+curl -fsSL "https://archive.apache.org/dist/jena/binaries/apache-jena-${JENA_VERSION:-5.4.0}.tar.gz" | tar -xz -C /opt \
+  && ln -sf "/opt/apache-jena-${JENA_VERSION:-5.4.0}/bin/riot" /usr/local/bin/riot || step "WARN: riot install failed — parse riot column will be honestly absent"
 step "start docker"
 systemctl enable --now docker || systemctl start docker || true
 for _ in \$(seq 1 60); do docker info >/dev/null 2>&1 && { step "docker up"; break; }; sleep 2; done


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous bead execution (sq-hmd7l.26), Claude Fable 5.

Executes the **canonical wave-1 comparative-benchmark run**: the five tier-1 same-box competitor gathers (fts / geo / hdt / update / parse) bin-packed onto dedicated QUIET EC2 boxes via `scripts/bench/multi-axis-box.sh`, `CANONICAL=1`, min-of-N, one engine at a time, and appends the canonical rows to each per-axis gap record with full provenance.

## Run provenance

| box | axes | instance (c6i.4xlarge, eu-west-2, tag `sparq-bench`) | commit | outcome |
|---|---|---|---|---|
| 1 | fts geo hdt update parse | `i-01a735e27b1764317` | `cb1fc98c` | fts/geo/update canonical rows; parse rows minus riot (comma bug); hdt-cpp failed (invocation bug) |
| 2 | hdt parse | `i-06efda08048633f55` | `a1bf9b48` | parse rows COMPLETE incl. riot; hdt-cpp err root-caused |
| 3 | hdt | `i-0d42a7d98f84e0a0d` | `4324828b` | hdt count crosscheck GREEN both engines |

Every box self-terminated (shutdown-behavior=terminate + user-data watchdog); **`scripts/orphan-check-bench.sh` clean after the run** (no orphans, ephemeral keypairs/SGs deleted). Engine code on the branch is identical to `origin/main` `343aee547` — all commits here are bench-script/record-only.

## Honest results (no spin)

- **fts** — CLEARLY-AHEAD on all 4 translated workloads (~75× to ~1954×), count crosscheck green on every row; `near_slop2` NOT-COMPARABLE by design; **BEIR quality axis still NOT-RUN** (separate gather recipe; bead `sq-tvzyi`).
- **geo** — `nearest_k10/k100` CLEARLY-AHEAD (counts green, mode-asymmetry + scan-vs-index caveats recorded); **`within10km/50km` crosscheck RED** (jena-geosparql returned 0 hits — timings withheld per invariant, root-cause bead `sq-a8anf`); **`geof_within` AHEAD-BUT-NOT-OOM (~1.5×)** — dominance-gap row for `sq-hmd7l.27`.
- **hdt** — the hard gate is GREEN: both engines decode snikmeta to exactly 328 triples; timings advisory-only (container-spawn measurement boundary dominates the tiny fixture; larger-archive gather noted for `sq-hmd7l.27`).
- **update** — **BEHIND: sparq p99 4.01 ms vs oxigraph 0.61 ms (~6.6×), throughput 275/s vs 2245/s (~8.2×)**, counts green (350 = 350), symmetric loopback-HTTP surface — a real engine-side gap row for `sq-hmd7l.27`. Fuseki column absent (container readiness, bead `sq-l7diu`); envelope row-drop-on-parity-fail harness bug (bead `sq-do5fx`, rows transcribed from `run.log`).
- **parse** — NT 16T CLEARLY-AHEAD (~9.3× vs serd); NT 1T AHEAD-BUT-NOT-OOM (~1.2×); **Turtle 1T BEHIND serd (~2×)** — dominance-gap row for `sq-hmd7l.27`; Turtle 16T ~3.2×. All competitor counts green (rapper/serdi/riot, both formats, 2.56 M triples / 170 MB NT).

## Runner/harness fixes required to get the data (same PR, minimal)

1. `multi-axis-box.sh`: survive cloud-init's **unset `HOME`** (first real launch died at line 91 under `set -u`); provision `serdi` + Jena riot; parse axis actually runs `bench-ext` (the competitor columns were never invoked).
2. `hdt-same-box.sh`: `hdt2rdf` **requires an explicit output operand** (verbatim: `ERROR: You must supply an input and output`) — decode into a rw scratch mount; surface `hdt-cpp.err` into the run log (the /tmp pointer is pruned on a self-terminating box); advisory wall-clock.
3. `bench/parse`: riot 5.4.0 prints `Triples = 2,560,000` with grouping separators — count parse fixed + regression test (verbatim observed output).

## Follow-up beads filed

`sq-do5fx` (update envelope row-drop), `sq-l7diu` (fuseki readiness), `sq-a8anf` (geo within* zero-hit root cause), `sq-tvzyi` (BEIR canonical gather). BEHIND / not-OOM rows are recorded in the gap records for the consolidation bead **`sq-hmd7l.27`** (which files the P1 profiling-first fix beads).

**Do NOT arm** — verdict-pipeline review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)