### PR TITLE
feat(canon): constrained ground-triple-term (error-on-nested-bnode) rdf12 variant (sq-iaxd) [FABLE-5]

### DIFF
--- a/crates/sparq-canon/README.md
+++ b/crates/sparq-canon/README.md
@@ -74,27 +74,27 @@ sparq-canon = { path = "crates/sparq-canon", features = ["rdf12-triple-terms"] }
 let nq = sparq_canon::canonicalize_rdf12(&dataset)?;             // quads
 let cg = sparq_canon::canonicalize_triples_rdf12(&triples)?;     // single graph
 let m  = sparq_canon::issue_dataset_rdf12(&dataset)?;            // issuer map
+// Constrained: requires GROUND triple terms (errors on any nested blank node).
+let vc = sparq_canon::canonicalize_rdf12_ground_terms(&dataset)?;
 // Hash-profile parity with the standard path: pick a hash via `*_with::<D: Digest>`.
 let nq384 = sparq_canon::canonicalize_rdf12_with::<sha2::Sha384>(&dataset)?;
 ```
 
-**Boundary:** SHA-256 is the default; a `*_with::<D: Digest>` sibling of each v2
-entry point (e.g. `canonicalize_rdf12_with`) selects another hash — notably
-`sha2::Sha384` — for parity with the standard path's `canonicalize_quads_with`.
-The non-generic entry points are SHA-256 and byte-identical to before; a
-different `D` may yield a different (still canonical, isomorphism-stable under
-that `D`) relabelling. Triple terms occur only as objects in oxrdf 0.3 (a
-triple's subject is `NamedOrBlankNode`), so nesting descends strictly through
-the object position; the HNDQ poison-graph limit still applies.
+**Constrained ground-triple-term variant** (`canonicalize_rdf12_ground_terms` +
+`issue_dataset`/`triples`/`*_with` siblings): a thin wrapper that fails closed
+with `CanonError::NestedBlankNode` unless every triple term is blank-node-free —
+the common credential/VC case. Accepted input never exercises the nested-bnode
+HNDQ descent: it is exactly RDFC-1.0 with triple terms as opaque constants.
+
+**Boundary:** SHA-256 is the default; each v2 entry point has a `*_with::<D:
+Digest>` sibling (notably `sha2::Sha384`) for standard-path parity. A different
+`D` may yield a different (still canonical, isomorphism-stable) relabelling.
+Triple terms occur only as objects in oxrdf 0.3; the HNDQ limit still applies.
 
 **Distinguishing power (regression-tested).** An adversarial soundness audit of
 the nested-bnode descent (sq-mu1cd / sq-63g0) found the profile **sound** (0
-confirmed defects / 5 refuted suspicions): distinct nested structure never
-collapses, because the serialization re-renders the real `Term::Triple` with c14n
-labels. The audit's sharper non-isomorphic vectors are landed as permanent
-regression tests in `tests/rdf12_triple_term_canon.rs` §5 — each **brute-force-proven
-non-isomorphic** by an independent oracle before asserting the canon differs, so a
-future false-equal is caught. That comment block carries the full per-vector detail.
+defects / 5 refuted suspicions); its sharper non-isomorphic vectors are pinned as
+brute-force-anchored regression tests in `tests/rdf12_triple_term_canon.rs` §5.
 
 ### Opt-in, single-sourced
 

--- a/crates/sparq-canon/src/lib.rs
+++ b/crates/sparq-canon/src/lib.rs
@@ -64,6 +64,14 @@
 //! (only present with the feature on). With the feature OFF the crate is
 //! byte-identical to before — the standard surface still returns
 //! [`CanonError::TripleTerm`] on triple terms.
+//!
+//! The same feature also carries a **constrained ground-triple-term** variant
+//! (`canonicalize_rdf12_ground_terms` and siblings): a thin wrapper that fails
+//! closed with [`CanonError::NestedBlankNode`] if any blank node occurs inside
+//! a triple term, and otherwise delegates. With every triple term ground
+//! (blank-node-free — the common credential/VC case), none of the non-standard
+//! nested-bnode HNDQ-descent semantics are reachable: the run is exactly the
+//! RDFC-1.0 algorithm with triple terms as opaque constants. [FABLE-5] sq-iaxd.
 
 #![forbid(unsafe_code)]
 
@@ -129,8 +137,11 @@ pub mod rdf12;
 #[cfg(feature = "rdf12-triple-terms")]
 pub use rdf12::{
     canonicalize_graph_content_rdf12, canonicalize_graph_content_rdf12_with, canonicalize_rdf12,
-    canonicalize_rdf12_with, canonicalize_triples_rdf12, canonicalize_triples_rdf12_with,
-    issue_dataset_rdf12, issue_dataset_rdf12_with,
+    canonicalize_rdf12_ground_terms, canonicalize_rdf12_ground_terms_with, canonicalize_rdf12_with,
+    canonicalize_triples_rdf12, canonicalize_triples_rdf12_ground_terms,
+    canonicalize_triples_rdf12_ground_terms_with, canonicalize_triples_rdf12_with,
+    issue_dataset_rdf12, issue_dataset_rdf12_ground_terms, issue_dataset_rdf12_ground_terms_with,
+    issue_dataset_rdf12_with,
 };
 
 /// The hash-function trait RDFC-1.0 is parameterized over (`digest::Digest`),
@@ -148,6 +159,13 @@ pub enum CanonError {
     /// feature and use the non-standard `canonicalize_rdf12` /
     /// `canonicalize_triples_rdf12` profile to canonicalize triple terms.
     TripleTerm,
+    /// A blank node occurs **inside** an RDF 1.2 triple term. Returned only by
+    /// the opt-in `rdf12-triple-terms` profile's constrained ground-triple-term
+    /// entry points (`canonicalize_rdf12_ground_terms` and siblings), which
+    /// require every triple term to be blank-node-free and fail closed
+    /// otherwise. Use the full `canonicalize_rdf12` descent to relabel nested
+    /// blank nodes instead. [FABLE-5] sq-iaxd.
+    NestedBlankNode,
     /// Bridge serialization/parse failure (should not happen for RDFC-1.0-model
     /// content; surfaced rather than swallowed).
     Bridge(String),
@@ -163,6 +181,14 @@ impl std::fmt::Display for CanonError {
                     f,
                     "RDF 1.2 triple terms are outside the W3C RDFC-1.0 data model; \
                      enable the `rdf12-triple-terms` profile to canonicalize them"
+                )
+            }
+            CanonError::NestedBlankNode => {
+                write!(
+                    f,
+                    "blank node nested inside an RDF 1.2 triple term; the constrained \
+                     ground-triple-term profile requires blank-node-free triple terms \
+                     (use the full `canonicalize_rdf12` descent to relabel nested blank nodes)"
                 )
             }
             CanonError::Bridge(e) => write!(f, "oxrdf bridge error: {e}"),
@@ -749,6 +775,24 @@ mod tests {
     fn canonicalize_nquads_empty() {
         assert_eq!(canonicalize_nquads("").unwrap(), "");
         assert_eq!(canonicalize_nquads("\n\n").unwrap(), "");
+    }
+
+    /// [FABLE-5] sq-iaxd: `CanonError::NestedBlankNode` is an ungated variant
+    /// (only *constructed* by the opt-in `rdf12-triple-terms` ground-terms
+    /// wrappers), so its `Display` must render in the default feature state
+    /// too. Pins the message's two load-bearing halves: the condition and the
+    /// full-descent escape hatch.
+    #[test]
+    fn nested_blank_node_error_display_default_features() {
+        let msg = CanonError::NestedBlankNode.to_string();
+        assert!(
+            msg.contains("blank node nested inside an RDF 1.2 triple term"),
+            "Display must name the condition: {msg:?}"
+        );
+        assert!(
+            msg.contains("canonicalize_rdf12"),
+            "Display must point at the full-descent escape hatch: {msg:?}"
+        );
     }
 
     #[test]

--- a/crates/sparq-canon/src/rdf12.rs
+++ b/crates/sparq-canon/src/rdf12.rs
@@ -54,9 +54,30 @@
 //! - The HNDQ poison-graph call limit is enforced (default 4000) and surfaces as
 //!   [`CanonError::Canonicalization`], so pathological inputs fail closed.
 //!
+//! ## Constrained ground-triple-term variant (no nested blank nodes)
+//!
+//! [`canonicalize_rdf12_ground_terms`] (and its `issue_dataset` /
+//! `canonicalize_triples` / `*_with` siblings) is a **thin wrapper** over the
+//! full profile that first checks every triple term is **ground** — contains
+//! no blank node at any nesting depth — and fails closed with
+//! [`CanonError::NestedBlankNode`] otherwise. This is the common
+//! credential/VC shape (asserted/quoted statements about ground content), and
+//! it is semantically the *least* adventurous slice of this profile: with all
+//! triple terms ground, the nested-bnode HNDQ-descent extension is
+//! unreachable (the descent finds nothing to enrol or gossip), so the run is
+//! exactly the RDFC-1.0 algorithm over an alphabet extended with opaque
+//! triple-term constants. A caller that wants a canonical form whose
+//! well-definedness does **not** rest on the novel nested-bnode gossip design
+//! uses these entry points; nested-bnode inputs are rejected rather than
+//! silently canonicalized under the extension. Top-level blank nodes (quad
+//! subject/object/graph) are ordinary RDFC-1.0 bnodes and remain fine. Still
+//! NON-STANDARD: the serialization carries RDF-1.2 `<<( … )>>` tokens, which
+//! W3C RDFC-1.0 has no notion of.
+//!
 //! [OPUS-4.8] sq-hslb — full non-standard RDF-1.2 triple-term canon profile;
 //! sq-5i1d — `*_with::<D: Digest>` hash-profile parity (SHA-384).
 //! Fable unavailable; flag for re-review when Fable returns.
+//! [FABLE-5] sq-iaxd — constrained ground-triple-term (no-nested-bnode) variant.
 
 use crate::CanonError;
 use digest::Digest;
@@ -193,6 +214,109 @@ pub fn canonicalize_graph_content_rdf12_with<D: Digest>(
     // profile too.
     let triples = crate::graph_triples(g)?;
     canonicalize_triples_rdf12_with::<D>(&triples)
+}
+
+// ---------------------------------------------------------------------------
+// Constrained ground-triple-term variant ([FABLE-5] sq-iaxd): thin wrappers
+// that fail closed on any blank node nested inside a triple term, then
+// delegate. With every triple term ground, the nested-bnode HNDQ-descent
+// extension above is unreachable, so these entry points exercise exactly the
+// RDFC-1.0 algorithm with triple terms as opaque constants (see module docs).
+// ---------------------------------------------------------------------------
+
+/// **NON-STANDARD (constrained).** Like [`canonicalize_rdf12`], but requires
+/// every triple term to be **ground** (no blank node at any nesting depth) and
+/// fails closed with [`CanonError::NestedBlankNode`] otherwise — the common
+/// credential/VC case. Top-level blank nodes are ordinary RDFC-1.0 bnodes and
+/// are relabelled as usual. On accepted input the output is byte-identical to
+/// [`canonicalize_rdf12`] (this is a thin guard + delegate wrapper), and the
+/// nested-bnode HNDQ-descent extension is never exercised.
+pub fn canonicalize_rdf12_ground_terms(dataset: &[Quad]) -> Result<String, CanonError> {
+    canonicalize_rdf12_ground_terms_with::<Sha256>(dataset)
+}
+
+/// **NON-STANDARD (constrained).** Like [`canonicalize_rdf12_ground_terms`] but
+/// parameterized over the RDFC-1.0 hash function `D` ([`crate::Digest`]); see
+/// [`canonicalize_rdf12_with`] for the hash-profile semantics.
+pub fn canonicalize_rdf12_ground_terms_with<D: Digest>(
+    dataset: &[Quad],
+) -> Result<String, CanonError> {
+    ensure_ground_triple_terms(dataset)?;
+    canonicalize_rdf12_with::<D>(dataset)
+}
+
+/// **NON-STANDARD (constrained).** Like [`issue_dataset_rdf12`], but fails
+/// closed with [`CanonError::NestedBlankNode`] if any blank node occurs inside
+/// a triple term. See [`canonicalize_rdf12_ground_terms`].
+pub fn issue_dataset_rdf12_ground_terms(
+    dataset: &[Quad],
+) -> Result<std::collections::HashMap<String, String>, CanonError> {
+    issue_dataset_rdf12_ground_terms_with::<Sha256>(dataset)
+}
+
+/// **NON-STANDARD (constrained).** Like [`issue_dataset_rdf12_ground_terms`]
+/// but parameterized over the RDFC-1.0 hash function `D` ([`crate::Digest`]).
+pub fn issue_dataset_rdf12_ground_terms_with<D: Digest>(
+    dataset: &[Quad],
+) -> Result<std::collections::HashMap<String, String>, CanonError> {
+    ensure_ground_triple_terms(dataset)?;
+    issue_dataset_rdf12_with::<D>(dataset)
+}
+
+/// **NON-STANDARD (constrained).** Like [`canonicalize_triples_rdf12`], but
+/// requires every triple term to be ground (no nested blank node) and fails
+/// closed with [`CanonError::NestedBlankNode`] otherwise. See
+/// [`canonicalize_rdf12_ground_terms`].
+pub fn canonicalize_triples_rdf12_ground_terms(
+    triples: &[Triple],
+) -> Result<crate::CanonicalGraph, CanonError> {
+    canonicalize_triples_rdf12_ground_terms_with::<Sha256>(triples)
+}
+
+/// **NON-STANDARD (constrained).** Like
+/// [`canonicalize_triples_rdf12_ground_terms`] but parameterized over the
+/// RDFC-1.0 hash function `D` ([`crate::Digest`]).
+pub fn canonicalize_triples_rdf12_ground_terms_with<D: Digest>(
+    triples: &[Triple],
+) -> Result<crate::CanonicalGraph, CanonError> {
+    if triples.iter().any(|t| term_has_nested_bnode(&t.object)) {
+        return Err(CanonError::NestedBlankNode);
+    }
+    canonicalize_triples_rdf12_with::<D>(triples)
+}
+
+/// The ground-triple-term guard: `Err(NestedBlankNode)` iff any blank node
+/// occurs **inside** a triple-term object of any quad, at any nesting depth.
+/// Top-level subject/object/graph blank nodes do not count — those are
+/// ordinary RDFC-1.0 blank nodes.
+fn ensure_ground_triple_terms(dataset: &[Quad]) -> Result<(), CanonError> {
+    if dataset.iter().any(|q| term_has_nested_bnode(&q.object)) {
+        return Err(CanonError::NestedBlankNode);
+    }
+    Ok(())
+}
+
+/// True iff `term` is a triple term containing a blank node at any depth.
+/// A top-level `Term::BlankNode` is NOT nested and returns `false`.
+fn term_has_nested_bnode(term: &Term) -> bool {
+    match term {
+        Term::Triple(t) => triple_contains_bnode(t),
+        _ => false,
+    }
+}
+
+/// True iff the (triple-term) triple contains a blank node in its subject or
+/// (recursively) its object. Predicates are always IRIs; in oxrdf 0.3 a
+/// triple's subject is `NamedOrBlankNode`, so only the object recurses.
+fn triple_contains_bnode(t: &Triple) -> bool {
+    if matches!(t.subject, NamedOrBlankNode::BlankNode(_)) {
+        return true;
+    }
+    match &t.object {
+        Term::BlankNode(_) => true,
+        Term::Triple(inner) => triple_contains_bnode(inner),
+        _ => false,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1262,5 +1386,110 @@ mod private_tests {
             relabel_graph_canonical(&GraphName::DefaultGraph, &issued),
             GraphName::DefaultGraph
         );
+    }
+
+    // ---- ground-triple-term guard helpers ([FABLE-5] sq-iaxd) ----
+
+    /// A TOP-LEVEL blank-node object is NOT "nested" — the guard must accept it
+    /// (it is an ordinary RDFC-1.0 bnode). Kills a `_ => false` → `_ => true`
+    /// arm mutation and pins the load-bearing top-level/nested distinction.
+    #[test]
+    fn term_has_nested_bnode_false_for_top_level_bnode_and_iri() {
+        assert!(!term_has_nested_bnode(&Term::BlankNode(bn("top"))));
+        assert!(!term_has_nested_bnode(&Term::NamedNode(iri("http://ex/o"))));
+        assert!(!term_has_nested_bnode(&Term::Literal(
+            oxrdf::Literal::new_simple_literal("v")
+        )));
+    }
+
+    /// A bnode in the triple term's SUBJECT position must be detected.
+    #[test]
+    fn term_has_nested_bnode_detects_inner_subject() {
+        let tt = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::BlankNode(bn("inner")),
+            iri("http://ex/p"),
+            Term::Literal(oxrdf::Literal::new_simple_literal("v")),
+        )));
+        assert!(term_has_nested_bnode(&tt));
+    }
+
+    /// A bnode in the triple term's OBJECT position must be detected, and a
+    /// fully ground triple term must NOT be.
+    #[test]
+    fn term_has_nested_bnode_detects_inner_object_and_accepts_ground() {
+        let with_bnode = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("inner")),
+        )));
+        assert!(term_has_nested_bnode(&with_bnode));
+        let ground = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::NamedNode(iri("http://ex/o")),
+        )));
+        assert!(!term_has_nested_bnode(&ground));
+    }
+
+    /// `triple_contains_bnode` must recurse through a depth-2 triple term
+    /// (a bnode only at the deepest level). Kills a "no recursion" mutation.
+    #[test]
+    fn triple_contains_bnode_recurses_to_depth_two() {
+        let deepest = Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/x")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("deep")),
+        );
+        let mid = Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/y")),
+            iri("http://ex/q"),
+            Term::Triple(Box::new(deepest)),
+        );
+        assert!(triple_contains_bnode(&mid), "depth-2 bnode must be found");
+        // Same shape but ground at every depth: not detected.
+        let ground_deepest = Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/x")),
+            iri("http://ex/p"),
+            Term::Literal(oxrdf::Literal::new_simple_literal("v")),
+        );
+        let ground_mid = Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/y")),
+            iri("http://ex/q"),
+            Term::Triple(Box::new(ground_deepest)),
+        );
+        assert!(!triple_contains_bnode(&ground_mid));
+    }
+
+    /// `ensure_ground_triple_terms` must accept a dataset whose only bnodes are
+    /// top-level (subject/graph) and reject one with a nested bnode.
+    #[test]
+    fn ensure_ground_triple_terms_guard() {
+        let ground_tt = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::NamedNode(iri("http://ex/o")),
+        )));
+        let ok = Quad::new(
+            NamedOrBlankNode::BlankNode(bn("top")),
+            iri("http://ex/says"),
+            ground_tt,
+            GraphName::BlankNode(bn("g")),
+        );
+        assert!(ensure_ground_triple_terms(std::slice::from_ref(&ok)).is_ok());
+        let bad_tt = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("inner")),
+        )));
+        let bad = Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+            iri("http://ex/says"),
+            bad_tt,
+            GraphName::DefaultGraph,
+        );
+        assert!(matches!(
+            ensure_ground_triple_terms(&[ok, bad]),
+            Err(CanonError::NestedBlankNode)
+        ));
     }
 }

--- a/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
+++ b/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
@@ -1143,3 +1143,308 @@ fn canonicalize_graph_content_rdf12_with_sha384_relabels_bnode() {
         "single-bnode graph must canonicalize identically under any hash"
     );
 }
+
+// ---------------------------------------------------------------------------
+// 7) Constrained ground-triple-term variant ([FABLE-5] sq-iaxd): the thin
+//    error-on-nested-bnode wrappers. Contract under test:
+//    (a) on ground-triple-term input each wrapper is byte-identical to the
+//        full profile it delegates to (SHA-256 and SHA-384);
+//    (b) any blank node INSIDE a triple term — inner subject, inner object,
+//        or deeper — fails closed with `CanonError::NestedBlankNode`;
+//    (c) TOP-LEVEL blank nodes stay ordinary RDFC-1.0 bnodes (accepted and
+//        relabelled), so the guard's nested/top-level distinction is pinned.
+// ---------------------------------------------------------------------------
+
+/// A ground triple term `<<( <s> <p> <o> )>>`.
+fn ground_tt() -> Term {
+    tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/p"),
+        Term::NamedNode(iri("http://ex/o")),
+    )
+}
+
+/// A triple term with a blank node in its OBJECT position.
+fn tt_inner_obj_bnode(label: &str) -> Term {
+    tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/p"),
+        Term::BlankNode(bn(label)),
+    )
+}
+
+/// A quad asserting `who says <tt>` in the default graph.
+fn says_quad(who: &str, object: Term) -> Quad {
+    Quad::new(
+        NamedOrBlankNode::NamedNode(iri(who)),
+        iri("http://ex/says"),
+        object,
+        GraphName::DefaultGraph,
+    )
+}
+
+/// Direct test for `canonicalize_rdf12_ground_terms`: a ground-triple-term
+/// dataset with a TOP-LEVEL bnode subject is accepted, relabels the top-level
+/// bnode, and is byte-identical to the full profile (delegation).
+#[test]
+fn ground_terms_accepts_and_matches_full_profile() {
+    let dataset = vec![
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("holder")),
+            iri("http://ex/says"),
+            ground_tt(),
+            GraphName::DefaultGraph,
+        ),
+        says_quad("http://ex/issuer", Term::Literal(Literal::new_simple_literal("v"))),
+    ];
+    let constrained = sparq_canon::canonicalize_rdf12_ground_terms(&dataset).unwrap();
+    let full = sparq_canon::canonicalize_rdf12(&dataset).unwrap();
+    assert_eq!(
+        constrained, full,
+        "constrained variant must be byte-identical to the full profile on accepted input"
+    );
+    assert!(
+        constrained.contains("_:c14n0"),
+        "top-level bnode must be relabelled: {constrained:?}"
+    );
+    assert!(
+        constrained.contains("<<("),
+        "ground triple-term token form must be preserved: {constrained:?}"
+    );
+}
+
+/// Direct test for `canonicalize_rdf12_ground_terms_with::<Sha384>`: delegation
+/// equivalence must hold under a non-default hash profile too.
+#[test]
+fn ground_terms_with_sha384_matches_full_profile() {
+    let dataset = vec![
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("x")),
+            iri("http://ex/says"),
+            ground_tt(),
+            GraphName::DefaultGraph,
+        ),
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("y")),
+            iri("http://ex/q"),
+            Term::BlankNode(bn("x")),
+            GraphName::DefaultGraph,
+        ),
+    ];
+    let constrained = sparq_canon::canonicalize_rdf12_ground_terms_with::<Sha384>(&dataset).unwrap();
+    let full = sparq_canon::canonicalize_rdf12_with::<Sha384>(&dataset).unwrap();
+    assert_eq!(constrained, full, "SHA-384 delegation must be byte-identical");
+    // And the SHA-256 default is reachable through the non-generic entry point.
+    let c256 = sparq_canon::canonicalize_rdf12_ground_terms(&dataset).unwrap();
+    assert_eq!(
+        c256,
+        sparq_canon::canonicalize_rdf12_ground_terms_with::<Sha256>(&dataset).unwrap(),
+        "non-generic entry point must be the SHA-256 profile"
+    );
+}
+
+/// Direct test for `issue_dataset_rdf12_ground_terms` (+ `_with`): the issuer
+/// map on accepted input equals the full profile's, and top-level bnodes are
+/// issued canonical labels.
+#[test]
+fn ground_terms_issuer_map_matches_full_profile() {
+    let dataset = vec![
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("only")),
+            iri("http://ex/says"),
+            ground_tt(),
+            GraphName::DefaultGraph,
+        ),
+    ];
+    let m = sparq_canon::issue_dataset_rdf12_ground_terms(&dataset).unwrap();
+    assert_eq!(
+        m.get("only").map(String::as_str),
+        Some("c14n0"),
+        "single top-level bnode must issue as c14n0: {m:?}"
+    );
+    assert_eq!(
+        m,
+        sparq_canon::issue_dataset_rdf12(&dataset).unwrap(),
+        "issuer map must equal the full profile's on accepted input"
+    );
+    let m384 = sparq_canon::issue_dataset_rdf12_ground_terms_with::<Sha384>(&dataset).unwrap();
+    assert_eq!(
+        m384,
+        sparq_canon::issue_dataset_rdf12_with::<Sha384>(&dataset).unwrap(),
+        "SHA-384 issuer map must equal the full profile's"
+    );
+}
+
+/// Direct test for `canonicalize_triples_rdf12_ground_terms` (+ `_with`): the
+/// single-graph wrapper delegates on ground input and keeps the
+/// `CanonicalGraph` lines/triples contract.
+#[test]
+fn ground_terms_triples_matches_full_profile() {
+    let t1 = Triple::new(
+        NamedOrBlankNode::BlankNode(bn("top")),
+        iri("http://ex/says"),
+        ground_tt(),
+    );
+    let t2 = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/q"),
+        Term::Literal(Literal::new_simple_literal("leaf")),
+    );
+    let c = sparq_canon::canonicalize_triples_rdf12_ground_terms(&[t1.clone(), t2.clone()]).unwrap();
+    let full = sparq_canon::canonicalize_triples_rdf12(&[t1.clone(), t2.clone()]).unwrap();
+    assert_eq!(c.lines, full.lines, "lines must equal the full profile's");
+    assert_eq!(c.triples, full.triples, "triples must equal the full profile's");
+    assert_eq!(c.lines.len(), 2, "two triples -> two canonical lines");
+    let c384 =
+        sparq_canon::canonicalize_triples_rdf12_ground_terms_with::<Sha384>(&[t1.clone(), t2.clone()])
+            .unwrap();
+    let full384 = sparq_canon::canonicalize_triples_rdf12_with::<Sha384>(&[t1, t2]).unwrap();
+    assert_eq!(c384.lines, full384.lines, "SHA-384 delegation must agree");
+}
+
+/// On triple-term-FREE input the constrained variant agrees byte-for-byte with
+/// the STANDARD `rdf-canon`-backed path (inherited from the full profile's
+/// standard-path agreement, asserted directly here for the wrapper).
+#[test]
+fn ground_terms_agrees_with_standard_path_on_triple_term_free_input() {
+    let dataset = vec![
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("b0")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("b1")),
+            GraphName::DefaultGraph,
+        ),
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("b1")),
+            iri("http://ex/q"),
+            Term::Literal(Literal::new_simple_literal("v")),
+            GraphName::DefaultGraph,
+        ),
+    ];
+    assert_eq!(
+        sparq_canon::canonicalize_rdf12_ground_terms(&dataset).unwrap(),
+        sparq_canon::canonicalize(&dataset).unwrap(),
+        "constrained variant must equal the standard path on RDF-1.1 input"
+    );
+}
+
+/// (b) Error contract: a bnode in the triple term's OBJECT position fails
+/// closed with `NestedBlankNode` on every wrapper — canonicalize, issuer map,
+/// and the `_with` siblings.
+#[test]
+fn nested_bnode_in_object_position_fails_closed() {
+    let dataset = vec![says_quad("http://ex/a", tt_inner_obj_bnode("inner"))];
+    assert!(matches!(
+        sparq_canon::canonicalize_rdf12_ground_terms(&dataset),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+    assert!(matches!(
+        sparq_canon::canonicalize_rdf12_ground_terms_with::<Sha384>(&dataset),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+    assert!(matches!(
+        sparq_canon::issue_dataset_rdf12_ground_terms(&dataset),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+    assert!(matches!(
+        sparq_canon::issue_dataset_rdf12_ground_terms_with::<Sha384>(&dataset),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+    // Contrast (non-vacuity): the FULL profile canonicalizes the same input.
+    assert!(
+        sparq_canon::canonicalize_rdf12(&dataset).is_ok(),
+        "the full descent must still accept what the constrained variant rejects"
+    );
+}
+
+/// (b) Error contract: a bnode in the triple term's SUBJECT position (a
+/// `NamedOrBlankNode`, so it can be blank) also fails closed.
+#[test]
+fn nested_bnode_in_subject_position_fails_closed() {
+    let inner_subj = tt(
+        NamedOrBlankNode::BlankNode(bn("inner")),
+        iri("http://ex/p"),
+        Term::Literal(Literal::new_simple_literal("v")),
+    );
+    let triples = vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/says"),
+        inner_subj,
+    )];
+    assert!(matches!(
+        sparq_canon::canonicalize_triples_rdf12_ground_terms(&triples),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+    assert!(matches!(
+        sparq_canon::canonicalize_triples_rdf12_ground_terms_with::<Sha384>(&triples),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+}
+
+/// (b) Error contract: a bnode at nesting depth 2 (a triple term inside a
+/// triple term) is found by the recursive guard.
+#[test]
+fn nested_bnode_at_depth_two_fails_closed() {
+    let deepest = tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/x")),
+        iri("http://ex/p"),
+        Term::BlankNode(bn("deep")),
+    );
+    let mid = tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/y")),
+        iri("http://ex/q"),
+        deepest,
+    );
+    let dataset = vec![says_quad("http://ex/a", mid)];
+    assert!(matches!(
+        sparq_canon::canonicalize_rdf12_ground_terms(&dataset),
+        Err(sparq_canon::CanonError::NestedBlankNode)
+    ));
+}
+
+/// (c) The guard must NOT be tripped by top-level bnodes anywhere a bnode can
+/// legally sit in RDF-1.1 (subject, object, graph name) — only by bnodes
+/// inside triple terms. A dataset mixing all three top-level positions with a
+/// ground triple term is accepted and isomorphism-stable (relabel + reorder).
+#[test]
+fn top_level_bnodes_everywhere_are_accepted_and_isomorphism_stable() {
+    let make = |s: &str, o: &str, g: &str, swap: bool| -> String {
+        let q1 = Quad::new(
+            NamedOrBlankNode::BlankNode(bn(s)),
+            iri("http://ex/says"),
+            ground_tt(),
+            GraphName::BlankNode(bn(g)),
+        );
+        let q2 = Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+            iri("http://ex/knows"),
+            Term::BlankNode(bn(o)),
+            GraphName::DefaultGraph,
+        );
+        let dataset = if swap { vec![q2, q1] } else { vec![q1, q2] };
+        sparq_canon::canonicalize_rdf12_ground_terms(&dataset).unwrap()
+    };
+    let a = make("s1", "o1", "g1", false);
+    let b = make("other1", "other2", "other3", true);
+    assert_eq!(
+        a, b,
+        "isomorphic ground-TT datasets must canonicalize identically"
+    );
+    assert!(a.contains("<<("), "triple-term token preserved: {a:?}");
+}
+
+/// The new error variant's `Display` must self-describe (used in fail-closed
+/// logs); check the message names the nested-bnode condition and the full
+/// profile's escape hatch.
+#[test]
+fn nested_blank_node_error_display() {
+    let msg = sparq_canon::CanonError::NestedBlankNode.to_string();
+    assert!(
+        msg.contains("nested") && msg.contains("triple term"),
+        "Display must name the condition: {msg:?}"
+    );
+    assert!(
+        msg.contains("canonicalize_rdf12"),
+        "Display must point at the full-descent escape hatch: {msg:?}"
+    );
+}

--- a/skills/rdf-canon/SKILL.md
+++ b/skills/rdf-canon/SKILL.md
@@ -102,11 +102,16 @@ if you want them without canonicalizing.
 
 ## Errors — fail closed
 
-`CanonError` has three variants:
+`CanonError` has four variants:
 
 - `TripleTerm` — the dataset contains an RDF 1.2 triple term as an object; these
   are outside W3C RDFC-1.0's data model, so the **standard** paths fail closed.
   Enable the opt-in `rdf12-triple-terms` profile (below) to canonicalize them.
+- `NestedBlankNode` — a blank node occurs **inside** a triple term. Only the
+  opt-in profile's constrained `*_ground_terms` entry points (below) construct
+  it: they require blank-node-free (ground) triple terms and fail closed
+  otherwise. The variant itself is always present (not feature-gated), so
+  matching on `CanonError` is identical in both feature states.
 - `Canonicalization(String)` — `rdf-canon` rejected the dataset. This includes
   the **HNDQ call-limit guard**: RDFC-1.0 has pathological-input blow-ups, so a
   poison graph trips the limit and fails closed rather than running unbounded.
@@ -143,7 +148,28 @@ let m  = sparq_canon::issue_dataset_rdf12(&dataset)?;         // issuer map
 let nq384 = sparq_canon::canonicalize_rdf12_with::<sha2::Sha384>(&dataset)?;
 let cg384 = sparq_canon::canonicalize_triples_rdf12_with::<sha2::Sha384>(&triples)?;
 let m384  = sparq_canon::issue_dataset_rdf12_with::<sha2::Sha384>(&dataset)?;
+
+// CONSTRAINED ground-triple-term variant (sq-iaxd): errors with
+// `CanonError::NestedBlankNode` if ANY blank node occurs inside a triple term
+// (at any depth — inner subject or inner object). Same `*_with` siblings.
+let vc  = sparq_canon::canonicalize_rdf12_ground_terms(&dataset)?;   // quads
+let vcg = sparq_canon::canonicalize_triples_rdf12_ground_terms(&triples)?;
+let vm  = sparq_canon::issue_dataset_rdf12_ground_terms(&dataset)?;  // issuer map
 ```
+
+**When to prefer the constrained `*_ground_terms` entry points.** The common
+credential/VC shape quotes or asserts **ground** content: triple terms with no
+blank nodes inside. On that input the constrained wrappers are byte-identical
+to the full profile (they are thin guard + delegate wrappers), but their
+well-definedness does **not** rest on the novel nested-bnode HNDQ-descent
+design — with every triple term ground, the run is exactly the RDFC-1.0
+algorithm over an alphabet extended with opaque triple-term constants, and a
+nested blank node is **rejected** (`CanonError::NestedBlankNode`) instead of
+silently canonicalized under the extension. Top-level blank nodes (quad
+subject/object/graph name) are ordinary RDFC-1.0 bnodes and stay fine. Use the
+full `canonicalize_rdf12` descent only when you actually need nested blank
+nodes relabelled. Still non-standard either way: the canonical N-Quads carry
+RDF-1.2 `<<( … )>>` tokens, which W3C RDFC-1.0 has no notion of.
 
 **Boundary / honesty:** SHA-256 is the default; a `*_with::<D: Digest>` sibling of
 each v2 entry point selects another hash (notably `sha2::Sha384`) for parity with
@@ -193,7 +219,9 @@ bridge + public API. The opt-in, off-by-default `rdf12-triple-terms` profile
 (sq-hslb [OPUS-4.8]) is a native RDFC-1.0 re-implementation extended to RDF 1.2
 triple terms — **non-standard** (W3C RDFC-1.0 is RDF-1.1-only) — now with a
 `*_with::<D: Digest>` hash-profile sibling on every entry point for SHA-384
-parity (sq-5i1d [OPUS-4.8]). The `canonicalize_nquads` / `parse_nquads` text seam
+parity (sq-5i1d [OPUS-4.8]) and a constrained ground-triple-term
+(error-on-nested-bnode) `*_ground_terms` wrapper family for the common
+credential/VC case (sq-iaxd [FABLE-5]). The `canonicalize_nquads` / `parse_nquads` text seam
 and the `sparq-wasm` opt-in `canon` feature (`canonicalizeNQuads` binding for the
 `@jeswr/sparq` RDF/JS `Dataset`) are sq-1dd5t [OPUS-4.8]; that wasm consumer pulls
 `sparq-canon` with `default-features = false` (the crate now disables


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — implementation PR for bead **sq-iaxd**.

## What

The deferred sq-hslb / #933 follow-up: a **constrained ground-triple-term variant** of the opt-in, **OFF-by-default** `rdf12-triple-terms` profile in `sparq-canon`.

- New thin wrapper family (guard + delegate): `canonicalize_rdf12_ground_terms`, `issue_dataset_rdf12_ground_terms`, `canonicalize_triples_rdf12_ground_terms`, each with a `*_with::<D: Digest>` sibling (crate idiom, sq-5i1d parity).
- New `CanonError::NestedBlankNode`: any blank node **inside** a triple term (inner subject, inner object, or deeper) fails closed. The variant is **ungated** so `CanonError` matching is identical in both feature states; it is only *constructed* by the gated wrappers. No downstream exhaustive matches exist (sparq-zk/sparq-vc only wrap via `From`).
- On accepted input the wrappers are byte-identical to the full profile. **Honest boundary:** with every triple term ground (the common credential/VC shape) the nested-bnode HNDQ-descent extension is unreachable — the run is exactly the RDFC-1.0 algorithm over an alphabet extended with opaque triple-term constants — but the output is still NON-STANDARD (RDF-1.2 `<<( … )>>` tokens; W3C RDFC-1.0 is RDF-1.1-only). Top-level bnodes (subject/object/graph) remain ordinary RDFC-1.0 bnodes.

Default build is unchanged: the feature stays OFF, `sparq-canon` is a non-default workspace member, no new dependencies.

## Tests (non-vacuous)

- 10 new integration tests (`tests/rdf12_triple_term_canon.rs` §7): delegation equivalence (SHA-256 + SHA-384, canonicalize/issuer-map/triples), standard-path agreement on triple-term-free input, fail-closed on inner-subject / inner-object / depth-2 nested bnodes **with an in-test contrast asserting the full profile accepts the same input** (so the rejection is provably the guard, not vacuity), top-level-bnode acceptance in all three quad positions + isomorphism stability (relabel + reorder), Display contract.
- 5 private-helper unit tests (`rdf12.rs::private_tests`) pinning the top-level-vs-nested distinction and the depth recursion.
- 1 default-state lib test covering the new Display arm with the feature OFF.

## Gates (run to completion, both states)

- `cargo build` / `cargo test -p sparq-canon` — GREEN default (feature OFF) and GREEN with `--features rdf12-triple-terms` (18 + 52 unit, 35 rdf12 integration, W3C suite, doctests).
- `cargo clippy --workspace --all-targets -- -D warnings` — GREEN (default) and GREEN for `-p sparq-canon --features rdf12-triple-terms`.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — GREEN; also GREEN without `--all-features` for `-p sparq-canon` (no intra-doc links from always-compiled docs to cfg-gated items — code spans only in `lib.rs`).
- `scripts/check-readme-template.py --enforce` — 0 deviations (README held at 120 lines by compressing two existing paragraphs).
- typos over touched markdown — clean.

## Docs

- `crates/sparq-canon/README.md` — constrained variant documented in the NON-STANDARD profile section.
- `skills/rdf-canon/SKILL.md` — error variant (now four), API example, when-to-prefer guidance, status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)