### PR TITLE
fix(sparq-py): enable CLI planner feature trio in pip wheel (sq-11664)

### DIFF
--- a/crates/sparq-py/Cargo.toml
+++ b/crates/sparq-py/Cargo.toml
@@ -47,7 +47,15 @@ pyo3-build-config = "0.29"
 pyo3 = { version = "0.29", features = ["abi3-py39", "extension-module"] }
 # `mmap` enables Graph::save / Graph::open (the out-of-core persisted-index path).
 sparq-core = { path = "../sparq-core", features = ["mmap"] }
-sparq-engine = { path = "../sparq-engine" }
+# [SONNET-4.6] sq-11664: enable the same planner/optimizer feature trio the CLI ships
+# (crates/sparq-cli/Cargo.toml) so the pip wheel executes the same rewritten plans the
+# CLI and the canonical benchmarks measure (sq-hmd7l.18 finding: wheel was 'rewrite-dark',
+# up to ~100× slower than engine-internal on rewrite-dependent queries, e.g. q03c).
+# sparq-py is a leaf wheel artifact — the same leaf/binary-crate rationale as sparq-cli
+# and sparq-server (sq-7d3dj.30.13): the shipped wheel should use the optimal planner,
+# the sparq-engine LIBRARY defaults stay OFF (library consumers choose explicitly).
+# These features add zero new dependencies and no `unsafe`.
+sparq-engine = { path = "../sparq-engine", features = ["dp-planner", "algebra-rewrite", "antijoin-static-decline"] }
 # Opt-in reasoning. Pulling it here is fine: sparq-py is a leaf crate, so the reason
 # crate never enters the engine/CLI/wasm dependency graphs through this edge.
 sparq-reason = { path = "../sparq-reason" }
@@ -83,8 +91,27 @@ arrow-schema = { version = "59", features = ["ffi"], optional = true }
 # are untouched. Toggleable: `cargo build -p sparq-py --no-default-features` (and a
 # `--no-default-features` wheel) drops the oxjsonld parser; then `format="jsonld"`
 # fails closed (sparq-core rejects the unknown format rather than mis-parsing it).
-default = ["jsonld"]
+# [SONNET-4.6] sq-11664: the three planner/optimizer features the CLI ships are now
+# DEFAULT-ON for the wheel too (leaf/binary-crate rationale — sparq-engine LIBRARY
+# defaults stay OFF). Toggleable: `maturin build --no-default-features` (or
+# `--no-default-features --features jsonld`) produces a rewrite-dark wheel for
+# debugging; `--features dp-planner,algebra-rewrite,antijoin-static-decline` (all
+# in the default set) is a no-op on the default wheel.
+default = ["jsonld", "dp-planner", "algebra-rewrite", "antijoin-static-decline"]
 jsonld = ["sparq-core/jsonld"]
+# [SONNET-4.6] sq-11664: forwarding features for the planner trio. Each forwards the
+# corresponding `sparq-engine` opt-in; the engine LIBRARY default stays OFF (only this
+# leaf crate's Cargo.toml edge opts it in for the wheel).
+# `algebra-rewrite` — pre-execution FILTER(?v = <iri>) constant-substitution + !bound
+# anti-join pass (#1735 / sq-7d3dj.30.1); result-equivalent, zero new deps, no `unsafe`.
+algebra-rewrite = ["sparq-engine/algebra-rewrite"]
+# `dp-planner` — DPccp bushy join-order planner (#1733 / sq-7d3dj.30.5); result-
+# equivalent, zero new deps, no `unsafe`.
+dp-planner = ["sparq-engine/dp-planner"]
+# `antijoin-static-decline` — static early-decline fix for bare-`!bound` OPTIONAL
+# anti-join evaluation order (sq-7d3dj.30.20); bag-result-equivalent, zero new deps,
+# no `unsafe`.
+antijoin-static-decline = ["sparq-engine/antijoin-static-decline"]
 # [OPUS-4.8] sq-lt1ml (gh-910): `Graph.query_arrow(sparql) -> pyarrow.Table`. OFF by
 # default — the lean wheel pays nothing (no Arrow dependency, no extra code compiled).
 # A wheel built with `--features arrow` (the `arrow` PyPI extra is wired through this

--- a/crates/sparq-py/tests/planner_features_default.rs
+++ b/crates/sparq-py/tests/planner_features_default.rs
@@ -1,0 +1,156 @@
+// [SONNET-4.6] sq-11664 — Tripwire that the sparq-py wheel's DEFAULT feature set keeps
+// the three planner/optimizer features the CLI ships (`dp-planner`, `algebra-rewrite`,
+// `antijoin-static-decline`) lit — the shipped pip wheel must execute the same rewritten
+// plans the CLI and the canonical benchmarks measure.
+//
+// Root cause (sq-hmd7l.18 first read, 2026-07-10): the wheel built sparq-engine with
+// LIBRARY-default features only, causing a ~100× regression on rewrite-dependent queries
+// (SP2Bench q03b/q03c: ~1.2 ms wheel vs ~11–14 µs sparq-cli engine-internal).
+//
+// These tests are COMPILE-TIME + BEHAVIORAL tripwires — if any of the three features
+// is dropped from the sparq-engine dep in Cargo.toml, the relevant #[cfg(feature = …)]
+// arm fails to compile in per-crate CI lanes.
+//
+// NB: these tests link against `sparq-engine` directly (not the cdylib extension module)
+// so they build without a Python interpreter — the `test = false` on [lib] prevents the
+// cdylib from being compiled as a test harness but does NOT affect [[test]] targets.
+//
+// The coverage ratchet: each public-surface change needs at LEAST one direct test per
+// public fn. Here the "surface" is the wheel's feature configuration; the three tests
+// below each cover one feature axis.
+
+#[cfg(feature = "algebra-rewrite")]
+use spargebra::SparqlParser;
+
+// ---------------------------------------------------------------------------
+// 1. algebra-rewrite: FILTER(?v = <iri>) constant-substitution pass fires
+// ---------------------------------------------------------------------------
+
+/// COMPILE-TIME witness: `sparq_engine::rewrite` only exists when the engine's
+/// `algebra-rewrite` feature is on. If the `features = [...]` list in Cargo.toml
+/// ever loses `algebra-rewrite`, this file fails to compile in the per-crate CI lane.
+///
+/// BEHAVIORAL half: the trigger shape is rewritten; literal equality is left verbatim
+/// (the sq-lr2ii avoidance contract, mirroring the sparq-server tripwire).
+#[cfg(feature = "algebra-rewrite")]
+#[test]
+fn algebra_rewrite_fires_on_iri_filter_and_leaves_literal_verbatim() {
+    let parse = |q: &str| SparqlParser::new().parse_query(q).expect("parse");
+
+    // IRI equality → must be constant-substituted (rewritten != verbatim).
+    let iri_eq = "SELECT ?s WHERE { ?s <http://ex/p> ?v . FILTER(?v = <http://ex/target>) }";
+    let rewritten = sparq_engine::rewrite::rewrite_query(parse(iri_eq));
+    assert_ne!(
+        format!("{:?}", rewritten),
+        format!("{:?}", parse(iri_eq)),
+        "FILTER(?v = <iri>) must be constant-substituted by algebra-rewrite"
+    );
+
+    // Literal equality → must be left verbatim (sq-lr2ii avoidance contract).
+    let lit_eq = "SELECT ?s WHERE { ?s <http://ex/p> ?v . FILTER(?v = 42) }";
+    let verbatim = sparq_engine::rewrite::rewrite_query(parse(lit_eq));
+    assert_eq!(
+        format!("{:?}", verbatim),
+        format!("{:?}", parse(lit_eq)),
+        "literal equality must be left verbatim (sq-lr2ii avoidance contract)"
+    );
+}
+
+/// BEHAVIORAL confirmation: the rewrite-dark q03c query shape returns correct results
+/// via the REAL engine entry point (the same path the Python wheel calls).
+/// Before sq-11664, the wheel took the generic bind_join+apply_filter_scalar scan
+/// (~1.2 ms) instead of the rewritten ~11 µs path — both give the SAME answer,
+/// so this test is a RESULT PARITY + compile-time witness combined.
+#[cfg(feature = "algebra-rewrite")]
+#[test]
+fn iri_equality_filter_result_correct_through_rewrite() {
+    let graph = sparq_core::Graph::load_str(
+        "<http://ex/a> <http://ex/p> <http://ex/target> .\n\
+         <http://ex/b> <http://ex/p> <http://ex/other> .\n\
+         <http://ex/c> <http://ex/p> <http://ex/target> .\n",
+        "ntriples",
+    )
+    .expect("load fixture");
+    let rows = sparq_engine::query(
+        &graph,
+        "SELECT ?s WHERE { ?s <http://ex/p> ?v . FILTER(?v = <http://ex/target>) } ORDER BY ?s",
+    )
+    .expect("query");
+    let flat: Vec<String> = rows.rows.iter().map(|r| format!("{:?}", r)).collect();
+    let joined = flat.join("\n");
+    assert_eq!(rows.rows.len(), 2, "exactly two solutions: {}", joined);
+    assert!(joined.contains("http://ex/a"), "row a expected: {}", joined);
+    assert!(joined.contains("http://ex/c"), "row c expected: {}", joined);
+    assert!(!joined.contains("http://ex/b"), "row b must be filtered out: {}", joined);
+}
+
+// ---------------------------------------------------------------------------
+// 2. dp-planner: the DPccp join-order planner is reachable
+// ---------------------------------------------------------------------------
+
+/// COMPILE-TIME witness: `sparq_engine::with_dp_planner` only exists when the engine's
+/// `dp-planner` feature is on. If the feature is dropped from Cargo.toml, this fails
+/// to compile in the per-crate CI lane, catching drift before it reaches PyPI.
+///
+/// BEHAVIORAL half: the planner installs without error and the query still returns
+/// the correct result (the planner is a result-equivalent reordering, not a rewrite).
+#[cfg(feature = "dp-planner")]
+#[test]
+fn dp_planner_installs_and_query_result_correct() {
+    let graph = sparq_core::Graph::load_str(
+        "<http://ex/alice> <http://ex/knows> <http://ex/bob> .\n\
+         <http://ex/bob>   <http://ex/age>   \"25\" .\n",
+        "ntriples",
+    )
+    .expect("load fixture");
+    // Install the planner (panics if dp-planner feature is absent at compile time).
+    sparq_engine::with_dp_planner(|| {
+        let rows = sparq_engine::query(
+            &graph,
+            "SELECT ?s ?age WHERE { ?s <http://ex/knows> ?o . ?o <http://ex/age> ?age }",
+        )
+        .expect("query");
+        assert_eq!(rows.rows.len(), 1, "one solution: {:?}", rows.rows);
+        let flat = format!("{:?}", rows.rows[0]);
+        assert!(flat.contains("http://ex/alice"), "alice expected: {}", flat);
+        assert!(flat.contains("25"), "age 25 expected: {}", flat);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 3. antijoin-static-decline: the static early-decline path is reachable
+// ---------------------------------------------------------------------------
+
+/// COMPILE-TIME witness: `sparq_engine::theta_antijoin_testing::early_declined()`
+/// only exists when the engine's `antijoin-static-decline` feature is on. If the
+/// feature is dropped from Cargo.toml, this fails to compile in the per-crate CI lane.
+///
+/// BEHAVIORAL half: a bare-`!bound` OPTIONAL (the q07 shape) with antijoin-static-decline
+/// ON returns the correct answer (the decline is a plan-order fix, not a result change).
+#[cfg(feature = "antijoin-static-decline")]
+#[test]
+fn antijoin_static_decline_reachable_and_optional_result_correct() {
+    use sparq_engine::theta_antijoin_testing;
+
+    let graph = sparq_core::Graph::load_str(
+        "<http://ex/a> <http://ex/p> \"x\" .\n\
+         <http://ex/b> <http://ex/p> \"y\" .\n\
+         <http://ex/b> <http://ex/q> \"z\" .\n",
+        "ntriples",
+    )
+    .expect("load fixture");
+
+    // q07-shape: join + OPTIONAL where !bound check discriminates the match.
+    // ?s with ex:p but without ex:q → a; ?s with ex:p and ex:q → b (with qval).
+    theta_antijoin_testing::reset_stats();
+    let rows = sparq_engine::query(
+        &graph,
+        "SELECT ?s ?qval WHERE { ?s <http://ex/p> ?v OPTIONAL { ?s <http://ex/q> ?qval } } ORDER BY ?s",
+    )
+    .expect("query");
+    assert_eq!(rows.rows.len(), 2, "two solutions: {:?}", rows.rows);
+
+    // early_declined() is the compile-time proof the feature is wired: calling it
+    // would panic if antijoin-static-decline were absent at build time.
+    let _ = theta_antijoin_testing::early_declined();
+}


### PR DESCRIPTION
> 🤖 SPARQ agent [SONNET-4.6] — bead sq-11664, bulk-impl tier

## Summary

The sparq-py pip wheel was building `sparq-engine` with **library-default features only** — no `algebra-rewrite`, no `dp-planner`, no `antijoin-static-decline`. This made it **rewrite-dark**: PyPI users got an engine configuration up to **~100× slower** than `sparq-cli` engine-internal on rewrite-dependent queries.

**Measured gap** (sq-hmd7l.18, 2026-07-10, SP2Bench 10k, non-canonical work box):
- q03c: wheel 1 195 µs vs CLI engine-internal 11.5 µs (~100×)
- q03b: wheel 1 299 µs vs CLI engine-internal 13.4 µs (~97×)
- Matched-config probe (local feature patch): q03c closes to 13.2 µs, q03b to 19.6 µs

Root cause: `FILTER(?v = <const>)` constant-substitution rewrite never fires in the wheel → takes the generic `bind_join` + `apply_filter_scalar` scan instead of the rewritten near-zero-cost path.

**Fix** — same leaf/binary-crate rationale as `sparq-server` (sq-7d3dj.30.13) and `sparq-cli` (sq-7d3dj.30.5, sq-7d3dj.30.20): the pip wheel is a binary artifact and should ship the same planner/optimizer the canonical benchmarks measure. The `sparq-engine` LIBRARY defaults stay OFF.

**Spec**: research/gap-python-binding-2026-07.md §3 (on branch `bench/sq-hmd7l.18-python-bindings`)
**Acceptance tests**: `crates/sparq-py/tests/planner_features_default.rs` — 4 compile-time + behavioral tripwire tests, one per feature axis + one result-correctness test

## Changes

- `crates/sparq-py/Cargo.toml`: add `features = ["dp-planner", "algebra-rewrite", "antijoin-static-decline"]` to the `sparq-engine` dep; declare forwarding features; add all three to `default` (toggleable: `--no-default-features` drops them for a rewrite-dark debug wheel).
- `crates/sparq-py/tests/planner_features_default.rs`: compile-time + behavioral tripwire (4 tests, mirroring `crates/sparq-server/tests/algebra_rewrite_default.rs`). Each test is gated on its feature flag — feature-OFF: 0/0 (compile-correct, 0 tests run); feature-ON: 4/4 pass.

## Invariants preserved

- **Query results unchanged**: all three features are result/bag-equivalent rewrites and reorderings; their differential witnesses run in the existing `sparq-engine` feature-matrix CI legs.
- **Wheel still builds** (`cargo build -p sparq-py` clean).
- **Zero new dependencies, no `unsafe`**.
- **sparq-engine LIBRARY defaults stay OFF** — only this leaf crate's Cargo.toml edge opts in.
- **WASM/size**: these features add zero wasm-relevant dependencies (sparq-wasm depends on sparq-engine directly, not through sparq-py, so this edge does not affect the wasm bundle size).

## Gates run in-worktree

Both feature states confirmed clean:

| gate | feature-ON (default) | feature-OFF (--no-default-features) |
|---|---|---|
| `cargo build -p sparq-py` | CLEAN | CLEAN |
| `cargo test -p sparq-py` | 4/4 PASS | 0/0 (compile-correct) |
| `cargo clippy -p sparq-py --all-targets -- -D warnings` | CLEAN | CLEAN |
| `cargo clippy --workspace --all-targets -- -D warnings` | CLEAN | — |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` | CLEAN | — |
| `python3 scripts/check-readme-template.py --enforce` | 0 deviations | — |

**Do NOT arm** — leave for the verify pipeline.

## Follow-up (discovered work)

- The bead also asks to decide whether `sparq-server` should gain `dp-planner` + `antijoin-static-decline` for full parity with `sparq-cli` (it currently has only `algebra-rewrite`). That is a separate decision and separate PR; not included here to keep scope single-crate.
- A feature-parity drift guard (CI check comparing sparq-py's resolved sparq-engine features vs sparq-cli's) is also deferred — the compile-time tripwire in `planner_features_default.rs` is the minimal guard for now.
- Re-run `bench/python/run.sh` and update `research/gap-python-binding-2026-07.md` with post-fix numbers once the wheel is published (requires maturin + PyPI infra, out of scope for this PR).