### PR TITLE
fix(gui): apply replace to first successful import + reveal workspace controls on keyboard focus (sq-810a0, sq-ds9pg) [FABLE-5]

### DIFF
--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -16,7 +16,7 @@
     "start": "npx --yes serve out",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/tauri-fs.test.ts"
+    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/gui/app/src/components/workbench/import-drawer.tsx
+++ b/gui/app/src/components/workbench/import-drawer.tsx
@@ -35,6 +35,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { useEngine, type ImportKind, type ImportMode } from "@/lib/engine-context";
+import { runImportBatch, type BatchSummary } from "@/lib/import-batch";
 import { useWorkspace } from "@/lib/workspace-context";
 import {
   FORMAT_OPTIONS,
@@ -98,6 +99,40 @@ interface FeedbackErr {
   message: string;
 }
 type Feedback = FeedbackOk | FeedbackErr | null;
+
+/**
+ * (sq-810a0) Build the batch-import completion feedback from a {@link BatchSummary}.
+ *
+ * Beyond the ok/failed counts, it now SIGNALS when a `replace` the user selected was NOT applied
+ * because every file that could have replaced the store failed — the old dataset was left intact.
+ * Before this fix that outcome was silent (the user could believe the store had been cleared).
+ */
+function batchFeedback(summary: BatchSummary): Feedback {
+  const { okCount, errCount, totalAdded, replaceRequested, replaceApplied } = summary;
+  const quads = `${totalAdded.toLocaleString()} quad${totalAdded === 1 ? "" : "s"}`;
+  // Replace was asked for but never landed on a file (all replace-eligible files failed).
+  const replaceNotApplied = replaceRequested && !replaceApplied && okCount > 0;
+
+  if (errCount === 0) {
+    return {
+      kind: "ok",
+      message: `Imported ${okCount} file${okCount === 1 ? "" : "s"} — ${quads} added.`,
+    };
+  }
+  if (okCount > 0) {
+    const replaceNote = replaceNotApplied
+      ? " The replace was NOT applied (the file(s) meant to replace the store failed); existing data was kept and the imported file(s) were added."
+      : "";
+    return {
+      kind: "error",
+      message: `${okCount} file${okCount === 1 ? "" : "s"} imported (${quads}); ${errCount} file${errCount === 1 ? "" : "s"} failed — see errors above.${replaceNote}`,
+    };
+  }
+  return {
+    kind: "error",
+    message: `All ${errCount} file${errCount === 1 ? "" : "s"} failed — see errors above.${replaceRequested ? " The store was left unchanged (replace not applied)." : ""}`,
+  };
+}
 
 function ImportDrawer({
   open,
@@ -200,59 +235,29 @@ function ImportDrawer({
     setFileStatuses({});
 
     void (async () => {
-      let totalAdded = 0;
-      const statuses: Record<string, FileItemStatus> = {};
-
-      for (let i = 0; i < webFiles.length; i++) {
-        const file = webFiles[i];
-        // First file uses the selected mode (may replace); subsequent files always add so the
-        // batch merges rather than having each file clobber the previous one.
-        const fileMode: ImportMode = i === 0 ? mode : "add";
-        const format = guessFormat(file.name);
-        try {
-          const result = await importRdf({
+      // Sequence the batch: the selected mode is applied to the FIRST file that imports
+      // SUCCESSFULLY (not to array index 0), 'add' thereafter (sq-810a0). Update each row
+      // incrementally so it lights up as it completes.
+      const { summary } = await runImportBatch(
+        webFiles,
+        mode,
+        (file) => file.name,
+        (file, fileMode) =>
+          importRdf({
             kind: "paste",
             mode: fileMode,
             preserveGraphs,
             label: file.name,
-            format,
+            format: guessFormat(file.name),
             text: file.text,
-          });
-          statuses[file.name] = { kind: "ok", added: result.added };
-          totalAdded += result.added;
-        } catch (err) {
-          // A single-file failure MUST NOT abort the batch — invariant from sq-eydh9.
-          statuses[file.name] = {
-            kind: "error",
-            message: err instanceof Error ? err.message : String(err),
-          };
-        }
-        // Update incrementally so each row lights up as it completes.
-        setFileStatuses({ ...statuses });
-      }
+          }),
+        (_key, _status, statuses) => setFileStatuses({ ...statuses }),
+      );
 
-      const okCount = Object.values(statuses).filter((s) => s.kind === "ok").length;
-      const errCount = Object.values(statuses).filter((s) => s.kind === "error").length;
-
-      if (errCount === 0) {
-        setFeedback({
-          kind: "ok",
-          message: `Imported ${okCount} file${okCount === 1 ? "" : "s"} — ${totalAdded.toLocaleString()} quad${totalAdded === 1 ? "" : "s"} added.`,
-        });
-      } else if (okCount > 0) {
-        setFeedback({
-          kind: "error",
-          message: `${okCount} file${okCount === 1 ? "" : "s"} imported (${totalAdded.toLocaleString()} quads); ${errCount} file${errCount === 1 ? "" : "s"} failed — see errors above.`,
-        });
-      } else {
-        setFeedback({
-          kind: "error",
-          message: `All ${errCount} file${errCount === 1 ? "" : "s"} failed — see errors above.`,
-        });
-      }
+      setFeedback(batchFeedback(summary));
 
       // Record the batch in workspace history.
-      if (okCount > 0) {
+      if (summary.okCount > 0) {
         const label =
           webFiles.length === 1 ? fileLabel(webFiles[0].name) : `${webFiles.length} files`;
         await recordImport(
@@ -282,25 +287,24 @@ function ImportDrawer({
     setFileStatuses({});
 
     void (async () => {
-      let totalAdded = 0;
-      const statuses: Record<string, FileItemStatus> = {};
-
-      for (let i = 0; i < nativePaths.length; i++) {
-        const path = nativePaths[i];
-        const label = fileLabel(path);
-        const format = guessFormat(path);
-        const fileMode: ImportMode = i === 0 ? mode : "add";
-        try {
+      // Sequence the batch: the selected mode is applied to the FIRST path that imports
+      // SUCCESSFULLY (not to array index 0), 'add' thereafter (sq-810a0). Each successful path is
+      // recorded in workspace history inside the importer callback, so a failed leading file that
+      // does NOT clear the store is never recorded — mirroring the pre-fix per-success recording.
+      const { summary } = await runImportBatch(
+        nativePaths,
+        mode,
+        (path) => path,
+        async (path, fileMode) => {
+          const label = fileLabel(path);
           const result = await importRdf({
             kind: "file",
             mode: fileMode,
             preserveGraphs,
             label,
-            format,
+            format: guessFormat(path),
             path,
           });
-          statuses[path] = { kind: "ok", added: result.added };
-          totalAdded += result.added;
           await recordImport(
             {
               kind: "local",
@@ -312,34 +316,12 @@ function ImportDrawer({
             snapshotStore(),
           );
           refreshDiskUsage();
-        } catch (err) {
-          statuses[path] = {
-            kind: "error",
-            message: err instanceof Error ? err.message : String(err),
-          };
-        }
-        setFileStatuses({ ...statuses });
-      }
+          return { added: result.added };
+        },
+        (_key, _status, statuses) => setFileStatuses({ ...statuses }),
+      );
 
-      const okCount = Object.values(statuses).filter((s) => s.kind === "ok").length;
-      const errCount = Object.values(statuses).filter((s) => s.kind === "error").length;
-
-      if (errCount === 0) {
-        setFeedback({
-          kind: "ok",
-          message: `Imported ${okCount} file${okCount === 1 ? "" : "s"} — ${totalAdded.toLocaleString()} quads added.`,
-        });
-      } else if (okCount > 0) {
-        setFeedback({
-          kind: "error",
-          message: `${okCount} file${okCount === 1 ? "" : "s"} ok, ${errCount} failed — see errors above.`,
-        });
-      } else {
-        setFeedback({
-          kind: "error",
-          message: `All ${errCount} file${errCount === 1 ? "" : "s"} failed — see errors above.`,
-        });
-      }
+      setFeedback(batchFeedback(summary));
     })().finally(() => setBusy(false));
   }, [nativePaths, mode, preserveGraphs, importRdf, recordImport, snapshotStore, refreshDiskUsage]);
 

--- a/gui/app/src/components/workbench/workspace-switcher.tsx
+++ b/gui/app/src/components/workbench/workspace-switcher.tsx
@@ -30,6 +30,11 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import {
+  WORKSPACE_ACTIONS_CONTAINER_CLASS,
+  WORKSPACE_RENAME_BUTTON_CLASS,
+  WORKSPACE_DELETE_BUTTON_CLASS,
+} from "@/lib/workspace-actions-visibility";
 import { useWorkspace } from "@/lib/workspace-context";
 import { useRegisterPaletteCommands } from "@/components/workbench/command-palette";
 import type { PaletteCommand } from "@/lib/palette-commands";
@@ -326,8 +331,20 @@ export function WorkspaceSwitcher() {
                         </span>
                       </button>
 
-                      {/* Rename + delete — shown on hover via group-hover */}
-                      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                      {/*
+                        (sq-ds9pg) Rename + delete — revealed on pointer hover (group-hover) AND on
+                        KEYBOARD FOCUS (group-focus-within). opacity-0 alone does NOT remove an
+                        element from the tab order, so a keyboard-only user tabbing through the row
+                        would land focus on these buttons while they were fully transparent — a WCAG
+                        2.1 AA 2.4.7 (Focus Visible) failure and a blind-Enter mis-activation hazard.
+                        group-focus-within:opacity-100 makes the whole action group visible the moment
+                        either button receives focus; the per-button focus-visible ring gives the
+                        required visible focus indicator.
+                      */}
+                      <div
+                        data-workspace-actions={ws.id}
+                        className={WORKSPACE_ACTIONS_CONTAINER_CLASS}
+                      >
                         <button
                           data-workspace-rename={ws.id}
                           onClick={(e) => {
@@ -335,7 +352,7 @@ export function WorkspaceSwitcher() {
                             setMode({ kind: "renaming", id: ws.id });
                             setInputValue(ws.name);
                           }}
-                          className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                          className={WORKSPACE_RENAME_BUTTON_CLASS}
                           aria-label={`Rename workspace ${ws.name}`}
                           title="Rename"
                         >
@@ -351,7 +368,7 @@ export function WorkspaceSwitcher() {
                               name: ws.name,
                             });
                           }}
-                          className="rounded p-0.5 text-muted-foreground hover:bg-destructive/20 hover:text-destructive"
+                          className={WORKSPACE_DELETE_BUTTON_CLASS}
                           aria-label={`Delete workspace ${ws.name}`}
                           title="Delete"
                         >

--- a/gui/app/src/lib/import-batch.test.ts
+++ b/gui/app/src/lib/import-batch.test.ts
@@ -1,0 +1,163 @@
+// (sq-810a0) [FABLE-5] — unit tests for the batch-import mode sequencer (import-batch.ts).
+//
+// THE REGRESSION UNDER TEST (GPT-5.6 GUI review, adversarially verified): the Import drawer's
+// WEB and NATIVE multi-file loops decided each file's import mode by ARRAY INDEX
+// (`i === 0 ? mode : "add"`). So a selected `replace` was pinned to file[0]. If file[0] FAILED to
+// parse (its importer throws BEFORE any store mutation) but a later file SUCCEEDED, the `replace`
+// was silently never applied: the old dataset survived and the later file was merged in as `add`
+// — the exact opposite of the user's replace intent.
+//
+// The load-bearing property proved here: with file[0] failing and file[1] succeeding, file[1] is
+// imported under `replace` (NOT `add`), so the store ends REPLACED-with-file[1], not old+file[1].
+// The mock importer models `runImport` (engine-context.tsx): it decodes then mutates a fake store
+// ONLY on success; a thrown parse error leaves the fake store untouched (as the real one does).
+//
+// Run via:   npm run test:unit   (gui/app)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { nextFileMode, runImportBatch } from "./import-batch.js";
+import type { ImportMode } from "./engine-context.js";
+
+// ── A fake store that mirrors runImport's replace/add semantics (engine-context.tsx §2) ─────────
+//
+// `replace` → the store becomes exactly the incoming file. `add` → the incoming file is appended.
+// A file whose name starts with "BAD" throws at "decode" — BEFORE any store mutation — exactly
+// like a parse error in the real importer.
+
+interface FakeItem {
+  name: string;
+  /** Quads this file contributes (its identity, so we can assert what survived). */
+  quads: string[];
+}
+
+class FakeStore {
+  contents: string[] = [];
+
+  /** Import one file under `mode`, replicating runImport: throw on decode (BAD*) before mutating. */
+  importOne = async (item: FakeItem, mode: ImportMode): Promise<{ added: number }> => {
+    if (item.name.startsWith("BAD")) {
+      // Decode fails first; the store is NOT mutated (storeRef.current stays as-is).
+      throw new Error(`parse error in ${item.name}`);
+    }
+    if (mode === "replace") {
+      this.contents = [...item.quads];
+    } else {
+      this.contents.push(...item.quads);
+    }
+    return { added: item.quads.length };
+  };
+}
+
+test("nextFileMode: replace carries until the first success, then add", () => {
+  // Not yet replaced → the selected `replace` is offered.
+  assert.equal(nextFileMode("replace", false), "replace");
+  // Already replaced (a prior success consumed it) → add.
+  assert.equal(nextFileMode("replace", true), "add");
+  // `add` selected → always add, regardless of state.
+  assert.equal(nextFileMode("add", false), "add");
+  assert.equal(nextFileMode("add", true), "add");
+});
+
+test("REGRESSION sq-810a0: file[0] fails, file[1] succeeds under REPLACE — store ends replaced-with-file[1], NOT old+file[1]", async () => {
+  const store = new FakeStore();
+  // The pre-existing dataset the user intends to REPLACE.
+  store.contents = ["<old> <p> <o> ."];
+
+  const files: FakeItem[] = [
+    { name: "BAD-first.ttl", quads: ["<a> <p> <a> ."] }, // fails at decode
+    { name: "good-second.ttl", quads: ["<b> <p> <b> ."] }, // succeeds
+  ];
+
+  const { statuses, summary } = await runImportBatch(
+    files,
+    "replace",
+    (f) => f.name,
+    store.importOne,
+  );
+
+  // file[0] failed, file[1] succeeded.
+  assert.equal(statuses["BAD-first.ttl"].kind, "error");
+  assert.equal(statuses["good-second.ttl"].kind, "ok");
+
+  // THE FIX: the store is REPLACED with file[1] — the stale <old> quad is GONE and file[1]'s
+  // quad is the only content. Under the buggy index-based logic file[1] would import as `add`,
+  // leaving the store as ["<old> …", "<b> …"] (old + file[1] coexisting).
+  assert.deepEqual(
+    store.contents,
+    ["<b> <p> <b> ."],
+    "the old dataset must be dropped and only file[1] must remain (replace applied to first success)",
+  );
+  assert.ok(!store.contents.includes("<old> <p> <o> ."), "the old quad must NOT survive a replace");
+
+  // Summary reflects that the replace was actually applied.
+  assert.equal(summary.replaceRequested, true);
+  assert.equal(summary.replaceApplied, true);
+  assert.equal(summary.okCount, 1);
+  assert.equal(summary.errCount, 1);
+});
+
+test("replace applied to file[0] when it succeeds; file[1] then adds", async () => {
+  const store = new FakeStore();
+  store.contents = ["<old> <p> <o> ."];
+  const files: FakeItem[] = [
+    { name: "good-first.ttl", quads: ["<a> <p> <a> ."] },
+    { name: "good-second.ttl", quads: ["<b> <p> <b> ."] },
+  ];
+
+  const { summary } = await runImportBatch(files, "replace", (f) => f.name, store.importOne);
+
+  // file[0] replaced (old gone), file[1] added on top.
+  assert.deepEqual(store.contents, ["<a> <p> <a> .", "<b> <p> <b> ."]);
+  assert.equal(summary.replaceApplied, true);
+});
+
+test("all files fail under replace → store unchanged, replaceApplied=false", async () => {
+  const store = new FakeStore();
+  store.contents = ["<old> <p> <o> ."];
+  const files: FakeItem[] = [
+    { name: "BAD-1.ttl", quads: ["<a> <p> <a> ."] },
+    { name: "BAD-2.ttl", quads: ["<b> <p> <b> ."] },
+  ];
+
+  const { summary } = await runImportBatch(files, "replace", (f) => f.name, store.importOne);
+
+  // Nothing succeeded → old data is intact (runImport never mutates on a failed decode).
+  assert.deepEqual(store.contents, ["<old> <p> <o> ."]);
+  assert.equal(summary.replaceApplied, false);
+  assert.equal(summary.replaceRequested, true);
+  assert.equal(summary.okCount, 0);
+  assert.equal(summary.errCount, 2);
+});
+
+test("add mode is unaffected: every file appends", async () => {
+  const store = new FakeStore();
+  store.contents = ["<old> <p> <o> ."];
+  const files: FakeItem[] = [
+    { name: "one.ttl", quads: ["<a> <p> <a> ."] },
+    { name: "two.ttl", quads: ["<b> <p> <b> ."] },
+  ];
+
+  const { summary } = await runImportBatch(files, "add", (f) => f.name, store.importOne);
+
+  assert.deepEqual(store.contents, ["<old> <p> <o> .", "<a> <p> <a> .", "<b> <p> <b> ."]);
+  assert.equal(summary.replaceRequested, false);
+  assert.equal(summary.replaceApplied, false);
+});
+
+test("a single failure does not abort the batch (sq-eydh9 invariant preserved)", async () => {
+  const store = new FakeStore();
+  const files: FakeItem[] = [
+    { name: "good-1.ttl", quads: ["<a> <p> <a> ."] },
+    { name: "BAD-mid.ttl", quads: ["<x> <p> <x> ."] },
+    { name: "good-2.ttl", quads: ["<b> <p> <b> ."] },
+  ];
+
+  const { statuses, summary } = await runImportBatch(files, "add", (f) => f.name, store.importOne);
+
+  assert.equal(statuses["good-1.ttl"].kind, "ok");
+  assert.equal(statuses["BAD-mid.ttl"].kind, "error");
+  assert.equal(statuses["good-2.ttl"].kind, "ok"); // batch continued past the failure
+  assert.equal(summary.okCount, 2);
+  assert.equal(summary.errCount, 1);
+});

--- a/gui/app/src/lib/import-batch.ts
+++ b/gui/app/src/lib/import-batch.ts
@@ -1,0 +1,117 @@
+// (sq-810a0) [FABLE-5] — the batch-import mode sequencer shared by the Import drawer's WEB and
+// NATIVE multi-file loops (import-drawer.tsx).
+//
+// THE BUG THIS FIXES (GPT-5.6 GUI review, adversarially verified): the loops decided the
+// per-file import mode by ARRAY INDEX — `i === 0 ? mode : "add"` — so the selected `replace`
+// was pinned to file[0]. If file[0] FAILED to parse (its `importRdf` throws before any store
+// mutation — engine-context.tsx decodes at step 1, mutates only after a successful decode) but a
+// later file SUCCEEDED, the `replace` was silently never applied: the old dataset survived and
+// the later file was merged in as `add`, contradicting the user's replace intent.
+//
+// THE FIX: apply the selected mode to the FIRST file that actually imports SUCCESSFULLY, and
+// `add` for every file after that first success. A `replace` is therefore only ever "spent" on a
+// file that really cleared+loaded the store; if the first file(s) fail, the `replace` carries
+// forward to the first one that works. Modelled here as a pure, DOM-free sequencer so it is
+// unit-testable (import-batch.test.ts) with a mock importer and no React/WASM.
+
+import type { ImportMode } from "@/lib/engine-context";
+
+/** Per-item outcome of a batch import. Mirrors the drawer's `FileItemStatus`. */
+export type BatchItemStatus =
+  | { kind: "ok"; added: number }
+  | { kind: "error"; message: string };
+
+/** The result of importing a single item under a resolved mode. */
+export interface BatchImportResult {
+  added: number;
+}
+
+/**
+ * The resolved per-file mode for the file at batch position `index`, given whether a `replace`
+ * has ALREADY been applied to an earlier, successful file.
+ *
+ * - selected `add`      → always `add` (nothing to sequence).
+ * - selected `replace`  → `replace` until (and including) the first SUCCESSFUL import, then `add`.
+ *
+ * `replacedAlready` MUST reflect a *successful* replace only — see {@link runImportBatch}. A
+ * failed file does not consume the replace, so the next file inherits it.
+ */
+export function nextFileMode(selected: ImportMode, replacedAlready: boolean): ImportMode {
+  return !replacedAlready && selected === "replace" ? "replace" : "add";
+}
+
+/**
+ * Summary flags describing what the batch actually did — used to build honest completion
+ * feedback, so a user who asked to REPLACE is told when the replace was NOT applied.
+ */
+export interface BatchSummary {
+  okCount: number;
+  errCount: number;
+  totalAdded: number;
+  /** The user selected `replace`. */
+  replaceRequested: boolean;
+  /** A `replace` was actually applied to some file (i.e. some file succeeded under replace). */
+  replaceApplied: boolean;
+}
+
+/**
+ * Sequence a batch import with the correct first-successful-replace semantics.
+ *
+ * `importOne(item, mode)` performs the real import (decode + store mutation) for one item under
+ * the resolved `mode`; it must REJECT on a per-file failure without mutating the store — exactly
+ * how `importRdf`/`runImport` behave (a parse error throws at decode, before any store write).
+ *
+ * `onStatus(key, status)` is called after each item settles so the drawer can light up each row
+ * incrementally. `keyOf` maps an item to its status-map key (filename / path).
+ *
+ * Returns the per-item status map plus a {@link BatchSummary}. Guarantees:
+ *  - the selected mode is applied to the FIRST successful import, `add` thereafter;
+ *  - a failing item never consumes the `replace` — it carries to the next item;
+ *  - a single failure NEVER aborts the batch (invariant from sq-eydh9).
+ */
+export async function runImportBatch<T>(
+  items: readonly T[],
+  selected: ImportMode,
+  keyOf: (item: T) => string,
+  importOne: (item: T, mode: ImportMode) => Promise<BatchImportResult>,
+  onStatus?: (key: string, status: BatchItemStatus, statuses: Record<string, BatchItemStatus>) => void,
+): Promise<{ statuses: Record<string, BatchItemStatus>; summary: BatchSummary }> {
+  const statuses: Record<string, BatchItemStatus> = {};
+  let replaced = false;
+  let totalAdded = 0;
+
+  for (const item of items) {
+    const key = keyOf(item);
+    // Resolve the mode from the SUCCESS-tracked `replaced` flag, not the array index.
+    const fileMode = nextFileMode(selected, replaced);
+    try {
+      const result = await importOne(item, fileMode);
+      statuses[key] = { kind: "ok", added: result.added };
+      totalAdded += result.added;
+      // Only a SUCCESSFUL replace consumes the replace; everything after is `add`.
+      if (fileMode === "replace") replaced = true;
+    } catch (err) {
+      // A single-file failure MUST NOT abort the batch (invariant from sq-eydh9); the replace is
+      // NOT consumed, so it carries forward to the next file.
+      statuses[key] = {
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+    onStatus?.(key, statuses[key], statuses);
+  }
+
+  const okCount = Object.values(statuses).filter((s) => s.kind === "ok").length;
+  const errCount = Object.values(statuses).filter((s) => s.kind === "error").length;
+
+  return {
+    statuses,
+    summary: {
+      okCount,
+      errCount,
+      totalAdded,
+      replaceRequested: selected === "replace",
+      replaceApplied: replaced,
+    },
+  };
+}

--- a/gui/app/src/lib/workspace-actions-visibility.test.ts
+++ b/gui/app/src/lib/workspace-actions-visibility.test.ts
@@ -1,0 +1,63 @@
+// (sq-ds9pg) [FABLE-5] — regression test for the workspace rename/delete action-group
+// focus-visibility contract (workspace-actions-visibility.ts).
+//
+// THE REGRESSION (GPT-5.6 GUI review, adversarially verified): the action group was hidden with
+// `opacity-0 … group-hover:opacity-100` ONLY, with no reveal on keyboard focus. `opacity-0` keeps
+// the buttons in the tab order, so a keyboard-only user tabbed onto fully-transparent rename/delete
+// buttons with no visible focus indicator — a WCAG 2.1 AA 2.4.7 (Focus Visible) failure.
+//
+// No jsdom is available in this build-free node:test harness, so we assert the VISIBILITY CONTRACT
+// directly on the classnames the component actually renders (they are imported from the same
+// module the component imports — see workspace-switcher.tsx — so this cannot drift from the markup).
+// The load-bearing assertion: the container reveals on keyboard focus (`group-focus-within`) as
+// well as pointer hover, and each button carries a visible focus ring. Reverting the fix (dropping
+// `group-focus-within:opacity-100`) makes this go red.
+//
+// Run via:   npm run test:unit   (gui/app)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  WORKSPACE_ACTIONS_CONTAINER_CLASS,
+  WORKSPACE_RENAME_BUTTON_CLASS,
+  WORKSPACE_DELETE_BUTTON_CLASS,
+} from "./workspace-actions-visibility.js";
+
+test("action group is revealed on KEYBOARD FOCUS, not just pointer hover (WCAG 2.4.7)", () => {
+  const classes = WORKSPACE_ACTIONS_CONTAINER_CLASS.split(/\s+/);
+
+  // It starts hidden…
+  assert.ok(classes.includes("opacity-0"), "the group is opacity-0 by default");
+  // …revealed on pointer hover (unchanged)…
+  assert.ok(
+    classes.includes("group-hover:opacity-100"),
+    "the group must reveal on pointer hover",
+  );
+  // …AND — the fix — revealed when either inner button receives keyboard focus.
+  assert.ok(
+    classes.includes("group-focus-within:opacity-100"),
+    "REGRESSION sq-ds9pg: the group MUST reveal on keyboard focus (group-focus-within) — " +
+      "opacity-0 alone leaves the buttons tabbable but invisible (WCAG 2.4.7 failure)",
+  );
+});
+
+test("each action button self-reveals on focus and shows a visible focus ring", () => {
+  for (const [name, cls] of [
+    ["rename", WORKSPACE_RENAME_BUTTON_CLASS],
+    ["delete", WORKSPACE_DELETE_BUTTON_CLASS],
+  ] as const) {
+    const classes = cls.split(/\s+/);
+    assert.ok(
+      classes.includes("focus-visible:opacity-100"),
+      `${name} button must become visible on focus even outside the group reveal`,
+    );
+    assert.ok(
+      classes.includes("focus-visible:ring-2"),
+      `${name} button must render a visible focus ring (2.4.7 focus indicator)`,
+    );
+    assert.ok(
+      classes.includes("focus-visible:outline-none"),
+      `${name} button replaces the default outline with the ring cleanly`,
+    );
+  }
+});

--- a/gui/app/src/lib/workspace-actions-visibility.ts
+++ b/gui/app/src/lib/workspace-actions-visibility.ts
@@ -1,0 +1,39 @@
+// (sq-ds9pg) [FABLE-5] — the visibility contract for the workspace row's rename/delete action
+// group (workspace-switcher.tsx).
+//
+// THE BUG THIS ENCODES A REGRESSION GUARD FOR (GPT-5.6 GUI review, adversarially verified): the
+// action group was hidden with `opacity-0 … group-hover:opacity-100` ONLY. `opacity-0` does NOT
+// remove an element from the tab order (unlike display:none / visibility:hidden / [hidden]), so a
+// keyboard-only user tabbing through a workspace row landed focus on the (fully transparent)
+// rename then delete buttons with no visible focus indicator — a WCAG 2.1 AA 2.4.7 (Focus
+// Visible) failure and a blind-Enter delete-confirm mis-activation hazard.
+//
+// THE CONTRACT: the group MUST reveal on KEYBOARD FOCUS as well as pointer hover. Centralising the
+// classnames here (a) keeps the component and its unit test reading the SAME strings, so the test
+// cannot silently drift from the rendered markup, and (b) makes the a11y requirement explicit and
+// regression-proof: dropping `group-focus-within:opacity-100` makes the group-visibility test go
+// red (mutation-verified in workspace-actions-visibility.test.ts).
+
+/**
+ * Classes for the container that wraps the per-row rename + delete buttons.
+ *
+ * `group-hover:opacity-100`        — reveal on pointer hover (unchanged behaviour).
+ * `group-focus-within:opacity-100` — reveal when EITHER button inside receives keyboard focus,
+ *                                    fixing the 2.4.7 focus-visibility failure.
+ */
+export const WORKSPACE_ACTIONS_CONTAINER_CLASS =
+  "flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity " +
+  "group-hover:opacity-100 group-focus-within:opacity-100";
+
+/** Shared focus-visible ring + self-reveal applied to each action button. */
+const FOCUS_VISIBLE_BASE = "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2";
+
+/** Classes for the rename button (neutral focus ring). */
+export const WORKSPACE_RENAME_BUTTON_CLASS =
+  "rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground " +
+  `${FOCUS_VISIBLE_BASE} focus-visible:ring-ring/50`;
+
+/** Classes for the delete button (destructive focus ring). */
+export const WORKSPACE_DELETE_BUTTON_CLASS =
+  "rounded p-0.5 text-muted-foreground hover:bg-destructive/20 hover:text-destructive " +
+  `${FOCUS_VISIBLE_BASE} focus-visible:ring-destructive/50`;


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]

Fixes two verified GPT-5.6 GUI-review bugs, paired in one PR (both `gui/app`, distinct components) to keep the CI footprint to one push. References **sq-810a0** and **sq-ds9pg**.

## (A) sq-810a0 — replace-mode multi-file import silently skips replace

`import-drawer.tsx` decided each file's import mode by **array index** (`i === 0 ? mode : "add"`) in **both** batch loops (web `onImportWebFiles`, native `onImportNativeFiles`). Because `importRdf`/`runImport` decode *before* any store mutation, a parse failure throws leaving the store untouched. So if **file[0] failed** to parse but a later file **succeeded**, the selected `replace` was pinned to the failed file[0] and silently never applied: the old dataset survived and the later file was merged in as `add` — the opposite of the user's replace intent.

**Fix:** a shared DOM-free sequencer `src/lib/import-batch.ts` (`runImportBatch` / `nextFileMode`) applies the selected mode to the **first file that imports *successfully***, `add` thereafter. A failed file does **not** consume the `replace`, so it carries forward to the next file. Both loops route through it (invariants preserved: incremental per-row status, per-success `recordImport` in the native loop, single-failure-never-aborts from sq-eydh9). Completion feedback now also **signals** when a requested replace was not applied because all replace-eligible files failed (previously silent — the bead's preferred improvement).

## (B) sq-ds9pg — workspace rename/delete controls tabbable while invisible (WCAG 2.4.7)

`workspace-switcher.tsx` hid the rename/delete action group with `opacity-0 … group-hover:opacity-100` only. `opacity-0` does **not** remove elements from the tab order, so a keyboard-only user tabbed onto fully-transparent buttons with no visible focus indicator — a WCAG 2.1 AA **2.4.7 (Focus Visible)** failure and a blind-Enter delete-confirm mis-activation hazard.

**Fix:** reveal the action group on keyboard focus (`group-focus-within:opacity-100`) as well as hover, and give each button a visible `focus-visible` ring. Classnames are centralised in `src/lib/workspace-actions-visibility.ts` so the component and its regression test read the **same** strings.

## Tests (node:test, build-free — the `test:unit` suite `gui.yml` now runs)

- **`import-batch.test.ts`** — the regression case: file[0] throws, file[1] succeeds under `replace` ⇒ the fake store (which mirrors `runImport`'s replace/add + mutate-only-on-success semantics) ends **replaced-with-file[1]**, not `old + file[1]`. Plus first-file-success, all-fail, add-mode, and the batch-continues-past-failure invariant.
- **`workspace-actions-visibility.test.ts`** — asserts the container reveals on `group-focus-within` (not just hover) and each button carries a `focus-visible` ring.
- Both files added to the `test:unit` npm script.

### Mutation verification

- (A) reverting the fix (consume `replace` even on failure ≈ index-0 semantics) ⇒ the sq-810a0 regression tests go **red** (2 fail).
- (B) dropping `group-focus-within:opacity-100` ⇒ the WCAG 2.4.7 test goes **red**.
- Both reverted after verifying; suite is 35/35 green.

## Gates (`cd gui/app`)

- `npm run lint` — clean (no ESLint warnings/errors)
- `npx tsc --noEmit` — clean
- `npm run test:unit` — **35/35 pass**
- `npm run build` — green (web/default target)
- `npm run build:tauri` — green (loaders touched)

Not armed.