### PR TITLE
fix(gui): reach the Tauri fs backend + serialize per-workspace saves + surface quota failures [FABLE-5] (sq-w3dmj, sq-9i1h9)

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -261,6 +261,13 @@ jobs:
         working-directory: gui/app
         run: npm run typecheck
 
+      # (sq-w3dmj) [FABLE-5] — the gui/app node:test unit suite (pure helpers: editor keys +
+      # the global-first Tauri fs plugin resolution). Build-free (on-the-fly TS loader); was
+      # previously never exercised in CI.
+      - name: GUI frontend unit tests
+        working-directory: gui/app
+        run: npm run test:unit
+
       # The hosted "Try the GUI live" web target (sub-path basePath).
       - name: GUI frontend static export (web target)
         working-directory: gui/app

--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -16,7 +16,7 @@
     "start": "npx --yes serve out",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts"
+    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/tauri-fs.test.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/gui/app/src/components/workbench/status-bar.tsx
+++ b/gui/app/src/components/workbench/status-bar.tsx
@@ -105,7 +105,7 @@ export function StatusBar() {
     ingest,
     nativeLoaderAvailable,
   } = useEngine();
-  const { backend } = useWorkspace();
+  const { backend, saveError } = useWorkspace();
 
   // [OPUS-4.8] sq-cno90 — PREFER the OS-reported on-disk figure when the desktop probe returned one;
   // otherwise fall back to the snapshot-bytes estimate (the web target). Labelled honestly either
@@ -135,6 +135,15 @@ export function StatusBar() {
         loader: <span className="text-[var(--success)]">{nativeLoaderAvailable ? "native" : "in-tab"}</span>
       </span>
       <span title="Where the workspace persists">backend: {backendLabel(backend)}</span>
+
+      {/* (sq-w3dmj) A failed workspace save is SURFACED, not swallowed — e.g. the localStorage
+          quota exhausted by a large snapshot. Without this the app keeps its in-memory state but
+          the on-launch restore silently reloads an older snapshot. */}
+      {saveError !== null && (
+        <span className="text-destructive" title={saveError} data-workspace-save-error>
+          save failed — workspace not persisted
+        </span>
+      )}
 
       {/* push the #820 stats to the right edge. */}
       <span className="ml-auto" />

--- a/gui/app/src/lib/tauri-fs.test.ts
+++ b/gui/app/src/lib/tauri-fs.test.ts
@@ -1,0 +1,76 @@
+// (sq-w3dmj) [FABLE-5] — unit tests for the GLOBAL-FIRST Tauri fs plugin resolution in
+// tauri-fs.ts.
+//
+// The load-bearing property under test: `loadTauriFs()` must resolve the plugin from the
+// `window.__TAURI__.fs` runtime global BEFORE attempting the bare dynamic
+// `import("@tauri-apps/plugin-fs")`. Under Node (as in the static-export webview) that bare
+// import can NEVER resolve — the package is intentionally absent — so a non-null result here
+// PROVES the global-first path was taken. The dropped global-first step is exactly the sq-w3dmj
+// regression: with it missing, the desktop TauriWorkspaceStore was unreachable and persistence
+// silently degraded to localStorage.
+//
+// Run via:   npm run test:unit   (gui/app)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { loadTauriFs } from "./tauri-fs.js";
+
+/** A well-formed fake of the `@tauri-apps/plugin-fs` module surface. */
+function fakeFsModule() {
+  return {
+    BaseDirectory: { AppLocalData: 11 },
+    readTextFile: async () => "",
+    writeTextFile: async () => {},
+    remove: async () => {},
+    exists: async () => false,
+    mkdir: async () => {},
+    readDir: async () => [],
+  };
+}
+
+/** Install / clear a fake `window` global for one test (Node has none by default). */
+function setWindow(value: unknown): void {
+  (globalThis as { window?: unknown }).window = value;
+}
+function clearWindow(): void {
+  delete (globalThis as { window?: unknown }).window;
+}
+
+test("loadTauriFs resolves window.__TAURI__.fs FIRST — selected over the always-failing bare import", async (t) => {
+  t.after(clearWindow);
+  const mod = fakeFsModule();
+  setWindow({ __TAURI__: { fs: mod } });
+
+  const api = await loadTauriFs();
+
+  // Under Node the bare import("@tauri-apps/plugin-fs") always rejects (the package is
+  // intentionally absent), so a resolved API proves the runtime global won the resolution.
+  assert.ok(api, "expected the injected window.__TAURI__.fs global to resolve");
+  assert.equal(api.baseDir, 11); // BaseDirectory.AppLocalData projected onto TauriFsApi.baseDir
+  // Every member is the global module's own function, projected 1:1 (no wrapping, no loss).
+  assert.equal(api.readTextFile, mod.readTextFile);
+  assert.equal(api.writeTextFile, mod.writeTextFile);
+  assert.equal(api.remove, mod.remove);
+  assert.equal(api.exists, mod.exists);
+  assert.equal(api.mkdir, mod.mkdir);
+  assert.equal(api.readDir, mod.readDir);
+});
+
+test("loadTauriFs returns null with no window at all (SSR / Node)", async () => {
+  clearWindow();
+  assert.equal(await loadTauriFs(), null);
+});
+
+test("loadTauriFs returns null in a plain browser (window without __TAURI__)", async (t) => {
+  t.after(clearWindow);
+  setWindow({});
+  assert.equal(await loadTauriFs(), null);
+});
+
+test("loadTauriFs ignores a malformed global (writeTextFile not a function) and falls through to null", async (t) => {
+  t.after(clearWindow);
+  setWindow({ __TAURI__: { fs: { writeTextFile: "not-a-function" } } });
+  // The malformed global is rejected, the bare-import fallback rejects under Node → null,
+  // so the store factory degrades to the web backend instead of crashing.
+  assert.equal(await loadTauriFs(), null);
+});

--- a/gui/app/src/lib/tauri-fs.ts
+++ b/gui/app/src/lib/tauri-fs.ts
@@ -1,18 +1,32 @@
 "use client";
 
-// [OPUS-4.8] sq-ixc3.13 (epic sq-ixc3) — the OPTIONAL Tauri filesystem loader for workspace
-// persistence in the operational GUI. A sibling of site/src/lib/tauri-fs.ts (same discipline):
-// it bridges the framework-agnostic `@sparq/client` workspace store (sq-atb0) to the Tauri 2
-// `@tauri-apps/plugin-fs` plugin WITHOUT the static (web) build ever depending on a Tauri
-// package.
+// [FABLE-5] sq-w3dmj (was [OPUS-4.8] sq-ixc3.13, epic sq-ixc3) — the OPTIONAL Tauri filesystem
+// loader for workspace persistence in the operational GUI. A sibling of the historical
+// site/src/lib/tauri-fs.ts (same discipline): it bridges the framework-agnostic `@sparq/client`
+// workspace store (sq-atb0) to the Tauri 2 `@tauri-apps/plugin-fs` plugin WITHOUT the static
+// (web) build ever depending on a Tauri package.
 //
-// HOW IT STAYS STATIC-EXPORT-SAFE. `@tauri-apps/plugin-fs` is imported with a `webpackIgnore`
-// dynamic `import()` evaluated only inside a Tauri webview (feature-detected by `isTauriRuntime`).
-// On the hosted "Try the GUI live" web build the import is never reached, never bundled.
+// HOW IT RESOLVES AT RUNTIME (sq-w3dmj). The desktop shell registers `tauri_plugin_fs` and sets
+// `app.withGlobalTauri = true` (gui/src-tauri/tauri.conf.json), so Tauri injects the plugin onto
+// `window.__TAURI__.fs`. We resolve the fs API from THAT runtime global FIRST — the ONLY path
+// that can work in a pre-bundled static-export webview, which has no import map and therefore
+// can never resolve a bare module specifier. The (webpack-ignored, unbundled) bare `import()` is
+// kept strictly as a fallback for a hypothetical bundler-based Tauri host. The previous version
+// of this file dropped the global-first step and relied on the bare import alone, so the import
+// always rejected inside the desktop shell and persistence silently degraded to localStorage —
+// that regression is what sq-w3dmj fixes (restoring the historical site loader's behaviour).
 //
-// HONEST LIMITATION. The on-disk path activates only when the Tauri shell grants the `fs`
-// capability scoped to AppLocalData (follow-up bead sq-ixc3.6). Until then this loader returns
-// `null` and the GUI cleanly degrades to the browser localStorage backend — even inside Tauri.
+// HOW IT STAYS STATIC-EXPORT-SAFE. `@tauri-apps/plugin-fs` is NOT a dependency
+// (gui/app/package.json); the fallback imports it with a `webpackIgnore` dynamic `import()`
+// evaluated only inside a Tauri webview (feature-detected by `isTauriRuntime` in
+// `createWorkspaceStore`). On the hosted "Try the GUI live" web build neither the global nor
+// the import resolves, so the loader returns `null` and the GUI cleanly degrades to the
+// browser localStorage backend.
+//
+// CAPABILITY SCOPE (sq-ixc3.6). The fs grant is LEAST-PRIVILEGE: the shell's capability
+// (gui/src-tauri/capabilities/default.json) scopes every fs permission to
+// `$APPLOCALDATA/workspaces` ONLY. A call outside that scope is denied by Tauri and rejects,
+// which the workspace store treats the same as an absent plugin.
 
 import { type TauriFsApi } from "@sparq/client";
 
@@ -30,30 +44,73 @@ interface TauriFsModule {
   readDir: TauriFsApi["readDir"];
 }
 
-/** Dynamically import the Tauri fs plugin (webpackIgnore keeps it out of the web bundle). */
+/**
+ * Read the fs plugin off the Tauri runtime global, when present. The desktop shell sets
+ * `app.withGlobalTauri = true` and registers `tauri_plugin_fs`, so Tauri injects the plugin at
+ * `window.__TAURI__.fs` — the resolution path that works for a PRE-BUNDLED static export that
+ * never imports a Tauri npm package (mirrors how tauri-ipc.ts reads
+ * `window.__TAURI__.core.invoke`). Returns `undefined` in a plain browser (no `__TAURI__`),
+ * where the caller falls through to the bare-import fallback and ultimately the web backend.
+ */
+function readGlobalTauriFs(): TauriFsModule | undefined {
+  if (typeof window === "undefined") return undefined;
+  const fs = (window as unknown as { __TAURI__?: { fs?: unknown } }).__TAURI__?.fs;
+  if (fs && typeof (fs as { writeTextFile?: unknown }).writeTextFile === "function") {
+    return fs as TauriFsModule;
+  }
+  return undefined;
+}
+
+/**
+ * Dynamically import `@tauri-apps/plugin-fs` at runtime — the SECONDARY path, for a
+ * hypothetical bundler-based Tauri host that can resolve the bare specifier. Isolated in its
+ * own helper so the single `@ts-expect-error` for the intentionally-absent module lands
+ * precisely on the import expression (`webpackIgnore` keeps it out of the bundle graph).
+ */
 function importTauriFsPlugin(): Promise<unknown> {
   // @ts-expect-error — optional Tauri-only module, intentionally absent from the static build.
   return import(/* webpackIgnore: true */ "@tauri-apps/plugin-fs");
 }
 
+/** Project a resolved `@tauri-apps/plugin-fs` module onto the `TauriFsApi` the store consumes. */
+function adaptFsModule(mod: TauriFsModule): TauriFsApi {
+  return {
+    baseDir: mod.BaseDirectory.AppLocalData,
+    readTextFile: mod.readTextFile,
+    writeTextFile: mod.writeTextFile,
+    remove: mod.remove,
+    exists: mod.exists,
+    mkdir: mod.mkdir,
+    readDir: mod.readDir,
+  };
+}
+
 /**
  * Resolve the Tauri filesystem API scoped to the app's local-data dir, or `null` if the plugin
- * is not importable / the fs capability was not granted. Passed to
- * `createWorkspaceStore({ loadTauriFs })`, which only calls it inside a Tauri webview.
+ * is not present / the fs capability was not granted. Passed to
+ * `createWorkspaceStore({ loadTauriFs })`, which only calls it inside a Tauri webview — and
+ * whose RESOLVED `store.backend` (not a Tauri-presence guess) is what the status bar / switcher
+ * "saved on device" labels render, so the label is honest by construction.
+ *
+ * Resolution order (sq-w3dmj): (1) the `window.__TAURI__.fs` runtime global injected by the
+ * desktop shell — the path the pre-bundled static export REQUIRES; (2) a webpack-ignored bare
+ * `import()` for a hypothetical bundler-based host. Either way, a missing plugin / permission
+ * error / unusable shape resolves to `null` so the store factory falls back to the web backend
+ * rather than throwing.
  */
 export async function loadTauriFs(): Promise<TauriFsApi | null> {
+  // (1) Prefer the runtime global injected by the desktop shell. No import, so the static build
+  // never bundles a Tauri package; on a plain browser `__TAURI__` is absent and this is skipped.
+  const global = readGlobalTauriFs();
+  if (global) return adaptFsModule(global);
+
+  // (2) Fallback: a bundler-based host that can resolve the bare specifier at runtime. In the
+  // static-export webview and on the hosted web build the specifier is unresolvable, the import
+  // rejects, and we return `null`.
   try {
     const mod = (await importTauriFsPlugin()) as unknown as TauriFsModule;
     if (typeof mod?.writeTextFile !== "function") return null;
-    return {
-      baseDir: mod.BaseDirectory.AppLocalData,
-      readTextFile: mod.readTextFile,
-      writeTextFile: mod.writeTextFile,
-      remove: mod.remove,
-      exists: mod.exists,
-      mkdir: mod.mkdir,
-      readDir: mod.readDir,
-    };
+    return adaptFsModule(mod);
   } catch {
     // No plugin / capability not granted — the web (localStorage) backend takes over.
     return null;

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -23,8 +23,11 @@
 
 import * as React from "react";
 import {
+  createSerializedWorkspaceSaver,
   createWorkspaceStore,
+  describeWorkspaceSaveError,
   newWorkspace,
+  type SerializedWorkspaceSaver,
   type Workspace,
   type WorkspaceBackend,
   type WorkspaceInferenceMode,
@@ -49,6 +52,13 @@ export interface WorkspaceContextValue {
   workspace: Workspace | null;
   /** Which concrete persistence backend resolved (for an honest "saved on device / in browser" label). */
   backend: WorkspaceBackend | null;
+  /**
+   * (sq-w3dmj) Human-readable description of the most recent FAILED workspace save — e.g. the
+   * localStorage quota exhausted by a large snapshot — or `null` while saves succeed. Surfaced
+   * in the status bar so a persistence failure is never silent (the old persist() swallowed it,
+   * which meant silent data loss on the next restore). Cleared by the next successful save.
+   */
+  saveError: string | null;
   /** The imported-source metadata list for the active workspace (drives the rail's Imports subgroup). */
   sources: WorkspaceSourceMeta[];
   /**
@@ -132,8 +142,13 @@ const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null)
 export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   const [workspace, setWorkspaceState] = React.useState<Workspace | null>(null);
   const [backend, setBackend] = React.useState<WorkspaceBackend | null>(null);
+  const [saveError, setSaveError] = React.useState<string | null>(null);
   const [workspaces, setWorkspaces] = React.useState<WorkspaceSummary[]>([]);
   const storeRef = React.useRef<WorkspaceStore | null>(null);
+  // (sq-9i1h9) EVERY save goes through this serializer (a per-workspace promise chain + a
+  // monotonic revision counter) so a slow older save can never land after — and overwrite — a
+  // newer one on the async Tauri fs backend (which sq-w3dmj makes reachable).
+  const saverRef = React.useRef<SerializedWorkspaceSaver | null>(null);
   // A synchronous mirror of the active workspace so async mutators (switch/delete) can read it
   // without a stale-closure functional-setState dance.
   const workspaceRef = React.useRef<Workspace | null>(null);
@@ -169,7 +184,9 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     (async () => {
       const store = await createWorkspaceStore({ loadTauriFs });
       if (cancelled) return;
+      const saver = createSerializedWorkspaceSaver((w) => store.save(w));
       storeRef.current = store;
+      saverRef.current = saver;
       setBackend(store.backend);
       // Restore the last-opened workspace if there is one, else create a fresh default.
       let ws: Workspace | null = null;
@@ -184,7 +201,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
         ws = newWorkspace("default workspace", STARTER_QUERY);
         freshDefault = true;
         try {
-          await store.save(ws);
+          await saver.save(ws);
           await store.setLastOpenedId(ws.id);
         } catch {
           /* in-memory / locked-down backend — keep the workspace for this session anyway */
@@ -204,17 +221,35 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     };
   }, [applyWorkspace, refreshList]);
 
-  // Persist a workspace (best-effort) + keep it as the last-opened, then refresh the switcher list.
+  // Persist a workspace + keep it as the last-opened, then refresh the switcher list.
+  //
+  // (sq-9i1h9) The save is SERIALIZED per workspace through `saverRef` (promise chain +
+  // monotonic revision counter), so concurrent persists can never land out of order on the
+  // async Tauri fs backend. (sq-w3dmj) A write failure no longer vanishes into a silent
+  // `.catch(() => {})`: it is surfaced via `saveError` (the status bar renders it) — the
+  // in-memory workspace stays intact either way. Returns the save promise so durability-
+  // sensitive callers can await it; it NEVER rejects and resolves `true` iff this state (or a
+  // newer one superseding it in the same chain) reached the backend.
   const persist = React.useCallback(
-    (ws: Workspace) => {
+    (ws: Workspace): Promise<boolean> => {
       const store = storeRef.current;
-      if (!store) return;
-      store
+      const saver = saverRef.current;
+      if (!store || !saver) return Promise.resolve(false);
+      return saver
         .save(ws)
         .then(() => store.setLastOpenedId(ws.id))
         .then(() => refreshList())
-        .catch(() => {
-          /* a write failure must not break the in-memory workspace */
+        .then(() => {
+          setSaveError((prev) => (prev === null ? prev : null));
+          return true;
+        })
+        .catch((err: unknown) => {
+          // A write failure must not break the in-memory workspace — but it must be VISIBLE
+          // (a swallowed QuotaExceededError meant the on-launch restore silently reloaded an
+          // older, smaller snapshot).
+          console.error("workspace save failed", err);
+          setSaveError(describeWorkspaceSaveError(err));
+          return false;
         });
     },
     [refreshList],
@@ -230,7 +265,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
         updatedAt: Date.now(),
       };
       applyWorkspace(next);
-      persist(next);
+      await persist(next);
     },
     [applyWorkspace, persist],
   );
@@ -245,7 +280,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
         updatedAt: Date.now(),
       };
       applyWorkspace(next);
-      persist(next);
+      await persist(next);
     },
     [applyWorkspace, persist],
   );
@@ -259,7 +294,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       if (base.inference === mode) return;
       const next: Workspace = { ...base, inference: mode, updatedAt: Date.now() };
       applyWorkspace(next);
-      persist(next);
+      await persist(next);
     },
     [applyWorkspace, persist],
   );
@@ -279,7 +314,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       const next: Workspace = { ...base, rulesDocs: nextDocs, updatedAt: Date.now() };
       applyWorkspace(next);
       engineRef.current.setN3Rules(nextDocs);
-      persist(next);
+      await persist(next);
     },
     [applyWorkspace, persist],
   );
@@ -292,7 +327,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       const next: Workspace = { ...base, rulesDocs: nextDocs, updatedAt: Date.now() };
       applyWorkspace(next);
       engineRef.current.setN3Rules(nextDocs);
-      persist(next);
+      await persist(next);
     },
     [applyWorkspace, persist],
   );
@@ -307,7 +342,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       const next: Workspace = { ...base, rulesDocs: nextDocs, updatedAt: Date.now() };
       applyWorkspace(next);
       engineRef.current.setN3Rules(nextDocs);
-      persist(next);
+      await persist(next);
     },
     [applyWorkspace, persist],
   );
@@ -321,24 +356,28 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     if (snapshot === null) return; // engine not ready — skip; a failed UPDATE never reaches here anyway
     const next: Workspace = { ...base, dataSnapshot: snapshot, updatedAt: Date.now() };
     applyWorkspace(next);
-    persist(next);
+    await persist(next);
   }, [applyWorkspace, persist]);
 
   // (sq-7gdfp) — belt-and-suspenders save: on page unload, snapshot the live engine store into
   // the active workspace one final time. This catches any in-flight state that was not yet
-  // persisted (e.g. if the debounce had not fired yet). For the localStorage backend the
-  // store.save() call completes synchronously before the page unloads; for the Tauri FS backend
-  // it is async and may not complete, but the explicit recordUpdateSnapshot after each UPDATE is
-  // the primary mechanism — this is a safety net only.
+  // persisted (e.g. if the debounce had not fired yet). For the localStorage backend the write
+  // lands in a microtask (the serializer chains it), which still flushes before the page is
+  // torn down; for the Tauri FS backend it is async and may not complete, but the explicit
+  // recordUpdateSnapshot after each UPDATE is the primary mechanism — this is a safety net only.
   React.useEffect(() => {
     const handleBeforeUnload = () => {
       const current = workspaceRef.current;
-      const store = storeRef.current;
-      if (!current || !store) return;
+      const saver = saverRef.current;
+      if (!current || !saver) return;
       const snapshot = engineRef.current.snapshotStore();
       if (snapshot === null) return;
       const next: Workspace = { ...current, dataSnapshot: snapshot, updatedAt: Date.now() };
-      void store.save(next).catch(() => {});
+      // (sq-9i1h9) through the serializer, so the final flush is ordered AFTER any in-flight
+      // save (an older in-flight save must not overwrite it). On the web backend the write
+      // still lands in a microtask before the page is torn down; nothing to surface here —
+      // the page is going away.
+      void saver.save(next).catch(() => {});
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
@@ -358,7 +397,9 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
             ? { ...current, dataSnapshot: snapshot, updatedAt: Date.now() }
             : current;
         try {
-          await store.save(saved);
+          // (sq-9i1h9) through the serializer, so this final flush of the OLD workspace can
+          // never be overwritten by one of its still-in-flight earlier saves.
+          await saverRef.current?.save(saved);
         } catch {
           /* best-effort — a save failure must not block the create */
         }
@@ -368,7 +409,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       applyWorkspace(ws);
       // A brand-new workspace is EMPTY (no sample) — an explicitly-created workspace stays empty.
       engineRef.current.hydrateFromSnapshot(null, { seedSampleWhenEmpty: false });
-      persist(ws);
+      await persist(ws);
       return ws;
     },
     [applyWorkspace, persist],
@@ -381,14 +422,15 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       if (active && active.id === id) {
         const next: Workspace = { ...active, name, updatedAt: Date.now() };
         applyWorkspace(next);
-        persist(next);
+        await persist(next);
         return;
       }
       if (!store) return;
       try {
         const ws = await store.load(id);
         if (!ws) return;
-        await store.save({ ...ws, name, updatedAt: Date.now() });
+        // (sq-9i1h9) through the serializer: same per-workspace chain as every other save.
+        await saverRef.current?.save({ ...ws, name, updatedAt: Date.now() });
         await refreshList();
       } catch {
         /* a rename of a stored (non-active) workspace is best-effort */
@@ -425,7 +467,8 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
             ? { ...current, dataSnapshot: snapshot, updatedAt: Date.now() }
             : current;
         try {
-          await store.save(saved);
+          // (sq-9i1h9) through the serializer — see createWorkspace step 1.
+          await saverRef.current?.save(saved);
         } catch {
           /* best-effort — a save failure must not block the switch */
         }
@@ -488,7 +531,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
           applyWorkspace(fresh);
           // A fresh default AFTER an explicit delete seeds the sample so the app is never blank.
           engineRef.current.hydrateFromSnapshot(null, { seedSampleWhenEmpty: true });
-          persist(fresh);
+          await persist(fresh);
         }
       }
       void refreshList();
@@ -500,6 +543,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     () => ({
       workspace,
       backend,
+      saveError,
       sources: workspace?.sources ?? [],
       workspaces,
       recordImport,
@@ -519,6 +563,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     [
       workspace,
       backend,
+      saveError,
       workspaces,
       recordImport,
       setEditorQuery,

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -713,6 +713,11 @@ export {
   type WorkspaceStoreOptions,
   type KeyValueStorage,
   type TauriFsApi,
+  // (sq-9i1h9) serialized per-workspace saves + (sq-w3dmj) save-failure surfacing.
+  type SerializedWorkspaceSaver,
+  createSerializedWorkspaceSaver,
+  describeWorkspaceSaveError,
+  isQuotaExceededError,
   WORKSPACE_SCHEMA,
   WORKSPACE_INFERENCE_MODES,
   parseInferenceMode,

--- a/packages/sparq-client/src/workspace.ts
+++ b/packages/sparq-client/src/workspace.ts
@@ -654,3 +654,116 @@ export async function createWorkspaceStore(
   if (kv) return new WebWorkspaceStore(kv);
   return new MemoryWorkspaceStore();
 }
+
+// ---------------------------------------------------------------------------
+// (sq-9i1h9) Serialized per-workspace saves — out-of-order overwrite protection.
+// ---------------------------------------------------------------------------
+
+/**
+ * Serializes whole-workspace saves PER WORKSPACE so a slow OLDER save can never land after —
+ * and overwrite — a NEWER one. Obtain one via {@link createSerializedWorkspaceSaver} and route
+ * EVERY save for a given store through it.
+ */
+export interface SerializedWorkspaceSaver {
+  /**
+   * Enqueue a save of `ws`. Resolves when this state is durably written — or when it has been
+   * SUPERSEDED by a newer save for the same workspace that follows it in the same chain (each
+   * save writes the whole workspace, so the newer snapshot covers this one). Rejects only when
+   * this revision's own write fails (e.g. the localStorage quota is exhausted).
+   */
+  save(ws: Workspace): Promise<void>;
+}
+
+/**
+ * Build a {@link SerializedWorkspaceSaver} over an underlying whole-workspace `write` (normally
+ * a bound {@link WorkspaceStore}.save).
+ *
+ * WHY (sq-9i1h9). The GUI persists by firing `store.save(ws)` from every mutator without
+ * awaiting. On the async Tauri fs backend a save is a multi-await IPC sequence
+ * (ensureDir → writeTextFile → readIds → writeIds), so two un-serialized saves can interleave
+ * and an OLDER save can complete after a NEWER one — the on-disk file then holds the stale
+ * snapshot. (The web/memory backends write synchronously, so the race is specific to the async
+ * backend — which sq-w3dmj makes reachable.)
+ *
+ * HOW. Two cooperating mechanisms, per workspace id:
+ *   1. a PROMISE CHAIN — at most one underlying write is in flight per workspace, in enqueue
+ *      order, so writes can never interleave (a failed write does not wedge the chain);
+ *   2. a MONOTONIC REVISION COUNTER — each enqueued save takes the next revision; when a
+ *      queued save's turn arrives and a newer revision has since been requested, its write is
+ *      DROPPED (the newer whole-workspace snapshot that follows in the chain covers it).
+ */
+export function createSerializedWorkspaceSaver(
+  write: (ws: Workspace) => Promise<void>,
+): SerializedWorkspaceSaver {
+  /** Per-workspace tail of the save chain (the most recently enqueued step). */
+  const tails = new Map<string, Promise<void>>();
+  /** Per-workspace newest REQUESTED revision (assigned at enqueue time, monotonic). */
+  const latest = new Map<string, number>();
+
+  return {
+    save(ws: Workspace): Promise<void> {
+      const id = ws.id;
+      const revision = (latest.get(id) ?? 0) + 1;
+      latest.set(id, revision);
+      // Write only if this is STILL the newest requested revision when its turn arrives — a
+      // stale revision is dropped (see the revision-counter contract above).
+      const runIfCurrent = (): Promise<void> | undefined =>
+        latest.get(id) === revision ? write(ws) : undefined;
+      const prev = tails.get(id) ?? Promise.resolve();
+      // Chain after the previous save WHATEVER its outcome: an older save's failure must
+      // neither wedge nor fail the newer saves queued behind it.
+      const step = prev.then(runIfCurrent, runIfCurrent);
+      tails.set(id, step);
+      // Reset the per-id book-keeping once the chain fully drains (this step settled while
+      // still the tail), so deleted workspaces do not accumulate entries forever. The handler
+      // also keeps a fire-and-forget rejected tail from surfacing as an unhandled rejection;
+      // the CALLER's copy of `step` still rejects normally.
+      const gc = () => {
+        if (tails.get(id) === step) {
+          tails.delete(id);
+          latest.delete(id);
+        }
+      };
+      step.then(gc, gc);
+      return step;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (sq-w3dmj) Save-failure classification — surfacing, not swallowing.
+// ---------------------------------------------------------------------------
+
+/**
+ * True when `err` is the browser's storage-quota-exhausted failure — the `QuotaExceededError`
+ * `DOMException` thrown by `localStorage.setItem` when a large workspace snapshot no longer
+ * fits (plus Firefox's legacy `NS_ERROR_DOM_QUOTA_REACHED` name). Checked structurally by
+ * `name` (not `instanceof DOMException`) so it works across realms and in Node tests.
+ */
+export function isQuotaExceededError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const name = (err as { name?: unknown }).name;
+  return name === "QuotaExceededError" || name === "NS_ERROR_DOM_QUOTA_REACHED";
+}
+
+/**
+ * A short, honest, user-facing description of a failed workspace save, for surfacing in the
+ * GUI instead of swallowing the failure (sq-w3dmj): the quota case names the real limit (and
+ * that the desktop on-disk backend does not share it); anything else carries the underlying
+ * message when there is one.
+ */
+export function describeWorkspaceSaveError(err: unknown): string {
+  if (isQuotaExceededError(err)) {
+    return (
+      "workspace save failed: browser storage quota exceeded — the snapshot is too large for " +
+      "localStorage (the desktop app's on-disk backend has no such limit)"
+    );
+  }
+  const message =
+    typeof err === "object" &&
+    err !== null &&
+    typeof (err as { message?: unknown }).message === "string"
+      ? (err as { message: string }).message
+      : "";
+  return message ? `workspace save failed: ${message}` : "workspace save failed";
+}

--- a/site/test/workspace.test.mjs
+++ b/site/test/workspace.test.mjs
@@ -17,8 +17,11 @@ import {
   WebWorkspaceStore,
   MemoryWorkspaceStore,
   TauriWorkspaceStore,
+  createSerializedWorkspaceSaver,
   createWorkspaceStore,
+  describeWorkspaceSaveError,
   detectWebStorage,
+  isQuotaExceededError,
   isTauriRuntime,
   newWorkspace,
   parseInferenceMode,
@@ -311,4 +314,125 @@ test("parseWorkspace skips malformed rulesDocs entries but keeps valid ones", ()
   assert.ok(parsed);
   assert.equal(parsed.rulesDocs.length, 1);
   assert.equal(parsed.rulesDocs[0].name, "good");
+});
+
+// --- (sq-9i1h9) serialized per-workspace saves -------------------------------
+
+test("createSerializedWorkspaceSaver: a DELAYED older save cannot overwrite a NEWER one (Tauri backend)", async () => {
+  const fs = fakeFs();
+  const store = new TauriWorkspaceStore(fs);
+  const ws = newWorkspace("Race", "SELECT 1");
+  // Delay only the FIRST underlying write — the exact out-of-order-overwrite scenario: fired
+  // un-serialized (plain store.save), the slow OLD write would land after — and clobber — the
+  // fast NEW one, leaving the on-disk file at the stale snapshot.
+  let firstDelay = 25;
+  const write = async (w) => {
+    const d = firstDelay;
+    firstDelay = 0;
+    if (d) await new Promise((r) => setTimeout(r, d));
+    await store.save(w);
+  };
+  const saver = createSerializedWorkspaceSaver(write);
+  const oldRev = { ...ws, editor: { ...ws.editor, query: "OLD" } };
+  const newRev = { ...ws, editor: { ...ws.editor, query: "NEW" } };
+  const p1 = saver.save(oldRev);
+  const p2 = saver.save(newRev);
+  await Promise.all([p1, p2]);
+  const loaded = await store.load(ws.id);
+  // Serialized + revision-countered, the file MUST end at the newest revision. (Mutation check:
+  // swap `saver.save` for the raw un-serialized `write` above and this assertion goes red —
+  // the delayed OLD write lands last.)
+  assert.equal(loaded.editor.query, "NEW");
+});
+
+test("createSerializedWorkspaceSaver: stale queued revisions are DROPPED (monotonic revision counter)", async () => {
+  const writes = [];
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const saver = createSerializedWorkspaceSaver(async (w) => {
+    if (writes.length === 0) await gate; // hold the FIRST write in flight
+    writes.push(w.editor.query);
+  });
+  const ws = newWorkspace("Coalesce", "SELECT 1");
+  const p1 = saver.save({ ...ws, editor: { ...ws.editor, query: "v1" } });
+  await new Promise((r) => setImmediate(r)); // let the v1 write actually START (held by the gate)
+  const p2 = saver.save({ ...ws, editor: { ...ws.editor, query: "v2" } });
+  const p3 = saver.save({ ...ws, editor: { ...ws.editor, query: "v3" } });
+  release();
+  await Promise.all([p1, p2, p3]);
+  // v1 was already in flight; while it ran, v2 went stale (v3 arrived) and is dropped — its
+  // state is covered by the newer whole-workspace write v3 in the same chain.
+  assert.deepEqual(writes, ["v1", "v3"]);
+});
+
+test("createSerializedWorkspaceSaver: a failing save rejects its caller but does NOT wedge the chain", async () => {
+  const writes = [];
+  let failFirst = true;
+  const saver = createSerializedWorkspaceSaver(async (w) => {
+    if (failFirst) {
+      failFirst = false;
+      throw new Error("disk full");
+    }
+    writes.push(w.editor.query);
+  });
+  const ws = newWorkspace("Wedge", "SELECT 1");
+  await assert.rejects(saver.save({ ...ws, editor: { ...ws.editor, query: "v1" } }), /disk full/);
+  await saver.save({ ...ws, editor: { ...ws.editor, query: "v2" } });
+  assert.deepEqual(writes, ["v2"]);
+});
+
+test("createSerializedWorkspaceSaver: chains are PER workspace — one slow workspace never blocks another", async () => {
+  const done = [];
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const saver = createSerializedWorkspaceSaver(async (w) => {
+    if (w.name === "slow") await gate;
+    done.push(w.name);
+  });
+  const a = newWorkspace("slow", "SELECT 1");
+  const b = newWorkspace("fast", "SELECT 1");
+  const pa = saver.save(a);
+  const pb = saver.save(b);
+  await pb; // resolves while `a`'s write is still gated — independent chains
+  assert.deepEqual(done, ["fast"]);
+  release();
+  await pa;
+  assert.deepEqual(done, ["fast", "slow"]);
+});
+
+// --- (sq-w3dmj) quota-exceeded surfacing -------------------------------------
+
+test("WebWorkspaceStore.save PROPAGATES QuotaExceededError — never swallowed at the store layer", async () => {
+  const kv = fakeKv();
+  kv.setItem = () => {
+    const e = new Error("the quota has been exceeded");
+    e.name = "QuotaExceededError";
+    throw e;
+  };
+  const store = new WebWorkspaceStore(kv);
+  await assert.rejects(store.save(newWorkspace("Big", "SELECT 1")), (e) => {
+    assert.equal(e.name, "QuotaExceededError");
+    return true;
+  });
+});
+
+test("isQuotaExceededError + describeWorkspaceSaveError classify a quota failure honestly", () => {
+  const quota = new Error("exceeded");
+  quota.name = "QuotaExceededError";
+  assert.equal(isQuotaExceededError(quota), true);
+  assert.match(describeWorkspaceSaveError(quota), /quota/i);
+
+  // Firefox's legacy name is covered too.
+  const legacy = new Error("legacy");
+  legacy.name = "NS_ERROR_DOM_QUOTA_REACHED";
+  assert.equal(isQuotaExceededError(legacy), true);
+  assert.match(describeWorkspaceSaveError(legacy), /quota/i);
+
+  // A non-quota failure keeps its underlying message; junk degrades to a generic label.
+  const other = new Error("boom");
+  assert.equal(isQuotaExceededError(other), false);
+  assert.match(describeWorkspaceSaveError(other), /boom/);
+  assert.equal(isQuotaExceededError(null), false);
+  assert.match(describeWorkspaceSaveError(null), /workspace save failed/);
+  assert.equal(isQuotaExceededError("string"), false);
 });


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]

Fixes **sq-w3dmj** and **sq-9i1h9** together (they interlock: fixing the first activates the race the second describes). Both are GPT-5.6-review-verified findings. **Closes both beads.**

## (A) sq-w3dmj — desktop persistence never reached the Tauri fs backend

`gui/app/src/lib/tauri-fs.ts` resolved the fs plugin **only** via a bare dynamic `import("@tauri-apps/plugin-fs")`. The package is intentionally absent (static-export discipline) and a pre-bundled webview has no import map, so the import **always rejected** → `createWorkspaceStore` silently degraded to `WebWorkspaceStore(localStorage)` even inside the desktop shell.

- Restored the historical site loader's (`fa6704097`, PR #1048) **global-first** resolution: `readGlobalTauriFs()` reads `window.__TAURI__.fs` (injected by `withGlobalTauri` + registered `tauri_plugin_fs`) with a `writeTextFile`-is-a-function shape check, tried **before** the bare-import fallback.
- The "saved on device" labels (status bar + workspace switcher) already render the store's **resolved** `backend` — never a Tauri-presence guess — so they are honest by construction once the loader resolves truthfully.
- **Quota failures surface instead of being swallowed:** `persist()`'s old `.catch(() => {})` hid `QuotaExceededError`, meaning the on-launch restore silently reloaded an older snapshot (silent data loss). Now: `saveError` on the workspace context + a `data-workspace-save-error` status-bar indicator + `console.error`; classification via new `isQuotaExceededError` / `describeWorkspaceSaveError` in `@sparq/client`.

## (B) sq-9i1h9 — un-serialized whole-workspace saves race on the async backend

Every mutator fired `store.save(ws)` without serialization. `TauriWorkspaceStore.save` is a multi-await IPC sequence (`ensureDir → writeTextFile → readIds → writeIds`), so an **older save could land after a newer one**, leaving the on-disk file at the stale snapshot. Latent today only because of (A); fixing (A) alone would have activated it.

- New `createSerializedWorkspaceSaver` (`packages/sparq-client/src/workspace.ts`): per-workspace **promise chain** (at most one write in flight, in enqueue order — writes can never interleave; a failed write rejects its caller but never wedges the chain) **and** a **monotonic revision counter** (a queued save that went stale is dropped — the newer whole-workspace snapshot follows in the same chain).
- **Every** save in `workspace-context.tsx` routes through it: `persist()`, the create/switch step-1 flush of the old workspace, non-active rename, and the `beforeunload` final flush (which is therefore ordered after any in-flight save).
- `persist()` now **returns the save promise** (never rejects; resolves `true` iff the state — or a newer revision superseding it — reached the backend); all mutators await it.

## Tests (node:test — the runner both surfaces already use)

- `gui/app/src/lib/tauri-fs.test.ts` (4 tests): a mocked `window.__TAURI__.fs` is selected **over the always-failing bare import** (under Node the bare import can never resolve, so a non-null result proves global-first); null on SSR/plain-browser/malformed-global.
- `site/test/workspace.test.mjs` (+6 tests): delayed-older-save race ends at the **newest** revision on a `TauriWorkspaceStore` over a fake fs; stale queued revisions dropped (`["v1","v3"]`); failing save doesn't wedge the chain; chains are per-workspace; `WebWorkspaceStore.save` propagates `QuotaExceededError`; quota classification.

**Mutation verification** (both fixes reverted locally once, then restored):
- (A) with the pre-fix `HEAD` loader: `not ok 1 - loadTauriFs resolves window.__TAURI__.fs FIRST…` (3 pass / 1 fail).
- (B) with the saver bypassed (`{ save: write }`, i.e. un-serialized): `not ok 21 - …DELAYED older save cannot overwrite a NEWER one` (25 pass / 1 fail).

## Gates

- `gui/app`: `npm run lint` ✓ (0 warnings) · `tsc --noEmit` ✓ · `npm run build` ✓ + `npm run build:tauri` ✓ · `npm run test:unit` 27/27 ✓
- `packages/sparq-client`: `tsc --noEmit` ✓ · its de-facto suite (`site npm run test:unit`) **315/315** ✓
- `.github/workflows/gui.yml`: now runs the gui/app unit suite (it was previously never exercised in CI); YAML validated.

## Follow-up

- **sq-icftq** (P3): the shared `__index__.json` read-modify-write race across **different** workspace ids inside `TauriWorkspaceStore` — intentionally out of scope for per-workspace serialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)