### PR TITLE
fix(site): Cmd-K palette 'App' must HARD-navigate — the last live /app txt-redirect path (sq-vw3ax.11.1) [FABLE-5]

### DIFF
--- a/site/e2e/command-palette.spec.ts
+++ b/site/e2e/command-palette.spec.ts
@@ -101,3 +101,98 @@ test("clicking a result row navigates to its surface", async ({ page }) => {
   await page.waitForURL("**/showcase/zk-car-hire/**", { timeout: 15_000 });
   expect(new URL(page.url()).pathname).toContain("/showcase/zk-car-hire");
 });
+
+// ── palette → /app hard-navigation guard (regression) ──────────────────────────────────────────
+//
+// [FABLE-5] sq-vw3ax.11.1 — /app is served in production by a SEPARATE Next.js build (gui/app)
+// overlaid at /app/ (sq-vnd0i), so EVERY user-reachable navigation to /app from the site UI must
+// be a HARD full-page navigation. The Cmd-K palette's "App" row was the last live instance of the
+// txt-redirect bug class: its go() handler did a next/router soft push, which across the two
+// distinct Next builds fetches the foreign RSC Flight payload /app/index.txt and lands on a raw
+// .txt instead of the GUI. This guard mirrors the hard-nav assertion in e2e/download-app.spec.ts
+// §6: mark the document, select the row, then assert the sentinel is GONE (the document was
+// replaced by a full page load), and contrast it with a same-build page (Benchmarks) whose soft
+// push KEEPS the same document + client-side router. In `next dev` the overlay is absent, so /app
+// resolves to the site's own /app fallback page — a real HTML document — which is fine: the guard
+// asserts NAVIGATION SEMANTICS (hard vs soft), not GUI content.
+//
+// The test MUST fail if go()'s external branch is reverted to a plain router.push (verified
+// non-vacuous by that mutation).
+
+/** Open the palette (keyboard), filter to a single row by its title, return the visible option. */
+async function openAndFilter(page: Page, query: string, name: RegExp) {
+  await page.keyboard.press(`${MOD}+KeyK`);
+  const dialog = palette(page);
+  await expect(dialog).toBeVisible();
+  await dialog.getByPlaceholder("Search surfaces, pages, actions…").fill(query);
+  const option = dialog.getByRole("option", { name });
+  await expect(option).toBeVisible();
+  return option;
+}
+
+/** Stamp a sentinel on the live document; it survives a soft SPA nav but not a hard page load. */
+async function markDocument(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as unknown as Record<string, unknown>).__sparq_e2e_doc_mark = "palette-hard-nav-guard";
+  });
+}
+
+/** Whether the sentinel stamped by {@link markDocument} is still on the current document. */
+function sentinelPresent(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () =>
+      (window as unknown as Record<string, unknown>).__sparq_e2e_doc_mark ===
+      "palette-hard-nav-guard",
+  );
+}
+
+test("selecting App HARD-navigates (document replaced) — the /app txt-redirect guard", async ({
+  page,
+}) => {
+  // The "App" row is the only external TOP_PAGES entry; match it by its unique blurb (the option's
+  // accessible name is the title + blurb, so an anchored /^App$/ would not match).
+  const appRow = await openAndFilter(page, "App", /live operational GUI/i);
+
+  await markDocument(page);
+
+  // Set the navigation waiter BEFORE the click so we never miss the event.
+  const navPromise = page.waitForURL("**/app/**", { waitUntil: "domcontentloaded" });
+  await appRow.click();
+  await navPromise;
+
+  // A hard navigation replaces the document, so the sentinel is GONE. If go() had done a soft
+  // router.push (the bug), the same document would survive and the sentinel would persist.
+  expect(
+    await sentinelPresent(page),
+    "Expected a HARD full-page navigation to /app (document replaced) but the sentinel survived: " +
+      "the palette soft-navigated. go() must window.location.assign for the external /app entry, " +
+      "else a next/router push fetches the foreign RSC payload /app/index.txt instead of the GUI.",
+  ).toBe(false);
+
+  // Landed under /app (the separate build's overlay in prod; the site's /app fallback in dev).
+  expect(new URL(page.url()).pathname).toContain("/app");
+});
+
+test("selecting a same-build page (Benchmarks) SOFT-navigates (document survives)", async ({
+  page,
+}) => {
+  // Benchmarks is a same-build TOP_PAGES entry with no `external` flag, so go() keeps the soft
+  // router.push — the contrast that proves the hard-nav is scoped to the external /app entry, not
+  // a blanket change to every palette row.
+  const benchRow = await openAndFilter(page, "Benchmarks", /Per-commit, same-box benchmark/i);
+
+  await markDocument(page);
+
+  const navPromise = page.waitForURL("**/benchmarks/**", { waitUntil: "domcontentloaded" });
+  await benchRow.click();
+  await navPromise;
+
+  // A soft SPA transition keeps the SAME document, so the sentinel SURVIVES.
+  expect(
+    await sentinelPresent(page),
+    "Expected a SOFT client-side navigation to /benchmarks (same document) but the sentinel was " +
+      "lost: a same-build page must keep the router.push soft nav, not hard-reload the document.",
+  ).toBe(true);
+
+  expect(new URL(page.url()).pathname).toContain("/benchmarks");
+});

--- a/site/src/components/command-palette.tsx
+++ b/site/src/components/command-palette.tsx
@@ -35,6 +35,7 @@ import {
 import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
+import { withBasePath } from "@/lib/base-path";
 import { Badge } from "@/components/ui/badge";
 import {
   FLAGSHIPS,
@@ -62,11 +63,14 @@ const REPO_URL = "https://github.com/jeswr/sparq";
 
 // [OPUS-4.8] sq-vw3ax.3 — the palette is the 0-click fast path now the sidebar is gone, so it
 // must jump to each surface's NEW home, not a removed /surface/* route that only redirects.
-// The 5 retained deep pages + /try keep their own route; every other surface lives as a row
-// under /capabilities#<theme>. Resolving here (not at the data source) keeps surfaces.ts a pure
-// structural source while the palette routes to the post-redesign IA.
+// The 5 retained deep pages keep their own /surface/<slug> route; every other surface lives as a
+// row under /capabilities#<theme>. Resolving here (not at the data source) keeps surfaces.ts a
+// pure structural source while the palette routes to the post-redesign IA.
+// [FABLE-5] sq-vw3ax.11.1 — the dead `slug === "try"` special case was removed: the /try surface
+// no longer exists in data/surfaces.ts (sq-4hiqe removed /try; it is now a hard-redirect stub to
+// /app), so the branch could never fire. Every remaining surface is a same-build /surface or
+// /capabilities route reachable by a soft push — none is the separate-build /app workbench.
 function surfaceHref(surface: Surface, groupId: string): string {
-  if (surface.slug === "try") return surface.href; // the live REPL keeps its own /try route
   if (DEEP_PAGE_SLUGS.has(surface.slug)) return surface.href; // retained deep page
   return capabilityAnchor(groupId); // a demo/soon row lives in the gallery
 }
@@ -90,17 +94,26 @@ export function useCommandPalette() {
 // The fixed top-level destinations of the slim top bar that are NOT capability surfaces (so
 // they are not in GROUPS). Option-B (sq-rclb8): "Try" (the live REPL) lives in the surface data
 // (the first Query & data surface), so it is not repeated here; "App" is the SEPARATE live
-// operational GUI destination (a placeholder today; the GUI track fills it) — it replaces the old
-// "/gui · Try the GUI" entry, which now client-redirects to /app. /about is folded into Home
-// #how-it-runs (it redirects), so the palette points there. /capabilities is the new gallery;
-// /download + /app are the discovery gaps the maintainer flagged.
-const TOP_PAGES: { href: string; title: string; blurb: string }[] = [
+// operational GUI destination — it replaces the old "/gui · Try the GUI" entry, which now
+// client-redirects to /app. /about is folded into Home #how-it-runs (it redirects), so the
+// palette points there. /capabilities is the new gallery; /download + /app are the discovery
+// gaps the maintainer flagged.
+//
+// [FABLE-5] sq-vw3ax.11.1 — `external: true` marks a destination served in production by a
+// SEPARATE deployed Next.js app at the same origin (here: /app = the gui/app workbench overlaid
+// at /app/ by pages.yml, sq-vnd0i). Such a slot MUST be a hard, full-page navigation (see `go`),
+// mirroring app-shell.tsx's NavLink — a next/router soft push across the two distinct Next builds
+// would fetch the foreign RSC Flight payload (/app/index.txt) and land on a raw .txt instead of
+// the GUI. Selecting "App" via Cmd-K was the last live instance of that /app txt-redirect bug.
+const TOP_PAGES: { href: string; title: string; blurb: string; external?: boolean }[] = [
   { href: "/", title: "Home", blurb: "Overview — what sparq is, the live REPL, the flagships." },
   // [OPUS-4.8] sq-vw3ax.6 — the curated "show me it working" gallery (3 flagships + Live REPL).
   // Discoverable here in Cmd-K (0 clicks) without bloating the slim top bar — the bar stays at 6.
   { href: "/examples", title: "Examples", blurb: "The curated 'show me it working' demo gallery." },
   { href: "/capabilities", title: "Capabilities", blurb: "Every surface in one gallery, by theme." },
-  { href: "/app", title: "App", blurb: "The live operational GUI (hosted web app coming soon)." },
+  // [FABLE-5] sq-vw3ax.11.1 — the hosted GUI is LIVE at /app now (not "coming soon"); marked
+  // external so `go` hard-navigates across the two Next builds (see TOP_PAGES comment above).
+  { href: "/app", title: "App", blurb: "The live operational GUI — the in-browser workbench.", external: true },
   { href: "/benchmarks", title: "Benchmarks", blurb: "Per-commit, same-box benchmark dashboard." },
   // [OPUS-4.8] sq-1scgk — /papers is now a top-bar destination (maintainer 2026-07-04 item
   // 9b); it stays indexed here too, exactly like the other bar pages above.
@@ -270,12 +283,28 @@ export function CommandPalette({ children }: { children: React.ReactNode }) {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [setOpen]);
 
-  // Navigate (or run an action), then close. next/navigation's router.push respects the
-  // configured basePath, so "/surface/zk" resolves under /sparq on Pages and at root under
-  // Tauri — no manual basePath juggling here.
+  // Navigate (or run an action), then close.
+  //
+  // A same-build route is a SOFT next/navigation push: router.push respects the configured
+  // basePath, so "/surface/zk" resolves under /sparq on Pages and at root under Tauri — no manual
+  // basePath juggling, and the SPA transition keeps the site's own client alive.
+  //
+  // [FABLE-5] sq-vw3ax.11.1 — an `external` destination (only /app today) is served by a SEPARATE
+  // Next.js build overlaid at /app/, so it MUST be a HARD full-page navigation: window.location
+  // .assign to the base-path-prefixed, trailing-slashed URL, mirroring app-shell.tsx's NavLink
+  // <a href={withBasePath(...)}>. A soft router.push across the two distinct Next builds would
+  // fetch the foreign RSC Flight payload /app/index.txt and land on a raw .txt — the exact
+  // txt-redirect bug. INVARIANT: every user-reachable navigation to /app from the site UI is a
+  // hard navigation. Next does NOT auto-prefix a hand-written location.assign, hence withBasePath;
+  // the trailing slash matches `trailingSlash: true` so the static export's directory index
+  // resolves (identical to the NavLink's `href.endsWith("/") ? href : ${href}/`).
   const go = React.useCallback(
-    (href: string) => {
+    (href: string, external?: boolean) => {
       setOpen(false);
+      if (external) {
+        window.location.assign(withBasePath(href.endsWith("/") ? href : `${href}/`));
+        return;
+      }
       router.push(href);
     },
     [router, setOpen],
@@ -429,7 +458,9 @@ export function CommandPalette({ children }: { children: React.ReactNode }) {
                     title={p.title}
                     blurb={p.blurb}
                     keywords={["page", p.blurb]}
-                    onSelect={() => go(p.href)}
+                    // [FABLE-5] sq-vw3ax.11.1 — an external page (/app) hard-navigates; every
+                    // other same-build page keeps the soft router.push.
+                    onSelect={() => go(p.href, p.external)}
                   />
                 ))}
               </Command.Group>


### PR DESCRIPTION
> 🤖 **SPARQ agent** — site lane, `[FABLE-5]`. Autonomous fix; not armed for merge.

## What & why

`sq-vw3ax.11.1` (child of the `sq-vw3ax.11` Home//app//download UX epic; design record `research/site-home-app-download-residuals.md` §2c / §4 R1 on PR #1816's branch).

The Cmd-K command palette's `go()` handler did a next/router **soft** `router.push(href)` for **every** entry, including `/app`. `/app` is served in production by a **separate Next.js build** (`gui/app`) overlaid at `/app/` (`pages.yml`, sq-vnd0i), so a soft push across the two distinct Next builds fetches the foreign RSC Flight payload `/app/index.txt` and lands on a **raw `.txt`** instead of the GUI. Selecting "App" via Cmd-K was the **last live instance** of the `/app` txt-redirect bug class — every other `/app` entry point (nav bar, hero, capability CTAs, download, stubs) is already a hard anchor.

## Fix (`site/src/components/command-palette.tsx` — exclusive file)

- Mark the `/app` `TOP_PAGES` entry `external: true`, and branch `go()` to a **HARD** `window.location.assign(withBasePath(href + "/"))` for external entries — mirroring `app-shell.tsx`'s `NavLink` `<a href={withBasePath(...)}>` (base-path-prefixed + trailing slash for `trailingSlash: true`). Every same-build route keeps the **soft** `router.push`.
- Fix the stale `"hosted web app coming soon"` blurb — the hosted GUI is **live** at `/app` now.
- Delete the dead `slug === "try"` special case in `surfaceHref` (no `/try` surface exists in `data/surfaces.ts` since sq-4hiqe removed `/try`).

**INVARIANT:** every user-reachable navigation to `/app` from the site UI is a hard, full-page navigation. No capability claims added.

## Test (`site/e2e/command-palette.spec.ts` — exclusive file)

New regression guard mirroring the hard-nav assertions in `e2e/download-app.spec.ts` §6:
- **`selecting App HARD-navigates`** — marks the document, selects the "App" row, asserts the sentinel is **gone** (a full page load replaced the document). In `next dev` the overlay is absent, so `/app` resolves to the site's own `/app` fallback page — a real HTML document — so the guard asserts **navigation semantics** (hard vs soft), not GUI content.
- **`selecting a same-build page (Benchmarks) SOFT-navigates`** — the contrast: a same-build page keeps the soft `router.push`, so the sentinel **survives**. This proves the hard-nav is scoped to the external `/app` entry, not a blanket change.

**Non-vacuity verified empirically:** reverting `go()`'s external branch to a plain `router.push` turned the App hard-nav test **RED** (`Expected: false, Received: true` — the sentinel survived), while the same-build soft-nav test stayed green; then restored → all green.

## Gates (all green)

- `cd site && npm run lint` — clean (no ESLint warnings or errors)
- `npx tsc --noEmit` — clean
- `npm run build` — static export succeeded end-to-end (`out/app/index.html` emitted; `postbuild` wasm-free bundle-guard **PASS**; basePath `/sparq` preserved)
- `npx playwright test e2e/command-palette.spec.ts --project=chromium` — **5 passed** (3 existing + 2 new)
- **WASM prereq:** built the lean bundle first (`cd js && npm run build:wasm:lean` — a build artifact only, no `crates/` changes) so the site build's `sync-wasm` prebuild gate passes.

## Scope

Exclusive files only: `site/src/components/command-palette.tsx`, `site/e2e/command-palette.spec.ts`. No `crates/` source; build-regenerated `*.generated.json` reverted to `origin/main` (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)