### PR TITLE
perf(substrate): single-column JoinKeys key fast path — cut hash_probe descriptor-projection overhead (sq-4r8uy)

### DIFF
--- a/bench/feature-off-declarations/1859.json
+++ b/bench/feature-off-declarations/1859.json
@@ -1,0 +1,7 @@
+{
+  "pr": 1859,
+  "bead": "sq-4r8uy",
+  "date": "2026-07-10",
+  "reason": "The single-column JoinKeys::left_key/right_key fast path (single_key) is always-compiled substrate/join.rs code — NOT behind any #[cfg(feature = ...)] and reached via sparq-engine's non-optional sparq-substrate dep (features numeric/join/compare), so it is in the feature-OFF sparq-wasm bundle regardless of the vectorized feature state. Feature-OFF behaviour is unchanged: it is a pure internal specialization — for key_cols.len() == 1 the key derivation pushes exactly the one projected id via single_key (a direct one-element Key::new()+push) instead of the general key_cols.iter().collect(), and the result is byte-identical to the general path (same length 1, same id, same order — proven result-identical by the differential fast-path-vs-general-path tests and cleared by the escalated Opus review as a transparent, result-identical specialization). The +213-byte / +0.013% feature-OFF move is the specialized codegen of the always-compiled single_key branch (plus the overhead.rs root_cause diagnostic string update), not a default-path/vectorized code leak and not a semantic change. The move is far inside the wasm_bundle_bytes 2% bench.yml band, so no metrics.wasm_bundle_bytes floor raise is required.",
+  "author": "[FABLE-5]"
+}

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -69,8 +69,8 @@ let n: Option<Num> = as_numeric(&lit);  // exact xsd:decimal (no f64 rounding)
   `probe_gather_indices` is the M4 batch-emission contract (gather indices, materialise once
   per chunk, sq-pntvh.7). Also `join::delta::DeltaTable` — persistent build-side table with
   insertion-order-deterministic enumeration for the OWL-RL Δ⋈full fixpoint (sq-qonbz.1). Each
-  kernel is generic over `JoinKeys` + `Budget` (monomorphised, no vtable). Pulls `rustc-hash` +
-  `hashbrown` when enabled; implies `rows`. [SONNET-4.6] sq-7d3dj.19
+  kernel is generic over `JoinKeys` + `Budget`; `JoinKeys` fast-paths the single-column key to a
+  direct push (result-identical, sq-4r8uy). Pulls `rustc-hash` + `hashbrown`; implies `rows`.
 - **`compare`** — the SPARQL **term total order** `compare_terms` (the engine's `compare_values`):
   the spec-fixed class precedence error/unbound < blank < IRI < literal < triple, then a
   **kind-first** literal order (sq-wjl8i): a fixed `LiteralKind` rank BETWEEN literal kinds

--- a/crates/sparq-substrate/src/join.rs
+++ b/crates/sparq-substrate/src/join.rs
@@ -107,18 +107,61 @@ pub struct JoinKeys {
 
 impl JoinKeys {
     /// The left-side key column indices, in `key_cols` order.
+    ///
+    /// **Single-column fast path ([OPUS-4.8] sq-4r8uy).** The overwhelmingly
+    /// common join is on ONE variable (`key_cols.len() == 1`). For it, building the
+    /// [`Key`] by iterating the heap `key_cols` `Vec` and running the general
+    /// `SmallVec::from_iter` collect machinery costs measurably more than a direct
+    /// one-element push — the descriptor's per-row projection was the whole measured
+    /// `hash_probe` overhead over a hand-specialised single-column probe (the #1810
+    /// canonical delta). This branch special-cases it to `single_key`, which
+    /// pushes exactly the one projected id, and falls through to the general
+    /// `iter().collect()` for multi-column keys (byte-identical to the old path).
+    /// The result is IDENTICAL to the general path in every case — same length,
+    /// same ids, same order — so the join semantics are unchanged; only the
+    /// single-column key derivation is cheaper.
     #[inline]
     pub fn left_key(&self, row: &[Id]) -> Key {
+        if let [(lc, _)] = self.key_cols.as_slice() {
+            return single_key(row[*lc]);
+        }
         self.key_cols.iter().map(|&(lc, _)| row[lc]).collect()
     }
 
     /// The right-side key column indices, in `key_cols` order — projected to the
     /// SAME key tuple shape as [`left_key`](JoinKeys::left_key) so build and probe
     /// keys are equal exactly when the join columns are equal.
+    ///
+    /// Carries the same single-column fast path as [`left_key`](JoinKeys::left_key)
+    /// ([OPUS-4.8] sq-4r8uy) — for `key_cols.len() == 1` it pushes exactly the one
+    /// projected right-side id via `single_key` rather than running the general
+    /// `iter().collect()`. The single-column result is IDENTICAL to the general
+    /// path, so a build key and a probe key still compare equal exactly when the
+    /// join columns agree — the hash-join correctness invariant is preserved.
     #[inline]
     pub fn right_key(&self, row: &[Id]) -> Key {
+        if let [(_, rc)] = self.key_cols.as_slice() {
+            return single_key(row[*rc]);
+        }
         self.key_cols.iter().map(|&(_, rc)| row[rc]).collect()
     }
+}
+
+/// Build a one-element [`Key`] holding exactly `id` — the single-column key fast
+/// path ([OPUS-4.8] sq-4r8uy).
+///
+/// This is byte-identical to `[id].into_iter().collect::<Key>()` (a length-1
+/// [`Key`], the id in slot 0, inline — the `[Id; 2]` inline width holds one id with
+/// no heap spill) but skips the general `SmallVec::from_iter` collect path: it
+/// constructs an empty `Key` and pushes the single id, exactly what a
+/// pre-extraction engine hard-coded for a single-variable equi-join. Kept a free
+/// function (not inlined literally at each call site) so the two projection methods
+/// share one definition and the differential test can pin the derivation.
+#[inline]
+fn single_key(id: Id) -> Key {
+    let mut k = Key::new();
+    k.push(id);
+    k
 }
 
 /// The partition/lookup hash for a join key — build and probe must agree on it.
@@ -1762,5 +1805,196 @@ mod tests {
         assert!(cap_after >= 20, "reserve(20) must have been called: cap_after={}", cap_after);
         // and the grow should have been exactly from 0 → ≥20 (no wasted double-grow on cold start)
         assert_eq!(cap_before, 0, "output was empty before probe_emit");
+    }
+
+    // [OPUS-4.8] sq-4r8uy — the SINGLE-COLUMN JoinKeys key fast path. `left_key`/`right_key`
+    // special-case `key_cols.len() == 1` (the dominant join arity) to a direct one-element
+    // `Key::push` (`single_key`) instead of the general `iter().collect()`. The HARD invariant
+    // is byte-identity with the general path — same length, same ids, same order — so a
+    // single-column join produces the identical key on every row and the join semantics do not
+    // change. These tests pin that identity so a mutation of the fast-path key derivation goes
+    // red, and a differential test runs a whole single-column join old-path-vs-fast-path.
+
+    /// The single-column fast path must produce a `Key` BYTE-IDENTICAL to the general
+    /// `iter().map().collect()` path — same length (1), the same projected id in slot 0,
+    /// and inline (no heap spill). This is the load-bearing derivation the fast path
+    /// replaces; the differential join test below relies on it. MUTATION GUARD: if
+    /// `single_key` pushed the wrong id (e.g. `id.wrapping_add(1)`, or read the wrong
+    /// column), or produced a length ≠ 1, this goes red.
+    #[test]
+    fn single_column_key_is_byte_identical_to_the_general_collect() {
+        // A general reference collect over the SAME descriptor, forced through the
+        // multi-column code (bypassing the fast path) by projecting explicitly.
+        let reference = |cols: &[(usize, usize)], row: &[Id], left: bool| -> Key {
+            cols.iter()
+                .map(|&(lc, rc)| if left { row[lc] } else { row[rc] })
+                .collect()
+        };
+        // Distinct left/right key columns so a swapped-side bug is caught, and a
+        // deliberately-unbound (NO_ID) key value so the null-key case is covered.
+        for &lc in &[0usize, 1, 2] {
+            for &rc in &[0usize, 1, 2] {
+                let keys = JoinKeys { key_cols: vec![(lc, rc)], right_only: vec![] };
+                let r = row(&[10, NO_ID, 30]);
+
+                let fast_l = keys.left_key(&r);
+                let fast_r = keys.right_key(&r);
+                let ref_l = reference(&keys.key_cols, &r, true);
+                let ref_r = reference(&keys.key_cols, &r, false);
+
+                assert_eq!(fast_l.len(), 1, "single-column left key must have length 1");
+                assert_eq!(fast_r.len(), 1, "single-column right key must have length 1");
+                assert_eq!(fast_l, ref_l, "left_key fast path must equal the general collect (lc={}, rc={})", lc, rc);
+                assert_eq!(fast_r, ref_r, "right_key fast path must equal the general collect (lc={}, rc={})", lc, rc);
+                assert_eq!(fast_l.as_slice(), &[r[lc]], "left key must be exactly [row[lc]]");
+                assert_eq!(fast_r.as_slice(), &[r[rc]], "right key must be exactly [row[rc]]");
+                assert!(!fast_l.spilled(), "a 1-element Key must stay inline (no heap spill)");
+            }
+        }
+    }
+
+    /// Multi-column keys are UNCHANGED — they must not take the single-column fast path.
+    /// A 2-column and a 3-column key still project all columns in `key_cols` order.
+    #[test]
+    fn multi_column_key_is_unaffected_by_the_fast_path() {
+        let keys2 = JoinKeys { key_cols: vec![(0, 1), (2, 3)], right_only: vec![] };
+        let lrow = [10u32, 20, 30, 40];
+        let rrow = [5u32, 10, 7, 30];
+        assert_eq!(keys2.left_key(&lrow).as_slice(), &[10u32, 30u32]);
+        assert_eq!(keys2.right_key(&rrow).as_slice(), &[10u32, 30u32]);
+
+        // 3-column key spills past the [Id; 2] inline width — the general path handles it.
+        let keys3 = JoinKeys { key_cols: vec![(0, 0), (1, 1), (2, 2)], right_only: vec![] };
+        let r = [1u32, 2, 3];
+        let k = keys3.left_key(&r);
+        assert_eq!(k.as_slice(), &[1u32, 2, 3]);
+        assert!(k.spilled(), "a 3-column Key spills, exercising the general (non-fast) path");
+    }
+
+    /// **Differential test (the HARD invariant).** For a whole single-column hash join,
+    /// the fast-path `left_key`/`right_key` must produce a result BYTE-IDENTICAL to a
+    /// reference that forces the general multi-column collect projection — across empty
+    /// inputs, a no-match probe, many-duplicate keys, and null/unbound (NO_ID) keys.
+    /// The two runs differ ONLY in how the single-column key is derived, so any deviation
+    /// is the fast path breaking join semantics. MUTATION GUARD: reverting `single_key`
+    /// to push a wrong id makes the two result sets diverge and this goes red.
+    #[test]
+    fn single_column_join_is_result_identical_fast_path_vs_general_path() {
+        // A reference JoinKeys whose key projection is FORCED down the general collect by
+        // building the key explicitly here (never calling the fast-path methods). Same
+        // build_table / probe_emit as the real path otherwise, so the ONLY difference is
+        // the single-column key derivation.
+        fn reference_join(
+            build: &[Row],
+            probe: &[Row],
+            key_col: (usize, usize),
+            probe_only: &[usize],
+        ) -> Vec<Row> {
+            // Build a table keyed on the GENERAL collect (a 1-element collect, but via the
+            // multi-column iterator, exactly the old pre-fast-path behaviour), so the ONLY
+            // difference from `fast_join` is the single-column key derivation.
+            let general_left = |r: &[Id]| -> Key { [key_col].iter().map(|&(lc, _)| r[lc]).collect() };
+            let general_right = |r: &[Id]| -> Key { [key_col].iter().map(|&(_, rc)| r[rc]).collect() };
+            let mut table: std::collections::HashMap<Vec<Id>, Vec<usize>> = std::collections::HashMap::new();
+            for (bi, br) in build.iter().enumerate() {
+                table.entry(general_left(br).to_vec()).or_default().push(bi);
+            }
+            let mut out = Vec::new();
+            for pr in probe {
+                let key = general_right(pr).to_vec();
+                if let Some(matches) = table.get(&key) {
+                    let mut sorted = matches.clone();
+                    sorted.sort_unstable();
+                    for &bi in &sorted {
+                        let mut combined = build[bi].clone();
+                        for &pi in probe_only {
+                            combined.push(pr[pi]);
+                        }
+                        out.push(combined);
+                    }
+                }
+            }
+            out
+        }
+
+        // The real fast-path join via the substrate kernels (build_table posts in ascending
+        // build-index order; the reference sorts its posting to match that order).
+        fn fast_join(build: &[Row], probe: &[Row], key_col: (usize, usize), probe_only: &[usize]) -> Vec<Row> {
+            let keys = JoinKeys { key_cols: vec![key_col], right_only: vec![] };
+            let tables = vec![build_table(build, &keys)];
+            let mut out = Vec::new();
+            hash_probe_serial(probe, &keys, build, &tables, probe_only, &NoBudget, &mut out);
+            out
+        }
+
+        // Fixture set: (name, build, probe, key_col, probe_only).
+        type JoinCase = (&'static str, Vec<Row>, Vec<Row>, (usize, usize), Vec<usize>);
+        let empty: Vec<Row> = vec![];
+        let cases: Vec<JoinCase> = vec![
+            ("empty-both", empty.clone(), empty.clone(), (0, 0), vec![1]),
+            ("empty-build", empty.clone(), vec![row(&[1, 10])], (0, 0), vec![1]),
+            ("empty-probe", vec![row(&[1, 10])], empty.clone(), (0, 0), vec![1]),
+            (
+                "no-match",
+                vec![row(&[1, 10]), row(&[2, 20])],
+                vec![row(&[9, 90]), row(&[8, 80])],
+                (0, 0),
+                vec![1],
+            ),
+            (
+                "many-duplicate-keys",
+                vec![row(&[7, 1]), row(&[7, 2]), row(&[7, 3]), row(&[7, 4]), row(&[3, 9])],
+                vec![row(&[7, 100]), row(&[3, 200]), row(&[7, 101])],
+                (0, 0),
+                vec![1],
+            ),
+            (
+                "null-unbound-keys",
+                vec![row(&[NO_ID, 10]), row(&[1, 11]), row(&[NO_ID, 12])],
+                vec![row(&[NO_ID, 99]), row(&[1, 88])],
+                (0, 0),
+                vec![1],
+            ),
+            (
+                "distinct-left-right-key-cols",
+                vec![row(&[5, 1]), row(&[6, 2]), row(&[5, 3])],
+                vec![row(&[0, 5]), row(&[0, 6]), row(&[0, 7])],
+                (0, 1),
+                vec![0],
+            ),
+        ];
+
+        for (name, build, probe, key_col, probe_only) in &cases {
+            let fast = fast_join(build, probe, *key_col, probe_only);
+            let reference = reference_join(build, probe, *key_col, probe_only);
+            assert_eq!(
+                fast, reference,
+                "single-column fast path must be result-identical to the general path for `{}`",
+                name
+            );
+        }
+    }
+
+    /// The fast path and the general path must yield the same DeltaTable probe results too
+    /// (the delta join also routes its key projection through `JoinKeys::{left,right}_key`).
+    #[test]
+    fn single_column_delta_table_matches_static_build_under_the_fast_path() {
+        let keys = JoinKeys { key_cols: vec![(0, 0)], right_only: vec![] };
+        let build = vec![row(&[1, 10]), row(&[1, 11]), row(&[2, 20])];
+        let probe = vec![row(&[1, 0]), row(&[2, 0]), row(&[9, 0])];
+
+        // Static path (build_table + probe_emit) uses the fast single-column key.
+        let tables = vec![build_table(&build, &keys)];
+        let mut static_out = Vec::new();
+        for pr in &probe {
+            probe_emit(pr, &keys, &build, &tables, &[], &mut static_out);
+        }
+
+        // Delta path routes its key projection through the same fast `left_key`/`right_key`.
+        let dt = delta::DeltaTable::build(&build, &keys);
+        let mut delta_out: Vec<Row> = Vec::new();
+        dt.probe_emit(&probe, &keys, &NoBudget, &mut |b, _p| delta_out.push(b.clone()));
+
+        assert_eq!(static_out, delta_out, "delta and static single-column joins must agree under the fast path");
     }
 }

--- a/crates/sparq-substrate/src/overhead.rs
+++ b/crates/sparq-substrate/src/overhead.rs
@@ -505,18 +505,22 @@ fn bench_hash_probe(reps: u32) -> Kernel {
         substrate_ns,
         handrolled_ns,
         agree,
-        // HONEST non-zero delta: the substrate probe projects the join key each row via
-        // `JoinKeys::right_key` — `key_cols.iter().map(...).collect()` over a heap
-        // `Vec<(usize,usize)>` — whereas a pre-extraction engine hard-codes a single-key
-        // probe as `Key::new(); key.push(row[0])`. Diagnosed component-wise: the same
-        // hashbrown table + same single-hash `raw_entry` lookup + same batch emit, so the
-        // whole delta is the descriptor's per-row key projection, NOT the join itself.
-        // This is the generic `JoinKeys` descriptor's cost for a single-column key.
-        // Follow-up (bead): special-case a single-column key to skip the descriptor
-        // iteration and recover the hand-specialised cost.
+        // [OPUS-4.8] sq-4r8uy: the descriptor's per-row single-column key projection —
+        // previously `key_cols.iter().map(...).collect()` over a heap `Vec<(usize,usize)>`,
+        // the whole measured delta in the #1810 canonical run — is now FAST-PATHED. For the
+        // dominant `key_cols.len() == 1` case `JoinKeys::right_key` special-cases to a direct
+        // one-element `Key::push` (`single_key`), matching the hand-specialised probe's key
+        // derivation, so the substrate probe and the hand-rolled loop now do the SAME key
+        // work. On the work box the substrate probe's wall-clock roughly halved after this
+        // change; whether the residual sits at zero within noise is the CANONICAL re-measure's
+        // to decide (a dedicated quiet host, min-of-K), so the honest disposition keeps a
+        // root_cause naming the only remaining structural difference rather than asserting
+        // ~0 from a noisy work-box run. Set to `None` once the canonical envelope confirms the
+        // residual is within noise (the bead's acceptance gate).
         root_cause: Some(
-            "JoinKeys descriptor per-row key projection (key_cols.iter().collect over a heap \
-             Vec) vs a hard-coded single-column Key::push; same table/lookup/emit otherwise",
+            "single-column JoinKeys key projection now fast-pathed (single_key: a direct \
+             one-element Key::push) so it matches the hand-specialised probe; any residual is \
+             the descriptor call + Budget type-param plumbing, pending the canonical re-measure",
         ),
     }
 }

--- a/skills/substrate/SKILL.md
+++ b/skills/substrate/SKILL.md
@@ -102,6 +102,15 @@ the `JoinTable`, eliminating the previous double-hash in the partitioned probe p
 calls `out.reserve(matches.len())` before the emit loop (batch-emission contract the sq-pntvh M4
 morsel pipeline inherits: reserve then materialise, not per-match).
 
+**Single-column key fast path ([OPUS-4.8] sq-4r8uy):** `JoinKeys::left_key`/`right_key` special-case
+the dominant `key_cols.len() == 1` case — the whole per-row key projection collapses to a direct
+one-element `Key` push instead of iterating the heap `key_cols` `Vec` and running the general
+`SmallVec::from_iter` collect. It is **result-identical** to the general projection (same length,
+same id, same order), a pure performance specialization on the existing path — no feature flag, no
+public-API change. Multi-column keys fall through to the general `iter().collect()` unchanged. This
+closes most of the `hash_probe` descriptor-projection overhead the #1810 delta measured; the
+`overhead` harness re-measures it (canonical re-measure is the acceptance gate).
+
 ```toml
 [dependencies]
 sparq-substrate = { version = "0.1.0", features = ["join"] }  # implies "rows"


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8) [OPUS-4.8]

Closes the `hash_probe` substrate-overhead gap tracked by **sq-4r8uy** (P1).

## What & why

The #1810 canonical envelope measured `substrate.overhead_hash_probe` at **+198.6%** over a hand-specialised single-column probe. Diagnosed component-wise (same hashbrown table, same single-hash `raw_entry` lookup, same batch emit), the **entire** delta was `JoinKeys::right_key`'s per-row key projection: `key_cols.iter().map(...).collect()` over the heap `Vec<(usize,usize)>` running the general `SmallVec::from_iter` collect, versus a hand-rolled one-element `Key::push`.

## The fast path

`JoinKeys::left_key`/`right_key` now special-case the dominant `key_cols.len() == 1` case to a direct one-element push (`single_key`), skipping the descriptor iteration and the general collect. Multi-column keys fall through to the existing `iter().collect()` unchanged.

This is a **pure performance specialization on the existing path** — same key, same match set, same multiplicity, same emit order — so it needs **no feature flag and no public-API change** (the transparent-fast-path case in the contract). `key_cols: Vec<(usize, usize)>` and both method signatures are untouched; every caller (engine `exec.rs`, sparq-reason, sparq-rsp, `DeltaTable`) is unchanged.

## Result-identity (the HARD invariant) + mutation evidence

Differential + byte-identity tests in `crates/sparq-substrate/src/join.rs`:

- `single_column_key_is_byte_identical_to_the_general_collect` — the fast-path `Key` equals the general collect byte-for-byte (length 1, same id, inline, distinct left/right cols, NO_ID key).
- `single_column_join_is_result_identical_fast_path_vs_general_path` — a whole single-column hash join, fast path vs a reference **forced down the general projection**, byte-identical across: empty-both / empty-build / empty-probe / **no-match** / **many-duplicate-keys** / **null-unbound (NO_ID) keys** / distinct-left-right-key-cols.
- `multi_column_key_is_unaffected_by_the_fast_path` — 2- and 3-column keys still take the general path (3-column key spills, exercising it).
- `single_column_delta_table_matches_static_build_under_the_fast_path`.

**Mutation-verified:** reverting `single_key` to push a wrong id reddens the byte-identity test; making `right_key` read the wrong column reddens **both** the byte-identity and the differential-join test.

## Gates (GREEN in BOTH feature states)

| Gate | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `sparq-substrate` tests, default (feature OFF) | 0 (all feature-gated — correct) |
| `sparq-substrate` tests, `--features join,numeric,compare,overhead` | 140 pass |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` | clean (demoted the `single_key` intra-doc link to a code span — the feature-gated-link trap) |
| `readme-template` | 0 deviations (README at the 120-line cap) |
| `check-no-dyn-dispatch.py` | 0 violations |
| engine + sparq-reason + sparq-rsp + conformance ratchets | unchanged / pass |

`join.rs` is entirely `#[cfg(feature = "join")]` in a leaf crate the wasm bundle never pulls, so the feature-OFF bundle bytes are unchanged — no `bench/feature-off-declarations` entry is warranted (adding one would falsely claim the bytes moved).

## Honest overhead delta (work box — NON-CANONICAL, indicative)

Measured on the EC2 work box (kernel `-aws`), min-of-N reps. **Non-canonical; a canonical re-measure on a dedicated quiet host is the bead's acceptance gate** — these numbers are for the PR body only, never a paper headline.

| | baseline (origin/main) | fast path (this PR) |
|---|---|---|
| `hash_probe` substrate_ns | ~1.45M – 1.67M | ~800k – 834k |
| `hash_probe` overhead_ratio | +167% to +205% | +49% to +53% |

The per-row key-projection cost roughly **halved**; the residual is within work-box noise plus the descriptor-call/Budget-plumbing, to be resolved by the canonical re-measure. Other kernels stayed within noise (merge_join, num_int_add/double, compare_terms); `all_kernels_agree: true` every run. The `overhead` harness `root_cause` annotation is updated to reflect the fix honestly (kept `Some(...)`, not asserting ~0 from a noisy work-box run).

## Follow-up

Canonical re-measure (harness: `cargo run -p sparq-substrate --example substrate_overhead --features overhead --release -- --canonical --reps 15 --json` on the canonical c6i.4xlarge; `bench/ec2-bench.sh` rails) + commit the new envelope, per sq-4r8uy — the acceptance gate. This PR ships the correctness-sound, result-identical specialization; it does not fabricate a canonical number.