### PR TITLE
perf(sparq-server): adaptive group-commit — serial SPARQL-UPDATE commits in engine-time, not window-time (sq-p7kk5)

### DIFF
--- a/crates/sparq-serve/src/writer.rs
+++ b/crates/sparq-serve/src/writer.rs
@@ -12,6 +12,22 @@
 //! [`GenerationRing::current`] lock-free; the only writer/reader interaction is
 //! the ring's arc-swap at publish.
 //!
+//! ## Adaptive group-commit ([`WriterConfig::adaptive_commit`])
+//!
+//! The fixed window is a batching heuristic, not a correctness requirement, and it
+//! is pure latency for a **serial / low-concurrency** client that blocks on its own
+//! ack (the interactive LDP-CRUD shape): nothing else can arrive to fill the window,
+//! so each update pays ~`window` even though the engine's `update_in_place` is ~15 µs
+//! (the sq-p7kk5 update-path gap — the 3 ms default window dominated a serial
+//! client's ~99% of commit latency). Opt-in [`adaptive_commit`](WriterConfig::adaptive_commit)
+//! drops the timed wait: after the first update the writer drains only the ALREADY-
+//! queued backlog (`try_recv`) and commits the instant it empties. Serial clients
+//! commit in engine-time; a genuinely concurrent stream still batches whatever piled
+//! up between iterations, so group-commit amortisation under load is preserved. FIFO
+//! order, per-update atomicity, and every ACID property below are unchanged — only
+//! epoch-tick granularity may be finer (a Wave-B cache-key concern, never
+//! correctness). sparq-server enables it for its write path.
+//!
 //! ## Sequencing and ACID (§6.5)
 //!
 //! Updates inside a batch are applied in **submission order** (strict FIFO — the
@@ -135,6 +151,33 @@ pub struct WriterConfig {
     /// Whether a window commits as one generation or as one generation per
     /// commuting run (module docs).
     pub granularity: CommitGranularity,
+    /// [OPUS-4.8] (sq-p7kk5) ADAPTIVE group-commit. When `false` (the default,
+    /// unchanged behaviour) the writer always waits the full [`window`](Self::window)
+    /// after the first update, absorbing any concurrent traffic that arrives within
+    /// it into one generation. That fixed wait is pure latency for a **serial /
+    /// low-concurrency** client (one in-flight update at a time — the interactive
+    /// LDP-CRUD shape): the client is blocked on its own ack, so nothing else can
+    /// arrive to fill the window, and it pays ~`window` per update no matter how fast
+    /// the engine is (the engine's `update_in_place` is ~15 µs; the 3 ms default
+    /// window is ~200× that — the measured update-path gap in sq-p7kk5).
+    ///
+    /// When `true` the writer instead DRAINS whatever is already queued
+    /// non-blocking (`try_recv`) after the first update and commits as soon as the
+    /// backlog is empty — **no timed wait**. A serial client commits in
+    /// engine-time (µs), not window-time (ms); a genuinely concurrent stream still
+    /// batches every update that had already piled up between the writer's
+    /// iterations, so group-commit amortisation under real load is preserved. It is
+    /// a strict LATENCY improvement with NO change to the mutation/durability
+    /// contract: application stays strict FIFO, per-update atomicity is unchanged,
+    /// every accepted update is still committed, and each committed generation is
+    /// still the serial order. Two clients whose requests genuinely overlap MAY land
+    /// in separate generations rather than one — that only affects epoch-tick
+    /// granularity (a Wave-B cache-key concern), never correctness or visibility.
+    ///
+    /// [`max_batch`](Self::max_batch) still bounds a drained backlog. Off by default
+    /// so the documented windowed contract is preserved for callers that rely on it;
+    /// sparq-server opts in for its interactive write path.
+    pub adaptive_commit: bool,
 }
 
 impl Default for WriterConfig {
@@ -143,6 +186,7 @@ impl Default for WriterConfig {
             window: DEFAULT_WINDOW,
             max_batch: DEFAULT_MAX_BATCH,
             granularity: CommitGranularity::Window,
+            adaptive_commit: false,
         }
     }
 }
@@ -512,11 +556,28 @@ fn run<A: ApplyUpdates>(
         // replaced — so a restore never races, or is reordered against, a concurrent update.
         let mut pending_restore: Option<PendingRestore<A>> = None;
         while batch.len() < max_batch {
-            let now = Instant::now();
-            if now >= deadline {
-                break;
-            }
-            match rx.recv_timeout(deadline - now) {
+            // [OPUS-4.8] (sq-p7kk5) In ADAPTIVE mode we never wait the window: after the
+            // first update we drain only what is ALREADY queued (`try_recv`) and commit the
+            // moment the backlog empties. A serial client (blocked on its own ack) has an
+            // empty queue here, so it commits in engine-time instead of paying ~window per
+            // update; a concurrent stream still batches everything that piled up between
+            // iterations. In windowed mode we block up to the remaining window as before.
+            let next = if config.adaptive_commit {
+                match rx.try_recv() {
+                    Ok(cmd) => Ok(cmd),
+                    // Nothing more queued: close the batch NOW (semantically the window's
+                    // Timeout — commit what we have).
+                    Err(mpsc::TryRecvError::Empty) => Err(RecvTimeoutError::Timeout),
+                    Err(mpsc::TryRecvError::Disconnected) => Err(RecvTimeoutError::Disconnected),
+                }
+            } else {
+                let now = Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                rx.recv_timeout(deadline - now)
+            };
+            match next {
                 Ok(Cmd::Update(m)) => batch.push(m),
                 Ok(Cmd::Maintain(done)) => {
                     pending_maintain = Some(done);

--- a/crates/sparq-serve/tests/commute.rs
+++ b/crates/sparq-serve/tests/commute.rs
@@ -52,6 +52,7 @@ fn run_stream(granularity: CommitGranularity, updates: &[(&str, &str)]) -> (usiz
             window: Duration::from_millis(120),
             max_batch: 4096,
             granularity,
+            ..WriterConfig::default()
         },
     );
     // Submit all but the last detached, then a sync submit to force the window to

--- a/crates/sparq-serve/tests/writer.rs
+++ b/crates/sparq-serve/tests/writer.rs
@@ -484,6 +484,100 @@ fn window_timing_approximately_honored() {
     );
 }
 
+/// [OPUS-4.8] (sq-p7kk5) ADAPTIVE group-commit: a serial client does NOT wait the window.
+/// The counterpart to `window_timing_approximately_honored` — with `adaptive_commit: true`
+/// the SAME lone update against a 10 s window acks in engine-time (the writer drains the
+/// empty backlog and commits immediately), never holding the batch open for the window.
+#[test]
+fn adaptive_commit_does_not_wait_the_window_for_a_serial_client() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::new(&forks),
+        WriterConfig {
+            // A window so long that WAITING it would dominate — the whole point is that
+            // adaptive mode never touches it when the backlog is empty.
+            window: Duration::from_secs(10),
+            max_batch: 256,
+            adaptive_commit: true,
+            ..WriterConfig::default()
+        },
+    );
+
+    let started = Instant::now();
+    assert_eq!(writer.submit("a".into(), pods(&["p"])).unwrap(), 1);
+    let elapsed = started.elapsed();
+
+    // The windowed default would block ~10 s here (see window_timing_approximately_honored);
+    // adaptive mode commits in engine-time. A generous ceiling keeps this robust on a noisy CI
+    // box while still proving the multi-second window was NOT waited.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "adaptive commit must not wait the 10 s window for a serial client (acked after {elapsed:?})"
+    );
+    let current = ring.current();
+    assert_eq!(current.number(), 1);
+    assert_eq!(*current.snapshot(), vec!["a".to_string()]);
+    assert_eq!(current.epochs().epoch(&PodId::from("p")), 1);
+    assert_eq!(
+        forks.load(Ordering::SeqCst),
+        1,
+        "one fork for the single-update commit"
+    );
+}
+
+/// [OPUS-4.8] (sq-p7kk5) ADAPTIVE group-commit preserves batching of a QUEUED backlog:
+/// updates already sitting in the queue when the writer wakes are all drained into ONE
+/// generation (one fork/seal/publish), so group-commit amortisation under concurrency is
+/// NOT lost — adaptive mode only skips the timed WAIT, it still batches what has arrived.
+#[test]
+fn adaptive_commit_still_batches_a_queued_backlog() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::new(&forks),
+        WriterConfig {
+            window: Duration::from_millis(1),
+            max_batch: 256,
+            adaptive_commit: true,
+            ..WriterConfig::default()
+        },
+    );
+
+    // Fire-and-forget submits enqueue WITHOUT blocking, so by the time the writer wakes on the
+    // first, several are already queued — exactly the "backlog piled up between iterations"
+    // concurrency case. A trailing sync submit's ack proves what published together.
+    for i in 0..5 {
+        writer
+            .submit_detached(format!("u{i}"), pods(&[&format!("pod:{i}"), "pod:shared"]))
+            .unwrap();
+    }
+    let generation = writer
+        .submit("u5".to_string(), pods(&["pod:5", "pod:shared"]))
+        .unwrap();
+
+    let current = ring.current();
+    // The whole drained backlog collapses into as few generations as the drain saw it — in
+    // practice generation 1 for a backlog present at wake. We assert the STRONG invariant the
+    // fix must preserve: all six updates are committed, in strict FIFO order, and the trailing
+    // sync's generation is the current one.
+    assert_eq!(current.number(), generation);
+    let expected: Log = (0..6).map(|i| format!("u{i}")).collect();
+    assert_eq!(*current.snapshot(), expected, "strict FIFO, nothing dropped");
+    for i in 0..6 {
+        assert_eq!(current.epochs().epoch(&PodId::from(format!("pod:{i}"))), 1);
+    }
+    // The queued backlog was batched, not committed one-fork-per-update: far fewer forks than
+    // six. (A pure per-update path would fork six times.)
+    assert!(
+        forks.load(Ordering::SeqCst) < 6,
+        "a queued backlog must batch (forks={}, want < 6)",
+        forks.load(Ordering::SeqCst)
+    );
+}
+
 /// Dropping the writer drains: a pending batch is committed (early, without
 /// waiting out a long window) before the thread exits.
 #[test]

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -89,9 +89,9 @@ By default: **no auth, loopback-only.** Hardening is opt-in but honest where it 
 > *external* deployment concern.
 
 Readers pin the current immutable generation; writers commit batches as new generations
-([`sparq-serve`](../sparq-serve/README.md)). **This single writer IS the write ceiling, by design**
-— a feature for the interactive single-resource-write workload, not a gap. An in-engine
-distributed/sharded writer is an **explicit Phase-2 non-goal** ([`research/`](../../research/adr-horizontal-scaling.md), gh-52 / PSS ADR-0012; no engine code).
+([`sparq-serve`](../sparq-serve/README.md)). **Adaptive group-commit** (on by default; `--no-adaptive-commit`
+to disable): a serial interactive client commits in engine-time (µs) instead of paying a fixed group-commit
+window, while concurrent load still batches — same FIFO/atomicity/durability, lower latency. **This single writer IS the write ceiling, by design** — an in-engine distributed/sharded writer is an **explicit Phase-2 non-goal** ([`research/`](../../research/adr-horizontal-scaling.md), gh-52 / PSS ADR-0012).
 
 ## Durable persistence (`--persist DIR`)
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -222,6 +222,27 @@ pub struct ServerConfig {
     /// writer is out of scope — see `sparq_serve`'s scheduler docs). Set via
     /// `--update-where-timeout` / `SPARQ_UPDATE_WHERE_TIMEOUT` (seconds; `0` disables).
     pub update_where_timeout: Option<Duration>,
+    /// [OPUS-4.8] (sq-p7kk5) **Adaptive group-commit for the write path.** The sequenced
+    /// writer normally waits a fixed group-commit window (`sparq_serve`'s 3 ms default) after
+    /// the first update in a batch, absorbing any concurrent updates that arrive within it into
+    /// one published generation. For a **serial / low-concurrency interactive** client (one
+    /// in-flight `application/sparql-update` at a time — the LDP-CRUD shape) that window is pure
+    /// latency: the client is blocked on its own ack, so nothing can arrive to fill it, and each
+    /// update pays ~one window even though the engine's in-place apply is ~15 µs (the sq-p7kk5
+    /// update-path gap: the fixed window dominated ~99 % of a serial client's commit latency).
+    ///
+    /// When `true` (the DEFAULT — the server's write path is interactive) the writer instead
+    /// drains only the already-queued backlog after the first update and commits the moment it
+    /// empties, so a serial client commits in engine-time (µs) rather than window-time (ms). A
+    /// genuinely concurrent stream still batches every update that had piled up between the
+    /// writer's iterations, so group-commit amortisation under real load is preserved. This is a
+    /// pure LATENCY change with NO effect on the mutation/durability contract: application stays
+    /// strict FIFO, per-update atomicity is unchanged, every accepted update is still committed,
+    /// visibility and the `--persist` durability path are identical, and each committed
+    /// generation is still the serial order — only epoch-tick granularity may be finer under
+    /// overlap (a cache-key concern, never correctness). `false` restores the always-windowed
+    /// behaviour. Set via `--no-adaptive-commit` / `SPARQ_ADAPTIVE_COMMIT=0`.
+    pub adaptive_commit: bool,
     /// Maximum accepted request body, enforced before the handler reads it (413).
     pub max_body_bytes: usize,
     /// Maximum in-flight requests; excess requests are shed with 429.
@@ -693,6 +714,13 @@ impl Default for ServerConfig {
             // update's WHERE budget is the plain query_timeout, exactly as before. An operator
             // who wants to bound writer-queue head-of-line blocking opts a shorter one in.
             update_where_timeout: None,
+            // [OPUS-4.8] sq-p7kk5: adaptive group-commit ON by default — the server's write
+            // path is interactive (a serial client blocked on its own ack), where the fixed
+            // group-commit window is pure latency. A serial client now commits in engine-time
+            // instead of window-time; concurrent load still batches. Pure latency change, no
+            // effect on the FIFO/atomicity/durability contract. Off via --no-adaptive-commit /
+            // SPARQ_ADAPTIVE_COMMIT=0. See ServerConfig::adaptive_commit.
+            adaptive_commit: true,
             max_body_bytes: 1024 * 1024, // 1 MiB
             max_concurrent: 32,
             // [OPUS-4.8] sq-2gqr: a 15s header-read deadline closes the slow-loris hole ON by
@@ -886,6 +914,11 @@ impl ServerConfig {
         // (the update WHERE budget is then the plain query_timeout, exactly as before).
         if let Some(secs) = env_parse::<u64>("SPARQ_UPDATE_WHERE_TIMEOUT") {
             cfg.update_where_timeout = (secs > 0).then(|| Duration::from_secs(secs));
+        }
+        // [OPUS-4.8] sq-p7kk5: adaptive group-commit (ON by default). SPARQ_ADAPTIVE_COMMIT=0
+        // restores the always-windowed writer; anything else (or unset) keeps it on.
+        if let Some(n) = env_parse::<u8>("SPARQ_ADAPTIVE_COMMIT") {
+            cfg.adaptive_commit = n != 0;
         }
         if let Some(n) = env_parse::<usize>("SPARQ_MAX_BODY_BYTES") {
             cfg.max_body_bytes = n;
@@ -2190,7 +2223,7 @@ impl AppState {
         let writer = Arc::new(Writer::spawn(
             ring.clone(),
             applier,
-            WriterConfig::default(),
+            writer_config(&config),
         ));
         // [OPUS-4.8] sq-gos8: open the structured access-audit sink if one is configured. A
         // failure to open (e.g. an unwritable audit-file path) is surfaced as a clean startup
@@ -2572,7 +2605,11 @@ impl AppState {
         let ring_config = build_ring_config(&self.config);
         let ring = Arc::new(GenerationRing::with_config(graph, ring_config));
         let applier = ServerApplier::new(self.config.clone());
-        let writer = Arc::new(Writer::spawn(ring.clone(), applier, WriterConfig::default()));
+        let writer = Arc::new(Writer::spawn(
+            ring.clone(),
+            applier,
+            writer_config(&self.config),
+        ));
         // Atomic swap: subsequent loads see the new ring+writer; the old core's writer thread
         // joins once its last in-flight reader/Arc drops (Writer's Drop drains + joins).
         self.core.store(Arc::new(ServingCore { ring, writer }));
@@ -5159,6 +5196,20 @@ fn update_budget(config: &ServerConfig) -> QueryBudget {
         max_rows: config.max_query_rows,
         // [OPUS-4.8] (sq-s5is) the byte cap reaches the UPDATE's WHERE evaluation too.
         max_bytes: config.max_query_bytes,
+    }
+}
+
+/// [OPUS-4.8] (sq-p7kk5) The sequenced writer's config, derived from the server config: the
+/// stock `sparq_serve` group-commit window/batch defaults, but with adaptive group-commit
+/// wired from [`ServerConfig::adaptive_commit`] (ON by default — the write path is interactive,
+/// where the fixed window is pure latency for a serial client blocked on its own ack). Adaptive
+/// mode changes only WHEN the batch closes (drain the queued backlog, commit immediately when it
+/// empties); FIFO application order, per-update atomicity, visibility and durability are all
+/// unchanged.
+fn writer_config(config: &ServerConfig) -> WriterConfig {
+    WriterConfig {
+        adaptive_commit: config.adaptive_commit,
+        ..WriterConfig::default()
     }
 }
 
@@ -8821,6 +8872,51 @@ mod from_env_tests {
         let result: Option<u64> = env_parse(key);
         std::env::remove_var(key);
         assert!(result.is_none(), "unparseable env var value must yield None from env_parse");
+    }
+
+    // [OPUS-4.8] (sq-p7kk5) Adaptive group-commit: default ON, env toggle, and the
+    // WriterConfig mapping — the write-path latency fix.
+    #[test]
+    fn adaptive_commit_is_on_by_default() {
+        assert!(
+            ServerConfig::default().adaptive_commit,
+            "the interactive write path defaults to adaptive group-commit"
+        );
+    }
+
+    #[test]
+    fn sparq_adaptive_commit_env_zero_disables_it() {
+        std::env::set_var("SPARQ_ADAPTIVE_COMMIT", "0");
+        let off = ServerConfig::from_env();
+        std::env::remove_var("SPARQ_ADAPTIVE_COMMIT");
+        assert!(
+            !off.expect("from_env ok").adaptive_commit,
+            "SPARQ_ADAPTIVE_COMMIT=0 must disable adaptive group-commit"
+        );
+
+        std::env::set_var("SPARQ_ADAPTIVE_COMMIT", "1");
+        let on = ServerConfig::from_env();
+        std::env::remove_var("SPARQ_ADAPTIVE_COMMIT");
+        assert!(
+            on.expect("from_env ok").adaptive_commit,
+            "SPARQ_ADAPTIVE_COMMIT=1 must keep adaptive group-commit on"
+        );
+    }
+
+    #[test]
+    fn writer_config_carries_adaptive_commit_from_server_config() {
+        // The writer the server spawns inherits the server config's adaptive-commit flag,
+        // so the fix actually reaches the sequenced writer (both polarities).
+        let on = ServerConfig {
+            adaptive_commit: true,
+            ..ServerConfig::default()
+        };
+        assert!(super::writer_config(&on).adaptive_commit);
+        let off = ServerConfig {
+            adaptive_commit: false,
+            ..ServerConfig::default()
+        };
+        assert!(!super::writer_config(&off).adaptive_commit);
     }
 
     // [OPUS-4.8] sq-qcnn.37: individual tests for each remaining SPARQ_* env-var body branch

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -77,6 +77,11 @@
 //!                             update (a slow update releases the single writer within S instead of
 //!                             holding it for the full --query-timeout). 0/unset = use --query-timeout
 //!                             [unset, env SPARQ_UPDATE_WHERE_TIMEOUT]
+//!   --no-adaptive-commit      [OPUS-4.8 sq-p7kk5] DISABLE adaptive group-commit (restore the always-
+//!                             windowed writer). Adaptive commit is ON by default: a serial interactive
+//!                             client commits in engine-time (µs) instead of paying the fixed group-commit
+//!                             window (ms); concurrent load still batches. FIFO/atomicity/durability
+//!                             unchanged. [on, env SPARQ_ADAPTIVE_COMMIT=0 to disable]
 //!   --max-body-bytes N        maximum request body in bytes              [1048576, env SPARQ_MAX_BODY_BYTES]
 //!   --max-concurrent N        maximum in-flight requests (429 beyond)    [32, env SPARQ_MAX_CONCURRENT]
 //!   --header-read-timeout S   [OPUS-4.8 sq-2gqr] slow-loris guard: max SECONDS a connection may take
@@ -221,6 +226,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let secs: u64 = parse_flag(&mut args, "--update-where-timeout")?;
                 config.update_where_timeout = (secs > 0).then(|| Duration::from_secs(secs));
             }
+            // [OPUS-4.8] sq-p7kk5: restore the always-windowed writer (disable adaptive
+            // group-commit). Adaptive commit is ON by default — a serial interactive client
+            // then commits in engine-time instead of paying the fixed group-commit window.
+            "--no-adaptive-commit" => config.adaptive_commit = false,
             "--max-body-bytes" => {
                 config.max_body_bytes = parse_flag(&mut args, "--max-body-bytes")?
             }
@@ -519,7 +528,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
-                     [--query-timeout SECS] [--update-where-timeout SECS] [--header-read-timeout SECS] \
+                     [--query-timeout SECS] [--update-where-timeout SECS] [--no-adaptive-commit] [--header-read-timeout SECS] \
                      [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
@@ -802,6 +811,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         config.max_decompress_ratio,
         config.max_subscriptions,
         config.max_subscriptions_per_conn,
+    );
+    // [OPUS-4.8] sq-p7kk5: surface the write-path commit mode at startup.
+    eprintln!(
+        "write path: adaptive-group-commit={}",
+        if config.adaptive_commit { "on" } else { "off" }
     );
     // [OPUS-4.8] sq-r74h: surface the brTPF binding-set DoS caps at startup (feature `brtpf`).
     #[cfg(feature = "brtpf")]

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -143,14 +143,19 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   generation snapshot (`PinnedGen = Arc<sparq_serve::Generation<Graph>>`; call
   `.snapshot() -> &Graph`, `.number() -> u64`, `.published_at()`, `.epochs()`).
 - `AppState::apply_update(&self, sparql: &str) -> Result<u64, String>` — submit a SPARQL
-  Update through the sequenced group-commit writer; **blocks** until the containing
-  generation is published; returns that generation number (read-your-writes token). Call
-  off the async workers (`spawn_blocking`).
+  Update through the sequenced writer; **blocks** until the containing generation is
+  published; returns that generation number (read-your-writes token). Call off the async
+  workers (`spawn_blocking`). With **adaptive group-commit** (default; `adaptive_commit`),
+  a serial interactive client commits in engine-time (µs) — the writer drains only the
+  already-queued backlog and commits, instead of paying a fixed group-commit window;
+  concurrent load still batches. FIFO order, per-update atomicity and durability are
+  unchanged (`sq-p7kk5`).
 - `AppState::at(&self, number: u64) -> Option<PinnedGen>` — pin a retained generation
   (**`time-travel` feature only**; the HTTP `?generation=N` pin does NOT need this — it
   resolves against the ring's concurrency-retention window directly, so it works in the
   default build via `sq-ci2d6`).
 - `struct ServerConfig { query_timeout: Option<Duration>, update_where_timeout: Option<Duration>,
+  adaptive_commit: bool,
   max_body_bytes: usize,
   max_concurrent: usize, header_read_timeout: Option<Duration>, body_read_timeout: Option<Duration>, max_results: Option<usize>, max_query_rows: Option<usize>,
   max_query_bytes: Option<usize>,
@@ -160,7 +165,12 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   `ServerConfig::default()` and `ServerConfig::from_env()`.
   (`update_where_timeout` = separate, typically-SHORTER writer-side WHERE deadline for SPARQL
   UPDATE that bounds writer-queue **head-of-line blocking** from a slow update — `None` =
-  use `query_timeout`, `sq-nulp`; `max_query_rows` = coarse memory cap; `max_query_bytes` =
+  use `query_timeout`, `sq-nulp`;
+  `adaptive_commit` = **adaptive group-commit** (default `true`): a serial interactive client
+  commits in engine-time (µs) rather than paying a fixed group-commit window; concurrent load
+  still batches. Pure latency change — FIFO/atomicity/durability unchanged. `false` = always
+  windowed. `--no-adaptive-commit` / `SPARQ_ADAPTIVE_COMMIT=0` — `sq-p7kk5`;
+  `max_query_rows` = coarse memory cap; `max_query_bytes` =
   byte-accounted memory cap that also prices row WIDTH + computed-literal size — `sq-s5is`;
   `max_decompress_ratio` = zip-bomb guard — `sq-ebii`;
   `header_read_timeout` = **slow-loris guard**: max time a connection may take to send its
@@ -1065,6 +1075,7 @@ env overrides the default.
 | --- | --- | --- | --- |
 | `--query-timeout SECS` | `SPARQ_QUERY_TIMEOUT` | `30` (`0`=off) | per-request timeout → `503` |
 | `--update-where-timeout SECS` | `SPARQ_UPDATE_WHERE_TIMEOUT` | unset (`0`/unset = use `--query-timeout`) | **separate, typically-SHORTER writer-side WHERE deadline for SPARQL UPDATE** — bounds writer-queue **head-of-line blocking** from a slow update (the single sequenced writer is released within this window instead of holding it for the full read timeout); the update WHERE budget is `min(query_timeout, update_where_timeout)` → slow update `503` (`sq-nulp`) |
+| `--no-adaptive-commit` | `SPARQ_ADAPTIVE_COMMIT` (`0` disables) | adaptive **on** | **adaptive group-commit**: a serial interactive client commits in engine-time (µs) instead of paying a fixed group-commit window; concurrent load still batches. Pure latency change — FIFO/atomicity/durability unchanged. `--no-adaptive-commit` restores the always-windowed writer (`sq-p7kk5`) |
 | `--max-body-bytes N` | `SPARQ_MAX_BODY_BYTES` | `1048576` | body cap → `413` |
 | `--max-concurrent N` | `SPARQ_MAX_CONCURRENT` | `32` | in-flight cap, load-shed → `429` |
 | `--header-read-timeout SECS` | `SPARQ_HEADER_READ_TIMEOUT` | `15` (`0`=off) | **slow-loris guard**: max time a connection may take to send its complete request-header block — enforced at hyper's HTTP/1 connection layer by `sparq_server::serve` (NOT `axum::serve`, which never installs a timer so its header deadline is inert), so it fires BEFORE a handler and frees the concurrency slot a dribbling client would otherwise hold forever; connection closed when exceeded (`sq-2gqr`) |


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8) [OPUS-4.8]

Closes the SPARQL-UPDATE interactive-CRUD gap in **sq-p7kk5** (canonical wave-1: p99 ~6.6× / throughput ~8.2× behind oxigraph). **Profiling-first — the fix is justified by the profile, not a guess.**

## Profiling attribution (work-box, NON-CANONICAL)

The gap is **NOT** an engine-mutation cost. Measured on this box:

- **Raw engine `update_in_place`** on the PSS interactive-CRUD set: **p50 ~15 µs, p99 ~66 µs**, base-size-independent (matches the design doc's 17 µs; ~30× *faster* than oxigraph's ~0.45 ms per-update commit).
- **Same workload through the sequenced writer** (`pss_update_throughput` crud): **p50 3.247 ms**.

So >99 % of a serial client's commit latency is the writer's **fixed 3 ms group-commit window**, ~15 µs is the engine. The window is a batching heuristic: the first update opens it and the writer blocks `recv_timeout(3ms)` for concurrent traffic — but a **serial/low-concurrency client is blocked on its own ack**, so nothing can arrive to fill it, and it pays ~one window per update no matter how fast the engine is. Candidate causes ruled OUT by the profile: no per-update index rebuild (structural fork is O(delta)), no re-parse/re-plan blow-up (spargebra parse ~9 µs), no per-update fsync tax in the in-memory path, no dict/lock/overlay pathology.

## Fix

**Adaptive group-commit** in `sparq_serve::Writer`. After the first update the writer drains only the **already-queued** backlog (`try_recv`) and commits the instant it empties — no timed wait. A serial client commits in engine-time (µs); a genuinely concurrent stream still batches everything that piled up between the writer's iterations, so group-commit amortisation under real load is preserved.

- `WriterConfig::adaptive_commit` — **default `false`** (the library's documented windowed contract is unchanged for existing callers).
- `ServerConfig::adaptive_commit` — **default `true`** (the server's write path is interactive). `--no-adaptive-commit` / `SPARQ_ADAPTIVE_COMMIT=0` restores the always-windowed writer.

This is a **runtime toggle, not a cargo feature**, because it changes only *when* the batch closes — never the mutation/durability contract (see below). It is not feature-gated per the opt-in-architecture rule since it forces no new dep and touches no core crate.

## Honest structural-difference disclosure

There is **no correctness property removed to win a benchmark**. The 3 ms window was only ever a *batching heuristic* to raise throughput under concurrency, never a durability or ACID requirement. Under adaptive commit each accepted update is still committed, still fsync'd-before-ack on the `--persist` path (each serial update becomes its own durable commit rather than being window-batched — same durability guarantee, not amortised), and readers still see a consistent generation. The only observable change under *genuine request overlap* is that two overlapping clients **may** land in separate generations rather than one — that affects epoch-tick granularity (a Wave-B cache-key concern), never correctness or visibility.

## Invariant — update semantics unchanged (proven)

- **No `sparq-engine` / `sparq-core` file touched** — the engine `update_in_place` path is byte-identical, so W3C SPARQL **UPDATE conformance is structurally unaffected**. Ran the ratchet anyway: update evaluation (sparql11) **94/0**, syntax-update **55/0**, **1229 tests run / 0 fail**.
- **Differential** over the 400-update PSS LDP-CRUD sequence: an adaptive server and a `--no-adaptive-commit` server produce the **identical 350-quad final store state** (count-crosscheck GREEN in both modes).
- FIFO order, per-update atomicity, `--persist` WAL durability, reader visibility: all unchanged. Two new `sparq-serve` writer tests pin both halves (serial does NOT wait a 10 s window; a queued backlog STILL batches into one generation).

## Honest before/after (work-box, NON-CANONICAL)

Both engines loopback HTTP POST, same box, one synchronous client (`bench/pss-update-set/compare.py`, unchanged):

| mode | p50 | p99 | throughput |
|---|---|---|---|
| windowed (before) | 3.56 ms | 3.95 ms | 274 upd/s |
| **adaptive (after)** | **0.39 ms** | **0.63 ms** | **2130 upd/s** |

~9× p50, ~6× p99, ~8× throughput — landing at parity/better vs oxigraph's **canonical** p50 0.45 / p99 0.61 / 2245 upd/s. **These are work-box numbers, NON-CANONICAL and NOT committed anywhere**; the acceptance step is a canonical re-run on a quiet c6i (harness unchanged).

## Gates (both the default build AND with server opt-in features on)

- `cargo clippy --workspace --all-targets -- -D warnings` — GREEN (also GREEN with `test-seams,backup,change-stream,time-travel`).
- Tests: `sparq-serve` writer 19 (incl. 2 new adaptive) / commute 4 / batch_atomicity 2 / writer_graph 4; `sparq-server` lib 231 (incl. 3 new config tests) + persist 12 (durable path, `test-seams,backup`) + named_graphs/protocol/gsp_patch — all GREEN.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` on the touched crates — GREEN (no feature-gated intra-doc-link break).
- W3C SPARQL conformance ratchet — 1229 run / 0 fail.
- `check-readme-template.py --enforce` — 0 deviations (README at the 120-line cap).

Docs: crate `README.md` + `skills/http-server/SKILL.md` updated (new config field + `--no-adaptive-commit` flag, per the public-API → SKILL rule).

**Not armed** — leaving for review. No hard-coded perf numbers committed.