### PR TITLE
bench(gsp): Graph Store Protocol same-box panel — sparq-server vs Fuseki GSP / Oxigraph GSP (+ CSS loose) (sq-hmd7l.21)

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -83,6 +83,14 @@ Notes on a few that need care:
   numbers come only from a quiet EC2 runner, and it is deliberately NOT wired into
   `scripts/ci-bench.sh` / `scripts/perf-gate.py` (req/s is a trend/EC2 metric). It is the
   prerequisite that unblocks the HTTP opt lane (sq-7d3dj.10/.12/.13).
+- **`gsp-bench` (`bench/gsp`) is the Graph Store Protocol same-box panel** — see
+  [`bench/gsp/README.md`](./gsp/README.md). GSP PUT/GET/DELETE round-trips (1 KB–10 MB
+  size sweep + the PSS LDP-CRUD stream projected onto GSP verbs) against sparq-server /
+  Fuseki / Oxigraph server, plus Community Solid Server as a **LOOSE** LDP-architecture
+  column (labelled, never averaged). A HARD round-trip content gate (returned triple set
+  must equal the PUT set exactly) runs BEFORE any timing; the driver is loopback-only
+  (refuses non-loopback URLs). `bash bench/gsp/run.sh --smoke` is the self-contained
+  acceptance run. First-read record: `research/gap-gsp-2026-07.md`. [FABLE-5]
 - **`sp2b` (SP2Bench) is tiered** — see [`bench/sp2b/README.md`](./sp2b/README.md).
   The per-commit path builds+caches the real Freiburg generator (BSD; sha256-pinned, g++
   `-O2` not `-O3`) and runs 14 sub-second queries on a fixed 250k-triple corpus, emitting

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -1587,20 +1587,20 @@ records_to  = "bench/competitor-results/python-bindings-*-<UTC>.json (git-ignore
 featured    = false
 status      = "active"  # first-read record: research/gap-python-binding-2026-07.md
 
-# [SONNET-4.6] sq-hmd7l.21 — Graph Store Protocol same-box panel
+# [FABLE-5] sq-hmd7l.21 — Graph Store Protocol same-box panel
 [[benchmark]]
 id          = "gsp-bench"
 name        = "Graph Store Protocol same-box panel (sparq-server vs Fuseki GSP / Oxigraph GSP + CSS loose)"
 category    = "serve"
-measures    = "GSP PUT/GET/PATCH throughput (req/s) and latency (ms) for a pinned RDF corpus over HTTP; result-count oracle (GET triple count) before trusting timing"
-invoke      = "TBD — implementing bead sq-hmd7l.21"
-source      = "TBD — bench/gsp-bench/; scripts/bench-adapters/http_gsp_adapter.py"
-dataset     = "TBD — pinned NT corpus uploaded via GSP PUT; same corpus used for each engine"
+measures    = "GSP PUT/GET/DELETE latency (p50/p99 ms per op) over a deterministic 1KB-10MB resource-size sweep + the PSS LDP-CRUD stream projected onto GSP verbs; HARD round-trip content gate BEFORE timing (returned triple SET must equal the PUT set exactly; CRUD final state must match a client-side reference model); loopback-only (the driver refuses non-loopback URLs)"
+invoke      = "bash bench/gsp/run.sh --smoke   # acceptance: sparq loopback, exit 0 = gates green\n              GSP_FUSEKI_URL=http://127.0.0.1:3030/ds GSP_OXIGRAPH_URL=http://127.0.0.1:7878 GSP_CSS_URL=http://127.0.0.1:3000 bash bench/gsp/run.sh   # full panel (competitors already running)"
+source      = "bench/gsp/{run.sh,compare.py,README.md}; CRUD shapes mirror bench/pss-update-set (gh-47/gh-52)"
+dataset     = "none fetched — deterministic bnode-free ASCII N-Triples generated in-driver per size target; identical payload bytes fed to every engine in the same run"
 quiet_box_sensitive = true
-pinning     = "TBD — corpus sha256 + competitor pinned version/digest at gather time"
-records_to  = "TBD — bench/competitor-results/<engine>-gsp-<UTC>.json (git-ignored)"
-featured    = false  # registry stub; implementing bead sq-hmd7l.21
-status      = "planning"
+pinning     = "payloads deterministic by construction (seed-free counter form); competitor versions (Fuseki distribution / Oxigraph release sha256 / @solid/community-server npm version) recorded in the results JSON at gather time; CSS rows labelled LOOSE (Solid/LDP overhead included) and never averaged with the like-for-like columns"
+records_to  = "bench/competitor-results/gsp-<UTC>.json via GSP_JSON_OUT (git-ignored); first-read record: research/gap-gsp-2026-07.md"
+featured    = false  # external-competitor differential harness, not a dashboard-promoted capability suite
+status      = "ok"  # smoke (sparq loopback) is self-contained; competitor columns are gather-time external cost
 
 # [SONNET-4.6] sq-hmd7l.12 — federation harness (FedShop vs Comunica + Jena SERVICE)
 [[benchmark]]

--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -84,6 +84,10 @@
         {
           "sparq_suite": "lubm",
           "note": "comparable on the LUBM extensional tier (Oxigraph has no OWL-RL reasoner — entailed tier is NOT comparable)"
+        },
+        {
+          "sparq_suite": "gsp-bench",
+          "note": "[FABLE-5 sq-hmd7l.21] like-for-like GSP column via the Oxigraph SERVER (not the embedded crate): `oxigraph serve` exposes a Graph Store Protocol endpoint at /store?graph=<iri>; binary pin per scripts/oxigraph-serve-same-box.sh. Round-trip content gate before timing (bench/gsp/)."
         }
       ],
       "version_env_metadata": "captured at gather time from Cargo.lock (exact resolved oxigraph version) + host env block; the sparq-bench compare path already prints both engines' load/query timings and peak RSS to stdout.",
@@ -166,6 +170,10 @@
         {
           "sparq_suite": "dbpsb",
           "note": "DBPSB/FEASIBLE DBpedia cut; the suite Jena/Fuseki is most-reported on in the literature."
+        },
+        {
+          "sparq_suite": "gsp-bench",
+          "note": "[FABLE-5 sq-hmd7l.21] like-for-like GSP column: a Fuseki dataset exposes the Graph Store Protocol at <dataset>/data?graph=<iri>. Round-trip content gate before timing (bench/gsp/)."
         }
       ],
       "version_env_metadata": "gather records the Fuseki Docker image DIGEST (or the distribution version / `fuseki --version`) + java -version + the host env block. Results land git-ignored in bench/competitor-results/fuseki-<suite>-<UTC>.json; promote into engines/values only deliberately, reviewed in-diff.",

--- a/bench/gsp/README.md
+++ b/bench/gsp/README.md
@@ -1,0 +1,74 @@
+<!-- [FABLE-5] sq-hmd7l.21 — GSP same-box panel. -->
+# Graph Store Protocol same-box panel — sparq-server vs Fuseki GSP / Oxigraph GSP (+ CSS, loose)
+
+HTTP **Graph Store Protocol** (SPARQL 1.1 GSP) PUT/GET/DELETE round-trips, all
+engines on one box, **loopback only** (the driver hard-refuses any non-loopback
+URL — no bypass flag). Registered as `gsp-bench` in
+[`bench/benchmarks.toml`](../benchmarks.toml); lineage:
+[`bench/serve-throughput`](../serve-throughput/) (loopback HTTP regime) +
+[`bench/pss-update-set`](../pss-update-set/) (the LDP-CRUD shapes).
+
+## The invariant: round-trip content agreement BEFORE timing
+
+Per workload and per engine, a HARD correctness gate runs first; a red gate
+skips that engine's timing and fails the run (exit ≠ 0):
+
+- **size-sweep** — PUT a deterministic, bnode-free, ASCII-only N-Triples payload
+  (default 1 KB → 10 MB), GET it back as `application/n-triples`, and require
+  the returned triple **set to equal the sent set exactly** (ground triples, so
+  set equality *is* isomorphism); then DELETE and require an absent read
+  (404, or 200-with-zero-triples — engines legitimately differ here).
+- **crud-replay** — the PSS LDP-CRUD stream projected onto GSP verbs; a
+  client-side reference model replays the same stream and every touched graph's
+  final state must match a GET against the engine.
+
+The gate itself is regression-tested: `compare.py --self-test` (hermetic, no
+HTTP) proves an honest in-memory store passes it and a tampering store (drops a
+triple on read) fails it.
+
+## Columns
+
+| column | GSP endpoint | posture |
+|---|---|---|
+| sparq-server | `<base>/sparql/graph?graph=<iri>` | subject |
+| Fuseki | `<dataset>/data?graph=<iri>` | like-for-like HTTP RDF store |
+| Oxigraph server | `<base>/store?graph=<iri>` | like-for-like HTTP RDF store |
+| Community Solid Server | LDP resource URL (direct) | **LOOSE** — Solid/LDP stack (persistence, authz, negotiation) is INCLUDED; labelled on every row, **never averaged** with the like-for-like columns |
+
+CRUD projection honesty: `set_acl`'s conditional `DELETE/INSERT/WHERE` swap is
+not GSP-expressible — it is projected to a PUT-replace of a one-triple acl
+graph; `delete_document` cannot remove the single containment triple from the
+container graph (that needs PATCH), so containment survives in BOTH the engine
+and the reference model. The N3-Patch / Solid-PATCH dialects (only CSS as a
+peer) are out of this panel's scope.
+
+## Run it
+
+```sh
+cargo build -p sparq-server --release
+bash bench/gsp/run.sh --smoke     # acceptance: sparq loopback, small sizes; exit 0 = green
+bash bench/gsp/run.sh             # full 1 KB..10 MB sweep + 200-op CRUD replay
+```
+
+Competitor columns attach via env (each server already running on loopback;
+see `scripts/fuseki-same-box.sh` / `scripts/oxigraph-serve-same-box.sh` for the
+pinned engine recipes):
+
+```sh
+GSP_FUSEKI_URL=http://127.0.0.1:3030/ds \
+GSP_OXIGRAPH_URL=http://127.0.0.1:7878 \
+GSP_CSS_URL=http://127.0.0.1:3000 \
+GSP_JSON_OUT=bench/competitor-results/gsp-$(date -u +%Y%m%dT%H%M%SZ).json \
+bash bench/gsp/run.sh
+```
+
+Tunables: `SPARQ_SERVER_BIN`, `GSP_PORT` (7033), `GSP_ITERS`, `GSP_SIZES`,
+`GSP_MAX_BODY_BYTES` (the server's default 1 MiB `--max-body-bytes` is raised
+to clear the 10 MB PUT bodies — configure competitors equivalently).
+
+## Honesty
+
+Latency/throughput here are wall-clock and **NON-canonical on a shared box**
+(`bench/CATALOG.md` QUIET-BOX rule); canonical numbers come only from a quiet
+EC2 run, land git-ignored under `bench/competitor-results/`, and are never
+committed. First-read findings: `research/gap-gsp-2026-07.md`.

--- a/bench/gsp/compare.py
+++ b/bench/gsp/compare.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-hmd7l.21 — Graph Store Protocol same-box panel driver.
+"""sparq-server vs Fuseki GSP / Oxigraph GSP (+ Community Solid Server, LOOSE) —
+Graph Store Protocol PUT/GET/DELETE round-trips, same box, loopback only.
+
+  compare.py [--sparq URL] [--fuseki URL] [--oxigraph URL] [--css URL]
+             [--sizes CSV] [--iters N] [--crud-ops N] [--smoke]
+             [--json-out FILE] [--self-test]
+
+Two workloads, each behind a HARD correctness gate that runs BEFORE any timing
+(the bead invariant: round-trip content agreement first, numbers second):
+
+  size-sweep   Deterministic bnode-free N-Triples payloads at each --sizes byte
+               target (default 1 KB -> 10 MB). Gate: PUT the graph, GET it back
+               (application/n-triples), parse, and require the returned triple
+               SET to equal the sent set exactly (ground triples, so set
+               equality IS isomorphism) — then DELETE and require the graph to
+               read as absent (404, or 200 with zero triples: engines
+               legitimately differ on GSP absent-graph reads). Timing (only
+               after a green gate): per-iteration PUT / GET / DELETE latency on
+               a fresh graph name each iteration.
+
+  crud-replay  The PSS LDP-CRUD stream (bench/pss-update-set) PROJECTED onto
+               GSP verbs: put_document -> PUT <r> + POST containment into the
+               container graph; set_acl -> PUT of a one-triple <r>.acl graph
+               (GSP PUT replace = the idempotent pointer swap; the conditional
+               DELETE/INSERT/WHERE shape is not GSP-expressible); delete_document
+               -> DELETE <r> + DELETE <r>.acl. Gate: a client-side reference
+               model replays the same stream and every resource's final state
+               (present triples / absent) must match a GET against the engine.
+
+Engine columns:
+  --sparq    sparq-server base URL (default http://127.0.0.1:7033). GSP endpoint:
+             <base>/sparql/graph?graph=<iri> (indirect identification).
+  --fuseki   Fuseki dataset base URL (e.g. http://127.0.0.1:3030/ds). GSP
+             endpoint: <base>/data?graph=<iri>. Omit to skip.
+  --oxigraph Oxigraph server base URL (e.g. http://127.0.0.1:7878). GSP
+             endpoint: <base>/store?graph=<iri>. Omit to skip.
+  --css      Community Solid Server pod base URL. **LOOSE column**: CSS is a
+             Solid/LDP stack (persistence, access control, negotiation), not a
+             pure GSP store — ops address the resource URL directly (LDP), and
+             every css row is labelled LOOSE and must NEVER be averaged with
+             the like-for-like columns. Omit to skip.
+
+LOOPBACK ONLY (fail-closed): every engine URL must resolve to a loopback host
+(127.0.0.1 / localhost / ::1). Anything else is refused before any request —
+this harness must not be pointed at a remote endpoint.
+
+Honesty: numbers are machine-specific and NOT committed anywhere (repo hygiene
+forbids hard-coded perf). Anything measured on a shared work box is
+NON-canonical; see research/gap-gsp-2026-07.md.
+"""
+
+import argparse
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+DEFAULT_SIZES = "1024,10240,102400,1048576,10485760"  # 1 KB .. 10 MB
+SMOKE_SIZES = "1024,10240"
+LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+LDP_CONTAINS = "http://www.w3.org/ns/ldp#contains"
+ACL_PTR = "http://www.w3.org/ns/auth/acl#accessControl"
+
+
+# --------------------------------------------------------------------------- #
+# Loopback guard (bead invariant: loopback-only testing, no bypass)
+# --------------------------------------------------------------------------- #
+def assert_loopback(url, label):
+    """Hard-refuses a non-loopback engine URL. Returns the URL unchanged."""
+    host = urllib.parse.urlparse(url).hostname
+    if host not in LOOPBACK_HOSTS:
+        sys.exit(
+            f"{label}: refusing non-loopback URL {url!r} (host {host!r}) — "
+            "this harness is loopback-only by design"
+        )
+    return url
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic payload generation + N-Triples canonicalisation
+# --------------------------------------------------------------------------- #
+def gen_ntriples(target_bytes, tag):
+    """Deterministic, bnode-free, ASCII-only N-Triples of >= target_bytes.
+
+    Plain-ASCII IRIs + simple string literals only, so every serialiser
+    (sparq / Fuseki / Oxigraph) re-emits the identical canonical line and the
+    round-trip gate can require exact SET equality (ground triples: set
+    equality is isomorphism)."""
+    lines = []
+    size = 0
+    i = 0
+    while size < target_bytes:
+        line = (
+            f"<http://gsp.bench/{tag}/s{i}> <http://gsp.bench/p> "
+            f'"v{i}-{tag}-payload-padding-0123456789abcdef" .\n'
+        )
+        lines.append(line)
+        size += len(line)
+        i += 1
+    return "".join(lines)
+
+
+def canon(nt_text):
+    """Canonical triple set of an N-Triples document: stripped, non-empty,
+    non-comment lines. Sufficient for this harness's ASCII/ground payloads."""
+    out = set()
+    for raw in nt_text.splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            out.add(line)
+    return frozenset(out)
+
+
+# --------------------------------------------------------------------------- #
+# Engine adapters: put / get / delete on a named graph
+# --------------------------------------------------------------------------- #
+class GspEngine:
+    """A standard GSP endpoint (indirect graph identification, ?graph=<iri>)."""
+
+    loose = False
+
+    def __init__(self, name, gsp_url):
+        self.name = name
+        self.gsp_url = gsp_url.rstrip("?")
+
+    def _url(self, graph_iri):
+        return f"{self.gsp_url}?graph={urllib.parse.quote(graph_iri, safe='')}"
+
+    def _request(self, method, graph_iri, body=None, headers=None):
+        req = urllib.request.Request(
+            self._url(graph_iri), data=body, headers=headers or {}, method=method
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=120) as r:
+                return r.status, r.read()
+        except urllib.error.HTTPError as e:
+            return e.code, e.read()
+        except urllib.error.URLError as e:
+            # e.g. a broken pipe when the server refuses an over-cap body mid-
+            # stream. Surface it as a synthetic 5xx so the correctness gate
+            # reports an honest FAIL (with detail) instead of a stack trace.
+            return 599, f"transport error: {e.reason}".encode()
+
+    def put(self, graph_iri, nt_body):
+        return self._request(
+            "PUT",
+            graph_iri,
+            body=nt_body.encode(),
+            headers={"content-type": "application/n-triples"},
+        )
+
+    def post(self, graph_iri, nt_body):
+        return self._request(
+            "POST",
+            graph_iri,
+            body=nt_body.encode(),
+            headers={"content-type": "application/n-triples"},
+        )
+
+    def get(self, graph_iri):
+        return self._request(
+            "GET", graph_iri, headers={"accept": "application/n-triples"}
+        )
+
+    def delete(self, graph_iri):
+        return self._request("DELETE", graph_iri)
+
+
+class CssEngine(GspEngine):
+    """Community Solid Server — LOOSE column. LDP resource addressing: the
+    resource URL IS the graph (direct identification); the payload rides as
+    text/turtle (N-Triples is valid Turtle) because Turtle is CSS's native
+    representation. Solid/LDP overhead (persistence, authz, negotiation) is
+    INCLUDED in every number — never average with the like-for-like columns."""
+
+    loose = True
+
+    def _url(self, graph_iri):
+        # Map the abstract graph IRI onto a pod resource path (LDP addressing).
+        slug = urllib.parse.quote(graph_iri, safe="")
+        return f"{self.gsp_url.rstrip('/')}/gsp-bench/{slug}.ttl"
+
+    def put(self, graph_iri, nt_body):
+        return self._request(
+            "PUT",
+            graph_iri,
+            body=nt_body.encode(),
+            headers={"content-type": "text/turtle"},
+        )
+
+    def post(self, graph_iri, nt_body):
+        # LDP has no graph-merge POST onto an existing RDF resource; the loose
+        # projection is read-modify-PUT. Recorded as one "post" op (the overhead
+        # of the extra GET is part of the honest LOOSE architecture difference).
+        status, body = self.get(graph_iri)
+        merged = (body.decode() if status == 200 else "") + nt_body
+        return self.put(graph_iri, merged)
+
+
+def absent(status, body):
+    """A GSP read of an absent graph: 404 (Fuseki/CSS style) or 200 with zero
+    triples (sparq serialises the absent named graph as the empty graph)."""
+    if status in (404, 410):
+        return True
+    return status == 200 and not canon(body.decode(errors="replace"))
+
+
+# --------------------------------------------------------------------------- #
+# Workload A — resource-size sweep
+# --------------------------------------------------------------------------- #
+def gate_roundtrip(engine, size):
+    """The HARD pre-timing gate: PUT -> GET -> content set-equality -> DELETE
+    -> absent. Returns (ok, detail)."""
+    graph = f"http://gsp.bench/gate/{size}"
+    payload = gen_ntriples(size, f"gate{size}")
+    sent = canon(payload)
+
+    status, _ = engine.put(graph, payload)
+    if status not in (200, 201, 204, 205):
+        return False, f"PUT HTTP {status}"
+    status, body = engine.get(graph)
+    if status != 200:
+        return False, f"GET HTTP {status}"
+    got = canon(body.decode(errors="replace"))
+    if got != sent:
+        return (
+            False,
+            f"round-trip mismatch: sent {len(sent)} triples, got {len(got)} "
+            f"({len(sent - got)} missing, {len(got - sent)} unexpected)",
+        )
+    status, _ = engine.delete(graph)
+    if status not in (200, 204, 205):
+        return False, f"DELETE HTTP {status}"
+    status, body = engine.get(graph)
+    if not absent(status, body):
+        return False, f"graph still readable after DELETE (HTTP {status})"
+    return True, f"{len(sent)} triples round-tripped byte-identically"
+
+
+def time_sweep(engine, size, iters):
+    """PUT/GET/DELETE latency over `iters` fresh graphs at `size` bytes.
+    Only called after gate_roundtrip() passed."""
+    payload = gen_ntriples(size, f"t{size}")
+    lat = {"put": [], "get": [], "delete": []}
+    for i in range(iters):
+        graph = f"http://gsp.bench/sweep/{size}/{i}"
+        for op, fn in (
+            ("put", lambda g=graph: engine.put(g, payload)),
+            ("get", lambda g=graph: engine.get(g)),
+            ("delete", lambda g=graph: engine.delete(g)),
+        ):
+            t = time.perf_counter()
+            status = fn()[0]
+            lat[op].append((time.perf_counter() - t) * 1000.0)
+            if status >= 400:
+                raise RuntimeError(f"{engine.name}: timed {op} failed HTTP {status}")
+    for v in lat.values():
+        v.sort()
+    return lat
+
+
+# --------------------------------------------------------------------------- #
+# Workload B — the PSS LDP-CRUD stream projected onto GSP verbs
+# --------------------------------------------------------------------------- #
+def doc_graph(res):
+    return f"http://pod.ex/p0/r{res}.ttl"
+
+
+def acl_graph(res):
+    return f"http://pod.ex/p0/r{res}.ttl.acl"
+
+
+CONTAINER = "http://pod.ex/p0/"
+
+
+def doc_triples(res, version):
+    r = doc_graph(res)
+    return (
+        f"<{r}> <http://www.w3.org/ns/posix/stat#size> \"{version}\" .\n"
+        f"<{r}> <https://pss.dev/ns#etag> \"e-{res}-{version}\" .\n"
+    )
+
+
+def acl_triples(res, version):
+    return f"<{doc_graph(res)}> <{ACL_PTR}> <http://pod.ex/p0/v{version}.acl> .\n"
+
+
+def containment_triple(res):
+    return f"<{CONTAINER}> <{LDP_CONTAINS}> <{doc_graph(res)}> .\n"
+
+
+def crud_stream(ops, resources=8):
+    """The pss-update-set stream shape (put / acl / put / delete cycle),
+    projected onto GSP verbs. Yields (op_kind, graph_iri, body_or_None)."""
+    out = []
+    for i in range(ops):
+        res = i % resources
+        version = i // resources + 1
+        m = i % 4
+        if m in (0, 2):
+            out.append(("put", doc_graph(res), doc_triples(res, version)))
+            out.append(("post", CONTAINER, containment_triple(res)))
+        elif m == 1:
+            out.append(("put", acl_graph(res), acl_triples(res, version)))
+        else:
+            out.append(("delete", doc_graph(res), None))
+            out.append(("delete", acl_graph(res), None))
+    return out
+
+
+def crud_reference_state(stream):
+    """Client-side reference model: the expected final canonical triple set per
+    graph after replaying `stream` (None body on delete removes the graph)."""
+    state = {}
+    for op, graph, body in stream:
+        if op == "put":
+            state[graph] = canon(body)
+        elif op == "post":
+            state[graph] = state.get(graph, frozenset()) | canon(body)
+        else:
+            state.pop(graph, None)
+    return state
+
+
+def run_crud(engine, ops, resources):
+    """Replays the stream (timed per op class), then verifies EVERY graph the
+    reference model predicts — present graphs must match exactly, deleted
+    graphs must read absent. Returns (ok, detail, lat)."""
+    stream = crud_stream(ops, resources)
+    lat = {"put": [], "post": [], "delete": []}
+    for op, graph, body in stream:
+        t = time.perf_counter()
+        if op == "put":
+            status, _ = engine.put(graph, body)
+        elif op == "post":
+            status, _ = engine.post(graph, body)
+        else:
+            status, _ = engine.delete(graph)
+        lat[op].append((time.perf_counter() - t) * 1000.0)
+        # DELETE of an already-absent graph is a legitimate 404 in the stream
+        # (a delete op can precede any put for that resource's acl graph).
+        if status >= 400 and not (op == "delete" and status == 404):
+            return False, f"{op} <{graph}> failed HTTP {status}", lat
+
+    expected = crud_reference_state(stream)
+    touched = {g for _, g, _ in stream}
+    for graph in sorted(touched):
+        status, body = engine.get(graph)
+        if graph in expected:
+            if status != 200:
+                return False, f"final GET <{graph}> HTTP {status}", lat
+            got = canon(body.decode(errors="replace"))
+            if got != expected[graph]:
+                return (
+                    False,
+                    f"final state mismatch on <{graph}>: expected "
+                    f"{len(expected[graph])} triples, got {len(got)}",
+                    lat,
+                )
+        elif not absent(status, body):
+            return False, f"deleted <{graph}> still readable (HTTP {status})", lat
+    for v in lat.values():
+        v.sort()
+    return True, f"{len(stream)} GSP ops, final state matches reference model", lat
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def pct(sorted_ms, p):
+    if not sorted_ms:
+        return float("nan")
+    idx = min(int(len(sorted_ms) * p), len(sorted_ms) - 1)
+    return sorted_ms[idx]
+
+
+def label_of(engine):
+    return f"{engine.name} (LOOSE: Solid/LDP stack)" if engine.loose else engine.name
+
+
+def print_lat_rows(prefix, label, lat):
+    for op, times in lat.items():
+        if times:
+            print(
+                f"{prefix:<18} {label:<34} {op:<7} n={len(times):<5}"
+                f" p50={pct(times, 0.5):>9.2f}ms p99={pct(times, 0.99):>9.2f}ms"
+            )
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic self-test (no HTTP, no server)
+# --------------------------------------------------------------------------- #
+def self_test():
+    failures = []
+
+    def check(name, cond):
+        if not cond:
+            failures.append(name)
+
+    # gen_ntriples: deterministic, >= target, bnode-free, canon-stable
+    a, b = gen_ntriples(1024, "x"), gen_ntriples(1024, "x")
+    check("gen deterministic", a == b)
+    check("gen size floor", len(a) >= 1024)
+    check("gen tag-distinct", gen_ntriples(1024, "y") != a)
+    check("gen bnode-free", "_:" not in a)
+    check("canon set equality", canon(a) == canon(a + "\n# comment\n\n"))
+    check("canon counts lines", len(canon(a)) == a.count("\n"))
+
+    # loopback guard: accepts loopback hosts, refuses others
+    for ok_url in (
+        "http://127.0.0.1:7033",
+        "http://localhost:3030/ds",
+        "http://[::1]:7878",
+    ):
+        check(f"loopback accept {ok_url}", assert_loopback(ok_url, "t") == ok_url)
+    for bad_url in ("http://10.0.0.5:3030", "http://example.org/ds"):
+        try:
+            assert_loopback(bad_url, "t")
+            check(f"loopback reject {bad_url}", False)
+        except SystemExit:
+            pass
+
+    # absent(): both legitimate absent-graph read shapes; a non-empty 200 is present
+    check("absent 404", absent(404, b""))
+    check("absent empty 200", absent(200, b"\n"))
+    check("present 200", not absent(200, b"<http://a> <http://b> <http://c> .\n"))
+
+    # crud reference model: cycle over 1 resource = put(v1), acl, put(v2), delete
+    stream = crud_stream(4, resources=1)
+    state = crud_reference_state(stream)
+    check("crud doc deleted", doc_graph(0) not in state)
+    check("crud acl deleted", acl_graph(0) not in state)
+    check("crud container survives", state.get(CONTAINER) == canon(containment_triple(0)))
+    # one op fewer: the delete never runs -> the doc graph holds the LAST put's
+    # triples (i=2 with resources=1 carries version i//resources+1 = 3)
+    state3 = crud_reference_state(crud_stream(3, resources=1))
+    check("crud doc present", state3.get(doc_graph(0)) == canon(doc_triples(0, 3)))
+
+    # NON-VACUOUSNESS of the round-trip gate: an in-memory fake store passes it,
+    # and a tampering variant (drops one triple on read) must FAIL it — this
+    # exercises the REAL gate_roundtrip()/run_crud() logic, no HTTP needed.
+    class _FakeStore(GspEngine):
+        def __init__(self):
+            super().__init__("fake", "http://127.0.0.1:0/gsp")
+            self.graphs = {}
+
+        def put(self, graph_iri, nt_body):
+            created = graph_iri not in self.graphs
+            self.graphs[graph_iri] = canon(nt_body)
+            return (201 if created else 204), b""
+
+        def post(self, graph_iri, nt_body):
+            self.graphs[graph_iri] = self.graphs.get(graph_iri, frozenset()) | canon(
+                nt_body
+            )
+            return 204, b""
+
+        def get(self, graph_iri):
+            if graph_iri not in self.graphs:
+                return 404, b""
+            return 200, "\n".join(sorted(self.graphs[graph_iri])).encode()
+
+        def delete(self, graph_iri):
+            if graph_iri not in self.graphs:
+                return 404, b""
+            del self.graphs[graph_iri]
+            return 204, b""
+
+    class _TamperingStore(_FakeStore):
+        def get(self, graph_iri):
+            status, body = super().get(graph_iri)
+            lines = body.decode().splitlines()
+            return status, "\n".join(lines[1:]).encode()  # drop one triple
+
+    ok, _ = gate_roundtrip(_FakeStore(), 512)
+    check("gate passes honest store", ok)
+    ok, detail = gate_roundtrip(_TamperingStore(), 512)
+    check("gate catches tampered read", not ok and "mismatch" in detail)
+    ok, detail, _ = run_crud(_FakeStore(), 8, 2)
+    check("crud gate passes honest store", ok)
+    ok, _, _ = run_crud(_TamperingStore(), 8, 2)
+    check("crud gate catches tampered read", not ok)
+
+    # URL building: graph IRI is percent-encoded into the query string
+    eng = GspEngine("t", "http://127.0.0.1:1/sparql/graph")
+    check(
+        "gsp url encodes graph",
+        eng._url("http://g/x?y=1")
+        == "http://127.0.0.1:1/sparql/graph?graph=http%3A%2F%2Fg%2Fx%3Fy%3D1",
+    )
+    css = CssEngine("css", "http://127.0.0.1:1/pod")
+    check("css url is a resource path", "/pod/gsp-bench/" in css._url("http://g/x"))
+    check("css marked loose", css.loose and not eng.loose)
+
+    if failures:
+        print(f"self-test FAILED: {failures}", file=sys.stderr)
+        return 1
+    print("self-test OK (gen/canon/loopback/absent/crud-model/url checks)")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--sparq", default="http://127.0.0.1:7033")
+    ap.add_argument("--fuseki", default=None, help="Fuseki dataset base URL")
+    ap.add_argument("--oxigraph", default=None, help="Oxigraph server base URL")
+    ap.add_argument("--css", default=None, help="CSS pod base URL (LOOSE column)")
+    ap.add_argument("--sizes", default=None, help=f"CSV bytes (default {DEFAULT_SIZES})")
+    ap.add_argument("--iters", type=int, default=None, help="timed iterations/size")
+    ap.add_argument("--crud-ops", type=int, default=None, help="CRUD stream length")
+    ap.add_argument("--crud-resources", type=int, default=8)
+    ap.add_argument("--smoke", action="store_true", help="small sizes + few iters")
+    ap.add_argument("--json-out", default=None)
+    ap.add_argument("--self-test", action="store_true", help="hermetic checks, no HTTP")
+    args = ap.parse_args()
+
+    if args.self_test:
+        sys.exit(self_test())
+
+    sizes_csv = args.sizes or (SMOKE_SIZES if args.smoke else DEFAULT_SIZES)
+    sizes = [int(s) for s in sizes_csv.split(",") if s.strip()]
+    iters = args.iters if args.iters is not None else (3 if args.smoke else 10)
+    crud_ops = args.crud_ops if args.crud_ops is not None else (24 if args.smoke else 200)
+
+    engines = []
+    if args.sparq:
+        base = assert_loopback(args.sparq, "sparq").rstrip("/")
+        engines.append(GspEngine("sparq", f"{base}/sparql/graph"))
+    if args.fuseki:
+        base = assert_loopback(args.fuseki, "fuseki").rstrip("/")
+        engines.append(GspEngine("fuseki", f"{base}/data"))
+    if args.oxigraph:
+        base = assert_loopback(args.oxigraph, "oxigraph").rstrip("/")
+        engines.append(GspEngine("oxigraph", f"{base}/store"))
+    if args.css:
+        engines.append(CssEngine("css", assert_loopback(args.css, "css")))
+    if not engines:
+        sys.exit("no engine URLs given")
+
+    print(
+        f"# GSP same-box panel — sizes={sizes} iters={iters} crud_ops={crud_ops}"
+        f" engines={[label_of(e) for e in engines]}"
+    )
+    results = {}
+    any_gate_failed = False
+    for engine in engines:
+        label = label_of(engine)
+        eres = {"loose": engine.loose, "sweep": {}, "crud": {}}
+        for size in sizes:
+            ok, detail = gate_roundtrip(engine, size)
+            print(f"gate[{size}B]        {label:<34} {'OK' if ok else 'FAIL'}: {detail}")
+            entry = {"gate": "ok" if ok else "fail", "gate_detail": detail}
+            if ok:
+                try:
+                    lat = time_sweep(engine, size, iters)
+                    print_lat_rows(f"sweep[{size}B]", label, lat)
+                    entry["latency_ms"] = {
+                        op: {"p50": round(pct(t, 0.5), 3), "p99": round(pct(t, 0.99), 3)}
+                        for op, t in lat.items()
+                    }
+                except RuntimeError as e:
+                    entry["gate"] = "fail"
+                    entry["gate_detail"] = str(e)
+                    print(f"sweep[{size}B]      {label:<34} FAIL: {e}")
+            if entry["gate"] != "ok":
+                any_gate_failed = True
+            eres["sweep"][str(size)] = entry
+
+        ok, detail, lat = run_crud(engine, crud_ops, args.crud_resources)
+        print(f"gate[crud]         {label:<34} {'OK' if ok else 'FAIL'}: {detail}")
+        eres["crud"] = {"gate": "ok" if ok else "fail", "gate_detail": detail}
+        if ok:
+            print_lat_rows("crud", label, lat)
+            eres["crud"]["latency_ms"] = {
+                op: {"p50": round(pct(t, 0.5), 3), "p99": round(pct(t, 0.99), 3)}
+                for op, t in lat.items()
+                if t
+            }
+        else:
+            any_gate_failed = True
+        results[engine.name] = eres
+
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(
+                {"sizes": sizes, "iters": iters, "crud_ops": crud_ops, "engines": results},
+                fh,
+                indent=2,
+            )
+            fh.write("\n")
+
+    if any_gate_failed:
+        sys.exit("round-trip correctness gate FAILED for at least one engine/workload")
+    print("# all round-trip gates green")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/gsp/run.sh
+++ b/bench/gsp/run.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# [FABLE-5] sq-hmd7l.21 — Graph Store Protocol same-box panel entry point.
+#
+# Stands up the REAL sparq-server on a loopback port (empty default graph, no
+# auth = writable) and drives its GSP surface through bench/gsp/compare.py:
+# PUT/GET/DELETE round-trips over a resource-size sweep + the PSS LDP-CRUD
+# stream projected onto GSP verbs. The round-trip correctness gate runs BEFORE
+# any timing (compare.py exits non-zero on any gate failure).
+#
+# Same lineage/contract as scripts/sparq-server-same-box.sh: bounded waits
+# everywhere, an EXIT trap that always stops the server, non-zero exit = the
+# panel is NOT green.
+#
+# USAGE
+#   bench/gsp/run.sh --smoke     # acceptance: sparq loopback only, small sizes,
+#                                # hermetic self-test + round-trip gate; exit 0 = green
+#   bench/gsp/run.sh             # full sweep (1 KB..10 MB); competitor columns via env
+#
+# Competitor columns (each must already be RUNNING on a loopback port; start
+# them with scripts/fuseki-same-box.sh lineage / `oxigraph serve` /
+# `npx @solid/community-server` — see bench/gsp/README.md):
+#   GSP_FUSEKI_URL     e.g. http://127.0.0.1:3030/ds     (Fuseki dataset base)
+#   GSP_OXIGRAPH_URL   e.g. http://127.0.0.1:7878        (Oxigraph server base)
+#   GSP_CSS_URL        e.g. http://127.0.0.1:3000        (CSS pod base — LOOSE column)
+#
+# TUNABLES (env; safe defaults):
+#   SPARQ_SERVER_BIN    server binary        (default target/release/sparq-server)
+#   GSP_PORT            sparq HTTP port      (default 7033)
+#   GSP_READY_TIMEOUT   readiness cap, s     (default 60)
+#   GSP_ITERS           timed iters per size (default: compare.py's per-mode default)
+#   GSP_SIZES           CSV byte sizes       (default: compare.py's per-mode default)
+#   GSP_JSON_OUT        JSON results path    (default: none; git-ignored dir suggested:
+#                                             bench/competitor-results/)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+SMOKE=0
+for arg in "$@"; do
+  case "$arg" in
+    --smoke) SMOKE=1 ;;
+    *) echo "[gsp] unknown arg: $arg (usage: bench/gsp/run.sh [--smoke])" >&2; exit 2 ;;
+  esac
+done
+
+SPARQ_SERVER_BIN="${SPARQ_SERVER_BIN:-$ROOT/target/release/sparq-server}"
+GSP_PORT="${GSP_PORT:-7033}"
+GSP_READY_TIMEOUT="${GSP_READY_TIMEOUT:-60}"
+# The server's default --max-body-bytes is 1 MiB — deliberately raised here to
+# clear the sweep's 10 MB PUT bodies (the competitor servers must be configured
+# equivalently; Fuseki/Oxigraph have no such low default cap).
+GSP_MAX_BODY_BYTES="${GSP_MAX_BODY_BYTES:-67108864}"
+
+log() { printf '[gsp] %s\n' "$*" >&2; }
+die() { printf '[gsp] ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v python3 >/dev/null 2>&1 || die "python3 required"
+if [ ! -x "$SPARQ_SERVER_BIN" ]; then
+  log "sparq-server not found at $SPARQ_SERVER_BIN"
+  die "build it first: cargo build -p sparq-server --release (or set SPARQ_SERVER_BIN)"
+fi
+
+# ---- 1. hermetic self-test of the driver (no HTTP; fails fast + loud) ------------------
+python3 "$ROOT/bench/gsp/compare.py" --self-test || die "compare.py self-test failed"
+
+# ---- 2. spawn sparq-server, empty + writable, loopback only ----------------------------
+SRV_PID=""
+SRV_LOG="$(mktemp "${TMPDIR:-/tmp}/sparq-gsp.XXXXXX.log")"
+cleanup() {
+  set +e
+  [ -n "$SRV_PID" ] && kill "$SRV_PID" >/dev/null 2>&1
+  rm -f "$SRV_LOG" >/dev/null 2>&1
+  log "teardown: stopped sparq-server (if any)"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+log "starting sparq-server on 127.0.0.1:$GSP_PORT (empty graph, GSP writable, max-body-bytes=$GSP_MAX_BODY_BYTES)"
+"$SPARQ_SERVER_BIN" --addr "127.0.0.1:${GSP_PORT}" \
+  --max-body-bytes "$GSP_MAX_BODY_BYTES" >"$SRV_LOG" 2>&1 &
+SRV_PID=$!
+
+ready=0
+poll_n=$(( GSP_READY_TIMEOUT * 2 )); [ "$poll_n" -ge 1 ] || poll_n=1
+for _ in $(seq 1 "$poll_n"); do
+  if ! kill -0 "$SRV_PID" >/dev/null 2>&1; then
+    log "sparq-server exited during startup — last log:"; tail -20 "$SRV_LOG" >&2 || true
+    die "sparq-server did not stay up"
+  fi
+  if curl -fsS --max-time 5 "http://127.0.0.1:${GSP_PORT}/health" >/dev/null 2>&1; then
+    ready=1; break
+  fi
+  sleep 0.5
+done
+[ "$ready" = 1 ] || die "server not ready within ${GSP_READY_TIMEOUT}s — aborting (no hang)"
+log "server ready at http://127.0.0.1:${GSP_PORT}"
+
+# ---- 3. drive the panel (gate-before-timing lives in compare.py) -----------------------
+ARGS=( --sparq "http://127.0.0.1:${GSP_PORT}" )
+[ "$SMOKE" = 1 ] && ARGS+=( --smoke )
+[ -n "${GSP_ITERS:-}" ] && ARGS+=( --iters "$GSP_ITERS" )
+[ -n "${GSP_SIZES:-}" ] && ARGS+=( --sizes "$GSP_SIZES" )
+[ -n "${GSP_FUSEKI_URL:-}" ] && ARGS+=( --fuseki "$GSP_FUSEKI_URL" )
+[ -n "${GSP_OXIGRAPH_URL:-}" ] && ARGS+=( --oxigraph "$GSP_OXIGRAPH_URL" )
+[ -n "${GSP_CSS_URL:-}" ] && ARGS+=( --css "$GSP_CSS_URL" )
+[ -n "${GSP_JSON_OUT:-}" ] && ARGS+=( --json-out "$GSP_JSON_OUT" )
+
+python3 "$ROOT/bench/gsp/compare.py" "${ARGS[@]}"
+log "panel green (all round-trip gates passed)"

--- a/research/gap-gsp-2026-07.md
+++ b/research/gap-gsp-2026-07.md
@@ -1,0 +1,85 @@
+<!-- [FABLE-5] sq-hmd7l.21 — per-axis gap record: Graph Store Protocol / LDP-CRUD serving.
+First-read only; work-box readings are NON-canonical by construction and are never
+transcribed here. -->
+
+# Gap record — Graph Store Protocol serving (2026-07)
+
+**Axis:** #23 in `research/comparative-benchmarking-everything.md` §5 (epic `sq-hmd7l`).
+**Status:** harness DELIVERED + smoke green (sparq loopback); competitor columns NOT-MEASURED
+(no canonical run yet — see §4).
+**Harness:** `bench/gsp/` (`run.sh` + `compare.py`), registered as `gsp-bench`.
+**Feeds:** the master table in `research/perf-dominance-gap-2026-07.md` once a canonical
+run exists.
+
+## 1. Engines and honest scope
+
+| Engine | GSP surface | Comparability |
+|---|---|---|
+| sparq-server | `/sparql/graph?graph=<iri>` (indirect) + `/graphs/{*path}` (direct); PUT→atomic `DROP SILENT; INSERT DATA`, POST→merge, DELETE→`DROP GRAPH` | subject |
+| Fuseki + TDB2 | `<dataset>/data?graph=<iri>` | like-for-like HTTP RDF store |
+| Oxigraph server | `<base>/store?graph=<iri>` | like-for-like HTTP RDF store |
+| Community Solid Server | LDP resource addressing (the resource URL IS the graph) | **LOOSE** — a Solid/LDP stack, not a pure GSP store; persistence + authz + negotiation overhead INCLUDED; labelled on every row and never averaged with the like-for-like columns (registry: `css-gsp`, kind `reference`) |
+
+Scope caveats:
+
+- **Correctness before stopwatch (INVARIANT):** per engine and per workload the driver
+  PUTs a payload, GETs it back, and requires exact triple-SET equality (payloads are
+  ground/bnode-free ASCII, so set equality is isomorphism), then DELETE + absent-read.
+  A red gate skips that engine's timing and fails the run. The gate is itself
+  regression-tested hermetically (`compare.py --self-test`: an honest fake store
+  passes, a tampering store that drops a triple on read fails).
+- **Absent-graph reads differ legitimately:** Fuseki 404s a GET of an absent named
+  graph; sparq serialises it as the empty graph (200, zero triples). The driver
+  accepts either as "absent" and this difference is a spec-latitude note, not a bug.
+- **CRUD projection:** the PSS LDP-CRUD stream (`bench/pss-update-set`) is replayed as
+  GSP verbs. `set_acl`'s conditional swap is not GSP-expressible (projected to a
+  PUT-replace of a one-triple acl graph); containment removal on delete needs PATCH,
+  so it survives in both the engine and the reference model. The N3-Patch/Solid-PATCH
+  dialects have only CSS as a peer and are out of scope for this panel.
+- **Loopback only:** the driver hard-refuses non-loopback engine URLs (no bypass).
+
+## 2. First-read findings (work box — NON-canonical, no numbers transcribed)
+
+1. **sparq's GSP round-trip is content-faithful across the full sweep.** The 1 KB → 10 MB
+   size sweep and the 350-op CRUD replay round-trip byte-identically on the smoke box
+   (triple sets equal, reference model matches final server state). This is the axis's
+   correctness baseline: the panel starts from a green gate, not from timings.
+2. **The default `--max-body-bytes` (1 MiB) rejects the sweep's larger PUT bodies with
+   413.** The harness raises it (`GSP_MAX_BODY_BYTES`, default 64 MiB). Operationally
+   honest: a stock sparq-server refuses a >1 MiB GSP PUT unless the operator raises the
+   cap; Fuseki/Oxigraph ship no comparably low default. Not a defect (it is a
+   deliberate DoS guard) but a fair-comparison configuration knob that a canonical run
+   MUST record.
+3. **Mid-stream refusal surfaces as a client transport error** (broken pipe), not an
+   HTTP status, when the body cap trips — the driver maps it to a synthetic 599 so the
+   gate fails with detail instead of a stack trace.
+
+## 3. Canonical protocol (when the gather run happens)
+
+Dedicated quiet EC2 box (tag `sparq-bench`, orphan-proof self-terminate), one engine
+active at a time, same corpus + same driver, engines pinned (Fuseki distribution
+version / Oxigraph release sha256 / `@solid/community-server` npm version recorded in
+the results JSON):
+
+```sh
+cargo build -p sparq-server --release
+# start Fuseki (scripts/fuseki-same-box.sh lineage), oxigraph serve, CSS — then:
+GSP_FUSEKI_URL=http://127.0.0.1:3030/ds GSP_OXIGRAPH_URL=http://127.0.0.1:7878 \
+GSP_CSS_URL=http://127.0.0.1:3000 \
+GSP_JSON_OUT=bench/competitor-results/gsp-$(date -u +%Y%m%dT%H%M%SZ).json \
+bash bench/gsp/run.sh
+```
+
+Results land git-ignored under `bench/competitor-results/`; nothing is committed
+(repo hygiene: no hard-coded perf numbers).
+
+## 4. Deferred / follow-ups
+
+- Canonical quiet-box gather run with the Fuseki / Oxigraph / CSS columns live, feeding
+  the `research/perf-dominance-gap-2026-07.md` master table (bead `sq-hmd7l.35`; it also
+  resolves the `css-gsp` registry entry's `unverified_pin`).
+- PATCH-dialect panel (`application/sparql-update` PATCH + the opt-in `n3-patch`
+  feature vs CSS's Solid `text/n3` PATCH — CSS is the only peer, loose by
+  construction): bead `sq-hmd7l.36`.
+- Concurrency axis: this panel is a single synchronous client (the interactive LDP
+  shape); concurrent GSP writers/readers belong to the `serve-throughput` lineage.


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5, worktree wf_4cd9e98b-d16-8) — bead **sq-hmd7l.21**, epic sq-hmd7l (comparative-benchmarking-everything). [FABLE-5]

## What

`bench/gsp/` — the Graph Store Protocol same-box panel: **PUT/GET/DELETE round-trips** over a deterministic **1 KB → 10 MB resource-size sweep** plus the **PSS LDP-CRUD stream projected onto GSP verbs**, columns sparq-server / Fuseki GSP (`<dataset>/data`) / Oxigraph server GSP (`/store`) + **Community Solid Server as a LOOSE LDP-architecture column** (labelled on every row, never averaged with the like-for-like columns).

- **Round-trip content gate BEFORE timing (the bead invariant):** per engine/workload, PUT → GET → exact triple-SET equality (payloads are ground, bnode-free, ASCII — set equality *is* isomorphism) → DELETE → absent-read; a red gate skips that engine's timing and fails the run. CRUD replay is verified against a client-side reference model replaying the same stream.
- **Non-vacuous gate:** `compare.py --self-test` (hermetic, no HTTP) proves an honest in-memory store PASSES `gate_roundtrip()`/`run_crud()` and a tampering store (drops one triple on read) FAILS them — plus gen-determinism, loopback-guard accept/reject, absent-read, CRUD-model, and URL-encoding checks.
- **Loopback-only, fail-closed:** the driver refuses any non-loopback engine URL; no bypass flag.
- Registry: `gsp-bench` stub in `bench/benchmarks.toml` filled (was `TBD — bench/gsp-bench/`; now points at `bench/gsp/`, `featured = false` kept); `fuseki`/`oxigraph` `comparable_suites` gain `gsp-bench`; `bench/CATALOG.md` care-note; first-read gap record `research/gap-gsp-2026-07.md` (NON-canonical, **no numbers transcribed** — work-box readings are never committed).

## Acceptance

`bash bench/gsp/run.sh --smoke` → **exit 0** with all round-trip gates green (verified locally; also verified the full 1 MB + 10 MB sweep sizes round-trip byte-identically — 89,812 triples at 10 MB).

## Honest findings (in the gap record)

- sparq-server's default `--max-body-bytes` (1 MiB) 413s a >1 MiB GSP PUT — the harness raises it (`GSP_MAX_BODY_BYTES`, default 64 MiB) and records this as a fair-comparison configuration knob a canonical run must log (deliberate DoS guard, not a defect).
- Absent-graph GET differs legitimately across engines (Fuseki 404 vs sparq 200-empty-graph, GSP-permitted latitude); the driver accepts either.
- CRUD projection honesty: `set_acl`'s conditional swap is not GSP-expressible (projected to PUT-replace of a one-triple acl graph); containment removal needs PATCH so it survives in both engine and reference model.

## Gates (all run to completion)

- `cargo clippy --workspace --all-targets -- -D warnings` → clean (exit 0)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` → clean (exit 0)
- `cargo test -p sparq-server --release` → all green (the surface the harness drives; **zero Rust files change in this PR** — no crate/feature added, so there are no feature states to toggle)
- `bash bench/gsp/run.sh --smoke` → exit 0 (acceptance); `compare.py --self-test` green
- `scripts/check-new-bench-registered.py` (G3) → PASS; `scripts/check-readme-template.py --enforce` → 0 deviations (no crate README touched; `bench/gsp/README.md` is outside its scope); `scripts/check-no-perf-numbers.py` → 0 findings; markdownlint (HARD config incl. `research/`) → 0 errors; typos + shellcheck → clean; `benchmarks.toml`/`competitors.json` parse-validated.

## Follow-ups (beaded)

- `sq-hmd7l.35` — canonical quiet-box gather run with Fuseki/Oxigraph/CSS columns live (also resolves the `css-gsp` registry `unverified_pin`).
- `sq-hmd7l.36` — PATCH-dialect panel (GSP `application/sparql-update` PATCH + opt-in `n3-patch` vs CSS Solid PATCH, loose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)