### PR TITLE
build(vectors): target-gate memmap2 out of wasm32 builds + DiskAnnIndex::open_from_bytes (sq-98c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,7 +607,8 @@ jobs:
        contains(needs.select.outputs.affected, '"sparq-text-wasm"') ||
        contains(needs.select.outputs.affected, '"sparq-shacl-wasm"') ||
        contains(needs.select.outputs.affected, '"sparq-introspect"') ||
-       contains(needs.select.outputs.affected, '"sparq-solid"'))
+       contains(needs.select.outputs.affected, '"sparq-solid"') ||
+       contains(needs.select.outputs.affected, '"sparq-vectors"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -795,6 +796,24 @@ jobs:
         run: cargo clippy -p sparq-solid --target wasm32-unknown-unknown --all-targets -- -D warnings
       - name: Headless wasm tests (sparq-solid materialize, wasm-pack test --node)
         run: wasm-pack test --node crates/sparq-solid
+      # [FABLE-5] sq-98c: sparq-vectors wasm-safety — memmap2 is target-gated out of wasm32
+      # builds (`[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`), so the crate must
+      # keep compiling to wasm32 with the default features and its wasm graph must stay
+      # memmap2-free (the bead's acceptance criterion, asserted below with `cargo tree`).
+      # `open_from_bytes` (`.spqv` AND `.spqg`) is the filesystem-less read path there. clippy
+      # is LIB-ONLY (no --all-targets): the dev-deps pull sparq-core's `mmap` feature, whose
+      # wasm32 lint surface is out of this lane's scope — the crate's own wasm-cfg'd code is
+      # fully covered by the lib check.
+      - name: Build sparq-vectors for the wasm32 target
+        run: cargo build -p sparq-vectors --target wasm32-unknown-unknown
+      - name: Assert memmap2 is absent from the sparq-vectors wasm32 graph
+        run: |
+          if cargo tree -p sparq-vectors --target wasm32-unknown-unknown -e normal | grep -q memmap2; then
+            echo "::error::memmap2 leaked into the sparq-vectors wasm32 dependency graph"
+            exit 1
+          fi
+      - name: clippy (wasm32 target, sparq-vectors, deny warnings)
+        run: cargo clippy -p sparq-vectors --target wasm32-unknown-unknown -- -D warnings
 
   # NOTE: sparq-py's pytest suite (incl. the new test_parity.py result-parity +
   # panic-surface tests) is run by the dedicated `python.yml` workflow ("Python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ dependencies = [
 name = "sparq-vectors"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "instant-distance",
  "memmap2",
  "oxrdf 0.3.3",

--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -90,6 +90,8 @@ wasm = [
   "sparq-shacl-wasm",
   "sparq-introspect",
   "sparq-solid",
+  # [FABLE-5] sq-98c: rlib-only wasm smoke — memmap2 target-gated out on wasm32.
+  "sparq-vectors",
 ]
 # [SONNET-4.6] sq-mel85: bench.yml `bench` job — the perf regression gate.
 # TRUE INVARIANT: every hard-gated metric measured on the PR/merge_group tier must have

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -158,7 +158,6 @@ embeddings = ["provider", "dep:reqwest"]
 sparq-core = { path = "../sparq-core", version = "0.1.0" }
 oxrdf.workspace = true
 rustc-hash.workspace = true
-memmap2.workspace = true
 # HNSW (pure Rust, minimal deps, maintained). Evaluated against hnsw_rs 0.3 (heavier
 # dependency tree: anndists/simd feature plumbing); instant-distance is the smaller,
 # cleaner fit for an in-RAM index rebuilt from the mmap'd store on open.
@@ -193,6 +192,24 @@ sparq-introspect = { path = "../sparq-introspect", version = "0.1.0", optional =
 # compile it — `sparq-vectors` stays free of any SHACL/engine dependency unless this reader is opted
 # in. sparq-shacl is itself an opt-in crate that nothing in the workspace depends on by default.
 sparq-shacl = { path = "../sparq-shacl", version = "0.1.0", optional = true }
+
+# [FABLE-5] sq-98c: memmap2 is NATIVE-ONLY — target-gated out of every wasm32 build so the
+# crate compiles to wasm without a memory-map dependency. This is a TARGET cfg rather than a
+# cargo feature ON PURPOSE: cargo features are additive (enabling one can never REMOVE a
+# dependency), and the workspace's wasm crates already prefer `cfg(target_arch = "wasm32")`
+# gating over a feature so the choice never leaks into the native build via feature
+# unification (see crates/sparq-wasm/Cargo.toml). On wasm32 the file-open read paths
+# (`VectorStore::open`, `DiskAnnIndex::open`) fall back to a buffered `std::fs::read` into
+# the same validated owned-bytes backing `open_from_bytes` uses; native is unchanged (mmap).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+memmap2.workspace = true
+
+# oxrdf pulls `rand`/getrandom (blank-node ids). On wasm there is no OS RNG, so select
+# getrandom's browser backend (crypto.getRandomValues). The matching
+# `--cfg getrandom_backend="wasm_js"` is set in the workspace .cargo/config.toml — exactly
+# as the shipped wasm bundle crates (sparq-wasm / sparq-introspect / …) do. [FABLE-5]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 # [OPUS-4.8] sq-88c6: DEV-only. The `hybrid_search` example/tests fuse this crate's ANN
 # (`VectorIndex::nearest_term`) with `sparq-sim`'s structural similarity

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -45,10 +45,10 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
 
 ## ✨ Features
 
-- **`VectorStore`** — memory-mapped `.spqv`; `get` is one binary search + a contiguous
-  `&[f32]`; corrupt files rejected up front. `StreamingWriter` builds stores bigger than
-  RAM in O(1) memory, byte-identical to the in-RAM builder. `open_from_bytes` for
-  filesystem-less use.
+- **`VectorStore`** — memory-mapped `.spqv` (native); `get` is one binary search + a contiguous
+  `&[f32]`; corrupt files rejected up front. `StreamingWriter` builds stores bigger than RAM in
+  O(1) memory, byte-identical to the in-RAM builder. **Compiles on wasm32** (sq-98c): memmap2 is
+  target-gated out; `open_from_bytes` (`.spqv` and `.spqg` alike) is the filesystem-less read path.
 - **Exact vs approximate search** — `nearest_exact` (answer-exact ground truth) and the
   persistent on-disk `DiskAnnIndex` in the default build; the in-RAM HNSW `VectorIndex`
   behind the **opt-in `approx-ann`** feature, the **only** third-party-ANN dependency

--- a/crates/sparq-vectors/src/diskann.rs
+++ b/crates/sparq-vectors/src/diskann.rs
@@ -96,8 +96,10 @@
 
 use crate::fingerprint::{self, Fingerprint, FINGERPRINT_LEN};
 use crate::quant::{DistanceTable, EncodedStore, PqConfig, ProductQuantizer};
-use crate::store::VectorStore;
-use memmap2::Mmap;
+// [FABLE-5] (sq-98c) The read backing is shared with `.spqv`: a memory map on native targets,
+// f32-aligned owned bytes on wasm32 / `open_from_bytes` (memmap2 is target-gated out of wasm
+// builds in Cargo.toml). Every record read derefs to `[u8]`, so the paths are identical.
+use crate::store::{open_backing, Bytes, VectorStore};
 use oxrdf::Term;
 use sparq_core::dict::Id;
 use sparq_core::Graph;
@@ -477,13 +479,15 @@ fn write_graph(
 
 // ───────────────────────────── on-disk search ─────────────────────────────
 
-/// A **persistent on-disk Vamana index** opened over a `.spqg` file (memory-mapped) — the
-/// out-of-core counterpart to `VectorIndex`. Built once with
+/// A **persistent on-disk Vamana index** opened over a `.spqg` file (memory-mapped on native
+/// targets) — the out-of-core counterpart to `VectorIndex`. Built once with
 /// [`build`](Self::build) / [`build_with`](Self::build_with), reopened with [`open`](Self::open)
-/// at near-zero cost (mmap + header validation, no rebuild). Search reads node records directly
-/// from the map; see the module docs for the format and the honest scope vs. full DiskANN.
+/// at near-zero cost (mmap + header validation, no rebuild) or from fetched/embedded bytes with
+/// [`open_from_bytes`](Self::open_from_bytes) (the wasm/filesystem-less path — memmap2 is
+/// target-gated out of wasm32 builds). Search reads node records directly
+/// from the backing; see the module docs for the format and the honest scope vs. full DiskANN.
 pub struct DiskAnnIndex {
-    map: Mmap,
+    map: Bytes,
     dim: usize,
     degree: usize,
     count: usize,
@@ -603,16 +607,37 @@ impl DiskAnnIndex {
     /// [OPUS-4.8] (sq-32i5) A version-2 file's graph fingerprint is read for
     /// [`check_graph`](Self::check_graph). A legacy version-1 file (32-byte header, no fingerprint)
     /// still opens — its fingerprint is `None`, so `check_graph` reports it as unverifiable.
+    ///
+    /// [FABLE-5] (sq-98c) On wasm32 (memmap2 target-gated out) this reads the whole file into
+    /// the same f32-aligned owned backing [`open_from_bytes`](Self::open_from_bytes) uses —
+    /// identical validation, no map. `wasm32-unknown-unknown` has no filesystem, so there the
+    /// read fails with a clean I/O error and `open_from_bytes` is the supported path.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<DiskAnnIndex, String> {
         let path = path.as_ref();
+        // [FABLE-5] (sq-98c) Memory map on native targets; on wasm32 (memmap2 target-gated out)
+        // `open_backing` reads the whole file into the f32-aligned owned backing instead —
+        // identical validation. `wasm32-unknown-unknown` has no filesystem, so there the read
+        // fails with a clean I/O error and [`open_from_bytes`](Self::open_from_bytes) is the
+        // supported path.
+        let map = open_backing(path)?;
+        Self::open_validated(map, &path.display().to_string())
+    }
+
+    /// Opens a `.spqg` document held entirely in memory — for environments without a
+    /// filesystem (the bytes were fetched, embedded, or decompressed by the caller), the
+    /// `.spqg` counterpart of [`VectorStore::open_from_bytes`]. Validation is identical to
+    /// [`open`](Self::open); record reads borrow the owned buffer (f32-aligned, so the vector
+    /// casts are as sound as on the page-aligned map) instead of a memory map. [FABLE-5] (sq-98c)
+    pub fn open_from_bytes(bytes: Vec<u8>) -> Result<DiskAnnIndex, String> {
+        Self::open_validated(Bytes::owned(bytes), "<bytes>")
+    }
+
+    /// Shared header/size validation behind [`open`](Self::open) and
+    /// [`open_from_bytes`](Self::open_from_bytes). [FABLE-5] (sq-98c)
+    fn open_validated(map: Bytes, origin: &str) -> Result<DiskAnnIndex, String> {
         if cfg!(target_endian = "big") {
             return Err(".spqg is a little-endian format; big-endian targets are unsupported".into());
         }
-        let file = std::fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
-        // SAFETY: read-only map of a regular file; external mutation is out of contract (same
-        // stance as `.spqv` and sparq-core's mmap'd indexes).
-        let map = unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", path.display()))?;
-        let origin = path.display().to_string();
         if map.len() < HEADER_LEN_V1 {
             return Err(format!("{origin}: truncated header"));
         }
@@ -678,7 +703,7 @@ impl DiskAnnIndex {
                         map.len()
                     ));
                 }
-                Some(Self::parse_pq_section(&map[nodes_end..], count, dim, &origin)?)
+                Some(Self::parse_pq_section(&map[nodes_end..], count, dim, origin)?)
             }
             t => return Err(format!("{origin}: unsupported encoding tag {t}")),
         };
@@ -775,9 +800,11 @@ impl DiskAnnIndex {
         let start = self.data_offset + slot as usize * self.record_len + 8;
         let bytes = &self.map[start..start + self.dim * 4];
         debug_assert_eq!(bytes.as_ptr() as usize % std::mem::align_of::<f32>(), 0);
-        // SAFETY: a memory map is page-aligned and `start` is a multiple of 4 (data_offset
-        // [32 or 56] + slot·record_len[a multiple of 4] + 8), so the pointer is f32-aligned; the
-        // range is in bounds (validated in `open`); f32 accepts any bit pattern; slice borrows map.
+        // SAFETY: the backing base is f32-aligned — a memory map is page-aligned, and the owned
+        // backing (`open_from_bytes` / wasm32) is 4-byte-aligned by construction (`AlignedBytes`,
+        // see store.rs) — and `start` is a multiple of 4 (data_offset [32 or 56] +
+        // slot·record_len[a multiple of 4] + 8), so the pointer is f32-aligned; the range is in
+        // bounds (validated in `open_validated`); f32 accepts any bit pattern; slice borrows map.
         unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, self.dim) }
     }
 

--- a/crates/sparq-vectors/src/import.rs
+++ b/crates/sparq-vectors/src/import.rs
@@ -1,5 +1,10 @@
 //! [OPUS-4.8] (sq-xsq9) Bulk import of **externally-computed** embeddings into a `.spqv`
 //! [`VectorStore`].
+// [FABLE-5] (sq-98c) The public entry points (`import_npy` / `import_numeric_dump`) are
+// `#[cfg(not(target_arch = "wasm32"))]` (they need a real filesystem), which leaves the private
+// npy-header/streaming machinery intentionally unused on wasm32 — silence dead_code there ONLY;
+// the native build keeps full dead-code detection.
+#![cfg_attr(target_arch = "wasm32", allow(dead_code))]
 //!
 //! The in-process embed path ([`crate::embed_labels`] / [`crate::embed_entities`]) runs an
 //! [`Embedder`](crate::Embedder) over the graph. This module is the *bring-your-own-embeddings*

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -82,6 +82,9 @@
 
 use crate::fingerprint::{self, Fingerprint, FINGERPRINT_LEN};
 use crate::spqv_provenance::EmbeddingProvenance;
+// [FABLE-5] (sq-98c) memmap2 is a native-only dependency (target-gated out of wasm32 builds in
+// Cargo.toml); on wasm the read paths use the owned-bytes backing below instead of a map.
+#[cfg(not(target_arch = "wasm32"))]
 use memmap2::Mmap;
 use rustc_hash::FxHashMap;
 use sparq_core::dict::Id;
@@ -112,7 +115,7 @@ const HEADER_LEN: usize = HEADER_LEN_V1 + FINGERPRINT_LEN;
 /// `&[f32]` via `from_raw_parts`, which is UNDEFINED BEHAVIOR on an unaligned pointer. Backing the
 /// owned bytes with a `Vec<u32>` (alignment 4) guarantees the base — and therefore every
 /// `HEADER_LEN + slot·dim·4` offset (all multiples of 4) — is f32-aligned. See review 1874.
-struct AlignedBytes {
+pub(crate) struct AlignedBytes {
     /// Backing storage; only `len` bytes are logically valid (the last word may be padding).
     words: Vec<u32>,
     len: usize,
@@ -142,17 +145,55 @@ impl AlignedBytes {
 /// Read-phase backing bytes: a memory map ([`VectorStore::open`]) or an owned
 /// buffer ([`VectorStore::open_from_bytes`] — environments without a
 /// filesystem). Both deref to `[u8]`; every read path is shared.
-enum Bytes {
+/// `pub(crate)` so [`crate::diskann`] shares the same backing for `.spqg` files. [FABLE-5]
+pub(crate) enum Bytes {
+    /// [FABLE-5] (sq-98c) Native-only: memmap2 is target-gated out of wasm32 builds, where
+    /// the owned-bytes backing serves every read instead.
+    #[cfg(not(target_arch = "wasm32"))]
     Map(Mmap),
     /// [OPUS-4.8] f32-aligned owned bytes (see `AlignedBytes`) so the `slot_vector` f32 cast is
     /// always aligned — a plain `Vec<u8>` is alignment 1 and would risk UB. Review 1874.
     Owned(AlignedBytes),
 }
 
+impl Bytes {
+    /// Copies `bytes` into the f32-aligned owned backing. Shared by the `open_from_bytes`
+    /// entry points here and in [`crate::diskann`]. [FABLE-5]
+    pub(crate) fn owned(bytes: Vec<u8>) -> Bytes {
+        Bytes::Owned(AlignedBytes::from_vec(bytes))
+    }
+}
+
+/// [FABLE-5] (sq-98c) Opens the read backing for a store/index file: a read-only memory map on
+/// native targets, a buffered `std::fs::read` into the f32-aligned owned backing on wasm32
+/// (memmap2 is target-gated out of wasm builds; a wasm target WITH a filesystem, e.g. WASI,
+/// reads the whole file — on `wasm32-unknown-unknown` the read fails with a clean I/O error,
+/// and [`VectorStore::open_from_bytes`] / [`DiskAnnIndex::open_from_bytes`] are the
+/// filesystem-less paths). Validation downstream is identical for both backings.
+///
+/// [`DiskAnnIndex::open_from_bytes`]: crate::diskann::DiskAnnIndex::open_from_bytes
+pub(crate) fn open_backing(path: &Path) -> Result<Bytes, String> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let file = std::fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+        // SAFETY: read-only map of a regular file; we treat concurrent external
+        // modification of the file as out of contract (same stance as sparq-core's
+        // mmap'd dictionary/indexes).
+        let map = unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", path.display()))?;
+        Ok(Bytes::Map(map))
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        Ok(Bytes::owned(bytes))
+    }
+}
+
 impl std::ops::Deref for Bytes {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
         match self {
+            #[cfg(not(target_arch = "wasm32"))]
             Bytes::Map(m) => m,
             Bytes::Owned(v) => v.as_bytes(),
         }
@@ -282,14 +323,15 @@ impl VectorStore {
     /// file (32-byte header, no fingerprint) still opens — its `fingerprint` is `None`, so
     /// `check_graph` reports it as unverifiable rather than silently passing. Rebuild such a store to
     /// enable the staleness check.
+    ///
+    /// [FABLE-5] (sq-98c) On wasm32 (memmap2 target-gated out) this reads the whole file into
+    /// the same f32-aligned owned backing [`open_from_bytes`](Self::open_from_bytes) uses —
+    /// identical validation, no map. `wasm32-unknown-unknown` has no filesystem, so there the
+    /// read fails with a clean I/O error and `open_from_bytes` is the supported path.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<VectorStore, String> {
         let path = path.as_ref();
-        let file = std::fs::File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
-        // SAFETY: read-only map of a regular file; we treat concurrent external
-        // modification of the file as out of contract (same stance as sparq-core's
-        // mmap'd dictionary/indexes).
-        let map = unsafe { Mmap::map(&file) }.map_err(|e| format!("mmap {}: {e}", path.display()))?;
-        Self::open_validated(Bytes::Map(map), path.to_path_buf(), &path.display().to_string())
+        let backing = open_backing(path)?;
+        Self::open_validated(backing, path.to_path_buf(), &path.display().to_string())
     }
 
     /// Opens a `.spqv` document held entirely in memory — for environments
@@ -300,7 +342,7 @@ impl VectorStore {
     pub fn open_from_bytes(bytes: Vec<u8>) -> Result<VectorStore, String> {
         // [OPUS-4.8] Copy into a 4-byte-aligned backing so the read-phase f32 casts are aligned
         // (a plain Vec<u8> is alignment 1 — casting its slices to &[f32] is UB). Review 1874.
-        Self::open_validated(Bytes::Owned(AlignedBytes::from_vec(bytes)), PathBuf::new(), "<bytes>")
+        Self::open_validated(Bytes::owned(bytes), PathBuf::new(), "<bytes>")
     }
 
     /// Shared header/index validation behind [`open`](Self::open) and
@@ -497,6 +539,10 @@ impl VectorStore {
             .and_then(|()| file.write_all(&index_bytes))
             .and_then(|()| file.flush())
             .map_err(|e| format!("write {}: {e}", self.path.display()))?;
+        // [FABLE-5] (sq-98c) Explicit close before the reopen below. On wasm32 the `File` stub
+        // has no `Drop` impl, which trips clippy's `drop_non_drop` there — the close is still
+        // intentional on every target that can reach this path (native + WASI).
+        #[allow(clippy::drop_non_drop)]
         drop(file);
 
         let reopened = VectorStore::open(&self.path)?;
@@ -1294,6 +1340,9 @@ impl StreamingWriter {
                 .and_then(|()| file.write_all(&count.to_le_bytes()))
                 .and_then(|()| file.sync_all())
                 .map_err(|e| format!("write {}: {e}", path.display()))?;
+            // [FABLE-5] (sq-98c) See `finalize`: intentional close-before-reopen; on wasm32 the
+            // `File` stub has no `Drop` impl and clippy's `drop_non_drop` fires there.
+            #[allow(clippy::drop_non_drop)]
             drop(file);
             std::fs::remove_file(&ids_path).ok();
             VectorStore::open(&path)

--- a/crates/sparq-vectors/tests/diskann.rs
+++ b/crates/sparq-vectors/tests/diskann.rs
@@ -499,3 +499,80 @@ fn open_rejects_corrupt_and_wrong_magic() {
     assert!(DiskAnnIndex::open(&path).is_err());
     let _ = std::fs::remove_file(&path);
 }
+
+// [FABLE-5] (sq-98c) `open_from_bytes` — the filesystem-less / wasm read path (memmap2 is
+// target-gated out of wasm32 builds; on wasm the graph arrives as fetched/embedded bytes).
+// The owned backing must be RESULT-IDENTICAL to the memory map: same neighbours, same scores,
+// same metadata. This also exercises the f32-alignment `debug_assert` in `node_vector` over
+// the owned (`AlignedBytes`) backing — a plain `Vec<u8>` base would trip it.
+#[test]
+fn open_from_bytes_returns_identical_neighbours_to_mmap_open() {
+    const DIM: usize = 8;
+    let store_path = tmp("diskann-bytes.spqv");
+    let graph_path = tmp("diskann-bytes.spqg");
+    let mut store = VectorStore::create(&store_path, DIM).unwrap();
+    let mut state = 11_u64;
+    for id in 1..=60_u32 {
+        let v = rand_vec(&mut state, DIM);
+        store.put(id, &v).unwrap();
+    }
+    store.finalize().unwrap();
+    let cfg = VamanaConfig { degree: 8, build_beam: 16, search_beam: 24, ..Default::default() };
+    let mapped = DiskAnnIndex::build_with(&store, &graph_path, cfg).unwrap();
+
+    let bytes = std::fs::read(&graph_path).unwrap();
+    let owned = DiskAnnIndex::open_from_bytes(bytes).unwrap();
+    assert_eq!(owned.len(), mapped.len());
+    assert_eq!(owned.dim(), mapped.dim());
+    assert_eq!(owned.fingerprint(), mapped.fingerprint());
+    assert!(!owned.has_pq_cache());
+    // NOTE: `build_with` seeds `search_beam` from the config while `open`/`open_from_bytes`
+    // use the default; compare two opened handles so the traversals are identical.
+    let reopened = DiskAnnIndex::open(&graph_path).unwrap();
+    let mut state = 99_u64;
+    for _ in 0..10 {
+        let q = rand_vec(&mut state, DIM);
+        assert_eq!(owned.nearest(&q, 5), reopened.nearest(&q, 5));
+    }
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+// [FABLE-5] (sq-98c) The PQ candidate cache (trailing `.spqg` section) must also parse + serve
+// identically from owned bytes — the section offsets are relative, not map-page-dependent.
+#[test]
+fn open_from_bytes_serves_the_pq_index_identically() {
+    const DIM: usize = 8;
+    let store_path = tmp("diskann-bytes-pq.spqv");
+    let graph_path = tmp("diskann-bytes-pq.spqg");
+    let mut store = VectorStore::create(&store_path, DIM).unwrap();
+    let mut state = 13_u64;
+    for id in 1..=60_u32 {
+        let v = rand_vec(&mut state, DIM);
+        store.put(id, &v).unwrap();
+    }
+    store.finalize().unwrap();
+    let cfg = VamanaConfig { degree: 8, build_beam: 16, search_beam: 24, ..Default::default() };
+    // M (subspaces) must divide into the small test dimension; the default M=16 needs dim ≥ 16.
+    let pq_cfg = PqConfig { m: 4, ..Default::default() };
+    DiskAnnIndex::build_with_pq(&store, &graph_path, cfg, pq_cfg).unwrap();
+
+    let reopened = DiskAnnIndex::open(&graph_path).unwrap();
+    let owned = DiskAnnIndex::open_from_bytes(std::fs::read(&graph_path).unwrap()).unwrap();
+    assert!(owned.has_pq_cache(), "the PQ section must survive the owned-bytes open");
+    let mut state = 101_u64;
+    for _ in 0..10 {
+        let q = rand_vec(&mut state, DIM);
+        assert_eq!(owned.nearest(&q, 5), reopened.nearest(&q, 5));
+    }
+    let _ = std::fs::remove_file(&store_path);
+    let _ = std::fs::remove_file(&graph_path);
+}
+
+// [FABLE-5] (sq-98c) Validation is identical to `open`: bad magic / truncation reject up front.
+#[test]
+fn open_from_bytes_rejects_corrupt_and_wrong_magic() {
+    assert!(DiskAnnIndex::open_from_bytes(b"NOPExxxxxxxxxxxxxxxxxxxxxxxxxxxxxx".to_vec()).is_err());
+    assert!(DiskAnnIndex::open_from_bytes(b"SPQG".to_vec()).is_err());
+    assert!(DiskAnnIndex::open_from_bytes(Vec::new()).is_err());
+}

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -145,6 +145,9 @@ _LANE_SEEDS: dict[str, list[str]] = {
         "sparq-shacl-wasm",
         "sparq-introspect",
         "sparq-solid",
+        # [FABLE-5] sq-98c: not a bundle crate — the wasm job build+clippy-gates that
+        # sparq-vectors keeps compiling on wasm32 with memmap2 target-gated out.
+        "sparq-vectors",
     ],
     # [SONNET-4.6] sq-mel85: perf-gate bench closure (see the `bench` bullet above).
     "bench": [

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -168,6 +168,7 @@ DiskAnnIndex::build(&VectorStore, path) / ::build_with(&store, path, VamanaConfi
 DiskAnnIndex::build_for(&store, path, &Graph) / ::build_with_for(&store, path, cfg, &Graph)  // embeds the graph fingerprint
 DiskAnnIndex::build_with_pq(&store, path, cfg, PqConfig) -> Result<..>          // [OPUS-4.8] sq-qamd: + a PQ candidate cache (search on codes, re-rank off mmap); persisted as a trailing .spqg section (encoding tag 1)
 DiskAnnIndex::open(path) -> Result<DiskAnnIndex, String>                        // mmap + header check, NO rebuild (reloads any PQ section)
+DiskAnnIndex::open_from_bytes(bytes: Vec<u8>) -> Result<DiskAnnIndex, String>   // [FABLE-5] sq-98c: filesystem-less/wasm — identical validation, result-identical search
 impl DiskAnnIndex { fn nearest(&self, &[f32], k) -> Vec<(Id, f32)>; fn nearest_term(..) -> Vec<(Term, f32)>; fn len()/dim();
                     fn has_pq_cache() -> bool;                                  // [OPUS-4.8] sq-qamd: PQ-guided search when true
                     fn fingerprint() -> Option<Fingerprint>; fn check_graph(&store, &Graph) -> Result<(), String>;
@@ -423,7 +424,19 @@ let store = w.finalize()?;                                   // a normal, valida
 
 let bytes = std::fs::read("/tmp/big.spqv").unwrap();         // or fetched/embedded
 let store2 = VectorStore::open_from_bytes(bytes)?;           // identical validation, no filesystem
+let idx = sparq_vectors::DiskAnnIndex::open_from_bytes(std::fs::read("/tmp/big.spqg").unwrap())?; // .spqg counterpart
 ```
+
+**wasm32 (sq-98c):** the crate **compiles to wasm** with the default features — `memmap2` is
+**target-gated out** of every wasm32 build (a `[target.'cfg(not(target_arch = "wasm32"))']`
+dependency, NOT a cargo feature: features are additive, so a feature could never *remove* the
+dependency, and a target cfg can't leak into the native build via feature unification). On wasm
+`VectorStore::open` / `DiskAnnIndex::open` fall back to a buffered `std::fs::read` into the same
+f32-aligned owned backing (works on wasm targets WITH a filesystem, e.g. WASI; on browser
+`wasm32-unknown-unknown` the read fails with a clean I/O error) — `open_from_bytes` is the
+supported browser path for both file kinds. The CI `wasm` lane build+clippy-gates this and
+asserts the wasm graph stays memmap2-free. `import_*` still need `std::fs` and are compiled off
+the wasm target.
 
 ### 7. Bulk-import embeddings computed ELSEWHERE (NumPy `.npy` / flat dump)
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implemented by Claude Fable 5 (bead `sq-98c`).

## What

`sparq-vectors` now **compiles to `wasm32` with a memmap2-free dependency graph** (the bead's acceptance criterion), verified by a new CI leg. Native behaviour is unchanged (mmap, same errors, same formats).

- **`Cargo.toml`** — `memmap2` moves to `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`; a wasm32 target dep on `getrandom` (`wasm_js`) makes the transitive `oxrdf → rand → getrandom` chain compile, exactly as the shipped wasm crates do (paired with the `--cfg getrandom_backend="wasm_js"` already in `.cargo/config.toml`).
- **`store.rs`** — the read backing (`Bytes`) gates its `Map(Mmap)` variant off wasm32; `VectorStore::open` falls back to a buffered `std::fs::read` into the same f32-aligned owned backing `open_from_bytes` uses (identical validation). On browser `wasm32-unknown-unknown` (no filesystem) the read fails with a clean I/O error — `open_from_bytes` is the supported path there; on wasm targets **with** a filesystem (WASI) `open` works.
- **`diskann.rs`** — `DiskAnnIndex` shares that backing, and gains **`DiskAnnIndex::open_from_bytes`** — the `.spqg` counterpart of `VectorStore::open_from_bytes`, so the wasm surface is actually usable for ANN, not just the exact scan.
- **`import.rs`** — wasm32-only `allow(dead_code)` for the private `.npy` machinery whose fs-based public entry points were already compiled off wasm (native dead-code detection untouched).
- **CI (`ci.yml` wasm lane)** — builds `sparq-vectors` for wasm32, **asserts the wasm graph is memmap2-free** (`cargo tree -e normal | grep`), and lib-clippys it `-D warnings`. Lane seeds updated in `scripts/ci_select.py` + `ci/path-ownership.toml` (pinned by `test_ci_select_wiring.py`, green).
- **Docs** — crate README (stays exactly at the 120-line cap, `readme-template --enforce` 0 deviations) + `skills/vector-search/SKILL.md` (new API + a wasm32 section).

## Why a target cfg and not a literal `wasm` cargo feature

The bead's TODO wording said "a `wasm` cargo feature gating memmap2 out". Cargo features are **additive** — enabling a feature can never *remove* a dependency — so that mechanism cannot exist as written. The workspace already prefers exactly this target-cfg idiom for the same dependency class (see `crates/sparq-wasm/Cargo.toml`: "no feature needed (which avoids leaking that choice to the native build via feature unification)"), and `import.rs` in this crate already used `cfg(not(target_arch = "wasm32"))`. Documented on the bead (proceed-and-document); the acceptance criteria ("wasm target compiles without memmap2, feature resolves correctly in workspace") are met: wasm32 resolution drops memmap2, native resolution is byte-identical (`Cargo.lock` gains only the `getrandom` edge, already in the workspace lock).

## Tests

- `open_from_bytes_returns_identical_neighbours_to_mmap_open` — **result-equivalence** of the owned-bytes backing vs the memory map (plain index): same neighbours/scores/metadata. Non-vacuous for alignment too: it drives `node_vector`'s f32-alignment `debug_assert` over the owned (`AlignedBytes`) backing.
- `open_from_bytes_serves_the_pq_index_identically` — the trailing PQ candidate-cache section parses + serves identically from owned bytes.
- `open_from_bytes_rejects_corrupt_and_wrong_magic` — validation parity with `open`.

## Gates run (all green)

- `cargo clippy --workspace --all-targets -- -D warnings` (default state)
- `cargo clippy -p sparq-vectors --all-targets --all-features -- -D warnings` (feature-ON state)
- `cargo test -p sparq-vectors` (default) and `cargo test -p sparq-vectors --all-features`
- `cargo build -p sparq-vectors --target wasm32-unknown-unknown` + `cargo clippy -p sparq-vectors --target wasm32-unknown-unknown -- -D warnings` + `cargo tree … --target wasm32-unknown-unknown -e normal` shows **no memmap2**
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `python3 scripts/check-readme-template.py --enforce` → 0 deviations; `pytest scripts/tests/test_ci_select_wiring.py` → 33 passed; typos (markdown surface) clean; privacy-claims clean

## Honest boundaries

- This PR gates **compile-shape only**: the CI leg proves the wasm32 build + graph, not runtime behaviour in a wasm executor. A `wasm-pack test --node` runtime smoke is beaded as **sq-139hh** (needs a bytes-fixture strategy — the store writers are fs-based).
- The wasm32 clippy leg is lib-only: `--all-targets` would compile the dev-deps' `sparq-core mmap` feature for wasm32, whose lint surface is out of this crate's scope.
- Discovered while grounding: `sparq-introspect`'s wasm32 `sparq-core default-features = false` override is ineffective (cargo feature-union keeps rayon in its wasm graph, contradicting its comment) — beaded as **sq-lxkr1**.

Follow-up beads: `sq-139hh`, `sq-lxkr1`.
