### PR TITLE
perf(shacl): id-level core-constraint fast path + Rc-shared pattern regexes (sq-7d3dj.33.4)

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -8,10 +8,10 @@
 </p>
 
 Opt-in **SHACL Core + SHACL-SPARQL (`sh:sparql`)** validation over
-[`sparq_core::Graph`]s. Constraints are evaluated by direct, index-backed permutation
-scans (no SPARQL round-trip) except `sh:sparql`, which routes its `sh:select` through
-`sparq-engine`. Validation yields a `ValidationReport` — `conforms` + per-result detail,
-`to_turtle()` (the W3C SHACL report vocabulary), and `to_text()`.
+[`sparq_core::Graph`]s. Core constraints run at the dictionary-id level via direct,
+index-backed permutation scans (no SPARQL round-trip; terms materialise only at the
+report boundary); `sh:sparql` routes its `sh:select` through `sparq-engine`. Reports:
+`conforms` + per-result detail, `to_turtle()` (W3C vocabulary), `to_text()`.
 
 Like `sparq-reason`, this crate is **isolated**: no other sparq crate depends on it, so
 the core engine and the default wasm bundle carry zero SHACL code. The browser/JS

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -4,17 +4,22 @@
 use crate::model::{
     sh, Component, ComponentDef, ComponentMeta, PreparedComponentValidator, ShapesModel, Target,
 };
-use crate::path::Path;
+use crate::path::{Path, PathIds};
 use crate::report::{ShapeDiagnostic, ValidationResult};
 use crate::sparql::{ComponentResultFields, PreparedValidator};
 use crate::view::GraphView;
 use oxrdf::{Literal, Term};
 use rustc_hash::FxHashMap;
+use sparq_core::dict::{is_inline, Id, TermParts};
 use sparq_core::Graph;
+use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::rc::Rc;
 
 const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+/// The datatype of every dictionary inline id ([FABLE-5] sq-7d3dj.33.4).
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 /// [OPUS-4.8] (sq-0mjfd) The RDF-1.2 reification predicate: a reifier `?r` reifies
 /// a triple-term via `?r rdf:reifies <<( s p o )>>`. Used by `sh:reifierShape`.
 const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
@@ -27,6 +32,24 @@ thread_local! {
     /// priming so `validate` takes the per-focus path — lets the in-crate
     /// differential test diff the batched report against the per-focus one.
     static FORCE_NO_BATCH: Cell<bool> = const { Cell::new(false) };
+    /// [FABLE-5] (sq-7d3dj.33.4) Test-only: when set, `validate_shape_at` never
+    /// resolves a focus-node id, so value nodes are computed by the Term-level
+    /// path walk and every constraint takes the Term-level route — lets the
+    /// in-crate differential tests diff the id-fast-path report against the
+    /// original Term-level one.
+    static FORCE_NO_IDFAST: Cell<bool> = const { Cell::new(false) };
+    /// [FABLE-5] (sq-7d3dj.33.4) Test-only: counts (shape, focus) validations that
+    /// took the id-level value-node walk, so the differential tests can assert
+    /// the fast path actually FIRED (non-vacuity — with a never-firing fast path
+    /// the report diff would be trivially, meaninglessly equal).
+    static IDFAST_WALKS: Cell<u64> = const { Cell::new(0) };
+}
+
+/// [FABLE-5] (sq-7d3dj.33.4) Test-only: the number of id-level value-node walks
+/// taken on this thread (see `IDFAST_WALKS`).
+#[cfg(test)]
+pub(crate) fn idfast_walks() -> u64 {
+    IDFAST_WALKS.with(Cell::get)
 }
 
 /// [OPUS-4.8] (sq-7d3dj.33.1) Test-only helper: run `f` (typically a `validate`
@@ -41,6 +64,18 @@ pub(crate) fn with_sparql_batching_disabled<R>(f: impl FnOnce() -> R) -> R {
     r
 }
 
+/// [FABLE-5] (sq-7d3dj.33.4) Test-only helper: run `f` with the id-level
+/// core-constraint fast path forced OFF (Term-level walk everywhere), restoring
+/// the prior state afterwards. Used by the id-fastpath report-equivalence tests.
+#[cfg(test)]
+pub(crate) fn with_id_fastpath_disabled<R>(f: impl FnOnce() -> R) -> R {
+    let prev = FORCE_NO_IDFAST.with(Cell::get);
+    FORCE_NO_IDFAST.with(|c| c.set(true));
+    let r = f();
+    FORCE_NO_IDFAST.with(|c| c.set(prev));
+    r
+}
+
 /// Runs every targeted shape over its focus nodes. Results are deliberately NOT
 /// deduplicated: the SHACL test suite expects one result per constraint-component
 /// OCCURRENCE (e.g. two sh:class violations on one value) and per traversal route
@@ -50,19 +85,7 @@ pub(crate) fn validate_graph(
     data: &Graph,
     shapes: &ShapesModel,
 ) -> (Vec<ValidationResult>, Vec<ShapeDiagnostic>) {
-    let mut v = Validator {
-        data: GraphView::new(data),
-        shapes,
-        stack: Vec::new(),
-        memo: vec![FxHashMap::default(); shapes.shapes.len()],
-        min_reentry: usize::MAX,
-        regexes: FxHashMap::default(),
-        uvf_targets: FxHashMap::default(),
-        diagnostics: Vec::new(),
-        active_meta: None,
-        sparql_batch: FxHashMap::default(),
-        node_expr_cache: None,
-    };
+    let mut v = Validator::new(data, shapes);
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
         // [OPUS-4.8] (sq-7d3dj.33.1) Enumerate this shape's focus nodes ONCE, then
@@ -103,19 +126,7 @@ pub(crate) fn validate_graph(
 /// targets), so it stays in lock-step with validation, including the SHACL-1.2
 /// data-dependent targets (`sh:targetWhere` / SPARQL-valued `sh:targetNode`).
 pub(crate) fn count_focus_nodes(data: &Graph, shapes: &ShapesModel) -> usize {
-    let mut v = Validator {
-        data: GraphView::new(data),
-        shapes,
-        stack: Vec::new(),
-        memo: vec![FxHashMap::default(); shapes.shapes.len()],
-        min_reentry: usize::MAX,
-        regexes: FxHashMap::default(),
-        uvf_targets: FxHashMap::default(),
-        diagnostics: Vec::new(),
-        active_meta: None,
-        sparql_batch: FxHashMap::default(),
-        node_expr_cache: None,
-    };
+    let mut v = Validator::new(data, shapes);
     let mut all: Vec<Term> = Vec::new();
     for &sid in &shapes.targeted {
         all.extend(v.focus_nodes(sid));
@@ -139,20 +150,34 @@ pub(crate) fn count_focus_nodes(data: &Graph, shapes: &ShapesModel) -> usize {
 /// condition may be any shape. Gated to the feature so it adds nothing when off.
 #[cfg(feature = "shacl-af")]
 pub(crate) fn conforms_node(data: &Graph, shapes: &ShapesModel, sid: usize, node: &Term) -> bool {
-    let mut v = Validator {
-        data: GraphView::new(data),
-        shapes,
-        stack: Vec::new(),
-        memo: vec![FxHashMap::default(); shapes.shapes.len()],
-        min_reentry: usize::MAX,
-        regexes: FxHashMap::default(),
-        uvf_targets: FxHashMap::default(),
-        diagnostics: Vec::new(),
-        active_meta: None,
-        sparql_batch: FxHashMap::default(),
-        node_expr_cache: None,
-    };
+    let mut v = Validator::new(data, shapes);
     v.conforms(node, sid)
+}
+
+/// [FABLE-5] (sq-7d3dj.33.4) The value nodes of one (shape, focus) validation, in
+/// either representation. The id form comes from the compiled-path walk and lets
+/// the id-capable constraint arms check values without materialising terms;
+/// [`ValueNodes::materialize`] converts in place (order-preserving) the first
+/// time a Term-level arm needs `&[Term]`. Both routes materialise data-graph ids
+/// through the same dictionary, so the representations are interchangeable
+/// term-for-term.
+enum ValueNodes {
+    Terms(Vec<Term>),
+    Ids(Vec<Id>),
+}
+
+impl ValueNodes {
+    /// The Term form, converting from ids on first use (then cached in place).
+    fn materialize(&mut self, g: &GraphView) -> &[Term] {
+        if let ValueNodes::Ids(ids) = self {
+            let terms = ids.iter().map(|&id| g.term_of(id)).collect();
+            *self = ValueNodes::Terms(terms);
+        }
+        match self {
+            ValueNodes::Terms(v) => v,
+            ValueNodes::Ids(_) => unreachable!("converted to Terms above"),
+        }
+    }
 }
 
 struct Validator<'a> {
@@ -169,7 +194,13 @@ struct Validator<'a> {
     /// `conforms` frame was pushed (`usize::MAX` = none). A frame may be
     /// memoised only if no re-entry pointed BELOW it.
     min_reentry: usize,
-    regexes: FxHashMap<String, Option<regex::Regex>>,
+    /// Compiled `sh:pattern` regexes, keyed by `source\0flags`. `Rc`-shared —
+    /// handing a CLONE of a `regex::Regex` to each focus node gives every clone a
+    /// fresh, EMPTY cache pool, so each `is_match` rebuilt the lazy-DFA cache from
+    /// scratch (the profiled `Pool::get_slow → create_cache` hot spot on the
+    /// `datatype_range` workload); sharing one `Regex` through an `Rc` keeps its
+    /// warm cache pool across all focus nodes. [FABLE-5] (sq-7d3dj.33.4)
+    regexes: FxHashMap<String, Option<Rc<regex::Regex>>>,
     /// [OPUS-4.8] (sq-vg3y) Per-shape target-node cache for `sh:uniqueValuesFor`
     /// (the constraint needs every target node of the shape, but is evaluated once
     /// per focus node — compute the target scan once).
@@ -200,19 +231,58 @@ struct Validator<'a> {
     /// [`validate_shape`] to drain from the pre-computed map instead of re-running
     /// the SPARQL query per focus node (the O(N_focus) root cause).
     node_expr_cache: Option<(usize, FxHashMap<Term, Vec<Term>>)>,
+    /// [FABLE-5] (sq-7d3dj.33.4) Per-shape compiled id-level paths (index = shape
+    /// id; `None` = the shape has no `sh:path`). Compiled once per validation run
+    /// so the per-focus walk never re-hashes a predicate IRI string.
+    compiled_paths: Vec<Option<PathIds>>,
+    /// [FABLE-5] (sq-7d3dj.33.4) Id-keyed layer over [`Self::memo`]: `(focus id,
+    /// shape) → bool` conformance, so the hot `sh:node` route (`conforms_id`)
+    /// resolves a memo hit from a u32 hash without materialising the focus term.
+    /// An entry is stored ONLY when the Term-keyed memo stored one (the same
+    /// context-free rule — see [`Validator::conforms`]).
+    memo_ids: Vec<FxHashMap<Id, bool>>,
 }
 
 impl<'a> Validator<'a> {
+    /// [FABLE-5] (sq-7d3dj.33.4) The one construction site (was triplicated across
+    /// `validate_graph` / `count_focus_nodes` / `conforms_node`): builds the empty
+    /// caches and eagerly compiles every shape's `sh:path` to its id-level form
+    /// (cheap — shapes graphs are small; the data graph never mutates under `'a`).
+    fn new(data: &'a Graph, shapes: &'a ShapesModel) -> Self {
+        let view = GraphView::new(data);
+        let compiled_paths = shapes
+            .shapes
+            .iter()
+            .map(|s| s.path.as_ref().map(|p| p.compile(&view)))
+            .collect();
+        Validator {
+            data: view,
+            shapes,
+            stack: Vec::new(),
+            memo: vec![FxHashMap::default(); shapes.shapes.len()],
+            min_reentry: usize::MAX,
+            regexes: FxHashMap::default(),
+            uvf_targets: FxHashMap::default(),
+            diagnostics: Vec::new(),
+            active_meta: None,
+            sparql_batch: FxHashMap::default(),
+            node_expr_cache: None,
+            compiled_paths,
+            memo_ids: vec![FxHashMap::default(); shapes.shapes.len()],
+        }
+    }
+
     /// The focus nodes selected by shape `sid`'s targets, deduplicated. Takes `sid`
     /// (not a `&Shape`) and `&mut self` because the SHACL-1.2 `sh:targetWhere`
     /// target evaluates conformance through the validator (which mutates the
     /// conformance memo/stack), and the SPARQL-valued target runs a query.
     fn focus_nodes(&mut self, sid: usize) -> Vec<Term> {
         let mut out = Vec::new();
-        // Clone the targets so the per-target `&mut self` work (sh:targetWhere
-        // conformance, SPARQL target queries) does not alias the model borrow.
-        let targets = self.shapes.shapes[sid].targets.clone();
-        for t in &targets {
+        // Read the model through the validator's own `&'a` reference (independent
+        // of the `&mut self` per-target work below) — no `targets.clone()` needed.
+        // [FABLE-5] (sq-7d3dj.33.4)
+        let shapes: &'a ShapesModel = self.shapes;
+        for t in &shapes.shapes[sid].targets {
             match t {
                 Target::Node(n) => out.push(n.clone()),
                 Target::Class(c) | Target::ImplicitClass(c) => {
@@ -294,6 +364,13 @@ impl<'a> Validator<'a> {
     /// (re-entry at exactly its depth) is still memoisable — re-running it
     /// from an empty stack reproduces the same self-referential assumption.
     fn conforms(&mut self, node: &Term, sid: usize) -> bool {
+        self.conforms_at(node, None, sid)
+    }
+
+    /// [FABLE-5] (sq-7d3dj.33.4) [`Self::conforms`] with an optional focus-id hint
+    /// forwarded to [`Self::validate_shape_at`] (see there); the recursion-guard /
+    /// memo logic is unchanged.
+    fn conforms_at(&mut self, node: &Term, node_id: Option<Option<Id>>, sid: usize) -> bool {
         if let Some(i) = self.stack.iter().position(|(n, s)| n == node && *s == sid) {
             // Recursive re-entry: treat as conforming, and record how deep the
             // cycle reaches so the frames above it skip the memo.
@@ -307,7 +384,7 @@ impl<'a> Validator<'a> {
         let saved = std::mem::replace(&mut self.min_reentry, usize::MAX);
         self.stack.push((node.clone(), sid));
         let mut tmp = Vec::new();
-        self.validate_shape(sid, node, &mut tmp);
+        self.validate_shape_at(sid, node, node_id, &mut tmp);
         self.stack.pop();
         let ok = tmp.is_empty();
         if self.min_reentry >= depth {
@@ -316,6 +393,24 @@ impl<'a> Validator<'a> {
         }
         // Propagate cycle reach to the enclosing frame.
         self.min_reentry = saved.min(self.min_reentry);
+        ok
+    }
+
+    /// [FABLE-5] (sq-7d3dj.33.4) Id-keyed [`Self::conforms`] — the hot `sh:node`
+    /// route. A [`Self::memo_ids`] hit answers from a u32 hash with NO term
+    /// materialisation; a miss materialises the term once, runs the Term-level
+    /// `conforms` (which owns the recursion guard + memo rule), and mirrors the
+    /// verdict into `memo_ids` ONLY when the Term-keyed memo stored it — the same
+    /// context-free rule, so the two memos never disagree.
+    fn conforms_id(&mut self, id: Id, sid: usize) -> bool {
+        if let Some(&cached) = self.memo_ids[sid].get(&id) {
+            return cached;
+        }
+        let term = self.data.term_of(id);
+        let ok = self.conforms_at(&term, Some(Some(id)), sid);
+        if self.memo[sid].contains_key(&term) {
+            self.memo_ids[sid].insert(id, ok);
+        }
         ok
     }
 
@@ -337,16 +432,50 @@ impl<'a> Validator<'a> {
     }
 
     fn validate_shape(&mut self, sid: usize, focus: &Term, out: &mut Vec<ValidationResult>) {
-        let shape = &self.shapes.shapes[sid];
+        self.validate_shape_at(sid, focus, None, out);
+    }
+
+    /// [FABLE-5] (sq-7d3dj.33.4) [`Self::validate_shape`] with an optional focus-id
+    /// hint: `Some(fid)` means the caller already resolved `focus` against the data
+    /// dictionary (`fid = None` ⇒ absent). With a resolved id, value nodes are
+    /// computed by the compiled id-level path walk and the id-capable constraint
+    /// arms in [`Self::eval_component`] skip Term materialisation entirely; when
+    /// the focus is absent from the data graph (or the hint says so), everything
+    /// falls back to the original Term-level route unchanged.
+    fn validate_shape_at(
+        &mut self,
+        sid: usize,
+        focus: &Term,
+        focus_id: Option<Option<Id>>,
+        out: &mut Vec<ValidationResult>,
+    ) {
+        // Read the model through the validator's own `&'a` reference — independent
+        // of the `&mut self` below, so the previous per-focus-node deep clones of
+        // `components` / `component_meta` are gone. [FABLE-5] (sq-7d3dj.33.4)
+        let shapes: &'a ShapesModel = self.shapes;
+        let shape = &shapes.shapes[sid];
         if shape.deactivated {
             return;
         }
+        #[cfg(test)]
+        let focus_id = if FORCE_NO_IDFAST.with(Cell::get) {
+            Some(None) // pretend the focus is unresolved → full Term-level route
+        } else {
+            focus_id
+        };
+        // The focus node's dictionary id, resolved AT MOST ONCE per (shape, focus)
+        // validation (the Term-level route paid one dictionary hash per graph
+        // lookup instead). `None` = absent from the data graph.
+        let fid: Option<Id> = match focus_id {
+            Some(f) => f,
+            None => self.data.id_of(focus),
+        };
         // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 SPARQL-valued value nodes: when the shape
         // carries `sh:values [ sh:select … ]` / `[ sh:sparqlExpr … ]`, the value
         // nodes are COMPUTED by the node expression (`$this` = focus node) instead
         // of derived by traversing `sh:path`. The reported `sh:resultPath` is still
         // the shape's path (set in `result`), so only the value-node SET changes.
-        let values: Vec<Term> = match shape.value_expr {
+        let mut values: ValueNodes = match shape.value_expr {
             Some(idx) => {
                 // [SONNET-4.6] (sq-7d3dj.33.5) Use the pre-computed batch map when
                 // available (set by `validate_graph` before the focused shape loop);
@@ -358,16 +487,26 @@ impl<'a> Validator<'a> {
                         None
                     }
                 });
-                crate::view::dedup(cached.unwrap_or_else(|| {
-                    self.shapes.select_exprs[idx].eval(self.data.graph(), focus)
-                }))
+                ValueNodes::Terms(crate::view::dedup(cached.unwrap_or_else(|| {
+                    shapes.select_exprs[idx].eval(self.data.graph(), focus)
+                })))
             }
             None => match &shape.path {
-                Some(path) => path.values(&self.data, focus),
-                None => vec![focus.clone()],
+                Some(path) => match (&self.compiled_paths[sid], fid) {
+                    // Id fast path: walk the compiled path over ids.
+                    (Some(pids), Some(f)) => {
+                        #[cfg(test)]
+                        IDFAST_WALKS.with(|c| c.set(c.get() + 1));
+                        ValueNodes::Ids(pids.values_ids(&self.data, f))
+                    }
+                    _ => ValueNodes::Terms(path.values(&self.data, focus)),
+                },
+                // The focus node itself. Kept as the caller's EXACT term (never
+                // round-tripped through the dictionary), so a focus originating
+                // outside the data graph is reported verbatim.
+                None => ValueNodes::Terms(vec![focus.clone()]),
             },
         };
-        let components = shape.components.clone();
         // [OPUS-4.8] (sq-pb0wm) Per-constraint-statement RDF-1.2 reified-annotation
         // overrides, PARALLEL to `components`. A `{| sh:deactivated true |}` on a
         // single constraint statement suppresses ONLY that occurrence (the shape
@@ -376,13 +515,12 @@ impl<'a> Validator<'a> {
         // occurrence's results. `result()` reads `self.active_meta` (set here) to
         // apply the message/severity override; deactivation is handled by skipping
         // the component outright.
-        let metas = shape.component_meta.clone();
-        for (i, comp) in components.iter().enumerate() {
+        for (i, comp) in shape.components.iter().enumerate() {
             // Index access with a default fallback: a component WITHOUT a parallel
             // meta entry (should never happen — the vectors are kept index-aligned)
             // is treated as un-annotated rather than silently skipped (a `zip` would
             // truncate the longer vector and lose the trailing component). [OPUS-4.8] (sq-pb0wm)
-            let meta = metas.get(i);
+            let meta = shape.component_meta.get(i);
             if meta.is_some_and(ComponentMeta::is_deactivated) {
                 continue; // this constraint occurrence is deactivated (sq-pb0wm)
             }
@@ -392,7 +530,7 @@ impl<'a> Validator<'a> {
                 Some(m) if !m.is_empty() => Some(m.clone()),
                 _ => None,
             };
-            self.eval_component(sid, focus, &values, comp, out);
+            self.eval_component(sid, focus, &mut values, comp, out);
             self.active_meta = None;
         }
     }
@@ -468,10 +606,148 @@ impl<'a> Validator<'a> {
         &mut self,
         sid: usize,
         focus: &Term,
-        values: &[Term],
+        values: &mut ValueNodes,
         comp: &Component,
         out: &mut Vec<ValidationResult>,
     ) {
+        let g = self.data;
+        // ---- id-level fast arms ([FABLE-5] sq-7d3dj.33.4) --------------------
+        // While the value nodes are still ids (from the compiled-path walk), the
+        // hot Core components check them without materialising a single term —
+        // only a VIOLATING value materialises, for its report entry. Every arm
+        // mirrors its Term-level twin below decision-for-decision over the same
+        // dictionary records (differential-tested: `idfast_` tests in lib.rs).
+        // Any other component materialises the values once and takes the
+        // unchanged Term-level route.
+        if let ValueNodes::Ids(ids) = &*values {
+            match comp {
+                Component::MinCount(n) => {
+                    if (ids.len() as u64) < *n {
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            None,
+                            "MinCountConstraintComponent",
+                            format!("Fewer than {n} values"),
+                        ));
+                    }
+                    return;
+                }
+                Component::MaxCount(n) => {
+                    if (ids.len() as u64) > *n {
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            None,
+                            "MaxCountConstraintComponent",
+                            format!("More than {n} values"),
+                        ));
+                    }
+                    return;
+                }
+                Component::Datatype(dts) => {
+                    for &v in ids {
+                        if !datatype_ok_id(&g, v, dts) {
+                            out.push(self.result(
+                                sid,
+                                focus,
+                                Some(g.term_of(v)),
+                                "DatatypeConstraintComponent",
+                                iri_set_message("datatype", dts),
+                            ));
+                        }
+                    }
+                    return;
+                }
+                Component::NodeKind(kinds) => {
+                    for &v in ids {
+                        if !kinds.iter().any(|kind| node_kind_matches_id(&g, v, kind)) {
+                            out.push(self.result(
+                                sid,
+                                focus,
+                                Some(g.term_of(v)),
+                                "NodeKindConstraintComponent",
+                                iri_set_message("node kind", kinds),
+                            ));
+                        }
+                    }
+                    return;
+                }
+                Component::MinLength(n) => {
+                    for &v in ids {
+                        let ok = string_repr_id(&g, v)
+                            .map(|s| s.chars().count() as u64 >= *n)
+                            .unwrap_or(false);
+                        if !ok {
+                            out.push(self.result(
+                                sid,
+                                focus,
+                                Some(g.term_of(v)),
+                                "MinLengthConstraintComponent",
+                                format!("Value is shorter than {n} characters"),
+                            ));
+                        }
+                    }
+                    return;
+                }
+                Component::MaxLength(n) => {
+                    for &v in ids {
+                        let ok = string_repr_id(&g, v)
+                            .map(|s| s.chars().count() as u64 <= *n)
+                            .unwrap_or(false);
+                        if !ok {
+                            out.push(self.result(
+                                sid,
+                                focus,
+                                Some(g.term_of(v)),
+                                "MaxLengthConstraintComponent",
+                                format!("Value is longer than {n} characters"),
+                            ));
+                        }
+                    }
+                    return;
+                }
+                Component::Pattern { source, flags } => {
+                    match self.regex_for(source, flags.as_deref()) {
+                        None => self.note_pattern_skipped(sid, source, flags.as_deref()),
+                        Some(re) => {
+                            for &v in ids {
+                                let ok = match string_repr_id(&g, v) {
+                                    Some(s) => re.is_match(&s),
+                                    None => false,
+                                };
+                                if !ok {
+                                    out.push(self.result(
+                                        sid,
+                                        focus,
+                                        Some(g.term_of(v)),
+                                        "PatternConstraintComponent",
+                                        format!("Value does not match pattern \"{source}\""),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    return;
+                }
+                Component::Node(inner) => {
+                    for &v in ids {
+                        if !self.conforms_id(v, *inner) {
+                            out.push(self.result(
+                                sid,
+                                focus,
+                                Some(g.term_of(v)),
+                                "NodeConstraintComponent",
+                                "Value does not conform to the node shape".into(),
+                            ));
+                        }
+                    }
+                    return;
+                }
+                _ => {} // no id twin — materialise and take the Term-level route
+            }
+        }
+        let values: &[Term] = values.materialize(&g);
         match comp {
             Component::Class(cls) => {
                 for v in values {
@@ -1677,11 +1953,15 @@ impl<'a> Validator<'a> {
         }
     }
 
-    fn regex_for(&mut self, source: &str, flags: Option<&str>) -> Option<regex::Regex> {
+    fn regex_for(&mut self, source: &str, flags: Option<&str>) -> Option<Rc<regex::Regex>> {
         let key = format!("{}\u{0}{}", source, flags.unwrap_or(""));
         self.regexes
             .entry(key)
-            .or_insert_with(|| regex::Regex::new(&compose_pattern(source, flags)).ok())
+            .or_insert_with(|| {
+                regex::Regex::new(&compose_pattern(source, flags))
+                    .ok()
+                    .map(Rc::new)
+            })
             .clone()
     }
 
@@ -1831,6 +2111,73 @@ fn string_repr(t: &Term) -> Option<String> {
         Term::NamedNode(n) => Some(n.as_str().to_string()),
         Term::Literal(l) => Some(l.value().to_string()),
         _ => None,
+    }
+}
+
+// ---- id-level twins of the value-check helpers ([FABLE-5] sq-7d3dj.33.4) ------
+// Each mirrors its Term-level twin decision-for-decision over the dictionary's
+// zero-copy record parts, so the id fast arms in `eval_component` report exactly
+// what the Term-level arms would (differential-tested in `lib.rs::idfast_*`).
+
+/// Id twin of the `Component::Datatype` value check: a literal whose
+/// (well-formed) datatype is in the allowed set. An inline id IS a canonical
+/// `xsd:integer` literal (always well-formed); a stored literal checks its
+/// zero-copy record parts; IRIs / blank nodes / triple terms are not literals.
+fn datatype_ok_id(g: &GraphView, id: Id, dts: &[String]) -> bool {
+    if is_inline(id) {
+        return dts.iter().any(|dt| dt == XSD_INTEGER);
+    }
+    match g.graph().dict.term_parts(id) {
+        TermParts::Lit {
+            value,
+            datatype,
+            lang,
+        } => dts.iter().any(|dt| dt == datatype) && well_formed_parts(value, datatype, lang.is_some()),
+        _ => false,
+    }
+}
+
+/// Id twin of [`node_kind_matches`] (single `sh:nodeKind` IRI vs one value id).
+fn node_kind_matches_id(g: &GraphView, id: Id, kind: &str) -> bool {
+    let local = kind.strip_prefix(crate::model::SH).unwrap_or(kind);
+    if is_inline(id) {
+        // Inline ids are xsd:integer literals.
+        return matches!(local, "Literal" | "BlankNodeOrLiteral" | "IRIOrLiteral");
+    }
+    match g.graph().dict.term_parts(id) {
+        TermParts::Iri { .. } => matches!(local, "IRI" | "BlankNodeOrIRI" | "IRIOrLiteral"),
+        TermParts::Lit { .. } => {
+            matches!(local, "Literal" | "BlankNodeOrLiteral" | "IRIOrLiteral")
+        }
+        TermParts::Blank(_) => {
+            matches!(local, "BlankNode" | "BlankNodeOrIRI" | "BlankNodeOrLiteral")
+        }
+        // A triple term matches no SHACL node kind — same as the Term-level
+        // `node_kind_matches` catch-all.
+        TermParts::Triple(_) => false,
+    }
+}
+
+/// Id twin of [`string_repr`]: the string a `sh:pattern` / length constraint
+/// checks — zero-copy for stored literals (the hot case) and for prefix-less
+/// IRIs; blank nodes and triple terms have none (`None` ⇒ violation, matching
+/// the Term-level arms).
+fn string_repr_id<'g>(g: &GraphView<'g>, id: Id) -> Option<Cow<'g, str>> {
+    if is_inline(id) {
+        // Inline xsd:integer: its canonical lexical form (rare on this path).
+        return match g.term_of(id) {
+            Term::Literal(l) => Some(Cow::Owned(l.value().to_string())),
+            _ => None,
+        };
+    }
+    match g.graph().dict.term_parts(id) {
+        TermParts::Iri { prefix, suffix } => Some(if prefix.is_empty() {
+            Cow::Borrowed(suffix)
+        } else {
+            Cow::Owned(format!("{prefix}{suffix}"))
+        }),
+        TermParts::Lit { value, .. } => Some(Cow::Borrowed(value)),
+        TermParts::Blank(_) | TermParts::Triple(_) => None,
     }
 }
 
@@ -2122,10 +2469,17 @@ fn days_from_civil(y: i64, m: u32, d: u32) -> i64 {
 /// Is the literal's lexical form in the lexical space of its (known XSD)
 /// datatype? Unknown datatypes are accepted (no lexical check possible).
 fn well_formed(l: &Literal) -> bool {
-    let dt = l.datatype();
-    let v = l.value();
-    let Some(local) = dt.as_str().strip_prefix(XSD) else {
-        return dt.as_str() != RDF_LANG_STRING || l.language().is_some();
+    well_formed_parts(l.value(), l.datatype().as_str(), l.language().is_some())
+}
+
+/// [FABLE-5] (sq-7d3dj.33.4) The body of [`well_formed`] over raw literal parts,
+/// so the id-level datatype arm can check a stored literal's zero-copy record
+/// (`Dict::term_parts`) without constructing an `oxrdf::Literal`. `has_lang`
+/// covers both a plain language tag and a `lang--dir` RDF 1.2 slot (only
+/// presence matters here, exactly as `l.language().is_some()` did).
+fn well_formed_parts(v: &str, dt: &str, has_lang: bool) -> bool {
+    let Some(local) = dt.strip_prefix(XSD) else {
+        return dt != RDF_LANG_STRING || has_lang;
     };
     match local {
         "integer" => parse_integer(v).is_some(),
@@ -2144,7 +2498,7 @@ fn well_formed(l: &Literal) -> bool {
         "decimal" => is_decimal(v),
         "float" | "double" => is_float(v),
         "boolean" => parse_bool(v).is_some(),
-        "dateTime" | "dateTimeStamp" | "date" | "time" => timestamp(v, dt.as_str()).is_some(),
+        "dateTime" | "dateTimeStamp" | "date" | "time" => timestamp(v, dt).is_some(),
         _ => true,
     }
 }

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -1283,3 +1283,149 @@ mod expression_tests {
         );
     }
 }
+
+// [FABLE-5] (sq-7d3dj.33.4) Report-equivalence tests for the id-level
+// core-constraint fast path: the SAME (data, shapes) pair validated with the
+// fast path ON (the default) and OFF (`eval::with_id_fastpath_disabled`) must
+// produce BYTE-IDENTICAL reports — result order included (stricter than the
+// order-independent `result_keys`) — and the fast path must actually FIRE
+// (non-vacuity via the id-walk counter, mirroring the sq-7d3dj.33.1 idiom).
+#[cfg(test)]
+mod idfast_tests {
+    use super::*;
+
+    fn g(ttl: &str) -> Graph {
+        let prelude = "@prefix sh: <http://www.w3.org/ns/shacl#> .\n\
+            @prefix ex: <http://example.org/> .\n\
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+            @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n";
+        Graph::load_str(&format!("{prelude}{ttl}"), "turtle").unwrap()
+    }
+
+    /// Validates twice — id fast path ON then OFF — asserting (a) the fast path
+    /// fired at least `min_walks` id-level value walks (anti-vacuity), (b) the
+    /// forced-off run fired NONE (the toggle works), and (c) the two reports are
+    /// byte-identical including order (`Debug` covers every field of every
+    /// result, recursively through `sh:detail`).
+    fn assert_identical_reports(data: &Graph, shapes: &Graph, min_walks: u64) {
+        let before = eval::idfast_walks();
+        let fast = validate(data, shapes);
+        let walks = eval::idfast_walks() - before;
+        assert!(
+            walks >= min_walks,
+            "id fast path fired {walks} id walks, expected >= {min_walks} (vacuous differential)"
+        );
+        let before = eval::idfast_walks();
+        let slow = eval::with_id_fastpath_disabled(|| validate(data, shapes));
+        assert_eq!(
+            eval::idfast_walks(),
+            before,
+            "with_id_fastpath_disabled failed: the forced run still took id walks"
+        );
+        assert_eq!(fast.conforms, slow.conforms, "conforms diverged");
+        assert_eq!(
+            format!("{:?}", fast.results),
+            format!("{:?}", slow.results),
+            "id-fast-path report differs from the Term-level report"
+        );
+    }
+
+    /// Datatype (well-/ill-formed lexicals, language-tagged, IRI, blank-node and
+    /// INLINE-integer values), pattern (+flags, IRI/blank subjects), lengths
+    /// (multi-byte chars), counts and nodeKind — the id arms of the benchmarked
+    /// `datatype_range` workload shape.
+    #[test]
+    fn idfast_value_constraints_report_equivalent() {
+        let data = g(r#"
+            ex:a a ex:T ; ex:age 42 ; ex:name "Alice" ; ex:mail "a@ex.org" .
+            ex:b a ex:T ; ex:age "4.2"^^xsd:integer ; ex:name "Bo"@en ; ex:mail "nope" .
+            ex:c a ex:T ; ex:age "007"^^xsd:integer ; ex:name ex:iriName ; ex:mail _:b1 .
+            ex:d a ex:T ; ex:age "-3"^^xsd:integer , 7 ; ex:name "Δδ" ; ex:mail "X@Y.Z" .
+            ex:e a ex:T ; ex:age <<( ex:s ex:p ex:o )>> ; ex:name _:b2 .
+        "#);
+        let shapes = g(r#"
+            ex:S a sh:NodeShape ; sh:targetClass ex:T ;
+              sh:property [ sh:path ex:age ; sh:datatype xsd:integer ; sh:maxCount 1 ;
+                            sh:pattern "^4" ; sh:minLength 2 ] ;
+              sh:property [ sh:path ex:name ; sh:datatype xsd:string ; sh:minCount 1 ;
+                            sh:minLength 3 ; sh:maxLength 5 ; sh:nodeKind sh:Literal ;
+                            sh:pattern "^[A-Za-zΔδ]+$" ] ;
+              sh:property [ sh:path ex:mail ; sh:pattern "^[^@]+@.+$" ; sh:flags "i" ;
+                            sh:nodeKind ( sh:Literal sh:BlankNode ) ] .
+        "#);
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "fixture must produce violations to compare");
+        assert_identical_reports(&data, &shapes, 4);
+    }
+
+    /// Every path form (predicate / inverse / sequence / alternative /
+    /// zeroOrMore / oneOrMore / zeroOrOne / absent predicate) plus `sh:node`
+    /// through the id-keyed conformance memo — the benchmarked `node_paths`
+    /// workload shape, with a knows-cycle exercising the id closure.
+    #[test]
+    fn idfast_paths_and_node_report_equivalent() {
+        let data = g(r#"
+            ex:s1 a ex:Student ; ex:advisor ex:profHead ; ex:memberOf ex:dept ;
+                  ex:email "s1@u.edu" ; ex:knows ex:s2 ; ex:nick "n1" .
+            ex:s2 a ex:Student ; ex:advisor ex:profPlain ; ex:knows ex:s1 .
+            ex:s3 a ex:Student ; ex:memberOf ex:orphanDept ; ex:phone "555" .
+            ex:profHead ex:headOf ex:dept .
+            ex:dept ex:subOrgOf ex:univ .
+            ex:t1 ex:teaches ex:s1 . ex:t2 ex:teaches ex:s1 .
+        "#);
+        let shapes = g(r#"
+            ex:P a sh:NodeShape ; sh:targetClass ex:Student ;
+              sh:property [ sh:path ex:advisor ; sh:node ex:HeadShape ] ;
+              sh:property [ sh:path ( ex:memberOf ex:subOrgOf ) ; sh:minCount 1 ] ;
+              sh:property [ sh:path [ sh:inversePath ex:teaches ] ; sh:maxCount 1 ] ;
+              sh:property [ sh:path [ sh:alternativePath ( ex:email ex:phone ) ] ; sh:minCount 1 ] ;
+              sh:property [ sh:path [ sh:zeroOrMorePath ex:knows ] ; sh:maxCount 1 ] ;
+              sh:property [ sh:path [ sh:oneOrMorePath ex:knows ] ; sh:minCount 1 ] ;
+              sh:property [ sh:path [ sh:zeroOrOnePath ex:nick ] ; sh:minCount 2 ] ;
+              sh:property [ sh:path ex:absentPredicate ; sh:minCount 1 ] .
+            ex:HeadShape a sh:NodeShape ; sh:property [ sh:path ex:headOf ; sh:minCount 1 ] .
+        "#);
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "fixture must produce violations to compare");
+        assert_identical_reports(&data, &shapes, 8);
+    }
+
+    /// A cyclic `sh:node` reference: the recursion guard treats re-entry as
+    /// conforming and the context-free memo rule decides what may be cached —
+    /// `conforms_id`'s id-keyed memo layer must mirror the Term-keyed verdicts.
+    #[test]
+    fn idfast_cyclic_node_report_equivalent() {
+        let data = g(r#"
+            ex:n1 a ex:N ; ex:next ex:n2 ; ex:label "one" .
+            ex:n2 a ex:N ; ex:next ex:n1 .
+            ex:n3 a ex:N ; ex:next ex:n3 ; ex:label "three" .
+        "#);
+        let shapes = g(r#"
+            ex:A a sh:NodeShape ; sh:targetClass ex:N ;
+              sh:property [ sh:path ex:next ; sh:node ex:A ] ;
+              sh:property [ sh:path ex:label ; sh:minCount 1 ] .
+        "#);
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "fixture must produce violations to compare");
+        assert_identical_reports(&data, &shapes, 3);
+    }
+
+    /// A `sh:targetNode` focus ABSENT from the data graph: no id resolves, so the
+    /// whole validation of that focus takes the Term-level fallback — including
+    /// the zeroOrOne path whose value set contains the (dictionary-less) focus
+    /// term itself. `min_walks = 0`: no id walk is expected here.
+    #[test]
+    fn idfast_absent_focus_falls_back_to_term_route() {
+        let data = g("ex:present ex:p 1 .");
+        let shapes = g(r#"
+            ex:G a sh:NodeShape ; sh:targetNode ex:ghost ;
+              sh:property [ sh:path [ sh:zeroOrOnePath ex:p ] ; sh:datatype xsd:integer ] .
+        "#);
+        let r = validate(&data, &shapes);
+        assert!(
+            !r.conforms,
+            "the ghost focus itself flows through the zeroOrOne path and violates xsd:integer"
+        );
+        assert_identical_reports(&data, &shapes, 0);
+    }
+}

--- a/crates/sparq-shacl/src/path.rs
+++ b/crates/sparq-shacl/src/path.rs
@@ -1,9 +1,10 @@
 //! SHACL property paths: the parsed form, evaluation by direct graph walks, and
 //! serialisation back to a Turtle path expression for validation reports.
 
-use crate::view::{dedup, GraphView, RDF_FIRST};
+use crate::view::{dedup, dedup_ids, GraphView, RDF_FIRST};
 use oxrdf::Term;
 use rustc_hash::FxHashSet;
+use sparq_core::dict::Id;
 
 const SH: &str = "http://www.w3.org/ns/shacl#";
 
@@ -99,6 +100,27 @@ impl Path {
         self.step(g, start, true)
     }
 
+    /// [FABLE-5] (sq-7d3dj.33.4) Compiles this path against `g`'s dictionary:
+    /// every predicate IRI is resolved to its id ONCE, so the per-focus-node walk
+    /// ([`PathIds::values_ids`]) never re-hashes a predicate string. A predicate
+    /// that is invalid or absent from the dictionary compiles to `None` — that
+    /// step matches nothing, exactly like the Term-level `triples` guard.
+    pub(crate) fn compile(&self, g: &GraphView) -> PathIds {
+        match self {
+            Path::Predicate(p) => PathIds::Predicate(g.pred_id(p)),
+            Path::Inverse(inner) => PathIds::Inverse(Box::new(inner.compile(g))),
+            Path::Sequence(parts) => {
+                PathIds::Sequence(parts.iter().map(|p| p.compile(g)).collect())
+            }
+            Path::Alternative(parts) => {
+                PathIds::Alternative(parts.iter().map(|p| p.compile(g)).collect())
+            }
+            Path::ZeroOrMore(inner) => PathIds::ZeroOrMore(Box::new(inner.compile(g))),
+            Path::OneOrMore(inner) => PathIds::OneOrMore(Box::new(inner.compile(g))),
+            Path::ZeroOrOne(inner) => PathIds::ZeroOrOne(Box::new(inner.compile(g))),
+        }
+    }
+
     /// One application of the path from `node`; `forward` flips under inversion.
     fn step(&self, g: &GraphView, node: &Term, forward: bool) -> Vec<Term> {
         match self {
@@ -189,6 +211,95 @@ impl Path {
             Path::ZeroOrOne(p) => format!("({})?", p.to_sparql_property_path()?),
         })
     }
+}
+
+/// [FABLE-5] (sq-7d3dj.33.4) The id-level compiled form of a [`Path`]: predicate
+/// IRIs pre-resolved to dictionary ids (`None` = invalid/absent → matches
+/// nothing). [`PathIds::values_ids`] mirrors [`Path::values`] step-for-step over
+/// the same permutation scans, so the id walk yields exactly the ids of the
+/// terms the Term-level walk yields, in the same discovery order — the
+/// result-equivalence the id fast path rests on (differential-tested in
+/// `lib.rs::idfast_equivalence`).
+#[derive(Debug, Clone)]
+pub(crate) enum PathIds {
+    Predicate(Option<Id>),
+    Inverse(Box<PathIds>),
+    Sequence(Vec<PathIds>),
+    Alternative(Vec<PathIds>),
+    ZeroOrMore(Box<PathIds>),
+    OneOrMore(Box<PathIds>),
+    ZeroOrOne(Box<PathIds>),
+}
+
+impl PathIds {
+    /// The value-node ids reachable from `start` along this path (a set, in
+    /// discovery order) — the id twin of [`Path::values`].
+    pub(crate) fn values_ids(&self, g: &GraphView, start: Id) -> Vec<Id> {
+        self.step_ids(g, start, true)
+    }
+
+    /// One application of the path from `node` — the id twin of [`Path::step`].
+    fn step_ids(&self, g: &GraphView, node: Id, forward: bool) -> Vec<Id> {
+        match self {
+            PathIds::Predicate(p) => match p {
+                None => Vec::new(),
+                Some(p) => {
+                    if forward {
+                        g.objects_ids(node, *p)
+                    } else {
+                        g.subjects_ids(*p, node)
+                    }
+                }
+            },
+            PathIds::Inverse(inner) => inner.step_ids(g, node, !forward),
+            PathIds::Sequence(parts) => {
+                let mut nodes = vec![node];
+                let order: Vec<&PathIds> = if forward {
+                    parts.iter().collect()
+                } else {
+                    parts.iter().rev().collect()
+                };
+                for p in order {
+                    nodes = dedup_ids(nodes.iter().flat_map(|&n| p.step_ids(g, n, forward)));
+                    if nodes.is_empty() {
+                        break;
+                    }
+                }
+                nodes
+            }
+            PathIds::Alternative(parts) => {
+                dedup_ids(parts.iter().flat_map(|p| p.step_ids(g, node, forward)))
+            }
+            PathIds::ZeroOrOne(inner) => {
+                dedup_ids(std::iter::once(node).chain(inner.step_ids(g, node, forward)))
+            }
+            PathIds::ZeroOrMore(inner) => closure_ids(g, node, inner, forward, true),
+            PathIds::OneOrMore(inner) => closure_ids(g, node, inner, forward, false),
+        }
+    }
+}
+
+/// Breadth-first reachability closure over ids — the id twin of [`closure`].
+fn closure_ids(g: &GraphView, start: Id, inner: &PathIds, forward: bool, reflexive: bool) -> Vec<Id> {
+    let mut seen: FxHashSet<Id> = FxHashSet::default();
+    let mut out: Vec<Id> = Vec::new();
+    let mut queue: Vec<Id> = vec![start];
+    if reflexive {
+        seen.insert(start);
+        out.push(start);
+    }
+    let mut i = 0;
+    while i < queue.len() {
+        let n = queue[i];
+        i += 1;
+        for next in inner.step_ids(g, n, forward) {
+            if seen.insert(next) {
+                out.push(next);
+                queue.push(next);
+            }
+        }
+    }
+    out
 }
 
 /// Breadth-first reachability closure of `inner` from `start`; `reflexive`
@@ -674,6 +785,52 @@ mod tests {
                 .unwrap(),
             format!("(<{EX}a>)?")
         );
+    }
+
+    /// [FABLE-5] (sq-7d3dj.33.4) The compiled id-level walk must yield EXACTLY the
+    /// terms of the Term-level walk, in the SAME discovery order (the report-
+    /// equivalence the eval fast path rests on), across every path form —
+    /// including an absent predicate (compiles to a matches-nothing step) and a
+    /// knows-cycle through the id closure.
+    #[test]
+    fn values_ids_mirror_values_order_exactly() {
+        let g = graph(
+            "ex:a ex:knows ex:b , ex:c . ex:b ex:knows ex:a . ex:c ex:knows ex:d .
+             ex:b ex:name \"B\" . ex:d ex:name \"D\" .
+             ex:x ex:parent ex:a . ex:y ex:parent ex:a .",
+        );
+        let view = GraphView::new(&g);
+        let paths = [
+            Path::Predicate(p("knows")),
+            Path::Predicate(p("absent")),
+            Path::Inverse(Box::new(Path::Predicate(p("parent")))),
+            Path::Sequence(vec![Path::Predicate(p("knows")), Path::Predicate(p("name"))]),
+            Path::Alternative(vec![Path::Predicate(p("knows")), Path::Predicate(p("parent"))]),
+            Path::ZeroOrMore(Box::new(Path::Predicate(p("knows")))),
+            Path::OneOrMore(Box::new(Path::Predicate(p("knows")))),
+            Path::ZeroOrOne(Box::new(Path::Predicate(p("knows")))),
+            Path::Inverse(Box::new(Path::Sequence(vec![
+                Path::Predicate(p("knows")),
+                Path::Predicate(p("name")),
+            ]))),
+        ];
+        for path in &paths {
+            let compiled = path.compile(&view);
+            for start in ["a", "b", "d", "x"] {
+                let start_term = n(start);
+                let by_terms = path.values(&view, &start_term);
+                let start_id = view.id_of(&start_term).expect("start interned");
+                let by_ids: Vec<Term> = compiled
+                    .values_ids(&view, start_id)
+                    .into_iter()
+                    .map(|id| view.term_of(id))
+                    .collect();
+                assert_eq!(
+                    by_ids, by_terms,
+                    "id walk diverged for {path:?} from ex:{start}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/sparq-shacl/src/view.rs
+++ b/crates/sparq-shacl/src/view.rs
@@ -6,6 +6,7 @@
 //! (bound-prefix range scan on the best permutation), never a full-graph filter.
 
 use oxrdf::{NamedNode, Term};
+use sparq_core::dict::Id;
 use sparq_core::Graph;
 
 pub(crate) const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -56,6 +57,44 @@ impl<'g> GraphView<'g> {
                 ]
             })
             .collect()
+    }
+
+    // ---- id-level twins ([FABLE-5] sq-7d3dj.33.4) --------------------------------
+    // The Term-level lookups above pay a dictionary hash of every bound term PLUS an
+    // `oxrdf::Term` materialisation per matched row on EVERY call — the profiled hot
+    // cost of core-constraint validation (find_iri/hash_iri + Term alloc churn per
+    // focus node). These twins keep the whole per-focus walk at the `Id` level and
+    // materialise a `Term` only at the report boundary. Row order is identical to
+    // the Term-level methods (same permutation scans).
+
+    /// The dictionary id of `t`, or `None` when absent (matches nothing).
+    pub(crate) fn id_of(&self, t: &Term) -> Option<Id> {
+        self.g.id_of(t)
+    }
+
+    /// The id of a predicate IRI string (`None`: invalid IRI or absent from the
+    /// dictionary — either way the predicate matches nothing, exactly like the
+    /// Term-level `triples` guard).
+    pub(crate) fn pred_id(&self, iri: &str) -> Option<Id> {
+        let n = NamedNode::new(iri).ok()?;
+        self.g.id_of(&Term::NamedNode(n))
+    }
+
+    /// Materialises the term for `id` (the report boundary).
+    pub(crate) fn term_of(&self, id: Id) -> Term {
+        self.g.dict.term(id)
+    }
+
+    /// Object ids of `(s, p, ?)` — id twin of [`Self::objects`], same row order.
+    pub(crate) fn objects_ids(&self, s: Id, p: Id) -> Vec<Id> {
+        let scan = self.g.store.scan(&[Some(s), Some(p), None]);
+        scan.rows.iter().map(|r| scan.to_spo(r)[2]).collect()
+    }
+
+    /// Subject ids of `(?, p, o)` — id twin of [`Self::subjects`], same row order.
+    pub(crate) fn subjects_ids(&self, p: Id, o: Id) -> Vec<Id> {
+        let scan = self.g.store.scan(&[None, Some(p), Some(o)]);
+        scan.rows.iter().map(|r| scan.to_spo(r)[0]).collect()
     }
 
     /// True iff the fully-ground triple is present.
@@ -258,6 +297,20 @@ pub(crate) fn dedup(items: impl IntoIterator<Item = Term>) -> Vec<Term> {
     for t in items {
         if seen.insert(t.clone()) {
             out.push(t);
+        }
+    }
+    out
+}
+
+/// Order-preserving dedup over ids — the id twin of [`dedup`]. Ids and terms are
+/// in bijection (the dictionary is injective), so deduplicating ids keeps exactly
+/// the elements (and order) the Term-level dedup would. [FABLE-5] (sq-7d3dj.33.4)
+pub(crate) fn dedup_ids(items: impl IntoIterator<Item = Id>) -> Vec<Id> {
+    let mut seen: rustc_hash::FxHashSet<Id> = rustc_hash::FxHashSet::default();
+    let mut out = Vec::new();
+    for id in items {
+        if seen.insert(id) {
+            out.push(id);
         }
     }
     out

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -256,6 +256,19 @@ pre-binding rules force it to group by `$this`). `sparq_shacl::sparql_constraint
 exposes a per-thread `sh:sparql` query-execution counter (snapshot the delta across a
 `validate` call) so a perf guard can assert the batched path fired.
 
+*Id-level core-constraint fast path (perf, sq-7d3dj.33.4).* Core constraints are
+evaluated at the **dictionary-id level**: each shape's `sh:path` is compiled once per
+`validate` (predicate IRIs → ids), the per-focus path walk and dedup run over `u32`
+ids, and the hot value checks (`sh:datatype` / `sh:pattern` / `sh:nodeKind` /
+`sh:minCount`·`maxCount` / `sh:minLength`·`maxLength` / `sh:node`, which also gets an
+id-keyed conformance memo) read the dictionary's zero-copy literal records — a term is
+materialised only for a VIOLATING value, at the report boundary. Compiled `sh:pattern`
+regexes are `Rc`-shared across focus nodes (a per-focus `Regex` clone would rebuild the
+lazy-DFA cache on every match). All of it is internal — no API or feature flag — and the
+report is byte-identical to the Term-level route: a focus node absent from the data
+dictionary (e.g. a `sh:targetNode` naming a ghost IRI) falls back to the Term-level walk,
+and the in-crate `idfast_*` differential tests diff full reports fast-vs-forced-slow.
+
 **SHACL-1.2 core constraints (always on, no feature flag).** The disjunctive
 *set* spellings of `sh:datatype` / `sh:nodeKind` — `sh:datatype ( xsd:string
 rdf:langString )`, `sh:nodeKind ( sh:BlankNode sh:IRI )` — conform a value node


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]

**Bead:** sq-7d3dj.33.4 (P2, performance-dominance) — SHACL core-constraint headroom: `datatype_range` / `node_paths` were AHEAD of Jena but below the order-of-magnitude bar at some scales (research/shacl-baseline-2026-07.md §2).

## Profiling attribution (before any code change)

`perf` (cycles:u, LUBM(1) per-workload, work box — NON-canonical) on the two flagged workloads:

- **`datatype_range`** — `Regex::is_match` was **7.6%** of the whole bench process, of which **~4.3% was `Pool::get_slow → hybrid::dfa::Cache::new`**: `regex_for` handed each focus node a **cloned** `regex::Regex`, and a clone starts with a fresh, EMPTY lazy-DFA cache pool — so every focus node re-built the DFA cache from scratch. Plus ~4% `GraphView::triples` Term materialisation.
- **`node_paths`** — `Path::step → GraphView::triples → Dict::find_iri` (**~5.6%**, `hash_iri`+`split_iri` of the full focus/predicate IRI strings on every lookup), Term-keyed dedup ~3.5%, malloc/free churn ~3.5%: the term↔id boundary was crossed per focus node.
- Parse/planning < 1% — the cost was per-focus Term-level plumbing, not re-evaluation.

## Fix (internal only — no new public API, no cargo feature)

1. **`Rc`-share compiled `sh:pattern` regexes** so the warm cache pool survives across focus nodes.
2. **Compile each shape's `sh:path` once per validation run** (predicate IRIs → dictionary ids, `PathIds`); the per-focus path walk + dedup run over `u32` ids, order-identical to the Term walk.
3. **Id-level fast arms** for `sh:datatype` / `sh:pattern` / `sh:nodeKind` / `sh:minCount`·`maxCount` / `sh:minLength`·`maxLength` / `sh:node` over the dictionary's zero-copy records (`well_formed_parts` twin; inline-integer ids handled); a term materialises only for a **violating** value, at the report boundary. `sh:node` gains an id-keyed conformance memo under the same context-free rule as the Term memo.
4. Focus id resolved **at most once** per (shape, focus); the per-focus-node deep clones of `components`/`component_meta`/`targets` removed via the `&'a` model reborrow.
5. A focus absent from the data dictionary (e.g. a ghost `sh:targetNode`) falls back to the Term-level route verbatim — the caller's term is never round-tripped through the dictionary.

## Honest before/after (work box — NON-canonical; same-box interleaved A/B; identical violations/conforms/focus_nodes in every cell)

| workload | scale | before | after | speedup |
|---|---|---:|---:|---|
| datatype_range | LUBM(1), 103k triples | 14.8 ms | 3.7 ms | ~4.0× |
| node_paths | LUBM(1) | 7.6 ms | 4.0 ms | ~1.9× |
| datatype_range | LUBM(10), 1.32M | ~210 ms | ~63 ms | ~3.3× |
| node_paths | LUBM(10) | ~124 ms | ~75 ms | ~1.65× |

Directionally vs the sq-7d3dj.33 Jena columns this moves `datatype_range` from ~1.2×/7.3× ahead to roughly ~9×/~26×, and `node_paths` from ~4.6×/16.9× to ~16×/~31× — **but the gathers ran under different box conditions, so the citable ratios must come from the canonical quiet-box re-run (sq-7d3dj.33.3, noted there)**. Honest residual: the post-fix profile has no single dominator left — remaining time is owned-report construction (one `ValidationResult` with severity/messages/path/term clones per violation; the public report contract), Term-level focus-target enumeration, and the irreducible index scans. `datatype_range` at LUBM(1) may still land shy of a clean 10× vs Jena; the residual + un-twinned Term-level arms are beaded as **sq-j9hls** (profile-first).

## Result-equivalence (the load-bearing invariant)

- **`idfast_*` differential tests** (lib.rs): full-report **byte equality including order** (`Debug` of the whole results vec, every field, recursive `sh:detail`) fast-vs-forced-slow via `with_id_fastpath_disabled` (same idiom as the 33.1 batching differential), with a **non-vacuity id-walk counter** asserting the fast path fired (and did NOT fire under the toggle). Fixtures cover well-/ill-formed lexicals, language + RDF-1.2 `lang--dir` slots, inline-integer ids, IRI/blank/triple-term values, every path form incl. a knows-cycle closure, cyclic `sh:node` (recursion-guard/memo interplay), and the absent-focus Term fallback.
- **Mutation spot-check**: seeding a well-formedness bug into the id datatype arm turns the differential red (0 passed / 1 failed); restored.
- **Order-sensitive mirror test** `values_ids_mirror_values_order_exactly` (path.rs): id walk ≡ Term walk element-for-element across all path forms/starts.
- **W3C core + SHACL 1.2 ratchets green in BOTH feature states**: 274 tests (default) / 385 (`--all-features`), 0 failures.
- **`bench/shacl/run.sh` expected.tsv gate green**: all 5 workloads match (violations + conforms + focus_nodes).

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings`: default ✅ and `--all-features` ✅
- `cargo test -p sparq-shacl`: 274 ✅ (default) / 385 ✅ (`--all-features`); conformance scoreboard floors ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` ✅
- coverage: sparq-shacl **95.84%** line (floor 93) ✅
- `scripts/check-readme-template.py --enforce`: 0 deviations (README held at the 120-line cap) ✅

Docs: `skills/shacl-validation/SKILL.md` gains the id-fast-path paragraph; the crate README's evaluation blurb updated in place.

Follow-ups: sq-j9hls (residual id-level surfaces, profile-first) · sq-7d3dj.33.3 (canonical quiet-box gather for citable ratios, noted to run post-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)