### PR TITLE
feat(reason/conformance): D-entailment — substrate value-space comparator + crate-local value-space matrix arm (sq-pbz04.6.3, sq-pbz04.6.4)

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -616,6 +616,41 @@ pub const SUITES: &[Suite] = &[
                through sparq-reason's opt-in Profile::D (rdfD1 typing + typed \
                value-space equality)",
     },
+    // [FABLE-5] sq-pbz04.6.4 (epic sq-pbz04.6) — the sparq D VALUE-SPACE MATRIX arm, a
+    // sparq EXTENSION ratchet tallied SEPARATELY from the W3C D-entailment row above
+    // (the W3C `sparql11/entailment` corpus is a SINGLE D-only test; the real value-space
+    // coverage is sparq's own hand-authored matrix). Mirrors the OWL 2 QL / EL / RIF-Core
+    // extension precedent — program honesty rule 4: the standards-conformance count is NOT
+    // padded with sparq's own cases. The floor const (`pub const D_VALUE_MATRIX_FLOOR`)
+    // lives in `tests/d_entail_suite.rs` (behind the opt-in `d-entail` feature, inside the
+    // `gated` module — the guard reads it TEXTUALLY, so the `#[cfg]`/module nesting do not
+    // affect the match); `tests/scoreboard_floors.rs` pins this mirror to it so the two can
+    // never drift. The runner drives value-equal-distinct-lexical pairs (integer⊂decimal
+    // incl. the 2^53+1 non-aliasing guard, boolean true/1, the hex/base64 octet pair),
+    // facet-ill-formed negatives (rdfD1 must NOT type 200^^byte / a leading-space token),
+    // and disjoint-space negatives (decimal vs double, date vs dateTime) through the REAL
+    // `Profile::D` value-space comparator (now on the shared sparq-substrate seam,
+    // sq-pbz04.6.3) — plus broadened-map end-to-end cases through the same
+    // materialize→answer-restriction→engine-query path as the W3C lane.
+    Suite {
+        label: "D value-space matrix (integer/decimal/boolean/binary/temporal)",
+        family: "sparq extension",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "d_entail_suite",
+            feature: "d-entail",
+        },
+        ci_job: "inference-conformance",
+        ratchet_floor: 24,
+        floor_basis: "value-space assertions (sparq EXTENSION over the D datatype map, \
+                      NOT the W3C sparql11/entailment conformance count)",
+        note: "EXTENSION ratchet — sparq's own hand-authored D value-space matrix over the \
+               recognized datatype map (integer⊂decimal incl. 2^53+1 non-aliasing, boolean \
+               true/1, hex/base64 octet identity, facet-ill-formed negatives, decimal-vs-\
+               double + date-vs-dateTime disjoint-space negatives), driven through the REAL \
+               Profile::D value-space comparator + the materialize→answer-restriction→engine \
+               end-to-end path; tallied SEPARATELY, never faked as W3C conformance passes",
+    },
     // [OPUS-4.8] sq-ddpgx (epic sq-my8wd) — the W3C SPARQL 1.1 `sparql11/service`
     // EVALUATION ratchet. The runner is crate-local here
     // (`tests/service_eval_suite.rs`) but behind the OPT-IN `service` feature

--- a/crates/sparq-conformance/tests/d_entail_suite.rs
+++ b/crates/sparq-conformance/tests/d_entail_suite.rs
@@ -133,4 +133,255 @@ mod gated {
             D_ENTAIL_FLOOR
         );
     }
+
+    // ── [FABLE-5] sq-pbz04.6.4 — the crate-local D VALUE-SPACE MATRIX arm ────────────
+    //
+    // A sparq-EXTENSION ratchet, tallied SEPARATELY from the W3C `D_ENTAIL_FLOOR` above
+    // (mirroring the OWL 2 QL certain-answer-oracle precedent, program honesty rule 4:
+    // the standards-conformance count is NOT padded with sparq's own extension cases).
+    // The W3C `sparql11/entailment` corpus is a SINGLE D-only test; the real
+    // value-space coverage lives here, driven through the REAL `Profile::D` materializer
+    // + the same value-space comparator (`d_value_eq`/`d_value_key`, now on the shared
+    // `sparq-substrate` seam — sq-pbz04.6.3) + the same end-to-end
+    // materialize→answer-restriction→engine-query path as the W3C lane.
+    //
+    // FLOOR = the MEASURED assertion count (a sparq EXTENSION unit, never aspirational),
+    // may only RISE. Mirrored in the central scoreboard (`scoreboard::SUITES`) and pinned
+    // by `tests/scoreboard_floors.rs` (read textually).
+    pub const D_VALUE_MATRIX_FLOOR: usize = 24;
+
+    use sparq_core::dict::{Dict, Id};
+    use sparq_reason::{d_value_eq, d_value_key, materialize_d, Profile, Recognized};
+
+    const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+    /// A value-space matrix case: two typed literals + whether they denote the SAME
+    /// D-value. Drives the REAL `d_value_eq` (the substrate-delegated value-space key).
+    struct EqCase {
+        a_lex: &'static str,
+        a_dt: &'static str,
+        b_lex: &'static str,
+        b_dt: &'static str,
+        equal: bool,
+        why: &'static str,
+    }
+
+    /// A well-formedness (rdfD1-typability) matrix case: a single typed literal + whether
+    /// it has a D-VALUE (is well-formed for its recognized datatype). An ill-formed literal
+    /// has NO value and rdfD1 must NOT type it.
+    struct WellFormedCase {
+        lex: &'static str,
+        dt: &'static str,
+        well_formed: bool,
+        why: &'static str,
+    }
+
+    fn dt(local: &str) -> String {
+        format!("{}{}", XSD, local)
+    }
+
+    /// The value-EQUALITY matrix: value-equal-distinct-lexical pairs (integer/decimal incl.
+    /// the 2^53+1 guard, boolean true/1, the hex/base64 octet pair) + disjoint-space
+    /// negatives (decimal vs double, date vs dateTime at a shared instant).
+    fn eq_cases() -> Vec<EqCase> {
+        vec![
+            // ── value-equal-distinct-lexical POSITIVES ──
+            EqCase { a_lex: "1", a_dt: "integer", b_lex: "1.0", b_dt: "decimal", equal: true,
+                     why: "integer ⊂ decimal: 1 == 1.0" },
+            EqCase { a_lex: "01", a_dt: "integer", b_lex: "+1", b_dt: "integer", equal: true,
+                     why: "leading zero / sign are the same value" },
+            EqCase { a_lex: "-0", a_dt: "integer", b_lex: "0", b_dt: "decimal", equal: true,
+                     why: "signed zero == zero" },
+            EqCase { a_lex: "1.50", a_dt: "decimal", b_lex: "1.5", b_dt: "decimal", equal: true,
+                     why: "trailing fraction zeros are insignificant" },
+            EqCase { a_lex: "true", a_dt: "boolean", b_lex: "1", b_dt: "boolean", equal: true,
+                     why: "boolean true == 1" },
+            EqCase { a_lex: "false", a_dt: "boolean", b_lex: "0", b_dt: "boolean", equal: true,
+                     why: "boolean false == 0" },
+            EqCase { a_lex: "61", a_dt: "hexBinary", b_lex: "YQ==", b_dt: "base64Binary", equal: true,
+                     why: "octet [0x61] is one value across hex/base64 (D2)" },
+            // ── DISJOINT-space + distinct-value NEGATIVES ──
+            EqCase { a_lex: "1.0", a_dt: "decimal", b_lex: "1.0", b_dt: "double", equal: false,
+                     why: "decimal and double are DISJOINT primitive value spaces" },
+            EqCase { a_lex: "1", a_dt: "integer", b_lex: "1.0", b_dt: "double", equal: false,
+                     why: "integer/decimal space is disjoint from IEEE double" },
+            EqCase { a_lex: "1.0", a_dt: "decimal", b_lex: "1.0", b_dt: "float", equal: false,
+                     why: "decimal and float are DISJOINT value spaces" },
+            EqCase { a_lex: "2004-04-12T13:20:00Z", a_dt: "dateTime",
+                     b_lex: "2004-04-12", b_dt: "date", equal: false,
+                     why: "date and dateTime are DISJOINT value spaces even at a shared instant" },
+            EqCase { a_lex: "1", a_dt: "integer", b_lex: "2", b_dt: "decimal", equal: false,
+                     why: "distinct numeric values" },
+            // ── the 2^53+1 NON-ALIASING guard (an f64 would wrongly equate these) ──
+            EqCase { a_lex: "9007199254740993", a_dt: "integer",
+                     b_lex: "9007199254740992", b_dt: "integer", equal: false,
+                     why: "2^53+1 must NOT alias 2^53 (unsound-f64 guard)" },
+            EqCase { a_lex: "9007199254740993", a_dt: "integer",
+                     b_lex: "9007199254740993.0", b_dt: "decimal", equal: true,
+                     why: "2^53+1 exactly equals its own decimal spelling" },
+        ]
+    }
+
+    /// The WELL-FORMEDNESS (facet) matrix: facet-ill-formed negatives (rdfD1 must NOT type
+    /// `200^^xsd:byte`, a leading-space `xsd:token`) + well-formed positives.
+    fn well_formed_cases() -> Vec<WellFormedCase> {
+        vec![
+            // ── facet-ill-formed NEGATIVES (rdfD1 must NOT type) ──
+            WellFormedCase { lex: "200", dt: "byte", well_formed: false,
+                             why: "200 is outside xsd:byte [-128,127] — no D-value" },
+            WellFormedCase { lex: " a", dt: "token", well_formed: false,
+                             why: "leading space is illegal for xsd:token" },
+            WellFormedCase { lex: "4294967296", dt: "unsignedInt", well_formed: false,
+                             why: "exceeds xsd:unsignedInt max" },
+            WellFormedCase { lex: "abc", dt: "integer", well_formed: false,
+                             why: "non-numeric lexical is ill-formed for xsd:integer" },
+            // ── well-formed POSITIVES ──
+            WellFormedCase { lex: "127", dt: "byte", well_formed: true, why: "xsd:byte max" },
+            WellFormedCase { lex: "a b", dt: "token", well_formed: true,
+                             why: "single internal space is a valid xsd:token" },
+            WellFormedCase { lex: "1", dt: "integer", well_formed: true, why: "valid integer" },
+            WellFormedCase { lex: "2004-04-12T13:20:00Z", dt: "dateTime", well_formed: true,
+                             why: "valid dateTime with tz" },
+            WellFormedCase { lex: "en-US", dt: "language", well_formed: true,
+                             why: "valid xsd:language" },
+            WellFormedCase { lex: "YQ==", dt: "base64Binary", well_formed: true,
+                             why: "valid base64 octet" },
+        ]
+    }
+
+    /// The crate-local D value-space matrix arm: every case classifies through the REAL
+    /// value-space comparator; the floor is the MEASURED assertion count. Feature-ON.
+    ///
+    /// MUTATION WITNESS: flip any `equal:`/`well_formed:` expectation (e.g. set the
+    /// `2^53+1 must NOT alias` case to `equal: true`) and this test goes RED — the arm is
+    /// non-vacuous over the value-space semantics, not a tautology.
+    #[test]
+    fn d_value_space_matrix() {
+        let eqs = eq_cases();
+        let wfs = well_formed_cases();
+        let mut asserted = 0usize;
+
+        for c in &eqs {
+            let got = d_value_eq(c.a_lex, &dt(c.a_dt), c.b_lex, &dt(c.b_dt));
+            assert_eq!(
+                got, c.equal,
+                "value-equality matrix: ({:?}^^{}, {:?}^^{}) expected equal={} ({}), got {}",
+                c.a_lex, c.a_dt, c.b_lex, c.b_dt, c.equal, c.why, got
+            );
+            asserted += 1;
+        }
+        for c in &wfs {
+            let got = d_value_key(c.lex, &dt(c.dt)).is_some();
+            assert_eq!(
+                got, c.well_formed,
+                "well-formedness (rdfD1-typability) matrix: {:?}^^{} expected well_formed={} \
+                 ({}), got {}",
+                c.lex, c.dt, c.well_formed, c.why, got
+            );
+            asserted += 1;
+        }
+
+        // The floor is the MEASURED count and may only RISE.
+        assert_eq!(
+            asserted,
+            D_VALUE_MATRIX_FLOOR,
+            "D value-space matrix asserted {} cases but the pinned floor is {} — raise the \
+             floor (and the scoreboard mirror) in the same commit when you add cases; a floor \
+             may only RISE",
+            asserted,
+            D_VALUE_MATRIX_FLOOR
+        );
+        println!("\nsparq D value-space matrix (EXTENSION, NOT W3C conformance)");
+        // Positional args per the CodeQL `rust/unused-variable` false-positive guard.
+        println!("TOTAL d-value-matrix {} (floor {})", asserted, D_VALUE_MATRIX_FLOOR);
+    }
+
+    /// Broadened-map END-TO-END case: a recognized well-formed literal is driven through
+    /// the REAL `Profile::D` materializer, then the closure is serialized DROPPING
+    /// literal-subject rows (the SPARQL Entailment-Regimes answer restriction — the same
+    /// path as the W3C lane) and queried through the REAL engine. rdfD1's typing triple
+    /// `"l"^^d rdf:type d` is GENERALIZED (literal subject), so it can NEVER be a SPARQL
+    /// answer — the query over the typed subject correctly returns NO rows, exactly why
+    /// `d-ent-01` returns no rows. This proves the closure + restriction end-to-end.
+    #[test]
+    fn d_materialize_answer_restriction_end_to_end() {
+        let mut dict = Dict::new();
+        // Data: <s> <p> "1"^^xsd:integer .   (a recognized, well-formed literal object)
+        let s = dict.intern(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://e/s")));
+        let p = dict.intern(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://e/p")));
+        let one = dict.intern(&oxrdf::Term::Literal(oxrdf::Literal::new_typed_literal(
+            "1",
+            oxrdf::NamedNode::new_unchecked(dt("integer")),
+        )));
+        let mut ids: Vec<[Id; 3]> = vec![[s, p, one]];
+
+        // Materialize the D closure through the REAL Profile::D (STANDARD recognized map).
+        let added = sparq_reason::materialize(Profile::D, &mut dict, &mut ids);
+        assert_eq!(added, 1, "rdfD1 types the recognized integer literal (generalized triple)");
+
+        // Serialize the closure DROPPING literal-subject rows — the answer restriction.
+        let mut nt = String::new();
+        for t in &ids {
+            let (so, po, oo) = (dict.term(t[0]), dict.term(t[1]), dict.term(t[2]));
+            if matches!(so, oxrdf::Term::Literal(_)) {
+                continue; // generalized triple: literal subject can never be an answer
+            }
+            nt.push_str(&format!("{} {} {} .\n", so, po, oo));
+        }
+
+        let graph = sparq_core::Graph::load_dataset(&nt, "nquads")
+            .unwrap_or_else(|e| panic!("load closure: {e}"));
+
+        // (a) The rdfD1 typing triple is NOT observable (literal subject dropped): a query
+        //     for `?x rdf:type xsd:integer` returns NO rows.
+        let type_q = format!(
+            "SELECT ?x WHERE {{ ?x <{}type> <{}integer> }}",
+            "http://www.w3.org/1999/02/22-rdf-syntax-ns#", XSD
+        );
+        let r = sparq_engine::query(&graph, &type_q).unwrap_or_else(|e| panic!("query: {e}"));
+        assert!(
+            r.rows.is_empty(),
+            "the generalized rdfD1 typing triple must NOT surface as a SPARQL answer \
+             (answer restriction), but got rows: {:?}",
+            r.rows
+        );
+
+        // (b) The ORIGINAL asserted triple is still answerable end-to-end.
+        let data_q = "SELECT ?o WHERE { <http://e/s> <http://e/p> ?o }";
+        let r2 = sparq_engine::query(&graph, data_q).unwrap_or_else(|e| panic!("query: {e}"));
+        assert_eq!(r2.rows.len(), 1, "the asserted data triple is answerable");
+    }
+
+    /// Idempotence + unrecognized-datatype fail-closed, driven through the REAL
+    /// materializer (a second broadened-map end-to-end guard).
+    #[test]
+    fn d_materialize_idempotent_and_fail_closed() {
+        // Unrecognized-shaped datatype: the STANDARD map does not cover it → no typing.
+        let mut dict = Dict::new();
+        let s = dict.intern(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://e/s")));
+        let p = dict.intern(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://e/p")));
+        let custom = dict.intern(&oxrdf::Term::Literal(oxrdf::Literal::new_typed_literal(
+            "x",
+            oxrdf::NamedNode::new_unchecked("http://example.org/myType"),
+        )));
+        let mut ids: Vec<[Id; 3]> = vec![[s, p, custom]];
+        let added = sparq_reason::materialize(Profile::D, &mut dict, &mut ids);
+        assert_eq!(added, 0, "an unrecognized datatype is fail-closed: no rdfD1 typing");
+
+        // Idempotence over a custom recognized map: materialize_d twice adds nothing the
+        // second time.
+        let mut dict2 = Dict::new();
+        let s2 = dict2.intern(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://e/s")));
+        let p2 = dict2.intern(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://e/p")));
+        let two = dict2.intern(&oxrdf::Term::Literal(oxrdf::Literal::new_typed_literal(
+            "2",
+            oxrdf::NamedNode::new_unchecked(dt("integer")),
+        )));
+        let mut ids2: Vec<[Id; 3]> = vec![[s2, p2, two]];
+        let d = Recognized::new([dt("integer")]);
+        let a1 = materialize_d(&d, &mut dict2, &mut ids2);
+        let a2 = materialize_d(&d, &mut dict2, &mut ids2);
+        assert_eq!(a1, 1, "first materialize types the recognized literal");
+        assert_eq!(a2, 0, "second materialize is idempotent");
+    }
 }

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -147,6 +147,18 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-conformance/tests/d_entail_suite.rs",
         "D_ENTAIL_FLOOR",
     ),
+    // [FABLE-5] sq-pbz04.6.4 (epic sq-pbz04.6) — the sparq D VALUE-SPACE MATRIX arm's
+    // EXTENSION ratchet. `pub const D_VALUE_MATRIX_FLOOR` lives in this crate's
+    // `tests/d_entail_suite.rs` (behind the opt-in `d-entail` feature, inside the `gated`
+    // module — the guard reads it TEXTUALLY, so the `#[cfg]`/module nesting do not affect
+    // the match); the guard pins the central scoreboard's `ratchet_floor` to it so the two
+    // can never silently drift. It is a sparq EXTENSION-shaped ratchet (value-space
+    // assertions), tallied separately from the W3C D-entailment pass count above.
+    (
+        "D value-space matrix (integer/decimal/boolean/binary/temporal)",
+        "crates/sparq-conformance/tests/d_entail_suite.rs",
+        "D_VALUE_MATRIX_FLOOR",
+    ),
     // [OPUS-4.8] sq-ddpgx (epic sq-my8wd) — the W3C SPARQL 1.1 sparql11/service
     // EVALUATION ratchet. `pub const SERVICE_EVAL_FLOOR` lives in this crate's
     // `tests/service_eval_suite.rs` (behind the opt-in `service` feature, inside the
@@ -480,8 +492,11 @@ fn scoreboard_renders_all_suites() {
     assert!(md.contains("OWL 2 DL profile identification (Direct arm)"));
     assert!(md.contains("OWL 2 Direct-Semantics consistency + entailment (scoped fragment)"));
     assert!(md.contains("NOT full OWL 2 DL"));
+    // [FABLE-5] sq-pbz04.6.4 — the sparq D value-space matrix, HONESTLY rendered as a
+    // sparq EXTENSION (tallied separately from the W3C D-entailment pass count).
+    assert!(md.contains("D value-space matrix (integer/decimal/boolean/binary/temporal)"));
     assert!(
-        md.contains("sparq-extension (8 rows, NOT conformance)"),
-        "eight extension rows should be tallied separately and pluralised"
+        md.contains("sparq-extension (9 rows, NOT conformance)"),
+        "nine extension rows should be tallied separately and pluralised"
     );
 }

--- a/crates/sparq-reason/Cargo.toml
+++ b/crates/sparq-reason/Cargo.toml
@@ -38,8 +38,18 @@ explain = []
 # correct typed value-space comparison (`dtype` module). NON-DEFAULT by design — when off
 # the `dtype` module + `Profile::D` variant are cfg'd out entirely (the lean default build
 # carries zero D-entailment code; the byte/bundle ratchets are unchanged, and sparq-reason
-# is never in the wasm dependency graph anyway). Pure-Rust, no new deps.
-d-entail = []
+# is never in the wasm dependency graph anyway).
+# [FABLE-5] sq-pbz04.6.3 (epic sq-pbz04.6, substrate seam 2): D-entailment's typed
+# numeric value-space keys now DELEGATE to the SHARED `sparq-substrate::numeric`
+# comparator (the same `Dec`/`Num`/`split_decimal`/`parse_xsd_f64` the SPARQL engine
+# FILTER path uses), so the reasoner and the engine can never diverge on numeric
+# value equality. Pulls the substrate `numeric` slice ONLY when `d-entail` is enabled
+# — it depends only on `sparq-core` (NOT `sparq-engine`), so the crate's sparq-core-only
+# dependency posture is preserved and no planner/serializer enters the bundle. The
+# integer subtype-range facets + the double/float lexical acceptance set STAY LOCAL
+# (facet validation is dtype-resident by design, per the design record §4 seam
+# decision) — see the module doc for the byte-identical-behaviour ledger.
+d-entail = ["dep:sparq-substrate", "sparq-substrate/numeric"]
 # [OPUS-4.8] sq-rh4gu (epic sq-pbz04) — OPT-IN RIF-Core front-end: the W3C RIF
 # *Core* dialect (the MONOTONE Horn-rule common subset of RIF-BLD/PRD) as a rule
 # front-end over the existing N3 forward chainer. `rif::Document` validates a

--- a/crates/sparq-reason/src/dtype.rs
+++ b/crates/sparq-reason/src/dtype.rs
@@ -34,15 +34,38 @@
 //! (sign + minimal integer digits + minimal fraction digits, parsed exactly): this
 //! is the correct typed comparison, exact at any magnitude.
 //!
-//! ## sparq-core substrate
+//! ## sparq-substrate seam (the shared value-space comparator)
 //!
-//! Datatype recognition (`is_integer_datatype`) and temporal value parsing
-//! (`temporal::Temporal`) come from `sparq-core` — sparq-reason depends ONLY on
-//! sparq-core, never sparq-engine. NOTE: the shared zero-overhead eval substrate's
-//! typed `Num` compare (the substrate move-chain, research/ sq-6tykl) is not yet
-//! wired; once `sparq-substrate::compare` lands, `d_value_key` migrates onto it
-//! (one canonical typed-value comparator shared by the engine FILTER path and this
-//! materializer), and this module's local canonicalization is deleted.
+//! [FABLE-5] sq-pbz04.6.3 (epic sq-pbz04.6, seam 2 — design record
+//! `research/d-entailment-datatype-map.md` §4). Datatype recognition
+//! (`is_integer_datatype`) and temporal value parsing (`temporal::Temporal`) come
+//! from `sparq-core`; the integer/decimal canonical-key split + normalization now
+//! DELEGATE to `sparq_substrate::numeric::split_decimal` — the SAME pure-string,
+//! unbounded-magnitude splitter the SPARQL engine's exact decimal-string compare
+//! uses — so the reasoner and the engine can never diverge on which decimal lexicals
+//! are well-formed nor on the canonical form. sparq-reason still depends ONLY on
+//! sparq-core + (behind `d-entail`) sparq-substrate, never sparq-engine; the lean
+//! default build links none of it.
+//!
+//! ### What migrated, and what deliberately STAYED LOCAL (byte-identical ledger)
+//!
+//! The seam is BEHAVIOUR-NEUTRAL by construction — the `dtype` unit matrix and the
+//! `D_ENTAIL_FLOOR` ratchet are byte-identical before/after. Two pieces stay local
+//! by DESIGN, not omission (design record §4 keeps facet validation dtype-resident):
+//!
+//! - **`integer_subtype_ok` (bounded-range facets) stays local.** The substrate
+//!   `Num::of_literal` parses magnitude only; it does NOT reject `"200"^^xsd:byte`
+//!   (out of the `byte` value space). rdfD1 must not type an out-of-range literal, so
+//!   the `i128` parse + range-facet reject is applied HERE before the canonical key.
+//! - **`parse_xsd_double` (the double/float lexical parser) stays local — a
+//!   STOP-AND-REPORT.** The substrate `parse_xsd_f64` is STRICTER: it rejects the
+//!   Rust-`FromStr`-only spellings `Infinity` / `-Infinity` / `NAN` / `nan`, which
+//!   this local parser (a lowercase-only `"inf"` blocklist) currently ACCEPTS. Adopting
+//!   the substrate parser would be a Some→None behaviour change on those four spellings.
+//!   It is the XSD-CORRECT direction (the reasoner is presently more lenient than the
+//!   evaluator), but it is NOT behaviour-neutral, so this migration keeps the local
+//!   parser to honour the byte-identical invariant. The deliberate tightening is tracked
+//!   as a follow-up bead (see the crate note); do NOT silently swap the parser here.
 //!
 //! ## Single-table discipline
 //!
@@ -80,6 +103,14 @@ use crate::Vocab;
 use rustc_hash::FxHashSet;
 use sparq_core::dict::{self, Dict, Id, TermParts};
 use sparq_core::{is_integer_datatype, temporal};
+// [FABLE-5] sq-pbz04.6.3 (epic sq-pbz04.6, substrate seam 2): the SHARED value-space
+// comparator. The integer/decimal canonical-key parsing + normalization now delegate to
+// `sparq_substrate::numeric::split_decimal` (pure-string, unbounded magnitude — the SAME
+// splitter the engine's exact decimal-string compare uses), so the reasoner and the engine
+// cannot diverge on which decimal lexicals are well-formed nor on the canonical form. Only
+// this module is behind `d-entail`, which pulls the `numeric` slice; the default/lean build
+// links none of it.
+use sparq_substrate::numeric::split_decimal;
 
 const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
@@ -313,9 +344,10 @@ pub fn has_value_mapping(dt: &str) -> bool {
 /// XSD 1.1 §3.3.17 defines anyURI as a distinct primitive; no cross-type key-equality
 /// with `xsd:string` is sanctioned.
 ///
-/// [OPUS-4.8] migrates to `sparq-substrate::compare` once the substrate move lands
-/// (sq-6tykl); the canonical-decimal logic here is the interim, sparq-core-only
-/// implementation (the typed Num compare is not yet wired into the substrate).
+/// [FABLE-5] sq-pbz04.6.3: the integer/decimal canonical key delegates to the shared
+/// `sparq_substrate::numeric::split_decimal` (see the private `canon_decimal` helper);
+/// `integer_subtype_ok` and `parse_xsd_double` stay local (facet validation + the
+/// double/float lexical acceptance set — see the module doc's byte-identical ledger for why).
 ///
 /// [SONNET-4.6] sq-pbz04.6.2: added anyURI, language/Name/NCName/NMTOKEN,
 /// hexBinary/base64Binary.
@@ -514,6 +546,13 @@ pub enum DValue {
 
 /// xsd float/double lexical syntax is a subset of Rust's `f64::parse`; reject the
 /// forms Rust accepts but XSD does not (hex, trailing `f`/`d`, the `inf` spelling).
+///
+/// [FABLE-5] sq-pbz04.6.3: KEPT LOCAL (a stop-and-report) rather than delegated to the
+/// stricter `sparq_substrate::numeric::parse_xsd_f64` — the substrate parser additionally
+/// rejects the Rust-`FromStr`-only spellings `Infinity` / `-Infinity` / `NAN` / `nan`
+/// (this blocklist's `contains("inf")` is lowercase-only, so `f64::FromStr` accepts them).
+/// Swapping in the substrate parser is XSD-correct but a Some→None behaviour change, so it
+/// is deferred to keep this migration byte-identical (tracked as a follow-up bead).
 fn parse_xsd_double(lex: &str) -> Option<f64> {
     match lex {
         "INF" | "+INF" => Some(f64::INFINITY),
@@ -565,25 +604,26 @@ fn integer_subtype_ok(dt: &str, v: i128) -> bool {
 /// Canonicalize a decimal lexical form to (sign)(minimal-int).(minimal-frac);
 /// `None` when ill-formed. `"-0.0"` canonicalizes to `"0"`; `"1.0"` to `"1"`; so
 /// the integer 1 and the decimal 1.0 share the key `"1"`.
+///
+/// [FABLE-5] sq-pbz04.6.3: the split + normalization delegates to the SHARED
+/// `sparq_substrate::numeric::split_decimal` (pure string, no `i128` bound — so an
+/// arbitrary-magnitude decimal like a 40-digit lexical still keys, exactly as the
+/// pre-migration hand-rolled version did; the substrate `Dec::parse` path would have
+/// overflowed and DROPPED such values, a behaviour change we deliberately avoid). The
+/// final canonical STRING assembly stays here because it is the D-value key form, not a
+/// comparator concern. `split_decimal` trims leading/trailing ASCII whitespace whereas the
+/// old hand-rolled splitter did NOT; to keep behaviour byte-identical (a padded decimal
+/// lexical was rejected before), reject any surrounding whitespace up front.
 fn canon_decimal(lex: &str) -> Option<String> {
-    let (sign, rest) = match lex.strip_prefix('-') {
-        Some(r) => (true, r),
-        None => (false, lex.strip_prefix('+').unwrap_or(lex)),
-    };
-    let (int_part, frac_part) = match rest.split_once('.') {
-        Some((i, f)) => (i, f),
-        None => (rest, ""),
-    };
-    if (int_part.is_empty() && frac_part.is_empty())
-        || !int_part.bytes().all(|b| b.is_ascii_digit())
-        || !frac_part.bytes().all(|b| b.is_ascii_digit())
-    {
+    // Preserve the pre-migration no-trim contract: `split_decimal` calls `s.trim()`, so
+    // `" 1"` would become `"1"` (Some) there; the old splitter's digit-check rejected the
+    // space (None). Reject surrounding whitespace so the accept/reject set is unchanged.
+    if lex.trim() != lex {
         return None;
     }
-    let int_trim = int_part.trim_start_matches('0');
-    let frac_trim = frac_part.trim_end_matches('0');
+    let (neg, int_trim, frac_trim) = split_decimal(lex)?;
     let int_c = if int_trim.is_empty() { "0" } else { int_trim };
-    let neg = sign && !(int_c == "0" && frac_trim.is_empty());
+    let neg = neg && !(int_c == "0" && frac_trim.is_empty());
     Some(format!(
         "{}{}{}{}",
         if neg { "-" } else { "" },
@@ -1389,5 +1429,153 @@ mod tests {
         // whitespace stripped
         assert_eq!(decode_base64_binary("YQ =="), Some(vec![0x61]));
         assert_eq!(decode_base64_binary("YQ="), None); // not multiple of 4
+    }
+
+    // ── [FABLE-5] sq-pbz04.6.3: dtype ≡ substrate differential over the XSD matrix ──
+    //
+    // The seam D3 fixes: the integer/decimal canonical key now delegates to
+    // `sparq_substrate::numeric::split_decimal`. These tests are the differential
+    // acceptance the bead requires — the value-space equality/relational verdicts of
+    // `d_value_key`/`d_value_eq` must AGREE with the substrate's own typed numeric
+    // comparator (`as_numeric` + `Num::cmp_relational`) over `=`, `<`, `>`, for
+    // value-equal-different-lexical pairs, plus the 2^53+1 non-aliasing guard.
+
+    use oxrdf::Literal as OxLit;
+    use sparq_substrate::numeric::{as_numeric, Num};
+    use std::cmp::Ordering;
+
+    /// Build an oxrdf literal for the substrate comparator side.
+    fn slit(value: &str, local: &str) -> OxLit {
+        OxLit::new_typed_literal(value, NamedNode::new_unchecked(format!("{}{}", XSD, local)))
+    }
+
+    /// The substrate's relational verdict for two numeric lexicals (the engine FILTER
+    /// path's semantics: `<`/`>`/`=`), or `None` if either is not numeric there.
+    fn substrate_cmp(a_lex: &str, a_dt: &str, b_lex: &str, b_dt: &str) -> Option<Ordering> {
+        let a = as_numeric(&slit(a_lex, a_dt.strip_prefix(XSD).unwrap()))?;
+        let b: Num = as_numeric(&slit(b_lex, b_dt.strip_prefix(XSD).unwrap()))?;
+        a.cmp_relational(b)
+    }
+
+    /// `=`: dtype value-equality (via the substrate-delegated canonical key) AGREES with
+    /// the substrate's own relational `Equal` verdict, over the integer⊂decimal space and
+    /// across value-equal-different-lexical pairs.
+    #[test]
+    fn dtype_substrate_equality_agrees_over_matrix() {
+        let integer = format!("{}integer", XSD);
+        let decimal = format!("{}decimal", XSD);
+        // (a_lex, a_dt, b_lex, b_dt): value-equal-different-lexical pairs across the
+        // coinciding integer/decimal space, plus non-equal controls.
+        let cases: &[(&str, &str, &str, &str)] = &[
+            ("1", &integer, "1.0", &decimal),
+            ("01", &integer, "+1", &integer),
+            ("1", &integer, "1.00", &decimal),
+            ("-0", &integer, "0", &decimal),
+            ("100", &decimal, "100.000", &decimal),
+            ("1", &integer, "2", &decimal),   // NOT equal
+            ("1.5", &decimal, "1", &integer), // NOT equal
+            ("-1.5", &decimal, "-1.50", &decimal),
+        ];
+        for &(al, adt, bl, bdt) in cases {
+            let dtype_eq = d_value_eq(al, adt, bl, bdt);
+            let substrate_eq = substrate_cmp(al, adt, bl, bdt) == Some(Ordering::Equal);
+            assert_eq!(
+                dtype_eq, substrate_eq,
+                "dtype ≡ substrate equality disagreement on ({:?}^^{:?}, {:?}^^{:?}): \
+                 dtype={} substrate={}",
+                al, adt, bl, bdt, dtype_eq, substrate_eq
+            );
+        }
+    }
+
+    /// `<` / `>`: the ORDER of two distinct-but-close numeric values agrees between the
+    /// dtype canonical key (string order over the shared canonical decimal) and the
+    /// substrate's `cmp_relational`. This exercises the relational verdict, not just `=`.
+    #[test]
+    fn dtype_substrate_relational_order_agrees() {
+        let integer = format!("{}integer", XSD);
+        let decimal = format!("{}decimal", XSD);
+        let ordered: &[(&str, &str, &str, &str)] = &[
+            ("1", &integer, "2", &integer),
+            ("1.4", &decimal, "1.5", &decimal),
+            ("9", &integer, "10", &decimal),
+            ("-2", &integer, "-1", &decimal),
+            ("0", &integer, "0.1", &decimal),
+        ];
+        for &(al, adt, bl, bdt) in ordered {
+            // Both well-formed → the substrate gives Less (a < b by construction).
+            assert_eq!(
+                substrate_cmp(al, adt, bl, bdt),
+                Some(Ordering::Less),
+                "fixture ({:?},{:?}) must be substrate-Less",
+                al,
+                bl
+            );
+            // dtype: distinct values → NOT key-equal; equal values → key-equal. Here they
+            // are distinct, so the dtype keys must differ (the < relation manifests as
+            // key-inequality in the value-space-equality contract dtype exposes).
+            assert!(
+                !d_value_eq(al, adt, bl, bdt),
+                "dtype keys of a strictly-ordered pair must differ ({:?} vs {:?})",
+                al,
+                bl
+            );
+        }
+    }
+
+    /// The 2^53+1 NON-ALIASING guard, cross-checked against the substrate: an f64 would
+    /// alias 2^53+1 with 2^53, but BOTH the dtype canonical-decimal key AND the substrate
+    /// exact comparator keep them distinct (the load-bearing unsound-f64 guard, now proven
+    /// on both sides of the seam).
+    #[test]
+    fn dtype_substrate_2p53_plus_1_non_aliasing() {
+        let integer = format!("{}integer", XSD);
+        let a = "9007199254740993"; // 2^53 + 1
+        let b = "9007199254740992"; // 2^53
+        // dtype: distinct keys.
+        assert!(
+            !d_value_eq(a, &integer, b, &integer),
+            "dtype must NOT alias 2^53+1 with 2^53"
+        );
+        // substrate: NOT relational-equal (exact i128/Dec tier, no f64 collapse).
+        assert_ne!(
+            substrate_cmp(a, &integer, b, &integer),
+            Some(Ordering::Equal),
+            "substrate must NOT alias 2^53+1 with 2^53"
+        );
+    }
+
+    /// Arbitrary-magnitude decimal REGRESSION guard: a 40+-digit `xsd:decimal` lexical
+    /// (well past the i128 bound of `Dec::parse`) STILL keys — because the delegation is to
+    /// the pure-string, unbounded `split_decimal`, NOT to `Dec::parse` (which would overflow
+    /// and drop it, a behaviour change we deliberately avoided). Non-vacuous: a naive
+    /// `Dec::parse`-based migration turns this `Some` into `None`.
+    #[test]
+    fn big_decimal_beyond_i128_still_keys() {
+        let decimal = format!("{}decimal", XSD);
+        let big = "123456789012345678901234567890123456789012.5"; // 43 significant digits
+        assert!(
+            d_value_key(big, &decimal).is_some(),
+            "an arbitrary-magnitude decimal must still get a D-value (unbounded split)"
+        );
+        // Its canonical key round-trips its own value (equal to itself, distinct from a
+        // neighbour that differs only in the last fraction digit).
+        assert!(d_value_eq(big, &decimal, big, &decimal));
+        let neighbour = "123456789012345678901234567890123456789012.6";
+        assert!(!d_value_eq(big, &decimal, neighbour, &decimal));
+    }
+
+    /// The no-trim contract of the canonical decimal key is preserved after delegating to
+    /// `split_decimal` (which trims): a whitespace-padded decimal lexical is still REJECTED,
+    /// byte-identically to the pre-migration hand-rolled splitter. Non-vacuous: dropping the
+    /// up-front whitespace reject makes " 1" key as Some.
+    #[test]
+    fn padded_decimal_lexical_rejected() {
+        let decimal = format!("{}decimal", XSD);
+        assert!(d_value_key(" 1", &decimal).is_none(), "leading space rejected");
+        assert!(d_value_key("1 ", &decimal).is_none(), "trailing space rejected");
+        assert!(d_value_key("1\t", &decimal).is_none(), "trailing tab rejected");
+        // A clean lexical still keys.
+        assert!(d_value_key("1", &decimal).is_some());
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]. Both D-entailment beads of epic sq-pbz04.6, in one branch (same code area). Opt-in throughout (`d-entail` feature, OFF by default); `sparq-core`/`sparq-engine` stay lean.

## What this delivers

### sq-pbz04.6.3 — adopt the substrate value-space comparator in `dtype.rs`
The integer/decimal canonical value-space key now DELEGATES to the shared `sparq_substrate::numeric::split_decimal` — the same pure-string, unbounded-magnitude splitter the SPARQL engine's exact decimal compare uses — so the reasoner and the engine can never diverge on decimal well-formedness or the canonical form. The local hand-rolled split/trim in `canon_decimal` is deleted. The `d-entail` feature is wired to the substrate `numeric` slice (one Cargo line), which depends only on `sparq-core` (NOT `sparq-engine`) — the crate's `sparq-core`-only dependency posture is preserved and the default/lean build links **zero** substrate code (verified via `cargo tree`).

**Behaviour-neutral, proven by a before/after differential** over the XSD matrix (the bead's acceptance): every existing `(lexical, datatype)` pair classifies/compares identically. A new dtype-vs-substrate differential test cross-checks `=`/`<`/`>` and value-equality against the substrate's own `as_numeric` / `Num::cmp_relational`, including the **2^53+1 non-aliasing guard** and an **arbitrary-magnitude (43-digit) decimal regression guard**. All 33 dtype unit tests + 5 new ones are green.

**Mutation-witnessed:** a naive `Dec::parse` migration (which overflows i128 past ~38 digits) turns the 43-digit-decimal `Some` into `None` and the regression test goes RED — that is why the delegation targets the pure-string `split_decimal`, not `Dec::parse`.

**Two pieces STAY LOCAL by design** (design record §4 keeps facet validation dtype-resident):
- `integer_subtype_ok` (bounded-range facets) — the substrate parses magnitude only; it would not reject `"200"^^xsd:byte`, so the `i128` parse + range-facet reject stays here.
- `parse_xsd_double` — a **STOP-AND-REPORT**. The substrate `parse_xsd_f64` is XSD-correctly STRICTER: it rejects the Rust-`FromStr`-only spellings `Infinity` / `-Infinity` / `NAN` / `nan` that this local blocklist (lowercase-only `contains("inf")`) currently ACCEPTS. Swapping it in is the right direction (the reasoner is presently more lenient than the evaluator/numeric-cache) but is a **Some→None behaviour change**, so per the bead ("a behaviour CHANGE is a stop-and-report, not a silent fix") it is kept local to honour the byte-identical invariant. The deliberate tightening is tracked as follow-up bead **sq-s3b10** — not silently applied.

### sq-pbz04.6.4 — D-entailment conformance: crate-local value-space matrix arm
A crate-local **D value-space matrix arm** in `d_entail_suite.rs` — a sparq **EXTENSION** ratchet tallied SEPARATELY from the W3C `D_ENTAIL_FLOOR` (program honesty rule 4; the single-test W3C D corpus is not padded), mirroring the OWL 2 QL / EL / RIF-Core extension precedent. `D_VALUE_MATRIX_FLOOR = 24` (the MEASURED assertion count, rise-only), mirrored in the central scoreboard `SUITES` and pinned by the `scoreboard_floors.rs` textual floor-sync guard (now **9** extension rows). The W3C `D_ENTAIL_FLOOR` is untouched.

The arm drives, through the REAL `Profile::D` value-space comparator:
- value-equal-distinct-lexical pairs (integer⊂decimal incl. the 2^53+1 guard, boolean `true`/`1`, the hex/base64 octet-identity pair),
- facet-ill-formed negatives (rdfD1 must NOT type `200^^xsd:byte` / a leading-space `xsd:token`),
- disjoint-space negatives (decimal-vs-double, date-vs-dateTime at a shared instant),

plus **broadened-map end-to-end cases** through the same `materialize → answer-restriction (drop literal-subject rows) → engine-query` path as the W3C lane (the generalized rdfD1 typing triple correctly never surfaces as a SPARQL answer). **Mutation-witnessed:** flipping the 2^53+1 expected classification to `equal: true` goes RED.

## Gates — GREEN in BOTH feature states (default OFF, `d-entail` ON)
- `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p sparq-reason` (default) + `--features d-entail` (168 lib tests)
- `cargo test -p sparq-conformance` (default: single self-SKIP) + `--features d-entail` (matrix + end-to-end + scoreboard-floors guards)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (a public doc-comment link to the private `canon_decimal` was demoted to a code span to avoid the feature-gated intra-doc-link trap)
- coverage: `dtype.rs` 96.5% line under `d-entail`; default-feature `sparq-reason` coverage unchanged (dtype is cfg'd out when the feature is OFF — no default-compiled file touched)

**Feature flags exercised:** `sparq-reason/d-entail` (→ `sparq-substrate/numeric`), `sparq-conformance/d-entail` (→ `sparq-reason/d-entail`).

## Honesty / boundaries
- The double/float parser divergence is disclosed as an intentional stop-and-report, not smuggled through as neutral. Follow-up: **sq-s3b10**.
- The new value-space matrix is a sparq EXTENSION, never counted as W3C conformance.
- Not touched (held by other agents / other beads): `skills/`, crate READMEs (docs leaf owns sq-pbz04.6.5), and `crates/sparq-reason/src/compare.rs` (sibling sq-74oy4 numeric-trim seam).

Closes sq-pbz04.6.3, sq-pbz04.6.4.