### PR TITLE
docs(reason): RIF-Core and D-entailment documentation

### DIFF
--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -37,11 +37,12 @@ let g = Graph::from_parts(dict, triples);
 - **OWL 2 RL** — property/class axioms over the same fixpoint engine; use `sparq-reason-el`
   for complete class classification.
 - **D-entailment** (opt-in `d-entail`) — `Profile::D`: rdfD1 datatype-typing rule under a
-  recognized 23-XSD-datatype map (string, boolean, 12 integer types, decimal, double, float,
-  date/dateTime/dateTimeStamp, language, anyURI, hexBinary/base64Binary) with **correct
-  typed value-space equality** (`"1"^^xsd:integer` = `"1.0"^^xsd:decimal`, never f64).
-  Fail-closed: unmapped datatypes/facet-invalid literals rejected; `xsd:time`, durations,
-  XML datatypes deferred.
+  recognized 30-XSD-datatype map (string/normalizedString/token + the
+  language/Name/NCName/NMTOKEN pattern-restricted types, boolean, 13 integer types, decimal,
+  double, float, date/dateTime/dateTimeStamp, anyURI, hexBinary/base64Binary; plus always-on
+  `rdf:langString`) with **correct typed value-space equality** (`"1"^^xsd:integer` =
+  `"1.0"^^xsd:decimal`, never f64). Fail-closed: unmapped datatypes/facet-invalid literals
+  rejected; `xsd:time`, durations, XML datatypes deferred.
 - **Notation3** — user-supplied `{ … } => { … }` rules with EYE-validated builtins.
 - **RIF-Core** (opt-in `rif-core`) — W3C RIF **Core** dialect (monotone Horn subset of
   RIF-BLD/PRD) as `rif::Document` over the N3 chainer. Atoms: frame/membership/subclass

--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -34,26 +34,21 @@ let g = Graph::from_parts(dict, triples);
 ## ✨ Features
 
 - **RDFS entailment** — the non-explosive subset (rdfs2/3/5/7/9/11), materialized in one pass.
-- **OWL 2 RL** — property/class axioms (`sameAs`, `inverseOf`, Transitive / Symmetric,
-  `equivalentClass` / `equivalentProperty`, …) over the same fixpoint engine. Complete for the
-  assertion-style RL/RDF rules (W3C OWL-RL conformance row is at the profile ceiling — the
-  documented divergences are conclusions provably outside RL, not missing rules); use
-  `sparq-reason-el` for complete class classification.
-- **D-entailment** (opt-in `d-entail`) — `Profile::D`: the rdfD1 datatype-typing rule under
-  a recognized datatype map, with **correct typed value-space equality**
-  (`"1"^^xsd:integer` is the same value as `"1.0"^^xsd:decimal`, never an f64 fast path).
-- **Notation3** — `{ … } => { … }` rules with EYE-validated builtins (a separate subsystem).
-- **RIF-Core** (opt-in `rif-core`) — the W3C RIF **Core** dialect (the **monotone Horn**
-  common subset of RIF-BLD/PRD) as a `rif::Document` rule front-end over the N3 chainer:
-  frame/membership/subclass atoms + numeric/string/list builtins with **range-restriction
-  safety** enforced (unsafe rules are rejected, never looped). **Equal-atom semantics
-  (sq-pbz04.5.4 + sq-26vwp):** Equal in a rule head is rejected (Core syntactic restriction);
-  body Equal is resolved at **compile time by substitution/unification** (not an `owl:sameAs`
-  triple) — `t=t` eliminated, `?x=t` substituted (binds `?x`), `?x=?y` unified — so same-node
-  reflexivity fires without a `sameAs` assertion and an asserted `sameAs` never over-derives;
-  distinct **ground** constants stay rejected fail-closed pending the value-space comparator
-  (sq-v5evr/#1646). **Monotone, NAF excluded by design.** Full RIF-BLD/PRD + the SPARQL-RIF
-  entailment regime are documented out-of-scope (`rif::UNIMPLEMENTED`), not faked.
+- **OWL 2 RL** — property/class axioms over the same fixpoint engine; use `sparq-reason-el`
+  for complete class classification.
+- **D-entailment** (opt-in `d-entail`) — `Profile::D`: rdfD1 datatype-typing rule under a
+  recognized 23-XSD-datatype map (string, boolean, 12 integer types, decimal, double, float,
+  date/dateTime/dateTimeStamp, language, anyURI, hexBinary/base64Binary) with **correct
+  typed value-space equality** (`"1"^^xsd:integer` = `"1.0"^^xsd:decimal`, never f64).
+  Fail-closed: unmapped datatypes/facet-invalid literals rejected; `xsd:time`, durations,
+  XML datatypes deferred.
+- **Notation3** — user-supplied `{ … } => { … }` rules with EYE-validated builtins.
+- **RIF-Core** (opt-in `rif-core`) — W3C RIF **Core** dialect (monotone Horn subset of
+  RIF-BLD/PRD) as `rif::Document` over the N3 chainer. Atoms: frame/membership/subclass
+  plus numeric/string/list builtins. **Range-restriction safety enforced** (unsafe rules
+  rejected). **Body `Equal` resolved at compile time** (substitution/unification, not
+  `owl:sameAs` triples); Equal in heads rejected. Distinct ground constants fail-closed
+  pending value-space comparator. SPARQL-RIF entailment and larger RIF dialects deferred.
 - **Incremental maintenance** — `MaterializedGraph` keeps the closure current under
   inserts/deletes by exact derivation counting; cost scales with the change, not a re-run.
 - **Proof trees** (`explain` feature) — `why(triple)` returns which rule fired from which

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -173,12 +173,12 @@ let _entailed: Vec<[sparq_core::dict::Id;3]> = doc.closure(&mut dict)?;  // mono
 
 ## D-entailment datatype typing (opt-in `d-entail` feature, `sparq_reason::dtype`)
 
-The RDF 1.1 Semantics D-entailment regime materializes the **rdfD1 datatype-typing rule**: a well-formed literal of a recognized datatype `d` entails a typing triple. `materialize(Profile::D, …)` adds the recognized 23-XSD-datatype map via `Recognized::standard()` (or bring a custom map via `materialize_d(d, …, …)`):
+The RDF 1.1 Semantics D-entailment regime materializes the **rdfD1 datatype-typing rule**: a well-formed literal of a recognized datatype `d` entails a typing triple. `materialize(Profile::D, …)` adds the recognized 30-XSD-datatype map via `Recognized::standard()` — the `DTYPE_TABLE` single source of truth in `dtype.rs` — plus the always-recognized `rdf:langString` (or bring a custom map via `materialize_d(d, …, …)`):
 
 **Supported datatypes** (complete signed/unsigned integer family, exact decimals/temporal):
 - String family: `xsd:string`, `xsd:normalizedString`, `xsd:token`; pattern-restricted derived types `xsd:language`, `xsd:Name`, `xsd:NCName`, `xsd:NMTOKEN`.
 - Boolean: `xsd:boolean`.
-- Integer family (all 12 XSD types): `xsd:integer`, `xsd:long`/`xsd:int`/`xsd:short`/`xsd:byte` (signed); `xsd:unsignedLong`/`xsd:unsignedInt`/`xsd:unsignedShort`/`xsd:unsignedByte` (unsigned); `xsd:nonNegativeInteger`/`xsd:positiveInteger`/`xsd:nonPositiveInteger`/`xsd:negativeInteger` (restricted).
+- Integer family (13 XSD types — `xsd:integer` + 12 derived): `xsd:long`/`xsd:int`/`xsd:short`/`xsd:byte` (signed); `xsd:unsignedLong`/`xsd:unsignedInt`/`xsd:unsignedShort`/`xsd:unsignedByte` (unsigned); `xsd:nonNegativeInteger`/`xsd:positiveInteger`/`xsd:nonPositiveInteger`/`xsd:negativeInteger` (restricted).
 - Numeric: `xsd:decimal` (exact, unbounded magnitude via canonical-decimal STRING comparison, never f64), `xsd:double`, `xsd:float` (IEEE 754, distinct value spaces).
 - Temporal: `xsd:dateTime`, `xsd:dateTimeStamp`, `xsd:date`.
 - URI: `xsd:anyURI`.

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -171,6 +171,23 @@ let _entailed: Vec<[sparq_core::dict::Id;3]> = doc.closure(&mut dict)?;  // mono
   and malformed XML each produce a named `ImportError` variant. Parsing only — no new inference
   beyond the existing `rif-core` forward chainer. Unblocks sq-pbz04.5.5 (W3C RIF WG test-suite arm).
 
+## D-entailment datatype typing (opt-in `d-entail` feature, `sparq_reason::dtype`)
+
+The RDF 1.1 Semantics D-entailment regime materializes the **rdfD1 datatype-typing rule**: a well-formed literal of a recognized datatype `d` entails a typing triple. `materialize(Profile::D, …)` adds the recognized 23-XSD-datatype map via `Recognized::standard()` (or bring a custom map via `materialize_d(d, …, …)`):
+
+**Supported datatypes** (complete signed/unsigned integer family, exact decimals/temporal):
+- String family: `xsd:string`, `xsd:normalizedString`, `xsd:token`; pattern-restricted derived types `xsd:language`, `xsd:Name`, `xsd:NCName`, `xsd:NMTOKEN`.
+- Boolean: `xsd:boolean`.
+- Integer family (all 12 XSD types): `xsd:integer`, `xsd:long`/`xsd:int`/`xsd:short`/`xsd:byte` (signed); `xsd:unsignedLong`/`xsd:unsignedInt`/`xsd:unsignedShort`/`xsd:unsignedByte` (unsigned); `xsd:nonNegativeInteger`/`xsd:positiveInteger`/`xsd:nonPositiveInteger`/`xsd:negativeInteger` (restricted).
+- Numeric: `xsd:decimal` (exact, unbounded magnitude via canonical-decimal STRING comparison, never f64), `xsd:double`, `xsd:float` (IEEE 754, distinct value spaces).
+- Temporal: `xsd:dateTime`, `xsd:dateTimeStamp`, `xsd:date`.
+- URI: `xsd:anyURI`.
+- Binary: `xsd:hexBinary`, `xsd:base64Binary` (shared octet-sequence value space).
+
+**Value-space equality (the load-bearing invariant):** `"1"^^xsd:integer` and `"1.0"^^xsd:decimal` denote THE SAME value and must compare equal in D-entailment. Integer/decimal are compared as a canonical-decimal STRING (sign + minimal integer/fraction digits), NEVER via f64 (which aliases integers past 2^53 and loses decimal precision — silent bugs in semantic equality). `xsd:float`/`xsd:double` are IEEE value spaces; `xsd:date` and `xsd:dateTime` are disjoint temporal families (even at the same instant).
+
+**Fail-closed posture:** unmapped datatypes are not typed; facet-invalid literals (`"200"^^xsd:byte`, `" a"^^xsd:token`) are rejected before value mapping; `xsd:time`, duration types, and XML datatypes (`rdf:XMLLiteral`) are deferred — tracked in the design record (`research/d-entailment-datatype-map.md` §3.2), never silently mapped. The `Recognized::default()` set carries ONLY the always-recognized `xsd:string` / `rdf:langString` pair — safe to materialize over arbitrary data.
+
 ## OWL 2 EL classification (`sparq-reason-el`, separate opt-in crate)
 
 OWL 2 RL is **sound but silently incomplete for class classification**: it has no rule that reasons *through* an existential successor, so `--reason owl` over an EL ontology (GO/ChEBI/SNOMED-style) returns a `rdfs:subClassOf` hierarchy that **silently omits** subsumptions like `A ⊑ D` from `A ⊑ ∃r.B`, `B ⊑ C`, `∃r.C ⊑ D` (Krötzsch, ISWC 2012). **`sparq-reason-el`** closes that gap — a consequence-based classifier that normalizes the TBox (Baader–Brandt–Lutz forms) and saturates `S(C)`/`R(r)` under completion rules **CR1–CR5** to compute the **complete** subsumption lattice, then emits it into the **same** `(Dict, Vec<[Id;3]>)` seam as the RL `scm-*` rules (queryable by plain BGP eval).


### PR DESCRIPTION
> 🤖 SPARQ agent [HAIKU-4.5]

Implements beads **sq-pbz04.5.6** + **sq-pbz04.6.5** together (they share files).

## Summary

- **sq-pbz04.5.6 (RIF docs):** Documents RIF-Core monotone-Horn front-end over N3 chainer. Covers accepted safety class (range-restriction, Datalog safety), the RIF→N3 lowering boundary, builtin deferral ledger, and Equal-atom compile-time semantics (substitution/unification, not `owl:sameAs` triples). Includes rif-core/rif-xml feature flags, rif::Document API surface, and honest scope (RIF-Core subset; SPARQL-RIF entailment regime out-of-scope).

- **sq-pbz04.6.5 (D-entailment docs):** Documents rdfD1 datatype-typing rule under the **30-XSD** recognized-datatype map (7 string-family + boolean + 13 integer + decimal/double/float + date/dateTime/dateTimeStamp + anyURI + hexBinary/base64Binary; plus always-on `rdf:langString`). Emphasizes value-space equality distinction (canonical-decimal STRING, never f64; IEEE float/double disjoint; date/dateTime temporal families). Includes fail-closed posture (unmapped/facet-invalid literals rejected) and deferral ledger (xsd:time, durations, XML datatypes tracked as deferred).

## Changes

1. **crates/sparq-reason/README.md** (96 lines, under the 120-line readme-template gate):
   - Tightened D-entailment and RIF-Core bullets with key detail (30 XSD types, range-restriction enforcement, body-Equal compile-time semantics)
   - Preserved load-bearing honesty: fail-closed behavior, deferred features explicitly named

2. **skills/inference/SKILL.md** (new D-entailment section after RIF):
   - Added full D-entailment section: supported datatypes, value-space equality caveat, fail-closed posture
   - Cross-referenced design record for deferral ledger
   - Preserved existing RIF-Core section (already comprehensive)

## Verification

- ✅ `scripts/check-readme-template.py --enforce`: 0 deviations (README 96 lines)
- ✅ `npx markdownlint-cli2 *.md`: 0 errors on both files
- ✅ `typos` clean
- ✅ `cargo doc -p sparq-reason --all-features`: rustdoc green (feature-gated items as code spans)
- ✅ Grep verification:
  - `rif-core`, `rif-xml`, `d-entail` features in `Cargo.toml`
  - Builtins (`NumericAdd`, `StringConcat`, `ListLength`) in `rif.rs`
  - Datatypes (`hexBinary`, `base64Binary`, `anyURI`) in `dtype.rs`; **30 rows in DTYPE_TABLE** (category sum 7+1+13+3+3+1+2 = 30)

## Note (post-open fix)

Mechanical-verify caught an initial miscount ("23-XSD-datatype map") — the "23" was the design record's *pre-broadening* `Recognized::standard()` snapshot, stale vs the merged D2-broadened code (30 datatypes). Corrected in `3ff4fce21`.

Beads depend on completed upstream: sq-pbz04.5.2/.3/.4 (RIF), sq-pbz04.6.3/.4 (D-entailment).

🤖 Claude Fable 5 (Haiku 4.5)