### PR TITLE
fix(jsonld): expand conformance 259 → 276 — FsLoader + @id-null + IRI-colon + @nest + @reverse@index (sq-oy1f.45)

### DIFF
--- a/crates/sparq-conformance/src/floors/expand.rs
+++ b/crates/sparq-conformance/src/floors/expand.rs
@@ -96,4 +96,32 @@
 /// network under `NoopLoader`) and 10 deeper divergences deferred to follow-up beads
 /// (`@id: null` retention t0122, relative-IRI-with-colon t0109, rdf-star reverse
 /// `@index` t0131, `invalid IRI mapping` / `invalid scoped context` shapes).
-pub const FLOOR: usize = 259;
+///
+/// ## [SONNET-4.6] sq-oy1f.45 — expand() correctness raise 259 → 276
+///
+/// Six additional spec-faithful fixes flip 17 previously-failing positive cases to pass
+/// (measured 276 pass / 0 fail / 109 skip):
+///
+/// * **FsLoader wiring** — the expand test harness now uses `FsLoader` (maps the W3C
+///   suite URL prefix to the local fixture directory) instead of `NoopLoader`, so
+///   `@context` / `@import` relative-URL references in test inputs are resolved from
+///   the checked-out files. Fixes t0126, t0127, t0128, tc031, tso08, tso09, tso11,
+///   tc034, tso05, tso06 (10 cases).
+/// * **`@id: null` retention** — `@id` with a string value that expands to nothing
+///   (keyword-form strings that don't map to an IRI) now emits `"@id": null` per
+///   §5.1.2 step 13.4.1, instead of omitting the property. Fixes t0122.
+/// * **Relative-IRI-with-colon** — `expand_iri` (step 6) now validates the prefix
+///   against RFC 3986 scheme rules (`is_valid_scheme`) before treating a colon-
+///   containing term as a compact or absolute IRI. Prefixes starting with `#`, `?`,
+///   etc. fall through to vocab/base resolution. Fixes t0109.
+/// * **`@nest` property-scoped context** — step 14 now applies any property-scoped
+///   `@context` declared on a `@nest`-aliased term (using `propagate = true` so the
+///   context persists into child node objects). Fixes tc037 and tc038.
+/// * **`@reverse` + `@index`** — `create_reverse_definition` now processes `@index`
+///   before storing the definition, matching the behaviour of `finish_definition`
+///   for forward terms with `@container: [@reverse, @index]`. Fixes t0131.
+/// * **Invalid IRI mapping in 1.0 mode** — the round-trip check in
+///   `create_term_definition` (§4.2.2 step 14.3.3) is now gated on JSON-LD 1.1
+///   mode and skipped when the expanded value is itself a keyword (e.g. `@type`),
+///   matching the spec's 1.1-only semantics. Fixes t0026 and t0071.
+pub const FLOOR: usize = 276;

--- a/crates/sparq-conformance/tests/jsonld_suite/expand.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite/expand.rs
@@ -6,7 +6,10 @@
 use super::common::*;
 use serde_json::Value;
 // [SONNET-4.6] sq-kk1mq — native expand() for the document-level expand oracle.
-use sparq_jsonld::{expand as jsonld_expand, JsonLdOptions, NoopLoader, ProcessingMode};
+// [SONNET-4.6] sq-oy1f.45 — FsLoader maps the W3C suite URL prefix to local fixtures so
+// `@context`/`@import` relative-URL references (e.g. t0126, tc034, tso08) are resolved
+// from the local checkout rather than hitting the network.
+use sparq_jsonld::{expand as jsonld_expand, FsLoader, JsonLdOptions, ProcessingMode};
 use std::path::Path;
 
 /// [SONNET-4.6] sq-kk1mq — run the W3C JSON-LD `expand` category with the
@@ -48,6 +51,11 @@ pub fn run_expand_native(root: &Path) -> Score {
             return s;
         }
     };
+    // [SONNET-4.6] sq-oy1f.45 — FsLoader maps the suite's base URL prefix to the local
+    // fixture directory so `@context` / `@import` IRI references in test inputs are
+    // resolved against the checked-out files instead of hitting the network.  The mapping
+    // mirrors the `SUITE_BASE` constant (`https://w3c.github.io/json-ld-api/tests/`).
+    let loader = FsLoader::new().map_prefix(SUITE_BASE, root);
     for e in &entries {
         if e.requires.is_some() {
             s.skip();
@@ -118,8 +126,9 @@ pub fn run_expand_native(root: &Path) -> Score {
             }
         }
 
-        // 3. Call the native expand() algorithm.
-        let expanded = match jsonld_expand(&input_json, &opts, &NoopLoader) {
+        // 3. Call the native expand() algorithm. The FsLoader resolves any `@context` /
+        // `@import` relative-URL references to local fixture files (sq-oy1f.45).
+        let expanded = match jsonld_expand(&input_json, &opts, &loader) {
             Ok(j) => j,
             Err(why) => {
                 s.fail(&e.id, format!("expand() error: {}", why));

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -337,10 +337,11 @@ const LIB_SOURCED_EXPECTED: &[(&str, usize)] = &[
     ("W3C JSON-LD 1.1 fromRdf", 51),
     ("W3C JSON-LD 1.1 compact", 186),
     ("W3C JSON-LD 1.1 frame", 61),
-    // [FABLE-5] sq-oy1f.37 — raised 240 → 259 (expand() correctness: value-object
-    // @type collapse + empty-array-property retention + free-floating value/list
-    // drop). Bumped in the SAME commit as src/floors/expand.rs::FLOOR (rise-only).
-    ("W3C JSON-LD 1.1 expand", 259),
+    // [SONNET-4.6] sq-oy1f.45 — raised 259 → 276 (expand() correctness: FsLoader
+    // wiring + @id-null retention + IRI-colon scheme check + @nest scoped ctx
+    // propagation + @reverse @index + 1.0-mode round-trip guard). Bumped in the
+    // SAME commit as src/floors/expand.rs::FLOOR (rise-only).
+    ("W3C JSON-LD 1.1 expand", 276),
     // [FABLE-5] sq-oy1f.26 — oracle-change re-pin (RDF-writer 50 → native flatten() 53).
     // The native lane composes over expand() and inherits the sq-oy1f.37 expand raises,
     // so merging main flips its 7 inherited fails to passes and it now MEASURES 53 pass /

--- a/crates/sparq-jsonld/src/context/iri.rs
+++ b/crates/sparq-jsonld/src/context/iri.rs
@@ -93,16 +93,28 @@ impl ActiveContext {
                 if prefix == "_" || suffix.starts_with("//") {
                     return Some(value.to_string());
                 }
-                // If the prefix is a term flagged `@prefix`, concatenate.
-                if let Some(pdef) = self.term_definitions.get(prefix) {
-                    if pdef.prefix {
-                        if let Some(piri) = &pdef.iri {
-                            return Some(format!("{}{}", piri, suffix));
+                // [SONNET-4.6] sq-oy1f.45 — a colon in a fragment (e.g. `#Test:2`) does
+                // NOT mark a compact-IRI prefix; the prefix must be a valid RFC 3986 URI
+                // scheme (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )).  A non-scheme
+                // prefix (starting with `#`, containing non-scheme chars, etc.) means the
+                // value is a relative reference — fall through to base resolution (step 8).
+                // W3C expand/0109: `#Test:2` must resolve against the base, not be returned
+                // as-is as if it were an absolute IRI.
+                if !is_valid_scheme(prefix) {
+                    // Not a compact IRI (prefix is not a valid scheme); fall through to
+                    // vocab / base resolution.
+                } else {
+                    // If the prefix is a term flagged `@prefix`, concatenate.
+                    if let Some(pdef) = self.term_definitions.get(prefix) {
+                        if pdef.prefix {
+                            if let Some(piri) = &pdef.iri {
+                                return Some(format!("{}{}", piri, suffix));
+                            }
                         }
                     }
+                    // Otherwise the value already contains a valid scheme: treat as absolute IRI.
+                    return Some(value.to_string());
                 }
-                // Otherwise the value already contains a colon: treat it as an absolute IRI.
-                return Some(value.to_string());
             }
         }
         // step 7: a vocabulary reference with a `@vocab` mapping.

--- a/crates/sparq-jsonld/src/context/process.rs
+++ b/crates/sparq-jsonld/src/context/process.rs
@@ -486,8 +486,18 @@ pub(crate) fn create_term_definition(
                 return Err(JsonLdError::new(E::InvalidIriMapping));
             }
             def.iri = Some(expanded.clone());
-            // Round-trip check for compact / relative-IRI terms.
-            if term.find(':').is_some_and(|i| i > 0) || term.contains('/') {
+            // Round-trip check for compact / relative-IRI terms (JSON-LD 1.1 §4.2.2 step
+            // 14.3.3).  This check is ABSENT from the JSON-LD 1.0 algorithm — it was added
+            // in 1.1 to disallow inconsistent compact-IRI redefinitions.  In JSON-LD 1.0
+            // mode the check is skipped (W3C expand/0026 maps rdf:type→@type and
+            // expand/0071 remaps v:term→v:somethingElse — both VALID in 1.0).
+            // The check is also skipped when the IRI mapping is a keyword (e.g. `@type`):
+            // keywords are not IRIs, so the round-trip "expand term = IRI mapping" predicate
+            // cannot hold and the check would always fire spuriously.
+            if env.mode != ProcessingMode::JsonLd10
+                && !is_keyword(&expanded)
+                && (term.find(':').is_some_and(|i| i > 0) || term.contains('/'))
+            {
                 defined.insert(term.to_string(), true);
                 let rt = expand_iri_in_context(active, term, false, true, local, defined, env)?;
                 if rt.as_deref() != Some(expanded.as_str()) {
@@ -598,6 +608,25 @@ fn create_reverse_definition(
             j if is_null(j) => vec![],
             _ => return Err(JsonLdError::new(E::InvalidReverseProperty)),
         };
+    }
+    // [SONNET-4.6] sq-oy1f.45 — §4.2.2 step 18: `@index` applies to `@container @index`
+    // terms including reverse properties (W3C expand/0131: a `@reverse` + `@container @index`
+    // + `@index "predicate"` combination).  The non-reverse path processes `@index` inside
+    // `finish_definition`, but `create_reverse_definition` returns early before reaching
+    // `finish_definition`.  Apply it here so the property-valued-index key is stored.
+    if let Some(idx) = value.get("@index") {
+        if env.mode == ProcessingMode::JsonLd10 || !def.container.iter().any(|m| m == "@index") {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+        let Json::Str(is) = idx else {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        };
+        let is = is.clone();
+        match expand_iri_in_context(active, &is, false, true, local, defined, env)? {
+            Some(e) if is_absolute_iri(&e) => {}
+            _ => return Err(JsonLdError::new(E::InvalidTermDefinition)),
+        }
+        def.index = Some(is);
     }
     def.reverse = true;
     active.term_definitions.insert(term.to_string(), def);

--- a/crates/sparq-jsonld/src/expand.rs
+++ b/crates/sparq-jsonld/src/expand.rs
@@ -392,6 +392,28 @@ fn expand_object(
 
     // step 14: process deferred @nest keys into the same result.
     for nest_key in nests.clone() {
+        // [SONNET-4.6] sq-oy1f.45 — §5.1.2 step 14: apply any property-scoped context
+        // declared on the @nest-aliased term (tc037/tc038).  The context is applied with
+        // override_protected = true and propagate = true so that term definitions from the
+        // nest's scoped context remain visible when descending into child node objects
+        // (e.g. the `agent → @nest` alias in tc038 must be visible inside `aut`'s value).
+        let nest_ctx_and_base: Option<(Json, Option<String>)> = active_context
+            .term_definition(&nest_key)
+            .and_then(|td| td.context().cloned().map(|c| (c, td.base_url.clone())));
+        let nest_processed;
+        let nest_active: &ActiveContext = if let Some((sctx, sbase)) = &nest_ctx_and_base {
+            nest_processed = active_context.process_scoped(
+                sctx,
+                sbase.as_deref(),
+                true,  // override_protected: may redefine protected terms
+                true,  // propagate: keep context in child nodes (not a type-scoped ctx)
+                ctx.loader,
+                ctx.options,
+            )?;
+            &nest_processed
+        } else {
+            active_context
+        };
         for nv in as_array(element.get(&nest_key).cloned().unwrap_or_else(json_null)) {
             if !matches!(nv, Json::Obj(_)) || has_key_expanding_to(active_context, &nv, "@value") {
                 return Err(JsonLdError::new(E::InvalidNestValue));
@@ -399,7 +421,7 @@ fn expand_object(
             let mut inner_nests = Vec::new();
             expand_object(
                 ctx,
-                active_context,
+                nest_active,
                 type_scoped_context,
                 active_property,
                 &nv,
@@ -431,8 +453,14 @@ fn expand_keyword(
     match expanded_property {
         "@id" => match value {
             Json::Str(s) => {
-                if let Some(iri) = active_context.expand_iri(s, true, false) {
-                    set_obj(result, "@id", Json::Str(iri));
+                // [SONNET-4.6] sq-oy1f.45 — §5.1.2 step 13.4.1: "set result[@id] to the
+                // result of IRI expanding value" — the spec always stores the result,
+                // including null (a keyword-form string that is not a recognised keyword
+                // expands to null per §5.2 step 2).  W3C expand/0122 expects
+                // `{"@id": null}` for `@ignoreMe`, not an empty node object `{}`.
+                match active_context.expand_iri(s, true, false) {
+                    Some(iri) => set_obj(result, "@id", Json::Str(iri)),
+                    None => set_obj(result, "@id", json_null()),
                 }
             }
             Json::Arr(items) if frame_expansion => {


### PR DESCRIPTION
## Summary

Six spec-faithful expander fixes lift the W3C JSON-LD 1.1 `expand` conformance floor from **259 → 276** (+17 positive cases, zero new failures, 109 skips unchanged). All gates green in both the default and `jsonld-suite` feature states.

### Changes

| Fix | Cases | Files |
|-----|-------|-------|
| FsLoader in test harness (swap `NoopLoader` → `FsLoader` mapping suite URL prefix to local fixtures) | t0126, t0127, t0128, tc031, tso05, tso06, tso08, tso09, tso11, tc034 (+10) | `tests/jsonld_suite/expand.rs` |
| `@id: null` retention — §5.1.2 step 13.4.1: emit `"@id": null` when keyword-form string expands to nothing | t0122 (+1) | `src/expand.rs` |
| Relative-IRI-with-colon — validate prefix with `is_valid_scheme` before treating as compact/absolute IRI (`#Test:2` → prefix `#Test` is not a valid scheme → falls through to vocab/base) | t0109 (+1) | `src/context/iri.rs` |
| `@nest` property-scoped context — step 14 applies the `@context` declared on a `@nest`-aliased term with `propagate=true` so child node objects retain the scoped definitions | tc037, tc038 (+2) | `src/expand.rs` |
| `@reverse` + `@index` — `create_reverse_definition` now processes `@index` before storing, matching `finish_definition` for forward terms | t0131 (+1) | `src/context/process.rs` |
| 1.0-mode round-trip guard — guard §4.2.2 step 14.3.3 round-trip check on JSON-LD 1.1 mode; skip when expanded value is a keyword (`@type` etc.) | t0026, t0071 (+2) | `src/context/process.rs` |

### Ratchet

Both floor files updated in this commit (rise-only ratchet):
- `crates/sparq-conformance/src/floors/expand.rs` `FLOOR = 276`
- `crates/sparq-conformance/tests/scoreboard_floors.rs` `LIB_SOURCED_EXPECTED … 276`

### Honest scope

The remaining 0 `fail` (109 `skip`) are `NegativeEvaluationTests` (error-code completeness unverified, deferred to a child bead of sq-oy1f) — no cases were silently converted to skips to inflate the pass count.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p sparq-jsonld` — 96+37+45+1+1 = 180 tests, 0 failures
- [x] `cargo test -p sparq-conformance --features jsonld-suite --test jsonld_suite` — 14 tests, 0 failures (TOTAL expand 276 0 109)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- [x] `python3 scripts/check-readme-template.py --enforce` — 0 deviations across 52 READMEs

> **SPARQ agent** 🤖
> Implements bead `sq-oy1f.45` (W3C JSON-LD 1.1 expand conformance fixes, wave 2).