### PR TITLE
bench(n3): cwm + jen3 competitor columns with a closure-count gate in the EYE comparison harness (sq-hmd7l.11)

### DIFF
--- a/bench/competitors.json
+++ b/bench/competitors.json
@@ -576,7 +576,7 @@
       "pinned_version": "cwm (pin the exact version/git commit at gather time; `cwm --version` or `python2 cwm.py --version`)",
       "version_source": "`cwm --version` or the git commit of the checked-out source, recorded in the gather results file",
       "install_recipe": "download from https://www.w3.org/2000/10/swap/cwm.py (or the cwm git mirror). Requires Python 2 or the community Python 3 fork. gather-only — NOT a committed dependency.",
-      "run_recipe": "cwm bench/inference/socrates.n3 --think for the socrates closure; cwm gen_deeptaxonomy.n3 --think for the DeepTaxonomy closure. Cross-check closure triple count before timing.",
+      "run_recipe": "CWM=<path>/cwm bench/inference/eye-comparison.sh (the cwm column; graceful 'absent' skip without the tool). The harness runs `cwm <file> --think --data` (closure serialized with rules stripped) and closure-gates the count BEFORE timing; socrates+dt1k only by default (CWM_HEAVY=1 / CWM_DT100K=1 for the larger cells) — cwm is the honest SLOW column.",
       "comparable_suites": [
         {
           "sparq_suite": "inference-eye-comparison",
@@ -591,24 +591,22 @@
     },
     {
       "id": "jen3",
-      "name": "jen3 (N3 reasoner, JavaScript)",
-      "kind": "js-lib",
-      "role": "[SONNET-4.6 sq-hmd7l.1] jen3 is a JavaScript N3 reasoner (npm). The JS-ecosystem N3 counterpart to EYE and cwm, run via Node.js. MIT -> numbers are publishable. Part of the N3-reasoners comparison row in sq-hmd7l.11.",
-      "pinned_version": "jen3 (pin the exact npm version at gather time)",
-      "version_source": "the resolved npm version in the gather box's node_modules, recorded in the results file",
-      "install_recipe": "`npm install jen3` at gather time. gather-only — NOT a committed dependency.",
-      "run_recipe": "scripts/bench-adapters/n3_reasoner_adapter.mjs with ENGINE=jen3; reasons over the same N3 corpora as EYE. Cross-check closure triple count before timing.",
+      "name": "jen3 (N3 reasoner, Java — Apache Jena fork with Notation3 support)",
+      "kind": "binary",
+      "role": "[FABLE-5 sq-hmd7l.11, correcting the sq-hmd7l.1 stub] jen3 (github.com/william-vw/jen3) is a JAVA fork of Apache Jena adding Notation3 parsing + forward-chaining N3 inference — NOT an npm/JavaScript library (the original stub mis-registered it; corrected against the real GitHub release + a verified local run). Executed via `java -jar jen3.jar`. Apache-2.0 (Jena lineage) -> numbers are publishable. The fourth column of the N3-reasoners comparison (sq-hmd7l.11).",
+      "pinned_version": "jen3 v0.0.1 (github.com/william-vw/jen3 release asset jen3.jar, sha256 e886af61cbbd84c2cdd8231e4313759949e418fea75ed185a5723d3f6f7f27c6)",
+      "version_source": "the GitHub release tag + the sha256 of the downloaded jen3.jar, recorded in the gather results file",
+      "install_recipe": "download jen3.jar from https://github.com/william-vw/jen3/releases (v0.0.1); needs a JRE (verified on OpenJDK 21). gather-only — NOT a committed dependency.",
+      "run_recipe": "JEN3_JAR=<path>/jen3.jar bench/inference/eye-comparison.sh (the jen3 column; graceful 'absent' skip without the jar). CLI verified: `java -jar jen3.jar -n3 <file> -conclusion` serializes the full closure, `-inferences` only the derived (rule-free) triples — the harness closure-gates on the latter BEFORE timing.",
       "comparable_suites": [
         {
           "sparq_suite": "inference-eye-comparison",
-          "note": "N3 forward closure on the same corpora as EYE and cwm — jen3 is the fourth column; cross-check closure triple count vs sparq-cli reason n3 before trusting timing"
+          "note": "N3 forward closure on the same corpora as EYE and cwm — jen3 is the fourth column; the harness asserts the closure triple count against the deterministic expected size before trusting any timing"
         }
       ],
-      "version_env_metadata": "gather records the resolved jen3 npm version, node --version, and the host env block",
+      "version_env_metadata": "gather records the jen3 release tag + jar sha256, java -version, and the host env block",
       "quiet_box_sensitive": true,
-      "dashboard_engine_id": "jen3",
-      "unverified_pin": true,
-      "honesty_caveat": "npm version is unverified and TBD; to be pinned to a real npm version at the first gather run."
+      "dashboard_engine_id": "jen3"
     },
     {
       "id": "vlog",

--- a/bench/inference/README.md
+++ b/bench/inference/README.md
@@ -1,5 +1,24 @@
 # Inference benchmarks
 
+## N3 competitor columns — `eye-comparison.sh` (EYE / cwm / jen3)
+
+`bench/inference/eye-comparison.sh` compares sparq's N3 forward closure against
+**EYE** (the pinned reference — required; the run fails early without it) and two
+optional columns added by sq-hmd7l.11: **cwm** (W3C SWAP, Python — the honest
+*slow* column) and **jen3** (`java -jar jen3.jar`, a Java/Apache-Jena fork with N3
+support — *not* an npm library). An absent optional tool prints `absent` in its
+column and the run stays green (graceful skip). Knobs: `CWM=`, `JEN3_JAR=`,
+`JAVA=`, plus heavy-cell opt-ins `CWM_HEAVY=1` and `EYE_DT100K=1` /
+`JEN3_DT100K=1` / `CWM_DT100K=1`.
+
+**Correctness gate before timing** (mirrors `bench/deep-taxonomy/run.sh`): each
+workload's sparq closure count is asserted against its deterministic structural
+expected size, and each present competitor's closure is cross-checked against the
+same count *before* its cell is timed — counting is done by sparq's N3 parser
+over a rule-free document (asserted; re-derivation over rules could mask an
+under-deriving competitor). A mismatch fails the run loudly. See
+`research/gap-n3-2026-07.md` for the method + fidelity caveats.
+
 ## DeepTaxonomy (DT) — the rule-heavy stress test
 `gen_deeptaxonomy.py N` → 1 instance fact + an N-deep subClassOf chain + a transitivity rule.
 The instance must be re-typed up the whole chain; NAIVE forward chaining re-derives the entire

--- a/bench/inference/eye-comparison.md
+++ b/bench/inference/eye-comparison.md
@@ -1,5 +1,19 @@
 # sparq-reason vs EYE — N3 inference benchmark (2026-06, updated fixpoint-opt)
 
+> **Update (sq-hmd7l.11, 2026-07)** [FABLE-5]: the runner grew two optional
+> competitor columns — **cwm** (W3C SWAP, Python; `cwm <f> --think --data`) and
+> **jen3** (`java -jar jen3.jar -n3 <f> -conclusion`; a Java/Apache-Jena fork
+> with N3 support, GitHub release v0.0.1 — *not* an npm library). Absent tool ⇒
+> the column prints `absent` and the run stays green; EYE remains the pinned,
+> required reference. Before any competitor cell is timed, its closure count is
+> now cross-checked in-run against the deterministic expected sizes below
+> (sparq's own count is asserted too, mirroring `bench/deep-taxonomy`); jen3 is
+> gated via its rule-free `-inferences` output (ground + derived = closure),
+> cwm via its rule-stripped `--data` closure. cwm defaults to the small cells
+> only (`CWM_HEAVY=1` opts into the rest) — it is the honest *slow* column.
+> No numbers in this file were re-measured; the tables below remain the 2026-06
+> EYE-only record. Method + caveats: `research/gap-n3-2026-07.md`.
+
 **Machine:** Apple M1 (fanless), macOS 25.4.0, same machine for both engines.
 **Engines:** sparq `target/release/sparq-cli reason <f> n3 n3 /dev/null`
 (parse → forward closure → serialize full closure to /dev/null) vs

--- a/bench/inference/eye-comparison.sh
+++ b/bench/inference/eye-comparison.sh
@@ -1,13 +1,35 @@
 #!/usr/bin/env bash
-# sparq-reason (N3 engine) vs EYE — same machine, same workloads, wall
-# seconds (sparq min-of-3; EYE min-of-3 on the quick cells, single run on the
-# minutes-long ones, dt100k skipped — see the loop). Both engines parse the
-# document, run the forward closure, and SERIALIZE the full closure (sparq:
-# `reason <f> n3 n3 /dev/null`; EYE: `--pass > /dev/null`), so the comparison
-# covers the whole pipeline.
+# sparq-reason (N3 engine) vs EYE / cwm / jen3 — same machine, same workloads, wall
+# seconds (sparq min-of-3; competitors min-of-3 on the quick cells, single run on the
+# minutes-long ones — see the loop). Every engine parses the document, runs the
+# forward closure, and SERIALIZES the closure (sparq: `reason <f> n3 n3 /dev/null`;
+# EYE: `--pass > /dev/null`; cwm: `--think --data > /dev/null`; jen3:
+# `-conclusion > /dev/null`), so the comparison covers the whole pipeline.
 #
 #   EYE=$HOME/.local/bin/eye SPARQ_CLI=target/release/sparq-cli \
 #     bench/inference/eye-comparison.sh
+#
+# Columns (sq-hmd7l.11) [FABLE-5]:
+#   EYE is the PINNED REFERENCE competitor — required (the run fails early and
+#   loudly without it). cwm and jen3 are OPTIONAL columns: an absent tool prints
+#   'absent' in its column and the run stays green (graceful skip).
+#     CWM=cwm                                   cwm executable (W3C SWAP, Python)
+#     JEN3_JAR=$HOME/.local/opt/jen3/jen3.jar   jen3 jar (william-vw/jen3 — a Java/
+#                                               Apache-Jena fork with N3 support; NOT an npm lib)
+#     JAVA=java                                 JVM used to run the jen3 jar
+#     CWM_HEAVY=1     also run cwm on dt10k/anc500/grid30 (cwm is the honest SLOW
+#                     column — literature places it at minutes on DT-1000 already,
+#                     so the bigger cells are minutes-to-hours: opt-in only)
+#     EYE_DT100K=1 / JEN3_DT100K=1 / CWM_DT100K=1   run dt100k (hours+ — never by default)
+#
+# CORRECTNESS GATE (self-asserting, before timing) [FABLE-5] (sq-hmd7l.11):
+# mirroring bench/deep-taxonomy/run.sh, every workload's sparq closure count is
+# asserted against its DETERMINISTIC structural expected size, and every present
+# competitor's closure is cross-checked against that same expected count BEFORE its
+# cell is timed — a wrong closure fails the run loudly (timing a wrong closure is
+# worse than no number). Counting is done by sparq's own N3 parser over a RULE-FREE
+# document (asserted: with `=>` rules present, sparq's re-derivation could MASK an
+# under-deriving competitor, so the counter refuses rule-carrying input).
 #
 # Workloads (generated here, scalable):
 #   socrates   — vendored EYE case (startup/latency floor)
@@ -27,9 +49,28 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 CLI="${SPARQ_CLI:-target/release/sparq-cli}"
 EYE="${EYE:-eye}"
+CWM="${CWM:-cwm}"
+JEN3_JAR="${JEN3_JAR:-$HOME/.local/opt/jen3/jen3.jar}"
+JAVA="${JAVA:-java}"
 JSON_OUT="${SPARQ_INFER_JSON:-}"
 JSON_ROWS=""   # accumulated `{ ... }` row objects, comma-joined at the end
 B="$(mktemp -d)"; trap 'rm -rf "$B"' EXIT
+
+# EYE is the pinned reference — fail early and clearly rather than mid-table.
+if ! command -v "$EYE" >/dev/null 2>&1; then
+  echo "ERROR: EYE not found ('$EYE') — EYE is the pinned reference column;" \
+       "install eyereasoner/eye (install.sh) or set EYE=/path/to/eye" >&2
+  exit 1
+fi
+# cwm / jen3 are optional: absent => the whole column reports 'absent' (graceful skip).
+HAVE_CWM=0
+if command -v "$CWM" >/dev/null 2>&1; then HAVE_CWM=1; else
+  echo "note: cwm not found ('$CWM') — cwm column reports 'absent' (set CWM=/path/to/cwm)" >&2
+fi
+HAVE_JEN3=0
+if command -v "$JAVA" >/dev/null 2>&1 && [ -f "$JEN3_JAR" ]; then HAVE_JEN3=1; else
+  echo "note: jen3 not found (JAVA='$JAVA', JEN3_JAR='$JEN3_JAR') — jen3 column reports 'absent'" >&2
+fi
 
 cp crates/sparq-reason/tests/eye/socrates.n3 "$B/socrates.n3"
 python3 bench/inference/gen_deeptaxonomy.py 1000   > "$B/dt1k.n3"
@@ -49,6 +90,26 @@ for i in range(N):
         if j + 1 < N: print(f':n{i}_{j} :edge :n{i}_{j+1} .')
 EOF
 
+# ---- deterministic structural corpus constants (bench/deep-taxonomy expected.tsv
+# analogue — these are corpus SHAPES, not performance numbers) [FABLE-5] ------------
+# ground facts:  socrates 2 (vendored);  dtN = N+1 (1 instance + N `:sc` links);
+#                anc500 = 500 chain links;  grid30 = 2·30·29 = 1,740 edges.
+# closure:       socrates 3 (+1 derived);  dtN = 2N+1 (instance typed up the chain);
+#                anc500 = 501·500/2 = 125,250 (all ordered chain pairs);
+#                grid30 = 1,740 edges + 215,325 reach = 217,065.
+ground_facts() {
+  case "$1" in
+    socrates) echo 2;; dt1k) echo 1001;; dt10k) echo 10001;; dt100k) echo 100001;;
+    anc500) echo 500;; grid30) echo 1740;;
+  esac
+}
+expected_closure() {
+  case "$1" in
+    socrates) echo 3;; dt1k) echo 2001;; dt10k) echo 20001;; dt100k) echo 200001;;
+    anc500) echo 125250;; grid30) echo 217065;;
+  esac
+}
+
 mon() { # min-of-N wall seconds: mon <runs> <cmd…>
   local runs="$1"; shift
   local best=""
@@ -63,37 +124,130 @@ mon() { # min-of-N wall seconds: mon <runs> <cmd…>
   echo "$best"
 }
 
-# [OPUS-4.8] (sq-k5qq) Append one JSON row to the accumulator. Args: workload, sparq_s,
-# eye_s ("skipped" emits a null + "skipped": true). Workload names are static idents, so a
-# JSON-safe quote is enough; numeric seconds are emitted as bare JSON numbers.
-add_json_row() {
-  [ -n "$JSON_OUT" ] || return 0
-  local w="$1" sparq="$2" eye="$3" eye_field
-  if [ "$eye" = skipped ]; then
-    eye_field='"eye_seconds": null, "eye_skipped": true'
-  else
-    eye_field="\"eye_seconds\": $eye, \"eye_skipped\": false"
+# Ground-triple count of a RULE-FREE N3 document, counted by sparq's own N3 parser:
+# with no `=>` rules present the N3 closure IS the document, so the self-reported
+# closure count is a pure parse+dedup count. Rule-freedom is ASSERTED first — over a
+# rule-carrying document sparq would RE-DERIVE the closure and mask an under-deriving
+# competitor, so the counter fails closed instead. [FABLE-5] (sq-hmd7l.11)
+n3_ground_count() {
+  if grep -q '=>' "$1"; then
+    echo "ERROR: $1 contains N3 rules ('=>') — refusing to count (re-derivation would mask a bad closure)" >&2
+    return 1
   fi
-  local row="{ \"workload\": \"$w\", \"sparq_seconds\": $sparq, $eye_field }"
+  "$CLI" reason "$1" n3 n3 2>/dev/null | grep -oE '^[0-9]+' | head -1
+}
+
+gate() { # gate <engine> <workload> <got> <want> — the self-asserting closure gate
+  if [ "$3" != "$4" ]; then
+    echo "ERROR: $1 closure cross-check FAILED on $2: got ${3:-nothing}, expected $4 — refusing to time a wrong closure" >&2
+    exit 1
+  fi
+}
+
+runs_for() { # min-of-3 on the quick cells, single run on the minutes-long ones
+  case "$1" in dt10k|dt100k|anc500|grid30) echo 1;; *) echo 3;; esac
+}
+
+# Default competitor cell sets — conservative, heavy cells opt-in:
+#  * EYE  runs everything but dt100k (≈9 h at its observed ≈N^1.95 DT scaling; EYE_DT100K=1).
+#  * jen3 runs everything but dt100k (unmeasured at that depth; JEN3_DT100K=1) —
+#    its smaller cells were verified tractable on a dev box before defaulting them in.
+#  * cwm  runs only socrates + dt1k (the honest SLOW column — literature places cwm
+#    at minutes on DT-1000 already); CWM_HEAVY=1 adds dt10k/anc500/grid30 and
+#    CWM_DT100K=1 the hours+ dt100k cell.
+eye_cell_on()  { [ "$1" != dt100k ] || [ -n "${EYE_DT100K:-}" ]; }
+jen3_cell_on() { [ "$1" != dt100k ] || [ -n "${JEN3_DT100K:-}" ]; }
+cwm_cell_on() {
+  case "$1" in
+    socrates|dt1k) return 0;;
+    dt100k) [ -n "${CWM_DT100K:-}" ];;
+    *) [ -n "${CWM_HEAVY:-}" ];;
+  esac
+}
+
+# [OPUS-4.8] (sq-k5qq) / [FABLE-5] (sq-hmd7l.11) One JSON fragment per engine column:
+# `json_col <name> <value>` where value is numeric seconds, 'skipped' (cell gated off)
+# or 'absent' (tool not installed). Workload/engine names are static idents, so a
+# JSON-safe quote is enough; numeric seconds are emitted as bare JSON numbers. The
+# eye field names are unchanged from the original sq-k5qq shape; cwm/jen3 fields are
+# strictly additive.
+json_col() {
+  case "$2" in
+    absent)  echo "\"$1_seconds\": null, \"$1_skipped\": true, \"$1_absent\": true";;
+    skipped) echo "\"$1_seconds\": null, \"$1_skipped\": true";;
+    *)       echo "\"$1_seconds\": $2, \"$1_skipped\": false";;
+  esac
+}
+add_json_row() { # add_json_row <workload> <sparq_s> <eye> <cwm> <jen3>
+  [ -n "$JSON_OUT" ] || return 0
+  local row
+  row="{ \"workload\": \"$1\", \"sparq_seconds\": $2, $(json_col eye "$3"), $(json_col cwm "$4"), $(json_col jen3 "$5") }"
   if [ -z "$JSON_ROWS" ]; then JSON_ROWS="$row"; else JSON_ROWS="$JSON_ROWS,$row"; fi
 }
 
-printf '%-10s %12s %12s\n' workload sparq eye
+cell() { # print one right-aligned table cell; numeric seconds get an 's' suffix
+  case "$1" in absent|skipped) printf ' %12s' "$1";; *) printf ' %11ss' "$1";; esac
+}
+
+printf '%-10s %12s %12s %12s %12s\n' workload sparq eye cwm jen3
 for w in socrates dt1k dt10k dt100k anc500 grid30; do
+  exp=$(expected_closure "$w")
+
+  # ---- sparq: self-assert the closure size (deep-taxonomy analogue), then time ----
+  ref=$("$CLI" reason "$B/$w.n3" n3 n3 2>/dev/null | grep -oE '^[0-9]+' | head -1)
+  gate sparq "$w" "$ref" "$exp"
   s=$(mon 3 "$CLI" reason "$B/$w.n3" n3 n3 /dev/null)
-  printf '%-10s %11ss ' "$w" "$s"
-  # EYE on dt100k is ≈9 h at its observed ≈N^1.95 DT scaling — never run it by
-  # default (set EYE_DT100K=1 if you truly mean it). dt10k/anc500/grid30 are
-  # minutes per EYE run: single run, documented as such in eye-comparison.md.
-  if [ "$w" = dt100k ] && [ -z "${EYE_DT100K:-}" ]; then
-    printf '%12s\n' 'skipped'
-    add_json_row "$w" "$s" skipped
-    continue
+  printf '%-10s' "$w"; cell "$s"
+
+  # ---- EYE (pinned reference; timing-only — its closure agreement is the pinned
+  # cross-check recorded in eye-comparison.md, and its cells are unchanged here) ----
+  if eye_cell_on "$w"; then
+    e=$(mon "$(runs_for "$w")" "$EYE" --quiet --nope "$B/$w.n3" --pass)
+  else
+    e=skipped
   fi
-  eruns=3; case "$w" in dt10k|dt100k|anc500|grid30) eruns=1;; esac
-  e=$(mon "$eruns" "$EYE" --quiet --nope "$B/$w.n3" --pass)
-  printf '%11ss\n' "$e"
-  add_json_row "$w" "$s" "$e"
+  cell "$e"
+
+  # ---- cwm: closure gate BEFORE timing (--data strips rules => countable) ---------
+  if [ "$HAVE_CWM" = 0 ]; then
+    c=absent
+  elif ! cwm_cell_on "$w"; then
+    c=skipped
+  else
+    if ! "$CWM" "$B/$w.n3" --think --data > "$B/$w.cwm.n3" 2>"$B/$w.cwm.err"; then
+      echo "ERROR: cwm failed on $w:" >&2; sed -n '1,5p' "$B/$w.cwm.err" >&2; exit 1
+    fi
+    got=$(n3_ground_count "$B/$w.cwm.n3")
+    gate cwm "$w" "$got" "$exp"
+    c=$(mon "$(runs_for "$w")" "$CWM" "$B/$w.n3" --think --data)
+  fi
+  cell "$c"
+
+  # ---- jen3: closure gate BEFORE timing. `-inferences` emits ONLY the derived
+  # (rule-free) triples, so the gate is ground(input) + derived == expected closure —
+  # sound because every workload's derived set is disjoint from its input facts.
+  # Timing then serializes the FULL closure (`-conclusion`), the same pipeline shape
+  # as EYE --pass / cwm --think --data. ---------------------------------------------
+  if [ "$HAVE_JEN3" = 0 ]; then
+    j=absent
+  elif ! jen3_cell_on "$w"; then
+    j=skipped
+  else
+    if ! "$JAVA" -jar "$JEN3_JAR" -n3 "$B/$w.n3" -inferences > "$B/$w.jen3.n3" 2>"$B/$w.jen3.err"; then
+      echo "ERROR: jen3 failed on $w:" >&2; sed -n '1,5p' "$B/$w.jen3.err" >&2; exit 1
+    fi
+    derived=$(n3_ground_count "$B/$w.jen3.n3")
+    if [ -z "$derived" ]; then
+      echo "ERROR: could not count jen3's derived triples on $w (unparseable output?)" >&2
+      exit 1
+    fi
+    gate jen3 "$w" "$(( $(ground_facts "$w") + derived ))" "$exp"
+    j=$(mon "$(runs_for "$w")" "$JAVA" -jar "$JEN3_JAR" -n3 "$B/$w.n3" -conclusion)
+  fi
+  cell "$j"
+
+  printf '\n'
+  add_json_row "$w" "$s" "$e" "$c" "$j"
 done
 
 # [OPUS-4.8] (sq-k5qq) Strictly-additive JSON emit: write the accumulated rows only when
@@ -101,7 +255,7 @@ done
 if [ -n "$JSON_OUT" ]; then
   {
     printf '{\n'
-    printf '  "harness": "sparq-reason vs EYE (eye-comparison)",\n'
+    printf '  "harness": "sparq-reason vs EYE/cwm/jen3 (eye-comparison)",\n'
     printf '  "note": "every wall-second figure is best-effort, MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files",\n'
     printf '  "rows": [ %s ]\n' "$JSON_ROWS"
     printf '}\n'

--- a/research/gap-n3-2026-07.md
+++ b/research/gap-n3-2026-07.md
@@ -1,0 +1,72 @@
+# N3 forward-closure competitor comparison — gap analysis
+
+> 🤖 SPARQ agent. [FABLE-5] sq-hmd7l.11. **FIRST-READ / NON-CANONICAL.** This record
+> documents the *method and the fidelity caveats* of the same-box N3-reasoner
+> comparison (`bench/inference/eye-comparison.sh`). It deliberately contains **no
+> hard-coded performance numbers** (repo hygiene: work-box timings are
+> non-canonical and live only in PR bodies / bead comments, never in committed
+> markdown). The committed 2026-06 EYE tables in `bench/inference/eye-comparison.md`
+> are the maintainer's pinned same-box record; citable multi-engine numbers come
+> from a dedicated quiet-box gather, never from a work box.
+
+## Axis
+
+The N3 (Notation3 rules) axis of the comparative-benchmarking epic (sq-hmd7l).
+Before this slice the axis had ONE competitor column: EYE — registered, compared,
+and pinned (`eye-comparison.md`, v11.24.4 on SWI-Prolog). The remaining breadth was
+the other two runnable N3 reasoners: **cwm** and **jen3**. Both are now columns of
+the same harness, over the same corpora, behind the same correctness gate.
+
+## Columns + verification state
+
+| column | what it is | invocation (verified?) | default cells |
+|---|---|---|---|
+| **sparq** | `sparq-cli reason <f> n3 n3 /dev/null` | reference | all |
+| **EYE** | SWI-Prolog N3 reasoner — the **pinned reference**, required (run fails early without it) | `eye --quiet --nope <f> --pass` (pinned 2026-06) | all but dt100k (`EYE_DT100K=1`) |
+| **jen3** | **Java** fork of Apache Jena with N3 support (github.com/william-vw/jen3) — the registry stub had mis-registered it as an npm JS lib; corrected | **VERIFIED** against release v0.0.1 (`jen3.jar`, sha256 in `bench/competitors.json`): `java -jar jen3.jar -n3 <f> -conclusion` (full closure), `-inferences` (derived only, rule-free) | all but dt100k (`JEN3_DT100K=1`); smaller cells verified tractable on a dev box first |
+| **cwm** | W3C SWAP reference N3 reasoner (Python) | **UNVERIFIED on this box** — cwm is not pip-installable under that name and is Python-2 legacy; the documented `cwm <f> --think --data` recipe is from cwm's own CLI docs and stays flagged `unverified_pin` in the registry until the first real gather | socrates + dt1k (`CWM_HEAVY=1`, `CWM_DT100K=1`) — the honest SLOW column |
+
+Absent tool ⇒ the column prints `absent` and the run exits 0 (graceful skip), so
+the harness stays green on boxes that only have EYE.
+
+## The load-bearing invariant: closure-count agreement BEFORE timing
+
+No competitor cell is timed until its closure size equals the deterministic
+structural expected size (the `bench/deep-taxonomy/expected.tsv` idea, inlined):
+socrates 3; dtN = 2N+1; anc500 = 501·500/2 = 125,250; grid30 = 217,065. sparq's own
+count is asserted against the same table every run, so a sparq-reason regression
+also fails the harness loudly rather than skewing the baseline.
+
+**Counting soundness caveat:** counts are produced by sparq's own N3 parser, which
+only yields a pure parse+dedup count over a **rule-free** document — over a
+rule-carrying document sparq would *re-derive* the closure and MASK an
+under-deriving competitor. The counter therefore asserts rule-freedom (`=>`
+absent) and fails closed. That is why jen3 is gated on its `-inferences` output
+(derived-only, rule-free; ground + derived = closure — sound here because every
+workload's derived set is disjoint from its input facts) and cwm on its
+rule-stripped `--data` closure, while jen3's *timed* command is `-conclusion`
+(full-closure serialization, the same pipeline shape as EYE `--pass`).
+
+## Fidelity caveats (honest boundary)
+
+- **Pipeline shape is aligned, not identical:** every column parses, closes, and
+  serializes; but EYE serializes rules+facts (`--pass`), cwm strips rules
+  (`--data`), jen3 `-conclusion` includes rules. Rule serialization is O(1) per
+  workload — negligible next to the closure — but it is a (documented) asymmetry.
+- **JVM/interpreter floors differ:** jen3 pays a JVM boot per run, EYE a saved-state
+  Prolog boot, cwm a Python interpreter start; the socrates cell exists precisely
+  to expose those floors.
+- **cwm's column is expected to be slow** (the RR-2023 literature places it minutes
+  on DT-1000); its default cells are deliberately small so the harness stays
+  runnable — enlarging them is an explicit opt-in, not a default cost.
+- **Work-box timings are NON-canonical.** The harness's ratio-reporting is
+  contention-robust (same-session, min-of-N), but citable numbers need the
+  dedicated quiet-box gather.
+
+## Gaps / follow-ups
+
+- cwm has no verified install on a modern (Python 3) box; the first gather must
+  pin a real cwm version/commit (or a vetted Python-3 fork) and flip the
+  registry's `unverified_pin`. Captured as a bead (see the sq-hmd7l epic).
+- First canonical multi-engine gather (quiet box, heavy knobs on) is part of the
+  epic's canonical wave, not this slice.


### PR DESCRIPTION
> 🤖 SPARQ agent — sq-hmd7l.11 (epic sq-hmd7l, comparative-benchmarking-everything). [FABLE-5]

## What

Extends the N3 comparison harness `bench/inference/eye-comparison.sh` with the two remaining runnable N3-reasoner competitor columns, **cwm** and **jen3**, per sq-hmd7l.11:

- **EYE stays the pinned, required reference** (the run now fails *early and clearly* if EYE is missing, instead of dying mid-table on a 127).
- **cwm / jen3 are optional columns**: an absent tool prints `absent` in its column and the run stays green (**graceful skip** — the bead's acceptance).
- **Closure-count cross-check BEFORE timing** (the deep-taxonomy self-asserting-gate pattern, inlined): every workload's sparq closure count is asserted against its deterministic structural expected size, and every present competitor's closure must match it before its cell is timed. Counting is done by sparq's own N3 parser over a **rule-free** document — rule-freedom is asserted (`=>` refused), because over a rule-carrying document sparq would re-derive the closure and *mask an under-deriving competitor*. jen3 is gated via its rule-free `-inferences` output (ground + derived = closure; the derived sets are disjoint from the input facts on all six workloads), cwm via its rule-stripped `--think --data` closure.
- Ratio-reporting shape preserved (same-session, min-of-N, contention-robust); the sq-k5qq `SPARQ_INFER_JSON` emit gains strictly-additive `cwm_*`/`jen3_*` fields (existing `sparq_seconds`/`eye_*` field names unchanged; no consumers of the old shape exist in-repo).
- Default cell sets are honest about cost: cwm (the deliberately-included SLOW column) defaults to socrates+dt1k (`CWM_HEAVY=1`/`CWM_DT100K=1` opt-ins); jen3 matches EYE's set (all but dt100k, `JEN3_DT100K=1`) — its smaller cells were verified tractable on this box before defaulting them in.

## Verified against the real tools (not just the skip path)

- **jen3**: the registry stub (sq-hmd7l.1) had mis-registered jen3 as an npm/JavaScript library. It is actually a **Java fork of Apache Jena** (github.com/william-vw/jen3). I downloaded the real release v0.0.1 `jen3.jar`, verified the actual CLI from its source (`-n3 <file> -conclusion` / `-inferences`), and ran the column end-to-end: closure gates pass on all five default cells (socrates/dt1k/dt10k/anc500/grid30 — e.g. dt1k: 1,000 derived + 1,001 ground = 2,001 ✓). `bench/competitors.json`'s jen3 entry is corrected accordingly (kind, install/run recipe, pinned release + jar sha256) — a deliberate, surgical edit outside the bead's FILES list, flagged here; the cwm entry keeps its `unverified_pin` honesty caveat and only its run_recipe now points at the real harness (the old recipe referenced a nonexistent adapter and a nonexistent socrates path).
- **cwm**: NOT verified on this box — it is not pip-installable under that name (the bead's "pip-installable" premise didn't hold) and is Python-2 legacy. The column ships with the documented cwm CLI (`--think --data`), graceful skip, and the closure gate will fail closed (never silently mis-time) if the invocation is wrong when a real cwm shows up. Follow-up bead filed for the first verified cwm gather.
- **EYE**: installed from the official repo (v11.24.4 on SWI-Prolog 9.0.4 — the same version pinned in `eye-comparison.md`) to run the acceptance.

## Acceptance (both runs exit 0 on this box)

1. `bash bench/inference/eye-comparison.sh` with jen3 present + cwm absent — full default cells, all closure gates green, cwm column `absent`.
2. Same with cwm AND jen3 both absent (`CWM=/nonexistent JEN3_JAR=/nonexistent`) — the bead's literal acceptance: graceful skip, exit 0.

Wall-second figures from these runs are work-box NON-canonical and are deliberately **not** committed anywhere (the JSON emit's own `note` says the same).

## Files

- `bench/inference/eye-comparison.sh` — the two columns + the self-asserting closure gate (shellcheck-clean)
- `bench/inference/README.md`, `bench/inference/eye-comparison.md` — column + gate documentation (no new numbers; the 2026-06 EYE tables are untouched)
- `research/gap-n3-2026-07.md` — NEW first-read gap record (method + fidelity caveats, flagged NON-canonical, zero hard-coded numbers)
- `bench/competitors.json` — jen3 entry corrected to ground truth + both N3 run_recipes pointed at the real harness

## Gates

- `bash bench/inference/eye-comparison.sh` — exit 0 in both configurations above (the bead's acceptance)
- shellcheck clean; `typos` clean; `scripts/check-readme-template.py --enforce` → 0 deviations (README 45 lines, ≤120 cap)
- `cargo clippy --workspace --all-targets -- -D warnings` — green; `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — green; `cargo test -p sparq-reason` — green. **No Rust code is touched by this PR** (bench scripts + docs + registry JSON only), so there is no new cargo feature and no feature-ON/OFF state to gate; the harness's counting oracle (`sparq-cli reason … n3`) is exercised for real by the acceptance runs.

Not touched (per the bead): `scripts/bench/materialize-same-box.sh` (owned by the materialization bead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
