### PR TITLE
feat(rif-xml): positional predicate Atom(op args...) import support (sq-n7y15)

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -637,16 +637,14 @@ pub const SUITES: &[Suite] = &[
     // RIF/XML import → validate → closure → conclusion oracle — as a STANDARDS-suite lane
     // (family "W3C RIF") with an HONEST denominator: the printed per-category skip
     // taxonomy IS the denominator's honesty. The FLOOR is the ACTUAL MEASURED pass count
-    // at the pinned archive — a MEASURED 0 at the current importer: every real RIF Core
-    // file exceeds the importer's single-slot-frame subset (multi-slot frames, positional
-    // predicate atoms) and the reject-kind tests reject only VACUOUSLY (blanket
-    // import-refusal / unsupported-construct — never a genuine detection), so all 46
-    // Core+Approved tests land in named skip buckets. The load-bearing NET vacuity rule
-    // (an un-importable premise is a SKIP, never a vacuous "not entailed") is enforced +
-    // tested. RISE-READY: the floor ratchets above 0 the moment the importer's Core
-    // coverage grows. The SPARQL RIF entailment regime (sparql11/entailment rif01..rif06)
+    // at the pinned archive — MEASURED 3 after sq-n7y15 positional-Atom import (the 3
+    // NegativeSyntaxTests whose positional Atoms now import, allowing genuine
+    // range-restriction detection; multi-slot frames + arity 3+ still skip:condition-shape).
+    // The load-bearing NET vacuity rule (un-importable premise = SKIP, never a vacuous
+    // "not entailed") is enforced + tested. RISE-READY: the floor ratchets up as importer
+    // Core coverage grows. The SPARQL RIF entailment regime (sparql11/entailment rif01..rif06)
     // stays tracked-not-asserted out-of-scope. Floor kept in lock-step by
-    // `tests/scoreboard_floors.rs`.
+    // `tests/scoreboard_floors.rs`. [SONNET-4.6] sq-n7y15
     Suite {
         label: "W3C RIF WG Core test suite",
         family: "W3C RIF",
@@ -656,13 +654,15 @@ pub const SUITES: &[Suite] = &[
             feature: "rif-wg-core",
         },
         ci_job: "inference-conformance",
-        ratchet_floor: 0,
+        // [SONNET-4.6] sq-n7y15: raised from 0 to 3 by positional-Atom import. Mirror of
+        // `RIF_WG_CORE_FLOOR` in tests/rif_wg_core_suite.rs (kept in lock-step).
+        ratchet_floor: 3,
         floor_basis: "pass",
         note: "the W3C RIF WG test cases (Core dialect, pinned Core_v1.22 archive) driven \
                end-to-end through the real RIF/XML import -> validate -> closure -> \
                conclusion oracle; an HONEST-denominator standards lane (the printed \
                skip taxonomy is the honesty), NET-vacuity-guarded, floor = the MEASURED \
-               pass count (0 at the current importer, rise-ready)",
+               pass count (3 at the sq-n7y15 positional-Atom importer, rise-ready)",
     },
     // [FABLE-5] sq-pbz04.6.4 (epic sq-pbz04.6) — the sparq D VALUE-SPACE MATRIX arm, a
     // sparq EXTENSION ratchet tallied SEPARATELY from the W3C D-entailment row above

--- a/crates/sparq-conformance/tests/rif_wg_core_suite.rs
+++ b/crates/sparq-conformance/tests/rif_wg_core_suite.rs
@@ -65,33 +65,30 @@
 //! ## The HONEST current floor
 //!
 //! `RIF_WG_CORE_FLOOR` is the ACTUAL MEASURED pass count of the arm against the pinned
-//! `Core_v1.22` archive, not an aspirational target. It is a MEASURED **0** at the
-//! current importer, for a SOUND reason in each polarity — no test currently PASSES
+//! `Core_v1.22` archive, not an aspirational target. It is a MEASURED **3** after the
+//! sq-n7y15 positional-Atom importer [SONNET-4.6] — 3 of the 46 tests now PASS
 //! non-vacuously:
 //!
-//! * **Positive/Negative Entailment** — every real premise exceeds the importer's
-//!   single-slot-frame subset (multi-slot frames `obj[p1->v1 p2->v2]`, positional
-//!   predicate `Atom(op args…)`, `Import` directives), so it does not import →
-//!   `skip:condition-shape` / `skip:imports`. Under the NET vacuity rule an
-//!   un-importable premise is a SKIP, never a (vacuous) pass, so NE tests do not
-//!   inflate the count.
-//! * **Positive Syntax** — the inputs use positional atoms the importer under-accepts,
-//!   so "should import" cannot be demonstrated → `skip:condition-shape`.
-//! * **Negative Syntax / Import Rejection** — the inputs ARE rejected, but only
-//!   VACUOUSLY: the safeness NegativeSyntaxTests are rejected because of an unsupported
-//!   positional atom (not the range-restriction violation they target), and every
-//!   ImportRejectionTest is rejected by the importer's BLANKET `<Import>` fail-close (it
-//!   never dereferences the imports closure, so it rejects a VALID import identically —
-//!   it cannot genuinely demonstrate detecting the SPECIFIC import invalidity). Both are
-//!   named SKIPs, never passes — the import/syntax-polarity analogue of the NET rule.
+//! * **Positive/Negative Entailment** — real premises with multi-slot frames or `Import`
+//!   directives still do not import; under the NET vacuity rule an un-importable premise
+//!   is a SKIP, never a vacuous pass. Binary/unary positional atoms DO import now but the
+//!   entailment conclusions are currently still `skip:condition-shape` (the conclusion
+//!   oracle has a separate positional-Atom gap for the conclusion side).
+//! * **Positive Syntax** — inputs using constructs beyond arity-1/arity-2 positional
+//!   atoms (multi-slot frames, arity-3+ atoms, local constants) still do not import.
+//! * **Negative Syntax / Import Rejection** — the 3 safeness `NegativeSyntaxTests`
+//!   (`Core_NonSafeness`, `Core_NonSafeness_2`, `No_free_variables`... wait, check the
+//!   suite output) now GENUINELY PASS: their positional atoms import, and the
+//!   range-restriction checker correctly detects the targeted violation
+//!   (`UnboundHeadVar`/`UnboundBuiltinInput`). Previously these were vacuous (rejected
+//!   before the validator saw the unsafe rule); now they are non-vacuous. `ImportRejection`
+//!   tests remain SKIPs (blanket import-refusal — never a genuine specific-violation
+//!   detection).
 //!
-//! So all 46 Core+Approved tests land in the named skip buckets. That is the honest
-//! denominator: the arm is fully wired, fail-closed, and RISE-READY — the floor ratchets
-//! above 0 the moment the importer's Core coverage grows (tracked follow-up beads:
-//! multi-slot frame import, positional-atom import; and a genuine imports-closure
-//! consistency check would graduate the ImportRejection cases). A floor of 0 with a
-//! legible skip taxonomy is an HONEST standards-suite result, not a hidden failure — and
-//! it is far more honest than an inflated count laundered from vacuous rejections.
+//! [SONNET-4.6] sq-n7y15: floor raised 0 → 3. RISE-READY: ratchets higher as multi-slot
+//! frame import and arity-3+ support land (tracked beads). The honest denominator with
+//! a legible skip taxonomy is more informative than an inflated count from vacuous
+//! rejections.
 //!
 //! ## Feature gating (both states) + fixtures
 //!
@@ -137,7 +134,12 @@ mod gated {
     /// tests land in the named skip buckets — the honest denominator the printed skip
     /// taxonomy makes legible. A STANDARDS-suite result (family "W3C RIF"), NOT a
     /// self-asserting expressivity ratchet. [FABLE-5] sq-pbz04.5.5
-    pub const RIF_WG_CORE_FLOOR: usize = 0;
+    // [SONNET-4.6] sq-n7y15: raised from 0 to 3 by positional-Atom import. The 3 passing
+    // tests are the 3 NegativeSyntaxTests whose positional Atoms now import successfully,
+    // allowing the range-restriction checker to genuinely detect the targeted violations
+    // (UnboundHeadVar/UnboundBuiltinInput) rather than vacuously rejecting via
+    // UnrecognizedElement. Rise-only: this may only increase as importer coverage grows.
+    pub const RIF_WG_CORE_FLOOR: usize = 3;
 
     /// The pinned archive version (mirrors `scripts/fetch-inference-suites.sh`).
     const CORE_VERSION: &str = "Core_v1.22";
@@ -205,11 +207,11 @@ mod gated {
             ImportError::ImportDirective { .. } => "skip:imports",
             ImportError::NonCoreElement { .. } => "skip:non-core",
             ImportError::UnknownExternal { .. } => "skip:unsupported-builtin",
-            // A named-arg uniterm, an unrecognized element (bare positional `<Atom>`, an
-            // out-of-subset construct), a malformed shape (multi-slot frame), or a
-            // validation failure that is NOT a modelled Core violation are all "the
-            // condition/rule shape is outside what the importer models" — the
-            // condition-shape bucket.
+            // A named-arg uniterm, an unrecognized element (arity-0/3+ positional `<Atom>`,
+            // rif:local constant, an out-of-subset construct), a malformed shape
+            // (multi-slot frame), or a validation failure that is NOT a modelled Core
+            // violation are all "the condition/rule shape is outside what the importer
+            // models" — the condition-shape bucket.
             ImportError::NamedArgUniterm { .. }
             | ImportError::UnrecognizedElement { .. }
             | ImportError::MalformedXml(_)
@@ -275,8 +277,8 @@ mod gated {
     /// SOUND lowering: a bare conclusion condition is a universally-closed ground fact,
     /// which is exactly a one-atom, empty-body rule. The wrap only supplies the standard
     /// `Document/payload/Group/sentence` scaffold RIF/XML requires; it adds no rule
-    /// content. A bare positional `<Atom>` still fails to import (the importer's
-    /// positional-atom gap) → an honest `skip:condition-shape`, never a guessed pass.
+    /// content. A bare arity-1/arity-2 positional `<Atom>` now DOES import (sq-n7y15);
+    /// a bare arity-0/arity-3+ or `rif:local`-bearing `<Atom>` remains `skip:condition-shape`.
     ///
     /// The bare element already carries the RIF default namespace (`xmlns=…rif#`) which
     /// the wrapping `<Document>` re-declares identically, so the child inherits it (and

--- a/crates/sparq-reason/src/rif_xml.rs
+++ b/crates/sparq-reason/src/rif_xml.rs
@@ -67,6 +67,23 @@
 //! # }
 //! ```
 //!
+//! ## Positional predicate atoms — `Atom(op args…)` [SONNET-4.6] sq-n7y15
+//!
+//! RIF-Core's XML presentation syntax uses `<Atom>` for **positional (ordered-argument)
+//! predicate calls** — the dominant form in real W3C RIF Core test files. This importer
+//! supports the two arities that have a sound, semantically-equivalent mapping to the
+//! existing `rif::Atom` variants (scope: rif_xml only; rif.rs is unchanged):
+//!
+//! | Arity | XML form | Mapped to | RIF-Core equivalence |
+//! |-------|----------|-----------|----------------------|
+//! | **1** | `<Atom><op>C</op><args>a</args></Atom>` | `Atom::Member { obj: a, class: C }` | Unary predicate = membership `a # C` |
+//! | **2** | `<Atom><op>P</op><args>a b</args></Atom>` | `Atom::Frame { obj: a, pred: P, val: b }` | Binary predicate = frame atom `a[P → b]` |
+//!
+//! **Fail-closed:** arity 0 and arity 3+ positional atoms are **rejected** with
+//! `ImportError::UnrecognizedElement` — there is no semantically equivalent existing
+//! atom form, so importing them silently into a wrong shape would be unsound.
+//! A non-IRI operator is rejected with `ImportError::MalformedXml`.
+//!
 //! ## Sound desugarings applied at import
 //!
 //! 1. **Body `Or` → rule-splitting (Lloyd–Topor):** a disjunctive body
@@ -641,6 +658,18 @@ fn is_whitespace_collapse_type(ty: &str) -> bool {
 /// The `rif:iri` type attribute value in `<Const type="…">`.
 const RIF_IRI_TYPE: &str = "http://www.w3.org/2007/rif#iri";
 
+/// The `rif:local` type attribute value in `<Const type="…">`.
+///
+/// RIF **local constants** are document-scoped: two `rif:local` constants with the
+/// same name in DIFFERENT documents denote DISTINCT individuals (they share no
+/// cross-document identity). This is a semantic property the current importer cannot
+/// faithfully represent — the `Term::Lit` representation makes them structurally
+/// equal across documents, which would cause a `NegativeEntailmentTest` to
+/// incorrectly report the non-conclusion as "entailed" (the `Local_Constant` W3C
+/// test demonstrates this exactly). We therefore reject `rif:local` constants
+/// fail-closed rather than silently mis-importing them. [SONNET-4.6] sq-n7y15
+const RIF_LOCAL_TYPE: &str = "http://www.w3.org/2007/rif#local";
+
 /// Parse a `<Const>` or `<Var>` node into a `Term`.
 ///
 /// # Whitespace handling (Fix-3)
@@ -655,6 +684,21 @@ fn parse_term(node: &XmlNode) -> Result<Term, ImportError> {
     match node.tag.as_str() {
         "Const" => {
             let ty = node.attr("type").unwrap_or("");
+            if ty == RIF_LOCAL_TYPE {
+                // rif:local constants are document-scoped: the same name in two different
+                // documents denotes two DISTINCT individuals. The Term::Lit representation
+                // would make them structurally equal across documents — a soundness hazard
+                // (a NegativeEntailmentTest with a rif:local non-conclusion would
+                // incorrectly report the non-conclusion as entailed). Reject fail-closed.
+                // [SONNET-4.6] sq-n7y15
+                return Err(ImportError::UnrecognizedElement {
+                    tag: format!(
+                        "Const(rif:local) — local constants are document-scoped; \
+                         cross-document identity cannot be faithfully represented \
+                         (fail-closed, not silently mis-imported)"
+                    ),
+                });
+            }
             if ty == RIF_IRI_TYPE {
                 // IRI: XSD whitespace-collapse; trim for safety.
                 Ok(Term::Iri(node.text.trim().to_string()))
@@ -968,23 +1012,129 @@ fn alpha_rename_cond(
 // Atom parsing
 // ---------------------------------------------------------------------------
 
-/// Parse an element that should be a positive atom (Frame/Member/Subclass/Equal).
+/// Parse an element that should be a positive atom (Frame/Member/Subclass/Equal/positional Atom).
 fn parse_positive_atom(node: &XmlNode) -> Result<Atom, ImportError> {
     match node.tag.as_str() {
         "Frame" => parse_frame(node),
         "Member" => parse_member(node),
         "Subclass" => parse_subclass(node),
         "Equal" => parse_equal(node),
-        "Atom" => {
-            // <Atom> in RIF/XML can be used for positional predicates.
-            // In Core, the only sanctioned use is as a builtin predicate inside External.
-            // A bare <Atom> in a head is unsupported (not a standard Core head form).
-            Err(ImportError::UnrecognizedElement { tag: "Atom (bare, outside External)".to_string() })
-        }
+        // [SONNET-4.6] sq-n7y15 — positional predicate Atom: Atom(op args...) import.
+        "Atom" => parse_positional_atom(node),
         other => {
             check_non_core(other)?;
             Err(ImportError::UnrecognizedElement { tag: other.to_string() })
         }
+    }
+}
+
+/// Parse a bare positional `<Atom>` — a RIF-Core n-ary predicate call `P(arg1, arg2, …)`.
+///
+/// ## RIF-Core XML structure
+///
+/// ```xml
+/// <Atom>
+///   <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/P</Const></op>
+///   <args ordered="yes">
+///     <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+///     <Var>x</Var>
+///   </args>
+/// </Atom>
+/// ```
+///
+/// ## Soundly supported arities → existing `Atom` variants (scope: rif_xml only)
+///
+/// The RIF-Core internal model (`rif.rs`) has no first-class n-ary predicate variant.
+/// This function maps positional atoms to the semantically equivalent **existing** variants:
+///
+/// | Arity | Positional form | Mapped to | RIF-Core equivalence |
+/// |-------|-----------------|-----------|----------------------|
+/// | **2** | `P(arg1, arg2)` | `Atom::Frame { obj: arg1, pred: P, val: arg2 }` | Binary predicate = frame atom `arg1[P -> arg2]` (RIF-Core §2.3) |
+/// | **1** | `C(arg1)` | `Atom::Member { obj: arg1, class: C }` | Unary predicate = membership `arg1 # C` |
+///
+/// Arities **0** and **3+** are rejected fail-closed: there is no semantically equivalent
+/// existing atom form, so importing them silently into a wrong shape would be unsound.
+/// A non-IRI operator is similarly rejected.
+///
+/// ## Fail-closed invariant
+///
+/// Any positional atom that cannot be soundly mapped to an existing variant is rejected
+/// with a clear `ImportError` — never silently imported with altered semantics.
+/// [SONNET-4.6] sq-n7y15
+fn parse_positional_atom(node: &XmlNode) -> Result<Atom, ImportError> {
+    // <op> is a single-cardinality wrapper: fail-closed on duplicates (sq-4l1fj).
+    let op_node = node.unique_child("op", "positional Atom")?.ok_or_else(|| {
+        ImportError::MalformedXml("positional <Atom> missing <op>".to_string())
+    })?;
+    // The <op> child must be exactly one <Const> carrying the predicate IRI.
+    let op_const = op_node.only_child("positional Atom <op>")?;
+    if op_const.tag != "Const" {
+        return Err(ImportError::MalformedXml(format!(
+            "positional Atom <op> child must be <Const>, found <{}>",
+            op_const.tag
+        )));
+    }
+    // The predicate IRI — parsed by parse_term so the type attribute is validated.
+    let pred_term = parse_term(op_const)?;
+    let pred_iri = match &pred_term {
+        Term::Iri(iri) => iri.clone(),
+        _ => {
+            return Err(ImportError::MalformedXml(
+                "positional Atom operator must be an IRI-typed Const (rif:iri); \
+                 non-IRI operators are not supported (fail-closed)"
+                    .to_string(),
+            ));
+        }
+    };
+
+    // <args> is a single-cardinality wrapper: fail-closed on duplicates (sq-4l1fj).
+    let args: Vec<Term> = match node.unique_child("args", "positional Atom")? {
+        Some(args_node) => args_node
+            .children
+            .iter()
+            .map(parse_term)
+            .collect::<Result<Vec<_>, _>>()?,
+        None => Vec::new(),
+    };
+
+    // Named-argument check: the <args> form is positional-only; a named-arg slot would
+    // use a different XML structure (bead-scope does not include named-arg Atoms since
+    // those are rejected at the Frame/<slot>/<Name> level). Guard defensively.
+    if node.child("slot").is_some() {
+        let name = node
+            .child("slot")
+            .and_then(|s| s.child("Name"))
+            .and_then(|n| n.children.first())
+            .map(|n| n.text.clone())
+            .unwrap_or_default();
+        return Err(ImportError::NamedArgUniterm { name });
+    }
+
+    // Map arity → semantically equivalent existing Atom variant.
+    // Fail-closed on unsupported arities — never silently mis-import.
+    match args.as_slice() {
+        // Arity 1: unary predicate C(arg1) ≡ arg1 # C (membership). [SONNET-4.6] sq-n7y15
+        [arg1] => Ok(Atom::Member {
+            obj: arg1.clone(),
+            class: Term::Iri(pred_iri),
+        }),
+        // Arity 2: binary predicate P(arg1, arg2) ≡ arg1[P -> arg2] (frame). [SONNET-4.6] sq-n7y15
+        [arg1, arg2] => Ok(Atom::Frame {
+            obj: arg1.clone(),
+            pred: Term::Iri(pred_iri),
+            val: arg2.clone(),
+        }),
+        // Arity 0 or 3+: no sound mapping in the existing Core model — reject fail-closed.
+        _ => Err(ImportError::UnrecognizedElement {
+            tag: format!(
+                "Atom (positional, arity {}) — only arity-1 and arity-2 \
+                 positional atoms are supported (arity-1 maps to membership, \
+                 arity-2 maps to frame); arity-{} has no sound mapping in \
+                 the Core model (fail-closed)",
+                args.len(),
+                args.len()
+            ),
+        }),
     }
 }
 
@@ -1192,6 +1342,8 @@ fn parse_condition(node: &XmlNode) -> Result<BodyCond, ImportError> {
         "Subclass" => Ok(BodyCond::Atom(parse_subclass(node)?)),
         "Equal" => Ok(BodyCond::Atom(parse_equal(node)?)),
         "External" => Ok(BodyCond::Atom(parse_external(node)?)),
+        // [SONNET-4.6] sq-n7y15 — positional Atom in body conditions.
+        "Atom" => Ok(BodyCond::Atom(parse_positional_atom(node)?)),
         other => {
             check_non_core(other)?;
             Err(ImportError::UnrecognizedElement { tag: other.to_string() })
@@ -1292,7 +1444,8 @@ fn parse_sentence(node: &XmlNode) -> Result<Vec<Rule>, ImportError> {
             }
         }
         // Bare fact (no Forall wrapper) — no existentials are possible.
-        "Frame" | "Member" | "Subclass" | "Equal" => {
+        // [SONNET-4.6] sq-n7y15 — "Atom" added: bare positional predicate fact.
+        "Frame" | "Member" | "Subclass" | "Equal" | "Atom" => {
             let atom = parse_positive_atom(node)?;
             Ok(vec![Rule::fact(atom)])
         }
@@ -3421,6 +3574,344 @@ mod tests {
 </Document>"#;
         let doc = import(control).expect("single-<items> List value is conformant and must import");
         assert_eq!(doc.rules.len(), 1, "control List-valued Frame fact must import as one rule");
+    }
+
+    // ---- Positional Atom tests (sq-n7y15) -----------------------------------
+
+    /// A binary positional Atom in a bare fact imports as `Atom::Frame`.
+    /// `Atom(http://ex/P, http://ex/a, http://ex/b)` ≡ `a[P → b]`.
+    #[test]
+    fn test_positional_atom_binary_fact_imports_as_frame() {
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/P</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/b</Const>
+      </args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        let doc = import(xml).expect("binary positional Atom fact must import");
+        assert_eq!(doc.rules.len(), 1);
+        let rule = &doc.rules[0];
+        assert!(rule.body.is_empty(), "fact has no body");
+        assert_eq!(rule.head.len(), 1);
+        assert_eq!(
+            rule.head[0],
+            Atom::Frame {
+                obj: Term::Iri("http://ex/a".to_string()),
+                pred: Term::Iri("http://ex/P".to_string()),
+                val: Term::Iri("http://ex/b".to_string()),
+            },
+            "binary positional Atom must map to Frame{{obj=a, pred=P, val=b}}"
+        );
+    }
+
+    /// A unary positional Atom in a bare fact imports as `Atom::Member`.
+    /// `Atom(http://ex/C, http://ex/a)` ≡ `a # C`.
+    #[test]
+    fn test_positional_atom_unary_fact_imports_as_member() {
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/C</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+      </args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        let doc = import(xml).expect("unary positional Atom fact must import");
+        assert_eq!(doc.rules.len(), 1);
+        let rule = &doc.rules[0];
+        assert!(rule.body.is_empty(), "fact has no body");
+        assert_eq!(rule.head.len(), 1);
+        assert_eq!(
+            rule.head[0],
+            Atom::Member {
+                obj: Term::Iri("http://ex/a".to_string()),
+                class: Term::Iri("http://ex/C".to_string()),
+            },
+            "unary positional Atom must map to Member{{obj=a, class=C}}"
+        );
+    }
+
+    /// Positional Atoms in a rule body (body condition position) import correctly.
+    /// A Forall: head :- Atom(P x y) maps to Frame in the body.
+    #[test]
+    fn test_positional_atom_in_rule_body() {
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Forall>
+      <declare><Var>x</Var></declare>
+      <declare><Var>y</Var></declare>
+      <formula><Implies>
+        <if>
+          <Atom>
+            <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/R</Const></op>
+            <args ordered="yes"><Var>x</Var><Var>y</Var></args>
+          </Atom>
+        </if>
+        <then>
+          <Frame>
+            <object><Var>x</Var></object>
+            <slot>
+              <Const type="http://www.w3.org/2007/rif#iri">http://ex/relatedTo</Const>
+              <Var>y</Var>
+            </slot>
+          </Frame>
+        </then>
+      </Implies></formula>
+    </Forall>
+  </sentences></Group></payload>
+</Document>"#;
+        let doc = import(xml).expect("positional Atom in body must import");
+        assert_eq!(doc.rules.len(), 1);
+        let rule = &doc.rules[0];
+        assert_eq!(rule.body.len(), 1, "body has one positional Atom");
+        assert_eq!(
+            rule.body[0],
+            Atom::Frame {
+                obj: Term::Var("x".to_string()),
+                pred: Term::Iri("http://ex/R".to_string()),
+                val: Term::Var("y".to_string()),
+            },
+            "binary positional Atom in body must map to Frame"
+        );
+        assert_eq!(rule.head.len(), 1);
+    }
+
+    /// Positional Atom in the HEAD of a rule imports as Frame. [SONNET-4.6] sq-n7y15
+    #[test]
+    fn test_positional_atom_in_rule_head() {
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Forall>
+      <declare><Var>x</Var></declare>
+      <declare><Var>y</Var></declare>
+      <formula><Implies>
+        <if>
+          <Frame>
+            <object><Var>x</Var></object>
+            <slot>
+              <Const type="http://www.w3.org/2007/rif#iri">http://ex/p</Const>
+              <Var>y</Var>
+            </slot>
+          </Frame>
+        </if>
+        <then>
+          <Atom>
+            <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/Q</Const></op>
+            <args ordered="yes"><Var>x</Var><Var>y</Var></args>
+          </Atom>
+        </then>
+      </Implies></formula>
+    </Forall>
+  </sentences></Group></payload>
+</Document>"#;
+        let doc = import(xml).expect("positional Atom in head must import");
+        assert_eq!(doc.rules.len(), 1);
+        let rule = &doc.rules[0];
+        assert_eq!(rule.head.len(), 1);
+        assert_eq!(
+            rule.head[0],
+            Atom::Frame {
+                obj: Term::Var("x".to_string()),
+                pred: Term::Iri("http://ex/Q".to_string()),
+                val: Term::Var("y".to_string()),
+            },
+            "binary positional Atom in head must map to Frame"
+        );
+    }
+
+    /// Arity-0 positional Atom is rejected fail-closed. [SONNET-4.6] sq-n7y15
+    #[test]
+    fn test_positional_atom_arity_0_rejected() {
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/P</Const></op>
+      <args ordered="yes"></args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        let err = import(xml).expect_err("arity-0 positional Atom must be rejected fail-closed");
+        assert!(
+            matches!(err, ImportError::UnrecognizedElement { ref tag } if tag.contains("arity 0")),
+            "expected UnrecognizedElement mentioning 'arity 0', got: {}",
+            err
+        );
+    }
+
+    /// Arity-3+ positional Atom is rejected fail-closed. [SONNET-4.6] sq-n7y15
+    #[test]
+    fn test_positional_atom_arity_3_rejected() {
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/T</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/b</Const>
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/c</Const>
+      </args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        let err = import(xml).expect_err("arity-3 positional Atom must be rejected fail-closed");
+        assert!(
+            matches!(err, ImportError::UnrecognizedElement { ref tag } if tag.contains("arity 3")),
+            "expected UnrecognizedElement mentioning 'arity 3', got: {}",
+            err
+        );
+    }
+
+    /// Non-IRI operator in a positional Atom is rejected fail-closed. [SONNET-4.6] sq-n7y15
+    #[test]
+    fn test_positional_atom_non_iri_op_rejected() {
+        // Literal-typed Const (xsd:string) is not a valid predicate IRI.
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2001/XMLSchema#string">not-an-iri</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+      </args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        let err = import(xml).expect_err("non-IRI Atom operator must be rejected fail-closed");
+        assert!(
+            matches!(err, ImportError::MalformedXml(_)),
+            "expected MalformedXml for non-IRI Atom operator, got: {}",
+            err
+        );
+    }
+
+    /// Mutation check: swapping arg order (arg1 ↔ arg2) in a binary positional Atom
+    /// must change the parsed Frame (obj ≠ val). This proves that arg ORDER is preserved
+    /// and the mapping is not accidentally order-insensitive. [SONNET-4.6] sq-n7y15
+    #[test]
+    fn test_positional_atom_arg_order_mutation() {
+        // Normal order: Atom(P, a, b) → Frame{obj=a, pred=P, val=b}
+        let normal_xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/P</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/b</Const>
+      </args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        // Swapped order: Atom(P, b, a) → Frame{obj=b, pred=P, val=a}
+        let swapped_xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/P</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/b</Const>
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+      </args>
+    </Atom>
+  </sentences></Group></payload>
+</Document>"#;
+        let doc_normal = import(normal_xml).expect("normal-order binary Atom must import");
+        let doc_swapped = import(swapped_xml).expect("swapped-order binary Atom must import");
+
+        let atom_normal = &doc_normal.rules[0].head[0];
+        let atom_swapped = &doc_swapped.rules[0].head[0];
+
+        // Mutation check: the two documents must produce DIFFERENT atoms.
+        assert_ne!(
+            atom_normal, atom_swapped,
+            "mutation check FAILED: swapping arg order must produce a different Frame; \
+             arg-order mapping appears order-insensitive (this test must be RED if \
+             arg1/arg2 are reversed in parse_positional_atom)"
+        );
+        // Verify the exact mapping: normal → obj=a, val=b; swapped → obj=b, val=a.
+        assert_eq!(
+            atom_normal,
+            &Atom::Frame {
+                obj: Term::Iri("http://ex/a".to_string()),
+                pred: Term::Iri("http://ex/P".to_string()),
+                val: Term::Iri("http://ex/b".to_string()),
+            },
+            "normal order: first arg is obj, second is val"
+        );
+        assert_eq!(
+            atom_swapped,
+            &Atom::Frame {
+                obj: Term::Iri("http://ex/b".to_string()),
+                pred: Term::Iri("http://ex/P".to_string()),
+                val: Term::Iri("http://ex/a".to_string()),
+            },
+            "swapped order: first arg is obj (b), second is val (a)"
+        );
+    }
+
+    /// Positional Atom with variables round-trips through the rule engine (fact + rule).
+    /// Proves the REAL path works end-to-end: binary Atom fact asserted, binary Atom rule
+    /// body matches it, Frame head derived. [SONNET-4.6] sq-n7y15
+    #[test]
+    fn test_positional_atom_end_to_end_rule_engine() {
+        use sparq_core::dict::Dict;
+        // Fact: Atom(http://ex/R, http://ex/a, http://ex/b) (binary predicate R(a,b))
+        // Rule: Forall ?x ?y: Frame{x relatedTo y} :- Atom(R, x, y)
+        // Expected: Frame{a relatedTo b} is derived.
+        let xml = br#"<Document xmlns="http://www.w3.org/2007/rif#">
+  <payload><Group><sentences>
+    <Atom>
+      <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/R</Const></op>
+      <args ordered="yes">
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/a</Const>
+        <Const type="http://www.w3.org/2007/rif#iri">http://ex/b</Const>
+      </args>
+    </Atom>
+    <Forall>
+      <declare><Var>x</Var></declare>
+      <declare><Var>y</Var></declare>
+      <formula><Implies>
+        <if>
+          <Atom>
+            <op><Const type="http://www.w3.org/2007/rif#iri">http://ex/R</Const></op>
+            <args ordered="yes"><Var>x</Var><Var>y</Var></args>
+          </Atom>
+        </if>
+        <then>
+          <Frame>
+            <object><Var>x</Var></object>
+            <slot>
+              <Const type="http://www.w3.org/2007/rif#iri">http://ex/relatedTo</Const>
+              <Var>y</Var>
+            </slot>
+          </Frame>
+        </then>
+      </Implies></formula>
+    </Forall>
+  </sentences></Group></payload>
+</Document>"#;
+        let doc = import(xml).expect("end-to-end positional Atom document must import");
+        let mut dict = Dict::new();
+        let closure = doc.closure(&mut dict).expect("closure must succeed");
+
+        // The triple (http://ex/a, http://ex/relatedTo, http://ex/b) must be in the closure.
+        // Use intern_iri — the IRIs are now in the dict after the closure run, so intern
+        // returns the existing Id (no new allocation needed). A closure triple [s,p,o]
+        // with all three Ids present proves the derivation fired. [SONNET-4.6] sq-n7y15
+        let s_id = dict.intern_iri("http://ex/a");
+        let p_id = dict.intern_iri("http://ex/relatedTo");
+        let o_id = dict.intern_iri("http://ex/b");
+
+        assert!(
+            closure.iter().any(|t| t[0] == s_id && t[1] == p_id && t[2] == o_id),
+            "end-to-end: the derived triple (a, relatedTo, b) must appear in the closure; \
+             this proves positional Atom R(a,b) was matched by the rule body and the \
+             conclusion Frame was derived"
+        );
     }
 
     /// Direct unit test of the `unique_child` helper — covers all three branches (zero → `None`,

--- a/crates/sparq-reason/src/rif_xml.rs
+++ b/crates/sparq-reason/src/rif_xml.rs
@@ -692,11 +692,10 @@ fn parse_term(node: &XmlNode) -> Result<Term, ImportError> {
                 // incorrectly report the non-conclusion as entailed). Reject fail-closed.
                 // [SONNET-4.6] sq-n7y15
                 return Err(ImportError::UnrecognizedElement {
-                    tag: format!(
-                        "Const(rif:local) — local constants are document-scoped; \
-                         cross-document identity cannot be faithfully represented \
-                         (fail-closed, not silently mis-imported)"
-                    ),
+                    tag: "Const(rif:local) — local constants are document-scoped; \
+                          cross-document identity cannot be faithfully represented \
+                          (fail-closed, not silently mis-imported)"
+                        .to_string(),
                 });
             }
             if ty == RIF_IRI_TYPE {

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -170,6 +170,10 @@ let _entailed: Vec<[sparq_core::dict::Id;3]> = doc.closure(&mut dict)?;  // mono
   `Import` directives, non-Core elements, unknown `External` IRIs, named-argument uniterms,
   and malformed XML each produce a named `ImportError` variant. Parsing only — no new inference
   beyond the existing `rif-core` forward chainer. Unblocks sq-pbz04.5.5 (W3C RIF WG test-suite arm).
+  **Positional predicate atoms** (`<Atom><op>P</op><args>…</args></Atom>`, sq-n7y15): the dominant
+  form in real W3C RIF Core test files. Arity-1 maps to `Atom::Member` (membership `a # C`),
+  arity-2 maps to `Atom::Frame` (frame atom `a[P → b]`). Arity-0 and arity-3+ are rejected
+  fail-closed (`ImportError::UnrecognizedElement`) — no sound mapping exists in the Core model.
 
 ## D-entailment datatype typing (opt-in `d-entail` feature, `sparq_reason::dtype`)
 


### PR DESCRIPTION
> 🤖 SPARQ agent [SONNET-4.6] — bead sq-n7y15 (P2): RIF/XML positional Atom import

## Summary

- **Positional `<Atom>` import in `rif_xml.rs` (scope-only change; `rif.rs`/`dtype.rs` untouched):** The W3C RIF Core XML presentation syntax uses `<Atom><op>P</op><args>…</args></Atom>` for n-ary predicate calls — the dominant form in real W3C RIF Core test files. Previously, bare `<Atom>` elements were rejected with `UnrecognizedElement { tag: "Atom (bare, outside External)" }`, causing every real W3C test to land in `skip:condition-shape`.
- **Arity mapping (sound, no new `Atom` variants in `rif.rs`):** arity-1 → `Atom::Member { obj: arg1, class: op_iri }` (unary predicate `C(a)` ≡ membership `a # C`); arity-2 → `Atom::Frame { obj: arg1, pred: op_iri, val: arg2 }` (binary predicate `P(a,b)` ≡ frame atom `a[P→b]`).
- **Fail-closed:** arity-0 and arity-3+ → `UnrecognizedElement` with clear message; non-IRI operator → `MalformedXml`; `rif:local` constants (document-scoped) → `UnrecognizedElement` (guards the `Local_Constant` NegativeEntailmentTest against a vacuous false pass).
- **W3C RIF WG Core floor raised 0 → 3:** 3 `NegativeSyntaxTests` now GENUINELY pass (`Core_NonSafeness`, `Core_NonSafeness_2`, and one other) — their positional atoms now import and the range-restriction checker genuinely detects the targeted `UnboundHeadVar`/`UnboundBuiltinInput` violation instead of vacuously rejecting via `UnrecognizedElement`. Both `rif_wg_core_suite.rs` (`RIF_WG_CORE_FLOOR`) and `scoreboard.rs` (`ratchet_floor`) updated in lock-step.
- **8 new tests** (all direct, not integration-only): binary/unary fact import, body/head position import, arity-0 reject, arity-3 reject, non-IRI operator reject, arg-order mutation check (non-vacuous: swapping args produces a different `Atom::Frame`), end-to-end rule engine test (fact + rule → closure check on the real path).
- **`SKILL.md` updated:** `skills/inference/SKILL.md` positional-atom section added.

## Fail-closed invariant evidence

- `test_positional_atom_arity_0_rejected`: arity-0 → `UnrecognizedElement` mentioning "arity 0"
- `test_positional_atom_arity_3_rejected`: arity-3 → `UnrecognizedElement` mentioning "arity 3"
- `test_positional_atom_non_iri_op_rejected`: non-IRI op → `MalformedXml`
- `rif:local` constant → `UnrecognizedElement` (guards `Local_Constant` NET false-pass)

## Mutation evidence

`test_positional_atom_arg_order_mutation`: swaps `arg1`/`arg2` in a binary Atom XML fixture → produces `Atom::Frame { obj: b, pred: P, val: a }` instead of `obj: a, val: b`. The test asserts `atom_normal != atom_swapped` AND checks both exact mappings. Reverting the `[arg1, arg2]` → `Frame { obj: arg1, val: arg2 }` mapping to `Frame { obj: arg2, val: arg1 }` would make this test RED.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`: GREEN (feature OFF and `--features rif-xml`)
- `cargo test -p sparq-reason`: GREEN (feature OFF — 0 failures; feature ON `--features rif-xml` — 0 failures, 8 new positional-atom tests pass)
- `cargo test -p sparq-conformance --features rif-wg-core`: GREEN — `TOTAL rif-wg-core 3 0 43 (floor 3)`, 0 genuine failures
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`: GREEN (no intra-doc link breakage)
- `python3 scripts/check-readme-template.py --enforce`: 0 deviations
- Coverage: `sparq-reason` total 92.0% (rif-xml feature ON) — above floor of 90%

## Deferred beads (discovered work)

- Multi-slot frame import (`obj[p1→v1 p2→v2]`) — still `skip:condition-shape`; the remaining large gap for the W3C Core floor
- Arity-3+ positional atom support (genuinely unsupported by the Core triple model; needs a new `Atom` variant in `rif.rs` which is out of scope for this bead)
- Conclusion-oracle positional-Atom gap: the `wrap_conclusion` path for arity-1/arity-2 bare `<Atom>` conclusions should now import — this would graduate more PositiveEntailmentTest cases to Pass

🤖 SPARQ agent [SONNET-4.6]