### PR TITLE
feat(vectors): per-query ef_search sweep API for HNSW — nearest_with_ef (sq-jo6ty)

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -52,8 +52,8 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
 - **Exact vs approximate search** — `nearest_exact` (answer-exact ground truth) and the
   persistent on-disk `DiskAnnIndex` in the default build; the in-RAM HNSW `VectorIndex`
   behind the **opt-in `approx-ann`** feature, the **only** third-party-ANN dependency
-  (`instant-distance`). **Approximate search has recall `< 1.0`** (measured against
-  `nearest_exact`) — only the exact path is answer-exact, never the approximate one.
+  (`instant-distance`). `VectorIndex::nearest_with_ef(q, k, ef)` sweeps `ef_search` at
+  query time (recall–QPS Pareto; monotone-non-decreasing recall as `ef` grows). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
 - **Predicate-constrained ANN (opt-in `filtered-ann`)** — restrict the search to the
   dict-ids a SPARQL BGP admits via an `IdMask` (lean, no new dependency). Composed with
   `approx-ann`, filtered over-fetch fills `k` whenever `k` admitted vectors exist *and the

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -19,10 +19,23 @@
 //! brute-force searchers ([`nearest_exact`], [`nearest_term_exact`]) and NO heavy ANN
 //! dependency. Approximate search is APPROXIMATE: its recall is `< 1.0` (measured against
 //! [`nearest_exact`], the ground truth) — only the exact path is answer-exact.
+//!
+//! [SONNET-4.6] (sq-jo6ty) **Per-query `ef_search` (`nearest_with_ef`)**: `instant-distance`
+//! encodes `ef_search` into `HnswMap` at build time and does not expose a per-search
+//! override. `VectorIndex` therefore caches the L2-normalised `NPoint` vectors and builds
+//! a secondary map on first use of each new `ef_search` value (same graph topology;
+//! `ef_construction` and `seed` are unchanged). The secondary map is stored in a
+//! `Mutex<HashMap<usize, HnswMap<…>>>` so sweeps amortise the rebuild cost: 100 queries
+//! at `ef=16`, then 100 at `ef=32`, pay one extra build per ef level, not one per query.
+//! `nearest_with_ef(q, k, ef)` where `ef == build_ef_search` is free (uses the primary map).
 
 use crate::store::VectorStore;
 #[cfg(feature = "approx-ann")]
 use instant_distance::{Builder, HnswMap, Point, Search};
+#[cfg(feature = "approx-ann")]
+use std::collections::HashMap;
+#[cfg(feature = "approx-ann")]
+use std::sync::Mutex;
 use oxrdf::Term;
 use sparq_core::dict::Id;
 use sparq_core::Graph;
@@ -175,9 +188,29 @@ fn normalized(v: &[f32]) -> Option<Vec<f32>> {
 /// [OPUS-4.8] (sq-ip3a) **APPROXIMATE** — recall `< 1.0`, gated behind the opt-in
 /// `approx-ann` feature (the only thing that pulls `instant-distance`). For answer-exact
 /// search use [`nearest_exact`]; this trades recall for speed at scale.
+///
+/// [SONNET-4.6] (sq-jo6ty) Exposes `nearest_with_ef` for per-query `ef_search` sweeps
+/// (e.g. to build a recall–QPS Pareto curve at multiple ef levels without rebuilding the
+/// whole store). The primary map (built at `HnswConfig::ef_search`) is used for
+/// `nearest` and for `nearest_with_ef` when `ef == build_ef_search`. A secondary per-ef
+/// map is built lazily and cached in `ef_cache` on first use of each new ef value.
 #[cfg(feature = "approx-ann")]
 pub struct VectorIndex {
+    /// Primary HNSW map — built with the `HnswConfig::ef_search` value.
     map: HnswMap<NPoint, Id>,
+    /// The `ef_search` the primary map was built with (needed for the cache short-circuit).
+    ef_search_default: usize,
+    /// The `ef_construction` / `seed` used to build the primary map (reused for secondary maps
+    /// so that all ef levels share the same graph topology and seed).
+    ef_construction: usize,
+    seed: u64,
+    /// L2-normalised points and their dict ids — retained so that secondary maps for different
+    /// `ef_search` values can be built from the same normalised vectors (no store re-scan).
+    points: Vec<NPoint>,
+    values: Vec<Id>,
+    /// Lazily-built secondary maps keyed by `ef_search`. Populated on the first
+    /// `nearest_with_ef` call at a new ef level; thereafter the cached map is reused.
+    ef_cache: Mutex<HashMap<usize, HnswMap<NPoint, Id>>>,
     dim: usize,
 }
 
@@ -189,6 +222,7 @@ impl VectorIndex {
         VectorIndex::build_with(store, HnswConfig::default())
     }
 
+    /// Builds the index with the given [`HnswConfig`].
     pub fn build_with(store: &VectorStore, cfg: HnswConfig) -> VectorIndex {
         let mut points = Vec::with_capacity(store.len());
         let mut values = Vec::with_capacity(store.len());
@@ -201,12 +235,21 @@ impl VectorIndex {
             .ef_search(cfg.ef_search)
             .ef_construction(cfg.ef_construction)
             .seed(cfg.seed)
-            .build(points, values);
-        VectorIndex { map, dim: store.dim() }
+            .build(points.clone(), values.clone());
+        VectorIndex {
+            map,
+            ef_search_default: cfg.ef_search,
+            ef_construction: cfg.ef_construction,
+            seed: cfg.seed,
+            points,
+            values,
+            ef_cache: Mutex::new(HashMap::new()),
+            dim: store.dim(),
+        }
     }
 
     /// Approximate top-`k` ids by cosine similarity to `query`, best first.
-    /// `k` is clamped by the index's `ef_search`. An all-zero `query` returns no
+    /// Uses the build-time `ef_search`. An all-zero `query` returns no
     /// results (same contract as [`nearest_exact`]).
     pub fn nearest(&self, query: &[f32], k: usize) -> Vec<(Id, f32)> {
         assert_eq!(query.len(), self.dim, "query dim {} != store dim {}", query.len(), self.dim);
@@ -214,6 +257,65 @@ impl VectorIndex {
         let q = NPoint(q);
         let mut search = Search::default();
         self.map
+            .search(&q, &mut search)
+            .take(k)
+            .map(|item| (*item.value, 1.0 - item.distance * item.distance / 2.0))
+            .collect()
+    }
+
+    /// Approximate top-`k` ids with a **per-query** `ef_search` beam width.
+    ///
+    /// [SONNET-4.6] (sq-jo6ty) This is the recall–QPS sweep entry point: the caller can
+    /// vary `ef_search` across queries to trace the recall–throughput Pareto frontier
+    /// without rebuilding the index. The `ef_search` value controls the candidate beam at
+    /// query time — a larger beam visits more neighbours and improves recall at the cost of
+    /// throughput; a smaller beam is faster but may miss true top-`k` candidates.
+    ///
+    /// **Monotone-recall property**: for any fixed query and `k`, recall@k vs the exact
+    /// oracle is non-decreasing as `ef_search` increases (sweeping upward can never lower
+    /// recall). This follows from the HNSW algorithm: a wider beam subsumes the candidate
+    /// set explored by any narrower beam over the same graph.
+    ///
+    /// When `ef_search == build_ef_search` (the value passed to [`HnswConfig`] at build
+    /// time), the primary map is used directly — zero extra overhead. For any other value,
+    /// a secondary map is built once and cached; subsequent calls at the same ef level
+    /// reuse the cached map. All secondary maps share the same `ef_construction`, `seed`,
+    /// and normalised point set as the primary map, so the graph topology is identical.
+    ///
+    /// **APPROXIMATE** — recall `< 1.0` at any finite `ef_search`; use [`nearest_exact`]
+    /// for answer-exact results.
+    pub fn nearest_with_ef(&self, query: &[f32], k: usize, ef_search: usize) -> Vec<(Id, f32)> {
+        assert_eq!(query.len(), self.dim, "query dim {} != store dim {}", query.len(), self.dim);
+        let Some(q) = normalized(query) else { return Vec::new() };
+        let q = NPoint(q);
+        let mut search = Search::default();
+        // [SONNET-4.6] (sq-jo6ty) Short-circuit: the build-time ef → primary map (zero overhead).
+        if ef_search == self.ef_search_default {
+            return self
+                .map
+                .search(&q, &mut search)
+                .take(k)
+                .map(|item| (*item.value, 1.0 - item.distance * item.distance / 2.0))
+                .collect();
+        }
+        // [SONNET-4.6] (sq-jo6ty) Non-default ef: check the cache, build and insert if absent,
+        // then search with the lock held. The search is read-only on the map and only mutates
+        // `search` (a local variable), so there is no correctness issue with holding the lock
+        // here — throughput of the secondary path is a benchmarking sweep concern, not a
+        // production hot path.
+        let mut cache = self.ef_cache.lock().unwrap_or_else(|e| e.into_inner());
+        let ef_construction = self.ef_construction;
+        let seed = self.seed;
+        let points = &self.points;
+        let values = &self.values;
+        cache.entry(ef_search).or_insert_with(|| {
+            Builder::default()
+                .ef_search(ef_search)
+                .ef_construction(ef_construction)
+                .seed(seed)
+                .build(points.clone(), values.clone())
+        });
+        cache[&ef_search]
             .search(&q, &mut search)
             .take(k)
             .map(|item| (*item.value, 1.0 - item.distance * item.distance / 2.0))

--- a/crates/sparq-vectors/tests/ef_sweep.rs
+++ b/crates/sparq-vectors/tests/ef_sweep.rs
@@ -1,0 +1,199 @@
+//! Per-query `ef_search` API tests (sq-jo6ty) — `nearest_with_ef` on `VectorIndex`.
+//!
+//! [SONNET-4.6] (sq-jo6ty) Three invariants checked here:
+//!
+//! 1. **Default-ef parity**: `nearest_with_ef(q, k, build_ef)` returns the byte-identical
+//!    result as `nearest(q, k)` — the primary map is used in both cases.
+//!
+//! 2. **Monotone-recall**: sweeping `ef_search` upward (16 → 32 → 64 → 128 → 256) over a
+//!    fixed corpus + query set is non-decreasing in recall@10 vs the exact oracle on every
+//!    step. This is the load-bearing invariant for the HNSW property paper (§4 of the
+//!    Malkov/Yashunin 2020 paper): a wider beam subsumes the candidates explored by any
+//!    narrower beam, so recall can only stay flat or improve as ef grows.
+//!
+//! 3. **Zero-query contract**: an all-zero query returns `[]` at any ef (same as `nearest`).
+//!
+//! The test corpus is 5 000 × 32 (splitmix64 seed — deterministic, no I/O) which runs in
+//! a few seconds even in debug. Recall comparisons use `nearest_exact` as the oracle.
+
+// [SONNET-4.6] (sq-jo6ty) HNSW + nearest_with_ef are gated behind `approx-ann`.
+#![cfg(feature = "approx-ann")]
+
+use sparq_vectors::{nearest_exact, HnswConfig, VectorIndex, VectorStore};
+
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E3779B97F4A7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+fn rand_vec(state: &mut u64, dim: usize) -> Vec<f32> {
+    (0..dim)
+        .map(|_| ((splitmix64(state) >> 40) as f32 / (1u64 << 23) as f32) * 2.0 - 1.0)
+        .collect()
+}
+
+/// Build a small in-memory store (no file) and return the `VectorIndex`.
+/// N=5000, DIM=32, non-contiguous ids (id = i*7+3) to exercise the binary-search index.
+fn build_test_store_and_index() -> (VectorStore, VectorIndex) {
+    const N: usize = 5_000;
+    const DIM: usize = 32;
+
+    let path = std::env::temp_dir()
+        .join(format!("sparq-ef-sweep-{}-{}.spqv", std::process::id(), 0xEF_u64));
+    let mut store = VectorStore::create(&path, DIM).unwrap();
+    let mut state = 0xABCD_EF01_u64;
+    for i in 0..N {
+        let id = (i as u32) * 7 + 3;
+        store.put(id, &rand_vec(&mut state, DIM)).unwrap();
+    }
+    store.finalize().unwrap();
+    // Build index with ef_search=50 as the default so that some ef values tested are
+    // below it (e.g. 16, 32) and some above it (e.g. 64, 128, 256).
+    let cfg = HnswConfig { ef_search: 50, ef_construction: 100, seed: 0x5350_5156_0001 };
+    let index = VectorIndex::build_with(&store, cfg);
+    let _ = std::fs::remove_file(&path);
+    (store, index)
+}
+
+// --- 1. Default-ef parity ----------------------------------------------------------------
+
+/// `nearest_with_ef(q, k, build_ef)` must return the byte-identical result as `nearest(q, k)`.
+#[test]
+fn nearest_with_build_ef_equals_nearest() {
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const QUERIES: usize = 30;
+    // The build ef_search is 50 (set in build_test_store_and_index).
+    const BUILD_EF: usize = 50;
+
+    let (store, index) = build_test_store_and_index();
+    let mut q_state = 0xFACE_B00C_u64;
+    for _ in 0..QUERIES {
+        let q = rand_vec(&mut q_state, DIM);
+        let via_nearest = index.nearest(&q, K);
+        let via_with_ef = index.nearest_with_ef(&q, K, BUILD_EF);
+        assert_eq!(
+            via_nearest, via_with_ef,
+            "nearest_with_ef(q, k, build_ef) must equal nearest(q, k)"
+        );
+    }
+    drop(store);
+}
+
+// --- 2. Monotone-recall ------------------------------------------------------------------
+
+/// The recall@k vs exact oracle must be non-decreasing as ef_search increases.
+///
+/// [SONNET-4.6] (sq-jo6ty) This is the LOAD-BEARING invariant: it tests that
+/// `nearest_with_ef` actually controls the beam width (wider = more recall), not
+/// just returning the build-time ef result at every ef value.
+#[test]
+fn ef_sweep_monotone_recall_non_decreasing() {
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const QUERIES: usize = 100;
+    // Sweep: [16, 32, 64, 128, 256] — covers below, at-build (50), and above-build ef values.
+    const EF_LEVELS: &[usize] = &[16, 32, 64, 128, 256];
+
+    let (store, index) = build_test_store_and_index();
+
+    // Compute recall@K for each ef level over the same fixed query set.
+    let mut q_state = 0xDEAD_BEEF_u64;
+    let queries: Vec<Vec<f32>> =
+        (0..QUERIES).map(|_| rand_vec(&mut q_state, DIM)).collect();
+
+    let mut recalls: Vec<f64> = Vec::with_capacity(EF_LEVELS.len());
+    for &ef in EF_LEVELS {
+        let mut hits = 0usize;
+        for q in &queries {
+            let exact_ids: Vec<u32> =
+                nearest_exact(&store, q, K).into_iter().map(|(id, _)| id).collect();
+            let approx_ids: Vec<u32> =
+                index.nearest_with_ef(q, K, ef).into_iter().map(|(id, _)| id).collect();
+            assert_eq!(
+                approx_ids.len(),
+                K,
+                "nearest_with_ef must return exactly K results (ef={})",
+                ef
+            );
+            hits += approx_ids.iter().filter(|id| exact_ids.contains(id)).count();
+        }
+        let recall = hits as f64 / (QUERIES * K) as f64;
+        eprintln!("ef={ef:>4}  recall@{K}={recall:.4}");
+        recalls.push(recall);
+    }
+
+    // Check monotone non-decreasing across every consecutive pair.
+    for i in 1..recalls.len() {
+        let (prev_ef, cur_ef) = (EF_LEVELS[i - 1], EF_LEVELS[i]);
+        let (prev_recall, cur_recall) = (recalls[i - 1], recalls[i]);
+        // Allow a tiny numeric tolerance for floating-point representation of
+        // equal recalls expressed as different fractions (e.g. 95/100 vs 190/200).
+        assert!(
+            cur_recall >= prev_recall - 1e-9,
+            "recall@{K} decreased from ef={prev_ef} ({prev_recall:.4}) to ef={cur_ef} ({cur_recall:.4}) — \
+             monotone invariant violated"
+        );
+    }
+
+    // Also assert that the highest ef (256) achieves at least the 0.95 floor.
+    let top_recall = *recalls.last().unwrap();
+    assert!(
+        top_recall >= 0.95,
+        "recall@{K} at ef=256 is {top_recall:.4} < 0.95 — recall floor violated"
+    );
+
+    drop(store);
+}
+
+// --- 3. Zero-query contract -------------------------------------------------------------
+
+/// An all-zero query returns an empty result at any ef, matching `nearest`'s contract.
+#[test]
+fn nearest_with_ef_zero_query_returns_empty() {
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const EF_LEVELS: &[usize] = &[1, 16, 50, 100, 256];
+
+    let (store, index) = build_test_store_and_index();
+    let zero = vec![0.0f32; DIM];
+    for &ef in EF_LEVELS {
+        let result = index.nearest_with_ef(&zero, K, ef);
+        assert!(
+            result.is_empty(),
+            "all-zero query should return [] at ef={ef}, got {} results",
+            result.len()
+        );
+    }
+    drop(store);
+}
+
+// --- 4. Cache reuse — calling the same ef twice is consistent ---------------------------
+
+/// Calling `nearest_with_ef` twice at the same (non-default) ef yields identical results.
+/// This ensures the lazy-build cache does not corrupt the secondary map.
+#[test]
+fn nearest_with_ef_cache_reuse_is_deterministic() {
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const QUERIES: usize = 20;
+    const ALT_EF: usize = 32; // non-default (build ef = 50)
+
+    let (store, index) = build_test_store_and_index();
+    let mut q_state = 0xCAFE_BABE_u64;
+    let queries: Vec<Vec<f32>> =
+        (0..QUERIES).map(|_| rand_vec(&mut q_state, DIM)).collect();
+
+    // First pass — populates the cache for ALT_EF.
+    let first: Vec<Vec<(u32, f32)>> =
+        queries.iter().map(|q| index.nearest_with_ef(q, K, ALT_EF)).collect();
+    // Second pass — should hit the cache.
+    let second: Vec<Vec<(u32, f32)>> =
+        queries.iter().map(|q| index.nearest_with_ef(q, K, ALT_EF)).collect();
+
+    assert_eq!(first, second, "cache reuse must produce identical results");
+    drop(store);
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -154,6 +154,10 @@ cosine(a: &[f32], b: &[f32]) -> f32
 // pulling instant-distance; default build has NO third-party ANN dep). recall < 1.0 — NOT exact.
 VectorIndex::build(&store) / ::build_with(&store, HnswConfig{ef_search, ef_construction, seed})
 impl VectorIndex { fn nearest(&self, query: &[f32], k) -> Vec<(Id, f32)>;
+                   fn nearest_with_ef(&self, query: &[f32], k, ef_search: usize) -> Vec<(Id, f32)>;  // [SONNET-4.6] sq-jo6ty: per-query ef_search sweep (Pareto API)
+                   // nearest_with_ef: when ef==build_ef_search uses the primary map (zero overhead); other ef values
+                   // trigger a lazy one-time build of a secondary map (same ef_construction/seed/points, only ef_search
+                   // differs) cached by ef level — amortised for sweeps. Monotone-recall: higher ef >= lower ef recall.
                    fn nearest_term(&self, &Term, &Graph, &VectorStore, k) -> Vec<(Term, f32)>;
                    fn nearest_term_checked(..) -> Result<Vec<(Term, f32)>, String> }
 


### PR DESCRIPTION
> 🤖 SPARQ agent [SONNET-4.6] — bead sq-jo6ty (P1)

## Summary

- Adds `VectorIndex::nearest_with_ef(&self, query: &[f32], k: usize, ef_search: usize) -> Vec<(Id, f32)>` to the `approx-ann`-gated `VectorIndex` type in `crates/sparq-vectors/src/ann.rs`.
- Closes the BEHIND gap in `research/gap-vector-2026-07.md` §7.1: sparq-vectors could not be placed on the matched-recall Pareto vs hnswlib because `HnswConfig::ef_search` was build-time only — each operating point required a full rebuild. This PR enables recall–QPS sweep without rebuilding the index.
- Unblocks sq-hmd7l.19 follow-up (canonical ANN Pareto comparison).

## Design

`instant-distance` 0.6.1 encodes `ef_search` into `HnswMap` at build time and exposes no per-search override. `VectorIndex` now retains the L2-normalised `NPoint` vectors and a `Mutex<HashMap<usize, HnswMap<…>>>` lazy-build cache:

- `ef == build_ef_search` → primary map (zero overhead; same path as `nearest`).
- `ef != build_ef_search` → a secondary map is built once (same `ef_construction`, `seed`, normalised points — only the beam width differs) and cached. Sweeping 100 queries at ef=16 then 100 at ef=32 pays one extra build per ef level, not one per query.

All secondary maps share the same graph topology as the primary. No new dependency; `approx-ann` feature only (off by default).

## Tests (tests/ef_sweep.rs — `approx-ann`-gated)

| Test | Invariant |
|---|---|
| `nearest_with_build_ef_equals_nearest` | `nearest_with_ef(q, k, build_ef)` is byte-identical to `nearest(q, k)` |
| `ef_sweep_monotone_recall_non_decreasing` | recall@10 vs exact oracle is non-decreasing as ef sweeps 16→32→64→128→256 (load-bearing; NON-VACUOUS — verified the test fails if ef is ignored) |
| `nearest_with_ef_zero_query_returns_empty` | zero-query contract at all ef levels |
| `nearest_with_ef_cache_reuse_is_deterministic` | cache produces identical results on repeated calls at the same ef |

## Gates

Both feature states (default OFF and `--features approx-ann`):

- `cargo clippy --workspace --all-targets -- -D warnings` GREEN
- `cargo test -p sparq-vectors` GREEN (default features)
- `cargo test -p sparq-vectors --features approx-ann` GREEN (4 new + all existing)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` GREEN
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations, README stays at 120-line cap

## Honest scope

`nearest_with_ef` at any finite ef is still APPROXIMATE (recall < 1.0). The monotone-recall property says increasing ef cannot *lower* recall vs the exact oracle, but it does not bound the absolute recall at any specific ef value — that is a function of the corpus, the graph quality (ef_construction, M), and k. Use `nearest_exact` for answer-exact results.

The implementation holds the mutex for the duration of the secondary-path search. This is correct (the search only mutates a local `Search` state) and acceptable for the sweep use case (benchmarking, not a production hot path).