### PR TITLE
bench(gsp): PATCH-dialect panel — sparql-update + opt-in Solid N3-Patch vs CSS (loose) (sq-hmd7l.36) [FABLE-5]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -85,10 +85,14 @@ Notes on a few that need care:
   prerequisite that unblocks the HTTP opt lane (sq-7d3dj.10/.12/.13).
 - **`gsp-bench` (`bench/gsp`) is the Graph Store Protocol same-box panel** — see
   [`bench/gsp/README.md`](./gsp/README.md). GSP PUT/GET/DELETE round-trips (1 KB–10 MB
-  size sweep + the PSS LDP-CRUD stream projected onto GSP verbs) against sparq-server /
-  Fuseki / Oxigraph server, plus Community Solid Server as a **LOOSE** LDP-architecture
-  column (labelled, never averaged). A HARD round-trip content gate (returned triple set
-  must equal the PUT set exactly) runs BEFORE any timing; the driver is loopback-only
+  size sweep + the PSS LDP-CRUD stream projected onto GSP verbs) plus a **PATCH-dialect
+  panel** (`application/sparql-update` + `text/n3` Solid N3-Patch; support probed per
+  engine, 405/415/501 records honest n/a — Fuseki/Oxigraph GSP implement no PATCH
+  dialect, sparq's `text/n3` is double-opt-in via the `n3-patch` feature +
+  `GSP_N3_PATCH=1`) against sparq-server / Fuseki / Oxigraph server, plus Community
+  Solid Server as a **LOOSE** LDP-architecture column (labelled, never averaged; the
+  only Solid-PATCH peer). A HARD content-agreement gate (returned triple set must equal
+  the sent/reference set exactly) runs BEFORE any timing; the driver is loopback-only
   (refuses non-loopback URLs). `bash bench/gsp/run.sh --smoke` is the self-contained
   acceptance run. First-read record: `research/gap-gsp-2026-07.md`. [FABLE-5]
 - **`sp2b` (SP2Bench) is tiered** — see [`bench/sp2b/README.md`](./sp2b/README.md).

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -1587,17 +1587,17 @@ records_to  = "bench/competitor-results/python-bindings-*-<UTC>.json (git-ignore
 featured    = false
 status      = "active"  # first-read record: research/gap-python-binding-2026-07.md
 
-# [FABLE-5] sq-hmd7l.21 — Graph Store Protocol same-box panel
+# [FABLE-5] sq-hmd7l.21 — Graph Store Protocol same-box panel (+ sq-hmd7l.36 PATCH dialects)
 [[benchmark]]
 id          = "gsp-bench"
 name        = "Graph Store Protocol same-box panel (sparq-server vs Fuseki GSP / Oxigraph GSP + CSS loose)"
 category    = "serve"
-measures    = "GSP PUT/GET/DELETE latency (p50/p99 ms per op) over a deterministic 1KB-10MB resource-size sweep + the PSS LDP-CRUD stream projected onto GSP verbs; HARD round-trip content gate BEFORE timing (returned triple SET must equal the PUT set exactly; CRUD final state must match a client-side reference model); loopback-only (the driver refuses non-loopback URLs)"
+measures    = "GSP PUT/GET/DELETE latency (p50/p99 ms per op) over a deterministic 1KB-10MB resource-size sweep + the PSS LDP-CRUD stream projected onto GSP verbs + a PATCH-dialect panel (application/sparql-update and text/n3 Solid N3-Patch: deterministic ground delete/insert patch stream, support probed per engine — 405/415/501 records honest n/a; Fuseki/Oxigraph GSP implement no PATCH dialect, sparq's text/n3 is double-opt-in via the n3-patch feature + GSP_N3_PATCH=1); HARD content-agreement gate BEFORE timing (returned triple SET must equal the PUT set exactly; CRUD + PATCH final state must match a client-side reference model); loopback-only (the driver refuses non-loopback URLs)"
 invoke      = "bash bench/gsp/run.sh --smoke   # acceptance: sparq loopback, exit 0 = gates green\n              GSP_FUSEKI_URL=http://127.0.0.1:3030/ds GSP_OXIGRAPH_URL=http://127.0.0.1:7878 GSP_CSS_URL=http://127.0.0.1:3000 bash bench/gsp/run.sh   # full panel (competitors already running)"
 source      = "bench/gsp/{run.sh,compare.py,README.md}; CRUD shapes mirror bench/pss-update-set (gh-47/gh-52)"
 dataset     = "none fetched — deterministic bnode-free ASCII N-Triples generated in-driver per size target; identical payload bytes fed to every engine in the same run"
 quiet_box_sensitive = true
-pinning     = "payloads deterministic by construction (seed-free counter form); competitor versions (Fuseki distribution / Oxigraph release sha256 / @solid/community-server npm version) recorded in the results JSON at gather time; CSS rows labelled LOOSE (Solid/LDP overhead included) and never averaged with the like-for-like columns"
+pinning     = "payloads + patch streams deterministic by construction (seed-free counter form); competitor versions (Fuseki distribution / Oxigraph release sha256 / @solid/community-server npm version) recorded in the results JSON at gather time; CSS rows labelled LOOSE (Solid/LDP overhead included; the ONLY Solid-PATCH peer) and never averaged with the like-for-like columns"
 records_to  = "bench/competitor-results/gsp-<UTC>.json via GSP_JSON_OUT (git-ignored); first-read record: research/gap-gsp-2026-07.md"
 featured    = false  # external-competitor differential harness, not a dashboard-promoted capability suite
 status      = "ok"  # smoke (sparq loopback) is self-contained; competitor columns are gather-time external cost

--- a/bench/gsp/README.md
+++ b/bench/gsp/README.md
@@ -1,9 +1,9 @@
-<!-- [FABLE-5] sq-hmd7l.21 — GSP same-box panel. -->
+<!-- [FABLE-5] sq-hmd7l.21 — GSP same-box panel. sq-hmd7l.36 — PATCH-dialect panel. -->
 # Graph Store Protocol same-box panel — sparq-server vs Fuseki GSP / Oxigraph GSP (+ CSS, loose)
 
-HTTP **Graph Store Protocol** (SPARQL 1.1 GSP) PUT/GET/DELETE round-trips, all
-engines on one box, **loopback only** (the driver hard-refuses any non-loopback
-URL — no bypass flag). Registered as `gsp-bench` in
+HTTP **Graph Store Protocol** (SPARQL 1.1 GSP) PUT/GET/DELETE/PATCH
+round-trips, all engines on one box, **loopback only** (the driver hard-refuses
+any non-loopback URL — no bypass flag). Registered as `gsp-bench` in
 [`bench/benchmarks.toml`](../benchmarks.toml); lineage:
 [`bench/serve-throughput`](../serve-throughput/) (loopback HTTP regime) +
 [`bench/pss-update-set`](../pss-update-set/) (the LDP-CRUD shapes).
@@ -21,10 +21,24 @@ skips that engine's timing and fails the run (exit ≠ 0):
 - **crud-replay** — the PSS LDP-CRUD stream projected onto GSP verbs; a
   client-side reference model replays the same stream and every touched graph's
   final state must match a GET against the engine.
+- **patch-panel** (`sq-hmd7l.36`) — RFC 5789 PATCH per **dialect**: a
+  deterministic ground delete/insert patch stream (replace / insert-only /
+  delete-only shapes) over a seeded graph, gated on final-content agreement
+  with the client-side reference model. Dialects: `application/sparql-update`
+  (`DELETE DATA`/`INSERT DATA`; GRAPH-wrapped for GSP addressing, bare for
+  CSS's LDP resources) and `text/n3` Solid **N3-Patch**
+  (`solid:InsertDeletePatch`). Support is **probed, never assumed**: a
+  405/415/501 on the first patch records an honest **n/a** row —
+  Fuseki/Oxigraph GSP implement no PATCH dialect, and a stock sparq build
+  answers 415 on `text/n3` (that dialect is double-opt-in: the `n3-patch`
+  cargo feature **and** the runtime flag; set `GSP_N3_PATCH=1` on a
+  `--features n3-patch` build to light it up). A 2xx with wrong final content
+  is a red gate, not an n/a.
 
-The gate itself is regression-tested: `compare.py --self-test` (hermetic, no
-HTTP) proves an honest in-memory store passes it and a tampering store (drops a
-triple on read) fails it.
+The gates are themselves regression-tested: `compare.py --self-test` (hermetic,
+no HTTP) proves an honest in-memory store passes them, a tampering store (drops
+a triple on read) and a lossy PATCH store (204 but ignores deletes) fail them,
+and a 405-only store records n/a.
 
 ## Columns
 
@@ -39,8 +53,9 @@ CRUD projection honesty: `set_acl`'s conditional `DELETE/INSERT/WHERE` swap is
 not GSP-expressible — it is projected to a PUT-replace of a one-triple acl
 graph; `delete_document` cannot remove the single containment triple from the
 container graph (that needs PATCH), so containment survives in BOTH the engine
-and the reference model. The N3-Patch / Solid-PATCH dialects (only CSS as a
-peer) are out of this panel's scope.
+and the reference model. PATCH-dialect honesty: **CSS is the only peer** for
+the Solid PATCH dialects — a **loose** comparison by construction, labelled on
+every row; Fuseki/Oxigraph record honest n/a there.
 
 ## Run it
 
@@ -63,6 +78,9 @@ bash bench/gsp/run.sh
 ```
 
 Tunables: `SPARQ_SERVER_BIN`, `GSP_PORT` (7033), `GSP_ITERS`, `GSP_SIZES`,
+`GSP_PATCH_OPS`, `GSP_N3_PATCH` (1 = run sparq with the opt-in `text/n3`
+N3-Patch dialect enabled; needs a `--features n3-patch` build — on a stock
+build the env var is ignored and the row honestly reads n/a),
 `GSP_MAX_BODY_BYTES` (the server's default 1 MiB `--max-body-bytes` is raised
 to clear the 10 MB PUT bodies — configure competitors equivalently).
 

--- a/bench/gsp/compare.py
+++ b/bench/gsp/compare.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 # [FABLE-5] sq-hmd7l.21 — Graph Store Protocol same-box panel driver.
+# [FABLE-5] sq-hmd7l.36 — PATCH-dialect panel (sparql-update + Solid N3-Patch).
 """sparq-server vs Fuseki GSP / Oxigraph GSP (+ Community Solid Server, LOOSE) —
-Graph Store Protocol PUT/GET/DELETE round-trips, same box, loopback only.
+Graph Store Protocol PUT/GET/DELETE/PATCH round-trips, same box, loopback only.
 
   compare.py [--sparq URL] [--fuseki URL] [--oxigraph URL] [--css URL]
-             [--sizes CSV] [--iters N] [--crud-ops N] [--smoke]
+             [--sizes CSV] [--iters N] [--crud-ops N] [--patch-ops N] [--smoke]
              [--json-out FILE] [--self-test]
 
-Two workloads, each behind a HARD correctness gate that runs BEFORE any timing
-(the bead invariant: round-trip content agreement first, numbers second):
+Three workloads, each behind a HARD correctness gate that runs BEFORE any
+timing is reported (the bead invariant: content agreement first, numbers
+second):
 
   size-sweep   Deterministic bnode-free N-Triples payloads at each --sizes byte
                target (default 1 KB -> 10 MB). Gate: PUT the graph, GET it back
@@ -28,6 +30,27 @@ Two workloads, each behind a HARD correctness gate that runs BEFORE any timing
                -> DELETE <r> + DELETE <r>.acl. Gate: a client-side reference
                model replays the same stream and every resource's final state
                (present triples / absent) must match a GET against the engine.
+
+  patch-panel  (sq-hmd7l.36) RFC 5789 PATCH on a graph resource, per DIALECT:
+               a deterministic ground delete/insert patch stream (replace /
+               insert-only / delete-only shapes) over a seeded graph. Dialects:
+                 sparql-update  Content-Type application/sparql-update — the
+                                body is DELETE DATA / INSERT DATA (named-graph
+                                targets wrap blocks in GRAPH <g>; CSS's LDP
+                                resource IS the graph, so its body is bare).
+                 n3-patch       Content-Type text/n3 — a Solid N3-Patch
+                                (solid:InsertDeletePatch with solid:deletes /
+                                solid:inserts formulas). On sparq this dialect
+                                is DOUBLE-OPT-IN (the `n3-patch` cargo feature
+                                AND --n3-patch / SPARQ_N3_PATCH=1); a stock
+                                build answers 415 and the row records n/a.
+               Gate: a client-side reference model applies the same stream and
+               the final GET must equal it exactly (ground triples: set
+               equality is isomorphism). Support is PROBED, not assumed: a
+               405/415/501 on the FIRST patch is an honest `n/a` row (Fuseki /
+               Oxigraph GSP endpoints implement no PATCH dialect); any other
+               rejection — or 2xx with wrong final content — is a red gate.
+               CSS is the ONLY Solid-PATCH peer and stays a LOOSE column.
 
 Engine columns:
   --sparq    sparq-server base URL (default http://127.0.0.1:7033). GSP endpoint:
@@ -170,6 +193,25 @@ class GspEngine:
     def delete(self, graph_iri):
         return self._request("DELETE", graph_iri)
 
+    # GSP indirect addressing names the graph in the query string, so the PATCH
+    # body must scope itself: DATA blocks are wrapped in GRAPH <g> for the
+    # sparql-update dialect; sparq's text/n3 handler graph-scopes server-side.
+    patch_body_graph_scoped = True
+
+    def patch(self, graph_iri, dialect, deletes, inserts):
+        """One RFC 5789 PATCH in the given dialect. `deletes`/`inserts` are
+        lists of ground N-Triples lines; the renderer produces the body."""
+        if dialect == "sparql-update":
+            scope = graph_iri if self.patch_body_graph_scoped else None
+            body = sparql_update_patch_body(scope, deletes, inserts)
+            ct = "application/sparql-update"
+        else:
+            body = n3_patch_body(deletes, inserts)
+            ct = "text/n3"
+        return self._request(
+            "PATCH", graph_iri, body=body.encode(), headers={"content-type": ct}
+        )
+
 
 class CssEngine(GspEngine):
     """Community Solid Server — LOOSE column. LDP resource addressing: the
@@ -179,6 +221,10 @@ class CssEngine(GspEngine):
     INCLUDED in every number — never average with the like-for-like columns."""
 
     loose = True
+
+    # The LDP resource URL IS the graph: a PATCH body applies to the resource's
+    # own content, so DATA blocks stay bare (no GRAPH <g> wrapping).
+    patch_body_graph_scoped = False
 
     def _url(self, graph_iri):
         # Map the abstract graph IRI onto a pod resource path (LDP addressing).
@@ -370,6 +416,133 @@ def run_crud(engine, ops, resources):
 
 
 # --------------------------------------------------------------------------- #
+# Workload C — PATCH-dialect panel (sq-hmd7l.36)
+# --------------------------------------------------------------------------- #
+PATCH_DIALECTS = ("sparql-update", "n3-patch")
+
+
+def build_patch_workload(ops, resources, tag):
+    """Deterministic ground delete/insert patch stream over `resources` seeded
+    subjects. Returns (seed_lines, patches, expected_final) where each patch is
+    (deletes, inserts) — lists of ground N-Triples lines — and expected_final
+    is the client-side reference model's final canonical triple set. Shapes
+    cycle replace / insert-only / replace / delete-only, and every delete names
+    exactly the triples the model says are present (so an honest engine can
+    apply each patch verbatim)."""
+
+    def mk(res, ver):
+        return (
+            f"<http://gsp.bench/patch/{tag}/s{res}> <http://gsp.bench/p> "
+            f'"v{ver}-{res}-{tag}" .'
+        )
+
+    state = {res: {mk(res, 0)} for res in range(resources)}
+    seed = [mk(res, 0) for res in range(resources)]
+    patches = []
+    for i in range(ops):
+        res = i % resources
+        shape = i % 4
+        new = mk(res, i + 1)
+        cur = sorted(state[res])
+        if shape in (0, 2):  # replace: remove what is present, add one triple
+            deletes, inserts = cur, [new]
+        elif shape == 1:  # insert-only: grow the subject by one triple
+            deletes, inserts = [], [new]
+        elif cur:  # delete-only: clear the subject
+            deletes, inserts = cur, []
+        else:  # nothing to remove — an empty patch is invalid, so insert
+            deletes, inserts = [], [new]
+        patches.append((deletes, inserts))
+        state[res] = (state[res] - set(deletes)) | set(inserts)
+    expected = frozenset(line for lines in state.values() for line in lines)
+    return seed, patches, expected
+
+
+def sparql_update_patch_body(graph_iri, deletes, inserts):
+    """`application/sparql-update` PATCH body: ground DELETE DATA / INSERT DATA
+    (delete first, one request = one atomic patch). With `graph_iri` the blocks
+    are wrapped in GRAPH <g> (GSP indirect addressing: bare DATA triples would
+    land in the default graph); None keeps them bare (the LDP resource IS the
+    graph). Empty op blocks are omitted."""
+
+    def block(lines):
+        inner = " ".join(lines)
+        return f"GRAPH <{graph_iri}> {{ {inner} }}" if graph_iri else inner
+
+    body = []
+    if deletes:
+        body.append(f"DELETE DATA {{ {block(deletes)} }}")
+    if inserts:
+        body.append(f"INSERT DATA {{ {block(inserts)} }}")
+    return " ;\n".join(body)
+
+
+def n3_patch_body(deletes, inserts):
+    """`text/n3` Solid N3-Patch body: one solid:InsertDeletePatch with ground
+    solid:deletes / solid:inserts formulas (empty formulas omitted — both sparq
+    and CSS reject an empty patch). The addressed resource/graph supplies the
+    scope, so the formulas stay bare."""
+    props = ["a solid:InsertDeletePatch"]
+    if deletes:
+        props.append(f"solid:deletes {{ {' '.join(deletes)} }}")
+    if inserts:
+        props.append(f"solid:inserts {{ {' '.join(inserts)} }}")
+    return (
+        "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n_:patch "
+        + " ;\n  ".join(props)
+        + " .\n"
+    )
+
+
+def run_patch(engine, dialect, ops, resources):
+    """Seed a fresh graph, replay the deterministic patch stream (timed per
+    patch), and gate on final-content agreement with the reference model.
+    Dialect support is PROBED: 405/415/501 on the FIRST patch is an honest
+    "n/a" verdict (e.g. Fuseki/Oxigraph GSP: no PATCH; a stock sparq build:
+    text/n3 is 415 unless the opt-in n3-patch feature+flag are on). Any other
+    rejection, or 2xx with wrong final content, is a red gate.
+    Returns (verdict, detail, sorted_lat_ms) with verdict in ok|fail|n/a."""
+    tag = dialect.replace("-", "")
+    graph = f"http://gsp.bench/patch/{tag}"
+    seed, patches, expected = build_patch_workload(ops, resources, tag)
+
+    status, _ = engine.put(graph, "".join(line + "\n" for line in seed))
+    if status not in (200, 201, 204, 205):
+        return "fail", f"seed PUT HTTP {status}", None
+    lat = []
+    for i, (deletes, inserts) in enumerate(patches):
+        t = time.perf_counter()
+        status, _ = engine.patch(graph, dialect, deletes, inserts)
+        lat.append((time.perf_counter() - t) * 1000.0)
+        if i == 0 and status in (405, 415, 501):
+            engine.delete(graph)
+            return "n/a", f"PATCH dialect not supported (HTTP {status})", None
+        if status >= 400:
+            return "fail", f"patch {i} rejected: HTTP {status}", None
+
+    status, body = engine.get(graph)
+    if status != 200:
+        return "fail", f"final GET HTTP {status}", None
+    got = canon(body.decode(errors="replace"))
+    if got != expected:
+        return (
+            "fail",
+            f"content mismatch after {len(patches)} patches: expected "
+            f"{len(expected)} triples, got {len(got)} "
+            f"({len(expected - got)} missing, {len(got - expected)} unexpected)",
+            None,
+        )
+    engine.delete(graph)
+    lat.sort()
+    return (
+        "ok",
+        f"{len(patches)} {dialect} patches applied, final graph matches "
+        "reference model",
+        lat,
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Reporting
 # --------------------------------------------------------------------------- #
 def pct(sorted_ms, p):
@@ -441,9 +614,37 @@ def self_test():
     state3 = crud_reference_state(crud_stream(3, resources=1))
     check("crud doc present", state3.get(doc_graph(0)) == canon(doc_triples(0, 3)))
 
+    # patch workload (sq-hmd7l.36): deterministic + reference-model-correct on
+    # a hand-computed tiny case. ops=4, resources=1 cycles replace (v0->v1),
+    # insert-only (+v2), replace ({v1,v2}->v3), delete-only (clear) -> empty.
+    w1 = build_patch_workload(4, 1, "t")
+    check("patch deterministic", w1 == build_patch_workload(4, 1, "t"))
+    seed, patches, expected = w1
+    check("patch seed one triple", len(seed) == 1)
+    check("patch final empty after delete-only", expected == frozenset())
+    check("patch insert-only shape", patches[1][0] == [] and patches[1][1])
+    check("patch replace deletes both", len(patches[2][0]) == 2)
+    check("patch delete-only shape", patches[3][1] == [] and len(patches[3][0]) == 1)
+    _, _, exp3 = build_patch_workload(3, 1, "t")
+    check("patch model tracks inserts", len(exp3) == 1)
+
+    # dialect renderers: graph scoping, op omission, N3-Patch shape
+    dels = ['<http://a> <http://p> "old" .']
+    ins = ['<http://a> <http://p> "new" .']
+    su = sparql_update_patch_body("http://g/1", dels, ins)
+    check("su body graph-wrapped", su.count("GRAPH <http://g/1>") == 2)
+    check("su body delete-first", su.index("DELETE DATA") < su.index("INSERT DATA"))
+    check("su body bare unscoped", "GRAPH" not in sparql_update_patch_body(None, dels, ins))
+    check("su body omits empty op", "DELETE" not in sparql_update_patch_body("http://g/1", [], ins))
+    n3 = n3_patch_body(dels, ins)
+    check("n3 patch type", "solid:InsertDeletePatch" in n3)
+    check("n3 both formulas", "solid:deletes {" in n3 and "solid:inserts {" in n3)
+    check("n3 omits empty formula", "solid:deletes" not in n3_patch_body([], ins))
+    check("n3 no where formula", "solid:where" not in n3)
+
     # NON-VACUOUSNESS of the round-trip gate: an in-memory fake store passes it,
     # and a tampering variant (drops one triple on read) must FAIL it — this
-    # exercises the REAL gate_roundtrip()/run_crud() logic, no HTTP needed.
+    # exercises the REAL gate_roundtrip()/run_crud()/run_patch() logic, no HTTP.
     class _FakeStore(GspEngine):
         def __init__(self):
             super().__init__("fake", "http://127.0.0.1:0/gsp")
@@ -471,11 +672,30 @@ def self_test():
             del self.graphs[graph_iri]
             return 204, b""
 
+        def patch(self, graph_iri, dialect, deletes, inserts):
+            # honest engine: applies delete-then-insert atomically
+            cur = self.graphs.get(graph_iri, frozenset())
+            self.graphs[graph_iri] = (cur - canon("\n".join(deletes))) | canon(
+                "\n".join(inserts)
+            )
+            return 204, b""
+
     class _TamperingStore(_FakeStore):
         def get(self, graph_iri):
             status, body = super().get(graph_iri)
             lines = body.decode().splitlines()
             return status, "\n".join(lines[1:]).encode()  # drop one triple
+
+    class _LossyPatchStore(_FakeStore):
+        def patch(self, graph_iri, dialect, deletes, inserts):
+            # claims success (204) but silently ignores the deletes
+            cur = self.graphs.get(graph_iri, frozenset())
+            self.graphs[graph_iri] = cur | canon("\n".join(inserts))
+            return 204, b""
+
+    class _NoPatchStore(_FakeStore):
+        def patch(self, graph_iri, dialect, deletes, inserts):
+            return 405, b""  # e.g. Fuseki/Oxigraph GSP: method not allowed
 
     ok, _ = gate_roundtrip(_FakeStore(), 512)
     check("gate passes honest store", ok)
@@ -485,6 +705,13 @@ def self_test():
     check("crud gate passes honest store", ok)
     ok, _, _ = run_crud(_TamperingStore(), 8, 2)
     check("crud gate catches tampered read", not ok)
+    for dialect in PATCH_DIALECTS:
+        verdict, _, lat = run_patch(_FakeStore(), dialect, 8, 2)
+        check(f"patch gate passes honest store ({dialect})", verdict == "ok" and lat)
+    verdict, detail, _ = run_patch(_LossyPatchStore(), "sparql-update", 8, 2)
+    check("patch gate catches ignored delete", verdict == "fail" and "mismatch" in detail)
+    verdict, detail, _ = run_patch(_NoPatchStore(), "n3-patch", 8, 2)
+    check("patch probe records honest n/a", verdict == "n/a" and "405" in detail)
 
     # URL building: graph IRI is percent-encoded into the query string
     eng = GspEngine("t", "http://127.0.0.1:1/sparql/graph")
@@ -500,7 +727,10 @@ def self_test():
     if failures:
         print(f"self-test FAILED: {failures}", file=sys.stderr)
         return 1
-    print("self-test OK (gen/canon/loopback/absent/crud-model/url checks)")
+    print(
+        "self-test OK (gen/canon/loopback/absent/crud-model/patch-model/"
+        "dialect-render/url checks)"
+    )
     return 0
 
 
@@ -515,6 +745,8 @@ def main():
     ap.add_argument("--iters", type=int, default=None, help="timed iterations/size")
     ap.add_argument("--crud-ops", type=int, default=None, help="CRUD stream length")
     ap.add_argument("--crud-resources", type=int, default=8)
+    ap.add_argument("--patch-ops", type=int, default=None, help="PATCH stream length")
+    ap.add_argument("--patch-resources", type=int, default=6)
     ap.add_argument("--smoke", action="store_true", help="small sizes + few iters")
     ap.add_argument("--json-out", default=None)
     ap.add_argument("--self-test", action="store_true", help="hermetic checks, no HTTP")
@@ -527,6 +759,7 @@ def main():
     sizes = [int(s) for s in sizes_csv.split(",") if s.strip()]
     iters = args.iters if args.iters is not None else (3 if args.smoke else 10)
     crud_ops = args.crud_ops if args.crud_ops is not None else (24 if args.smoke else 200)
+    patch_ops = args.patch_ops if args.patch_ops is not None else (12 if args.smoke else 120)
 
     engines = []
     if args.sparq:
@@ -545,7 +778,7 @@ def main():
 
     print(
         f"# GSP same-box panel — sizes={sizes} iters={iters} crud_ops={crud_ops}"
-        f" engines={[label_of(e) for e in engines]}"
+        f" patch_ops={patch_ops} engines={[label_of(e) for e in engines]}"
     )
     results = {}
     any_gate_failed = False
@@ -584,12 +817,41 @@ def main():
             }
         else:
             any_gate_failed = True
+
+        # PATCH-dialect panel (sq-hmd7l.36): probed per dialect; unsupported is
+        # an honest n/a row, wrong content is a red gate. CSS rows keep the
+        # LOOSE label (the ONLY Solid-PATCH peer — never averaged).
+        eres["patch"] = {}
+        for dialect in PATCH_DIALECTS:
+            verdict, detail, lat = run_patch(
+                engine, dialect, patch_ops, args.patch_resources
+            )
+            word = {"ok": "OK", "n/a": "n/a", "fail": "FAIL"}[verdict]
+            print(f"gate[patch:{dialect}] {label:<27} {word}: {detail}")
+            entry = {"gate": verdict, "gate_detail": detail, "loose": engine.loose}
+            if verdict == "ok" and lat:
+                print_lat_rows(f"patch[{dialect}]", label, {"patch": lat})
+                entry["latency_ms"] = {
+                    "patch": {
+                        "p50": round(pct(lat, 0.5), 3),
+                        "p99": round(pct(lat, 0.99), 3),
+                    }
+                }
+            elif verdict == "fail":
+                any_gate_failed = True
+            eres["patch"][dialect] = entry
         results[engine.name] = eres
 
     if args.json_out:
         with open(args.json_out, "w", encoding="utf-8") as fh:
             json.dump(
-                {"sizes": sizes, "iters": iters, "crud_ops": crud_ops, "engines": results},
+                {
+                    "sizes": sizes,
+                    "iters": iters,
+                    "crud_ops": crud_ops,
+                    "patch_ops": patch_ops,
+                    "engines": results,
+                },
                 fh,
                 indent=2,
             )

--- a/bench/gsp/run.sh
+++ b/bench/gsp/run.sh
@@ -3,9 +3,12 @@
 #
 # Stands up the REAL sparq-server on a loopback port (empty default graph, no
 # auth = writable) and drives its GSP surface through bench/gsp/compare.py:
-# PUT/GET/DELETE round-trips over a resource-size sweep + the PSS LDP-CRUD
-# stream projected onto GSP verbs. The round-trip correctness gate runs BEFORE
-# any timing (compare.py exits non-zero on any gate failure).
+# PUT/GET/DELETE round-trips over a resource-size sweep, the PSS LDP-CRUD
+# stream projected onto GSP verbs, and the PATCH-dialect panel (sq-hmd7l.36:
+# application/sparql-update always; text/n3 Solid N3-Patch when opted in — see
+# GSP_N3_PATCH below). The correctness gates run BEFORE any timing is reported
+# (compare.py exits non-zero on any gate failure; an engine that does not
+# implement a PATCH dialect records an honest n/a row instead).
 #
 # Same lineage/contract as scripts/sparq-server-same-box.sh: bounded waits
 # everywhere, an EXIT trap that always stops the server, non-zero exit = the
@@ -29,6 +32,12 @@
 #   GSP_READY_TIMEOUT   readiness cap, s     (default 60)
 #   GSP_ITERS           timed iters per size (default: compare.py's per-mode default)
 #   GSP_SIZES           CSV byte sizes       (default: compare.py's per-mode default)
+#   GSP_PATCH_OPS       PATCH stream length  (default: compare.py's per-mode default)
+#   GSP_N3_PATCH        1 = enable sparq's OPT-IN text/n3 Solid N3-Patch dialect
+#                       (exports SPARQ_N3_PATCH=1 to the spawned server; the binary
+#                       must be built with `--features n3-patch` — a stock build
+#                       ignores the env var and the text/n3 row honestly reads
+#                       n/a via 415). Default 0: the panel measures a stock build.
 #   GSP_JSON_OUT        JSON results path    (default: none; git-ignored dir suggested:
 #                                             bench/competitor-results/)
 set -euo pipefail
@@ -76,6 +85,13 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT TERM
 
+# Opt-in Solid N3-Patch dialect (sq-hmd7l.36): the env route (not --n3-patch)
+# so a stock feature-off binary starts cleanly and its text/n3 row reads n/a.
+if [ "${GSP_N3_PATCH:-0}" = 1 ]; then
+  export SPARQ_N3_PATCH=1
+  log "N3-Patch runtime opt-in requested (needs a --features n3-patch build)"
+fi
+
 log "starting sparq-server on 127.0.0.1:$GSP_PORT (empty graph, GSP writable, max-body-bytes=$GSP_MAX_BODY_BYTES)"
 "$SPARQ_SERVER_BIN" --addr "127.0.0.1:${GSP_PORT}" \
   --max-body-bytes "$GSP_MAX_BODY_BYTES" >"$SRV_LOG" 2>&1 &
@@ -101,6 +117,7 @@ ARGS=( --sparq "http://127.0.0.1:${GSP_PORT}" )
 [ "$SMOKE" = 1 ] && ARGS+=( --smoke )
 [ -n "${GSP_ITERS:-}" ] && ARGS+=( --iters "$GSP_ITERS" )
 [ -n "${GSP_SIZES:-}" ] && ARGS+=( --sizes "$GSP_SIZES" )
+[ -n "${GSP_PATCH_OPS:-}" ] && ARGS+=( --patch-ops "$GSP_PATCH_OPS" )
 [ -n "${GSP_FUSEKI_URL:-}" ] && ARGS+=( --fuseki "$GSP_FUSEKI_URL" )
 [ -n "${GSP_OXIGRAPH_URL:-}" ] && ARGS+=( --oxigraph "$GSP_OXIGRAPH_URL" )
 [ -n "${GSP_CSS_URL:-}" ] && ARGS+=( --css "$GSP_CSS_URL" )

--- a/research/gap-gsp-2026-07.md
+++ b/research/gap-gsp-2026-07.md
@@ -34,8 +34,16 @@ Scope caveats:
 - **CRUD projection:** the PSS LDP-CRUD stream (`bench/pss-update-set`) is replayed as
   GSP verbs. `set_acl`'s conditional swap is not GSP-expressible (projected to a
   PUT-replace of a one-triple acl graph); containment removal on delete needs PATCH,
-  so it survives in both the engine and the reference model. The N3-Patch/Solid-PATCH
-  dialects have only CSS as a peer and are out of scope for this panel.
+  so it survives in both the engine and the reference model.
+- **PATCH-dialect panel (`sq-hmd7l.36`, delivered):** a deterministic ground
+  delete/insert patch stream per dialect (`application/sparql-update` + `text/n3`
+  Solid N3-Patch), gated on final-content agreement with a client-side reference
+  model. Dialect support is probed, never assumed: 405/415/501 on the first patch is
+  an honest **n/a** row — Fuseki/Oxigraph GSP implement no RFC 5789 PATCH dialect,
+  and a stock sparq build answers 415 on `text/n3` (that dialect is double-opt-in:
+  the `n3-patch` cargo feature + the runtime flag; `GSP_N3_PATCH=1` in `run.sh`).
+  A 2xx with wrong final content is a red gate. **CSS is the only Solid-PATCH peer —
+  a LOOSE comparison by construction**, labelled on every row.
 - **Loopback only:** the driver hard-refuses non-loopback engine URLs (no bypass).
 
 ## 2. First-read findings (work box — NON-canonical, no numbers transcribed)
@@ -77,9 +85,8 @@ Results land git-ignored under `bench/competitor-results/`; nothing is committed
 
 - Canonical quiet-box gather run with the Fuseki / Oxigraph / CSS columns live, feeding
   the `research/perf-dominance-gap-2026-07.md` master table (bead `sq-hmd7l.35`; it also
-  resolves the `css-gsp` registry entry's `unverified_pin`).
-- PATCH-dialect panel (`application/sparql-update` PATCH + the opt-in `n3-patch`
-  feature vs CSS's Solid `text/n3` PATCH — CSS is the only peer, loose by
-  construction): bead `sq-hmd7l.36`.
+  resolves the `css-gsp` registry entry's `unverified_pin`). The gather run should
+  drive the PATCH-dialect panel twice for sparq: once stock (text/n3 → honest n/a)
+  and once with a `--features n3-patch` build + `GSP_N3_PATCH=1` (both dialects live).
 - Concurrency axis: this panel is a single synchronous client (the interactive LDP
   shape); concurrent GSP writers/readers belong to the `serve-throughput` lineage.


### PR DESCRIPTION
> 🤖 SPARQ agent — bead `sq-hmd7l.36` (epic `sq-hmd7l`, comparative-benchmarking-everything). [FABLE-5]

## What

Extends the GSP same-box panel (`bench/gsp/`) with the deferred **PATCH-dialect panel** (`research/gap-gsp-2026-07.md` §4): RFC 5789 `PATCH` on a graph resource, per dialect, gated on **content agreement before timing**.

- **Workload** — a deterministic ground delete/insert patch stream (replace / insert-only / delete-only shapes) over a seeded graph; a client-side reference model applies the same stream and the final `GET` must equal it exactly (ground bnode-free ASCII triples, so set equality is isomorphism).
- **Dialects** — `application/sparql-update` (`DELETE DATA`/`INSERT DATA`; `GRAPH <g>`-wrapped for GSP indirect addressing — bare DATA triples would land in the default graph; bare for CSS, whose LDP resource IS the graph) and `text/n3` Solid **N3-Patch** (`solid:InsertDeletePatch` with `solid:deletes`/`solid:inserts` formulas; sparq's handler graph-scopes server-side).
- **Probed support, honest n/a** — a 405/415/501 on the FIRST patch records an `n/a` row: Fuseki/Oxigraph GSP endpoints implement no RFC 5789 PATCH dialect, and a stock sparq build answers 415 on `text/n3` (that dialect is **double-opt-in**: the `n3-patch` cargo feature AND `--n3-patch`/`SPARQ_N3_PATCH=1`). A 2xx with wrong final content is a **red gate**, never an n/a.
- **CSS rows stay LOOSE** — CSS is the only Solid-PATCH peer, a loose comparison by construction (Solid/LDP persistence/authz/negotiation overhead included); labelled on every row (stdout + per-row `loose` in the JSON) and never averaged with the like-for-like columns.
- `run.sh` gains `GSP_N3_PATCH=1` (env-route opt-in — a stock feature-off binary starts cleanly and its `text/n3` row honestly reads n/a) and `GSP_PATCH_OPS`; registry (`bench/benchmarks.toml` `gsp-bench`), `bench/CATALOG.md`, `bench/gsp/README.md`, and the gap record updated.

## Feature-gating

**No Rust code changes** — the harness (Python + shell) exercises sparq-server's EXISTING always-on `application/sparql-update` PATCH and the EXISTING opt-in `n3-patch` cargo feature (default OFF, double-opt-in at runtime). Core stays lean; nothing new is forced onto the default build.

## Verification (all run to completion)

- `compare.py --self-test` — hermetic, non-vacuous: an honest in-memory store passes both dialects, a **lossy PATCH store** (returns 204 but silently ignores deletes) FAILS the content gate, a 405-only store records n/a; plus hand-computed reference-model checks and dialect-renderer checks.
- **Real-path smoke, BOTH feature states** against a real `sparq-server` on loopback:
  - stock build (`cargo build -p sparq-server --release`): `gate[patch:sparql-update] OK` (12 patches, final graph matches reference model), `gate[patch:n3-patch] n/a (HTTP 415)` — the honest opt-out row;
  - `--features n3-patch` + `GSP_N3_PATCH=1`: BOTH dialects `OK` against the reference model.
- `cargo clippy --workspace --all-targets -- -D warnings` (default) and `cargo clippy -p sparq-server --all-targets --features n3-patch -- -D warnings` — green.
- `cargo test -p sparq-server` and `cargo test -p sparq-server --features n3-patch` — green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations; `scripts/check-new-bench-registered.py` — PASS; `typos` — clean; `benchmarks.toml` parses.

## Honesty

No performance numbers are committed anywhere (work-box readings are non-canonical by construction); the smoke verifies gates, not speed. Canonical gather (bead `sq-hmd7l.35`) should drive the patch panel twice for sparq — stock and feature-on — noted on that bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
