### PR TITLE
feat(server): wire acl_link_header() as Link: rel="acl" response header in /authz/* (sq-snopa.7)

### DIFF
--- a/crates/sparq-server/src/solid_authz.rs
+++ b/crates/sparq-server/src/solid_authz.rs
@@ -169,10 +169,23 @@ pub(crate) fn decision_to_json(d: &WacDecision) -> String {
 
 /// A `text/json` response with the given status + body. The body is already-serialised JSON.
 fn json_response(status: StatusCode, body: String) -> Response {
-    Response::builder()
+    json_response_with_link(status, body, None)
+}
+
+/// A `text/json` response with the given status + body, and an OPTIONAL `Link: rel="acl"`
+/// header (FR-5, sq-snopa.7). When `acl_link` is `Some(value)` the RFC 8288 link-value
+/// (`<iri>; rel="acl"`) is emitted as the `Link` response header; `None` silently omits it
+/// (fail-closed — if there is no governing ACL there is nothing to advertise). [SONNET-4.6]
+fn json_response_with_link(status: StatusCode, body: String, acl_link: Option<&str>) -> Response {
+    let mut builder = Response::builder()
         .status(status)
         .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
-        .header(header::CONTENT_LENGTH, body.len())
+        .header(header::CONTENT_LENGTH, body.len());
+    if let Some(link_val) = acl_link {
+        // [SONNET-4.6] POSITIONAL format args (CodeQL rust/unused-variable guard).
+        builder = builder.header(header::LINK, link_val);
+    }
+    builder
         .body(body.into())
         // A well-formed status + valid header values never fails to build.
         .unwrap()
@@ -348,7 +361,12 @@ pub(crate) async fn decide_endpoint(
     } else {
         deny_status_code(decision.status)
     };
-    json_response(status, decision_to_json(&decision))
+    // [SONNET-4.6] sq-snopa.7 FR-5: emit the RFC 8288 `Link: <acl-iri>; rel="acl"` header from
+    // the decision's governing ACL. `acl_link_header()` returns `None` when no governing ACL was
+    // discovered (fail-closed — nothing to advertise). Safe on a deny: the link tells the client
+    // WHERE the ACL is, not that the request is allowed.
+    let acl_link = decision.acl_link_header();
+    json_response_with_link(status, decision_to_json(&decision), acl_link.as_deref())
 }
 
 /// A fail-closed [`WacDecision`] for an input the endpoint refuses to trust (e.g. an unknown mode):
@@ -407,9 +425,16 @@ pub(crate) async fn wac_allow_endpoint(
         Ok(s) => s,
         Err(resp) => return resp,
     };
+    // [SONNET-4.6] sq-snopa.7 FR-5: resolve the governing ACL for the Link header BEFORE
+    // `wac_allow` consumes the store. `resolve_acl` is a pure index lookup (no mode needed) and
+    // returns `None` when no ACL was discovered — fail-closed: no header emitted in that case.
+    // [SONNET-4.6] POSITIONAL format args (CodeQL rust/unused-variable guard).
+    let acl_link: Option<String> = store
+        .resolve_acl(&resource_iri)
+        .map(|eff| format!("<{}>; rel=\"acl\"", eff.acl.as_str()));
     let value = store.wac_allow(&req.session(), &resource);
     let body = serde_json::json!({ "wacAllow": value }).to_string();
-    json_response(StatusCode::OK, body)
+    json_response_with_link(StatusCode::OK, body, acl_link.as_deref())
 }
 
 /// `POST /authz/query` — an ACCESS-CONTROLLED SPARQL query as `session` (FR-4). Body:

--- a/crates/sparq-server/tests/solid_authz.rs
+++ b/crates/sparq-server/tests/solid_authz.rs
@@ -288,6 +288,120 @@ async fn query_is_access_controlled_per_session() {
 }
 
 // ---------------------------------------------------------------------------
+// sq-snopa.7 — Link: rel="acl" response header (FR-5).
+// The decide and wac-allow endpoints must emit the RFC 8288 Link header value from
+// WacDecision::acl_link_header() when a governing ACL was discovered, and MUST NOT emit it
+// when none was found (fail-closed — nothing to advertise).
+// ---------------------------------------------------------------------------
+
+/// decide emits `Link: <acl-iri>; rel="acl"` when a governing ACL is known.
+/// MUTATION SPOT-CHECK: change the expected value below to `<https://pod.ex/.OTHER>; rel="acl"`
+/// and this test goes red — confirming it exercises the real header, not a vacuous assertion.
+#[tokio::test]
+async fn decide_emits_link_header_when_governing_acl_known() {
+    // [SONNET-4.6] sq-snopa.7: assert the RFC-8288 Link header is present and correct.
+    let base = spawn(true).await;
+    let resp = client()
+        .post(format!("{base}/authz/decide"))
+        .json(&decide_body(
+            Some("https://alice.ex/card#me"),
+            "https://pod.ex/notes/n1",
+            "read",
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let link = resp
+        .headers()
+        .get("link")
+        .expect("decide must emit a Link header when a governing ACL is known")
+        .to_str()
+        .unwrap();
+    assert_eq!(
+        link,
+        r#"<https://pod.ex/.acl>; rel="acl""#,
+        "Link header must be the RFC-8288 link-value for the governing ACL"
+    );
+}
+
+/// decide does NOT emit a Link header when no governing ACL exists (resource outside the pod).
+/// Fail-closed: if there is no ACL document to advertise, nothing is emitted.
+#[tokio::test]
+async fn decide_omits_link_header_when_no_governing_acl() {
+    // [SONNET-4.6] sq-snopa.7: resource with no governing ACL → no Link header.
+    let base = spawn(true).await;
+    let resp = client()
+        .post(format!("{base}/authz/decide"))
+        .json(&decide_body(
+            Some("https://alice.ex/card#me"),
+            "https://other.ex/resource", // not in the WAC dataset — no governing ACL
+            "read",
+        ))
+        .send()
+        .await
+        .unwrap();
+    // The status is a deny (no grant) — but we are testing the HEADER, not the body.
+    assert!(
+        resp.headers().get("link").is_none(),
+        "decide must NOT emit a Link header when no governing ACL was discovered"
+    );
+}
+
+/// wac-allow emits `Link: <acl-iri>; rel="acl"` when a governing ACL is known.
+#[tokio::test]
+async fn wac_allow_emits_link_header_when_governing_acl_known() {
+    // [SONNET-4.6] sq-snopa.7: wac-allow must also carry the Link header.
+    let base = spawn(true).await;
+    let resp = client()
+        .post(format!("{base}/authz/wac-allow"))
+        .json(&serde_json::json!({
+            "dataset": WAC_NQUADS,
+            "session": { "agent": "https://alice.ex/card#me" },
+            "resource": "https://pod.ex/notes/n1",
+            "view": "wac",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let link = resp
+        .headers()
+        .get("link")
+        .expect("wac-allow must emit a Link header when a governing ACL is known")
+        .to_str()
+        .unwrap();
+    assert_eq!(
+        link,
+        r#"<https://pod.ex/.acl>; rel="acl""#,
+        "Link header must be the RFC-8288 link-value for the governing ACL"
+    );
+}
+
+/// wac-allow does NOT emit a Link header when no governing ACL exists.
+#[tokio::test]
+async fn wac_allow_omits_link_header_when_no_governing_acl() {
+    // [SONNET-4.6] sq-snopa.7: resource outside the dataset → no governing ACL → no Link header.
+    let base = spawn(true).await;
+    let resp = client()
+        .post(format!("{base}/authz/wac-allow"))
+        .json(&serde_json::json!({
+            "dataset": WAC_NQUADS,
+            "session": { "agent": "https://alice.ex/card#me" },
+            "resource": "https://other.ex/resource", // not in the WAC dataset
+            "view": "wac",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert!(
+        resp.headers().get("link").is_none(),
+        "wac-allow must NOT emit a Link header when no governing ACL was discovered"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // read-auth gating.
 // ---------------------------------------------------------------------------
 

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -257,12 +257,15 @@ Materialize the authorization view from the access-control documents, then enfor
   `Link: rel="acl"` surface (above). **Honest scope:** Phase-1 implements
   the WAC `accessTo` + container-`default` subset of [issue #992](https://github.com/jeswr/sparq/issues/992)
   (FR-1/6/7) — the per-resource decision + fail-closed contract + ACL walk. The **HTTP shell**
-  over this library surface (FR-4, sq-snopa.6) has now LANDED as `sparq-server`'s opt-in
+  over this library surface (FR-4, sq-snopa.6) has LANDED as `sparq-server`'s opt-in
   `solid-authz` feature — `POST /authz/decide`+`/wac-allow`+`/query`, a fail-closed thin wrapper
-  that maps these very verdicts onto HTTP status codes (an `AclStatus` `403`/`503` split); see the
-  `http-server` skill. That HTTP layer does NOT authenticate — it takes an already-resolved
-  session, exactly as this library does. The `decide` `scope` is the ACL-*document* discovery
-  scope, while whether a grant within that ACL applies is the verdict the oracle computes.
+  that maps these very verdicts onto HTTP status codes (an `AclStatus` `403`/`503` split). The
+  **FR-5 `Link: <acl-iri>; rel="acl"` response header** (sq-snopa.7) is now wired: `/authz/decide`
+  and `/authz/wac-allow` emit it from `acl_link_header()` / `resolve_acl()` when a governing ACL
+  was discovered; `None` ⇒ no header (fail-closed). See the `http-server` skill. That HTTP layer
+  does NOT authenticate — it takes an already-resolved session, exactly as this library does. The
+  `decide` `scope` is the ACL-*document* discovery scope, while whether a grant within that ACL
+  applies is the verdict the oracle computes.
 - `store.materialize_odrl_permission(&Policy, &Request) -> BridgeOutcome` — **opt-in**
   (`odrl-bridge` feature, OFF by default; [OPUS-4.8] sq-h3uk): run the `sparq-policy` ODRL
   evaluator and, on a *definite Permit*, materialize the equivalent `principal auth:<mode>

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -1029,10 +1029,12 @@ surface, `research/sparq-solid-scope.md` §4); this is exactly that missing shel
   "resource", "mode": "read"|"write"|"append"|"control", "view"? }`. Returns
   `{ "allow", "grantedModes", "governingAcl", "scope", "status", "aclLink" }`. An **allow** is `200`;
   a **deny** maps the FR-6 status — a definitive one (`resolved` without the mode / `noAcl`) is `403`,
-  a retryable one (`unloaded` / `transient`) is `503`. `aclLink` is the RFC-8288 `Link: rel="acl"`
-  header VALUE (FR-5), already in the body so `sq-snopa.7` need only lift it into a response header.
+  a retryable one (`unloaded` / `transient`) is `503`. When a governing ACL was discovered the
+  response also carries `Link: <acl-iri>; rel="acl"` (RFC 8288, FR-5, sq-snopa.7) — the `aclLink`
+  body field holds the same value. Fail-closed: no Link header when no governing ACL exists.
 - `POST /authz/wac-allow` — body `{ "dataset", "session", "resource", "view"? }` → `{ "wacAllow":
-  "user=\"…\",public=\"…\"" }`, the RFC permission advertisement.
+  "user=\"…\",public=\"…\"" }`, the RFC permission advertisement. Also emits `Link: <acl-iri>;
+  rel="acl"` when a governing ACL was discovered (FR-5, sq-snopa.7); omitted when none.
 - `POST /authz/query` — body `{ "dataset", "session", "mode"?, "query", "view"? }` runs an
   **access-controlled** SPARQL query as the session and returns SPARQL-results JSON; a grant-less
   session sees ZERO rows (empty view), never the whole store.
@@ -1048,10 +1050,12 @@ materialised `PodStore` through the concurrent-serving `AppState`).
 
 ```sh
 cargo run -p sparq-server --features solid-authz -- data.ttl --solid-authz
-curl -X POST http://127.0.0.1:3030/authz/decide -H 'Content-Type: application/json' -d '{
+curl -si -X POST http://127.0.0.1:3030/authz/decide -H 'Content-Type: application/json' -d '{
   "dataset": "<https://pod.ex/n1#it> <https://ex.dev/ns#t> \"hi\" <https://pod.ex/n1> .\n<https://pod.ex/.acl#o> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .\n<https://pod.ex/.acl#o> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .\n<https://pod.ex/.acl#o> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .",
   "session": { "agent": "https://alice.ex/card#me" }, "resource": "https://pod.ex/n1", "mode": "read", "view": "wac" }'
-# → 200 {"allow":true,"grantedModes":["read"],"governingAcl":"https://pod.ex/.acl","scope":"http://www.w3.org/ns/auth/acl#default","status":"resolved","aclLink":"<https://pod.ex/.acl>; rel=\"acl\""}
+# HTTP/1.1 200 OK
+# link: <https://pod.ex/.acl>; rel="acl"
+# → {"allow":true,"grantedModes":["read"],"governingAcl":"https://pod.ex/.acl","scope":"http://www.w3.org/ns/auth/acl#default","status":"resolved","aclLink":"<https://pod.ex/.acl>; rel=\"acl\""}
 ```
 
 **6. Hardening — flags / env / library.** Each flag overrides its `SPARQ_*` env var; the


### PR DESCRIPTION
> 🤖 SPARQ agent [SONNET-4.6] — bead sq-snopa.7 (FR-5 `Link: rel="acl"` response header wiring)

## Summary

Follow-on to sq-snopa.6 / #1812. The `/authz/decide` and `/authz/wac-allow` endpoints in the `solid-authz` feature now emit `Link: <acl-iri>; rel="acl"` (RFC 8288 §3) when a governing ACL was discovered, making the ACL document discoverable from a response — the missing FR-5 HTTP-layer wiring.

- **`/authz/decide`**: `WacDecision::acl_link_header()` (already computed for the `aclLink` body field) is lifted into the `Link` response header via the new `json_response_with_link()` helper.
- **`/authz/wac-allow`**: `PodStore::resolve_acl(&resource_iri)` (a pure index lookup, no mode needed) obtains the governing ACL IRI before `wac_allow()` runs; the RFC-8288 value is formatted and passed to the same helper.
- **Fail-closed**: `acl_link_header()` / `resolve_acl()` return `None` when no governing ACL was discovered — nothing is emitted (no header). Safe on a deny: the link tells the client *where* the ACL is, not that the request is allowed.
- **`/authz/query`** is unchanged — it returns SPARQL-results JSON, not a resource response.
- No new crate, no new feature flag — change is entirely inside the existing `solid-authz` gate in `crates/sparq-server/src/solid_authz.rs`.

## Files changed

- `crates/sparq-server/src/solid_authz.rs` — `json_response_with_link()` helper + two handler call-sites
- `crates/sparq-server/tests/solid_authz.rs` — 4 new integration tests (governing-ACL and no-ACL cases for both endpoints)
- `skills/http-server/SKILL.md` — document the landed FR-5 wiring
- `skills/access-control/SKILL.md` — update sq-snopa.7 follow-up note to reflect completion

## Gates run

| Gate | Feature OFF | Feature ON (`solid-authz`) |
|---|---|---|
| `cargo build -p sparq-server` | GREEN | GREEN |
| `cargo clippy -p sparq-server --all-targets -D warnings` | GREEN | GREEN |
| `cargo clippy --workspace --all-targets -D warnings` | GREEN | — |
| `cargo test -p sparq-server --test solid_authz` (14 tests) | N/A (file gated) | GREEN |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` | GREEN | — |
| `python3 scripts/check-readme-template.py --enforce` | 0 deviations (52 READMEs) | — |

## Test evidence

- 10 pre-existing integration tests: all pass
- 4 new Link-header tests: `decide_emits_link_header_when_governing_acl_known`, `decide_omits_link_header_when_no_governing_acl`, `wac_allow_emits_link_header_when_governing_acl_known`, `wac_allow_omits_link_header_when_no_governing_acl`
- **Mutation spot-check**: changed the expected Link value in `decide_emits_link_header_when_governing_acl_known` from `<https://pod.ex/.acl>; rel="acl"` to `<https://pod.ex/.OTHER>; rel="acl"` → test went **RED** (assertion failure, left=`<https://pod.ex/.acl>; rel="acl"`, right=`<https://pod.ex/.OTHER>; rel="acl"`); restored correct value → GREEN. Test is non-vacuous.

## No auto-merge (as instructed)