### PR TITLE
feat(reason-dl): DL L2 singleton owl:intersectionOf normalization + explicit-negative profile lane (sq-pbz04.4.16) [FABLE-5]

### DIFF
--- a/crates/sparq-conformance/src/inference/dl_suite.rs
+++ b/crates/sparq-conformance/src/inference/dl_suite.rs
@@ -52,10 +52,11 @@ use sparq_core::dict::{Dict, Id};
 use sparq_reason_dl::check::{ConsistencyVerdict, DirectChecker, EntailmentVerdict, UnknownReason};
 use sparq_reason_dl::profile::{profiles_from_extraction, Membership};
 use sparq_reason_dl::tableau::Budget;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 const T: &str = "http://www.w3.org/2007/OWL/testOntology#";
+const OWL: &str = "http://www.w3.org/2002/07/owl#";
 const OWL_ONTOLOGY: &str = "http://www.w3.org/2002/07/owl#Ontology";
 const OWL_IMPORTS: &str = "http://www.w3.org/2002/07/owl#imports";
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -152,6 +153,14 @@ pub struct DlReport {
     /// Profile-identification lane: one row per POSITIVE `test:profile` EL/QL/RL tag on
     /// a selected `ProfileIdentificationTest` (positive-only — module docs).
     pub profile: LaneTally,
+    /// EXPLICIT-NEGATIVE profile lane: one row per checkable
+    /// `owl:NegativePropertyAssertion(case, test:profile, {EL|QL|RL})` in the DIRECT arm —
+    /// the export's assertion that the case is NOT in that profile. Driven with
+    /// `expect_in = false`: a `NotIn`/`Unknown` verdict is a Pass/abstention, an `In` is a
+    /// Fail (the checker could not refute the full-profile membership). Separated from
+    /// [`DlReport::profile`] so the positive lane's pin never moves when the negative lane
+    /// grows. [FABLE-5] sq-pbz04.4.16
+    pub profile_negative: LaneTally,
     /// Reasoning lane, per declared check kind.
     pub consistency: LaneTally,
     /// See [`DlReport::consistency`].
@@ -185,6 +194,7 @@ impl DlReport {
         let mut out = Vec::new();
         for lane in [
             &self.profile,
+            &self.profile_negative,
             &self.consistency,
             &self.inconsistency,
             &self.positive_entailment,
@@ -215,6 +225,27 @@ impl DlReport {
             self.profile.out_of_fragment_total(),
             self.profile.out_of_scope_total(),
         );
+        // The explicit-negative profile lane (owl:NegativePropertyAssertion on test:profile).
+        // A `fail` HERE is an honest MEASURED gap — L2's In is axiom-grammar membership over
+        // the ALCH shadow and cannot always refute full-profile membership — NOT a soundness
+        // bug; it is pinned as a gap floor, never asserted to zero. [FABLE-5] sq-pbz04.4.16
+        let neg_total = self.profile_negative.total();
+        let neg_in_gap = self.profile_negative.fails.len();
+        let _ = writeln!(
+            md,
+            "  profile-identification (explicit-negative NPAs): {} rows — refuted (pass) {}, In-gap {}, abstained {}, out-of-scope {}",
+            neg_total,
+            self.profile_negative.pass,
+            neg_in_gap,
+            self.profile_negative.out_of_fragment_total(),
+            self.profile_negative.out_of_scope_total(),
+        );
+        let _ = writeln!(
+            md,
+            "  In-vs-negative gap (checkable): {} of {}",
+            neg_in_gap,
+            self.profile_negative.pass + neg_in_gap,
+        );
         for (kind, lane) in [
             ("consistency", &self.consistency),
             ("inconsistency", &self.inconsistency),
@@ -236,6 +267,7 @@ impl DlReport {
         let mut oos: BTreeMap<String, usize> = BTreeMap::new();
         for lane in [
             &self.profile,
+            &self.profile_negative,
             &self.consistency,
             &self.inconsistency,
             &self.positive_entailment,
@@ -364,6 +396,10 @@ struct Case {
     checks: Vec<&'static str>,
     profile_test: bool,
     positive_profiles: Vec<String>,
+    /// EL/QL/RL profiles the export EXPLICITLY negates for this case via a top-level
+    /// `owl:NegativePropertyAssertion(case, test:profile, profile)` — the negative lane's
+    /// expectations (checked with `expect_in = false`). [FABLE-5] sq-pbz04.4.16
+    negative_profiles: Vec<String>,
     premise: Option<String>,
     input: Option<String>,
     conclusion: Option<String>,
@@ -386,6 +422,14 @@ pub fn run_direct_arm(export_text: &str) -> Result<DlReport, String> {
         triples.push(t.map_err(|e| format!("all.rdf: {}", e))?);
     }
     let g = MiniGraph { triples };
+
+    // Pre-scan the top-level `owl:NegativePropertyAssertion` nodes for the EXPLICIT-NEGATIVE
+    // profile lane (sq-pbz04.4.16). A manifest-level profile negation is an NPA whose
+    // `assertionProperty` is `test:profile`, `sourceIndividual` is a TestCase IRI, and
+    // `targetIndividual` is one of {EL, QL, RL} — "case X is NOT in profile Y". NPAs embedded
+    // in premise/input ontology LITERALS are test DATA (parsed later, per case) and never seen
+    // here, so this only picks the manifest metadata. Keyed by the source (case) IRI.
+    let negated_profiles: HashMap<String, Vec<String>> = collect_profile_negations(&g);
 
     let mut report = DlReport::default();
     for case_node in g.subjects_with_type(&format!("{}TestCase", T)) {
@@ -456,6 +500,7 @@ pub fn run_direct_arm(export_text: &str) -> Result<DlReport, String> {
                 .filter(|p| known(p))
                 .map(|p| profile_name(p))
                 .collect(),
+            negative_profiles: negated_profiles.get(&case_iri).cloned().unwrap_or_default(),
             premise: lit("rdfXmlPremiseOntology"),
             input: lit("rdfXmlInputOntology"),
             conclusion: lit("rdfXmlConclusionOntology"),
@@ -468,9 +513,54 @@ pub fn run_direct_arm(export_text: &str) -> Result<DlReport, String> {
     Ok(report)
 }
 
+/// Collect the manifest-level EXPLICIT-NEGATIVE profile assertions
+/// (`owl:NegativePropertyAssertion(case, test:profile, {EL|QL|RL})`) keyed by the source
+/// (case) IRI. [FABLE-5] sq-pbz04.4.16
+///
+/// Only a top-level NPA whose `assertionProperty` is `test:profile` and whose
+/// `targetIndividual` is one of the three tractable profiles is collected — every other NPA
+/// (data-level negations in premise/input literals, non-profile assertion properties) is
+/// ignored. The result preserves EL/QL/RL encounter order per case for deterministic keys.
+fn collect_profile_negations(g: &MiniGraph) -> HashMap<String, Vec<String>> {
+    let assertion_prop = format!("{}assertionProperty", OWL);
+    let source_ind = format!("{}sourceIndividual", OWL);
+    let target_ind = format!("{}targetIndividual", OWL);
+    let profile_prop = format!("{}profile", T);
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for npa in g.subjects_with_type(&format!("{}NegativePropertyAssertion", OWL)) {
+        // assertionProperty must be exactly test:profile.
+        let is_profile = matches!(
+            g.object(&npa, &assertion_prop),
+            Some(Term::NamedNode(n)) if n.as_str() == profile_prop
+        );
+        if !is_profile {
+            continue;
+        }
+        let Some(Term::NamedNode(src)) = g.object(&npa, &source_ind) else {
+            continue;
+        };
+        let Some(Term::NamedNode(tgt)) = g.object(&npa, &target_ind) else {
+            continue;
+        };
+        let Some(profile) = tgt.as_str().strip_prefix(T) else {
+            continue;
+        };
+        if !matches!(profile, "EL" | "QL" | "RL") {
+            continue;
+        }
+        let case = src.as_str().to_string();
+        let list = out.entry(case).or_default();
+        // De-duplicate a repeated (case, profile) negation — one row per pair.
+        if !list.iter().any(|p| p == profile) {
+            list.push(profile.to_string());
+        }
+    }
+    out
+}
+
 /// Run both lanes' checks for one selected case.
 fn run_case(case: &Case, report: &mut DlReport) {
-    if case.profile_test {
+    if case.profile_test || !case.negative_profiles.is_empty() {
         run_profile_lane(case, report);
     }
     if !case.checks.is_empty() {
@@ -478,31 +568,63 @@ fn run_case(case: &Case, report: &mut DlReport) {
     }
 }
 
-/// The profile-identification lane — POSITIVE `test:profile` tags only (module docs).
+/// Pick the membership verdict for a named profile from a computed [`ProfileSet`].
+fn membership_of<'a>(
+    ps: &'a sparq_reason_dl::profile::ProfileSet,
+    name: &str,
+) -> &'a Membership {
+    match name {
+        "EL" => &ps.el,
+        "QL" => &ps.ql,
+        _ => &ps.rl,
+    }
+}
+
+/// The profile-identification lane — POSITIVE `test:profile` tags AND EXPLICIT-NEGATIVE
+/// `owl:NegativePropertyAssertion` negations. The positive tags feed [`DlReport::profile`]
+/// (checked `expect_in = true`); the negations feed [`DlReport::profile_negative`] (checked
+/// `expect_in = false`). Both directions share ONE extraction of the input ontology. The
+/// negative lane (sq-pbz04.4.16) unlocks the 322-row explicit-negative direction the module
+/// docs' MEASUREMENT deferred; an `In` verdict there is an honest gap (L2 cannot refute
+/// full-profile membership from axiom-grammar membership over the ALCH shadow alone), pinned
+/// as a gap floor, never asserted to zero.
 fn run_profile_lane(case: &Case, report: &mut DlReport) {
-    report.profile_cases += 1;
-    let assertions = &case.positive_profiles;
-    if assertions.is_empty() {
-        // No positive EL/QL/RL tag: either a species-only case (test:species DL/FULL —
-        // the design record's deferred species check) or an explicit-negatives-only
-        // case (the direction this lane measured and does not check — module docs).
+    let pos = &case.positive_profiles;
+    let neg = &case.negative_profiles;
+    if case.profile_test {
+        report.profile_cases += 1;
+    }
+    if case.profile_test && pos.is_empty() && neg.is_empty() {
+        // A ProfileIdentificationTest with no positive tag AND no explicit negation: either a
+        // species-only case (test:species DL/FULL — the deferred species check) or otherwise
+        // untagged — nothing to check in either direction.
         report
             .profile
-            .record_out_of_scope("no positive EL/QL/RL tag (species check deferred; explicit-negative direction not checked)");
+            .record_out_of_scope("no positive EL/QL/RL tag and no explicit negation (species check deferred)");
         return;
     }
     if case.imports {
-        for _ in assertions {
+        for _ in pos {
             report
                 .profile
+                .record_out_of_scope("uses owl:imports (no dereferencing in the harness)");
+        }
+        for _ in neg {
+            report
+                .profile_negative
                 .record_out_of_scope("uses owl:imports (no dereferencing in the harness)");
         }
         return;
     }
     let Some(input_xml) = case.input.clone().or_else(|| case.premise.clone()) else {
-        for _ in assertions {
+        for _ in pos {
             report
                 .profile
+                .record_out_of_scope("input only available in functional syntax");
+        }
+        for _ in neg {
+            report
+                .profile_negative
                 .record_out_of_scope("input only available in functional syntax");
         }
         return;
@@ -518,32 +640,43 @@ fn run_profile_lane(case: &Case, report: &mut DlReport) {
     let profile_set = match profile_set {
         Ok(Ok(ps)) => ps,
         Ok(Err(e)) => {
-            for name in assertions {
+            let observed = format!("input RDF/XML parse error: {}", e);
+            for name in pos {
                 let key = format!("owl2-dl/profile-{}: {}", name, case.ident);
-                report
-                    .profile
-                    .record(&key, TriState::Fail(format!("input RDF/XML parse error: {}", e)));
+                report.profile.record(&key, TriState::Fail(observed.clone()));
+            }
+            for name in neg {
+                let key = format!("owl2-dl/profile-neg-{}: {}", name, case.ident);
+                report.profile_negative.record(&key, TriState::Fail(observed.clone()));
             }
             return;
         }
         Err(_) => {
-            for name in assertions {
+            let observed = "profile pipeline panicked".to_string();
+            for name in pos {
                 let key = format!("owl2-dl/profile-{}: {}", name, case.ident);
-                report
-                    .profile
-                    .record(&key, TriState::Fail("profile pipeline panicked".to_string()));
+                report.profile.record(&key, TriState::Fail(observed.clone()));
+            }
+            for name in neg {
+                let key = format!("owl2-dl/profile-neg-{}: {}", name, case.ident);
+                report.profile_negative.record(&key, TriState::Fail(observed.clone()));
             }
             return;
         }
     };
-    for name in assertions {
-        let membership = match name.as_str() {
-            "EL" => &profile_set.el,
-            "QL" => &profile_set.ql,
-            _ => &profile_set.rl,
-        };
+    // Positive tags (expect In).
+    for name in pos {
         let key = format!("owl2-dl/profile-{}: {}", name, case.ident);
-        report.profile.record(&key, membership_tri(membership, true));
+        report
+            .profile
+            .record(&key, membership_tri(membership_of(&profile_set, name), true));
+    }
+    // Explicit negations (expect NotIn). An `In` here is the honest measured gap.
+    for name in neg {
+        let key = format!("owl2-dl/profile-neg-{}: {}", name, case.ident);
+        report
+            .profile_negative
+            .record(&key, membership_tri(membership_of(&profile_set, name), false));
     }
 }
 
@@ -832,16 +965,25 @@ mod tests {
         assert_eq!(report.inconsistency.pass, 1);
         assert!(report.all_fails().is_empty(), "{:?}", report.all_fails());
         assert_eq!(report.reasoning_pass(), 2);
-        // Profile lane (positive tags only): the ∀-restriction TBox is RL, so the
-        // positive RL tag passes; the mini export's explicit owl:NegativePropertyAssertion
-        // (NOT in EL) is deliberately NOT checked (module docs) — exactly one row.
+        // Positive profile lane: the ∀-restriction TBox is RL, so the positive RL tag passes
+        // — exactly one positive row.
         assert_eq!(report.profile_cases, 1);
         assert_eq!(report.profile.total(), 1);
         assert_eq!(report.profile.pass, 1);
-        // The render is counts-only and names the honest scope label.
+        // Explicit-negative profile lane (sq-pbz04.4.16): the mini export's
+        // `owl:NegativePropertyAssertion(case-profile, test:profile, EL)` asserts the case is
+        // NOT in EL. The input is an ∀R.B TBox — genuinely NotIn EL (EL forbids
+        // ObjectAllValuesFrom), so L2 REFUTES the membership and the negative row is a Pass
+        // (refuted). Exactly one negative row, no In-gap.
+        assert_eq!(report.profile_negative.total(), 1);
+        assert_eq!(report.profile_negative.pass, 1);
+        assert_eq!(report.profile_negative.fails.len(), 0);
+        // The render is counts-only, names the honest scope label, and prints the negative
+        // lane's In-vs-negative gap line.
         let md = report.render();
         assert!(md.contains("NOT full OWL 2 DL"));
         assert!(md.contains("NEVER counted as pass"));
+        assert!(md.contains("In-vs-negative gap"));
     }
 
     #[test]
@@ -864,5 +1006,51 @@ mod tests {
         let report = run_direct_arm(&fs_only).expect("mini export parses");
         assert_eq!(report.consistency.out_of_scope_total(), 1);
         assert_eq!(report.consistency.pass, 0);
+    }
+
+    /// Direct unit test of `collect_profile_negations` (sq-pbz04.4.16): a top-level
+    /// `owl:NegativePropertyAssertion(case, test:profile, EL)` is collected keyed by the
+    /// source case IRI; a NON-profile assertion property and a non-{EL,QL,RL} target are
+    /// ignored; a repeated (case, profile) pair is de-duplicated to one row.
+    #[test]
+    fn collect_profile_negations_filters_and_dedups() {
+        let export = r#"<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:test="http://www.w3.org/2007/OWL/testOntology#">
+  <owl:NegativePropertyAssertion>
+    <owl:sourceIndividual rdf:resource="http://ex/case-a"/>
+    <owl:assertionProperty rdf:resource="http://www.w3.org/2007/OWL/testOntology#profile"/>
+    <owl:targetIndividual rdf:resource="http://www.w3.org/2007/OWL/testOntology#EL"/>
+  </owl:NegativePropertyAssertion>
+  <owl:NegativePropertyAssertion>
+    <owl:sourceIndividual rdf:resource="http://ex/case-a"/>
+    <owl:assertionProperty rdf:resource="http://www.w3.org/2007/OWL/testOntology#profile"/>
+    <owl:targetIndividual rdf:resource="http://www.w3.org/2007/OWL/testOntology#EL"/>
+  </owl:NegativePropertyAssertion>
+  <owl:NegativePropertyAssertion>
+    <owl:sourceIndividual rdf:resource="http://ex/case-a"/>
+    <owl:assertionProperty rdf:resource="http://www.w3.org/2007/OWL/testOntology#profile"/>
+    <owl:targetIndividual rdf:resource="http://www.w3.org/2007/OWL/testOntology#DL"/>
+  </owl:NegativePropertyAssertion>
+  <owl:NegativePropertyAssertion>
+    <owl:sourceIndividual rdf:resource="http://ex/case-b"/>
+    <owl:assertionProperty rdf:resource="http://ex/notProfile"/>
+    <owl:targetIndividual rdf:resource="http://www.w3.org/2007/OWL/testOntology#RL"/>
+  </owl:NegativePropertyAssertion>
+</rdf:RDF>"#;
+        let parser = oxrdfxml::RdfXmlParser::new()
+            .with_base_iri("http://ex/")
+            .unwrap();
+        let triples: Vec<_> = parser
+            .for_slice(export.as_bytes())
+            .map(|t| t.unwrap())
+            .collect();
+        let g = MiniGraph { triples };
+        let map = collect_profile_negations(&g);
+        // case-a: EL (de-duplicated to one), DL ignored (not EL/QL/RL).
+        assert_eq!(map.get("http://ex/case-a"), Some(&vec!["EL".to_string()]));
+        // case-b: the assertion property is not test:profile → ignored entirely.
+        assert!(!map.contains_key("http://ex/case-b"));
     }
 }

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -1028,15 +1028,22 @@ pub const SUITES: &[Suite] = &[
             feature: "dl-direct",
         },
         ci_job: "inference-conformance",
-        ratchet_floor: 68,
+        ratchet_floor: 95,
         floor_basis: "positive-tag membership passes, EXACT-pinned (sparq EXTENSION over the \
                       L1/L2 ALCH-fragment checker — scoped fragment, NOT full OWL 2 DL and NOT \
-                      a W3C ProfileIdentificationTest conformance claim)",
+                      a W3C ProfileIdentificationTest conformance claim); re-pinned by \
+                      sq-pbz04.4.16 (M7 singleton-intersection normalization: +27, 68 -> 95)",
         note: "EXTENSION ratchet — the DIRECT-arm ProfileIdentificationTest cases whose \
                POSITIVE test:profile tags the L2 syntactic checker reproduces through the \
-               REAL fail-closed L1 extraction + grammar walk; explicit-negative and species \
-               assertions are not checked (documented), abstentions are never passes, and \
-               the 27 singleton-intersection divergences are pinned by name",
+               REAL fail-closed L1 extraction + grammar walk; abstentions are never passes. \
+               The 27 singleton-intersection (M7) divergences are FIXED by sq-pbz04.4.16 (L1 \
+               normalizes a 1-ary owl:intersectionOf to its member) and now pass; the \
+               positive PROFILE_DIVERGENCES pin is empty. The EXPLICIT-NEGATIVE direction is \
+               a SEPARATE lane (sq-pbz04.4.16): the export's owl:NegativePropertyAssertion \
+               profile negations refuted where L2 can (139), with an honest measured In-gap \
+               (180 of 319 checkable) where axiom-grammar membership over the ALCH shadow \
+               cannot refute full-profile membership (deferred restrictions); species \
+               assertions remain unchecked (documented)",
     },
     Suite {
         label: "OWL 2 Direct-Semantics consistency + entailment (scoped fragment)",
@@ -1047,21 +1054,24 @@ pub const SUITES: &[Suite] = &[
             feature: "dl-direct",
         },
         ci_job: "inference-conformance",
-        ratchet_floor: 190,
+        ratchet_floor: 182,
         floor_basis: "definitive expected verdicts through the L4 dispatch, EXACT-pinned \
                       (sparq EXTENSION over the scoped fragment — NOT full OWL 2 DL); \
                       re-pinned by sq-pbz04.4.11 (M1 named-composite fix, net +8); \
                       re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix: -3, 192 -> 189); \
                       re-pinned by sq-pbz04.4.13 (M2 conclusion-bnode existential-reading fix: \
-                      +1, 189 -> 190 — both M2 rows graduate to passes, one free-existential- \
-                      root conclusion bnode shifts to an honest abstention)",
+                      +1, 189 -> 190); re-pinned by sq-pbz04.4.16 (M7 singleton-intersection \
+                      normalization: -8, 190 -> 182 — 8 consistency cases re-route from the \
+                      ALCH tableau to the RL branch and honestly abstain via the documented \
+                      disjointWith divergence guard, never a wrong verdict; fail set unchanged)",
         note: "EXTENSION ratchet — the DIRECT-arm consistency / inconsistency / positive- / \
                negative-entailment tests decided by the REAL sparq-reason-dl L4 dispatch \
                (RL guarded / EL guarded / QL deferred / ALCH tableau) under a pinned \
                deterministic count budget; fail-closed abstentions are reported, never \
                passes, and all 5 remaining wrong-verdict divergences are pinned by name \
                with audited mechanisms (M1 FIXED sq-pbz04.4.11; M4 FIXED sq-pbz04.4.12; \
-               M2 FIXED sq-pbz04.4.13 — those rows now pass/abstain; remaining: M3/M5/M6)",
+               M2 FIXED sq-pbz04.4.13; M7 FIXED sq-pbz04.4.16 — those rows now pass/abstain; \
+               remaining: M3/M5/M6)",
     },
 ];
 

--- a/crates/sparq-conformance/tests/dl_suite.rs
+++ b/crates/sparq-conformance/tests/dl_suite.rs
@@ -74,13 +74,31 @@
 //!   WebOnt-Ontology-003's OWL-1-era non-entailment hinges on the stripped header.
 //! - **M6 — the premise/input literal does not parse with oxrdfxml** (a nested
 //!   `rdf:RDF` property element the strict parser rejects).
-//! - **M7 — L2 profile-grammar arity vs the official singleton-list normalization.**
-//!   L2 requires `ObjectIntersectionOf` arity ≥ 2 (the structural-spec arity); the
-//!   official tagging accepts the RDF singleton-intersection encoding (normalizing it
-//!   to its sole member), so positively-tagged cases carrying `owl:intersectionOf (x)`
-//!   come back `NotIn`. (WebOnt-I5.26-001 left this pin under sq-pbz04.4.12: its input's
-//!   anonymous singleton intersection appears in no axiom, so the M4 fix now ABSTAINS on it
-//!   rather than reaching the arity rule.)
+//! - **M7 — FIXED (sq-pbz04.4.16).** L2 requires `ObjectIntersectionOf` arity ≥ 2 (the
+//!   structural-spec arity); the official tagging accepts the OWL-1-era RDF
+//!   singleton-intersection encoding `_:B owl:intersectionOf ( :A )` by NORMALIZING it to
+//!   its sole member `:A`. The L1 extractor now performs that same model-preserving
+//!   normalization (`⊓{A} ≡ A` under Direct Semantics — a 1-ary intersection has exactly
+//!   its single conjunct's interpretation), so the 27 positively-tagged singleton cases
+//!   (`WebOnt-I5.26-002`/`-005`, `WebOnt-disjointWith-003`…`-009`, each EL/QL/RL) now
+//!   extract to the atomic member and PASS — the whole `PROFILE_DIVERGENCES` pin cleared.
+//!   The arity rule is UNCHANGED for genuine ≥ 2-member intersections. (WebOnt-I5.26-001
+//!   was already removed under sq-pbz04.4.12: its anonymous singleton intersection appears
+//!   in no axiom, so the M4 fix ABSTAINS on it rather than reaching this rule.) [FABLE-5]
+//!
+//! ## Explicit-negative profile lane (sq-pbz04.4.16)
+//!
+//! A SECOND profile direction is now wired: the export's manifest-level
+//! `owl:NegativePropertyAssertion(case, test:profile, {EL|QL|RL})` triples assert a case is
+//! NOT in a profile. Each checkable such row is driven with `expect_in = false` into the
+//! SEPARATE [`gated::DL_PROFILE_NEGATIVE_REFUTED`] lane. This is HONESTLY a partial check:
+//! L2's `In` is axiom-grammar membership over the extracted ALCH shadow and cannot always
+//! refute FULL-profile membership (the profile specs' non-grammar restrictions — anonymous
+//! individuals, datatype maps, global/species constraints — are unimplemented at L2, design
+//! record §4/§5, deferred). So an `In` verdict on an explicit negation is an honest MEASURED
+//! GAP, not a soundness bug: it is pinned as a gap floor with RISE-ONLY semantics (the gap
+//! may only shrink), NEVER asserted to zero, and kept OUT of the positive lane's fail set so
+//! the positive M7-cleared floor never moves when the negative lane grows.
 //!
 //! ## Feature gating (both states)
 //!
@@ -114,7 +132,36 @@ mod gated {
     /// `tests/scoreboard_floors.rs`. A sparq EXTENSION measurement over the L1/L2
     /// fragment, NOT a W3C ProfileIdentificationTest conformance claim.
     /// [FABLE-5] sq-pbz04.4.5
-    pub const DL_PROFILE_FLOOR: usize = 68;
+    /// Re-pinned by sq-pbz04.4.16 (M7 singleton-intersection normalization): +27 (68 → 95).
+    /// The 27 pinned M7 rows (`WebOnt-I5.26-002`/`-005`, `WebOnt-disjointWith-003`…`-009`,
+    /// each EL/QL/RL) whose singleton `owl:intersectionOf ( :A )` L1 now normalizes to its
+    /// member all PASS; `PROFILE_DIVERGENCES` is now empty. [FABLE-5]
+    pub const DL_PROFILE_FLOOR: usize = 95;
+
+    /// EXPLICIT-NEGATIVE profile lane REFUTED (pass) count — checkable
+    /// `owl:NegativePropertyAssertion(case, test:profile, {EL|QL|RL})` rows the L2 checker
+    /// DEFINITIVELY refuted (`NotIn`), driven `expect_in = false`. RISE-only: a genuine new
+    /// full-profile restriction only ADDS refutations. [FABLE-5] sq-pbz04.4.16
+    pub const DL_PROFILE_NEGATIVE_REFUTED: usize = 139;
+
+    /// EXPLICIT-NEGATIVE profile lane In-GAP — checkable explicit-negation rows where L2
+    /// answered `In` (could not refute full-profile membership from axiom-grammar membership
+    /// over the ALCH shadow). An HONEST measured limitation, NOT a soundness bug; FALL-only
+    /// (the gap may only shrink as L2 grows the deferred full-profile restrictions,
+    /// sq-1ivw7-style follow-ups). The In-vs-negative gap is `IN_GAP` of
+    /// `REFUTED + IN_GAP` = 180 of 319 (improved from the pre-lane measurement 211/322 — the
+    /// M7 normalization moved the 27 singleton cases into the checkable set on BOTH sides).
+    /// [FABLE-5] sq-pbz04.4.16
+    pub const DL_PROFILE_NEGATIVE_IN_GAP: usize = 180;
+
+    /// EXPLICIT-NEGATIVE profile lane ABSTAINED — explicit-negation rows where L1 extraction
+    /// refused (out-of-fragment input), so L2 abstained (`Unknown`) rather than answering
+    /// either direction. Pinned so the tri-state accounting closes. [FABLE-5] sq-pbz04.4.16
+    pub const DL_PROFILE_NEGATIVE_ABSTAINED: usize = 615;
+
+    /// EXPLICIT-NEGATIVE profile lane OUT-OF-SCOPE — explicit-negation rows excluded at
+    /// selection (owl:imports / functional-syntax-only input). [FABLE-5] sq-pbz04.4.16
+    pub const DL_PROFILE_NEGATIVE_OUT_OF_SCOPE: usize = 74;
 
     /// DIRECT consistency/entailment lane pass count through the L4 `DirectChecker` —
     /// the MEASURED value at the pinned export snapshot, EXACT-pinned (module docs).
@@ -122,8 +169,8 @@ mod gated {
     /// `tests/scoreboard_floors.rs`. A sparq EXTENSION measurement over the scoped
     /// fragment — NOT full OWL 2 DL.
     ///
-    /// COMPOSITION: 105 consistency + 14 inconsistency + 69 positive-entailment +
-    /// 2 negative-entailment = 190. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.12/.13
+    /// COMPOSITION: 97 consistency + 14 inconsistency + 69 positive-entailment +
+    /// 2 negative-entailment = 182. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.12/.13
     /// Re-pinned by sq-pbz04.4.11 (M1 named-composite fix): +8 net.
     /// Re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix): −3 (192 → 189) — three graphs with
     /// an unconsumed anonymous composite (`WebOnt-I5.26-001`/`-006` consistency; `WebOnt-I5.5-005`
@@ -137,7 +184,20 @@ mod gated {
     /// annotation, so it is unanchored / non-rollable — its old skolem pass was coincidental
     /// and unsound for a non-trivial class). Net positive-entailment +1 (70 − 1 = 69), all
     /// four consistency/inconsistency lanes unchanged. [OPUS-4.8] sq-pbz04.4.13
-    pub const DL_DIRECT_FLOOR: usize = 190;
+    /// Re-pinned by sq-pbz04.4.16 (M7 singleton-intersection normalization): −8 (190 → 182),
+    /// ALL in the CONSISTENCY lane (105 → 97) and ALL honest fail-closed abstentions (verified:
+    /// the fail set is UNCHANGED at 5, M3/M5/M6 — never a wrong verdict). MECHANISM: `WebOnt-
+    /// disjointWith-003`…`-009` (7) and `WebOnt-I5.26-005` (1) previously carried a singleton
+    /// `owl:intersectionOf ( :A )` whose arity-1 shape put them OUT of every profile, routing
+    /// consistency to the ALCH tableau (a definitive `Consistent`). The M7 normalization
+    /// collapses those singletons to their member, so the graphs are now correctly IN-RL and
+    /// dispatch routes them to the RL branch — which fail-closed ABSTAINS via the documented
+    /// `RlDivergenceGuard("owl:disjointWith")` (RL rule-set incompleteness on disjointness, the
+    /// DisjointClasses-001/-003 divergences), because "no clash" does not certify consistency
+    /// there. Honest routing to a guarded branch, not a lost capability — the tableau would
+    /// still decide these if reached; graduating them back is a deliberate future re-pin once
+    /// the RL divergence guard is narrowed or a tableau fallback is added. [FABLE-5]
+    pub const DL_DIRECT_FLOOR: usize = 182;
 
     /// Abstained (fail-closed OutOfFragment / guard / deferred / budget) row totals,
     /// EXACT-pinned so the tri-state accounting is closed: profile lane, then the four
@@ -164,7 +224,12 @@ mod gated {
     /// free-existential-root conclusion bnode of `WebOnt-AnnotationProperty-002` shifts from a
     /// (coincidental) Pass to a fail-closed `ConclusionAnonymousIndividual` abstention; the two
     /// graduated M2 cases move Fail → Pass (they never counted as abstentions). [OPUS-4.8]
-    pub const DL_DIRECT_ABSTAINED: usize = 464;
+    /// Re-pinned by sq-pbz04.4.16 (M7 singleton-intersection normalization): +8 (464 → 472).
+    /// The 8 consistency cases (`WebOnt-disjointWith-003`…`-009`, `WebOnt-I5.26-005`) that the
+    /// M7 fix re-routes from the ALCH tableau (Pass) to the RL branch move to a fail-closed
+    /// `RlDivergenceGuard("owl:disjointWith")` abstention — see [`DL_DIRECT_FLOOR`] for the full
+    /// mechanism (honest routing to a guarded branch, never a wrong verdict). [FABLE-5]
+    pub const DL_DIRECT_ABSTAINED: usize = 472;
 
     /// Audited, PINNED divergence rows (module docs — mechanisms M3/M5/M6): every row
     /// where a checker verdict contradicts the export expectation, keyed by the
@@ -216,45 +281,17 @@ mod gated {
         ),
     ];
 
-    /// PINNED profile-lane divergence rows (positive tags where L2 answers `NotIn`) —
-    /// same exact-set discipline as [`DOCUMENTED_DIVERGENCES`]. All 30 are ONE audited
-    /// mechanism (M7 in the module docs): the OWL-1-era singleton
-    /// `owl:intersectionOf ( :A )` encoding — `_:B owl:intersectionOf` with a
-    /// one-member list — which the export tags in-EL/QL/RL but L2's structural-spec
-    /// arity rule (≥ 2 members) rejects. [FABLE-5] sq-pbz04.4.5
-    const PROFILE_DIVERGENCES: &[(&str, &str)] = &[
-        // WebOnt-I5.26-001 (EL/QL/RL) REMOVED by sq-pbz04.4.12: its input carries an anonymous
-        // `owl:intersectionOf` that appears in no axiom, so the M4 orphan fix now makes
-        // extraction refuse it → the profile set is `Unknown` → the row ABSTAINS rather than
-        // producing the wrong `NotIn` (the M7 singleton divergence no longer applies). [OPUS-4.8]
-        ("owl2-dl/profile-EL: WebOnt-I5.26-002", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-I5.26-002", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-I5.26-002", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-I5.26-005", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-I5.26-005", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-I5.26-005", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-003", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-003", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-003", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-004", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-004", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-004", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-005", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-005", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-005", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-006", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-006", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-006", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-007", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-007", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-007", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-008", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-008", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-008", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-EL: WebOnt-disjointWith-009", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-QL: WebOnt-disjointWith-009", "M7 — singleton owl:intersectionOf operand list"),
-        ("owl2-dl/profile-RL: WebOnt-disjointWith-009", "M7 — singleton owl:intersectionOf operand list"),
-    ];
+    /// PINNED positive-profile divergence rows (positive tags where L2 answers `NotIn`) —
+    /// same exact-set discipline as [`DOCUMENTED_DIVERGENCES`]. NOW EMPTY: the single
+    /// audited mechanism (M7 — the OWL-1-era singleton `owl:intersectionOf ( :A )` encoding
+    /// L2's ≥ 2-member arity rule rejected) was FIXED by sq-pbz04.4.16 (L1 now normalizes a
+    /// 1-ary intersection to its sole member, model-preservingly), so all 27 rows
+    /// (`WebOnt-I5.26-002`/`-005`, `WebOnt-disjointWith-003`…`-009`, each EL/QL/RL) now PASS
+    /// and `DL_PROFILE_FLOOR` rose 68 → 95. `WebOnt-I5.26-001` had already been removed by
+    /// sq-pbz04.4.12 (its anonymous singleton appears in no axiom → the M4 orphan fix
+    /// ABSTAINS, never reaching the arity rule). The exact-set assertion keeps the lane
+    /// RED if any future regression re-introduces a positive-tag `NotIn`. [FABLE-5]
+    const PROFILE_DIVERGENCES: &[(&str, &str)] = &[];
 
     /// Locate the OWL WG export the same way the inference binary + el-suite lane do.
     fn owl_export() -> PathBuf {
@@ -367,6 +404,53 @@ mod gated {
                 + report.profile.fails.len()
                 + report.profile.out_of_fragment_total()
                 + report.profile.out_of_scope_total()
+        );
+
+        // ---- Explicit-negative profile lane (sq-pbz04.4.16) ----------------------------
+        // These are EXACT-pinned MEASUREMENTS of the explicit-negation direction (module
+        // docs). REFUTED (pass) is rise-only; the In-GAP is the honest L2 limitation and is
+        // fall-only (it shrinks as L2 grows the deferred full-profile restrictions — never
+        // rises without an unaudited regression). Both go RED on ANY move so a change is a
+        // deliberate re-pin, exactly like the positive floors.
+        println!(
+            "OWL 2 DL profile explicit-negative lane: refuted {} of {} checkable (In-gap {}), abstained {}",
+            report.profile_negative.pass,
+            report.profile_negative.pass + report.profile_negative.fails.len(),
+            report.profile_negative.fails.len(),
+            report.profile_negative.out_of_fragment_total()
+        );
+        assert_eq!(
+            report.profile_negative.pass, DL_PROFILE_NEGATIVE_REFUTED,
+            "negative-lane REFUTED count moved (got {}, pinned {}) — re-pin \
+             DL_PROFILE_NEGATIVE_REFUTED deliberately with evidence (rise-only)",
+            report.profile_negative.pass, DL_PROFILE_NEGATIVE_REFUTED
+        );
+        assert_eq!(
+            report.profile_negative.fails.len(),
+            DL_PROFILE_NEGATIVE_IN_GAP,
+            "negative-lane In-GAP moved (got {}, pinned {}) — the gap is fall-only; a RISE is \
+             an unaudited regression, a FALL is a deliberate re-pin when L2 grows a sound \
+             full-profile restriction",
+            report.profile_negative.fails.len(),
+            DL_PROFILE_NEGATIVE_IN_GAP
+        );
+        assert_eq!(
+            report.profile_negative.out_of_fragment_total(),
+            DL_PROFILE_NEGATIVE_ABSTAINED,
+            "negative-lane abstention total moved — the tri-state accounting is pinned"
+        );
+        assert_eq!(
+            report.profile_negative.out_of_scope_total(),
+            DL_PROFILE_NEGATIVE_OUT_OF_SCOPE,
+            "negative-lane out-of-scope total moved — the tri-state accounting is pinned"
+        );
+        // Closed accounting for the negative lane too.
+        assert_eq!(
+            report.profile_negative.total(),
+            report.profile_negative.pass
+                + report.profile_negative.fails.len()
+                + report.profile_negative.out_of_fragment_total()
+                + report.profile_negative.out_of_scope_total()
         );
     }
 

--- a/crates/sparq-reason-dl/src/extract.rs
+++ b/crates/sparq-reason-dl/src/extract.rs
@@ -810,8 +810,20 @@ fn decode_class_inner(
     }
     let result = if is_inter {
         let head = idx.intersection_of[&id];
-        decode_class_list(dict, v, idx, head, visiting, depth)
-            .map(ClassExpression::ObjectIntersectionOf)
+        // [FABLE-5] sq-pbz04.4.16 — singleton `owl:intersectionOf` normalization (M7).
+        // The OWL-1-era RDF encoding `_:B owl:intersectionOf ( :A )` — a one-member operand
+        // list — denotes the class `⊓{A}`, whose Direct-Semantics interpretation is EXACTLY
+        // that of its sole member `A` (OWL 2 Structural Specification §8.1: the extension of a
+        // 1-ary ObjectIntersectionOf is the intersection of the single conjunct's extension,
+        // i.e. the conjunct itself). The official test-suite tagging normalizes this singleton
+        // to its member before profile-checking, so `_:B owl:intersectionOf ( :A )` is tagged
+        // in EL/QL/RL. L2's structural-spec arity rule (≥ 2 members) would otherwise reject it
+        // as `NotIn`. Normalizing HERE — at L1 extraction, model-preservingly — makes the
+        // downstream profile checker AND the tableau see the equivalent atomic member, so the
+        // 27 pinned M7 profile divergences resolve without weakening the arity rule for genuine
+        // ≥ 2-member intersections. `decode_class_list` guarantees a non-empty list (an empty
+        // one is `MalformedList`), so a 1-element result is the only singleton case.
+        decode_class_list(dict, v, idx, head, visiting, depth).map(normalize_intersection)
     } else if is_union {
         let head = idx.union_of[&id];
         decode_class_list(dict, v, idx, head, visiting, depth).map(ClassExpression::ObjectUnionOf)
@@ -861,6 +873,28 @@ fn decode_restriction(
             "restriction {} missing its someValuesFrom/allValuesFrom filler",
             term_iri(dict, id)
         ))),
+    }
+}
+
+/// Normalize a decoded `owl:intersectionOf` operand list into a class expression, collapsing
+/// the OWL-1-era SINGLETON encoding `⊓{A}` to its sole member `A` (M7, sq-pbz04.4.16).
+///
+/// A one-member `ObjectIntersectionOf` has, under OWL 2 Direct Semantics, exactly the
+/// interpretation of its single conjunct (OWL 2 Structural Specification §8.1), so returning
+/// the member directly is MODEL-PRESERVING. The official OWL WG profile tagging performs this
+/// same normalization before deciding EL/QL/RL membership; without it, L2's structural-spec
+/// arity rule (≥ 2 members) would spuriously reject these positively-tagged cases as `NotIn`.
+///
+/// `members` is always non-empty ([`decode_class_list`] refuses an empty operand list with
+/// `MalformedList`), so the only singleton case is `len == 1`. A ≥ 2-member list is wrapped
+/// unchanged in `ObjectIntersectionOf`, preserving the arity rule for genuine intersections.
+fn normalize_intersection(members: Vec<ClassExpression>) -> ClassExpression {
+    let mut members = members;
+    if members.len() == 1 {
+        // `swap_remove(0)` moves the sole member out without a clone; the vec is discarded.
+        members.swap_remove(0)
+    } else {
+        ClassExpression::ObjectIntersectionOf(members)
     }
 }
 
@@ -1493,5 +1527,74 @@ mod tests {
         assert!(!is_triple_term(&dict, s));
         assert!(term_iri(&dict, s).contains("ex/s"));
         assert!(term_iri(&dict, lit).contains("lit"));
+    }
+
+    /// Direct unit test of `normalize_intersection` (sq-pbz04.4.16 / M7): a one-member
+    /// operand list collapses to its sole member; a ≥ 2-member list is preserved as an
+    /// `ObjectIntersectionOf`, keeping the profile-grammar arity rule intact.
+    #[test]
+    fn normalize_intersection_collapses_singleton_only() {
+        // Singleton → the member itself (using dict-free synthetic ids for the members).
+        let a = ClassExpression::Class(7);
+        assert_eq!(normalize_intersection(vec![a.clone()]), a);
+        // Two members → preserved as an intersection (arity rule unaffected).
+        let b = ClassExpression::Class(9);
+        let two = normalize_intersection(vec![a.clone(), b.clone()]);
+        assert_eq!(two, ClassExpression::ObjectIntersectionOf(vec![a, b]));
+    }
+
+    /// End-to-end M7: the OWL-1-era singleton encoding `_:B owl:intersectionOf ( :A )` used
+    /// as a subClassOf super-CE extracts to the atomic member `Class(A)` — NOT a 1-ary
+    /// `ObjectIntersectionOf` the profile-grammar arity rule would reject (sq-pbz04.4.16).
+    /// A genuine 2-member intersection still extracts as an `ObjectIntersectionOf`.
+    #[test]
+    fn extract_singleton_intersection_normalizes_to_member() {
+        // `:S rdfs:subClassOf [ owl:intersectionOf ( :A ) ]`.
+        let (dict, triples) = Graph::parse_to_triples(
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n\
+             @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+             <http://ex/S> rdfs:subClassOf [ owl:intersectionOf ( <http://ex/A> ) ] .",
+            "turtle",
+        )
+        .expect("parse");
+        let onto = extract(&dict, &triples).expect("accept");
+        let sup = onto
+            .axioms
+            .iter()
+            .find_map(|ax| match ax {
+                Axiom::SubClassOf { sup, .. } => Some(sup),
+                _ => None,
+            })
+            .expect("a SubClassOf axiom");
+        // The singleton intersection collapsed to the atomic member (never a 1-ary
+        // ObjectIntersectionOf).
+        assert!(
+            matches!(sup, ClassExpression::Class(_)),
+            "singleton intersection should normalize to its member, got {:?}",
+            sup
+        );
+
+        // A genuine 2-member intersection is preserved.
+        let (dict, triples) = Graph::parse_to_triples(
+            "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n\
+             @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+             <http://ex/S> rdfs:subClassOf [ owl:intersectionOf ( <http://ex/A> <http://ex/B> ) ] .",
+            "turtle",
+        )
+        .expect("parse");
+        let onto = extract(&dict, &triples).expect("accept");
+        let sup = onto
+            .axioms
+            .iter()
+            .find_map(|ax| match ax {
+                Axiom::SubClassOf { sup, .. } => Some(sup),
+                _ => None,
+            })
+            .expect("a SubClassOf axiom");
+        assert!(
+            matches!(sup, ClassExpression::ObjectIntersectionOf(m) if m.len() == 2),
+            "2-member intersection should be preserved, got {:?}",
+            sup
+        );
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]. Bead **sq-pbz04.4.16** (epic sq-pbz04.4 — OWL 2 Direct-Semantics arm). Two L2 follow-ups from the sq-pbz04.4.5 conformance arm, behind the opt-in `dl-direct` feature (OFF by default; forwards to `sparq-reason-dl/dispatch`). Do NOT arm — awaiting review.

## (1) M7 — singleton `owl:intersectionOf` normalization (30 pinned M7 divergences → cleared)

The OWL-1-era RDF encoding `_:B owl:intersectionOf ( :A )` (a one-member operand list) denotes `⊓{A}`, whose OWL 2 **Direct-Semantics** interpretation is *exactly* its sole member `A` (Structural Specification §8.1). The official OWL WG test-suite tagging normalizes this singleton before deciding profile membership, so it is tagged in EL/QL/RL — but L2's structural-spec arity rule (≥ 2 members) rejected it as `NotIn` (mechanism **M7**).

`extract()` now performs the same **model-preserving** normalization at L1: a 1-ary `ObjectIntersectionOf` collapses to its member; a ≥ 2-member intersection is **unchanged**, so the arity rule stays intact for genuine intersections.

**Result:** all **27** pinned M7 positive-profile divergences (`WebOnt-I5.26-002`/`-005`, `WebOnt-disjointWith-003`…`-009`, each EL/QL/RL) now **PASS** — `PROFILE_DIVERGENCES` is empty and `DL_PROFILE_FLOOR` rises **68 → 95**. (The pin held 27 after sq-pbz04.4.12 removed `WebOnt-I5.26-001`, whose anonymous singleton appears in no axiom and abstains via the M4 orphan fix — never reaching the arity rule.)

### Honest reasoning-lane consequence (verified, documented, NEVER a wrong verdict)

8 consistency cases (`WebOnt-disjointWith-003`…`-009`, `WebOnt-I5.26-005`) were previously out-of-profile by their arity-1 shape, so consistency dispatched to the ALCH tableau (a definitive `Consistent`). After normalization they are correctly **in-RL**, so dispatch routes them to the RL branch — which **fail-closed abstains** via the documented `RlDivergenceGuard("owl:disjointWith")` (RL rule-set incompleteness on disjointness; DisjointClasses-001/-003). Verified by branch/verdict diagnostic: all 8 → `RlDivergenceGuard`, and the **fail set is UNCHANGED at 5 (M3/M5/M6)**. `DL_DIRECT_FLOOR` re-pinned **190 → 182** (all in the consistency lane, 105 → 97) and `DL_DIRECT_ABSTAINED` **464 → 472**, deliberately with the mechanism documented. Honest routing to a guarded branch, not a lost capability — graduating them back is a deliberate future re-pin once the RL guard is narrowed or a tableau fallback added (bead below).

## (2) Explicit-negative profile lane — measured In-vs-negative gap

The export's manifest-level `owl:NegativePropertyAssertion(case, test:profile, {EL|QL|RL})` triples are now wired as explicit-negation expectations (driven `expect_in = false`) into a **separate** `DlReport::profile_negative` lane. This unlocks the negative direction the module docs' measurement had deferred.

**Honest measured In-vs-negative gap: `180` of `319` checkable (refuted `139`)** — improved from the pre-lane baseline **211/322** (the M7 normalization moved the 27 singleton cases into the checkable set on both sides). An `In` verdict on a negation is the honest L2 limitation — axiom-grammar membership over the extracted ALCH shadow cannot refute FULL-profile membership (the profile specs' non-grammar restrictions — anonymous individuals, datatype maps, global/species constraints — are unimplemented at L2, design record §4/§5, **deferred**). It is pinned as a **FALL-only gap floor** (the gap may only shrink), never asserted to zero, and kept **out of the positive lane's fail set** so the positive floor never moves when the negative lane grows.

## Gates — GREEN in BOTH feature states (default OFF + `dl-direct` ON)

- `cargo clippy --workspace --all-targets -- -D warnings` (default) and `-p sparq-conformance --features dl-direct` — clean.
- `cargo test -p sparq-reason-dl` (both states) — 18/71/41/25/1 green incl. new direct tests.
- `dl_suite` ratchet (feature ON) — **2 passed**: `dl_direct_arm_ratchet` (profile 95, direct 182, negative 139/180/615/74) + `dl_entailment_derivation_canary`.
- `scoreboard_floors` textual guard — **4 passed** (DL_PROFILE_FLOOR=95, DL_DIRECT_FLOOR=182 synced to `scoreboard::SUITES`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (new doc comments use code spans, not intra-doc links, to avoid the feature-gated-link trap).
- New direct unit tests: `normalize_intersection_collapses_singleton_only`, `extract_singleton_intersection_normalizes_to_member`, `collect_profile_negations_filters_and_dedups`.

## Scope discipline

Only DL-module files: `sparq-reason-dl/src/extract.rs`, `sparq-conformance/src/inference/dl_suite.rs`, `tests/dl_suite.rs`, `src/scoreboard.rs`. No skills/README edits; D-entailment (dtype.rs) and RIF areas untouched (parallel-agent-owned).

## Follow-ups (captured as beads)

1. **Sound full-profile restrictions to shrink the 180/319 negative In-gap** — the deferred non-grammar profile restrictions (RDF-Based cases, `owl:Thing`/`owl:Nothing` typing, equivalentClass reflexivity, datatype maps, anonymous individuals, global/species constraints). Each must never flip a positive-tagged case to `NotIn`.
2. **Narrow the RL divergence guard / add an ALCH tableau fallback** so the 8 `disjointWith` consistency cases can graduate back from the guard abstention to definitive `Consistent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)