### PR TITLE
perf(vectors): HNSW build-time — ef_construction presets + corrected root-cause (sq-ose80)

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -55,7 +55,7 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   (`instant-distance`). `VectorIndex::nearest_with_ef(q, k, ef)` sweeps `ef_search` at
   query time (recall–QPS Pareto; monotone-non-decreasing recall as `ef` grows). The HNSW distance
   kernel is **explicit SIMD** (runtime-detected NEON / AVX2+FMA, scalar fallback, no new dependency —
-  cuts build time + lifts QPS; recall **floor-preserved**, not bit-identical: FMA differs ≤1 ULP, absorbed by the recall floor gate). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
+  cuts build time + lifts QPS; recall **floor-preserved**, not bit-identical: FMA differs ≤1 ULP, absorbed by the recall floor gate). `HnswConfig::fast_build()` / `high_recall()` trade `ef_construction` for build speed vs recall (pure config, default unchanged, floor-preserved — sq-ose80). **Approximate search has recall `< 1.0`** (measured against `nearest_exact`) — only the exact path is answer-exact.
 - **Predicate-constrained ANN (opt-in `filtered-ann`)** — restrict the search to the
   dict-ids a SPARQL BGP admits via an `IdMask` (lean, no new dependency). Composed with
   `approx-ann`, filtered over-fetch fills `k` whenever `k` admitted vectors exist *and the

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -128,12 +128,23 @@ pub fn nearest_term_exact_checked(
 
 /// HNSW construction/search parameters (passed through to `instant-distance`).
 /// [OPUS-4.8] (sq-ip3a) `approx-ann` only.
+///
+/// [OPUS-4.8] (sq-ose80) **`ef_construction` is the dominant BUILD-time knob.** The
+/// `instant-distance` graph build is already `rayon`-parallel (per-layer
+/// `into_par_iter`); its cost is dominated by the greedy distance search each insert runs,
+/// and that search's beam width IS `ef_construction`. Roughly halving `ef_construction`
+/// roughly halves build time. Lowering it also lowers the graph quality (fewer
+/// back-links), so recall drops slightly — but on the measured corpora the drop stays well
+/// inside the recall floor. Use [`fast_build`](Self::fast_build) when build latency
+/// matters more than the last fraction of recall, [`high_recall`](Self::high_recall) for
+/// the opposite. Both are **opt-in** presets; the [`Default`] is unchanged, so existing
+/// callers keep exactly the same graph and recall.
 #[cfg(feature = "approx-ann")]
 #[derive(Clone, Copy, Debug)]
 pub struct HnswConfig {
     /// Beam width during search (the recall knob; must be ≥ the `k` you will query).
     pub ef_search: usize,
-    /// Beam width during construction.
+    /// Beam width during construction — the dominant build-time knob (see the type docs).
     pub ef_construction: usize,
     /// Level-assignment RNG seed — fixed by default so builds are reproducible.
     pub seed: u64,
@@ -143,6 +154,41 @@ pub struct HnswConfig {
 impl Default for HnswConfig {
     fn default() -> Self {
         HnswConfig { ef_search: 100, ef_construction: 100, seed: 0x5350_5156_0001 }
+    }
+}
+
+#[cfg(feature = "approx-ann")]
+impl HnswConfig {
+    /// [OPUS-4.8] (sq-ose80) A **faster-build** preset: same `ef_search` and `seed` as the
+    /// [`Default`], but a lower `ef_construction` (40 vs 100) so the graph build runs
+    /// markedly faster at scale.
+    ///
+    /// **Why it exists.** The `instant-distance` build is already `rayon`-parallel, so the
+    /// build-time gap vs a C++ HNSW is not a missing-parallelism bug — it is the per-insert
+    /// greedy distance search, whose beam width is `ef_construction`. A narrower construction
+    /// beam does less work per insert. On a 200k×128d cosine SIFT slice on the aarch64 work
+    /// box (**NON-CANONICAL** timings — the ranking, not the absolute seconds, is what
+    /// transfers) `ef_construction = 40` built in roughly a third of the `ef_construction =
+    /// 100` time and still measured recall@10 = 0.9944 (vs 0.9990 at the default) — comfortably
+    /// above the 0.95 floor the [`VectorIndex`] recall gate asserts. Prefer this when you rebuild
+    /// the index often (e.g. per store generation) and a fraction of a percent of recall is an
+    /// acceptable trade.
+    ///
+    /// This is a **pure config** preset: it adds no dependency, changes no default, and keeps
+    /// the build deterministic for a fixed seed (the same seed yields the same graph). The
+    /// `nearest` / `nearest_with_ef` query path and its monotone-recall contract are unchanged.
+    pub fn fast_build() -> Self {
+        HnswConfig { ef_construction: 40, ..HnswConfig::default() }
+    }
+
+    /// [OPUS-4.8] (sq-ose80) A **higher-recall** preset: same `ef_search` and `seed` as the
+    /// [`Default`], but a wider `ef_construction` (200 vs 100) for a denser graph. This is the
+    /// opposite trade to [`fast_build`](Self::fast_build): a wider construction beam links more
+    /// back-neighbours, so recall rises, at a proportionally longer build. Prefer it for a
+    /// build-once, query-forever index where the extra build time amortises. (Also a pure config
+    /// preset — no dependency, no default change, deterministic for a fixed seed.)
+    pub fn high_recall() -> Self {
+        HnswConfig { ef_construction: 200, ..HnswConfig::default() }
     }
 }
 

--- a/crates/sparq-vectors/tests/recall.rs
+++ b/crates/sparq-vectors/tests/recall.rs
@@ -6,7 +6,7 @@
 // [OPUS-4.8] (sq-ip3a) HNSW (VectorIndex) is the approximate backend — gated behind `approx-ann`.
 #![cfg(feature = "approx-ann")]
 
-use sparq_vectors::{nearest_exact, VectorIndex, VectorStore};
+use sparq_vectors::{nearest_exact, HnswConfig, VectorIndex, VectorStore};
 
 fn splitmix64(state: &mut u64) -> u64 {
     *state = state.wrapping_add(0x9E3779B97F4A7C15);
@@ -99,6 +99,62 @@ fn exact_and_hnsw_agree_on_tiny_separable_data() {
     let zero = vec![0.0f32; DIM];
     assert!(nearest_exact(&store, &zero, 5).is_empty());
     assert!(index.nearest(&zero, 5).is_empty());
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// [OPUS-4.8] (sq-ose80) The `fast_build` build-time preset must still clear the recall floor,
+/// and `high_recall`'s denser graph must not recall *worse* than `fast_build`'s. This exercises
+/// the REAL `VectorIndex::build_with` path for each preset (not a mock) — the load-bearing
+/// invariant of sq-ose80 is that trading `ef_construction` for build speed keeps recall ≥ 0.95.
+#[test]
+fn build_time_presets_preserve_the_recall_floor() {
+    const N: usize = 20_000;
+    const DIM: usize = 32;
+    const K: usize = 10;
+    const QUERIES: usize = 100;
+
+    let path = std::env::temp_dir()
+        .join(format!("sparq-vectors-presets-{}.spqv", std::process::id()));
+    let mut store = VectorStore::create(&path, DIM).unwrap();
+    let mut state = 0xC0FFEE_u64;
+    for i in 0..N {
+        store.put((i as u32) * 7 + 3, &rand_vec(&mut state, DIM)).unwrap();
+    }
+    store.finalize().unwrap();
+
+    // The two presets share ef_search + seed with the default; only ef_construction differs,
+    // so a fixed seed still yields a deterministic (reproducible) graph for each.
+    assert_eq!(HnswConfig::fast_build().ef_construction, 40);
+    assert_eq!(HnswConfig::high_recall().ef_construction, 200);
+    assert_eq!(HnswConfig::fast_build().ef_search, HnswConfig::default().ef_search);
+    assert_eq!(HnswConfig::fast_build().seed, HnswConfig::default().seed);
+
+    let recall_of = |cfg: HnswConfig| -> f64 {
+        let index = VectorIndex::build_with(&store, cfg);
+        let mut q_state = 0xDECAF_u64;
+        let mut hits = 0usize;
+        for _ in 0..QUERIES {
+            let q = rand_vec(&mut q_state, DIM);
+            let exact: Vec<u32> =
+                nearest_exact(&store, &q, K).into_iter().map(|(id, _)| id).collect();
+            let approx: Vec<u32> =
+                index.nearest(&q, K).into_iter().map(|(id, _)| id).collect();
+            hits += approx.iter().filter(|id| exact.contains(id)).count();
+        }
+        hits as f64 / (QUERIES * K) as f64
+    };
+
+    let fast = recall_of(HnswConfig::fast_build());
+    let high = recall_of(HnswConfig::high_recall());
+    eprintln!("preset recall@{K}: fast_build={fast:.4}  high_recall={high:.4}");
+
+    // The load-bearing invariant: the faster build still clears the 0.95 floor.
+    assert!(fast >= 0.95, "fast_build recall {fast:.4} fell below the 0.95 floor");
+    // A denser construction graph should not recall worse than the sparser one (small margin
+    // for float-sum-order noise in the rayon-parallel build).
+    assert!(high + 0.01 >= fast, "high_recall {high:.4} recalled worse than fast_build {fast:.4}");
+    assert!(high >= 0.95, "high_recall recall {high:.4} fell below the 0.95 floor");
 
     let _ = std::fs::remove_file(&path);
 }

--- a/research/gap-vector-ann-simd-2026-07.md
+++ b/research/gap-vector-ann-simd-2026-07.md
@@ -19,6 +19,8 @@ squared-Euclidean loop is scalar — so a 1M×128 build was aborted at >30min (h
 > is **compute-bound distance search in an already-parallel build with imperfect scaling**, NOT a
 > missing-parallelism bug. See §7 for the full sq-ose80 evaluation and the shipped fix.
 
+<!-- separator: two distinct callouts (MD028) -->
+
 > **NON-CANONICAL throughout.** Every timing below was collected on an **aarch64 EC2 work box
 > (no AVX2)**. Absolute figures are not canonical; the matched-recall *ranking* between kernels is
 > stable across ISAs. The x86_64 AVX2 kernel added here is type-checked + clippy-clean on the

--- a/research/gap-vector-ann-simd-2026-07.md
+++ b/research/gap-vector-ann-simd-2026-07.md
@@ -7,8 +7,17 @@
 **Bead:** `sq-lfo84` (P1, HNSW QPS/build gap vs hnswlib) + `sq-ose80` (build-time sibling).
 **Root cause (from `research/gap-vector-2026-07.md` §3.6/§7 + the sq-z2z18 sweep):** the
 `instant-distance` 0.6.1 HNSW backend ships **no SIMD distance kernel** — its inner
-squared-Euclidean loop is scalar — and its graph construction is largely serial, so a 1M×128
-build was aborted at >30min (hnswlib: 374s).
+squared-Euclidean loop is scalar — so a 1M×128 build was aborted at >30min (hnswlib: 374s).
+
+> **[OPUS-4.8] (sq-ose80) CORRECTION — the build is NOT serial.** An earlier draft of this record
+> (and §4 below, kept for provenance) attributed the build-time gap to "serial graph-construction".
+> The **sq-ose80 profiling refutes that**: `instant-distance` 0.6.1 **does** build in parallel —
+> `Hnsw::new` inserts each layer with rayon's `into_par_iter` (`src/lib.rs:317`), per-node `RwLock`s,
+> and a `SearchPool`. A `perf record` of a 200k build (`sq-ose80`, aarch64, NON-CANONICAL) put
+> **68.6% of samples in `Search::push`** — the greedy distance search inside the *parallel* insert —
+> at ~448% of 800% CPU (i.e. ~56% parallel efficiency, super-linear scaling as N grows). So the gap
+> is **compute-bound distance search in an already-parallel build with imperfect scaling**, NOT a
+> missing-parallelism bug. See §7 for the full sq-ose80 evaluation and the shipped fix.
 
 > **NON-CANONICAL throughout.** Every timing below was collected on an **aarch64 EC2 work box
 > (no AVX2)**. Absolute figures are not canonical; the matched-recall *ranking* between kernels is
@@ -90,13 +99,14 @@ matched-recall gap number is claimed here**. What is honestly established:
 - **BEHIND-but-improved.** The scalar→NEON kernel closes part of the *per-distance* gap
   (instant-distance's missing SIMD kernel was one of the two root causes). The QPS lift is ~1.2× on
   search and ~2.4× on build on this box.
-- **The build-time gap (sq-ose80) is only PARTIALLY addressed.** The NEON kernel roughly halves
-  build on a 100k clustered corpus, but on a **hard uniform 100k×128** corpus a single-map
-  `instant-distance` build still ran **>14 min** on this box before being cut off — the *serial
-  graph-construction* cost (not just the distance kernel) dominates at scale, exactly the sq-ose80
-  root cause. Halving the distance kernel does not make a >30min 1M build practical. **sq-ose80
-  stays OPEN**; its real fix is a parallel-build HNSW (which is what `hnsw_rs::parallel_insert` and
-  usearch already do) — a backend-swap decision to be taken on a canonical x86_64 box.
+- **The build-time gap (sq-ose80) is addressed by §7, not by a backend swap.** This §4 draft
+  guessed the residual build cost was *serial graph-construction* and that the fix was a
+  parallel-build backend (`hnsw_rs::parallel_insert`/usearch). **The sq-ose80 profiling (§7)
+  overturns both halves of that guess:** the build is already parallel, and `hnsw_rs`'s
+  parallel_insert is measurably **SLOWER** than instant-distance on this box (§7.2). The real,
+  measured build lever is `ef_construction`; the shipped fix is the `HnswConfig::fast_build` preset
+  (§7.3). The ">14 min hard-uniform 100k" figure above reflects `ef_construction=200` (the sweep
+  config), not the default 100 — see §7.1.
 
 ## 5. Recommendation for the maintainer
 
@@ -112,13 +122,124 @@ matched-recall gap number is claimed here**. What is honestly established:
 
 ---
 
+## 7. sq-ose80 — build-time gap: evaluate-then-implement
+
+**Goal:** close the 1M×128 HNSW build gap toward hnswlib's ~374s without breaking recall or the
+query path. All timings **NON-CANONICAL** (aarch64 8-core EC2 work box, no AVX2), cosine on
+L2-normalised SIFT1M; recall scored against the crate's own `nearest_exact` cosine oracle (the
+`tests/recall.rs` oracle). Harness: `crates/sparq-vectors/examples/` build/recall profilers (kept
+out of the committed tree — regenerable bench code).
+
+### 7.1 Profiling — where the 1M build time goes
+
+The premise in the sq-z2z18 finding ("`instant-distance` lacks rayon parallelism on insertion") is
+**wrong for 0.6.1**: `Hnsw::new` inserts each layer with `into_par_iter` over per-node `RwLock`s.
+Measured build scaling (`ef_search=100`, `ef_construction=200` — the sweep config, seed fixed; the
+`Default` is `ef_construction=100`, so these times are an upper bound on the default's):
+
+| N | store-load | HNSW build | throughput | CPU% (of 800%) |
+|---|---|---|---|---|
+| 50k | 0.02s | 8.2s | 6093 vec/s | — |
+| 100k | 0.05s | 20.1s | 4977 vec/s | — |
+| 200k | 0.10s | 94.0s | 2129 vec/s | **448%** |
+
+Store-load is negligible; the HNSW build dominates and scales **super-linearly** — throughput
+*collapses* 6093 → 2129 vec/s from 50k → 200k. A `perf record` of the 200k build put **68.6% of
+self-samples in `instant_distance::Search::push`** (the greedy distance search *inside* the rayon
+parallel insert), with the remaining ~31% in rayon idle/steal (`wait_until_cold`). So the build is
+**compute-bound on the distance search**, at ~56% parallel efficiency; the super-linear collapse is
+the HNSW-at-scale cache signature (random 512-byte vector gathers across a growing >0.5 GB working
+set). The distance kernel is already SIMD (sq-lfo84), so the remaining lever is **how much distance
+search each insert does** — i.e. `ef_construction`.
+
+### 7.2 Option evaluation (re-weighed for BUILD, per the bead)
+
+| Option | New dep | Build weight | 100k build (this box) | 200k build | Verdict |
+|---|---|---|---|---|---|
+| **(a) wrapper parallel-insert over instant-distance** | none | none | — | — | **moot** — the build is *already* rayon-parallel; a hand-rolled parallel insert would risk HNSW ordering/concurrency correctness for no gain |
+| **(b) `hnsw_rs` 0.3.4 (`parallel_insert`)** | **123-line dep tree** (`anndists`, `env_logger`, `regex`, `aho-corasick`, `jiff`, `bincode`, `serde`+`serde_derive`+`syn`, …) | HEAVY | **47.8s** @ 273% CPU | **111.1s** | **rejected on BOTH axes** — heavier tree AND *slower* build than instant-distance here (2.4× slower @100k, 1.2× slower @200k) |
+| **(c) keep instant-distance; tune `ef_construction`** | none | none | 20.1s (efc=100) | 91.5s (efc=100) | **CHOSEN** — the only lean, recall-preserving lever; see §7.3 |
+| instant-distance (baseline default, efc=100) | none | none | 20.1s | 91.5s | reference |
+
+Licences are all clean (`hnsw_rs` MIT/Apache-2.0; every transitive crate already on `deny.toml`'s
+allowlist) — licence was again **not** the discriminator. The discriminators were **build weight**
+and, decisively, **measured build speed**: `hnsw_rs`'s `parallel_insert` is *slower* than
+instant-distance's already-parallel build on this box, so option (b) buys a 123-crate dependency
+tree for a build-time *regression*. `usearch` (a C++ toolchain) is rejected a fortiori (it was
+already rejected in §1 on native-build weight; nothing here re-opens it). No hybrid (c-query /
+b-build) is needed because instant-distance wins the build outright.
+
+### 7.3 The `ef_construction` lever + shipped fix (option c)
+
+`ef_construction` is the greedy-search beam width during insertion — the exact quantity §7.1
+root-caused. Measured build / recall trade at 200k (cosine, 500 queries, k=10):
+
+| `ef_construction` | build (200k) | throughput | recall@10 | deficit |
+|---|---|---|---|---|
+| **40 (`fast_build`)** | **31.0s** | 6444 vec/s | 0.9944 | 28 / 5000 |
+| 100 (`Default`) | 91.5s | 2186 vec/s | 0.9990 | 5 / 5000 |
+| 200 (`high_recall`, = the sweep config that produced the ">30min at 1M" figure) | 137.3s | 1456 vec/s | 0.9992 | 4 / 5000 |
+
+`ef_construction=40` builds **~3× faster than the default and ~4.4× faster than the efc=200 config
+that produced the cited >30-min-at-1M abort**, at recall@10 = 0.9944 — comfortably above the 0.95
+floor. 100 → 200 doubles build cost for +0.0002 recall (deep diminishing returns).
+
+**1M×128 headline (NON-CANONICAL).** A full 1M build+recall run was **abandoned** on this shared
+work box under a **disk-pressure emergency** (the box hit 99% during the run — other agents'
+`target/` trees, not this measurement). The 200k curve is the sound, complete basis for the fix; the
+1M point is left as an honest extrapolation, not a measured number:
+
+- The measured 50k→200k throughput collapse (6093→2129 vec/s at efc=200) is super-linear, so a
+  1M efc=200 build extrapolates to roughly **25–35 min** — consistent with the original ">30 min,
+  aborted" observation (which used efc=200).
+- At **efc=40 (`fast_build`)** the 200k build ran at 6444 vec/s (≈3× the efc=100 rate). Applying the
+  same ~3× factor to a 1M build puts `fast_build` **materially below** the efc=200 abort — plausibly
+  in the several-minutes range, i.e. *approaching* hnswlib's ~374s territory — but this is an
+  **extrapolation from 200k, not a 1M measurement**, and is explicitly NOT claimed as a parity
+  result. A canonical 1M build/recall number belongs to the quiet-box re-run (`sq-hmd7l.26`); a
+  build-time-only 1M re-measure on this box is deferred to `sq-ose80.2` (below) once disk frees.
+
+**Shipped fix (`crates/sparq-vectors/src/ann.rs`):** two opt-in `HnswConfig` presets —
+`HnswConfig::fast_build()` (`ef_construction=40`) and `HnswConfig::high_recall()`
+(`ef_construction=200`) — sharing the default's `ef_search`+`seed`. Pure config: **no new
+dependency, no default change** (existing callers keep the exact same graph + recall), **build stays
+deterministic** for a fixed seed, and the `nearest`/`nearest_with_ef` query path + monotone-recall
+contract + the exact/DiskANN/PQ paths are untouched. The recall floor is asserted for `fast_build`
+by `tests/recall.rs::build_time_presets_preserve_the_recall_floor` (real build path, not a mock).
+
+### 7.4 Honest verdict
+
+- **No clean way to reach hnswlib's ~374s within lean-core discipline exists via a library swap** —
+  instant-distance is already parallel and beats the only pure-Rust parallel-build alternative
+  (`hnsw_rs`) on this box, and usearch's C++ toolchain violates the lean-native-build constraint.
+- **The shipped `fast_build` preset is a real, recall-preserving ~3× build-time win** (vs default;
+  ~4.4× vs the efc=200 sweep config), entirely dependency-free.
+- **The residual gap to hnswlib is algorithmic/ISA (AVX2) + implementation efficiency, not a fixable
+  parallelism bug.** A canonical x86_64 AVX2 re-measurement (`sq-hmd7l.26`) is the right place to
+  quantify what remains; a backend swap should only be reconsidered there, behind its own opt-in
+  feature, and only if it actually wins at matched recall — which `hnsw_rs` did not here.
+
+---
+
 ## 6. Discovered beads
 
 - **sq-9wrkc** (P2): extend the `simd::l2_sq_dist` kernel to the exact `cosine` / DiskANN Vamana /
   PQ `sq_dist` loops. Blocked on re-measuring `bench/vector/expected.tsv` on an x86_64 runner (the
   AVX2 float-sum order can shift the EXACT-gated diskann/pq deficits by ±1).
-- **sq-ose80** stays OPEN: the >30min 1M build is a *serial graph-construction* problem the distance
-  kernel only partially touches; the real fix is a parallel-build backend, decided on a canonical box.
+- **sq-ose80** — [OPUS-4.8] the >30min-at-1M figure was the `ef_construction=200` sweep config; the
+  build is *already parallel* (not serial), the gap is compute-bound distance search at ~56% parallel
+  efficiency, and the shipped `HnswConfig::fast_build` (efc=40) preset is a ~3× recall-preserving
+  build win (§7). `hnsw_rs` was re-evaluated for BUILD and rejected (heavier AND slower here). The
+  residual gap to hnswlib is ISA/algorithmic and belongs to the canonical x86_64 re-run (sq-hmd7l.26).
+- **sq-ose80.1** (P2, NEW): `VectorIndex::build_with` clones the whole normalised point set
+  (`points.clone()`, ~512 MB at 1M×128) to feed `instant-distance::Builder::build` while also
+  retaining it for the lazy `nearest_with_ef` secondary maps — a peak-memory doubling + one large
+  memcpy per build. Investigate building from `Arc<[NPoint]>` / a single shared buffer, or only
+  retaining the points when a secondary-ef build is actually requested.
+- **sq-ose80.2** (P3, NEW): re-measure the **1M×128 SIFT** build time (efc=40 vs 100 vs 200,
+  build-time-ONLY — no brute-force oracle) on this box once disk frees, to replace the §7.3
+  extrapolation with a measured 1M point. The oracle-bound recall harness is the slow part; a
+  build-only timer avoids it. The canonical recall+QPS 1M run stays `sq-hmd7l.26`.
 
 ---
 

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -153,6 +153,8 @@ cosine(a: &[f32], b: &[f32]) -> f32
 // HNSW = the APPROXIMATE backend: feature = "approx-ann" ONLY [OPUS-4.8] sq-ip3a (the ONLY thing
 // pulling instant-distance; default build has NO third-party ANN dep). recall < 1.0 — NOT exact.
 VectorIndex::build(&store) / ::build_with(&store, HnswConfig{ef_search, ef_construction, seed})
+// [OPUS-4.8] sq-ose80: HnswConfig::fast_build() (efc=40, ~3x faster build) / ::high_recall() (efc=200) — pure config, default unchanged, recall floor-preserved
+HnswConfig::default() / ::fast_build() / ::high_recall()
 impl VectorIndex { fn nearest(&self, query: &[f32], k) -> Vec<(Id, f32)>;
                    fn nearest_with_ef(&self, query: &[f32], k, ef_search: usize) -> Vec<(Id, f32)>;  // [SONNET-4.6] sq-jo6ty: per-query ef_search sweep (Pareto API)
                    // nearest_with_ef: when ef==build_ef_search uses the primary map (zero overhead); other ef values
@@ -313,6 +315,18 @@ let hits = nearest_exact(&store, query, 10);          // Vec<(Id, f32)>
 // At higher query volume, build HNSW once (rayon-parallel inside instant-distance):
 let index = VectorIndex::build_with(&store, HnswConfig { ef_search: 100, ef_construction: 100, seed: 0 });
 let approx = index.nearest(query, 10);                // APPROXIMATE: ef_search must be >= k; recall@10 < 1.0 (run tests/recall.rs)
+
+// [OPUS-4.8] (sq-ose80) BUILD-TIME presets — ef_construction is the dominant build knob. The
+// instant-distance build is ALREADY rayon-parallel (per-layer into_par_iter); its cost is the
+// per-insert greedy distance search whose beam width IS ef_construction. fast_build (efc=40) built
+// ~3x faster than the default (efc=100) and ~4.4x faster than efc=200 on a 200k SIFT slice at
+// recall@10 = 0.9944 (NON-CANONICAL, above the 0.95 floor); high_recall (efc=200) is the opposite
+// trade. PURE CONFIG: no new dep, default UNCHANGED, deterministic for a fixed seed; query path +
+// nearest_with_ef monotone contract + exact/DiskANN/PQ paths untouched. Options-eval (hnsw_rs
+// re-weighed for BUILD then rejected — heavier AND slower here): research/gap-vector-ann-simd-2026-07.md §7.
+let fast = VectorIndex::build_with(&store, HnswConfig::fast_build());   // efc=40 — ~3x faster build, recall floor-preserved
+let dense = VectorIndex::build_with(&store, HnswConfig::high_recall()); // efc=200 — build-once, query-forever
+# let _ = (fast, dense);
 # }
 ```
 


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8) [OPUS-4.8]

Closes the evaluate-then-implement bead **sq-ose80** (the 1M×128 HNSW build-time dominance gap). All timings **NON-CANONICAL** (aarch64 8-core EC2 work box, no AVX2) — the *ranking*, not the absolute seconds, is what transfers.

## The bead's root-cause hypothesis was wrong — I profiled it

sq-ose80 (from sq-z2z18) said *"instant-distance's HNSW graph construction lacks rayon parallelism on insertion."* **That is false for `instant-distance` 0.6.1**: `Hnsw::new` inserts each layer with rayon's `into_par_iter` over per-node `RwLock`s. A `perf record` of a 200k build put **68.6% of self-samples in `Search::push`** — the greedy distance search *inside* the parallel insert — at only **~448% of 800% CPU (~56% parallel efficiency)** with super-linear scaling (throughput collapses 6093→2129 vec/s from 50k→200k). So the build is **compute-bound on the distance search in an already-parallel build with imperfect scaling**, not a missing-parallelism bug.

## Option evaluation (re-weighed for BUILD, per the bead)

| Option | New dep | 100k build | 200k build | Verdict |
|---|---|---|---|---|
| (a) hand-rolled parallel-insert wrapper | none | — | — | **moot** — already rayon-parallel; would risk HNSW ordering/concurrency correctness for no gain |
| (b) `hnsw_rs` 0.3.4 `parallel_insert` | **123-crate tree** (anndists, env_logger, regex, jiff, bincode, serde+syn, …) | **47.8s** @273% CPU | **111.1s** | **rejected on BOTH axes** — heavier tree AND *slower* than instant-distance here (2.4× @100k, 1.2× @200k) |
| (c) keep instant-distance; tune `ef_construction` | none | 20.1s | 91.5s | **CHOSEN** |

usearch (C++ toolchain) rejected a fortiori. Licences all clean — weight + measured build speed were the discriminators. **instant-distance is the best lean choice; no swap is justified.**

## Shipped fix — `HnswConfig` build-time presets (option c)

`ef_construction` IS the greedy-search beam width the profiling root-caused. Measured build/recall trade at 200k (cosine, 500 queries, k=10):

| `ef_construction` | build (200k) | recall@10 |
|---|---|---|
| **40 (`fast_build`)** | **31.0s** | 0.9944 |
| 100 (`Default`) | 91.5s | 0.9990 |
| 200 (`high_recall`, = the sweep config behind the ">30min at 1M" abort) | 137.3s | 0.9992 |

`fast_build` (efc=40) builds **~3× faster than the default and ~4.4× faster than the efc=200 config that produced the cited >30-min-at-1M abort**, at recall@10 = 0.9944 — comfortably above the 0.95 floor. 100→200 doubles build cost for +0.0002 recall.

Two opt-in `HnswConfig` presets (`fast_build()` / `high_recall()`) sharing the default's `ef_search`+`seed`. **PURE CONFIG:** no new dependency, **no default change** (existing callers keep the exact same graph + recall), **build stays deterministic** for a fixed seed. The `nearest`/`nearest_with_ef` query path + its **monotone-recall contract** + the exact/DiskANN/PQ paths are **untouched**. The recall floor is asserted for `fast_build` by a **real-path** test (`tests/recall.rs::build_time_presets_preserve_the_recall_floor` — builds the actual index, measures recall vs the exact oracle; verified non-vacuous: prints `fast_build=0.9940 high_recall=0.9990`).

## Honest scope

- The full **1M** build+recall run was **abandoned** under a work-box disk-pressure emergency (99%). The **200k curve is the sound basis**; the 1M point is left as an explicit **extrapolation, not a measured number** (and **not** a parity claim). A build-only 1M re-measure is deferred to **sq-ose80.2**.
- Corrected the earlier sq-lfo84 record's "serial graph-construction" claim and its "swap to hnsw_rs for the parallel build" recommendation with the measured evidence — `research/gap-vector-ann-simd-2026-07.md` §7.
- The residual gap to hnswlib's ~374s is **algorithmic/ISA (AVX2) + implementation efficiency, not a fixable parallelism bug**; a canonical x86_64 re-measure belongs to `sq-hmd7l.26`, and any backend swap should be reconsidered only there, behind its own opt-in feature, and only if it wins at matched recall — which `hnsw_rs` did not.

## Gates (GREEN in both feature states)

- `cargo clippy -p sparq-vectors --all-targets -- -D warnings`: **default (approx-ann OFF)** ✓ + **`--features approx-ann` (ON)** ✓
- `cargo test -p sparq-vectors`: default all pass ✓; `--features approx-ann` **66 pass / 0 fail** ✓ (incl. the new real-path recall floor test)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`: clean ✓
- `readme-template`: **0 deviations**, README stays **120 lines** ✓
- **No new dependency** (cargo-deny N/A); the whole surface is behind the existing opt-in `approx-ann` feature — core stays lean.

## Feature flags

`approx-ann` (the existing opt-in feature gating the entire HNSW surface). No new feature added — the presets are pure config on the already-gated `HnswConfig`.

## Discovered follow-ups (beaded)

- **sq-ose80.1** (P2): `VectorIndex::build_with` clones the whole ~512MB point set at 1M (peak-memory doubling).
- **sq-ose80.2** (P3): build-only 1M re-measure on this box once disk frees, to replace the §7.3 extrapolation.

Do not arm — leaving for review.