### PR TITLE
ci(bench): move noisy timing benchmarks off PR/merge-queue to nightly EC2; keep the deterministic ratchet gating (sq-6vshe.6)

### DIFF
--- a/.github/workflows/bench-ec2.yml
+++ b/.github/workflows/bench-ec2.yml
@@ -1,21 +1,43 @@
 name: Benchmarks (EC2)
 
-# Cost-capped EC2-deferred heavy benchmark (roadmap G3). The cost PROTECTIONS live here:
-#   * rate limit  — runs ONLY weekly (cron) + manual dispatch; NEVER on push or pull_request,
-#                   so no per-commit and no fork-PR triggers.
-#   * fork guard  — the job is skipped unless it's the canonical repo.
+# Cost-capped EC2-deferred benchmark (roadmap G3). The cost PROTECTIONS live here:
+#   * rate limit  — runs ONLY on cron (weekly heavy + nightly full-suite) + manual dispatch; NEVER on
+#                   push or pull_request, so no per-commit and no fork-PR triggers.
+#   * fork guard  — the jobs are skipped unless it's the canonical repo.
 #   * OIDC        — assumes a short-lived, tag-scoped IAM role (no long-lived AWS keys); see
 #                   research/ci-ec2-design.md for the trust + permissions policies to create.
 #   * hard caps   — spot instance, a job timeout, and scripts/ec2-bench.sh's always-run cleanup
 #                   trap (terminate instance + delete key/SG) so a run can't leak compute.
-# Estimated spend ~$0.80/month (≈4-5 short spot runs), far under the $5/month cap; back it with an
-# AWS Budgets alarm on the purpose=sparq-ci-bench tag.
 #
-# NOT LIVE until `AWS_BENCH_ROLE_ARN` (repo variable) points at the IAM role; until then the run
-# fails harmlessly at the OIDC step (no instance launched, no cost).
+# TWO LANES (both on the SAME cost-capped EC2 rails — spot + tag purpose=sparq-ci-bench + the
+# always-run terminate/delete cleanup trap; NEVER touch prod i-090531b4ede8f2d3f / dev
+# i-00f76802f345b6b77):
+#   * ec2-bench (WEEKLY, Mondays 06:00 UTC) — the HEAVY campaign at the ~2M-triple scale (the
+#     roadmap-G3 large-hardware run). Publishes to dev/bench-ec2. UNCHANGED.
+#   * nightly-full-bench (NIGHTLY, 06:41 UTC) — [FABLE-5] sq-6vshe.6, MAINTAINER-DIRECTED. Runs the
+#     FULL NOISY TIMING SUITE (query latencies + well-known sp2b/dbpsb/watdiv/bsbm/lubm + the cargo-only
+#     fts/geo/vector/rsp/hdt/solid/nlq/zk hooks) at the SAME 200k CI scale the per-commit series used, on
+#     a quiet dedicated spot instance (contention-free wall-clock, unlike a shared GitHub runner). This is
+#     the lane the flaky/slow benchmark timing was MOVED TO: it was dragging the merge queue + flapping
+#     the gate on shared runners, so the per-PR bench lane now runs ONLY the fast deterministic byte-count
+#     ratchet (bench.yml `--deterministic-only`) and this nightly EC2 lane carries the full perf-tracking
+#     series. Publishes to dev/bench-nightly (a distinct dashboard dir, so it collides with neither the
+#     per-commit dev/bench nor the weekly heavy dev/bench-ec2). The perf-tracking is NOT lost — only moved.
+#
+# COST BASIS (why NIGHTLY is affordable):
+#   * The nightly runs the full suite at the 200k CI scale (NOT the 2M heavy scale), so a run is a short
+#     spot session on a c7g.4xlarge (arm64, spot ~$0.30-0.40/hr): build + full suite ~10-20 min ≈
+#     ~$0.07-0.14/run. 30 nights/month ≈ $2-4/month. Together with the weekly heavy (~$0.80/month) the
+#     EC2 bench total stays UNDER the $5/month cap. Back it with an AWS Budgets alarm on the
+#     purpose=sparq-ci-bench tag. If a future scale-up pushes over budget, drop the nightly cron to
+#     `weekly` (state the new cost basis in this header) — the design does not depend on the cadence.
+#
+# NOT LIVE until `AWS_BENCH_ROLE_ARN` (repo variable) points at the IAM role; until then the runs
+# fail harmlessly at the OIDC step (no instance launched, no cost).
 on:
   schedule:
-    - cron: '0 6 * * 1'      # Mondays 06:00 UTC
+    - cron: '0 6 * * 1'      # ec2-bench: Mondays 06:00 UTC (weekly heavy)
+    - cron: '41 6 * * *'     # nightly-full-bench: 06:41 UTC daily (offset off other nightly lanes)
   workflow_dispatch:
 
 # [OPUS-4.8] Least-privilege default (Scorecard TokenPermissions): top-level read-only;
@@ -30,7 +52,12 @@ concurrency:
 jobs:
   ec2-bench:
     name: heavy benchmark on EC2 (spot)
-    if: github.repository == 'sparq-org/sparq'
+    # [FABLE-5] sq-6vshe.6: the WEEKLY heavy campaign. Runs on the Monday cron OR a manual dispatch
+    # (unchanged manual behavior); the nightly '41 6 * * *' cron routes to nightly-full-bench instead,
+    # so a nightly tick never launches this heavy 2M-scale instance.
+    if: >-
+      github.repository == 'sparq-org/sparq' &&
+      (github.event_name != 'schedule' || github.event.schedule == '0 6 * * 1')
     runs-on: ubuntu-latest
     # [OPUS-4.8] Job-scoped writes (least privilege):
     #   id-token: write — assume the short-lived, tag-scoped IAM role via OIDC
@@ -87,3 +114,102 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: '@jeswr'
+
+  # [FABLE-5] (sq-6vshe.6 heavy-lane placement, MAINTAINER-DIRECTED) The NIGHTLY FULL-SUITE lane —
+  # the destination for the noisy timing benchmarks moved OFF the per-PR / merge_group bench gate. It
+  # runs ci-bench.sh's FULL suite (query latencies + all well-known + cargo-only latency suites) at the
+  # 200k CI scale on a QUIET dedicated spot instance (contention-free wall-clock, unlike a shared GitHub
+  # runner), reusing the SAME cost-capped EC2 rails as ec2-bench (spot + purpose=sparq-ci-bench tag + the
+  # always-run terminate/delete cleanup trap in scripts/ec2-bench.sh). Publishes the full series to
+  # dev/bench-nightly so the perf-tracking dashboard keeps its trend — the tracking is MOVED, not lost.
+  nightly-full-bench:
+    name: nightly full-suite benchmark on EC2 (spot)
+    # Nightly cron only (the '41 6 * * *' tick). A weekly-cron tick or a manual dispatch routes to the
+    # heavy ec2-bench job above instead, so this job never double-launches alongside it.
+    if: >-
+      github.repository == 'sparq-org/sparq' &&
+      github.event_name == 'schedule' && github.event.schedule == '41 6 * * *'
+    runs-on: ubuntu-latest
+    # Job-scoped writes (least privilege), identical to ec2-bench:
+    #   id-token: write — assume the short-lived, tag-scoped IAM role via OIDC
+    #   contents: write — github-action-benchmark pushes to the benchmark-data branch
+    permissions:
+      id-token: write
+      contents: write
+    timeout-minutes: 45        # hard wall-clock cap (backstop to the script's own cleanup trap)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ vars.AWS_BENCH_ROLE_ARN }}
+          aws-region: eu-west-2
+      - name: Launch spot, run FULL suite at 200k, always-terminate
+        run: bash scripts/ec2-bench.sh
+        env:
+          # Reuse the SAME script (single source of truth); the FULL-suite knobs make it install the
+          # well-known-suite toolchains + wasm target and run ci-bench.sh with GITHUB_REF=refs/heads/main
+          # (so every main-tier suite runs) at the 200k CI scale, writing nightly-bench-results.json.
+          BENCH_FULL_SUITE: '1'
+          BENCH_SCALE: '200000'
+          BENCH_OUT: nightly-bench-results.json
+      # First-run bootstrap: create the shared benchmark-data history branch on origin if it does not
+      # exist yet, so github-action-benchmark's `git fetch ... benchmark-data:benchmark-data` does not
+      # hard-fail with "couldn't find remote ref". Idempotent (mirrors ec2-bench + bench.yml).
+      - name: Ensure benchmark-data history branch exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin benchmark-data >/dev/null 2>&1; then
+            echo "benchmark-data branch already exists on origin — nothing to do."
+          else
+            echo "benchmark-data branch missing on origin — creating an orphan branch."
+            tmp="$(mktemp -d)"
+            git -C "$tmp" init -q
+            git -C "$tmp" checkout -q --orphan benchmark-data
+            git -C "$tmp" -c user.name=github-actions[bot] \
+                          -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+                          commit -q --allow-empty -m "chore(bench): initialise benchmark-data history branch"
+            git -C "$tmp" push -q \
+              "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              benchmark-data:benchmark-data
+            echo "Created and pushed orphan benchmark-data branch."
+          fi
+      - name: Track nightly full-suite series
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
+        with:
+          name: sparq engine (nightly full suite)
+          tool: customSmallerIsBetter
+          output-file-path: nightly-bench-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          gh-pages-branch: benchmark-data
+          benchmark-data-dir-path: dev/bench-nightly
+          alert-threshold: '150%'
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-comment-cc-users: '@jeswr'
+      # [FABLE-5] DEMOTION AUTO-BEAD PROTOCOL (research/ci-structural-speedup.md §7; mirrors fuzz.yml +
+      # differential.yml). The full noisy timing suite was DEMOTED off per-PR/merge_group to this nightly
+      # lane. If the nightly run FAILS (a suite correctness diff regressed, or the run itself broke) that
+      # failure must not silently rot — it auto-files a standing P1 bead + a GitHub issue naming the lane
+      # + run, so a finding the fast per-PR deterministic slice could not have caught is tracked to
+      # closure. gh failures degrade to warnings (the lane is already red); the JSONL append is
+      # best-effort (protected-main GH013 push may decline — the issue is the reliable channel).
+      - name: File a demoted-lane bead + issue on nightly failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          echo "nightly full-suite benchmark failed — see run ${{ github.run_id }}" > nightly-bench-fail.log
+          python3 scripts/ci-file-demoted-lane-failure.py \
+            --lane bench-nightly-full-suite \
+            --full-form "full ci-bench.sh timing suite at 200k on nightly EC2 (bench-ec2.yml nightly-full-bench)" \
+            --per-pr-form "deterministic byte-count ratchet only (bench.yml --deterministic-only)" \
+            --bead-prefix bnf \
+            --log nightly-bench-fail.log \
+            --jsonl .beads/issues.jsonl \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            || echo "::warning::demoted-lane filer failed (non-fatal; the lane is already red)"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,14 +31,32 @@ on:
   # lane (ci-select.yml maps the label to `--full`, which forces the perf gate to run).
   # The default types (opened/synchronize/reopened) are listed explicitly so adding the
   # label events does NOT drop `synchronize` (the push-to-PR trigger).
+  #
+  # [FABLE-5] (sq-6vshe.6 heavy-lane placement, MAINTAINER-DIRECTED) On a PR the `bench`
+  # job runs the FAST DETERMINISTIC form only — `ci-bench.sh --deterministic-only` — which
+  # hard-gates the byte-count / memory-layout ratchet (store/dict/wasm bytes; a pure
+  # function of the code, immune to shared-runner noise) but SKIPS every wall-clock timing
+  # loop + well-known / crate-example latency suite. Those NOISY, FLAKY timing benchmarks
+  # were dragging the merge queue and flapping the gate; they are RELOCATED to the nightly
+  # EC2 lane (bench-ec2.yml `nightly-full-bench`, cron), which publishes the full at-scale
+  # series to the benchmark-data branch the Pages dashboard reads. See the "Run benchmarks"
+  # step guard below and bench-ec2.yml.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-  # [OPUS-4.8] Merge queue: the perf gate must run on the queue's merge_group ref so
-  # the required ci-summary aggregates the benchmark check. The auto-push / baseline-
-  # commit / benchmark-data steps are all gated on push-to-main (see the step guards)
-  # — on merge_group github.ref is refs/heads/gh-readonly-queue/main/…, so (exactly as
-  # on a PR) they SKIP and only the perf gate computes + enforces the floor.
-  merge_group:
+  # [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) merge_group REMOVED. The deterministic
+  # byte-count ratchet is a pure function of the code: it already ran + hard-gated on the
+  # PR head (--deterministic-only above), it re-runs on push-to-main below, and the
+  # merged-tree wasm-feature-OFF invariant is INDEPENDENTLY guarded on merge_group by
+  # vectorized-feature-off.yml's `artifact-exact-equality` leg (a dynamic same-run
+  # byte-identity build of the merged tree). So re-running this job on the ephemeral
+  # merge_group ref added NO protection while occupying a runner slot + adding the full
+  # timing suite's wall-clock to EVERY merge — the queue-drag this change removes. With
+  # the merge_group trigger gone, this job simply does not appear as a check-run on the
+  # merge_group ref, and `ci-summary / gate` (the single required check) aggregates only
+  # the siblings that DO run there — it never waits on a check that was never scheduled
+  # (the branch-protection required set is the single `gate` context, NOT this job by name;
+  # see docs/branch-protection.md). Correctness checks (build/test/clippy/conformance/
+  # coverage/CodeQL/supply-chain) all still run on merge_group and still gate.
   workflow_dispatch:
   # [SONNET-4.6] sq-mel85 (design §6.1): the nightly FULL-RUN BACKSTOP for change-based
   # selection. bench.yml previously had NO schedule trigger, so a PR that selection-
@@ -212,7 +230,20 @@ jobs:
           key: bench-dbpsb-${{ runner.os }}-${{ hashFiles('bench/dbpsb/fetch.sh') }}
       - name: Build release binaries
         run: cargo build --release -p sparq-cli -p sparq-bench
-      - name: Run benchmarks
+      # [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) On a PR run ONLY the DETERMINISTIC byte-count
+      # metrics (`--deterministic-only`): the hard-gated store/dict/wasm bytes ratchet — a pure
+      # function of the code, seconds not minutes, immune to shared-runner noise. The full noisy
+      # timing suite (query latencies + well-known / crate-example suites + the parse timing metric)
+      # is RELOCATED to the nightly EC2 lane (bench-ec2.yml) so it no longer drags the merge queue or
+      # flaps the gate. On push-to-main / schedule / workflow_dispatch (NOT a PR) the FULL suite runs,
+      # so the auto-ratchet floor + the benchmark-data history (main-only steps below) stay continuous
+      # exactly as before — the per-commit trend on the Pages dashboard is unaffected. The two-line
+      # split keeps the emitted JSON path identical (bench-results.json) for every downstream step.
+      - name: Run benchmarks (PR — deterministic byte-count ratchet only)
+        if: github.event_name == 'pull_request'
+        run: bash scripts/ci-bench.sh --deterministic-only 200000 bench-results.json
+      - name: Run benchmarks (full suite — main / schedule / dispatch)
+        if: github.event_name != 'pull_request'
         run: bash scripts/ci-bench.sh 200000 bench-results.json
       # [OPUS-4.8] HARD regression RATCHET on the gated metrics (store/dict bytes-per-{triple,term},
       # store_bytes_per_triple_small, wasm_bundle_bytes = DETERMINISTIC byte counts; parse_ns_per_byte =

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -78,12 +78,32 @@ From the binding/packaging workflows (when those surfaces are exercised):
 | `maturin build + pytest` | `.github/workflows/python.yml` | The `sparq-rdf` PyPI binding (`import sparq`) build + pytest parity suite. |
 | (js binding job) | `.github/workflows/js.yml` | The `@jeswr/sparq` npm build/tests. |
 
-> Heavy benchmarks (`bench.yml`, `bench-ec2.yml`) and release/dist workflows are **not**
-> aggregated as per-PR gates (bench runs on PRs for feedback but its own hard gate
-> self-fails; release/dist fire only on tags). The **Scorecard** workflow
+> **Benchmarks — the DETERMINISTIC ratchet gates on PRs; the NOISY timing is nightly (sq-6vshe.6,
+> maintainer-directed).** On a `pull_request` the `bench.yml` `run + track benchmarks` job runs the
+> FAST DETERMINISTIC form only (`ci-bench.sh --deterministic-only`): the byte-count / memory-layout
+> ratchet (store/dict/wasm bytes — a pure function of the code, immune to shared-runner noise) IS
+> aggregated by the gate (its name has no advisory token) and hard-fails the gate on a real
+> regression. `bench.yml` no longer triggers on `merge_group` at all — the deterministic ratchet
+> already ran on the PR head, re-runs on push-to-main, and the merged-tree wasm-feature-OFF invariant
+> is independently guarded on `merge_group` by `vectorized-feature-off.yml`'s `artifact-exact-equality`
+> leg — so the bench check simply does not appear on the merge_group ref and the gate never waits on
+> it (the required set is the single `gate` context, not this job by name). The NOISY wall-clock timing
+> suites (query latencies + the well-known sp2b/dbpsb/watdiv/bsbm/lubm + cargo-only latency suites)
+> were dragging the merge queue and flapping the gate on shared runners, so they are RELOCATED to the
+> nightly EC2 lane (`bench-ec2.yml` `nightly-full-bench`, cron, quiet dedicated spot instance) which
+> publishes the full at-scale series to the `benchmark-data` branch the Pages dashboard reads — the
+> perf-tracking is moved, not lost. The weekly heavy EC2 campaign (`bench-ec2.yml` `ec2-bench`) and
+> release/dist workflows remain non-gating (release/dist fire only on tags). The **Scorecard** workflow
 > (`scorecard.yml`) re-scores posture on push to `main` and feeds the code-scanning
 > dashboard; **CodeQL** + **Scorecard** therefore both feed the gate/dashboard even
 > though only the per-commit `CodeQL analysis (rust)` check is a per-PR check-run.
+>
+> **No branch-protection ruleset change is required for this benchmark relocation.** The live ruleset
+> requires exactly one context (`gate`), never the `bench` job by name, and the aggregator discovers the
+> live check set at run time — so removing bench from `merge_group` and narrowing its PR run to the
+> deterministic ratchet needs no ruleset edit. (If the maintainer had ever added the bench job by name
+> to the required-checks list, THAT name would now need removing — but per the "select only
+> `ci-summary / gate`" rule above, it was never added.)
 
 ## Required reviews
 

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -28,12 +28,32 @@ cd "$(dirname "$0")/.."
 # [OPUS-4.8] (sq-dzfu) --parse-only: cheap TIMING re-measure for the perf-gate best-of-N flake fix.
 # When present as the first arg, ONLY the parse_ns_per_byte metric is (re-)measured (see measure_parse
 # below) and written out — no big corpus, no wasm build, no well-known suites.
+#
+# [FABLE-5] (sq-6vshe.6 heavy-lane placement, MAINTAINER-DIRECTED extension) --deterministic-only:
+#   scripts/ci-bench.sh --deterministic-only [scale=200000] [out.json=bench-results.json]
+# emits ONLY the DETERMINISTIC (runner-noise-immune) hard-gated byte-count / memory-layout metrics —
+# store_bytes_per_triple, comp_store_bytes_per_triple, store_bytes_per_triple_small, dict_bytes_per_term,
+# wasm_bundle_bytes — and NOTHING else. It deliberately SKIPS every wall-clock timing measurement (the
+# min-of-3 load loop, the min-of-5 parse loop, the query-latency loops, RDFS-inference timing, wasm-opt
+# trend) AND every well-known / crate-example suite (sp2b/dbpsb/watdiv/bsbm/lubm/deeptax/sameas/shacl/
+# geo/fts/vector/rsp/hdt/solid/nlq/zk). This is the FAST, DETERMINISTIC form of the per-PR / merge_group
+# bench gate (bench.yml): the deterministic byte-count RATCHET (scripts/perf-gate.py) still hard-gates
+# every PR against bench/perf-baseline.json — a pure function of the code, seconds not minutes, immune to
+# shared-runner noise — while the noisy latency suites are RELOCATED to the nightly EC2 lane (bench-ec2.yml)
+# so they no longer drag the merge queue or flap the gate. The stanzas below are the EXACT same load/wasm
+# commands the full run uses (single source of truth), just without the timing/suite blocks.
 PARSE_ONLY=0
+DET_ONLY=0
 if [ "${1:-}" = "--parse-only" ]; then
   PARSE_ONLY=1
   shift
   OUT="${1:-bench-results.json}"
   SCALE=0
+elif [ "${1:-}" = "--deterministic-only" ]; then
+  DET_ONLY=1
+  shift
+  SCALE="${1:-200000}"
+  OUT="${2:-bench-results.json}"
 else
   SCALE="${1:-200000}"
   OUT="${2:-bench-results.json}"
@@ -230,6 +250,43 @@ if [ "$PARSE_ONLY" = "1" ]; then
   measure_parse
   emit_json > "$OUT"
   echo "wrote $OUT (--parse-only):"; cat "$OUT"
+  exit 0
+fi
+
+# [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) --deterministic-only: emit ONLY the DETERMINISTIC
+# byte-count / memory-layout metrics the perf-gate HARD-gates, then exit. This is the FAST per-PR /
+# merge_group form (bench.yml): NO timing loops, NO well-known / crate-example suites. Every command
+# here is byte-for-byte the same one the full run below uses (one load summary for store/dict bytes,
+# one compressed-profile load, one fixed-scale small load, one wasm build) — so the ratchet compares
+# the identical values, just measured without the noisy latency work. `add` is idempotent-per-name;
+# the full run measures these too when it runs on the nightly EC2 lane.
+if [ "$DET_ONLY" = "1" ]; then
+  "$GEN" dump "$SCALE" "$TMP/data.nt" >/dev/null 2>&1
+  # store/dict bytes-per-{triple,term} — DETERMINISTIC memory-layout from the load summary line.
+  "$CLI" bench "$TMP/data.nt" ntriples "$Q" 1 count >/dev/null 2>"$TMP/e" || true
+  dbtriple=$(grep -oE '\([0-9]+ B/triple\)' "$TMP/e" | head -1 | grep -oE '[0-9]+' | head -1)
+  [ -n "${dbtriple:-}" ] && add store_bytes_per_triple bytes "$dbtriple"
+  dbterm=$(grep -oE '[0-9]+ B/term' "$TMP/e" | head -1 | grep -oE '[0-9]+' | head -1)
+  [ -n "${dbterm:-}" ] && add dict_bytes_per_term bytes "$dbterm"
+  # compressed-profile B/triple (SPARQ_STORE_PROFILE=compressed => into_compressed()) — DETERMINISTIC.
+  SPARQ_STORE_PROFILE=compressed "$CLI" bench "$TMP/data.nt" ntriples "$Q" 1 count >/dev/null 2>"$TMP/e_comp" || true
+  dcbtriple=$(grep -oE '\([0-9]+ B/triple\)' "$TMP/e_comp" | head -1 | grep -oE '[0-9]+' | head -1)
+  [ -n "${dcbtriple:-}" ] && add comp_store_bytes_per_triple bytes "$dcbtriple"
+  # store bytes-per-triple at the SECOND (fixed 50k) scale — catches per-triple-overhead regressions.
+  DET_FIX="${PARSE_FIX:-50000}"
+  "$GEN" dump "$DET_FIX" "$TMP/fix.nt" >/dev/null 2>&1
+  "$CLI" bench "$TMP/fix.nt" ntriples "$Q" 1 count >/dev/null 2>"$TMP/fe" || true
+  dbtriple2=$(grep -oE '\([0-9]+ B/triple\)' "$TMP/fe" | head -1 | grep -oE '[0-9]+' | head -1)
+  [ -n "${dbtriple2:-}" ] && add store_bytes_per_triple_small bytes "$dbtriple2"
+  # wasm bundle size (bytes, DETERMINISTIC) — same release-wasm profile the shipped bundle uses.
+  if rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown; then
+    if cargo build --profile release-wasm -q -p sparq-wasm --target wasm32-unknown-unknown 2>/dev/null; then
+      DET_WASM=$(ls target/wasm32-unknown-unknown/release-wasm/*.wasm 2>/dev/null | head -1)
+      [ -n "${DET_WASM:-}" ] && add wasm_bundle_bytes bytes "$(wc -c < "$DET_WASM" | tr -d ' ')"
+    fi
+  fi
+  emit_json > "$OUT"
+  echo "wrote $OUT (--deterministic-only):"; cat "$OUT"
   exit 0
 fi
 

--- a/scripts/ec2-bench.sh
+++ b/scripts/ec2-bench.sh
@@ -16,6 +16,17 @@ SCALE="${BENCH_SCALE:-2000000}"                 # ~10x the in-CI scale
 SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
 REPO="https://github.com/jeswr/sparq.git"
 TAGSPEC='ResourceType=instance,Tags=[{Key=purpose,Value=sparq-ci-bench}]'
+# [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) OUTPUT + FULL-SUITE knobs so the nightly lane can reuse
+# this SAME script (single source of truth) instead of a forked copy:
+#   BENCH_OUT         — results filename written to the CWD (default ec2-bench-results.json, weekly heavy).
+#   BENCH_FULL_SUITE  — when set (=1), the instance installs the well-known-suite toolchains
+#                       (g++/Boost/JRE/JDK/rapper/unzip/binaryen) AND runs ci-bench.sh with
+#                       GITHUB_REF=refs/heads/main, so EVERY latency suite (sp2b/dbpsb/watdiv/bsbm/lubm
+#                       + the cargo-only fts/geo/vector/rsp/hdt/solid/nlq/zk main-tier hooks) runs — the
+#                       full NOISY timing series that was RELOCATED off the per-PR / merge_group bench
+#                       lane. Empty (weekly heavy default) = today's toolchain-light run, unchanged.
+BENCH_OUT="${BENCH_OUT:-ec2-bench-results.json}"
+BENCH_FULL_SUITE="${BENCH_FULL_SUITE:-}"
 
 WORK="$(mktemp -d)"
 KEYFILE="$WORK/key"
@@ -64,17 +75,36 @@ for i in $(seq 1 30); do ssh $SSHO "ubuntu@$IP" true 2>/dev/null && break; sleep
 echo "== build + bench on the instance (public repo: clone with no creds) =="
 # The instance clones the public repo at this SHA, installs Rust, builds, runs the same emitter at
 # a larger scale, and prints ONLY the results JSON on stdout (captured below).
+#
+# [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) FULL-SUITE mode: when BENCH_FULL_SUITE is set, ALSO
+# install the well-known-suite toolchains + the wasm target and run ci-bench.sh with
+# GITHUB_REF=refs/heads/main so the instance runs EVERY latency suite (the noisy timing series moved
+# off the per-PR / merge_group bench lane). These commands mirror bench.yml's "Install well-known-suite
+# toolchains" + the wasm target the per-commit lane sets. In the default (weekly heavy) mode the block
+# is a no-op — today's toolchain-light run is unchanged.
+if [ -n "$BENCH_FULL_SUITE" ]; then
+  SUITE_APT='sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libboost-all-dev default-jdk raptor2-utils unzip binaryen >/dev/null 2>&1'
+  SUITE_WASM='rustup target add wasm32-unknown-unknown >/dev/null 2>&1 || true'
+  SUITE_REF='export GITHUB_REF=refs/heads/main'
+else
+  SUITE_APT='true'
+  SUITE_WASM='true'
+  SUITE_REF='true'
+fi
 REMOTE=$(cat <<REMOTE_EOF
 set -e
 sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential pkg-config git >/dev/null 2>&1
+$SUITE_APT
 command -v cargo >/dev/null || { curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal >/dev/null 2>&1; }
 . "\$HOME/.cargo/env"
+$SUITE_WASM
 git clone -q "$REPO" sparq && cd sparq && git checkout -q "$SHA"
 cargo build --release -q -p sparq-cli -p sparq-bench
+$SUITE_REF
 bash scripts/ci-bench.sh "$SCALE" /tmp/out.json >/dev/null 2>&1
 cat /tmp/out.json
 REMOTE_EOF
 )
-ssh $SSHO "ubuntu@$IP" "$REMOTE" > ec2-bench-results.json
-echo "== results =="; cat ec2-bench-results.json
-python3 -c "import json,sys; json.load(open('ec2-bench-results.json')); print('valid results JSON')"
+ssh $SSHO "ubuntu@$IP" "$REMOTE" > "$BENCH_OUT"
+echo "== results ($BENCH_OUT) =="; cat "$BENCH_OUT"
+python3 -c "import json,sys; json.load(open('$BENCH_OUT')); print('valid results JSON')"

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -411,13 +411,25 @@ class TestPhase2LaneScoping(unittest.TestCase):
         self.assertNotIn("if", job, "select must be unconditional (gate needs it green)")
         self.assertNotIn("needs", job)
 
-    def test_bench_runs_on_schedule_backstop(self):
+    def test_bench_runs_on_pr_and_schedule_but_not_merge_group(self):
         # sq-mel85 added a nightly schedule to bench.yml as the full-run backstop: a
         # schedule event carries no PR diff => selector mode=full => the fail-closed
-        # disjunct RUNS the whole suite. merge_group is retained for the perf gate.
+        # disjunct RUNS the whole suite.
+        # [FABLE-5] sq-6vshe.6 (MAINTAINER-DIRECTED): merge_group is REMOVED. On a PR the
+        # bench job runs the FAST DETERMINISTIC byte-count ratchet only (--deterministic-only),
+        # which still gates; the merged-tree deterministic ratchet is a pure function of the code
+        # (already ran on the PR head + re-runs on push-to-main), and the merged-tree wasm-
+        # feature-OFF invariant is independently guarded on merge_group by vectorized-feature-off.yml,
+        # so re-running bench on the merge_group ref only dragged the queue. The full NOISY timing
+        # suite moved to the nightly EC2 lane (bench-ec2.yml nightly-full-bench).
         on = _on_block(self.bench)
         self.assertIn("schedule", on, "bench.yml must have the nightly schedule backstop")
-        self.assertIn("merge_group", on, "bench.yml must run on merge_group for the gate")
+        self.assertIn("pull_request", on,
+                      "bench.yml must run on pull_request (the deterministic byte-count ratchet still gates)")
+        self.assertNotIn("merge_group", on,
+                         "bench.yml must NOT run on merge_group (sq-6vshe.6: the deterministic ratchet "
+                         "already gated the PR head + re-runs on push-to-main; the noisy timing suite "
+                         "moved to the nightly EC2 lane — keeping it on merge_group only dragged the queue)")
 
     def test_bench_main_history_and_ratchet_exclude_schedule(self):
         # CRITICAL (design §6.1 continuity, criterion (d)): the auto-ratchet + history +


### PR DESCRIPTION
> 🤖 SPARQ agent [FABLE-5]

Benchmarking on shared GitHub runners is non-deterministic (wall-clock timing) and slow, and it was dragging the merge queue. This MOVES the flaky/slow benchmark timing **off the PR / merge-queue required CI** onto a **nightly EC2** lane, while **keeping the fast, deterministic byte-count ratchet gating on PRs**. Both a flakiness fix and a queue-speed win. Refs **sq-6vshe** (child **sq-6vshe.6**, the heavy-lane-placement child — which had stopped short on the bench arm).

## STEP 1 — Inventory (grounded)
Every benchmark job triggered on `pull_request` / `merge_group`:
- **`bench.yml`** (`Benchmarks`) — job **`run + track benchmarks`** ran on `pull_request` **and** `merge_group`. Its name has no `advisory`/`informational` token, so it **is** aggregated by `ci-summary / gate` and gates. Its true hard gate is the `scripts/perf-gate.py` **deterministic byte-count ratchet** (store/dict/wasm bytes); the well-known suites were already main-only, but the **noisy wall-clock timing loops + wasm build ran on every PR and every merge_group entry** — the queue-drag.
- **`bench-ec2.yml`** (`Benchmarks (EC2)`) — already **weekly/manual only**, never on PR/merge_group. Not on the critical path.
- No other workflow runs `cargo bench`/`ci-bench.sh` on PR/merge_group. **No static required-check list references benchmarks** — the gate polls live siblings; branch protection requires exactly one context (`gate`).

## STEP 2 — What moved
- **PR bench run → `ci-bench.sh --deterministic-only`** (new flag): emits ONLY the hard-gated byte metrics (`store_bytes_per_triple`, `comp_store_bytes_per_triple`, `store_bytes_per_triple_small`, `dict_bytes_per_term`, `wasm_bundle_bytes`). No timing loops, no latency suites. Seconds, not minutes; immune to runner noise.
- **`bench.yml` `merge_group` trigger REMOVED** — the queue-drag. The deterministic ratchet already ran on the PR head + re-runs on push-to-main, and the merged-tree wasm-feature-OFF invariant is **independently** guarded on `merge_group` by `vectorized-feature-off.yml`'s `artifact-exact-equality` leg.
- **Full noisy timing suite → `bench-ec2.yml` `nightly-full-bench`** (cron `41 6 * * *`, quiet dedicated spot instance, 200k CI scale), publishing to **`dev/bench-nightly`** on the `benchmark-data` branch the Pages dashboard reads. **Perf-tracking is moved, not lost.** Reuses the existing cost-capped EC2 rails (spot + `purpose=sparq-ci-bench` tag + the always-run terminate/delete cleanup trap in `scripts/ec2-bench.sh`); **never touches prod `i-090531b4ede8f2d3f` / dev `i-00f76802f345b6b77`**. Demotion auto-bead protocol wired on nightly failure (`scripts/ci-file-demoted-lane-failure.py`, mirroring `fuzz.yml`).

**Why keep the deterministic ratchet on PR (not move ALL of bench):** the byte-count ratchet is a *fast deterministic smoke* — a pure function of the code, not flaky timing. Per the maintainer's Step 3 ("keep a FAST DETERMINISTIC smoke assertion on PR CI, move only the noisy timing"), it stays and gates; only the noisy timing moved.

## STEP 3 — Gate soundness (critical safety)
- **No branch-protection ruleset change required.** The live ruleset requires exactly one context (`gate`), never the bench job by name; the aggregator discovers the live check set at run time. If the bench job had ever been added by name it would need removing — but per the "select only `ci-summary / gate`" rule it never was. Documented in `docs/branch-protection.md`.
- **The gate does NOT pass vacuously.** `ci-summary` has no hard-coded expected-check list — it polls whatever siblings exist and passes iff none of the non-advisory ones failed. With bench off `merge_group`, the bench check simply doesn't appear there; the gate aggregates the remaining siblings (build/test/clippy/conformance/coverage/CodeQL/supply-chain/vectorized-feature-off/…, all still on `merge_group`) and **still fails if any of them fails**. The gate never waits on a check that never runs.
- **Non-vacuous verified both ways:** injected a +7% `wasm_bundle_bytes` regression into the deterministic-only JSON → `perf-gate.py` exit **2** (HARD FAIL); clean run → exit **0** (PASS).

## Cost basis
Nightly full suite at 200k on `c7g.4xlarge` spot (~$0.30–0.40/hr): build + full suite ~10–20 min ≈ **~$0.07–0.14/run** × 30 nights ≈ **$2–4/month**. With the weekly heavy (~$0.80/month) the EC2 bench total stays **under the $5/month cap**. If a future scale-up exceeds budget, drop the nightly cron to weekly (design is cadence-independent).

## Verification
- YAML valid (`yaml.safe_load`) + **actionlint clean** on both workflows.
- `ci-bench.sh --deterministic-only` **reproduced locally**: emits the 5 byte metrics; `perf-gate.py` **PASS** at scale 200k against the real `bench/perf-baseline.json`; **FAILS** on an injected regression.
- `perf-gate.py --self-test`, `ci_summary_gate` (33 tests), `ci_select_wiring` (33 tests), demoted-lane self-test — **all green**.
- `test_ci_select_wiring.py` updated to encode the **new** invariant (bench runs on `pull_request` + `schedule`, **NOT** `merge_group`) — the old test asserted the removed `merge_group` trigger; it was updated (not weakened) to the correct new contract.

## Compliance gap closed (honest level)
Removes the flaky-timing / slow-bench pole from per-PR + merge-queue CI **without weakening any deterministic guarantee**: the byte-count ratchet still hard-gates every PR, correctness checks are untouched, and the full perf series is preserved on the nightly EC2 dashboard lane. This is a **CI throughput + flakiness** fix, not a correctness-gate change.

**Files:** `.github/workflows/bench.yml`, `.github/workflows/bench-ec2.yml`, `scripts/ci-bench.sh`, `scripts/ec2-bench.sh`, `scripts/tests/test_ci_select_wiring.py`, `docs/branch-protection.md`.

Not arming — the verify pipeline arms; I will not disarm a pipeline arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)