### PR TITLE
bench(geo): fix jena-geosparql within*/nearest_k query renderings — jena 5.4.0 geof:distance cannot produce metres on CRS84 (sq-a8anf) [FABLE-5]

### DIFF
--- a/bench/geo/queries-jena/nearest_k10.rq
+++ b/bench/geo/queries-jena/nearest_k10.rq
@@ -1,18 +1,28 @@
-# [FABLE-5] sq-hmd7l.3 — PINNED jena-geosparql rendering of the `nearest_k10`
+# [FABLE-5] sq-a8anf — PINNED jena-geosparql rendering of the `nearest_k10`
 # workload for scripts/bench/geo-same-box.sh. sparq evaluates k-nearest via the
 # GeoIndex::nearest index surface; the DIALECT DIFFERS here because standard
-# GeoSPARQL has no k-nearest function, so the standard-visible rendering is a
-# distance ORDER BY + LIMIT k (any engine is free to optimize it internally;
+# GeoSPARQL has no k-nearest function, so the rendering is a distance
+# ORDER BY + LIMIT k (any engine is free to optimize it internally;
 # jena-geosparql's non-standard spatial:nearby needs a radius, so it is not a
 # faithful k-NN rendering — see research/gap-geo-2026-07.md). ?e tie-breaks
 # equal distances for a deterministic result SET; only the result-set SIZE is
 # cross-checked (== k on a corpus larger than k, the same invariant sparq's
 # expected.tsv pins), never coordinates or ordering.
-PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
-PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
-PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+# SORT KEY (sq-a8anf): the original standard-form key
+#   geof:distance(?wkt, centre, uom:metre)
+# throws per row on jena 5.4.0 (planar degree-space Euclidean + degree->metre
+# UnitsConversionException — research/gap-geo-2026-07.md §6d); in ORDER BY the
+# per-row error does NOT drop rows, it silently DEGENERATES the ordering to the
+# ?e tie-break, so the ==k size crosscheck stayed vacuously green while jena
+# was not distance-sorting at all (wave-1 nearest_k timings retracted, §6b).
+# spatialF:greatCircleGeom is Jena's working great-circle distance (metres, on
+# the same mean sphere as sparq's haversine) — verified on a fixture to return
+# the true nearest set.
+PREFIX geo:      <http://www.opengis.net/ont/geosparql#>
+PREFIX spatialF: <http://jena.apache.org/function/spatial#>
+PREFIX uom:      <http://www.opengis.net/def/uom/OGC/1.0/>
 SELECT ?e WHERE {
   ?e geo:asWKT ?wkt .
 }
-ORDER BY ASC(geof:distance(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre)) ?e
+ORDER BY ASC(spatialF:greatCircleGeom(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre)) ?e
 LIMIT 10

--- a/bench/geo/queries-jena/nearest_k100.rq
+++ b/bench/geo/queries-jena/nearest_k100.rq
@@ -1,13 +1,17 @@
-# [FABLE-5] sq-hmd7l.3 — PINNED jena-geosparql rendering of the `nearest_k100`
+# [FABLE-5] sq-a8anf — PINNED jena-geosparql rendering of the `nearest_k100`
 # workload for scripts/bench/geo-same-box.sh. Same rendering rationale + oracle
 # as nearest_k10.rq (standard GeoSPARQL has no k-nearest function; ORDER BY
-# distance + LIMIT k is the standard-visible form; result-set SIZE == k is the
-# only cross-checked value).
-PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
-PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
-PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+# distance + LIMIT k; result-set SIZE == k is the only cross-checked value),
+# and the same sq-a8anf sort-key correction: geof:distance(..., uom:metre)
+# throws per row on jena 5.4.0, which in ORDER BY silently degenerates the
+# ordering to the ?e tie-break (vacuously-green ==k crosscheck; wave-1 jena
+# nearest_k timings retracted — research/gap-geo-2026-07.md §6b/§6d).
+# spatialF:greatCircleGeom is Jena's working great-circle distance in metres.
+PREFIX geo:      <http://www.opengis.net/ont/geosparql#>
+PREFIX spatialF: <http://jena.apache.org/function/spatial#>
+PREFIX uom:      <http://www.opengis.net/def/uom/OGC/1.0/>
 SELECT ?e WHERE {
   ?e geo:asWKT ?wkt .
 }
-ORDER BY ASC(geof:distance(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre)) ?e
+ORDER BY ASC(spatialF:greatCircleGeom(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre)) ?e
 LIMIT 100

--- a/bench/geo/queries-jena/within10km.rq
+++ b/bench/geo/queries-jena/within10km.rq
@@ -1,16 +1,30 @@
-# [FABLE-5] sq-hmd7l.3 — PINNED jena-geosparql rendering of the `within10km`
-# workload for scripts/bench/geo-same-box.sh. Verbatim copy of
-# bench/geo/queries/within10km.rq (the standard GeoSPARQL dialect needs no
-# translation for Jena); pinned per-engine so an edit to the sparq-side file
-# cannot silently change the competitor replay — keep the two in sync on purpose.
-# Oracle: the COUNT must equal sparq's expected.tsv `within10km` size before any
-# timing is trusted (counts-not-coordinates). Metric caveat: sparq computes
-# spherical great-circle, Jena/Apache-SIS geof:distance is ellipsoidal geodesic
-# — a radius-boundary count disagreement is a recorded result, never adjusted.
-PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
-PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
-PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+# [FABLE-5] sq-a8anf — PINNED jena-geosparql rendering of the `within10km`
+# workload for scripts/bench/geo-same-box.sh. NOT a verbatim copy of
+# bench/geo/queries/within10km.rq: the standard GeoSPARQL form
+#   FILTER (geof:distance(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre) <= 10000)
+# is NON-EXECUTABLE on jena-geosparql 5.4.0 over bare-CRS84 wktLiterals. Jena's
+# geof:distance computes PLANAR Euclidean distance in the SRS's native units
+# (degrees for CRS84) and then unit-converts; degree->metre throws
+# UnitsConversionException ("Conversion between linear and non-linear units not
+# supported"), and inside a FILTER the per-row ExprEvalException silently drops
+# EVERY row — the wave-1 all-zero counts (root cause: UNITS; axis order and the
+# 3-arg function arity were verified correct — degree-unit distances match the
+# lon-lat deltas exactly, and geof_within agrees). See
+# research/gap-geo-2026-07.md §6d.
+# The rendering below uses Jena's documented great-circle radius predicate
+# spatialF:nearby(geom, geom, radius, unitsURI) — the SAME workload semantic
+# (great-circle metres on the IUGG/GRS80 mean sphere, the same sphere as
+# sparq's haversine), verified count-equal to sparq's expected.tsv (51) on the
+# pinned 100k corpus. Jena's index-accelerated path (spatial:withinCircle,
+# lat-lon arg order) is NOT usable on this corpus: it needs geo:hasGeometry
+# feature modelling the shared corpus does not have (its spatial index indexes
+# 0 items; follow-up bead sq-enfy3), so this is a filter scan on Jena's side.
+# Oracle: the COUNT must equal sparq's expected.tsv `within10km` size before
+# any timing is trusted (counts-not-coordinates).
+PREFIX geo:      <http://www.opengis.net/ont/geosparql#>
+PREFIX spatialF: <http://jena.apache.org/function/spatial#>
+PREFIX uom:      <http://www.opengis.net/def/uom/OGC/1.0/>
 SELECT (COUNT(?e) AS ?n) WHERE {
   ?e geo:asWKT ?wkt .
-  FILTER (geof:distance(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre) <= 10000)
+  FILTER (spatialF:nearby(?wkt, "POINT(0 51)"^^geo:wktLiteral, 10000, uom:metre))
 }

--- a/bench/geo/queries-jena/within50km.rq
+++ b/bench/geo/queries-jena/within50km.rq
@@ -1,14 +1,18 @@
-# [FABLE-5] sq-hmd7l.3 — PINNED jena-geosparql rendering of the `within50km`
-# workload for scripts/bench/geo-same-box.sh. Verbatim copy of
-# bench/geo/queries/within50km.rq (standard GeoSPARQL dialect; no translation
-# needed for Jena); pinned per-engine so the competitor replay cannot drift.
-# Oracle: COUNT == sparq's expected.tsv `within50km` size before any timing is
-# trusted (counts-not-coordinates; great-circle vs geodesic caveat as in
-# within10km.rq — a boundary disagreement is a recorded result).
-PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
-PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
-PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
+# [FABLE-5] sq-a8anf — PINNED jena-geosparql rendering of the `within50km`
+# workload for scripts/bench/geo-same-box.sh. NOT a verbatim copy of
+# bench/geo/queries/within50km.rq — same root cause + rendering rationale as
+# within10km.rq: jena 5.4.0 geof:distance is planar SRS-native-unit Euclidean,
+# and its degree->metre unit conversion throws UnitsConversionException per
+# row, which a FILTER silently drops -> the wave-1 all-zero count (see
+# research/gap-geo-2026-07.md §6d). spatialF:nearby is Jena's documented
+# great-circle radius predicate on the same mean sphere as sparq's haversine;
+# verified count-equal to sparq's expected.tsv (1547) on the pinned 100k
+# corpus. Oracle: COUNT == sparq's expected.tsv `within50km` size before any
+# timing is trusted (counts-not-coordinates).
+PREFIX geo:      <http://www.opengis.net/ont/geosparql#>
+PREFIX spatialF: <http://jena.apache.org/function/spatial#>
+PREFIX uom:      <http://www.opengis.net/def/uom/OGC/1.0/>
 SELECT (COUNT(?e) AS ?n) WHERE {
   ?e geo:asWKT ?wkt .
-  FILTER (geof:distance(?wkt, "POINT(0 51)"^^geo:wktLiteral, uom:metre) <= 50000)
+  FILTER (spatialF:nearby(?wkt, "POINT(0 51)"^^geo:wktLiteral, 50000, uom:metre))
 }

--- a/research/gap-geo-2026-07.md
+++ b/research/gap-geo-2026-07.md
@@ -87,10 +87,16 @@ competitor row: replaying the OGC topology fixture set against Jena is out of sc
 Float geometry is not bit-stable, so only result-set SIZES are cross-checked — never
 coordinate values. sparq counts are additionally hard-gated vs `bench/geo/expected.tsv`
 by `run.sh`. A **count disagreement is itself a recorded result** (both counts kept in
-`count_crosscheck`, the timing withheld). Disagreement is plausible on the radius
-workloads because sparq `within*` uses **spherical great-circle** distance while
-Jena / Apache SIS `geof:distance` uses **ellipsoidal geodesic** — radius-boundary
-membership can legitimately differ at the margin.
+`count_crosscheck`, the timing withheld).
+
+> **Correction (sq-a8anf, 2026-07-10).** This section originally predicted a plausible
+> margin disagreement on the radius workloads on the theory that Jena / Apache SIS
+> `geof:distance` is *ellipsoidal geodesic*. That was wrong: Jena 5.4.0's
+> `geof:distance` is **planar Euclidean in the SRS's native units** (degrees for
+> CRS84) and cannot convert degrees→metres at all (§6d). With the corrected
+> renderings both engines compute **spherical great-circle on the same mean sphere**
+> (sparq: haversine; Jena: `spatialF:nearby`), so only float-boundary edge points may
+> legitimately differ — and on the pinned corpus none do (counts agree exactly, §6d).
 
 ---
 
@@ -111,10 +117,19 @@ gap vs a sparq HTTP surface would be smaller, and the harness notes this.
 
 ## 5. Query translations (`bench/geo/queries-jena/`)
 
-Five pinned `.rq` files, one per workload. The within/geof_within queries are verbatim
-copies of the sparq-native files in `bench/geo/queries/` — no translation needed, as
-standard GeoSPARQL dialect (PREFIX `geo:`, `geof:distance`, `geof:sfWithin`, `uom:metre`)
-is supported identically by Jena.
+Five pinned `.rq` files, one per workload. The geof_within query is a verbatim copy of
+the sparq-native file in `bench/geo/queries/` — standard GeoSPARQL `geof:sfWithin` is
+supported identically by Jena.
+
+The **within10km / within50km** renderings are **not** verbatim copies (they originally
+were, which produced the wave-1 all-zero counts — §6b/§6d): the standard
+`FILTER(geof:distance(?wkt, centre, uom:metre) <= r)` form is **non-executable on
+jena-geosparql 5.4.0** over bare-CRS84 `wktLiteral`s, because Jena's `geof:distance`
+computes planar Euclidean distance in the SRS's native units (degrees) and its
+degree→metre unit conversion throws (`UnitsConversionException`), silently dropping
+every row inside a FILTER. The corrected renderings use Jena's documented great-circle
+radius predicate `spatialF:nearby(geom, geom, r, uom:metre)` — the same workload
+semantic on the same mean sphere as sparq's haversine (root-cause detail in §6d).
 
 The **nearest_k** queries differ: sparq evaluates k-nearest via the
 `GeoIndex::nearest` index surface; standard GeoSPARQL has no k-nearest function.
@@ -162,8 +177,8 @@ sparq counts additionally passed the `bench/geo/expected.tsv` hard gate.
 |---|---|---|---|---|
 | `within10km` | **DISAGREE** (sparq 51, jena 0) | 7.2 µs | WITHHELD (count-disagree) | NOT-MEASURED (crosscheck red — see below) |
 | `within50km` | **DISAGREE** (sparq 1547, jena 0) | 150.2 µs | WITHHELD (count-disagree) | NOT-MEASURED (crosscheck red — see below) |
-| `nearest_k10` | agree (10 = 10) | 6.1 µs | 1 517 437 µs | CLEARLY-AHEAD (~2.5 × 10⁵×, caveats below) |
-| `nearest_k100` | agree (100 = 100) | 70.0 µs | 1 635 714 µs | CLEARLY-AHEAD (~2.3 × 10⁴×, caveats below) |
+| `nearest_k10` | agree (10 = 10) — **vacuous, see §6d** | 6.1 µs | 1 517 437 µs | ~~CLEARLY-AHEAD~~ **RETRACTED** (§6d: jena ordering was degenerate) |
+| `nearest_k100` | agree (100 = 100) — **vacuous, see §6d** | 70.0 µs | 1 635 714 µs | ~~CLEARLY-AHEAD~~ **RETRACTED** (§6d: jena ordering was degenerate) |
 | `geof_within` | agree (1526 = 1526) | 90 458.9 µs | 137 888 µs | **AHEAD-BUT-NOT-OOM (~1.5×)** — dominance-gap row |
 
 Honest findings, for the consolidation bead `sq-hmd7l.27`:
@@ -175,12 +190,17 @@ Honest findings, for the consolidation bead `sq-hmd7l.27`:
    rendering of the `geof:distance ≤ radius` filter (jena executed the query fine:
    0 hits in ~0.61 s). Per the invariant the jena timings are withheld and NO
    comparative verdict is drawn. Harness root-cause bead filed (see §6c).
-2. **`nearest_k*` CLEARLY-AHEAD carries two caveats** (recorded in the envelope,
-   never adjusted): (a) mode asymmetry — jena is a full HTTP SPARQL round-trip vs
-   sparq's in-process index surface (the HTTP floor is negligible at the observed
-   1.5 s scale); (b) the jena rendering is the standard-visible
-   `ORDER BY ASC(geof:distance(...)) LIMIT k` full scan-and-sort, since standard
-   GeoSPARQL has no k-NN function — any engine is free to optimise it, jena does not.
+   **RESOLVED (sq-a8anf): root cause = units, renderings corrected — §6d.**
+2. **`nearest_k*` CLEARLY-AHEAD — RETRACTED by sq-a8anf (§6d).** The wave-1 jena
+   sort key `geof:distance(..., uom:metre)` threw per row (same §6d root cause);
+   in ORDER BY the error does not drop rows, it silently degenerates the ordering
+   to the `?e` tie-break, so the size-only `==k` crosscheck stayed green while
+   jena performed no distance sort (oracle-strengthening bead sq-6jl8z). The
+   original caveats stand for any re-gather: (a) mode asymmetry — jena is a full
+   HTTP SPARQL round-trip vs sparq's in-process index surface; (b) the jena
+   rendering is an `ORDER BY ASC(distance) LIMIT k` full scan-and-sort, since
+   standard GeoSPARQL has no k-NN function — any engine is free to optimise it,
+   jena does not.
 3. **`geof_within` is AHEAD-BUT-NOT-OOM (~1.5×) — a dominance-mandate gap row.**
    sparq's own 90.5 ms is ~600× slower than its `within50km` (150 µs) on the same
    corpus for a similar-cardinality result (1526 vs 1547) — root-cause hypothesis:
@@ -198,7 +218,78 @@ Honest findings, for the consolidation bead `sq-hmd7l.27`:
   bare `geo:wktLiteral` defaults to CRS84 lon-lat, but a lat-lon interpretation of
   `POINT(0 51)` puts the query centre ~5000 km from the corpus window — exactly the
   observed all-zero shape) before the radius workloads can carry a canonical
-  comparative verdict.
+  comparative verdict. **RESOLVED — root cause + corrected renderings in §6d.**
+
+---
+
+## 6d. sq-a8anf resolution: root cause = UNITS (jena `geof:distance` cannot produce metres on CRS84 data)
+
+Empirically pinned on jena-fuseki-geosparql 5.4.0 (the exact wave-1 jar, sha256
+`a2ef5e6f…`), first on a 4-point fixture with hand-computable great-circle
+distances from `POINT(0 51)`, then on the pinned 100 000-point corpus.
+
+**Root cause (units — not axis order, not function arity):** Jena's
+`geof:distance` computes **planar Euclidean distance in the SRS's native units**
+(degrees, for bare-CRS84 `wktLiteral`s) and then converts to the requested unit.
+Degree→metre is an angular→linear conversion, which Jena's `UnitsOfMeasure`
+refuses (`UnitsConversionException: "Conversion between linear and non-linear
+units not supported"` — string present in the shipped class). The per-row
+`ExprEvalException`:
+
+- inside the `within*` **FILTER** silently drops **every** row → the observed
+  0-hit counts (jena "executed fine" because expression errors are silent);
+- inside the `nearest_k*` **ORDER BY** drops **no** rows but degenerates the
+  ordering to the `?e` tie-break → a vacuously green `==k` size crosscheck over
+  a non-distance-sorted result (fixture proof: the broken key ranks a 260 km
+  point in the top-2 "nearest"; the corrected key returns the true pair).
+
+Eliminated hypotheses, same fixture: **axis order** — degree-unit distances match
+the lon-lat coordinate deltas exactly (CRS84 lon-lat is honoured; also
+`geof_within` agreed 1526 = 1526 in wave-1); **function arity** — the 3-arg
+signature is required (`Function 'DistanceFF' takes three arguments` on the
+2-arg form) and evaluates fine with an angular unit.
+
+**Fix (pinned renderings corrected, sparq side untouched):** the `within*`
+filters now use Jena's documented great-circle radius predicate
+`spatialF:nearby(?wkt, centre, r, uom:metre)`, and the `nearest_k*` sort key
+uses `spatialF:greatCircleGeom(?wkt, centre, uom:metre)` — both compute
+great-circle **metres on the same IUGG/GRS80 mean sphere as sparq's haversine**
+(fixture: 0.045° of latitude → 5003.78 m ⇔ implied R ≈ 6 371 008.8 m, sparq's
+sphere), so the §3 correction applies: the metric semantics now match, and only
+float-boundary edge points could legitimately differ.
+
+**Corrected jena counts on the pinned 100k corpus (work-box validation run,
+counts-only — correctness data, not timings):**
+
+| Workload | sparq (`expected.tsv`) | jena-geosparql (corrected rendering) | crosscheck |
+|---|---|---|---|
+| `within10km` | 51 | **51** | **agree** |
+| `within50km` | 1547 | **1547** | **agree** |
+
+jena-geosparql is therefore a **VALID competitor** on the radius workloads with
+the corrected renderings — the wave-1 zeros were harness misconfiguration
+(a standard-form query jena cannot execute), not a jena capability gap in the
+workload semantic. Two honest caveats stay recorded:
+
+1. **Jena's radius path here is a filter scan, not its spatial index.** Jena's
+   index-accelerated `spatial:withinCircle` property function (lat-lon arg
+   order) indexes only `geo:hasGeometry` feature→geometry structures; on this
+   corpus's direct `?e geo:asWKT` shape its spatial index holds 0 items and the
+   function binds nothing (verified). A feature-modelled corpus variant that
+   gives jena its index path is bead **sq-enfy3**; until then jena's radius
+   timings measure its great-circle filter scan (recorded, never adjusted).
+2. **No timings in this record:** the corrected-rendering validation ran on the
+   shared work box (NON-canonical, counts only). Valid jena radius + nearest_k
+   timings require a canonical quiet-box re-gather of the geo axis with the
+   corrected queries (a wave-2 re-run action; the wave-1 envelope's jena
+   `within*` WITHHELD rows and `nearest_k*` rows stay as the historical record,
+   with the `nearest_k*` verdicts retracted per §6b).
+
+Standard-form status for the record: the GeoSPARQL 1.0 standard rendering
+(`geof:distance` + `uom:metre` over CRS84 data) is **NOT-COMPARABLE on jena
+5.4.0** — that is a jena limitation of the standard function, documented here;
+the workload-semantic comparison (great-circle radius membership) is fully
+comparable via the corrected renderings above.
 
 ---
 

--- a/scripts/bench/geo-same-box.sh
+++ b/scripts/bench/geo-same-box.sh
@@ -36,9 +36,12 @@
 #   * NO TIMING WITHOUT RESULT-SET-SIZE AGREEMENT per query: a competitor timing
 #     enters the envelope's timing table ONLY where its count equals sparq's
 #     expected.tsv-gated count. A disagreement is itself a recorded RESULT
-#     (both counts kept, the timing withheld, nothing adjusted) — plausible here
-#     because sparq's within* metric is spherical great-circle while Jena/SIS is
-#     ellipsoidal geodesic, so radius-boundary membership may legitimately differ.
+#     (both counts kept, the timing withheld, nothing adjusted). Both engines'
+#     within* metric is spherical great-circle on the same mean sphere (sparq:
+#     haversine; jena: spatialF:nearby — the standard geof:distance+uom:metre
+#     form is non-executable on jena 5.4.0, root-caused in sq-a8anf /
+#     research/gap-geo-2026-07.md §6d), so only float-boundary edge points may
+#     legitimately differ.
 #   * per-workload wall-clock cap (TIMEOUT_S, covering the whole best-of-N
 #     series); a timeout/error degrades to an honest ERROR row, never a number.
 #   * a competitor that cannot run (no java, no jar, download or start-up
@@ -334,11 +337,14 @@ envelope = {
         "COUNTS-NOT-COORDINATES (bench/geo gate design): only result-set SIZES "
         "are compared — float geometry is not bit-stable. sparq counts are "
         "additionally hard-gated vs bench/geo/expected.tsv by run.sh. A "
-        "disagreement is a recorded RESULT (metric semantics may legitimately "
-        "differ: sparq within* is spherical great-circle, Jena/Apache-SIS "
-        "geof:distance is ellipsoidal geodesic — radius-boundary membership can "
-        "differ); the competitor timing for that workload is withheld, never "
-        "adjusted."
+        "disagreement is a recorded RESULT; the competitor timing for that "
+        "workload is withheld, never adjusted. Metric note (sq-a8anf): both "
+        "engines' within* is spherical great-circle on the same mean sphere "
+        "(sparq haversine; jena spatialF:nearby — jena 5.4.0 geof:distance is "
+        "planar SRS-native-unit Euclidean and its degree->metre conversion "
+        "throws, so the standard geof:distance+uom:metre rendering is "
+        "non-executable there; research/gap-geo-2026-07.md §6d), so only "
+        "float-boundary edge points may legitimately differ."
     ),
     "timings": timings,
     "timings_note": (


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]

Fixes **sq-a8anf** (P2 bug): jena-geosparql returned 0 hits on `within10km`/`within50km` in the canonical wave-1 geo same-box run (sparq 51/1547 vs jena 0/0), so the radius rows carried no comparative verdict.

## Root cause: UNITS (empirically pinned, hypotheses (a)/(c) eliminated)

jena-geosparql 5.4.0's `geof:distance` computes **planar Euclidean distance in the SRS's native units** (degrees for bare-CRS84 `wktLiteral`s) and then unit-converts. Degree→metre is angular→linear, which Jena's `UnitsOfMeasure` refuses — `UnitsConversionException: "Conversion between linear and non-linear units not supported"` (string extracted from the shipped 5.4.0 class, jar sha256 `a2ef5e6f…` — the exact wave-1 artifact). The per-row `ExprEvalException` is silent:

- in the `within*` **FILTER** it drops **every** row → the observed 0-hit counts;
- in the `nearest_k*` **ORDER BY** it drops **no** rows but degenerates the ordering to the `?e` tie-break → the `==k` size crosscheck stayed **vacuously green** over a non-distance-sorted result. Fixture proof: the broken key ranks a **260 km** point in the top-2 "nearest"; the corrected key returns the true pair. The wave-1 jena `nearest_k` CLEARLY-AHEAD verdicts are **retracted** in the gap record.

Eliminated on a 4-point fixture with hand-computable great-circle distances: **axis order** (degree-unit distances match the lon-lat deltas exactly; CRS84 lon-lat honoured) and **function arity** (3-arg is required and works with an angular unit).

## Fix (harness-side only; no engine source, sparq counts untouched)

Pinned renderings now use Jena's documented great-circle functions on the **same IUGG/GRS80 mean sphere as sparq's haversine** (fixture: 0.045° lat → 5003.78 m ⇒ implied R ≈ 6 371 008.8 m):

- `within10km`/`within50km`: `FILTER(spatialF:nearby(?wkt, "POINT(0 51)"^^geo:wktLiteral, r, uom:metre))`
- `nearest_k10`/`nearest_k100`: sort key `spatialF:greatCircleGeom(?wkt, centre, uom:metre)`

## Corrected jena counts (100k pinned corpus + full `GEO_SMOKE=1` harness run)

| workload | sparq (expected.tsv) | jena (corrected) | crosscheck |
|---|---|---|---|
| within10km | 51 | **51** | agree |
| within50km | 1547 | **1547** | agree |
| nearest_k10 / k100 | 10 / 100 | 10 / 100 | agree (now a real distance sort) |
| geof_within | 1526 | 1526 | agree (unchanged) |

**jena is a VALID competitor on the radius workloads** — the wave-1 zeros were harness misconfiguration (a standard-form query jena cannot execute), not a jena capability gap in the workload semantic. The GeoSPARQL-1.0 standard form (`geof:distance`+`uom:metre` over CRS84) itself is recorded as NOT-COMPARABLE on jena 5.4.0 in §6d. Valid jena timings still require a canonical quiet-box re-gather (wave-2 action); no timings are added to the record.

## Honest caveats recorded (gap record §6d)

1. Jena's radius path here is a **filter scan, not its spatial index**: `spatial:withinCircle` (lat-lon arg order) indexes only `geo:hasGeometry` feature→geometry structures; on this corpus's direct `geo:asWKT` shape its spatial index holds 0 items (verified). Follow-up bead **sq-enfy3** (feature-modelled corpus variant).
2. The size-only `==k` nearest_k oracle cannot detect a degenerate ordering. Follow-up bead **sq-6jl8z** (ID-set overlap oracle).
3. The old "Jena/SIS is ellipsoidal geodesic" margin claim in the harness/record was wrong and is corrected everywhere (§3 correction note).

## Gates

- Full `GEO_SMOKE=1` both-engine harness run green: statuses ok, crosscheck agree=true on all 5 workloads; sparq counts hard-asserted vs `bench/geo/expected.tsv` inside the run (gate unchanged).
- markdownlint-cli2 0 errors (research/ in scope); typos clean.
- No perf numbers added as prose — counts only (correctness data); wave-1 envelope rows stay as the historical record with retraction annotations.

Refs sq-a8anf. Follow-ups: sq-enfy3, sq-6jl8z.