### PR TITLE
feat(metamorph): wire TLP/NoREC oracles into CI — seeded driver + nightly metamorph.yml lane (sq-3dyje.9) [FABLE-5]

### DIFF
--- a/.github/workflows/metamorph.yml
+++ b/.github/workflows/metamorph.yml
@@ -1,0 +1,229 @@
+# [FABLE-5] Standing nightly metamorphic (TLP/NoREC) lane (bead sq-3dyje.9,
+# design record research/testing-strategy-assessment-2026-07.md §7.3).
+#
+# WHAT: drives crates/sparq-metamorph's SINGLE-ENGINE metamorphic oracles — TLP
+# (ternary logic partitioning re-derived for SPARQL's three-valued EBV semantics)
+# and NoREC (the non-optimizable-rewrite cardinality oracle) — over the crate's
+# seeded deterministic query/data generator, via the `metamorph-driver` binary.
+# TLP/NoREC catch the logic bugs cross-engine differentials structurally cannot:
+# bugs SHARED with the oracle engine, and surfaces where no oracle engine exists.
+# They need no cross-engine adjudication registry — a violation is sparq's own
+# evaluation paths disagreeing with each other.
+#
+# TWO SHARDS (mirroring differential.yml's window scheme):
+#   * smoke   — a FIXED regression window (seeds 0..2000), replayed every night:
+#     deterministic, so a red smoke shard means a fresh engine/driver REGRESSION
+#     on seeds known green. This is also the bead's acceptance window (the driver
+#     over it exits 0 on main).
+#   * nightly — an ADVANCING window (days-since-epoch × WINDOW_STRIDE), so each
+#     night explores a fresh, never-replayed seed range (the generator is a
+#     deterministic SplitMix64 — the seed IS the corpus).
+#
+# VERDICT DISCIPLINE (fail-closed, never silently skipped): every seed yields a
+# TLP and a NoREC verdict; Pass is counted, VIOLATION (wrong-result signal) and
+# ENGINE-FAILURE (a generated valid query failed to evaluate) both print a
+# deterministic repro line and fail the window; an empty window fails. The
+# non-vacuity anchor (the injected FilterDropsRow mutant must be flagged) is
+# enforced by `cargo test -p sparq-metamorph` in the per-PR CI, and the driver's
+# red path can be demonstrated any time with `--inject-filter-drops-row`.
+#
+# BUDGET: ~0.45 ms/seed measured locally (release, in-process engine); 500k
+# nightly seeds ≈ 4–15 min depending on runner throughput, well inside the
+# timeout. WINDOW_STRIDE must stay >= the nightly count so consecutive nights
+# can never replay a seed.
+#
+# ON FAILURE, each shard: (1) uploads the driver log — which contains the full
+# deterministic repro (VIOLATION/ENGINE-FAILURE seed lines + the FIRST FAILING
+# CASE block with replay command, queries, and graph) — as an artifact, and
+# (2) auto-files the finding via scripts/ci-file-metamorph-failure.py: a GitHub
+# issue with the repro inline (deduped per shard) + a P1 bug bead appended to
+# .beads/issues.jsonl with a BEST-EFFORT push (fail-soft on the GH013
+# protected-main ruleset rejection, exactly the differential.yml pattern; the
+# GitHub issue is the reliable channel the orchestrator's issue sweep beads from).
+#
+# TRIGGER — NIGHTLY/HEAVY tier ONLY (schedule + workflow_dispatch), like
+# differential.yml: this workflow never produces a check-run on a PR head
+# commit, so the `ci-summary / gate` aggregator never sees it and the per-PR
+# gate is unaffected. The per-PR guarantee for this crate is its self-test suite
+# (which includes the driver's non-vacuity tests) in the normal CI lanes.
+#
+# Third-party actions are pinned by full commit SHA (supply-chain hardening); the
+# trailing `# vX.Y.Z` comment is what Dependabot follows to bump the pin. Pins
+# match those already used by differential.yml / fuzz.yml / ci.yml.
+name: metamorph
+
+on:
+  workflow_dispatch:
+    inputs:
+      seed_start:
+        description: "seed window start for the nightly shard (default: days-since-epoch × stride — the advancing window)"
+        required: false
+        default: ""
+      count:
+        description: "seeds for the nightly shard (smoke keeps its fixed window)"
+        required: false
+        default: ""
+  # Daily heavy tier. 04:07 UTC — offset from ci.yml's coverage cron (03:17),
+  # differential.yml (03:53), fuzz.yml (04:23) and differential-update.yml
+  # (04:37) per the existing nightly stagger convention.
+  schedule:
+    - cron: "7 4 * * *"
+
+permissions:
+  contents: read
+
+# One nightly sweep at a time; never cancel a shard mid bug-filing.
+concurrency:
+  group: metamorph-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # The advancing-window stride (seeds/night for the nightly shard). MUST stay
+  # >= the nightly `count` below, or consecutive nights would replay seeds
+  # instead of exploring fresh ones.
+  WINDOW_STRIDE: "600000"
+
+jobs:
+  metamorph:
+    name: nightly metamorphic TLP/NoREC (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write # best-effort .beads bug-bead commit-back (fail-soft on GH013)
+      issues: write # auto-file the finding as a GitHub issue with the repro inline
+    strategy:
+      # Run both shards even if one finds a bug — a red smoke (regression) and a
+      # red nightly (fresh find) are distinct signals worth having together.
+      fail-fast: false
+      matrix:
+        include:
+          # Fixed regression window: the bead's acceptance window, green on main.
+          - { name: smoke, count: 2000, advancing: false }
+          # Advancing exploration window (see WINDOW_STRIDE).
+          - { name: nightly, count: 500000, advancing: true }
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable via toolchain input
+        with:
+          toolchain: stable
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Both shards build the identical driver binary — share ONE cache key
+          # across the matrix instead of two near-duplicate caches.
+          shared-key: metamorph-nightly
+      # Build once, distinctly, so a compile error is reported separately from an
+      # oracle failure.
+      - name: Build the metamorph driver
+        run: cargo build -p sparq-metamorph --release --bins
+      - name: Compute the seed window
+        id: window
+        env:
+          INPUT_SEED_START: ${{ github.event.inputs.seed_start }}
+          INPUT_COUNT: ${{ github.event.inputs.count }}
+          MATRIX_COUNT: ${{ matrix.count }}
+          MATRIX_ADVANCING: ${{ matrix.advancing }}
+        run: |
+          set -euo pipefail
+          if [ "$MATRIX_ADVANCING" = "true" ]; then
+            # Advancing window: start = days-since-epoch × stride, so exploration
+            # NEVER replays a previous night's range. A workflow_dispatch may pin
+            # an explicit start (e.g. to re-run a failing night's window).
+            if [ -n "$INPUT_SEED_START" ]; then
+              start="$INPUT_SEED_START"
+            else
+              days=$(( $(date -u +%s) / 86400 ))
+              start=$(( days * WINDOW_STRIDE ))
+            fi
+            count="$MATRIX_COUNT"
+            if [ -n "$INPUT_COUNT" ]; then
+              count="$INPUT_COUNT"
+            fi
+            if [ "$count" -gt "$WINDOW_STRIDE" ]; then
+              echo "::error::nightly count $count exceeds WINDOW_STRIDE $WINDOW_STRIDE — nights would replay seeds"
+              exit 1
+            fi
+          else
+            # The smoke shard's window is FIXED — it is the deterministic
+            # regression anchor and ignores dispatch overrides.
+            start=0
+            count="$MATRIX_COUNT"
+          fi
+          echo "start=$start" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Window for this shard: seeds $start..$(( start + count ))"
+      - name: Run the TLP/NoREC driver (fails on any violation or engine failure)
+        env:
+          START: ${{ steps.window.outputs.start }}
+          COUNT: ${{ steps.window.outputs.count }}
+        run: |
+          set -euo pipefail
+          # Tee the log: on a failure it contains the full deterministic repro
+          # (VIOLATION/ENGINE-FAILURE seed lines + the FIRST FAILING CASE block
+          # with replay + queries + graph), which the failure steps below upload
+          # and file. pipefail keeps the exit code.
+          ./target/release/metamorph-driver "$START" "$COUNT" 2>&1 \
+            | tee "$RUNNER_TEMP/metamorph-log.txt"
+      # ── failure path: preserve the repro + auto-file the finding ────────────────
+      - name: Auto-file the finding (GitHub issue + P1 bug bead, deduped)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Explicit repo for `gh issue …` (independent of the checkout's remote).
+          GH_REPO: ${{ github.repository }}
+          SHARD: ${{ matrix.name }}
+          START: ${{ steps.window.outputs.start }}
+          COUNT: ${{ steps.window.outputs.count }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci-file-metamorph-failure.py --self-test
+          python3 scripts/ci-file-metamorph-failure.py \
+            --log "$RUNNER_TEMP/metamorph-log.txt" \
+            --shard "$SHARD" \
+            --seed-start "${START:-unknown}" \
+            --count "${COUNT:-unknown}" \
+            --out-dir "$RUNNER_TEMP/metamorph-repro" \
+            --jsonl .beads/issues.jsonl \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+      - name: Commit the new bug bead back to main (best-effort; fail-soft on ruleset-blocked push)
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHARD: ${{ matrix.name }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .beads/issues.jsonl; then
+            echo "no bead appended (deduped or filing skipped) — nothing to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add .beads/issues.jsonl
+          git commit -m "chore(beads): auto-file metamorph P1 bug bead (${SHARD}) [skip ci]" \
+                     -m "Nightly metamorphic lane finding (sq-3dyje.9). [FABLE-5]"
+          # Best-effort push, exactly the differential.yml fail-soft pattern: the
+          # protected-main ruleset (GH013) rejects direct pushes until a bypass
+          # exists (sq-roe3); the GitHub issue filed above is the reliable channel.
+          set +e
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+          push_rc=$?
+          set -e
+          if [ "$push_rc" -ne 0 ]; then
+            echo "::warning title=metamorph bead push declined::Could not push the auto-filed bug bead to protected main (git push exit ${push_rc}; likely GH013 ruleset rejection). The GitHub issue filed in the previous step is the durable record; the orchestrator beads it on the next issue sweep."
+            exit 0
+          fi
+          echo "pushed the auto-filed bug bead to main."
+      - name: Upload the repro artifact (log + parsed seed/queries/graph)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: metamorph-repro-${{ matrix.name }}
+          path: |
+            ${{ runner.temp }}/metamorph-log.txt
+            ${{ runner.temp }}/metamorph-repro/
+          if-no-files-found: warn

--- a/crates/sparq-metamorph/README.md
+++ b/crates/sparq-metamorph/README.md
@@ -47,6 +47,11 @@ feature (off by default; pulls `ureq`): build an `EndpointConfig` preset, wrap i
   a developer-confirmation status; unfiled observations are not entries.
 - **Non-vacuity self-tests**: a deliberately-injected wrong-result mutant
   (`FilterDropsRow`) is flagged by all three oracles against the *real* sparq engine.
+- **Nightly CI driver** (`harness` + the `metamorph-driver` binary): seeded window ->
+  TLP + NoREC verdicts per seed, every verdict counted (fail-closed), deterministic
+  repro on failure. Driven by `.github/workflows/metamorph.yml` (advancing nightly
+  window + fixed smoke window, auto-filed findings). Red path on demand:
+  `metamorph-driver <start> <count> --inject-filter-drops-row`.
 
 ## 📚 Learn more
 

--- a/crates/sparq-metamorph/src/bin/metamorph-driver.rs
+++ b/crates/sparq-metamorph/src/bin/metamorph-driver.rs
@@ -1,0 +1,53 @@
+//! Thin CLI over [`sparq_metamorph::run_window`] — the nightly metamorphic CI lane's
+//! entry point (`.github/workflows/metamorph.yml`, bead `sq-3dyje.9`). [FABLE-5]
+//!
+//! ```text
+//! metamorph-driver <seed-start> <seed-count> [--inject-filter-drops-row]
+//! ```
+//!
+//! Exit code 0 iff every seed in the window passed both the TLP and NoREC oracles
+//! (fail-closed: violations, engine failures, and an empty window all exit 1). The
+//! `--inject-filter-drops-row` switch wraps the engine in the crate's seeded
+//! wrong-result mutant to demonstrate the red path end-to-end; the standing lane
+//! never sets it. All driver logic (and its tests) lives in the library's `harness`
+//! module — this binary only parses arguments and maps the report to an exit code.
+
+use std::process::ExitCode;
+
+use sparq_metamorph::run_window;
+
+fn usage() -> ExitCode {
+    eprintln!("usage: metamorph-driver <seed-start> <seed-count> [--inject-filter-drops-row]");
+    ExitCode::from(2)
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut inject = false;
+    let mut positional = Vec::new();
+    for arg in &args {
+        match arg.as_str() {
+            "--inject-filter-drops-row" => inject = true,
+            _ => positional.push(arg.as_str()),
+        }
+    }
+    let (Some(start), Some(count), None) = (
+        positional.first().and_then(|s| s.parse::<u64>().ok()),
+        positional.get(1).and_then(|s| s.parse::<u64>().ok()),
+        positional.get(2),
+    ) else {
+        return usage();
+    };
+    if inject {
+        println!("NOTE: --inject-filter-drops-row set — the wrong-result mutant is active; this run MUST fail.");
+    }
+    let mut stdout = std::io::stdout().lock();
+    match run_window(start, count, inject, &mut stdout) {
+        Ok(report) if report.all_pass() => ExitCode::SUCCESS,
+        Ok(_) => ExitCode::FAILURE,
+        Err(e) => {
+            eprintln!("metamorph-driver: io error writing the log: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/sparq-metamorph/src/harness.rs
+++ b/crates/sparq-metamorph/src/harness.rs
@@ -1,0 +1,349 @@
+//! **The seeded CI driver window** — feed generated cases to the TLP + NoREC oracles
+//! and report every verdict, fail-closed. [FABLE-5] Bead `sq-3dyje.9` (epic
+//! `sq-3dyje`, design record `research/testing-strategy-assessment-2026-07.md` §7.3).
+//!
+//! This module is the missing plumbing between the oracles and CI: the
+//! `metamorph-driver` binary (`src/bin/metamorph-driver.rs`) is a thin wrapper over
+//! [`run_window`], and `.github/workflows/metamorph.yml` runs it nightly over an
+//! advancing seed window plus a fixed smoke window (mirroring `differential.yml`'s
+//! repro + auto-file pattern).
+//!
+//! # Verdict accounting (never silently skipped)
+//!
+//! Every seed in the window is checked by **both** single-engine oracles
+//! ([`crate::tlp`], [`crate::norec`]) against the in-process sparq engine, and every
+//! verdict is counted in the [`WindowReport`]:
+//!
+//! * [`Verdict::Pass`] — the relation held; counted, nothing printed.
+//! * [`Verdict::Violation`] — a wrong-result signal; a `VIOLATION seed=N` repro line
+//!   is printed and the window fails.
+//! * [`Verdict::EngineFailure`] — a query did not evaluate. The generator emits only
+//!   valid SPARQL inside the oracles' scope preconditions, so an engine failure on a
+//!   generated case is itself a finding (an engine-error bug or a harness bug), never
+//!   an excuse: an `ENGINE-FAILURE seed=N` line is printed and the window **fails**
+//!   (fail-closed — a lane that skips errors proves nothing).
+//!
+//! The first non-Pass verdict is echoed at the end of the log as a complete
+//! deterministic repro block (`FIRST FAILING CASE:` — seed, oracle, replay command,
+//! all queries, the N-Triples graph), which `scripts/ci-file-metamorph-failure.py`
+//! parses into the auto-filed GitHub issue + P1 bug bead.
+//!
+//! # Non-vacuity anchor
+//!
+//! [`check_seed`] takes an `inject_filter_drops_row` switch that wraps the engine in
+//! the [`FilterDropsRow`] wrong-result mutant. The self-tests assert a window over the
+//! mutant **fails with both oracles reporting violations** — a driver that cannot flag
+//! the crate's own seeded bug would make the whole lane vacuous. The binary exposes
+//! the switch as `--inject-filter-drops-row` so the same red-path can be demonstrated
+//! end-to-end in CI or locally (never enabled in the standing workflow).
+
+use std::io::{self, Write};
+
+use crate::engine::{FilterDropsRow, InProcessSparq, SparqlEngine};
+use crate::generate::{generate_case, GeneratedCase};
+use crate::norec::{check_norec, norec_queries};
+use crate::tlp::{check_tlp, tlp_queries};
+use crate::verdict::Verdict;
+
+/// The engine name used for every verdict this driver produces.
+const ENGINE_NAME: &str = "sparq";
+
+/// Both oracle verdicts for one generated seed, with the case kept for repro output.
+#[derive(Debug, Clone)]
+pub struct SeedOutcome {
+    /// The generated case (seed + data + pattern + predicate).
+    pub case: GeneratedCase,
+    /// The TLP verdict for this case.
+    pub tlp: Verdict,
+    /// The NoREC verdict for this case.
+    pub norec: Verdict,
+}
+
+impl SeedOutcome {
+    /// True iff both oracles passed.
+    pub fn is_pass(&self) -> bool {
+        self.tlp.is_pass() && self.norec.is_pass()
+    }
+}
+
+/// Aggregate verdict counts for one seed window. Every generated case lands in
+/// exactly one of pass / violation / engine-failure **per oracle** — nothing is
+/// skipped or silently dropped.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WindowReport {
+    /// First seed of the window.
+    pub start: u64,
+    /// Number of seeds checked (equals the requested count).
+    pub checked: u64,
+    /// Seeds where both oracles passed.
+    pub pass: u64,
+    /// TLP wrong-result violations.
+    pub tlp_violations: u64,
+    /// NoREC wrong-result violations.
+    pub norec_violations: u64,
+    /// Verdicts (across both oracles) where a query failed to evaluate.
+    pub engine_failures: u64,
+}
+
+impl WindowReport {
+    /// True iff the window is green: at least one seed was checked and **every**
+    /// verdict was a pass. Fail-closed: an empty window (`count == 0`) is NOT a
+    /// pass — a misconfigured lane that checks nothing must go red, not green.
+    pub fn all_pass(&self) -> bool {
+        self.checked > 0 && self.pass == self.checked
+    }
+
+    /// The one-line machine-readable summary the workflow log ends with (parsed by
+    /// `scripts/ci-file-metamorph-failure.py`).
+    pub fn summary_line(&self) -> String {
+        format!(
+            "metamorph seeds {}..{}: checked={} pass={} tlp-violation={} norec-violation={} engine-failure={}",
+            self.start,
+            self.start + self.checked,
+            self.checked,
+            self.pass,
+            self.tlp_violations,
+            self.norec_violations,
+            self.engine_failures
+        )
+    }
+}
+
+/// Run both oracles on the case generated from `seed`.
+///
+/// With `inject_filter_drops_row` set, the engine is wrapped in the
+/// [`FilterDropsRow`] wrong-result mutant (the non-vacuity red-path — see the module
+/// docs); the standing CI lane always passes `false`.
+///
+/// A data-load failure is reported as an engine failure on **both** oracles (the
+/// verdicts are counted, never skipped).
+pub fn check_seed(seed: u64, inject_filter_drops_row: bool) -> SeedOutcome {
+    let case = generate_case(seed);
+    match InProcessSparq::from_ntriples(ENGINE_NAME, &case.data_ntriples) {
+        Err(failure) => SeedOutcome {
+            case,
+            tlp: Verdict::EngineFailure(failure.clone()),
+            norec: Verdict::EngineFailure(failure),
+        },
+        Ok(engine) => {
+            if inject_filter_drops_row {
+                let mutant = FilterDropsRow::new(engine);
+                run_oracles(&mutant, case)
+            } else {
+                run_oracles(&engine, case)
+            }
+        }
+    }
+}
+
+fn run_oracles(engine: &dyn SparqlEngine, case: GeneratedCase) -> SeedOutcome {
+    let tlp = check_tlp(engine, &case.pattern, &case.predicate);
+    let norec = check_norec(engine, &case.pattern, &case.predicate);
+    SeedOutcome { case, tlp, norec }
+}
+
+/// One oracle verdict rendered as a log line (`None` for a pass — passes are counted
+/// in the summary, not printed per seed).
+fn verdict_line(oracle: &str, seed: u64, verdict: &Verdict) -> Option<String> {
+    match verdict {
+        Verdict::Pass { .. } => None,
+        Verdict::Violation(v) => Some(format!("VIOLATION seed={seed} oracle={oracle}: {v}")),
+        Verdict::EngineFailure(f) => {
+            Some(format!("ENGINE-FAILURE seed={seed} oracle={oracle}: {f}"))
+        }
+    }
+}
+
+/// Render the complete deterministic repro block for the first failing seed:
+/// replayable command, verdict detail, every oracle query, and the graph.
+fn first_failing_case_block(outcome: &SeedOutcome) -> String {
+    let seed = outcome.case.seed;
+    let mut block = String::from("FIRST FAILING CASE:\n");
+    block.push_str(&format!("seed={seed}\n"));
+    block.push_str(&format!(
+        "replay: cargo run -p sparq-metamorph --bin metamorph-driver -- {seed} 1\n"
+    ));
+    for (oracle, verdict) in [("tlp", &outcome.tlp), ("norec", &outcome.norec)] {
+        if let Some(line) = verdict_line(oracle, seed, verdict) {
+            block.push_str(&line);
+            block.push('\n');
+        }
+    }
+    let tlp = tlp_queries(&outcome.case.pattern, &outcome.case.predicate);
+    let norec = norec_queries(&outcome.case.pattern, &outcome.case.predicate);
+    block.push_str("--- queries ---\n");
+    for query in [
+        &tlp.base,
+        &tlp.branch_true,
+        &tlp.branch_false,
+        &tlp.branch_error,
+        &norec.optimized,
+        &norec.rewritten,
+    ] {
+        block.push_str(query);
+        block.push('\n');
+    }
+    block.push_str("--- graph ---\n");
+    block.push_str(&outcome.case.data_ntriples);
+    block
+}
+
+/// Drive the TLP + NoREC oracles over seeds `start .. start + count`, streaming a
+/// repro line per non-Pass verdict to `out`, then the `FIRST FAILING CASE:` block
+/// (if any) and the one-line summary. Returns the [`WindowReport`]; the caller
+/// (the `metamorph-driver` binary) turns [`WindowReport::all_pass`] into the exit
+/// code. Deterministic: same window + same switch, byte-identical output, forever.
+pub fn run_window(
+    start: u64,
+    count: u64,
+    inject_filter_drops_row: bool,
+    out: &mut dyn Write,
+) -> io::Result<WindowReport> {
+    let mut report = WindowReport {
+        start,
+        ..WindowReport::default()
+    };
+    let mut first_failure: Option<String> = None;
+    for seed in start..start + count {
+        let outcome = check_seed(seed, inject_filter_drops_row);
+        report.checked += 1;
+        if outcome.is_pass() {
+            report.pass += 1;
+        } else if first_failure.is_none() {
+            first_failure = Some(first_failing_case_block(&outcome));
+        }
+        for (oracle, verdict) in [("tlp", &outcome.tlp), ("norec", &outcome.norec)] {
+            match verdict {
+                Verdict::Pass { .. } => {}
+                Verdict::Violation(_) => {
+                    match oracle {
+                        "tlp" => report.tlp_violations += 1,
+                        _ => report.norec_violations += 1,
+                    }
+                    writeln!(out, "{}", verdict_line(oracle, seed, verdict).unwrap())?;
+                }
+                Verdict::EngineFailure(_) => {
+                    report.engine_failures += 1;
+                    writeln!(out, "{}", verdict_line(oracle, seed, verdict).unwrap())?;
+                }
+            }
+        }
+    }
+    if let Some(block) = &first_failure {
+        writeln!(out, "\n{block}")?;
+    }
+    writeln!(out, "{}", report.summary_line())?;
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_seed_passes_both_oracles_on_the_real_engine() {
+        let outcome = check_seed(0, false);
+        assert!(outcome.tlp.is_pass(), "TLP on seed 0: {:?}", outcome.tlp);
+        assert!(outcome.norec.is_pass(), "NoREC on seed 0: {:?}", outcome.norec);
+        assert!(outcome.is_pass());
+        assert_eq!(outcome.case.seed, 0);
+    }
+
+    #[test]
+    fn check_seed_with_injected_mutant_is_flagged() {
+        // The non-vacuity anchor: the FilterDropsRow mutant loses a row from every
+        // FILTER query, so TLP must flag it on any seed whose base is non-empty
+        // (the generator guarantees >= 4 base rows).
+        let outcome = check_seed(0, true);
+        assert!(
+            outcome.tlp.is_violation(),
+            "TLP must flag the injected mutant: {:?}",
+            outcome.tlp
+        );
+        assert!(!outcome.is_pass());
+    }
+
+    #[test]
+    fn window_report_all_pass_is_fail_closed_on_empty_and_on_any_non_pass() {
+        assert!(!WindowReport::default().all_pass(), "empty window must not pass");
+        let green = WindowReport {
+            start: 0,
+            checked: 5,
+            pass: 5,
+            ..WindowReport::default()
+        };
+        assert!(green.all_pass());
+        let red = WindowReport {
+            start: 0,
+            checked: 5,
+            pass: 4,
+            engine_failures: 1,
+            ..WindowReport::default()
+        };
+        assert!(!red.all_pass());
+    }
+
+    #[test]
+    fn summary_line_carries_every_count() {
+        let report = WindowReport {
+            start: 10,
+            checked: 5,
+            pass: 3,
+            tlp_violations: 2,
+            norec_violations: 1,
+            engine_failures: 1,
+        };
+        assert_eq!(
+            report.summary_line(),
+            "metamorph seeds 10..15: checked=5 pass=3 tlp-violation=2 norec-violation=1 engine-failure=1"
+        );
+    }
+
+    #[test]
+    fn run_window_green_path_prints_only_the_summary() {
+        let mut out = Vec::new();
+        let report = run_window(0, 5, false, &mut out).unwrap();
+        assert!(report.all_pass(), "seeds 0..5 must pass on main: {report:?}");
+        assert_eq!(report.checked, 5);
+        let text = String::from_utf8(out).unwrap();
+        assert!(!text.contains("VIOLATION"), "green window prints no repro: {text}");
+        assert!(!text.contains("FIRST FAILING CASE"), "{text}");
+        assert!(text.trim_end().ends_with(&report.summary_line()));
+    }
+
+    #[test]
+    fn run_window_red_path_prints_repro_and_fails() {
+        // Injected FilterDropsRow over a window: both oracles must report
+        // violations somewhere in the window, the log must carry per-seed repro
+        // lines plus the FIRST FAILING CASE block with replay + queries + graph.
+        let mut out = Vec::new();
+        let report = run_window(0, 25, true, &mut out).unwrap();
+        assert!(!report.all_pass());
+        assert!(report.tlp_violations > 0, "{report:?}");
+        assert!(report.norec_violations > 0, "{report:?}");
+        let text = String::from_utf8(out).unwrap();
+        assert!(text.contains("VIOLATION seed=0 oracle=tlp"), "{text}");
+        assert!(text.contains("FIRST FAILING CASE:"), "{text}");
+        assert!(text.contains("replay: cargo run -p sparq-metamorph --bin metamorph-driver -- 0 1"));
+        assert!(text.contains("--- queries ---") && text.contains("--- graph ---"));
+        assert!(text.contains("<http://example.org/s0>"), "graph inline: {text}");
+        assert!(text.contains(&report.summary_line()));
+    }
+
+    #[test]
+    fn run_window_is_deterministic() {
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        let ra = run_window(100, 10, true, &mut a).unwrap();
+        let rb = run_window(100, 10, true, &mut b).unwrap();
+        assert_eq!(ra, rb);
+        assert_eq!(a, b, "same window, byte-identical log");
+    }
+
+    #[test]
+    fn run_window_empty_window_is_red() {
+        let mut out = Vec::new();
+        let report = run_window(0, 0, false, &mut out).unwrap();
+        assert!(!report.all_pass(), "count=0 must fail closed");
+    }
+}

--- a/crates/sparq-metamorph/src/lib.rs
+++ b/crates/sparq-metamorph/src/lib.rs
@@ -24,6 +24,10 @@
 //! * [`generate`] — seeded, wall-clock-free, reproducible query/data generation.
 //! * [`engine`] — the engine-under-test trait, the in-process sparq driver, and the
 //!   deliberately-injected wrong-result mutant the self-tests must flag.
+//! * [`harness`] — the seeded CI driver window (bead `sq-3dyje.9`): generated cases →
+//!   TLP + NoREC verdicts, every verdict counted, fail-closed, deterministic repro on
+//!   failure. Entry point of the `metamorph-driver` binary and the nightly
+//!   `metamorph.yml` lane.
 //! * [`ledger`] — the found-bug record format (upstream issue link + confirmation
 //!   status REQUIRED per entry).
 //! * `driver` (cargo feature `protocol-drivers`, off by default) — HTTP drivers for
@@ -51,6 +55,7 @@
 pub mod differential;
 pub mod engine;
 pub mod generate;
+pub mod harness;
 pub mod ledger;
 pub mod norec;
 pub mod tlp;
@@ -62,6 +67,7 @@ pub mod driver;
 pub use differential::check_differential;
 pub use engine::{FilterDropsRow, InProcessSparq, SparqlEngine};
 pub use generate::{generate_case, GeneratedCase, SplitMix64};
+pub use harness::{check_seed, run_window, SeedOutcome, WindowReport};
 pub use ledger::{from_jsonl, to_jsonl, validate_entry, BugClass, ConfirmationStatus, FoundBug};
 pub use norec::{check_norec, norec_queries, NorecQueries};
 pub use tlp::{check_tlp, tlp_queries, TlpQueries};

--- a/scripts/ci-file-metamorph-failure.py
+++ b/scripts/ci-file-metamorph-failure.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# [FABLE-5] Auto-file a nightly metamorphic-lane finding (bead sq-3dyje.9).
+#
+# WHAT: the deterministic filing core of .github/workflows/metamorph.yml's failure
+# path — the metamorphic sibling of scripts/ci-file-differential-failure.py (same
+# structure, same safety properties, adapted to the single-engine TLP/NoREC
+# oracles of crates/sparq-metamorph). When a metamorph-driver window reports a
+# non-Pass verdict, this script:
+#   1. PARSES the captured driver log — the `VIOLATION seed=N` /
+#      `ENGINE-FAILURE seed=N` lines plus the "FIRST FAILING CASE:" block (seed +
+#      replay command + all oracle queries + graph), a complete deterministic
+#      repro (the generator is seeded SplitMix64 — the seed IS the corpus);
+#   2. WRITES the parsed repro to --out-dir (uploaded as a CI artifact);
+#   3. FILES a GitHub issue with the repro INLINE (via `gh`), deduped per shard:
+#      if an open `[metamorph]` issue for the same shard already exists it
+#      comments the fresh window/run instead of opening a duplicate;
+#   4. APPENDS a P1 bug bead to .beads/issues.jsonl (append-only, deduped against
+#      existing open metamorph beads for the shard). The workflow commits + pushes
+#      this BEST-EFFORT (fail-soft on the GH013 protected-main ruleset rejection);
+#      the GitHub issue is the reliable channel the orchestrator's issue sweep
+#      beads from.
+#
+# SAFETY / HONESTY PROPERTIES (same as the differential filing script)
+#   * Never edits or reorders existing JSONL lines (append-only).
+#   * Bead ids are derived (sq-mm + hash of date+shard) and collision-checked.
+#   * Idempotent per shard: a re-run neither opens a second issue nor appends a
+#     second bead.
+#   * `gh` failures degrade to warnings — filing must never mask the red lane.
+#
+# USAGE
+#   scripts/ci-file-metamorph-failure.py --log metamorph-log.txt --shard nightly \
+#       --seed-start N --count M --out-dir repro/ --jsonl .beads/issues.jsonl \
+#       --run-url URL
+#   scripts/ci-file-metamorph-failure.py --self-test   # hermetic; no gh, no writes
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+PROG = "ci-file-metamorph-failure"
+MARKER = "[metamorph]"
+
+_FAIL_RE = re.compile(r"^(?:VIOLATION|ENGINE-FAILURE) seed=(\d+) ", re.MULTILINE)
+_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+
+def log(msg: str) -> None:
+    print(f"[{PROG}] {msg}", file=sys.stderr)
+
+
+def parse_driver_log(text: str) -> dict:
+    """Extract the failing-seed list, the FIRST FAILING CASE block, the summary."""
+    # De-duplicate while preserving order (a seed may fail both oracles).
+    seeds: list[int] = []
+    for m in _FAIL_RE.findall(text):
+        s = int(m)
+        if s not in seeds:
+            seeds.append(s)
+    first_case = ""
+    marker = "FIRST FAILING CASE:"
+    if marker in text:
+        first_case = text.split(marker, 1)[1].strip()
+    summary = ""
+    for line in text.splitlines():
+        if line.startswith("metamorph seeds"):
+            summary = line.strip()
+    return {"seeds": seeds, "first_case": first_case, "summary": summary}
+
+
+def derive_bead_id(shard: str, date: str, existing_ids: set, n: int = 5) -> str:
+    """Deterministic, collision-checked bead id: sq-mm + hash(date+shard)."""
+    digest = hashlib.sha256(f"metamorph:{date}:{shard}".encode()).hexdigest()
+    chars = "".join(_ALPHABET[int(c, 16) % len(_ALPHABET)] for c in digest)
+    while True:
+        bead_id = f"sq-mm{chars[:n]}"
+        if bead_id not in existing_ids:
+            return bead_id
+        n += 1
+
+
+def existing_open_metamorph_bead(jsonl_path: Path, shard: str) -> str | None:
+    """The id of an existing open metamorph bead for this shard, if any (dedupe:
+    one standing bug bead per shard until it is closed)."""
+    if not jsonl_path.exists():
+        return None
+    with open(jsonl_path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                rec.get("_type") == "issue"
+                and rec.get("status") in ("open", "in_progress", "blocked")
+                and MARKER in rec.get("title", "")
+                and f"shard={shard}" in rec.get("title", "")
+            ):
+                return rec.get("id")
+    return None
+
+
+def all_bead_ids(jsonl_path: Path) -> set:
+    ids = set()
+    if not jsonl_path.exists():
+        return ids
+    with open(jsonl_path, encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(rec, dict) and rec.get("id"):
+                ids.add(rec["id"])
+    return ids
+
+
+def replay_command(parsed: dict, args) -> str:
+    first = parsed["seeds"][0] if parsed["seeds"] else None
+    if first is not None:
+        return f"cargo run -p sparq-metamorph --bin metamorph-driver -- {first} 1"
+    return (
+        f"cargo run -p sparq-metamorph --bin metamorph-driver -- "
+        f"{args.seed_start} {args.count}"
+    )
+
+
+def build_bead_record(bead_id: str, shard: str, parsed: dict, args, now: str) -> dict:
+    """A minimal, schema-shaped bead line (mirrors .beads/issues.jsonl records)."""
+    n = len(parsed["seeds"])
+    first = parsed["seeds"][0] if parsed["seeds"] else "?"
+    title = (
+        f"[BUG] {MARKER} shard={shard}: {n} TLP/NoREC oracle failure(s), "
+        f"first seed={first} (window {args.seed_start}+{args.count})"
+    )
+    description = (
+        f"Auto-filed by the nightly metamorphic lane (sq-3dyje.9). Run: {args.run_url}\n"
+        f"Failing seeds: {parsed['seeds'][:50]}{' …' if n > 50 else ''}\n"
+        f"Summary: {parsed['summary']}\n"
+        f"Replay: {replay_command(parsed, args)}\n"
+        f"Repro (seed + queries + graph) is inline in the linked GitHub issue and in "
+        f"the metamorph-repro artifact of the run. TLP/NoREC are SINGLE-ENGINE "
+        f"metamorphic oracles: a VIOLATION is an internal-consistency wrong-result "
+        f"signal in sparq itself (no cross-engine adjudication applies); an "
+        f"ENGINE-FAILURE is a generated valid query that failed to evaluate. "
+        f"🤖 SPARQ agent [FABLE-5]"
+    )
+    return {
+        "_type": "issue",
+        "id": bead_id,
+        "title": title,
+        "description": description,
+        "status": "open",
+        "priority": 1,
+        "issue_type": "bug",
+        "created_at": now,
+        "created_by": "metamorph CI",
+        "updated_at": now,
+        "labels": ["metamorph", "ci"],
+        "dependency_count": 0,
+        "dependent_count": 0,
+        "comment_count": 0,
+    }
+
+
+def append_bead(jsonl_path: Path, record: dict) -> None:
+    """Append-only, newline-safe: never touches existing lines."""
+    with open(jsonl_path, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def build_issue_body(bead_id: str, shard: str, parsed: dict, args) -> str:
+    n = len(parsed["seeds"])
+    seeds_line = ", ".join(str(s) for s in parsed["seeds"][:50]) + (" …" if n > 50 else "")
+    case = parsed["first_case"] or "(no FIRST FAILING CASE block captured — see the artifact log)"
+    return f"""> 🤖 **SPARQ agent** — auto-filed by the nightly metamorphic lane (bead sq-3dyje.9). [FABLE-5]
+
+The nightly TLP/NoREC metamorphic driver found **{n} failing seed(s)** in shard `{shard}` (seed window {args.seed_start}+{args.count}).
+
+- **Failing seeds:** {seeds_line}
+- **Deterministic replay:** `{replay_command(parsed, args)}`
+- **Run:** {args.run_url}
+- **Bead:** `{bead_id}` (P1, auto-appended; push best-effort)
+- **Artifact:** `metamorph-repro-{shard}` on the run above (full log)
+
+TLP/NoREC are **single-engine** metamorphic oracles (SQLancer's TLP/NoREC re-derived for SPARQL's three-valued EBV semantics): a `VIOLATION` means sparq's own evaluation paths are internally inconsistent — a wrong-result logic-bug signal that needs no cross-engine adjudication. An `ENGINE-FAILURE` means a generated, precondition-respecting query failed to evaluate (an engine-error bug or a harness bug). Both fail the lane; neither is ever skipped.
+
+### First failing case (seed + replay + queries + graph)
+
+```
+{case}
+```
+"""
+
+
+def gh(*argv: str) -> str:
+    """Run gh, returning stdout; raises CalledProcessError on failure."""
+    return subprocess.run(
+        ["gh", *argv], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def find_open_issue(shard: str) -> str | None:
+    """Number of an existing open metamorph issue for this shard, if any."""
+    try:
+        out = gh(
+            "issue", "list", "--state", "open",
+            "--search", f'in:title "{MARKER} shard={shard}"',
+            "--json", "number,title", "--limit", "10",
+        )
+        for item in json.loads(out or "[]"):
+            if MARKER in item.get("title", "") and f"shard={shard}" in item.get("title", ""):
+                return str(item["number"])
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        log(f"warning: issue dedupe search failed ({e}) — will attempt creation")
+    return None
+
+
+def file_github_issue(bead_id: str, shard: str, parsed: dict, args) -> None:
+    body = build_issue_body(bead_id, shard, parsed, args)
+    n = len(parsed["seeds"])
+    first = parsed["seeds"][0] if parsed["seeds"] else "?"
+    title = (
+        f"{MARKER} shard={shard}: {n} TLP/NoREC oracle failure(s) "
+        f"(first seed={first})"
+    )
+    existing = find_open_issue(shard)
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tf:
+        tf.write(body)
+        body_file = tf.name
+    try:
+        if existing:
+            gh("issue", "comment", existing, "--body-file", body_file)
+            log(f"commented the fresh window on existing open issue #{existing} (deduped)")
+        else:
+            url = gh("issue", "create", "--title", title, "--body-file", body_file)
+            log(f"filed GitHub issue: {url}")
+    except subprocess.CalledProcessError as e:
+        log(f"warning: gh issue filing failed (exit {e.returncode}): {e.stderr.strip() if e.stderr else e}")
+        log("the lane is already red and the artifact carries the repro — not fatal.")
+    finally:
+        os.unlink(body_file)
+
+
+def write_repro_artifact(out_dir: Path, parsed: dict, log_text: str, args) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "repro.md").write_text(
+        f"# metamorph repro — shard={args.shard}\n\n"
+        f"window: seeds {args.seed_start}+{args.count}\n"
+        f"failing seeds: {parsed['seeds']}\n"
+        f"summary: {parsed['summary']}\n\n"
+        f"## first failing case\n\n```\n{parsed['first_case']}\n```\n",
+        encoding="utf-8",
+    )
+    (out_dir / "metamorph-log.txt").write_text(log_text, encoding="utf-8")
+
+
+# ── self-test (hermetic: no gh, no repo writes) ──────────────────────────────────
+def self_test() -> int:
+    sample = (
+        "VIOLATION seed=42 oracle=tlp: tlp violation on [sparq]: partition union "
+        "differs from base (base=9 true=3 false=3 error=2)\n"
+        "VIOLATION seed=42 oracle=norec: norec violation on [sparq]: optimized "
+        "cardinality differs from rewrite true-count (optimized=3 rewrite-rows=9 rewrite-true=4)\n"
+        "ENGINE-FAILURE seed=57 oracle=tlp: engine failure [Evaluation] on sparq: parse error\n"
+        "\nFIRST FAILING CASE:\nseed=42\n"
+        "replay: cargo run -p sparq-metamorph --bin metamorph-driver -- 42 1\n"
+        "--- queries ---\nSELECT * WHERE { ?s <http://example.org/v> ?v }\n"
+        "--- graph ---\n<http://example.org/s0> <http://example.org/v> \"1\"^^<x> .\n"
+        "metamorph seeds 0..2000: checked=2000 pass=1998 tlp-violation=1 "
+        "norec-violation=1 engine-failure=1\n"
+    )
+    parsed = parse_driver_log(sample)
+    assert parsed["seeds"] == [42, 57], parsed["seeds"]  # deduped, order-preserving
+    assert "seed=42" in parsed["first_case"]
+    assert "--- graph ---" in parsed["first_case"]
+    assert parsed["summary"].startswith("metamorph seeds")
+    # No-failure log parses to empty (a red lane with no VIOLATION lines — e.g. a
+    # panic — still files, with the raw log as the payload).
+    empty = parse_driver_log("metamorph seeds 0..10: checked=10 pass=10 ...")
+    assert empty["seeds"] == [] and empty["first_case"] == ""
+
+    with tempfile.TemporaryDirectory() as td:
+        jsonl = Path(td) / "issues.jsonl"
+        jsonl.write_text(
+            json.dumps({"_type": "issue", "id": "sq-aaaaa", "title": "x", "status": "open"}) + "\n",
+            encoding="utf-8",
+        )
+        ids = all_bead_ids(jsonl)
+        assert ids == {"sq-aaaaa"}
+        # Deterministic id derivation + collision extension.
+        b1 = derive_bead_id("nightly", "2026-07-11", ids)
+        b2 = derive_bead_id("nightly", "2026-07-11", ids)
+        assert b1 == b2 and b1.startswith("sq-mm") and len(b1) == len("sq-mm") + 5
+        b3 = derive_bead_id("nightly", "2026-07-11", ids | {b1})
+        assert b3 != b1 and b3.startswith("sq-mm")
+
+        class A:  # minimal args stand-in
+            shard, seed_start, count = "nightly", "42", "2000"
+            run_url = "https://example.invalid/run/1"
+
+        assert replay_command(parsed, A).endswith("metamorph-driver -- 42 1")
+        assert replay_command(empty, A).endswith("metamorph-driver -- 42 2000")
+        rec = build_bead_record(b1, "nightly", parsed, A, "2026-07-11T00:00:00Z")
+        assert rec["priority"] == 1 and rec["issue_type"] == "bug" and rec["status"] == "open"
+        assert "sq-3dyje.9" in rec["description"] and "🤖" in rec["description"]
+        append_bead(jsonl, rec)
+        # Existing lines untouched; the new line parses; dedupe now finds it.
+        lines = jsonl.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2 and json.loads(lines[0])["id"] == "sq-aaaaa"
+        assert json.loads(lines[1])["id"] == b1
+        assert existing_open_metamorph_bead(jsonl, "nightly") == b1
+        assert existing_open_metamorph_bead(jsonl, "smoke") is None
+        # Issue body carries the inline repro + the self-id.
+        body = build_issue_body(b1, "nightly", parsed, A)
+        assert "🤖" in body and "SPARQ agent" in body
+        assert "--- graph ---" in body and "42" in body
+        assert "single-engine" in body  # honest oracle framing, not "vs Oxigraph"
+        # Artifact writer round-trip.
+        out = Path(td) / "repro"
+        write_repro_artifact(out, parsed, sample, argparse.Namespace(
+            shard="nightly", seed_start="42", count="2000"))
+        assert (out / "repro.md").exists() and (out / "metamorph-log.txt").exists()
+    log("self-test OK")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog=PROG)
+    ap.add_argument("--log", help="captured driver stdout+stderr")
+    ap.add_argument("--shard", help="workflow shard name (smoke | nightly)")
+    ap.add_argument("--seed-start", default="unknown")
+    ap.add_argument("--count", default="unknown")
+    ap.add_argument("--out-dir", help="repro artifact directory")
+    ap.add_argument("--jsonl", default=".beads/issues.jsonl")
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.log or not args.shard or not args.out_dir:
+        ap.error("--log, --shard and --out-dir are required (or use --self-test)")
+
+    log_text = Path(args.log).read_text(encoding="utf-8", errors="replace")
+    parsed = parse_driver_log(log_text)
+    log(f"parsed {len(parsed['seeds'])} failing seed(s) for shard {args.shard}")
+
+    write_repro_artifact(Path(args.out_dir), parsed, log_text, args)
+
+    jsonl = Path(args.jsonl)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    existing = existing_open_metamorph_bead(jsonl, args.shard)
+    if existing:
+        log(f"open metamorph bead {existing} already tracks shard {args.shard} — no new bead")
+        bead_id = existing
+    else:
+        bead_id = derive_bead_id(args.shard, now[:10], all_bead_ids(jsonl))
+        append_bead(jsonl, build_bead_record(bead_id, args.shard, parsed, args, now))
+        log(f"appended P1 bug bead {bead_id} to {jsonl}")
+
+    file_github_issue(bead_id, args.shard, parsed, args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implements bead `sq-3dyje.9` (epic sq-3dyje, design record `research/testing-strategy-assessment-2026-07.md` §7.3). [FABLE-5]

## What

`sparq-metamorph` implemented TLP + NoREC single-engine metamorphic oracles (with the injected-`FilterDropsRow` non-vacuity self-tests) but **no CI lane generated queries against them**. This PR adds the missing plumbing, mirroring `differential.yml`'s repro + auto-file pattern without touching `differential.yml`/`fuzz.yml` (owned by open sq-qcnn beads):

- **`harness` module** (`crates/sparq-metamorph/src/harness.rs`): `run_window` drives `generate_case` seeds through `check_tlp` + `check_norec` on the in-process sparq engine. **Every verdict is counted, never silently skipped**: `Pass` counts, `VIOLATION` (wrong-result signal) and `ENGINE-FAILURE` (a generated valid query failed to evaluate) both print a deterministic repro line and fail the window; an **empty window fails** (fail-closed). The first failing seed is echoed as a complete `FIRST FAILING CASE:` block (seed + replay command + all 6 oracle queries + graph).
- **`metamorph-driver` binary**: thin CLI (`<start> <count> [--inject-filter-drops-row]`), exit 0 iff all-pass. All logic (and tests) live in the library.
- **`scripts/ci-file-metamorph-failure.py`** (new file — conflicts with nobody): the metamorphic sibling of `ci-file-differential-failure.py` with honest single-engine wording (a TLP/NoREC violation is sparq's own evaluation paths disagreeing — no cross-engine adjudication registry applies). Files a deduped GitHub issue with the repro inline + appends a P1 bug bead (append-only, collision-checked `sq-mm…` ids, hermetic `--self-test`).
- **`.github/workflows/metamorph.yml`** (new): nightly (04:07 UTC, staggered) + `workflow_dispatch`; two shards — **smoke** (fixed regression window, seeds 0..2000) and **nightly** (advancing window, days-since-epoch × 600k stride, never replays a seed); SHA-pinned actions; schedule-only so the per-PR `ci-summary / gate` never sees it; on failure: repro artifact + auto-file + fail-soft bead commit-back (exact differential.yml pattern).

## Acceptance evidence (bead checklist)

- `cargo test -p sparq-metamorph` green **both feature states** (43 lib tests + 10 integration; new harness tests included, all sub-second).
- **Driver over the fixed smoke window exits 0 on main**: `metamorph-driver 0 2000` → `checked=2000 pass=2000`, exit 0 (~0.9 s local release). A 500k-seed probe window also passed clean.
- **Workflow YAML valid + SHA-pinned**: `actionlint` OK; pins copied verbatim from `differential.yml`.
- **Injected FilterDropsRow-class mutation produces a Fail verdict with repro**: `metamorph-driver 0 20 --inject-filter-drops-row` → exit 1, `tlp-violation=20 norec-violation=13`, log carries `VIOLATION seed=…` lines + the `FIRST FAILING CASE:` block with replay/queries/graph. Anchored permanently by `run_window_red_path_prints_repro_and_fails` (and the injection switch is a first-class CLI flag, so the red path is demonstrable any time). The end-to-end filing path was also exercised for real (issue #1938, immediately closed as a test).
- **Precondition/engine-failure verdicts counted, never skipped**: `ENGINE-FAILURE` fails the lane and is itemised in the summary line; `run_window_empty_window_is_red` pins the fail-closed empty case.

## Gates

- `cargo clippy --workspace --all-targets -- -D warnings` green; `-p sparq-metamorph --all-targets --features protocol-drivers` green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` green.
- `scripts/check-readme-template.py`: 0 deviations (README gained one feature bullet, 68 lines).
- `scripts/ci-file-metamorph-failure.py --self-test` green (hermetic).
- Coverage: every new public fn (`check_seed`, `run_window`, `WindowReport::{all_pass,summary_line}`, `SeedOutcome::is_pass`) has direct unit tests; sparq-metamorph has no floor entry, so the ratchet is unaffected.

**Do not merge manually** — merge-coordinator arms verified branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)