### PR TITLE
bench(wasm-compare): cross-engine BROWSER wasm harness — per-phase timings on the shipped bundle, Chromium/Firefox/WebKit + Node baseline (sq-3ul2n.1) [FABLE-5]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -246,6 +246,17 @@ Notes on a few that need care:
   opt-in via `SAMEAS_TIERS` for EC2/nightly. CI emits
   `sameas_size<N>_{closure_s,query_us,closure_triples}` (trend-only). The dashboard features it as
   a scaling suite (size axis).
+- **`wasm-compare` has a BROWSER half (implemented) and a competitor half (stub).**
+  [`bench/wasm-compare/browser/`](./wasm-compare/browser/README.md) (sq-3ul2n.1, the Tier-0
+  measurement gate of the browser-WASM program `research/browser-wasm-perf-assessment-2026-07.md`)
+  drives the SHIPPED `@jeswr/sparq` bundle through headless Chromium/Firefox/WebKit (Playwright,
+  self-contained npm dir — not a root workspace member) + a plain-Node baseline, attributing
+  wall time PER PHASE (fetch/compile/instantiate + `instantiateStreaming`, N-Triples+Turtle
+  load at 25k/100k/300k triples, five query shapes cold-vs-warm, CONSTRUCT serialization out,
+  and the ask→count→string→parse→chunks→wrapper boundary-marshalling ladder). Advisory
+  envelopes only (`results/`, git-ignored; the cross-engine row-count oracle is the sole hard
+  check; browsers that cannot launch skip-with-notice); deliberately NO CI lane. The
+  oxigraph-npm/n3js comparison half (sq-hmd7l.17) CONSUMES this harness.
 - **`wikidata-8b` is external-cost and gated.** It builds the full Wikidata
   truthy dump (~8-9.4B triples) on a 16 GB EC2 box (~$5-17). It is **blocked
   until dict-spill merges to public main** — see

--- a/bench/wasm-compare/browser/.gitignore
+++ b/bench/wasm-compare/browser/.gitignore
@@ -1,0 +1,4 @@
+# [FABLE-5] sq-3ul2n.1 — measurement outputs are scratch (advisory, regenerable),
+# never committed; Playwright + its browsers stay scoped to this dir.
+node_modules/
+results/

--- a/bench/wasm-compare/browser/README.md
+++ b/bench/wasm-compare/browser/README.md
@@ -1,0 +1,93 @@
+# wasm-compare/browser — cross-engine browser measurement harness
+
+<!-- [FABLE-5] sq-3ul2n.1 — the Tier-0 measurement gate of the browser-WASM
+     performance program (research/browser-wasm-perf-assessment-2026-07.md,
+     epic sq-3ul2n). Consumed by sq-hmd7l.17 (oxigraph-npm comparison). -->
+
+Per-phase wall-time attribution for the **shipped `@jeswr/sparq` web bundle**
+(the `js/` `build:wasm` output) across **headless Chromium, Firefox and WebKit**
+(Playwright) plus a **plain-Node baseline** — so a browser-side regression can
+be attributed to a LAYER (download vs compile vs instantiate vs parse vs query
+vs boundary marshalling) and to an ENGINE, not just observed as a slower total.
+
+**Every number this harness emits is ADVISORY / NON-CANONICAL.** It measures
+whatever host runs it (typically a shared, noisy work box). The deliverable is
+the repeatable per-phase attribution and the *cross-engine ratio structure*;
+absolute values must never be committed, baked into docs/tests, or gated on
+(repo rule: no hard-coded performance numbers in markdown). The only
+deterministic gate is the row/triple-count oracle: identical workload ⇒
+identical counts on every engine, and the run FAILS on divergence.
+
+## Run matrix
+
+| target | what runs | how |
+|---|---|---|
+| `node` | same wasm artifact + workload, no browser | child `node-baseline.mjs`; init decomposed as disk-read/compile/instantiate (`fetch_wasm` is a disk read — a floor, noted in-row); `init_streaming_total` skip-with-notice (no `file:` fetch in Node) |
+| `chromium` / `firefox` / `webkit` | two pages per engine, each in a **fresh browser process** (wasm compile caches are per-process — sharing one process would let the second page's compile hit a warm cache and mis-attribute) | Playwright headless; page A `?mode=streaming` times the shipped `initWasm()` path (fetch + `instantiateStreaming`, compile overlapped with download); page B `?mode=main` times the DECOMPOSED init then the full workload |
+
+A browser that cannot launch on the host **skips with an explicit notice**
+(an envelope with `skipped: true` + the install command) — never fabricated
+numbers, and never a hard failure (exit stays 0 for skips).
+
+## Phases emitted (per engine)
+
+- `init_streaming_total` — the real user path: bare `initWasm()` ⇒ `fetch` +
+  `WebAssembly.instantiateStreaming` (browser pages only).
+- `fetch_wasm` / `compile_wasm` / `instantiate_wasm` — the same path
+  decomposed (fresh process, cold compile).
+- `store_load` × {`ntriples`, `turtle`} × {25k, 100k, 300k triples},
+  `kind: first|warm` — parse + dictionary/index build. `first` includes
+  parser JIT tier-up (fixed phase order, documented below); `heap_bytes` and
+  `source_bytes` recorded per row.
+- `query` × {`scan-type`, `star-3`, `chain-2`, `triangle-wcoj`, `filter-age`}
+  (the five shapes from `crates/sparq-wasm/test/bench.cjs`), `kind: first`
+  (tier-up-inclusive cold) vs `warm` (best-of-K, batched for coarse timers).
+- `serialize_construct` — CONSTRUCT → N-Triples string out of wasm.
+- `marshal_*` — the boundary-marshalling probe set on the same pattern:
+  `ask` (floor; short-circuits) → `count` (lazy-count floor) →
+  `query_string` (wasm eval + JSON serialise + ONE string copy out) →
+  `query_json_parse` (+ JS `JSON.parse`) → `query_chunks` (chunked drain) →
+  `wrapper_bindings` (JS-wrapper `queryBindings`: + one `Bindings` Map/row,
+  one Term/cell). Adjacent deltas attribute copy vs parse vs materialisation;
+  `ask`/`count` are floors, **not** same-eval controls (they under-run eval).
+
+Workload determinism: generators are read-only ports of
+`crates/sparq-wasm/test/{bench,mem}.cjs` (source cited in `workload.mjs`),
+sized by exact TRIPLE count; expected row counts are computed per shape and
+asserted on every engine. Query phases run on the 100k-triple Turtle store
+(25k in `--quick`). Fixed phase order (N-Triples loads ascending, then
+Turtle, then queries) keeps `first` rows comparable across engines.
+
+## Running it
+
+```sh
+# once: deps + browsers (scoped to THIS dir — not a repo-root workspace member)
+cd bench/wasm-compare/browser
+npm ci
+npx playwright install chromium firefox webkit   # + `sudo npx playwright install-deps <engine>` for OS libs
+
+# the shipped bundle + wrapper must exist (or pass --build):
+#   repo root: npm ci --ignore-scripts;  js/: npm run build:wasm && npx tsc
+
+node run.mjs --engine chromium          # one engine
+node run.mjs                            # all: node + chromium + firefox + webkit
+node run.mjs --engine webkit --quick    # smoke tier (25k triples, few iters)
+```
+
+Envelopes land in `results/<engine>-<UTC>.json` (git-ignored; measurement
+output is scratch): `{suite, bead, advisory, note, engine, engine_version,
+git_commit, host, bundle:{bytes,sha256}, rows:[{phase, format?, triples?,
+query?, rows?, kind, ms, …}], skipped_phases}` — one envelope per engine, all
+sharing the same bundle sha so runs are provably apples-to-apples. A summary
+table + per-phase ratios vs the Node baseline print at the end. Exit codes:
+`0` ran/skipped-with-notice, `1` run error or cross-engine row-count
+divergence, `2` usage/missing artifacts.
+
+Interpretation notes: browser `fetch_wasm` is a loopback-HTTP number (server
+prewarmed, explicit `Content-Length`, `cache-control: no-store`) — it
+reflects engine network-stack + streaming behaviour, not real-world CDN
+latency. Timings on 1ms-clamped engines are recovered by batching
+(`measure()` in `workload.mjs`); `first` rows are single observations by
+nature. There is deliberately **no CI lane**: this is a measurement harness,
+run on demand (the timing benches were moved off the PR path in #1895 for the
+same reason).

--- a/bench/wasm-compare/browser/node-baseline.mjs
+++ b/bench/wasm-compare/browser/node-baseline.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// [FABLE-5] sq-3ul2n.1 — Node baseline for the cross-engine wasm harness.
+//
+// Runs the SAME shipped web-target artifact + the SAME shared workload as the
+// browser pages, directly under Node — the non-browser reference point that
+// separates "browsers are slow at X" from "the wasm is slow at X".
+//
+// Init decomposition mirrors the browser `mode=main` page: read bytes
+// (Node's analogue of fetch — no HTTP so the number is a floor, recorded as
+// such) / WebAssembly.compile / instantiate. `init_streaming_total` cannot be
+// measured here (Node fetch will not stream file: URLs → no
+// instantiateStreaming path) and is skipped WITH NOTICE, never estimated.
+//
+// Usage: node node-baseline.mjs --out <file.json> [--quick]
+// All timings ADVISORY / NON-CANONICAL.
+
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { runWorkload } from "./workload.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, "..", "..", "..");
+const WASM_PATH = path.join(REPO, "js", "wasm", "sparq_wasm_bg.wasm");
+
+function arg(name) {
+  const i = process.argv.indexOf(name);
+  return i === -1 ? undefined : process.argv[i + 1];
+}
+const OUT = arg("--out");
+const QUICK = process.argv.includes("--quick");
+if (!OUT) {
+  console.error("usage: node node-baseline.mjs --out <file.json> [--quick]");
+  process.exit(2);
+}
+
+const now = () => performance.now();
+const rows = [];
+const skipped = [
+  {
+    phase: "init_streaming_total",
+    reason: "Node cannot fetch file: URLs, so the instantiateStreaming shipped path is browser-only; not estimated",
+  },
+];
+
+let t = now();
+const bytes = await readFile(WASM_PATH);
+rows.push({ phase: "fetch_wasm", kind: "total", ms: now() - t, bytes: bytes.byteLength, iters: 1, note: "disk read, not HTTP — a floor for the browsers' fetch phase" });
+
+t = now();
+const module = await WebAssembly.compile(bytes);
+rows.push({ phase: "compile_wasm", kind: "total", ms: now() - t, iters: 1 });
+
+// Both imports resolve to the same glue module file → one shared instance,
+// exactly as in the browser page.
+const glue = await import(path.join(REPO, "js", "wasm", "sparq_wasm.js"));
+const { SparqStore } = await import(path.join(REPO, "js", "dist", "index.js"));
+t = now();
+await glue.default({ module_or_path: module });
+rows.push({ phase: "instantiate_wasm", kind: "total", ms: now() - t, iters: 1 });
+
+const wl = runWorkload({
+  Store: glue.Store,
+  SparqStore,
+  quick: QUICK,
+  log: (m) => console.error(`[node-baseline] ${m}`),
+});
+rows.push(...wl.rows);
+skipped.push(...wl.skipped);
+
+await writeFile(OUT, JSON.stringify({ ok: true, rows, skipped, mode: "node" }, null, 2));
+console.error(`[node-baseline] wrote ${rows.length} rows to ${OUT}`);

--- a/bench/wasm-compare/browser/package-lock.json
+++ b/bench/wasm-compare/browser/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "sparq-wasm-compare-browser",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sparq-wasm-compare-browser",
+      "version": "0.0.0",
+      "devDependencies": {
+        "playwright": "^1.61.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/bench/wasm-compare/browser/package.json
+++ b/bench/wasm-compare/browser/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sparq-wasm-compare-browser",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Cross-engine BROWSER wasm measurement harness for the shipped @jeswr/sparq bundle (sq-3ul2n.1): per-phase timings on Chromium/Firefox/WebKit via Playwright + a plain-Node baseline. Self-contained — not a repo-root npm workspace member, so its Playwright dependency never perturbs the site/js builds.",
+  "type": "module",
+  "scripts": {
+    "run": "node run.mjs",
+    "run:quick": "node run.mjs --quick",
+    "browsers": "playwright install chromium firefox webkit",
+    "lint": "node --check run.mjs && node --check node-baseline.mjs && node --check workload.mjs && node --check page/page.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.61.0"
+  }
+}

--- a/bench/wasm-compare/browser/page/index.html
+++ b/bench/wasm-compare/browser/page/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<!-- [FABLE-5] sq-3ul2n.1 — cross-engine wasm measurement page (driven by ../run.mjs via Playwright). -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>sparq wasm-compare browser harness</title>
+  </head>
+  <body>
+    <pre id="log">booting…</pre>
+    <script type="module" src="./page.mjs"></script>
+  </body>
+</html>

--- a/bench/wasm-compare/browser/page/page.mjs
+++ b/bench/wasm-compare/browser/page/page.mjs
@@ -1,0 +1,84 @@
+// [FABLE-5] sq-3ul2n.1 — browser side of the cross-engine wasm harness.
+//
+// Two modes, selected by `?mode=`:
+//   streaming — times the SHIPPED instantiation path exactly as
+//               js/packages/sparq-client does it: bare `initWasm()` →
+//               fetch + WebAssembly.instantiateStreaming with compile
+//               overlapped with download. One total number; nothing else runs
+//               (a wasm module instantiates once per page, so the decomposed
+//               phases need their own page load).
+//   main      — DECOMPOSED init (fetch+arrayBuffer / WebAssembly.compile /
+//               instantiate) so a regression attributes to download vs
+//               compile vs instantiation, then the full shared workload
+//               (store load/parse, query shapes cold+warm, serialization out,
+//               boundary-marshalling probes) from ../workload.mjs.
+//
+// Results land on `window.__WASM_COMPARE_RESULT__` (+ `__WASM_COMPARE_DONE__`)
+// for run.mjs to collect. All timings ADVISORY / NON-CANONICAL.
+
+import initWasm, { Store } from "/js/wasm/sparq_wasm.js";
+// The wrapper resolves its `../wasm/sparq_wasm.js` import to the SAME URL as
+// the raw import above → same module instance, so the decomposed init below
+// initialises both. Only sync wrapper entry points are used (fromStringSync /
+// queryBindings) — awaiting the wrapper's own init() would re-instantiate the
+// module and orphan every live Store.
+import { SparqStore } from "/js/dist/index.js";
+import { runWorkload } from "../workload.mjs";
+
+const WASM_URL = "/js/wasm/sparq_wasm_bg.wasm";
+const logEl = document.getElementById("log");
+const log = (msg) => {
+  logEl.textContent += `\n${msg}`;
+  console.log(`[harness] ${msg}`);
+};
+const now = () => performance.now();
+
+async function main() {
+  const params = new URLSearchParams(location.search);
+  const mode = params.get("mode") ?? "main";
+  const quick = params.get("quick") === "1";
+  const rows = [];
+  const skipped = [];
+
+  if (mode === "streaming") {
+    // Shipped path: bare init → fetch + instantiateStreaming (overlapped).
+    const t0 = now();
+    await initWasm();
+    rows.push({ phase: "init_streaming_total", kind: "total", ms: now() - t0, iters: 1 });
+    log(`init_streaming_total ${rows[0].ms.toFixed(1)}ms`);
+    return { rows, skipped, mode };
+  }
+
+  // Decomposed init: download / compile / instantiate, separately attributable.
+  let t = now();
+  const resp = await fetch(WASM_URL);
+  if (!resp.ok) throw new Error(`fetch ${WASM_URL}: ${resp.status}`);
+  const bytes = await resp.arrayBuffer();
+  rows.push({ phase: "fetch_wasm", kind: "total", ms: now() - t, bytes: bytes.byteLength, iters: 1 });
+
+  t = now();
+  const module = await WebAssembly.compile(bytes);
+  rows.push({ phase: "compile_wasm", kind: "total", ms: now() - t, iters: 1 });
+
+  t = now();
+  await initWasm({ module_or_path: module });
+  rows.push({ phase: "instantiate_wasm", kind: "total", ms: now() - t, iters: 1 });
+  log(rows.map((r) => `${r.phase} ${r.ms.toFixed(1)}ms`).join(", "));
+
+  const wl = runWorkload({ Store, SparqStore, quick, log });
+  rows.push(...wl.rows);
+  skipped.push(...wl.skipped);
+  return { rows, skipped, mode };
+}
+
+main()
+  .then((result) => {
+    window.__WASM_COMPARE_RESULT__ = { ok: true, ...result };
+    window.__WASM_COMPARE_DONE__ = true;
+    log("done ✓");
+  })
+  .catch((err) => {
+    window.__WASM_COMPARE_RESULT__ = { ok: false, error: String(err?.stack ?? err) };
+    window.__WASM_COMPARE_DONE__ = true;
+    log(`FAILED: ${err}`);
+  });

--- a/bench/wasm-compare/browser/run.mjs
+++ b/bench/wasm-compare/browser/run.mjs
@@ -143,6 +143,7 @@ function startServer() {
       const body = await readFile(file);
       res.writeHead(200, {
         "content-type": MIME[path.extname(file)] ?? "application/octet-stream",
+        "content-length": body.length, // explicit: chunked transfer would tax the fetch phase unevenly per engine
         "cache-control": "no-store", // fetch timings must hit the server, not a disk cache
       });
       res.end(body);
@@ -169,25 +170,35 @@ async function runNode(opts) {
 
 async function runBrowser(engine, opts, port, playwright) {
   const type = playwright[engine];
-  let browser;
-  try {
-    browser = await type.launch(
-      engine === "firefox"
-        ? { firefoxUserPrefs: { "privacy.reduceTimerPrecision": false } } // finer perf.now(); measure() batching covers engines that stay coarse
-        : {},
-    );
-  } catch (err) {
-    const reason =
-      `${engine} could not launch on this host: ${String(err?.message ?? err).split("\n")[0]} — ` +
-      `install it with \`npx playwright install ${engine}\` (+ \`sudo npx playwright install-deps ${engine}\` for OS libraries)`;
-    console.error(`[run] SKIP-WITH-NOTICE: ${reason}`);
-    return { skipped: true, reason };
-  }
-  try {
-    const version = `${engine} ${browser.version()} (playwright)`;
-    const rows = [];
-    const skipped = [];
-    for (const mode of ["streaming", "main"]) {
+  const rows = [];
+  const skipped = [];
+  let version;
+  // One FRESH browser process per mode: wasm compilation caches are
+  // per-process, so running `main` (decomposed WebAssembly.compile) in the
+  // same process as `streaming` would let whichever page runs second hit a
+  // warm compile cache and mis-attribute the compile phase.
+  for (const mode of ["streaming", "main"]) {
+    let browser;
+    try {
+      browser = await type.launch(
+        engine === "firefox"
+          ? { firefoxUserPrefs: { "privacy.reduceTimerPrecision": false } } // finer perf.now(); measure() batching covers engines that stay coarse
+          : {},
+      );
+    } catch (err) {
+      const firstLine =
+        String(err?.message ?? err)
+          .split("\n")
+          .map((l) => l.trim())
+          .filter((l) => l && !l.startsWith("browserType.launch"))[0] ?? String(err?.message ?? err).slice(0, 200);
+      const reason =
+        `${engine} could not launch on this host: ${firstLine} — ` +
+        `install it with \`npx playwright install ${engine}\` (+ \`sudo npx playwright install-deps ${engine}\` for OS libraries)`;
+      console.error(`[run] SKIP-WITH-NOTICE: ${reason}`);
+      return { skipped: true, reason };
+    }
+    try {
+      version = `${engine} ${browser.version()} (playwright)`;
       const page = await browser.newPage();
       page.on("console", (m) => {
         const text = m.text();
@@ -198,15 +209,14 @@ async function runBrowser(engine, opts, port, playwright) {
       await page.goto(`http://127.0.0.1:${port}/harness/page/index.html?mode=${mode}${q}`);
       await page.waitForFunction("window.__WASM_COMPARE_DONE__ === true", null, { timeout: opts.timeoutMs });
       const result = await page.evaluate("window.__WASM_COMPARE_RESULT__");
-      await page.close();
       if (!result.ok) return { ok: false, error: `${engine}/${mode}: ${result.error}`, version };
       rows.push(...result.rows);
       skipped.push(...(result.skipped ?? []));
+    } finally {
+      await browser.close();
     }
-    return { ok: true, rows, skipped, version };
-  } finally {
-    await browser.close();
   }
+  return { ok: true, rows, skipped, version };
 }
 
 // ---------- reporting ----------
@@ -303,6 +313,16 @@ const envelopes = [];
 let failed = false;
 
 const { server, port } = wantsBrowser ? await startServer() : { server: undefined, port: 0 };
+if (server) {
+  // Prewarm: one throwaway GET of the biggest asset so the FIRST engine's
+  // fetch phase does not also pay the server/OS cold file read.
+  await new Promise((resolve, reject) => {
+    http.get(`http://127.0.0.1:${port}/js/wasm/sparq_wasm_bg.wasm`, (res) => {
+      res.resume();
+      res.on("end", resolve);
+    }).on("error", reject);
+  });
+}
 try {
   for (const engine of opts.engines) {
     console.error(`\n[run] engine: ${engine}${opts.quick ? " (quick)" : ""}`);

--- a/bench/wasm-compare/browser/run.mjs
+++ b/bench/wasm-compare/browser/run.mjs
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+// [FABLE-5] sq-3ul2n.1 — cross-engine BROWSER wasm measurement harness (orchestrator).
+//
+// Drives the SAME shipped @jeswr/sparq web bundle (js `build:wasm` output) +
+// the SAME deterministic workload through headless Chromium, Firefox and
+// WebKit (via Playwright) plus a plain-Node baseline, timing each PHASE
+// separately — fetch / compile / instantiate (and the shipped overlapped
+// instantiateStreaming path), store load/parse per format+size, query shapes
+// cold (tier-up-inclusive) vs warm, serialization out, and the
+// boundary-marshalling probe set — so a regression attributes to a LAYER,
+// not just a total.
+//
+//   node run.mjs --engine chromium            # one engine
+//   node run.mjs --engine all                 # node + chromium + firefox + webkit
+//   node run.mjs --engine webkit --quick      # smoke tier (25k triples, few iters)
+//
+// Browsers that cannot launch on this host SKIP WITH AN EXPLICIT NOTICE
+// (an envelope with skipped:true) — never fabricated numbers. Exit codes:
+//   0 = every requested engine ran or skipped-with-notice
+//   1 = a run FAILED (page error / row-count oracle divergence across engines)
+//   2 = usage / missing build artifacts
+//
+// Every emitted number is ADVISORY / NON-CANONICAL: measured on whatever host
+// runs this (typically a shared EC2 work box). The deliverable is repeatable
+// per-phase ATTRIBUTION and the cross-engine ratio structure, not headline
+// numbers. Never bake emitted values into docs/tests/gates (repo rule).
+
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFile, writeFile, mkdir, stat } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, "..", "..", "..");
+const SUITE = "wasm-compare/browser";
+const BEAD = "sq-3ul2n.1";
+const ADVISORY_NOTE =
+  "ADVISORY / NON-CANONICAL — every `ms` is best-effort wall time measured on the running " +
+  "host (typically a non-canonical work box). The per-phase attribution and cross-engine " +
+  "ratios are the deliverable, not the absolute numbers; do not bake any value into " +
+  "committed docs, tests, or gates. Deterministic gate = the row/triple-count oracle.";
+
+const BROWSER_ENGINES = ["chromium", "firefox", "webkit"];
+const ALL_ENGINES = ["node", ...BROWSER_ENGINES];
+
+// ---------- CLI ----------
+function parseArgs(argv) {
+  const opts = { engines: [], quick: false, out: path.join(HERE, "results"), build: false, timeoutMs: 900_000 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--engine") {
+      const v = argv[++i];
+      if (!v) usage(`--engine requires a value`);
+      for (const e of v.split(",")) {
+        if (e === "all") opts.engines.push(...ALL_ENGINES);
+        else if (ALL_ENGINES.includes(e)) opts.engines.push(e);
+        else usage(`unknown engine '${e}' (expected ${ALL_ENGINES.join("/")}/all)`);
+      }
+    } else if (a === "--quick") opts.quick = true;
+    else if (a === "--build") opts.build = true;
+    else if (a === "--out") opts.out = path.resolve(argv[++i] ?? usage("--out requires a value"));
+    else if (a === "--timeout-ms") opts.timeoutMs = Number(argv[++i]) || opts.timeoutMs;
+    else usage(`unknown argument '${a}'`);
+  }
+  if (opts.engines.length === 0) opts.engines = [...ALL_ENGINES];
+  opts.engines = [...new Set(opts.engines)];
+  return opts;
+}
+function usage(msg) {
+  if (msg) console.error(`error: ${msg}`);
+  console.error(
+    "usage: node run.mjs [--engine node|chromium|firefox|webkit|all]... [--quick] [--build] [--out <dir>] [--timeout-ms <n>]",
+  );
+  process.exit(2);
+}
+
+// ---------- artifact checks ----------
+const WASM = path.join(REPO, "js", "wasm", "sparq_wasm_bg.wasm");
+const GLUE = path.join(REPO, "js", "wasm", "sparq_wasm.js");
+const DIST = path.join(REPO, "js", "dist", "index.js");
+
+async function ensureArtifacts(build) {
+  const missing = [];
+  for (const f of [WASM, GLUE, DIST]) {
+    try {
+      await stat(f);
+    } catch {
+      missing.push(path.relative(REPO, f));
+    }
+  }
+  if (missing.length === 0) return;
+  if (build) {
+    console.error(`[run] building missing artifacts (${missing.join(", ")})…`);
+    for (const script of ["build:wasm", "build:ts"]) {
+      const r = spawnSync("npm", ["run", script], { cwd: path.join(REPO, "js"), stdio: "inherit" });
+      if (r.status !== 0) {
+        console.error(`[run] npm run ${script} failed — is the repo-root \`npm ci\` done and wasm-pack installed?`);
+        process.exit(2);
+      }
+    }
+    return ensureArtifacts(false);
+  }
+  console.error(
+    `[run] missing shipped-bundle artifacts:\n  ${missing.join("\n  ")}\n` +
+      `build them first (or pass --build):\n` +
+      `  cd ${REPO} && npm ci --ignore-scripts\n` +
+      `  cd js && npm run build:wasm && npx tsc`,
+  );
+  process.exit(2);
+}
+
+// ---------- static server (serves the repo's js/ tree + this harness dir) ----------
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".wasm": "application/wasm", // required for instantiateStreaming
+  ".json": "application/json",
+  ".map": "application/json",
+};
+const ROOTS = { "/js/": path.join(REPO, "js"), "/harness/": HERE };
+
+function startServer() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, "http://localhost");
+      const prefix = Object.keys(ROOTS).find((p) => url.pathname.startsWith(p));
+      if (!prefix) {
+        res.writeHead(404).end("not found");
+        return;
+      }
+      const root = ROOTS[prefix];
+      const rel = url.pathname.slice(prefix.length);
+      const file = path.resolve(root, rel);
+      if (!file.startsWith(root + path.sep) && file !== root) {
+        res.writeHead(403).end("forbidden");
+        return;
+      }
+      const body = await readFile(file);
+      res.writeHead(200, {
+        "content-type": MIME[path.extname(file)] ?? "application/octet-stream",
+        "cache-control": "no-store", // fetch timings must hit the server, not a disk cache
+      });
+      res.end(body);
+    } catch {
+      res.writeHead(404).end("not found");
+    }
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, port: server.address().port }));
+  });
+}
+
+// ---------- engine runners ----------
+async function runNode(opts) {
+  const outFile = path.join(os.tmpdir(), `wasm-compare-node-${process.pid}.json`);
+  const args = [path.join(HERE, "node-baseline.mjs"), "--out", outFile];
+  if (opts.quick) args.push("--quick");
+  const r = spawnSync(process.execPath, args, { stdio: ["ignore", "inherit", "inherit"], timeout: opts.timeoutMs });
+  if (r.status !== 0) return { ok: false, error: `node-baseline exited ${r.status}` };
+  const result = JSON.parse(await readFile(outFile, "utf8"));
+  result.version = `node ${process.version} (V8 ${process.versions.v8})`;
+  return result;
+}
+
+async function runBrowser(engine, opts, port, playwright) {
+  const type = playwright[engine];
+  let browser;
+  try {
+    browser = await type.launch(
+      engine === "firefox"
+        ? { firefoxUserPrefs: { "privacy.reduceTimerPrecision": false } } // finer perf.now(); measure() batching covers engines that stay coarse
+        : {},
+    );
+  } catch (err) {
+    const reason =
+      `${engine} could not launch on this host: ${String(err?.message ?? err).split("\n")[0]} — ` +
+      `install it with \`npx playwright install ${engine}\` (+ \`sudo npx playwright install-deps ${engine}\` for OS libraries)`;
+    console.error(`[run] SKIP-WITH-NOTICE: ${reason}`);
+    return { skipped: true, reason };
+  }
+  try {
+    const version = `${engine} ${browser.version()} (playwright)`;
+    const rows = [];
+    const skipped = [];
+    for (const mode of ["streaming", "main"]) {
+      const page = await browser.newPage();
+      page.on("console", (m) => {
+        const text = m.text();
+        if (text.startsWith("[harness]") || m.type() === "error") console.error(`[${engine}/${mode}] ${text}`);
+      });
+      page.on("pageerror", (e) => console.error(`[${engine}/${mode}] pageerror: ${e}`));
+      const q = opts.quick ? "&quick=1" : "";
+      await page.goto(`http://127.0.0.1:${port}/harness/page/index.html?mode=${mode}${q}`);
+      await page.waitForFunction("window.__WASM_COMPARE_DONE__ === true", null, { timeout: opts.timeoutMs });
+      const result = await page.evaluate("window.__WASM_COMPARE_RESULT__");
+      await page.close();
+      if (!result.ok) return { ok: false, error: `${engine}/${mode}: ${result.error}`, version };
+      rows.push(...result.rows);
+      skipped.push(...(result.skipped ?? []));
+    }
+    return { ok: true, rows, skipped, version };
+  } finally {
+    await browser.close();
+  }
+}
+
+// ---------- reporting ----------
+const rowKey = (r) =>
+  [r.phase, r.format ?? "", r.triples ?? "", r.query ?? "", r.kind ?? ""].join("|");
+const rowLabel = (r) => {
+  let l = r.phase;
+  if (r.format) l += ` ${r.format}@${r.triples}`;
+  if (r.query) l += ` ${r.query}`;
+  if (r.kind && r.kind !== "total") l += ` [${r.kind}]`;
+  return l;
+};
+
+function printTables(envelopes) {
+  const ran = envelopes.filter((e) => !e.skipped);
+  if (ran.length === 0) return { divergent: false };
+  const keys = [];
+  const byEngine = new Map(ran.map((e) => [e.engine, new Map(e.rows.map((r) => [rowKey(r), r]))]));
+  for (const r of ran[0].rows) keys.push(rowKey(r));
+  for (const e of ran.slice(1))
+    for (const r of e.rows) if (!keys.includes(rowKey(r))) keys.push(rowKey(r));
+
+  const baseline = ran.find((e) => e.engine === "node") ?? ran[0];
+  const engines = ran.map((e) => e.engine);
+  const w0 = 46, wc = 14;
+  console.log(`\n== per-phase wall time, ms (${ADVISORY_NOTE.split("—")[0].trim()}) ==`);
+  console.log("phase".padEnd(w0) + engines.map((e) => e.padStart(wc)).join("") + `   vs ${baseline.engine}`);
+  let divergent = false;
+  for (const k of keys) {
+    const sample = ran.flatMap((e) => byEngine.get(e.engine).get(k) ?? []).at(0);
+    const cells = engines.map((eng) => {
+      const r = byEngine.get(eng).get(k);
+      return r ? r.ms.toFixed(r.ms < 1 ? 3 : 1).padStart(wc) : "—".padStart(wc);
+    });
+    const base = byEngine.get(baseline.engine).get(k);
+    const ratios = engines
+      .filter((eng) => eng !== baseline.engine)
+      .map((eng) => {
+        const r = byEngine.get(eng).get(k);
+        return r && base && base.ms > 0 ? `${eng[0]}×${(r.ms / base.ms).toFixed(2)}` : `${eng[0]}×—`;
+      })
+      .join(" ");
+    console.log(rowLabel(sample).padEnd(w0) + cells.join("") + "   " + ratios);
+    // deterministic oracle: row counts must agree across engines
+    const counts = new Set(
+      engines.map((eng) => byEngine.get(eng).get(k)?.rows).filter((v) => v !== undefined),
+    );
+    if (counts.size > 1) {
+      divergent = true;
+      console.log(`  !! ROW-COUNT DIVERGENCE at ${k}: ${[...counts].join(" vs ")}`);
+    }
+  }
+  return { divergent };
+}
+
+// ---------- main ----------
+const opts = parseArgs(process.argv.slice(2));
+await ensureArtifacts(opts.build);
+await mkdir(opts.out, { recursive: true });
+
+const wasmBytes = await readFile(WASM);
+const bundle = {
+  file: path.relative(REPO, WASM),
+  bytes: wasmBytes.length,
+  sha256: createHash("sha256").update(wasmBytes).digest("hex"),
+};
+const git = spawnSync("git", ["-C", REPO, "rev-parse", "HEAD"], { encoding: "utf8" });
+const host = {
+  platform: os.platform(),
+  arch: os.arch(),
+  cpus: os.cpus().length,
+  cpu_model: os.cpus()[0]?.model ?? "unknown",
+  node: process.version,
+  canonical: false, // this harness never produces canonical numbers by itself
+};
+
+const wantsBrowser = opts.engines.some((e) => BROWSER_ENGINES.includes(e));
+let playwright;
+if (wantsBrowser) {
+  try {
+    playwright = await import("playwright");
+  } catch {
+    console.error(
+      "[run] playwright is not installed — run `npm ci` (or `npm install`) in bench/wasm-compare/browser/ first",
+    );
+    process.exit(2);
+  }
+}
+const require = createRequire(import.meta.url);
+const playwrightVersion = wantsBrowser ? require("playwright/package.json").version : undefined;
+
+const utc = new Date().toISOString().replace(/[:.]/g, "-");
+const envelopes = [];
+let failed = false;
+
+const { server, port } = wantsBrowser ? await startServer() : { server: undefined, port: 0 };
+try {
+  for (const engine of opts.engines) {
+    console.error(`\n[run] engine: ${engine}${opts.quick ? " (quick)" : ""}`);
+    const t0 = performance.now();
+    const result =
+      engine === "node" ? await runNode(opts) : await runBrowser(engine, opts, port, playwright);
+    const envelope = {
+      suite: SUITE,
+      bead: BEAD,
+      advisory: true,
+      note: ADVISORY_NOTE,
+      engine,
+      engine_version: result.version ?? null,
+      playwright: engine === "node" ? undefined : playwrightVersion,
+      run_utc: new Date().toISOString(),
+      git_commit: git.status === 0 ? git.stdout.trim() : null,
+      host,
+      bundle,
+      quick: opts.quick,
+      harness_wall_ms: performance.now() - t0,
+      ...(result.skipped === true
+        ? { skipped: true, reason: result.reason }
+        : result.ok
+          ? { rows: result.rows, skipped_phases: result.skipped }
+          : { failed: true, error: result.error }),
+    };
+    if (result.ok === false) failed = true;
+    envelopes.push(envelope);
+    const file = path.join(opts.out, `${engine}-${utc}.json`);
+    await writeFile(file, JSON.stringify(envelope, null, 2));
+    console.error(`[run] wrote ${path.relative(process.cwd(), file)}${envelope.skipped ? " (SKIPPED-WITH-NOTICE)" : envelope.failed ? " (FAILED)" : ""}`);
+  }
+} finally {
+  server?.close();
+}
+
+const { divergent } = printTables(envelopes.filter((e) => e.rows));
+const skippedEngines = envelopes.filter((e) => e.skipped).map((e) => e.engine);
+if (skippedEngines.length > 0)
+  console.log(`\nskipped-with-notice: ${skippedEngines.join(", ")} (see envelope \`reason\` fields)`);
+console.log(`\n${ADVISORY_NOTE}`);
+if (divergent) {
+  console.error("\n[run] FAIL: cross-engine row-count divergence (correctness, not timing)");
+  process.exit(1);
+}
+if (failed) {
+  console.error("\n[run] FAIL: at least one engine run errored (see envelopes)");
+  process.exit(1);
+}

--- a/bench/wasm-compare/browser/workload.mjs
+++ b/bench/wasm-compare/browser/workload.mjs
@@ -1,0 +1,326 @@
+// [FABLE-5] sq-3ul2n.1 — shared workload for the cross-engine browser wasm harness.
+//
+// Runs UNCHANGED in a browser page (page/page.mjs) and in plain Node
+// (node-baseline.mjs): no `node:` imports, timing via `performance.now()`
+// (present in both), plain `throw` instead of `node:assert`.
+//
+// The dataset generators are ports of the ones in
+// `crates/sparq-wasm/test/bench.cjs` (buildTurtle) and
+// `crates/sparq-wasm/test/mem.cjs` (genNT) — reused READ-ONLY per the bead
+// spec (those files are CommonJS and cannot be imported from a browser page,
+// so the generator bodies are reproduced here with their source cited).
+// Both are deterministic: byte-identical output for a given size, so triple
+// counts and query row counts are exact cross-engine oracles.
+//
+// Every `ms` this module produces is ADVISORY / NON-CANONICAL — measured on
+// whatever host runs it. The deterministic gate is the row/triple-count
+// oracle; the timings attribute cost to a LAYER, they are not headlines.
+
+/** Workload tiers, in TRIPLES (the bead pins 25k/100k/300k). */
+export const DEFAULT_SIZES = [25_000, 100_000, 300_000];
+
+/**
+ * Turtle generator — port of `buildTurtle` in crates/sparq-wasm/test/bench.cjs
+ * (5 triples/entity: name, age, city, follows×2 — chains + cycles for WCOJ,
+ * star attributes, a numeric column for FILTER). Sized by TRIPLE count;
+ * `triples` must be a multiple of 5. All 5·n triples are distinct (the two
+ * follows targets differ for n > 6), so `store.size === triples` exactly.
+ */
+export function genTurtle(triples) {
+  if (triples % 5 !== 0) throw new Error(`genTurtle: ${triples} not a multiple of 5`);
+  const n = triples / 5;
+  const cities = ["Paris", "Berlin", "Tokyo", "Lima", "Cairo"];
+  const lines = ["@prefix ex: <http://ex/> ."];
+  for (let i = 0; i < n; i++) {
+    const age = 18 + (i % 60);
+    lines.push(
+      `ex:p${i} ex:name "Person ${i}" ; ex:age ${age} ; ex:city "${cities[i % cities.length]}" ; ` +
+        `ex:follows ex:p${(i + 1) % n} ; ex:follows ex:p${(i + 7) % n} .`,
+    );
+  }
+  return { text: lines.join("\n"), entities: n, triples };
+}
+
+/**
+ * N-Triples generator — port of `genNT` in crates/sparq-wasm/test/mem.cjs
+ * (7 triples/entity: type, name, age(typed int), follows×4 — exercises the
+ * custom byte-level N-Triples parser). Sized by TRIPLE count; `triples` must
+ * be a multiple of 7. The 4 follows targets (i·7+k mod n, k=0..3) are
+ * distinct for n > 4, so `store.size === triples` exactly.
+ */
+export function genNTriples(triples) {
+  if (triples % 7 !== 0) throw new Error(`genNTriples: ${triples} not a multiple of 7`);
+  const n = triples / 7;
+  const T = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
+  const XSDINT = "<http://www.w3.org/2001/XMLSchema#integer>";
+  const parts = [];
+  for (let i = 0; i < n; i++) {
+    const s = `<http://ex/n${i}>`;
+    parts.push(`${s} ${T} <http://ex/Person> .\n`);
+    parts.push(`${s} <http://ex/name> "name${i}" .\n`);
+    parts.push(`${s} <http://ex/age> "${20 + (i % 80)}"^^${XSDINT} .\n`);
+    for (let k = 0; k < 4; k++) parts.push(`${s} <http://ex/follows> <http://ex/n${(i * 7 + k) % n}> .\n`);
+  }
+  return { text: parts.join(""), entities: n, triples };
+}
+
+/** Nearest multiple of `m` at or above `t` — so "25k triples" is exact per format. */
+export function roundTo(t, m) {
+  return Math.ceil(t / m) * m;
+}
+
+/**
+ * The five query shapes from crates/sparq-wasm/test/bench.cjs QUERIES
+ * (reused read-only), with an exact expected-row-count formula per shape as a
+ * cross-engine correctness oracle. `n` = entity count of the turtle store the
+ * queries run against.
+ */
+export const QUERIES = [
+  {
+    name: "scan-type",
+    sparql: `PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:name ?n }`,
+    expected: (n) => n,
+  },
+  {
+    name: "star-3",
+    sparql: `PREFIX ex: <http://ex/> SELECT ?s ?n ?a ?c WHERE { ?s ex:name ?n . ?s ex:age ?a . ?s ex:city ?c }`,
+    expected: (n) => n,
+  },
+  {
+    name: "chain-2",
+    sparql: `PREFIX ex: <http://ex/> SELECT ?a ?b ?c WHERE { ?a ex:follows ?b . ?b ex:follows ?c }`,
+    // out-degree 2 and in-degree 2 per node → Σ_b in(b)·out(b) = 4n.
+    expected: (n) => 4 * n,
+  },
+  {
+    name: "triangle-wcoj",
+    sparql: `PREFIX ex: <http://ex/> SELECT ?a ?b ?c WHERE { ?a ex:follows ?b . ?b ex:follows ?c . ?c ex:follows ?a }`,
+    // step sums from {1,7}³ are 3/9/15/21, none ≡ 0 mod n for the harness
+    // sizes → 0 triangles (still exercises the WCOJ plan).
+    expected: (n) => 0,
+  },
+  {
+    name: "filter-age",
+    sparql: `PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a . FILTER(?a > 50) }`,
+    // ages are 18+(i%60) ∈ 18..77; >50 keeps residues 33..59. Counted exactly
+    // (n need not divide 60), mirroring the generator.
+    expected: (n) => {
+      let c = 0;
+      for (let i = 0; i < n; i++) if (18 + (i % 60) > 50) c++;
+      return c;
+    },
+  },
+];
+
+/** CONSTRUCT for the serialization-out phase (N-Triples emitted from wasm). */
+export const CONSTRUCT_QUERY = `PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:name ?n } WHERE { ?s ex:name ?n }`;
+
+/**
+ * Boundary-marshalling probe set (the #1885 phase 7): the SAME logical
+ * pattern crossed through hand-offs of increasing JS-side materialisation —
+ * ask (boolean, near-zero marshal floor) → count (usize) → query string out
+ * (one JSON string copy, unparsed) → query + JSON.parse → queryChunks
+ * (chunked string drain) → JS-wrapper queryBindings (JSON.parse + one
+ * Bindings Map per row + one Term per cell). Adjacent deltas attribute the
+ * boundary copy, the JSON.parse, and the RDF/JS materialisation separately.
+ * NOTE the interpretation caveats: `ask` short-circuits at the first row and
+ * `count` uses the engine's lazy-count paths, so both under-run the eval the
+ * `query` variants pay — they are floors, not same-eval controls. The
+ * apples-to-apples marshalling deltas are query vs queryChunks vs
+ * wrapper-queryBindings (identical wasm-side eval + serialisation).
+ */
+export const MARSHAL_QUERIES = [
+  {
+    name: "scan-type",
+    select: `PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:name ?n }`,
+    ask: `PREFIX ex: <http://ex/> ASK { ?s ex:name ?n }`,
+    expected: (n) => n,
+  },
+  {
+    name: "star-3",
+    select: `PREFIX ex: <http://ex/> SELECT ?s ?n ?a ?c WHERE { ?s ex:name ?n . ?s ex:age ?a . ?s ex:city ?c }`,
+    ask: `PREFIX ex: <http://ex/> ASK { ?s ex:name ?n . ?s ex:age ?a . ?s ex:city ?c }`,
+    expected: (n) => n,
+  },
+];
+
+const now = () => performance.now();
+
+/**
+ * Times `fn`: one measured FIRST call (cold — carries any remaining JIT
+ * tier-up / lazy init), then `warmup` unmeasured calls, then `iters` measured
+ * calls taking the BEST. Fast calls are batched so coarse browser timers
+ * (1ms-class under anti-fingerprinting clamps) still resolve them: if a call
+ * runs under `minSampleMs`, each sample loops the call enough times to exceed
+ * it and divides.
+ */
+export function measure(fn, { warmup = 2, iters = 5, minSampleMs = 20 } = {}) {
+  const t0 = now();
+  let out = fn();
+  const first = now() - t0;
+  for (let i = 0; i < warmup; i++) fn();
+  // Calibrate a batch size from one post-warmup call.
+  const c0 = now();
+  fn();
+  const oneMs = now() - c0;
+  const batch = oneMs >= minSampleMs ? 1 : Math.min(1000, Math.max(1, Math.ceil(minSampleMs / Math.max(oneMs, 0.0001))));
+  let best = Infinity;
+  for (let i = 0; i < iters; i++) {
+    const s = now();
+    for (let b = 0; b < batch; b++) out = fn();
+    const per = (now() - s) / batch;
+    if (per < best) best = per;
+  }
+  return { first, warm: best, iters, batch, out };
+}
+
+function check(cond, msg) {
+  if (!cond) throw new Error(`workload oracle failed: ${msg}`);
+}
+
+/**
+ * Runs the full per-phase workload against an ALREADY-INSTANTIATED wasm
+ * module. Init phases (fetch/compile/instantiate) are environment-specific
+ * and measured by the caller; everything from store-load onward is identical
+ * across browser pages and Node.
+ *
+ * @param {object} opts
+ * @param {any} opts.Store        raw wasm-bindgen `Store` class (js/wasm/sparq_wasm.js)
+ * @param {any} [opts.SparqStore] JS-wrapper class (js/dist/index.js); wrapper
+ *                                phases are skipped-with-notice if absent
+ * @param {number[]} [opts.sizes] workload tiers in triples
+ * @param {boolean} [opts.quick]  smoke mode: smallest tier, fewer iters
+ * @param {(msg: string) => void} [opts.log]
+ * @returns {{ rows: object[], skipped: object[] }}
+ */
+export function runWorkload({ Store, SparqStore, sizes = DEFAULT_SIZES, quick = false, log = () => {} }) {
+  const rows = [];
+  const skipped = [];
+  const tiers = quick ? [sizes[0]] : sizes;
+  const loadIters = (t) => (quick ? 1 : t >= 300_000 ? 2 : 3);
+  const qOpts = quick ? { warmup: 1, iters: 3 } : { warmup: 2, iters: 7 };
+
+  // ---- Phase: store load/parse (N-Triples then Turtle, ascending sizes). ----
+  // The very first load is the globally coldest call (parser tier-up); order
+  // is fixed and documented so cold rows are comparable across engines.
+  let queryStore; // turtle store the query phases run on (largest quick tier / 100k default)
+  let queryEntities = 0;
+  let queryTurtleText = "";
+  const queryTier = quick ? tiers[0] : 100_000;
+  for (const [format, gen, mult] of [
+    ["ntriples", genNTriples, 7],
+    ["turtle", genTurtle, 5],
+  ]) {
+    for (const t of tiers) {
+      const size = roundTo(t, mult);
+      const { text, entities, triples } = gen(size);
+      log(`load ${format} ${triples} triples (${entities} entities, ${(text.length / 1e6).toFixed(1)} MB source)…`);
+      let store;
+      const iters = loadIters(t);
+      const m = measure(
+        () => {
+          store = Store.load(text, format === "ntriples" ? "ntriples" : "turtle");
+          return store;
+        },
+        { warmup: 0, iters, minSampleMs: 0 }, // loads are ms-heavy: no batching, rebuild per iter
+      );
+      check(store.size === triples, `${format}@${triples}: store.size=${store.size}`);
+      const heap = store.heapBytes();
+      rows.push({ phase: "store_load", format, triples, entities, source_bytes: text.length, kind: "first", ms: m.first, iters: 1, heap_bytes: heap });
+      rows.push({ phase: "store_load", format, triples, entities, source_bytes: text.length, kind: "warm", ms: m.warm, iters, heap_bytes: heap });
+      if (format === "turtle" && t === queryTier) {
+        queryStore = store;
+        queryEntities = entities;
+        queryTurtleText = text;
+      }
+    }
+  }
+  check(queryStore, `no query store captured for tier ${queryTier}`);
+  log(`query phases on turtle store: ${queryStore.size} triples, n=${queryEntities}`);
+
+  // ---- Phase: query shapes (first = tier-up-inclusive cold, then warm best). ----
+  for (const q of QUERIES) {
+    const expected = q.expected(queryEntities);
+    let got = -1;
+    const m = measure(() => {
+      const parsed = JSON.parse(queryStore.query(q.sparql));
+      got = parsed.results.bindings.length;
+      return got;
+    }, qOpts);
+    check(got === expected, `${q.name}: rows=${got}, expected ${expected}`);
+    rows.push({ phase: "query", query: q.name, rows: got, kind: "first", ms: m.first, iters: 1 });
+    rows.push({ phase: "query", query: q.name, rows: got, kind: "warm", ms: m.warm, iters: m.iters, batch: m.batch });
+    log(`query ${q.name}: ${got} rows, first ${m.first.toFixed(2)}ms, warm ${m.warm.toFixed(3)}ms`);
+  }
+
+  // ---- Phase: serialization out (CONSTRUCT → N-Triples string from wasm). ----
+  {
+    let outLen = 0;
+    const m = measure(() => {
+      const nt = queryStore.queryQuads(CONSTRUCT_QUERY);
+      outLen = nt.length;
+      return outLen;
+    }, qOpts);
+    // One triple per entity; every line ends "\n".
+    const lines = queryStore.queryQuads(CONSTRUCT_QUERY).split("\n").filter((l) => l.length > 0).length;
+    check(lines === queryEntities, `serialize_construct: ${lines} triples out, expected ${queryEntities}`);
+    rows.push({ phase: "serialize_construct", query: "construct-name", rows: lines, out_bytes: outLen, kind: "first", ms: m.first, iters: 1 });
+    rows.push({ phase: "serialize_construct", query: "construct-name", rows: lines, out_bytes: outLen, kind: "warm", ms: m.warm, iters: m.iters, batch: m.batch });
+  }
+
+  // ---- Phase: boundary-marshalling share (ask / count / query / queryChunks / wrapper). ----
+  let wrapperStore;
+  if (SparqStore) {
+    // fromStringSync: the wasm engine is already instantiated by the caller,
+    // so the wrapper must NOT re-init (a second initWasm would re-instantiate
+    // and orphan the raw stores above).
+    wrapperStore = SparqStore.fromStringSync(queryTurtleText, "turtle");
+    check(wrapperStore.size === queryStore.size, `wrapper store size ${wrapperStore.size} != ${queryStore.size}`);
+  } else {
+    skipped.push({ phase: "marshal_wrapper_bindings", reason: "js/dist wrapper not provided in this environment" });
+  }
+  for (const mq of MARSHAL_QUERIES) {
+    const expected = mq.expected(queryEntities);
+    const variants = [
+      ["marshal_ask", () => queryStore.ask(mq.ask), (v) => v === true],
+      ["marshal_count", () => queryStore.count(mq.select), (v) => v === expected],
+      // raw boundary hand-off: wasm-side eval + JSON serialisation + ONE string copy out
+      ["marshal_query_string", () => queryStore.query(mq.select).length, (v) => v > 0],
+      // + the JS-side JSON.parse of that string (the wrapper's first layer)
+      [
+        "marshal_query_json_parse",
+        () => JSON.parse(queryStore.query(mq.select)).results.bindings.length,
+        (v) => v === expected,
+      ],
+      [
+        "marshal_query_chunks",
+        () => {
+          const cur = queryStore.queryChunks(mq.select);
+          let bytes = 0;
+          try {
+            for (;;) {
+              const chunk = cur.next();
+              if (chunk === undefined) break;
+              bytes += chunk.length;
+            }
+          } finally {
+            cur.free?.();
+          }
+          return bytes;
+        },
+        (v) => v > 0,
+      ],
+    ];
+    if (wrapperStore) {
+      variants.push(["marshal_wrapper_bindings", () => wrapperStore.queryBindings(mq.select).length, (v) => v === expected]);
+    }
+    for (const [phase, fn, ok] of variants) {
+      const m = measure(fn, qOpts);
+      check(ok(m.out), `${phase}/${mq.name}: unexpected result ${m.out}`);
+      rows.push({ phase, query: mq.name, rows: expected, kind: "warm", ms: m.warm, iters: m.iters, batch: m.batch });
+      log(`${phase} ${mq.name}: warm ${m.warm.toFixed(3)}ms`);
+    }
+  }
+
+  return { rows, skipped };
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implements bead `sq-3ul2n.1` (epic `sq-3ul2n`, browser-WASM performance program). Commit trailer `[FABLE-5]`.

## What this adds

The **Tier-0 measurement gate** of the browser-WASM program (`research/browser-wasm-perf-assessment-2026-07.md`): a self-contained, cross-engine BROWSER measurement harness at `bench/wasm-compare/browser/` that drives the **shipped `@jeswr/sparq` web bundle** (the `js/` `build:wasm` output — same artifact, same sha256 recorded in every envelope) through **headless Chromium, Firefox and WebKit** (Playwright ^1.61, scoped to the harness dir — NOT a repo-root workspace member) plus a **plain-Node baseline**, and attributes wall time **per phase** so a regression lands on a LAYER and an ENGINE, not a total.

**Measurement-only:** zero engine/bindings code change; the only files touched are `bench/wasm-compare/browser/**` (new) + one `bench/CATALOG.md` note (the bead's FILES contract).

## Phases attributed (per engine)

- `init_streaming_total` — the real shipped path (bare `initWasm()` ⇒ fetch + `instantiateStreaming`, compile overlapped with download)
- `fetch_wasm` / `compile_wasm` / `instantiate_wasm` — the same path decomposed, each mode in a **fresh browser process** (wasm compile caches are per-process; sharing one process mis-attributes the second page's compile)
- `store_load` × {N-Triples, Turtle} × {25k, 100k, 300k triples}, first (tier-up-inclusive) vs warm, with `heap_bytes`/`source_bytes`
- `query` × the five `bench.cjs` shapes (scan/star/chain/triangle-WCOJ/filter), first vs warm (batched timing recovers 1ms-clamped browser clocks)
- `serialize_construct` — CONSTRUCT → N-Triples out of wasm
- the boundary-marshalling ladder: `ask` → `count` → `query` string out → + `JSON.parse` → `queryChunks` drain → JS-wrapper `queryBindings` (adjacent deltas attribute copy vs parse vs RDF/JS materialisation)

Workload generators are read-only ports of `crates/sparq-wasm/test/{bench,mem}.cjs` (cited inline), deterministic by construction; **the only hard check is the row/triple-count oracle** — identical counts required on every engine, run fails on divergence (timing never gates).

## Engines that ran (this box)

All four: **Node 20 + Chromium + Firefox + WebKit** (`node run.mjs --engine all`, exit 0; WebKit needed `sudo npx playwright install-deps webkit`). A browser that cannot launch **skips with an explicit notice** (envelope `skipped: true` + install command, exit 0) — never fabricated numbers.

## Sample result — indicative, NON-CANONICAL work-box run

⚠️ Single run on the shared EC2 work box: **advisory numbers only** — the deliverable is the attribution/ratio structure, not these values. Nothing below is committed anywhere; envelopes live in git-ignored `results/`.

Condensed excerpt (ms; ratios vs the Node baseline):

| phase | node | chromium | firefox | webkit |
|---|---|---|---|---|
| init_streaming_total | n/a (skip-with-notice) | 53.6 | 466.6 | 90.0 |
| compile_wasm (cold, decomposed) | 43.3 | 19.5 | 177.3 | 16.0 |
| store_load turtle@300k [warm] | 1098.8 | 811.9 | 5587.1 | 586.0 |
| query star-3 [warm] | 46.7 | 34.5 | 117.7 | 29.0 |
| marshal star-3: string→+parse→wrapper | 14.8→61.5→154.6 | 14.3→34.6→49.6 | 98.6→122.7→163.3 | 28.0→62.0→104.0 |

What the structure already shows (indicative): Chromium/WebKit track the Node baseline within ~2× on most phases; **Firefox is 3–8× slower on parse/load and up to ~10× on some warm query phases** (recorded on `sq-3ul2n.9` as a first signal — NOT yet escalation evidence; needs quiet-box repetition + profiling); the wrapper's JS-side `JSON.parse` + `Bindings` materialisation is ~2.5–3.5× the raw wasm→JS string copy (recorded on `sq-3ul2n.5`); `instantiateStreaming` overlap works (Chromium total < decomposed sum). Cross-engine row counts: identical everywhere (oracle green).

## How to run

```sh
cd bench/wasm-compare/browser
npm ci && npx playwright install chromium firefox webkit
node run.mjs --engine chromium        # or firefox / webkit / node / all; --quick for the smoke tier
```

See `bench/wasm-compare/browser/README.md` for the run matrix, phase semantics and interpretation caveats. **Deliberately no CI lane** (measurement harness, run on demand — same reasoning that moved timing benches off the PR path in #1895).

## Gates / hygiene

- Plain-JS harness: `npm run lint` (node --check on all modules) green; no TS/eslint surface added.
- No Rust changes, no `supply-chain/` change, site/js builds untouched (harness dir is not a root workspace member; `results/` + `node_modules/` git-ignored).
- No hard-coded perf numbers in committed markdown (all numbers live in envelopes/PR body only); `readme-template` 0 deviations; `typos` clean.
- Follow-ups filed: notes on `sq-3ul2n.5`/`sq-3ul2n.9` + new spike bead for the measured Node `instantiate_wasm` anomaly (~50–100× browsers, one-time cost).

<details>
<summary>Full per-phase table from the sample run (indicative, non-canonical)</summary>

```
phase                                                   node      chromium       firefox        webkit
fetch_wasm                                               1.6          71.6          56.3         100.0
compile_wasm                                            43.3          19.5         177.3          16.0
instantiate_wasm                                        94.8           1.0         0.560           2.0
store_load ntriples@25004 [first]                      152.1          75.6         151.8          34.0
store_load ntriples@25004 [warm]                        39.4          15.0         119.4          13.0
store_load ntriples@100002 [first]                     172.9         127.4         589.0          55.0
store_load ntriples@100002 [warm]                      192.0         110.3         716.6          49.0
store_load ntriples@300006 [first]                     386.8         515.9        3082.4         163.0
store_load ntriples@300006 [warm]                      524.2         512.6        1631.6         159.0
store_load turtle@25000 [first]                        172.8         217.7         468.2         119.0
store_load turtle@25000 [warm]                          82.4         101.1         413.6          47.0
store_load turtle@100000 [first]                       420.9         510.3        1901.5         211.0
store_load turtle@100000 [warm]                        384.0         216.1        1982.3         187.0
store_load turtle@300000 [first]                      1337.0        1580.6        6533.9         628.0
store_load turtle@300000 [warm]                       1098.8         811.9        5587.1         586.0
query scan-type [first]                                 40.4          17.0          21.3          78.0
query scan-type [warm]                                  10.7           7.8          18.0           8.0
query star-3 [first]                                    95.7          86.9         127.0         129.0
query star-3 [warm]                                     46.7          34.5         117.7          29.0
query chain-2 [first]                                  183.3         303.8         294.5         127.0
query chain-2 [warm]                                   142.2          94.6         286.8         143.0
query triangle-wcoj [first]                             57.7          49.2         306.2         150.0
query triangle-wcoj [warm]                              24.7          31.7         262.5          58.0
query filter-age [first]                                11.4           7.9          10.8          14.0
query filter-age [warm]                                  5.3           3.6           9.1           5.2
serialize_construct construct-name [first]              46.9          33.0         131.5         152.0
serialize_construct construct-name [warm]               26.0          21.0         132.0          17.0
marshal_ask scan-type [warm]                           0.014         0.012         0.100         0.022
marshal_count scan-type [warm]                         0.014         0.011         0.165         0.028
marshal_query_string scan-type [warm]                    2.5           1.9          17.6           3.5
marshal_query_json_parse scan-type [warm]               10.8           7.6          33.6           8.0
marshal_query_chunks scan-type [warm]                    2.1           1.9          29.9           4.7
marshal_wrapper_bindings scan-type [warm]               20.6          11.2          60.4          29.0
marshal_ask star-3 [warm]                                2.4           1.7          22.3           3.0
marshal_count star-3 [warm]                              2.4           1.7          22.5           1.5
marshal_query_string star-3 [warm]                      14.8          14.3          98.6          28.0
marshal_query_json_parse star-3 [warm]                  61.5          34.6         122.7          62.0
marshal_query_chunks star-3 [warm]                      20.0          12.8          99.0          28.0
marshal_wrapper_bindings star-3 [warm]                 154.6          49.6         163.3         104.0
init_streaming_total                                       —          53.6         466.6          90.0
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
