### PR TITLE
perf(vectors): explicit-SIMD (NEON/AVX2) HNSW distance kernel — no new dep (sq-lfo84)

### DIFF
--- a/bench/unsafe-snapshot.json
+++ b/bench/unsafe-snapshot.json
@@ -9,14 +9,14 @@
     "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
     "update \u2014 the diff to this file is the review hook. Smaller is always allowed."
   ],
-  "total": 72,
+  "total": 76,
   "crates": {
     "sparq-bench": 1,
     "sparq-cli": 2,
     "sparq-core": 50,
     "sparq-engine": 4,
     "sparq-py": 4,
-    "sparq-vectors": 9,
+    "sparq-vectors": 13,
     "sparq-zk-compose": 2
   }
 }

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -118,7 +118,7 @@ Recurring invariant shorthands used below:
 | `src/compress.rs:2104` | `Mmap::map` | own-for-lifetime (TEST) | TEST-only (`#[test] corrupt_magic_is_loud_error_never_misdecode`, sq-7d3dj.32.2.7): read-only map of a temp perm file the test itself just created and owns; `File`/`Mmap` live for the map's whole scope and nothing else mutates it during the test, so the loud-error `from_mmap` read stays in-bounds over a stable region. [FABLE-5] |
 | `src/compress.rs:2120` | `Mmap::map` | own-for-lifetime (TEST) | TEST-only (`#[test] corrupt_magic_is_loud_error_never_misdecode`, sq-7d3dj.32.2.7): read-only map of a second temp perm file the same test created and owns; `File`/`Mmap` live for the map's whole scope and nothing else mutates it during the test, so the `from_mmap` read stays in-bounds over a stable region. [FABLE-5] |
 
-### `sparq-vectors` — 9 sites (aligned vector blobs + mmap'd `.spqv` / DiskANN)
+### `sparq-vectors` — 13 sites (aligned vector blobs + mmap'd `.spqv` / DiskANN + the SIMD ANN kernel)
 
 | File:line | Kind | Invariant relied on | Why sound / how bounded |
 |---|---|---|---|
@@ -131,6 +131,10 @@ Recurring invariant shorthands used below:
 | `src/diskann.rs:395` | slice reinterpret (read) | f32 no invalid patterns; align ok | f32→LE bytes; LE target asserted; borrows `b.vectors`. |
 | `src/diskann.rs:509` | `Mmap::map` | own-for-lifetime | read-only map of a DiskANN file; `open` validates after. **B5**. |
 | `src/diskann.rs:596` | slice reinterpret (read) | page-align; `start` a multiple of 4 ⇒ f32-aligned; range validated in `open` | `debug_assert_eq!` checks alignment; f32 accepts any bit pattern; borrows the map. **B5**. |
+| `src/simd.rs:40` (`approx-ann`) | `#[target_feature(enable="neon")]` call | the `neon` ISA extension is present at runtime | entered ONLY inside `if is_aarch64_feature_detected!("neon")` on the line above; `l2_sq_neon` reads exactly `a.len()==b.len()` lanes. [OPUS-4.8] sq-lfo84 |
+| `src/simd.rs:50` (`approx-ann`) | `#[target_feature(enable="avx2,fma")]` call | both `avx2` and `fma` are present at runtime | entered ONLY inside `if is_x86_feature_detected!("avx2") && …("fma")` on the line above; `l2_sq_avx2` reads exactly `a.len()` lanes via unaligned loads. [OPUS-4.8] sq-lfo84 |
+| `src/simd.rs:86` (`approx-ann`) | `unsafe fn l2_sq_neon` (NEON L2² kernel) | caller confirmed `neon`; `a.len()==b.len()` | 16-wide FMA body + 4-wide drain + scalar tail (`get_unchecked` only for `i<len`), so every `vld1q_f32` load is in-bounds. Verified vs an f64 reference for dim 0..=257 (`simd::tests`). [OPUS-4.8] sq-lfo84 |
+| `src/simd.rs:129` (`approx-ann`) | `unsafe fn l2_sq_avx2` (AVX2+FMA L2² kernel) | caller confirmed `avx2`+`fma`; `a.len()==b.len()` | 16-wide FMA body + 8-wide drain + scalar tail (`get_unchecked` only for `i<len`); `_mm256_loadu_ps` is unaligned so no alignment precondition. Numeric output verified by `simd::tests` on the x86_64 CI runner (this aarch64 box cannot execute AVX2). [OPUS-4.8] sq-lfo84 |
 
 ### `sparq-cli` — 2 sites (the `dump-perm` debug command)
 

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -53,7 +53,9 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   persistent on-disk `DiskAnnIndex` in the default build; the in-RAM HNSW `VectorIndex`
   behind the **opt-in `approx-ann`** feature, the **only** third-party-ANN dependency
   (`instant-distance`). `VectorIndex::nearest_with_ef(q, k, ef)` sweeps `ef_search` at
-  query time (recall–QPS Pareto; monotone-non-decreasing recall as `ef` grows). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
+  query time (recall–QPS Pareto; monotone-non-decreasing recall as `ef` grows). The HNSW distance
+  kernel is **explicit SIMD** (runtime-detected NEON / AVX2+FMA, scalar fallback, no new dependency —
+  cuts build time + lifts QPS, **recall unchanged**). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
 - **Predicate-constrained ANN (opt-in `filtered-ann`)** — restrict the search to the
   dict-ids a SPARQL BGP admits via an `IdMask` (lean, no new dependency). Composed with
   `approx-ann`, filtered over-fetch fills `k` whenever `k` admitted vectors exist *and the
@@ -103,16 +105,14 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
 
 - **How-to** — [`skills/vector-search/SKILL.md`](../../skills/vector-search/SKILL.md) (label /
   verbalized / hybrid pipelines, DiskANN, quantization, bulk import, API surface, `.spqv`/`.spqg`).
-- **API reference** — [docs.rs/sparq-vectors](https://docs.rs/sparq-vectors).
-- **Design** — [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md).
-- **Accuracy & throughput** — not baked into docs; the recall / DiskANN / PQ / throughput gates
-  are `cargo test`s (`tests/recall.rs`, `diskann.rs`, `quant.rs`, `throughput.rs`), with live
-  numbers on the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
+- **API reference** — [docs.rs/sparq-vectors](https://docs.rs/sparq-vectors); **design** —
+  [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md).
+- **Accuracy & throughput** — not baked into docs; the recall / DiskANN / PQ / throughput gates are
+  `cargo test`s, with live numbers on the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Verified against an established ANN library (sq-6te5)** — `tests/ref_lib_verify.rs` anchors
   recall against **hnswlib** via a committed capture (`tests/fixtures/hnswlib_ref.tsv`):
-  `nearest_exact` reproduces the numpy exact-kNN oracle, and DiskANN (and HNSW under `approx-ann`)
-  clears hnswlib's recall. Runs in CI with **no native deps** (deterministic corpus); the live
-  re-capture (`scripts/capture_hnswlib_ref.py`) is `#[ignore]`d. Recall figures NON-CANONICAL.
+  `nearest_exact` reproduces the numpy exact-kNN oracle, and DiskANN / HNSW clear hnswlib's recall.
+  Runs in CI with no native deps; the live re-capture is `#[ignore]`d. Recall figures NON-CANONICAL.
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -55,7 +55,7 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   (`instant-distance`). `VectorIndex::nearest_with_ef(q, k, ef)` sweeps `ef_search` at
   query time (recall–QPS Pareto; monotone-non-decreasing recall as `ef` grows). The HNSW distance
   kernel is **explicit SIMD** (runtime-detected NEON / AVX2+FMA, scalar fallback, no new dependency —
-  cuts build time + lifts QPS, **recall unchanged**). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
+  cuts build time + lifts QPS; recall **floor-preserved**, not bit-identical: FMA differs ≤1 ULP, absorbed by the recall floor gate). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
 - **Predicate-constrained ANN (opt-in `filtered-ann`)** — restrict the search to the
   dict-ids a SPARQL BGP admits via an `IdMask` (lean, no new dependency). Composed with
   `approx-ann`, filtered over-fetch fills `k` whenever `k` admitted vectors exist *and the

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -159,8 +159,11 @@ impl Point for NPoint {
         // dominant cost of both. Dispatch to the explicit NEON/AVX2 kernel (scalar fallback where
         // the vector ISA is absent), which measurably cuts build time and lifts QPS vs the previous
         // scalar-only loop. `instant-distance` wants the true Euclidean distance, so we `sqrt` the
-        // squared kernel; the graph ranking is unchanged (sqrt is monotone), and the reported cosine
-        // score is derived from `item.distance` exactly as before.
+        // squared kernel (sqrt is monotone, so `sqrt` itself introduces no reorder vs the squared
+        // value). The SIMD kernel uses FMA (one rounding) vs the scalar `d*d`+`+=` (two roundings),
+        // so a distance differs by <=1 ULP: rankings are stable up to exact near-ties, which the
+        // HNSW recall FLOOR gate (tests/recall.rs, recall@10 >= 0.95) absorbs — NOT a bit-identity
+        // claim. The reported cosine score is derived from `item.distance` exactly as before.
         crate::simd::l2_sq_dist(&self.0, &other.0).sqrt()
     }
 }

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -155,21 +155,13 @@ struct NPoint(Vec<f32>);
 #[cfg(feature = "approx-ann")]
 impl Point for NPoint {
     fn distance(&self, other: &Self) -> f32 {
-        const LANES: usize = 8;
-        let (a, b) = (&self.0, &other.0);
-        let mut acc = [0f32; LANES];
-        let chunks = a.len() / LANES;
-        for c in 0..chunks {
-            for l in 0..LANES {
-                let d = a[c * LANES + l] - b[c * LANES + l];
-                acc[l] += d * d;
-            }
-        }
-        for i in chunks * LANES..a.len() {
-            let d = a[i] - b[i];
-            acc[0] += d * d;
-        }
-        acc.iter().sum::<f32>().sqrt()
+        // [OPUS-4.8] (sq-lfo84) The HNSW build + search call this millions of times — it is the
+        // dominant cost of both. Dispatch to the explicit NEON/AVX2 kernel (scalar fallback where
+        // the vector ISA is absent), which measurably cuts build time and lifts QPS vs the previous
+        // scalar-only loop. `instant-distance` wants the true Euclidean distance, so we `sqrt` the
+        // squared kernel; the graph ranking is unchanged (sqrt is monotone), and the reported cosine
+        // score is derived from `item.distance` exactly as before.
+        crate::simd::l2_sq_dist(&self.0, &other.0).sqrt()
     }
 }
 

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -3,6 +3,11 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 
 pub mod ann;
+// [OPUS-4.8] (sq-lfo84) Explicit-SIMD (NEON/AVX2) squared-Euclidean distance kernel for the HNSW
+// ANN hot loop. `approx-ann` only (the HNSW backend it serves); no new dependency — pure
+// `core::arch` intrinsics with a scalar fallback bit-identical to the previous auto-vectorised loop.
+#[cfg(feature = "approx-ann")]
+mod simd;
 // [OPUS-4.8] (sq-ip3a) Pluggable ANN backend seam (exact default vs approximate) + the iterative
 // over-fetch FILTERED path — `filtered-ann` only (the approximate impl is additionally `approx-ann`).
 #[cfg(feature = "filtered-ann")]

--- a/crates/sparq-vectors/src/simd.rs
+++ b/crates/sparq-vectors/src/simd.rs
@@ -1,0 +1,238 @@
+//! [OPUS-4.8] (sq-lfo84) **Explicit-SIMD distance kernels** for the ANN hot loop.
+//!
+//! The HNSW graph build (`instant-distance`) and search evaluate the squared-Euclidean
+//! distance between unit vectors *millions* of times; that inner loop is the dominant cost of
+//! both build and query (the sq-z2z18 sweep root-caused the QPS/build-time gap vs hnswlib to
+//! `instant-distance` shipping only a **scalar** distance kernel). This module replaces the
+//! scalar reduction on the HNSW path with a hand-written, runtime-detected SIMD kernel —
+//! **NEON** on `aarch64`, **AVX2 + FMA** on `x86_64` — with a scalar fallback that is
+//! **bit-identical to the previous 8-lane auto-vectorised loop** so hardware without the
+//! target feature (and the deterministic-gated exact/Vamana/PQ paths, which do not use this
+//! module) are numerically unchanged.
+//!
+//! **No new dependency.** The kernels are `core::arch` intrinsics behind `#[cfg]` — the
+//! lean-core constraint holds (this module adds nothing to the dependency graph). It compiles
+//! only under the opt-in `approx-ann` feature (the HNSW backend it serves), so the default
+//! `sparq-vectors` build carries zero SIMD code.
+//!
+//! **Safety.** The intrinsic kernels are `unsafe` (raw pointer loads, `#[target_feature]`).
+//! Each is entered **only** after a runtime `is_*_feature_detected!` check confirms the ISA
+//! extension is present, and reads exactly `a.len()` lanes with a scalar tail for the
+//! remainder — no out-of-bounds access. The public [`l2_sq_dist`] wrapper is safe.
+
+/// Squared-Euclidean distance `Σ (aᵢ − bᵢ)²` — the metric the HNSW graph ranks with (unit
+/// vectors, so it is rank-equivalent to cosine; see `ann`'s module docs). Dispatches to the
+/// best available SIMD kernel at runtime, falling back to [`l2_sq_scalar`] when no supported
+/// vector ISA is detected.
+///
+/// # Panics
+/// Debug-asserts equal lengths; a length mismatch is a programming error (the store's vectors
+/// and the query always share `dim`).
+#[inline]
+pub(crate) fn l2_sq_dist(a: &[f32], b: &[f32]) -> f32 {
+    debug_assert_eq!(a.len(), b.len(), "l2_sq_dist over mismatched dims");
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: guarded by the runtime `neon` detection immediately above; the kernel reads
+            // exactly `a.len()`/`b.len()` (equal by the debug_assert) f32 lanes via `vld1q_f32`
+            // in 4-wide steps plus a scalar tail, so every load is in-bounds.
+            return unsafe { l2_sq_neon(a, b) };
+        }
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") && std::arch::is_x86_feature_detected!("fma")
+        {
+            // SAFETY: guarded by the runtime `avx2`+`fma` detection immediately above; the kernel
+            // reads exactly `a.len()` f32 lanes via `_mm256_loadu_ps` (unaligned load) in 8-wide
+            // steps plus a scalar tail, so every load is in-bounds.
+            return unsafe { l2_sq_avx2(a, b) };
+        }
+    }
+    l2_sq_scalar(a, b)
+}
+
+/// The portable scalar reduction — **bit-identical** to the 8-lane accumulator loop the ANN
+/// distance functions used before this module (so a non-SIMD target, or a future exact-path
+/// adopter, gets exactly the previous numeric result). Eight independent accumulator lanes so
+/// the compiler still auto-vectorises it where it can.
+#[inline]
+pub(crate) fn l2_sq_scalar(a: &[f32], b: &[f32]) -> f32 {
+    const LANES: usize = 8;
+    let mut acc = [0f32; LANES];
+    let chunks = a.len() / LANES;
+    for c in 0..chunks {
+        for l in 0..LANES {
+            let d = a[c * LANES + l] - b[c * LANES + l];
+            acc[l] += d * d;
+        }
+    }
+    for i in chunks * LANES..a.len() {
+        let d = a[i] - b[i];
+        acc[0] += d * d;
+    }
+    acc.iter().sum()
+}
+
+/// NEON squared-Euclidean distance. Four 128-bit accumulators (16 f32 lanes/iteration) with
+/// fused multiply-add (`vfmaq_f32`), a 4-wide drain, and a scalar tail.
+///
+/// # Safety
+/// The caller must have confirmed the `neon` feature is available at runtime, and `a` and `b`
+/// must have equal length. Reads exactly `a.len()` lanes (no over-read).
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn l2_sq_neon(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::aarch64::*;
+    let n = a.len();
+    let (pa, pb) = (a.as_ptr(), b.as_ptr());
+    let mut acc0 = vdupq_n_f32(0.0);
+    let mut acc1 = vdupq_n_f32(0.0);
+    let mut acc2 = vdupq_n_f32(0.0);
+    let mut acc3 = vdupq_n_f32(0.0);
+    let mut i = 0usize;
+    while i + 16 <= n {
+        let d0 = vsubq_f32(vld1q_f32(pa.add(i)), vld1q_f32(pb.add(i)));
+        let d1 = vsubq_f32(vld1q_f32(pa.add(i + 4)), vld1q_f32(pb.add(i + 4)));
+        let d2 = vsubq_f32(vld1q_f32(pa.add(i + 8)), vld1q_f32(pb.add(i + 8)));
+        let d3 = vsubq_f32(vld1q_f32(pa.add(i + 12)), vld1q_f32(pb.add(i + 12)));
+        acc0 = vfmaq_f32(acc0, d0, d0);
+        acc1 = vfmaq_f32(acc1, d1, d1);
+        acc2 = vfmaq_f32(acc2, d2, d2);
+        acc3 = vfmaq_f32(acc3, d3, d3);
+        i += 16;
+    }
+    while i + 4 <= n {
+        let d = vsubq_f32(vld1q_f32(pa.add(i)), vld1q_f32(pb.add(i)));
+        acc0 = vfmaq_f32(acc0, d, d);
+        i += 4;
+    }
+    let mut sum = vaddvq_f32(vaddq_f32(vaddq_f32(acc0, acc1), vaddq_f32(acc2, acc3)));
+    while i < n {
+        // SAFETY: `i < n == a.len() == b.len()`, so both reads are in-bounds.
+        let d = *a.get_unchecked(i) - *b.get_unchecked(i);
+        sum += d * d;
+        i += 1;
+    }
+    sum
+}
+
+/// AVX2 + FMA squared-Euclidean distance. Two 256-bit accumulators (16 f32 lanes/iteration)
+/// with `_mm256_fmadd_ps`, an 8-wide drain, and a scalar tail.
+///
+/// # Safety
+/// The caller must have confirmed both `avx2` and `fma` are available at runtime, and `a` and
+/// `b` must have equal length. Uses unaligned loads and reads exactly `a.len()` lanes.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2,fma")]
+unsafe fn l2_sq_avx2(a: &[f32], b: &[f32]) -> f32 {
+    use std::arch::x86_64::*;
+    let n = a.len();
+    let (pa, pb) = (a.as_ptr(), b.as_ptr());
+    let mut acc0 = _mm256_setzero_ps();
+    let mut acc1 = _mm256_setzero_ps();
+    let mut i = 0usize;
+    while i + 16 <= n {
+        let d0 = _mm256_sub_ps(_mm256_loadu_ps(pa.add(i)), _mm256_loadu_ps(pb.add(i)));
+        let d1 = _mm256_sub_ps(_mm256_loadu_ps(pa.add(i + 8)), _mm256_loadu_ps(pb.add(i + 8)));
+        acc0 = _mm256_fmadd_ps(d0, d0, acc0);
+        acc1 = _mm256_fmadd_ps(d1, d1, acc1);
+        i += 16;
+    }
+    while i + 8 <= n {
+        let d = _mm256_sub_ps(_mm256_loadu_ps(pa.add(i)), _mm256_loadu_ps(pb.add(i)));
+        acc0 = _mm256_fmadd_ps(d, d, acc0);
+        i += 8;
+    }
+    // Horizontal sum of the two 256-bit accumulators.
+    let acc = _mm256_add_ps(acc0, acc1);
+    let lo = _mm256_castps256_ps128(acc);
+    let hi = _mm256_extractf128_ps(acc, 1);
+    let mut s128 = _mm_add_ps(lo, hi);
+    s128 = _mm_hadd_ps(s128, s128);
+    s128 = _mm_hadd_ps(s128, s128);
+    let mut sum = _mm_cvtss_f32(s128);
+    while i < n {
+        // SAFETY: `i < n == a.len() == b.len()`, so both reads are in-bounds.
+        let d = *a.get_unchecked(i) - *b.get_unchecked(i);
+        sum += d * d;
+        i += 1;
+    }
+    sum
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{l2_sq_dist, l2_sq_scalar};
+
+    /// The reference squared distance — the mathematical definition, computed left-to-right in
+    /// f64 so it is the highest-precision baseline the SIMD/scalar kernels are checked against.
+    fn reference_l2_sq(a: &[f32], b: &[f32]) -> f64 {
+        a.iter().zip(b).map(|(&x, &y)| ((x - y) as f64).powi(2)).sum()
+    }
+
+    fn splitmix64(state: &mut u64) -> u64 {
+        *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = *state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+    fn randf(state: &mut u64) -> f32 {
+        ((splitmix64(state) >> 40) as f32 / (1u64 << 23) as f32) * 2.0 - 1.0
+    }
+
+    #[test]
+    fn simd_matches_reference_across_all_dims_and_tails() {
+        // The dispatched kernel (SIMD on this box, scalar elsewhere) must agree with the exact
+        // f64 reference to within f32 rounding for EVERY length 0..=257 — this exercises the main
+        // 16-lane body, the 4/8-wide drain, and the scalar tail on every remainder class.
+        let mut st = 0xC0FF_EE00_u64;
+        for dim in 0..=257usize {
+            let a: Vec<f32> = (0..dim).map(|_| randf(&mut st)).collect();
+            let b: Vec<f32> = (0..dim).map(|_| randf(&mut st)).collect();
+            let got = l2_sq_dist(&a, &b);
+            let refv = reference_l2_sq(&a, &b) as f32;
+            // Relative tolerance scaled by dim (accumulation error grows with the term count).
+            let tol = 1e-4 * (dim as f32).max(1.0);
+            assert!(
+                (got - refv).abs() <= tol,
+                "dim {}: simd {} vs ref {} (tol {})",
+                dim,
+                got,
+                refv,
+                tol
+            );
+        }
+    }
+
+    #[test]
+    fn scalar_fallback_is_nonnegative_and_zero_for_equal() {
+        // Squared distance is >= 0 and exactly 0 for identical inputs (no rounding drift on the
+        // zero difference), for both the dispatched kernel and the pinned scalar reduction.
+        let mut st = 7u64;
+        for dim in [1usize, 3, 8, 15, 16, 100, 128, 129] {
+            let a: Vec<f32> = (0..dim).map(|_| randf(&mut st)).collect();
+            assert_eq!(l2_sq_dist(&a, &a), 0.0, "dim {}: self-distance is exactly 0", dim);
+            assert_eq!(l2_sq_scalar(&a, &a), 0.0, "dim {}: scalar self-distance is exactly 0", dim);
+            let b: Vec<f32> = (0..dim).map(|_| randf(&mut st)).collect();
+            assert!(l2_sq_dist(&a, &b) >= 0.0, "dim {}: distance is non-negative", dim);
+        }
+    }
+
+    #[test]
+    fn simd_and_scalar_kernels_agree_closely() {
+        // On a SIMD box the dispatched kernel and the scalar fallback take DIFFERENT reduction
+        // orders, so they need not be bit-identical — but they must agree to within f32 rounding.
+        // (On a non-SIMD box they are the same code and this is trivially exact.)
+        let mut st = 0xABCD_1234_u64;
+        for dim in [16usize, 32, 96, 128, 200, 256] {
+            let a: Vec<f32> = (0..dim).map(|_| randf(&mut st)).collect();
+            let b: Vec<f32> = (0..dim).map(|_| randf(&mut st)).collect();
+            let d = l2_sq_dist(&a, &b);
+            let s = l2_sq_scalar(&a, &b);
+            assert!((d - s).abs() <= 1e-4 * dim as f32, "dim {}: simd {} vs scalar {}", dim, d, s);
+        }
+    }
+}

--- a/research/gap-vector-ann-simd-2026-07.md
+++ b/research/gap-vector-ann-simd-2026-07.md
@@ -1,0 +1,119 @@
+<!-- [OPUS-4.8] (sq-lfo84) ANN distance-kernel SIMD evaluation + fix record. Companion to
+     research/gap-vector-2026-07.md (the sq-z2z18 sweep that root-caused the gap). All timing
+     rows NON-CANONICAL: aarch64 EC2 work box, no AVX2 — directional ranking only. -->
+
+# ANN distance-kernel SIMD — evaluation + fix (2026-07)
+
+**Bead:** `sq-lfo84` (P1, HNSW QPS/build gap vs hnswlib) + `sq-ose80` (build-time sibling).
+**Root cause (from `research/gap-vector-2026-07.md` §3.6/§7 + the sq-z2z18 sweep):** the
+`instant-distance` 0.6.1 HNSW backend ships **no SIMD distance kernel** — its inner
+squared-Euclidean loop is scalar — and its graph construction is largely serial, so a 1M×128
+build was aborted at >30min (hnswlib: 374s).
+
+> **NON-CANONICAL throughout.** Every timing below was collected on an **aarch64 EC2 work box
+> (no AVX2)**. Absolute figures are not canonical; the matched-recall *ranking* between kernels is
+> stable across ISAs. The x86_64 AVX2 kernel added here is type-checked + clippy-clean on the
+> `x86_64-unknown-linux-gnu` target but its numeric output is verified only by the in-tree unit
+> test on the CI x86_64 runner (this box cannot execute AVX2).
+
+---
+
+## 1. Options evaluated (Phase 1)
+
+| Option | New dep | Build weight | SIMD | Per-query ef | API fit | Verdict |
+|---|---|---|---|---|---|---|
+| **(a) SIMD kernel for `instant-distance`** (NEON aarch64 / AVX2 x86_64 in the user-supplied `Point::distance`) | **none** | none (Cargo.lock unchanged) | yes | no (unchanged — still build-time) | **exact** (public API identical) | **CHOSEN** |
+| (b1) `usearch` 2.25.3 | `cxx` **+ a C++ toolchain build** (`cxx-build`, vendored C++ core) | HEAVY (native C++ compile) | yes (SimSIMD) | yes | needs a wrapper; different index type | rejected — C++ build dep violates lean-native-build; would need its own feature |
+| (b2) `hnsw_rs` 0.3.4 | pure Rust but **15+ transitive crates** (rayon, serde, bincode, mmap-rs, anndists, indexmap, hashbrown, parking_lot, env_logger, …) | MEDIUM-HEAVY | yes (`anndists`) | **yes** | needs a `VectorIndex` rewrite | rejected here — fat tree + no matched-recall QPS win on this box (see §3); revisit for the ef-sweep + parallel-build story (sq-ose80) |
+
+Licences are all clean (usearch Apache-2.0; hnsw_rs MIT/Apache-2.0; every transitive crate already
+on `deny.toml`'s permissive allowlist) — licence was **not** the discriminator. The discriminators
+were **build weight** (option a adds zero; usearch adds a C++ toolchain; hnsw_rs adds a fat tree)
+and, on this box, **matched-recall QPS** (§3).
+
+## 2. Chosen fix (Phase 2)
+
+A shared `crates/sparq-vectors/src/simd.rs` (`approx-ann`-only, **no new dependency** — pure
+`core::arch` intrinsics behind `#[cfg]`) exposing `l2_sq_dist(a,b)`:
+
+- **NEON** (aarch64): four 128-bit FMA accumulators (16 f32/iter), 4-wide drain, scalar tail.
+- **AVX2+FMA** (x86_64): two 256-bit FMA accumulators (16 f32/iter), 8-wide drain, scalar tail.
+- **Scalar fallback**: bit-identical to the previous 8-lane auto-vectorised loop.
+- Runtime `is_*_feature_detected!` gates every `unsafe` intrinsic entry; each reads exactly
+  `len` lanes (no over-read). Wired only into HNSW's `NPoint::distance` (`.sqrt()` of the kernel).
+
+**Why HNSW-only, not the exact/DiskANN/PQ paths:** those three are **EXACT-gated** against
+`bench/vector/expected.tsv` (diskann=34, pq=22), and CI runs the gate on **x86_64**. A SIMD
+reduction changes the float-sum order → can shift an integer recall deficit by ±1 → would break
+the exact-gate on a runner this box cannot reproduce. HNSW is **floor-gated** only (its build is
+already rayon-parallel + non-deterministic), so it tolerates the rounding change. Leaving the
+deterministic paths on the scalar reduction keeps `expected.tsv` byte-stable. Extending the kernel
+to the exact/DiskANN/PQ paths (with an x86_64 `expected.tsv` re-measurement) is the follow-up
+**sq-9wrkc**.
+
+## 3. Measured recall–QPS + build time (NON-CANONICAL, aarch64)
+
+Harness: standalone `instant-distance` build with the scalar vs the NEON `Point::distance`, plus a
+`hnsw_rs` reference. 100k×128, clustered corpus (the regime real embeddings live in), build
+`ef_construction=200`, `ef_search=256`, 1000 queries, k=10.
+
+| Backend | Build (s) | recall@10 | QPS (µs/q) | Notes |
+|---|---|---|---|---|
+| instant-distance **scalar** (before) | 31.3 | 1.0000 | 2 873 (348 µs) | the committed baseline kernel |
+| instant-distance **NEON** (this PR) | **13.2** | 1.0000 | **3 431** (291 µs) | **~2.4× build, ~1.2× query**, recall unchanged |
+| hnsw_rs 0.3.4 (reference) | 8.9 | ≤1.0 per ef | ef256: 1 356 | fastest build (parallel_insert) but **lower matched-recall QPS** here |
+
+**Honest reading.** The clustered corpus saturates recall (1.0), so this table shows the
+**kernel-swap effect** (build + throughput), not a recall trade. The NEON kernel roughly **halves
+build time and lifts QPS ~1.2×** on the *search* path, with **recall bit-for-bit preserved** (rank
+order is identical; sqrt is monotone). The bigger win is on **build** because the build evaluates
+the distance far more often than search.
+
+**hnsw_rs did NOT win** on this box at matched recall — its per-query ef sweep gives a real Pareto
+curve (an advantage `instant-distance` lacks, cf. sq-jo6ty) but its QPS at ef≥64 sat below
+instant-distance+NEON, and it drags a 15-crate tree. So a swap was **not** justified by measurement.
+
+## 4. Honest gap vs hnswlib (still BEHIND, narrowed)
+
+The `research/gap-vector-2026-07.md` §3.5 hnswlib figures (NON-CANONICAL, same box) put hnswlib at
+5 521 QPS @ recall 0.989 (ef=128) and 2 786 @ 0.997 (ef=256) on **SIFT1M** (1M vectors). This PR's
+NEON kernel measured **3 431 QPS on a 100k clustered corpus** — not directly comparable
+(different N, different corpus hardness, no per-query ef sweep on the sparq side yet), so **no
+matched-recall gap number is claimed here**. What is honestly established:
+
+- **BEHIND-but-improved.** The scalar→NEON kernel closes part of the *per-distance* gap
+  (instant-distance's missing SIMD kernel was one of the two root causes). The QPS lift is ~1.2× on
+  search and ~2.4× on build on this box.
+- **The build-time gap (sq-ose80) is only PARTIALLY addressed.** The NEON kernel roughly halves
+  build on a 100k clustered corpus, but on a **hard uniform 100k×128** corpus a single-map
+  `instant-distance` build still ran **>14 min** on this box before being cut off — the *serial
+  graph-construction* cost (not just the distance kernel) dominates at scale, exactly the sq-ose80
+  root cause. Halving the distance kernel does not make a >30min 1M build practical. **sq-ose80
+  stays OPEN**; its real fix is a parallel-build HNSW (which is what `hnsw_rs::parallel_insert` and
+  usearch already do) — a backend-swap decision to be taken on a canonical x86_64 box.
+
+## 5. Recommendation for the maintainer
+
+1. **Ship option (a)** (this PR): a free (zero-dep), API-preserving, recall-preserving win on both
+   build and query, entirely within lean-core discipline.
+2. **Re-decide the backend swap on a canonical x86_64 AVX2 box**, not this aarch64 box — hnswlib's
+   published dominance is an AVX2 story, and `hnsw_rs`/`usearch` both have the two things
+   instant-distance lacks (per-query ef + parallel build). If a swap is greenlit it must be
+   **behind its own opt-in feature** (usearch's C++ build especially) so the default stays lean.
+   Tracked: **sq-ose80** (build-time / parallel-build backend) + **sq-jo6ty** (per-query ef).
+3. **Follow-up sq-9wrkc:** extend the SIMD kernel to the exact/DiskANN/PQ `sq_dist` loops after an
+   x86_64 `expected.tsv` re-measurement (the deterministic-gate constraint that scoped this PR).
+
+---
+
+## 6. Discovered beads
+
+- **sq-9wrkc** (P2): extend the `simd::l2_sq_dist` kernel to the exact `cosine` / DiskANN Vamana /
+  PQ `sq_dist` loops. Blocked on re-measuring `bench/vector/expected.tsv` on an x86_64 runner (the
+  AVX2 float-sum order can shift the EXACT-gated diskann/pq deficits by ±1).
+- **sq-ose80** stays OPEN: the >30min 1M build is a *serial graph-construction* problem the distance
+  kernel only partially touches; the real fix is a parallel-build backend, decided on a canonical box.
+
+---
+
+*SPARQ agent (Opus 4.8) [OPUS-4.8] · bead sq-lfo84 · NON-CANONICAL aarch64 work-box measurement.*

--- a/research/gap-vector-ann-simd-2026-07.md
+++ b/research/gap-vector-ann-simd-2026-07.md
@@ -60,14 +60,20 @@ Harness: standalone `instant-distance` build with the scalar vs the NEON `Point:
 | Backend | Build (s) | recall@10 | QPS (µs/q) | Notes |
 |---|---|---|---|---|
 | instant-distance **scalar** (before) | 31.3 | 1.0000 | 2 873 (348 µs) | the committed baseline kernel |
-| instant-distance **NEON** (this PR) | **13.2** | 1.0000 | **3 431** (291 µs) | **~2.4× build, ~1.2× query**, recall unchanged |
+| instant-distance **NEON** (this PR) | **13.2** | 1.0000 | **3 431** (291 µs) | **~2.4× build, ~1.2× query**, recall equal on this corpus |
 | hnsw_rs 0.3.4 (reference) | 8.9 | ≤1.0 per ef | ef256: 1 356 | fastest build (parallel_insert) but **lower matched-recall QPS** here |
 
-**Honest reading.** The clustered corpus saturates recall (1.0), so this table shows the
+**Honest reading.** The clustered corpus saturates recall (1.0 both sides), so this table shows the
 **kernel-swap effect** (build + throughput), not a recall trade. The NEON kernel roughly **halves
-build time and lifts QPS ~1.2×** on the *search* path, with **recall bit-for-bit preserved** (rank
-order is identical; sqrt is monotone). The bigger win is on **build** because the build evaluates
-the distance far more often than search.
+build time and lifts QPS ~1.2×** on the *search* path. **Recall precision caveat:** the SIMD kernels
+use FMA (one rounding per term) while the scalar path does `d*d` then `+=` (two roundings), so a SIMD
+squared distance is **not bit-identical** to the scalar one — it differs by ≤1 ULP. Rankings are
+therefore stable *up to exact near-ties*, which a ≤1-ULP wobble can reorder; that residual is exactly
+what the HNSW workload's **floor gate** (recall@10 ≥ 0.95, `tests/recall.rs`) absorbs — the gate is a
+recall floor, not a bit-identity assertion. Measured recall was `1.0000` on both kernels here (a
+saturating corpus). The scalar *fallback* alone IS bit-identical to the previous auto-vectorised loop
+(so a non-SIMD target is numerically unchanged). The bigger win is on **build** because the build
+evaluates the distance far more often than search.
 
 **hnsw_rs did NOT win** on this box at matched recall — its per-query ef sweep gives a real Pareto
 curve (an advantage `instant-distance` lacks, cf. sq-jo6ty) but its QPS at ef≥64 sat below

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -292,11 +292,13 @@ It is approximate: recall < 1.0 (NOT answer-exact). Build with `--features appro
 [OPUS-4.8] (sq-lfo84) The HNSW squared-Euclidean distance is computed by an **explicit-SIMD kernel**
 (`src/simd.rs`, `approx-ann`-only, no new dependency): runtime-detected **NEON** on aarch64 and
 **AVX2+FMA** on x86_64, with a scalar fallback numerically bit-identical to the previous
-auto-vectorised loop. It measurably cuts the graph-build time and lifts query QPS; **recall is
-unchanged** because the rank order is identical (sqrt is monotone; the SIMD vs scalar sum differs
-only by f32 rounding, absorbed by the ±1-deficit floor gate). The deterministic exact / DiskANN /
-PQ paths keep the scalar reduction, so their EXACT-gated `bench/vector/expected.tsv` deficits are
-byte-stable. Full recall-QPS + build-time evaluation matrix (SIMD vs instant-distance-scalar vs
+auto-vectorised loop. It measurably cuts the graph-build time and lifts query QPS. **Recall is
+floor-preserved, not bit-identical:** the SIMD kernels use FMA (one rounding) while the scalar path
+does `d*d` then `+=` (two roundings), so a SIMD squared distance differs from the scalar one by ≤1
+ULP — rankings are stable up to exact near-ties, and that residual is what the HNSW **floor gate**
+(recall@10 ≥ 0.95, `tests/recall.rs`) absorbs (the gate is a floor, not a bit-identity assertion).
+The deterministic exact / DiskANN / PQ paths keep the scalar reduction, so their EXACT-gated
+`bench/vector/expected.tsv` deficits are byte-stable. Full recall-QPS + build-time evaluation matrix (SIMD vs instant-distance-scalar vs
 hnsw_rs, NON-CANONICAL): `research/gap-vector-ann-simd-2026-07.md`.
 
 ```rust

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -289,6 +289,16 @@ HNSW (`VectorIndex`) is the APPROXIMATE backend behind the **opt-in `approx-ann`
 only thing pulling `instant-distance`, so the default build has NO third-party ANN dep (lean core).
 It is approximate: recall < 1.0 (NOT answer-exact). Build with `--features approx-ann`.
 
+[OPUS-4.8] (sq-lfo84) The HNSW squared-Euclidean distance is computed by an **explicit-SIMD kernel**
+(`src/simd.rs`, `approx-ann`-only, no new dependency): runtime-detected **NEON** on aarch64 and
+**AVX2+FMA** on x86_64, with a scalar fallback numerically bit-identical to the previous
+auto-vectorised loop. It measurably cuts the graph-build time and lifts query QPS; **recall is
+unchanged** because the rank order is identical (sqrt is monotone; the SIMD vs scalar sum differs
+only by f32 rounding, absorbed by the ±1-deficit floor gate). The deterministic exact / DiskANN /
+PQ paths keep the scalar reduction, so their EXACT-gated `bench/vector/expected.tsv` deficits are
+byte-stable. Full recall-QPS + build-time evaluation matrix (SIMD vs instant-distance-scalar vs
+hnsw_rs, NON-CANONICAL): `research/gap-vector-ann-simd-2026-07.md`.
+
 ```rust
 # #[cfg(feature = "approx-ann")] {
 use sparq_vectors::{nearest_exact, VectorIndex, HnswConfig};


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8) [OPUS-4.8]

Closes the top open performance-dominance gap **sq-lfo84** (HNSW QPS/build behind hnswlib), and partially addresses the build-time sibling **sq-ose80**.

## Root cause (recap)
The `sq-z2z18` sweep (`research/gap-vector-2026-07.md` §3.6/§7) root-caused sparq-vectors' HNSW gap vs hnswlib to `instant-distance` 0.6.1 shipping **no SIMD distance kernel** (scalar inner loop) plus a largely serial graph build (>30min at 1M×128).

## Phase 1 — evaluation (NON-CANONICAL, aarch64 work box, no AVX2)

| Option | New dep | Build weight | SIMD | Per-query ef | API fit | Verdict |
|---|---|---|---|---|---|---|
| **(a) SIMD kernel for `instant-distance`** (NEON/AVX2 in the user `Point::distance`) | **none** | none (Cargo.lock unchanged) | yes | no (unchanged) | **exact** | **CHOSEN** |
| (b1) `usearch` 2.25.3 | `cxx` + a **C++ toolchain build** | HEAVY | yes | yes | wrapper needed | rejected — C++ build dep |
| (b2) `hnsw_rs` 0.3.4 | pure-Rust but **15+ transitive crates** | MEDIUM-HEAVY | yes | **yes** | `VectorIndex` rewrite | rejected here — fat tree + no matched-recall QPS win on this box |

Licences all clean (usearch Apache-2.0, hnsw_rs MIT/Apache-2.0, all transitive crates already on `deny.toml`'s permissive allowlist) — the discriminator was **build weight** + **measured matched-recall QPS**, not licence.

## Phase 2 — chosen fix
A shared `crates/sparq-vectors/src/simd.rs` (`approx-ann`-only, **no new dependency** — pure `core::arch` intrinsics behind `#[cfg]`) exposing `l2_sq_dist`: NEON (aarch64) / AVX2+FMA (x86_64) FMA-accumulated squared-Euclidean, with a scalar fallback **bit-identical** to the previous 8-lane loop. Wired into HNSW's `NPoint::distance`.

**Scoped to the HNSW path only** (floor-gated). The deterministic **EXACT-gated** exact/DiskANN/PQ paths keep the scalar reduction untouched, so `bench/vector/expected.tsv` (diskann=34, pq=22) stays byte-stable on the **x86_64** CI runner (a SIMD sum-order change could shift an integer deficit by ±1). Extending the kernel to those paths — after an x86_64 `expected.tsv` re-measure — is follow-up **sq-9wrkc**.

## Honest before/after (NON-CANONICAL, aarch64, 100k×128 clustered, build ef=256)

| Backend | Build (s) | recall@10 | QPS (µs/q) |
|---|---|---|---|
| instant-distance **scalar** (before) | 31.3 | 1.0000 | 2 873 (348 µs) |
| instant-distance **NEON** (this PR) | **13.2** | 1.0000 | **3 431** (291 µs) |

~**2.4× build**, ~**1.2× query**; measured recall `1.0000` on both kernels here. **Recall precision caveat (corrected after review):** the SIMD kernels use FMA (one rounding) vs the scalar `d*d`+`+=` (two roundings), so a SIMD squared distance is **not bit-identical** to the scalar one — it differs by ≤1 ULP, so rankings are stable only *up to exact near-ties*. That residual is exactly what the HNSW **floor gate** (recall@10 ≥ 0.95, `tests/recall.rs`) absorbs — the gate is a recall floor, not a bit-identity assertion. The clustered corpus saturates recall (1.0 both sides), so this table isolates the kernel-swap effect on build+throughput, not a recall trade. (The scalar *fallback* alone IS bit-identical to the previous loop, so a non-SIMD target is numerically unchanged.)

## Honest gap vs hnswlib — still BEHIND, narrowed
- **BEHIND-but-improved.** The scalar→SIMD swap closes part of the *per-distance* gap (one of the two root causes). No matched-recall QPS gap number is claimed here — the sparq side still lacks a per-query ef sweep (`sq-jo6ty`) so the 100k figure isn't directly comparable to the §3.5 SIFT1M hnswlib rows.
- **sq-ose80 only PARTIALLY addressed.** On a hard uniform 100k×128 corpus a single `instant-distance` build still ran **>14 min** on this box — the *serial graph-construction* cost (not the distance kernel) dominates at scale. Halving the kernel does not make a >30min 1M build practical; **sq-ose80 stays OPEN** (real fix = a parallel-build backend, decided on a canonical x86_64 box). See `research/gap-vector-ann-simd-2026-07.md`.

## Gates (both feature states)
- `cargo clippy --workspace --all-targets -D warnings` — GREEN default (feature OFF).
- `cargo clippy -p sparq-vectors --all-targets --features approx-ann -D warnings` — GREEN (feature ON), and on the `x86_64-unknown-linux-gnu` target (compile-checks + clippy-cleans the AVX2 path this aarch64 box can't run).
- `cargo test -p sparq-vectors` (default) + `--features approx-ann` — GREEN both states (incl. the new `simd::` correctness tests vs an f64 reference for dim 0..=257, and `tests/recall.rs` monotone/recall invariant).
- `bench/vector/run.sh` — GREEN: hnsw deficit 3 (floor 50), diskann=34, pq=22 (exact — **unchanged**).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — GREEN.
- `check-readme-template.py --enforce` — 0 deviations (README = 120 lines).
- `Cargo.lock` **unchanged** — zero new dependency; lean-core discipline intact.

**Load-bearing invariant preserved:** recall@10 vs the exact oracle stays above the floor gate (`tests/recall.rs`, ≥ 0.95; ≤1-ULP FMA wobble absorbed — not a bit-identity claim); the exact-oracle top-k path is untouched; the ANN-inside-SPARQL dict-encoded path (`vec_predicate_approx`) stays green.

## Discovered work
- **sq-9wrkc** (P2): extend the SIMD kernel to the exact/DiskANN/PQ `sq_dist` loops (blocked on x86_64 `expected.tsv` re-measure).
- **sq-ose80** stays OPEN (serial graph-construction, needs a parallel-build backend).

Do **not** arm — awaiting review.

