### PR TITLE
feat(shacl): extend validate_strict to parser-dependent + remaining syntax rules (sq-ehq4g) [FABLE-5]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -102,18 +102,18 @@ and call `validate_with_model`. CLI: `cargo run -p sparq-shacl --example validat
 
 ## Scope and non-goals
 
-`validate_strict` returns `Err(ShaclFailure)` for an unsound SHACL-SPARQL pre-binding
-(`MINUS`/`VALUES`/`SERVICE` / a sub-`SELECT` dropping `$this` / a `BIND` re-binding it,
-sq-0mjfd) and for **ill-formed shapes-graph constructs** — the W3C-suite `sht:Failure`
-outcome (an unparsable `sh:path`, a non-integer `sh:minCount`, a malformed SHACL list…;
-construct-local syntax checks, not a full SHACL-of-SHACL pass, sq-11a). `validate` skips
-both leniently. Out of scope: `$shapesGraph` — see `bd list -l area:sparq-shacl`.
-Validation results are **not deduplicated** across
-traversal routes (a nested shape reached through two parents reports twice, matching
-the suite), re-entrant recursion on the same focus/shape pair counts as conforming, and
-an **uncompilable `sh:pattern`** (e.g. a `(?!…)` lookahead) is **skipped** into
-`report.diagnostics`, never fail-closed onto every value (the Rust-vs-XPath regex
-dialect boundary — not an ill-formedness failure).
+`validate_strict` returns `Err(ShaclFailure)` for an unsound SHACL-SPARQL pre-binding (`MINUS`/
+`VALUES`/`SERVICE` / a sub-`SELECT` dropping `$this` / a `BIND` re-binding it, sq-0mjfd) and for
+**ill-formed shapes-graph constructs** — the W3C-suite `sht:Failure` outcome: an unparsable
+`sh:path` or pathless property shape, a non-integer `sh:minCount`, a malformed SHACL list, a
+non-node-kind `sh:nodeKind`, `sh:qualifiedValueShape` without either count, or a PRESENT
+`sh:select`/`sh:sparqlExpr` that does not parse — **fail-closed relative to this engine's SPARQL
+parser** (a valid query beyond its coverage is also rejected strictly). Construct-local checks,
+not a full SHACL-of-SHACL pass (sq-11a, sq-ehq4g); `validate` skips all leniently. Out of scope:
+`$shapesGraph` — see `bd list -l area:sparq-shacl`. Results are **not deduplicated** across
+traversal routes (a nested shape via two parents reports twice, matching the suite), re-entrant
+recursion counts as conforming, and an **uncompilable `sh:pattern`** is **skipped** into
+`report.diagnostics` (the Rust-vs-XPath regex boundary, sq-lz99x — never fail-closed).
 
 ## License
 

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -929,6 +929,18 @@ impl ShapesModel {
                 "a property shape must have exactly one sh:path value".to_string(),
             );
         }
+        // [FABLE-5] (sq-ehq4g) A node explicitly typed `sh:PropertyShape` with NO
+        // `sh:path` is ill-formed (the syntax rules give a property shape exactly
+        // one). Recorded, then parsed as the same degenerate no-path shape as
+        // before. The untyped `sh:property [ … ]` spelling is checked at its use
+        // site (the `sh:property` loop), which this type guard keeps single-shot.
+        if path_objects.is_empty() && g.has_type(node, &sh("PropertyShape")) {
+            self.record_ill_formed(
+                node,
+                "path",
+                "a property shape must have exactly one sh:path value".to_string(),
+            );
+        }
         let path = path_objects
             .into_iter()
             .next()
@@ -1077,6 +1089,21 @@ impl ShapesModel {
             // [FABLE-5] (sq-11a) Recorded when ill-formed; built as before.
             self.check_iri_or_iri_list(g, node, "nodeKind", &o);
             let kinds = iri_set(g, &o);
+            // [FABLE-5] (sq-ehq4g) Each kind must be one of the SIX sh:* node
+            // kinds (SHACL §4.6.1); recorded when not, then built as before (an
+            // unknown kind matches no value node at eval, unchanged).
+            for kind in &kinds {
+                if !is_node_kind_iri(kind) {
+                    self.record_ill_formed(
+                        node,
+                        "nodeKind",
+                        format!(
+                            "the value of sh:nodeKind must be one of the six sh:* node kinds, got <{}>",
+                            kind
+                        ),
+                    );
+                }
+            }
             if !kinds.is_empty() {
                 c.push(Component::NodeKind(kinds));
             }
@@ -1420,6 +1447,22 @@ impl ShapesModel {
         }
         for o in g.objects(node, &sh("property")) {
             self.check_shape_ref(node, "property", &o);
+            // [FABLE-5] (sq-ehq4g) The value of sh:property must be a PROPERTY
+            // shape, i.e. carry an sh:path (syntax rules; a pathless child would
+            // silently validate nothing). A literal value is already recorded
+            // above; an explicitly-typed `sh:PropertyShape` records once in its
+            // own parse instead. The degenerate child is still interned as before.
+            if !matches!(o, Term::Literal(_))
+                && !g.has_type(&o, &sh("PropertyShape"))
+                && g.objects(&o, &sh("path")).is_empty()
+            {
+                self.record_ill_formed(
+                    &o,
+                    "path",
+                    "a property shape (the value of sh:property) must have exactly one sh:path value"
+                        .to_string(),
+                );
+            }
             let id = self.shape_id(g, &o);
             shape.components.push(Component::Property(id));
             shape.property_children.push(id);
@@ -1456,7 +1499,25 @@ impl ShapesModel {
                 }
             }
         }
-        for o in g.objects(node, &sh("qualifiedValueShape")) {
+        // [FABLE-5] (sq-ehq4g) `sh:qualifiedValueShape` with NEITHER
+        // `sh:qualifiedMinCount` nor `sh:qualifiedMaxCount` is ill-formed: both
+        // qualified-cardinality constraint components (SHACL §4.7.5–6) then miss a
+        // mandatory parameter, and a shape with values for SOME but not all
+        // mandatory parameters of a component is ill-formed (SHACL §2.3.2).
+        // Recorded once per shape node; the inert component is built as before.
+        let qualified_shapes = g.objects(node, &sh("qualifiedValueShape"));
+        if !qualified_shapes.is_empty()
+            && g.object(node, &sh("qualifiedMinCount")).is_none()
+            && g.object(node, &sh("qualifiedMaxCount")).is_none()
+        {
+            self.record_ill_formed(
+                node,
+                "qualifiedValueShape",
+                "a shape with sh:qualifiedValueShape must also have sh:qualifiedMinCount or sh:qualifiedMaxCount"
+                    .to_string(),
+            );
+        }
+        for o in qualified_shapes {
             self.check_shape_ref(node, "qualifiedValueShape", &o);
             let id = self.shape_id(g, &o);
             let num = |p: &str| -> Option<u64> {
@@ -1510,8 +1571,8 @@ impl ShapesModel {
                 // [FABLE-5] (sq-11a) No `sh:select` string literal on the
                 // constraint node (SHACL-SPARQL §5.2.1 requires exactly one):
                 // recorded, then skipped exactly as before. (A PRESENT but
-                // unparsable/non-SELECT query stays a lenient skip — that outcome
-                // depends on this engine's SPARQL parser, not on the shapes graph.)
+                // unparsable/non-SELECT query is recorded inside
+                // `parse_sparql_constraint` instead — sq-ehq4g.)
                 self.record_ill_formed(
                     &sp,
                     "select",
@@ -1578,8 +1639,10 @@ impl ShapesModel {
     /// `sh:prefixes`) into [`Self::select_exprs`], returning its index. `None` when
     /// `node` carries neither (so the caller falls back to the literal/term reading
     /// — e.g. a plain `sh:targetNode` IRI), or when the derived query is ill-formed
-    /// (dropped leniently, like an ill-formed `sh:sparql`). `sh:select` takes
-    /// precedence over `sh:sparqlExpr` when both are present.
+    /// (dropped leniently, like an ill-formed `sh:sparql` — [FABLE-5] (sq-ehq4g)
+    /// but ALSO recorded for the strict channel, fail-closed relative to this
+    /// engine's SPARQL parser). `sh:select` takes precedence over `sh:sparqlExpr`
+    /// when both are present.
     fn intern_select_expr(&mut self, g: &GraphView, node: &Term) -> Option<usize> {
         // Only blank-node / IRI node-expression resources carry these predicates; a
         // literal `sh:targetNode` is a target node, never an expression.
@@ -1589,11 +1652,29 @@ impl ShapesModel {
         let prefixes = collect_prefixes_from(g, &g.objects(node, &sh("prefixes")));
         let prepared = match g.object(node, &sh("select")) {
             Some(Term::Literal(l)) => {
-                crate::sparql::PreparedSelectExpr::build_select(&prefixes, l.value())
+                let built = crate::sparql::PreparedSelectExpr::build_select(&prefixes, l.value());
+                if built.is_none() {
+                    self.record_ill_formed(
+                        node,
+                        "select",
+                        "the sh:select of a SPARQL-based node expression must parse as a SPARQL SELECT query"
+                            .to_string(),
+                    );
+                }
+                built
             }
             _ => match g.object(node, &sh("sparqlExpr")) {
                 Some(Term::Literal(l)) => {
-                    crate::sparql::PreparedSelectExpr::build_expr(&prefixes, l.value())
+                    let built = crate::sparql::PreparedSelectExpr::build_expr(&prefixes, l.value());
+                    if built.is_none() {
+                        self.record_ill_formed(
+                            node,
+                            "sparqlExpr",
+                            "the sh:sparqlExpr of a SPARQL-based node expression must parse as a SPARQL expression"
+                                .to_string(),
+                        );
+                    }
+                    built
                 }
                 _ => return None, // not a SPARQL node expression — caller's fallback
             },
@@ -1652,7 +1733,23 @@ impl ShapesModel {
         // (surfaced by `validate_strict`) and the constraint is then dropped
         // (`prepared = None`), so the lenient `validate` simply skips it.
         constraint.prepared = match crate::sparql::PreparedSparql::build(&constraint) {
-            Ok(prepared) => prepared,
+            Ok(prepared) => {
+                // [FABLE-5] (sq-ehq4g) A PRESENT `sh:select` whose (post-`$PATH`-
+                // substitution) text does not parse as a SPARQL SELECT query is
+                // ill-formed (SHACL-SPARQL §5.2.1): recorded for the strict
+                // channel, then skipped exactly as before (`prepared: None`).
+                // FAIL-CLOSED boundary: "does not parse" is relative to THIS
+                // engine's vendored SPARQL parser (see the crate README).
+                if prepared.is_none() {
+                    self.record_ill_formed(
+                        node,
+                        "select",
+                        "the sh:select query of an sh:sparql constraint must parse as a SPARQL SELECT query"
+                            .to_string(),
+                    );
+                }
+                prepared
+            }
             Err(violation) => {
                 self.pre_binding_failures.push(PreBindingFailure {
                     node: node.clone(),
@@ -1800,6 +1897,24 @@ fn is_integer_lexical(s: &str) -> bool {
 /// [FABLE-5] (sq-11a) True iff `s` is a valid `xsd:boolean` lexical form.
 fn is_boolean_lexical(s: &str) -> bool {
     matches!(s, "true" | "false" | "0" | "1")
+}
+
+/// [FABLE-5] (sq-ehq4g) True iff `iri` is one of the SIX `sh:nodeKind` values
+/// (SHACL §4.6.1): `sh:BlankNode` / `sh:IRI` / `sh:Literal` and the three
+/// pairwise unions. Anything else — including another `sh:`-namespace IRI — is
+/// an ill-formed `sh:nodeKind` value.
+fn is_node_kind_iri(iri: &str) -> bool {
+    iri.strip_prefix(SH).is_some_and(|local| {
+        matches!(
+            local,
+            "BlankNode"
+                | "IRI"
+                | "Literal"
+                | "BlankNodeOrIRI"
+                | "BlankNodeOrLiteral"
+                | "IRIOrLiteral"
+        )
+    })
 }
 
 fn iri_set(g: &GraphView, o: &Term) -> Vec<String> {

--- a/crates/sparq-shacl/tests/ill_formed_strict.rs
+++ b/crates/sparq-shacl/tests/ill_formed_strict.rs
@@ -376,6 +376,96 @@ fn sparql_constraint_without_select_fails() {
     );
 }
 
+// ---- parser-dependent rejections (sq-ehq4g): a PRESENT query that does not
+// ---- parse. Fail-closed relative to THIS engine's SPARQL parser (README).
+
+#[test]
+fn unparsable_sparql_constraint_select_fails() {
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:sparql [ sh:select "SELECT ??? garbage {" ] ."#,
+        "select",
+    );
+}
+
+#[test]
+fn non_select_sparql_constraint_query_fails() {
+    // A parsable but non-SELECT query (ASK) — sh:select requires a SELECT.
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:sparql [ sh:select "ASK { ?s ?p ?o }" ] ."#,
+        "select",
+    );
+}
+
+#[test]
+fn unparsable_target_node_select_expression_fails() {
+    // A SHACL-1.2 SPARQL-based node-expression target whose query is unparsable.
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode [ sh:select "not sparql at all" ] ."#,
+        "select",
+    );
+}
+
+#[test]
+fn unparsable_values_sparql_expr_fails() {
+    // A SHACL-1.2 `sh:values [ sh:sparqlExpr … ]` whose expression is unparsable.
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:property [ sh:path ex:p ; sh:values [ sh:sparqlExpr "((" ] ] ."#,
+        "sparqlExpr",
+    );
+}
+
+// ---- remaining non-construct-local syntax rules (sq-ehq4g) ----
+
+#[test]
+fn property_shape_missing_path_fails() {
+    // The value of sh:property must be a property shape, i.e. carry an sh:path.
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:property [ sh:minCount 1 ] ."#,
+        "path",
+    );
+}
+
+#[test]
+fn typed_property_shape_missing_path_fails() {
+    // An explicitly-typed sh:PropertyShape root with no sh:path.
+    assert_ill_formed(r#"ex:P a sh:PropertyShape ; sh:targetNode ex:n ."#, "path");
+}
+
+#[test]
+fn qualified_value_shape_without_counts_fails() {
+    // sh:qualifiedValueShape with NEITHER sh:qualifiedMinCount nor
+    // sh:qualifiedMaxCount: both qualified-cardinality components are missing a
+    // mandatory parameter (SHACL §4.7.5–6 partial-parameter ill-formedness).
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:property [ sh:path ex:p ;
+               sh:qualifiedValueShape [ sh:nodeKind sh:IRI ] ] ."#,
+        "qualifiedValueShape",
+    );
+}
+
+#[test]
+fn unknown_node_kind_fails() {
+    // Not one of the six sh:* node kinds (SHACL §4.6.1).
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ; sh:nodeKind ex:SomeKind ."#,
+        "nodeKind",
+    );
+}
+
+#[test]
+fn unknown_node_kind_in_list_fails() {
+    // sh:Iri (wrong case) is in the sh: namespace but is NOT a node kind.
+    assert_ill_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ; sh:nodeKind ( sh:IRI sh:Iri ) ."#,
+        "nodeKind",
+    );
+}
+
 // ---- well-formed edge cases must NOT be flagged (false-positive guard) ----
 
 #[test]
@@ -434,6 +524,51 @@ fn sequence_path_is_not_ill_formed() {
 }
 
 #[test]
+fn well_formed_sparql_queries_are_not_flagged() {
+    // (sq-ehq4g) Parsable SELECT queries in all three parser-dependent sites:
+    // an sh:sparql constraint, a node-expression target and sh:values.
+    assert_well_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:sparql [ sh:select "SELECT $this ?value WHERE { $this <http://example.org/p> ?value }" ] .
+           ex:T2 a sh:NodeShape ;
+             sh:targetNode [ sh:select "SELECT ?n WHERE { ?n a <http://example.org/T> }" ] ;
+             sh:property [ sh:path ex:p ;
+               sh:values [ sh:sparqlExpr "STRLEN(STR($this))" ] ] ."#,
+    );
+}
+
+#[test]
+fn node_shape_without_path_is_not_flagged() {
+    // (sq-ehq4g) Only sh:property values / typed sh:PropertyShapes need a path;
+    // node shapes referenced via sh:node / sh:targetWhere never do.
+    assert_well_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ; sh:node ex:Other ;
+             sh:targetWhere [ sh:nodeKind sh:IRI ] .
+           ex:Other a sh:NodeShape ; sh:nodeKind sh:IRI ."#,
+    );
+}
+
+#[test]
+fn qualified_value_shape_with_one_count_is_not_flagged() {
+    // (sq-ehq4g) Either count parameter alone is well-formed.
+    assert_well_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:property [ sh:path ex:p ;
+               sh:qualifiedValueShape [ sh:nodeKind sh:IRI ] ;
+               sh:qualifiedMaxCount 3 ] ."#,
+    );
+}
+
+#[test]
+fn all_six_node_kinds_are_not_flagged() {
+    assert_well_formed(
+        r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+             sh:nodeKind ( sh:BlankNode sh:IRI sh:Literal sh:BlankNodeOrIRI
+                           sh:BlankNodeOrLiteral sh:IRIOrLiteral ) ."#,
+    );
+}
+
+#[test]
 fn plain_rdfs_class_root_is_not_flagged() {
     // A shapes graph that also carries vocabulary triples (a plain rdfs:Class
     // with no SHACL constructs) must not produce failures.
@@ -478,6 +613,17 @@ fn shacl_failure_display_mentions_ill_formed() {
         text
     );
     assert!(text.contains("closed"), "display names the predicate: {}", text);
+}
+
+#[test]
+fn lenient_validate_still_skips_unparsable_sparql_select() {
+    // (sq-ehq4g) The parser-dependent rejection keeps the lenient invariant:
+    // the SAME unparsable sh:select is a strict failure and a lenient skip.
+    let shapes = r#"ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+                      sh:sparql [ sh:select "SELECT ??? garbage {" ] ."#;
+    assert!(run_strict(shapes).is_err());
+    let report = run_lenient(shapes);
+    assert!(report.conforms, "lenient skip unchanged: {}", report.to_text());
 }
 
 #[test]

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -90,7 +90,15 @@ pub fn validate_with_model(data: &Graph, model: &ShapesModel) -> ValidationRepor
 // languageIn/ignoredProperties), a literal shape ref (sh:node/not/property/…), a
 // non-boolean sh:closed/uniqueLang/…, a non-literal range comparand, an ill-formed
 // comparand path (sh:equals/lessThan/…), a non-IRI sh:target{Class,SubjectsOf,
-// ObjectsOf}, an sh:sparql node with no sh:select literal. Construct-local checks,
+// ObjectsOf}, an sh:sparql node with no sh:select literal. (sq-ehq4g) adds: a
+// PROPERTY shape with NO sh:path (an sh:property value, or a node typed
+// sh:PropertyShape), sh:qualifiedValueShape with NEITHER sh:qualifiedMinCount nor
+// sh:qualifiedMaxCount (both qualified components then miss a mandatory parameter),
+// an sh:nodeKind value outside the SIX sh:* kinds, and a PRESENT sh:select /
+// sh:sparqlExpr (on sh:sparql constraints AND on the SPARQL-based node expressions
+// of sh:targetNode/sh:values) whose text does not parse as the required query form
+// — FAIL-CLOSED relative to this engine's vendored SPARQL parser: a valid query
+// beyond the parser's coverage is also rejected strictly. Construct-local checks,
 // NOT a full SHACL-of-SHACL pass; ShaclFailure.ill_formed / ShapesModel::ill_formed()
 // carry (node, predicate, message). `validate` instead SKIPS all of the above
 // unchanged (its never-fails contract).
@@ -522,15 +530,17 @@ SHACL-spec-correct conforms/violations).
   stricter "only Violation fails" gate use `conforms_violations_only()`; for a custom
   `sh:conformanceDisallows` set use `conforms_with_disallowed(&[..])`.
 - **Ill-formed shapes are skipped by `validate`, reported as a failure by
-  `validate_strict` (sq-11a).** A shape never declared, an unparsable path, or an
-  `sh:select` that fails to parse (e.g. undeclared prefix) contributes no results;
-  the rest of validation still runs. `validate` never returns a `Result`/panics on
-  bad shapes — so a silently-empty report can mean "no targets" rather than
-  "conforms". When the distinction matters (CI shape linting, the suite's
+  `validate_strict` (sq-11a, sq-ehq4g).** A shape never declared, an unparsable path,
+  or an `sh:select` that fails to parse (e.g. undeclared prefix) contributes no
+  results; the rest of validation still runs. `validate` never returns a
+  `Result`/panics on bad shapes — so a silently-empty report can mean "no targets"
+  rather than "conforms". When the distinction matters (CI shape linting, the suite's
   `sht:Failure` entries), `validate_strict` rejects ill-formed constructs with
-  `ShaclFailure.ill_formed` (see the strict-validation list above) — but a PRESENT
-  `sh:select` whose query text our parser cannot parse stays a lenient skip (that
-  outcome depends on the engine's SPARQL parser, not on the shapes graph).
+  `ShaclFailure.ill_formed` (see the strict-validation list above). A PRESENT
+  `sh:select`/`sh:sparqlExpr` whose text does not parse is rejected strictly too
+  (sq-ehq4g) — FAIL-CLOSED relative to this engine's vendored SPARQL parser, so a
+  valid query using syntax the parser lacks is also rejected; prefer fixing the query
+  (or filing the parser gap) over weakening the strict gate.
 - **An uncompilable `sh:pattern` is SKIPPED, not fail-closed (sq-lz99x).** The Rust
   `regex` crate has no lookahead/lookbehind — neither does the XML Schema regex flavour
   the SHACL spec ties `sh:pattern` to — so e.g. `^(?!(TODO|TBD)).*` does not compile.


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — bead sq-ehq4g.

Extends the sq-11a strict ill-formed channel (`validate_strict` → `Err(ShaclFailure)`, the W3C-suite `sht:Failure` outcome) with the four rule families the bead names. The lenient `validate()` path is behaviourally **unchanged** (recording only).

## What is now rejected strictly

1. **Parser-dependent (`sh:sparql`)** — a PRESENT `sh:select` whose (post-`$PATH`-substitution) text does not parse as a SPARQL SELECT query (previously a silent lenient skip in both channels).
2. **Parser-dependent (SPARQL-based node expressions)** — a PRESENT `sh:select` / `sh:sparqlExpr` literal on a `sh:targetNode` / `sh:values` node expression whose text does not build (`intern_select_expr` failures).
3. **Property shape MISSING `sh:path`** — an `sh:property` value with no `sh:path`, or a node explicitly typed `sh:PropertyShape` with none (a type guard at the use site keeps the recording single-shot).
4. **`sh:qualifiedValueShape` with NEITHER count** — both qualified-cardinality components then miss a mandatory parameter (SHACL §2.3.2 partial-parameter ill-formedness).
5. **`sh:nodeKind` outside the six `sh:*` kinds** (SHACL §4.6.1), including the list form.

## Policy decision (the bead's "decide policy" item)

Rejection of a present-but-unparsable query is **FAIL-CLOSED relative to this engine's vendored SPARQL parser**: a valid query using syntax the parser lacks is ALSO rejected strictly. Honest boundary documented in the crate README ("Scope and non-goals") and `skills/shacl-validation/SKILL.md`. Rationale: a strict channel that silently skips what it cannot parse defeats its purpose (CI shape linting); the lenient channel keeps the old skip for anyone who prefers availability over strictness.

## Invariants pinned

- **Lenient unchanged**: every new ill-formed fixture is re-run through `validate` (still an infallible report; the focused `lenient_validate_still_skips_unparsable_sparql_select` shows the skip really skips).
- **W3C suites**: core **98/98**, shacl12 SPARQL **24/24** (incl. the 7 `sht:Failure` pre-binding entries), shacl12 node-expr — all green in both feature states.
- **Non-vacuous tests**: all 10 new strict tests verified FAILING before the implementation; 5 new false-positive guards (well-formed queries at all three sites, pathless NODE shapes via `sh:node`/`sh:targetWhere`, single-count qualified shapes, all six node kinds).

## Gates (all green, run to completion)

- `cargo build` / `cargo clippy --workspace --all-targets -- -D warnings` — default features
- `cargo clippy -p sparq-shacl --all-targets --all-features -- -D warnings` — `shacl-af` + `scs` ON
- `cargo test -p sparq-shacl` — default AND `--all-features` (59/59 strict tests; whole crate green; fast, <3s)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- `scripts/check-readme-template.py --enforce` — 0 deviations (README held at 120 lines)
- `typos` on all changed files — clean

No new dependencies, no new features, no public-API signature changes (new record sites behind the existing opt-in `validate_strict` surface of the already-opt-in `sparq-shacl` crate).

## Deferred (bead sq-c1v3e)

Non-IRI `sh:severity`, xsd:integer DATATYPE (vs lexical) count checks, `sh:entailment`, the symmetric `qualifiedMinCount`-without-`qualifiedValueShape` case, lenient-path `report.diagnostics` surfacing, and shacl-af structural node-expression build failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)