### PR TITLE
feat(gui): federated SERVICE query execution — native engine path + fail-closed per-workspace egress allowlist (sq-ixc3.14)

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -454,6 +454,17 @@ jobs:
       - name: Test (engine command layer)
         run: cargo test
 
+      # [FABLE-5] sq-ixc3.14 — the OPT-IN federation feature state: clippy + the native-lane
+      # federated-SERVICE tests (federation.rs), which join the live workspace snapshot with a
+      # LIVE loopback SPARQL endpoint through the real engine SERVICE client and prove the
+      # strict egress allowlist refuses an un-allowlisted endpoint pre-HTTP (fail-closed).
+      # Loopback-only — no external network. Keeps BOTH feature states green.
+      - name: Clippy (federation, -D warnings)
+        run: cargo clippy --all-targets --features federation -- -D warnings
+
+      - name: Test (federated SERVICE, native lane)
+        run: cargo test --features federation
+
   # [SONNET-4.6] sq-ymr2e.6 — SHRUNK tauri-driver smoke: max-3-assertion real-IPC test.
   #
   # Shrunk from the multi-step sq-pnnl harness to exactly 3 meaningful assertions:

--- a/gui/README.md
+++ b/gui/README.md
@@ -107,6 +107,14 @@ engine instead (no compressed-file / HDT path — the drawer says so). A success
 `WorkspaceSourceMeta` + a workspace snapshot (the `sq-atb0` save/open cache). The full on-disk
 workspace persistence path activates once the shell grants the `fs` capability (`sq-ixc3.6`).
 
+For **federation** (`sq-ixc3.14`), a SERVICE-bearing SELECT/ASK in the Query tool routes to the
+native `query_service` command (behind the crate's opt-in `federation` feature, which forwards to
+`sparq-engine/service`): the live store's N-Quads snapshot is evaluated natively, joining remote
+SPARQL endpoints under the engine's **strict fail-closed egress allowlist** — a SERVICE clause may
+dial ONLY the per-workspace `Federation` control's entries (host / host:port / `*.suffix`, the
+same grammar as sparq-server's `--service-allow`); everything else, including public hosts, is
+refused pre-HTTP. The browser build labels SERVICE **native-only** (CORS) instead of pretending.
+
 ## File ingest library (`lib/file-ingest.ts`, sq-vnh1v)
 
 The **file ingest library** is a shared zero-server multi-file upload harness for the RDF import (sq-eydh9), SHACL shapes (sq-txrui), and N3 rules (sq-glo5r) surfaces. It operates on a single `IngestResult` contract: every file is `accepted[]` (name, text, bytes) or `rejected[]` (name, reason) — **no silent drops**. 

--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -16,7 +16,7 @@
     "start": "npx --yes serve out",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts"
+    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/federation.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/gui/app/src/components/workbench/federation-control.tsx
+++ b/gui/app/src/components/workbench/federation-control.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+// [FABLE-5] sq-ixc3.14 — the per-workspace FEDERATION egress-allowlist control + the
+// workspace⇄engine sync + the honest run-location badge.
+//
+// Federated SERVICE queries execute on the DESKTOP shell's native engine (the in-tab WASM
+// engine cannot dial remote SPARQL endpoints — CORS), under the engine's STRICT fail-closed
+// egress policy: ONLY the endpoints allowlisted here are reachable, everything else is refused
+// pre-HTTP (the same `--service-allow` policy the network-exposed sparq-server enforces). The
+// allowlist is PERSISTED on the workspace (survives a restart) and pushed to the engine in
+// lockstep by {@link FederationBridge}, exactly like the inference-mode bridge.
+//
+// HONESTY: on the hosted web build the control still edits the persisted setting, but says
+// plainly that SERVICE execution is native-only there (the tools.ts taxonomy's framing) — the
+// browser build never pretends it can federate.
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+import { Globe, Plus, X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { useEngine } from "@/lib/engine-context";
+import { useWorkspace } from "@/lib/workspace-context";
+import { queryUsesService } from "@/lib/federation";
+
+/**
+ * Keep the ENGINE's federation egress allowlist in lockstep with the active workspace's
+ * PERSISTED setting. Renders null; mounted once in the workbench shell (like the inference
+ * bridge) so a restored workspace's allowlist applies before its first SERVICE run.
+ */
+export function FederationBridge() {
+  const { serviceAllowlist } = useWorkspace();
+  const { setServiceAllowlist } = useEngine();
+  React.useEffect(() => {
+    setServiceAllowlist(serviceAllowlist);
+  }, [serviceAllowlist, setServiceAllowlist]);
+  return null;
+}
+
+/**
+ * The honest "where does this query run" badge for the Query action row. A plain query runs
+ * in the in-tab WASM engine; a SERVICE-bearing query runs on the desktop's NATIVE engine
+ * (federated, allowlist-gated) — or, on the web build, is labelled native-only per the
+ * tools.ts tier taxonomy instead of pretending.
+ */
+export function RunLocationBadge({ query }: { query: string }) {
+  const { nativeFederationAvailable } = useEngine();
+  const federated = queryUsesService(query);
+  if (!federated) {
+    return (
+      <Badge
+        variant="outline"
+        className="h-5 gap-1 text-[10px]"
+        title="Where this query runs"
+        data-run-location="local-wasm"
+      >
+        LOCAL · in-tab WASM
+      </Badge>
+    );
+  }
+  if (nativeFederationAvailable) {
+    return (
+      <Badge
+        variant="outline"
+        className="h-5 gap-1 text-[10px] text-primary"
+        title="SERVICE detected: this query runs on the desktop's native engine, dialing only endpoints on the workspace's federation allowlist (fail-closed)"
+        data-run-location="native-federated"
+      >
+        NATIVE · federated SERVICE
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="h-5 gap-1 text-[10px] text-muted-foreground"
+      title="SERVICE detected: federated queries are native-only — the browser build cannot dial remote SPARQL endpoints (CORS). Run this in the sparq desktop app."
+      data-run-location="service-native-only"
+    >
+      SERVICE · native-only
+    </Badge>
+  );
+}
+
+/**
+ * The compact per-workspace federation allowlist editor for the query toolbar. Entries are
+ * `host`, `host:port`, or `*.suffix` (the same grammar as sparq-server's `--service-allow`).
+ * FAIL-CLOSED: an empty list refuses every SERVICE endpoint.
+ */
+export function FederationControl({ className }: { className?: string }) {
+  const { serviceAllowlist, setServiceAllowlist } = useWorkspace();
+  const { nativeFederationAvailable } = useEngine();
+  const [draft, setDraft] = React.useState("");
+
+  const add = React.useCallback(() => {
+    const entry = draft.trim();
+    if (!entry) return;
+    setDraft("");
+    if (serviceAllowlist.includes(entry)) return;
+    void setServiceAllowlist([...serviceAllowlist, entry]);
+  }, [draft, serviceAllowlist, setServiceAllowlist]);
+
+  const remove = React.useCallback(
+    (entry: string) => {
+      void setServiceAllowlist(serviceAllowlist.filter((e) => e !== entry));
+    },
+    [serviceAllowlist, setServiceAllowlist],
+  );
+
+  return (
+    <PopoverPrimitive.Root>
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          type="button"
+          data-federation-control
+          title="Federation: the SPARQL endpoints SERVICE queries may dial (fail-closed allowlist)"
+          className={cn(
+            "flex items-center gap-1.5 rounded-md border bg-background px-1.5 py-0.5",
+            "text-[11px] text-muted-foreground hover:bg-accent/40",
+            className,
+          )}
+        >
+          <Globe className="size-3.5" aria-hidden />
+          <span className="font-medium">Federation</span>
+          <span data-federation-count className={serviceAllowlist.length > 0 ? "text-primary" : ""}>
+            {serviceAllowlist.length}
+          </span>
+        </button>
+      </PopoverPrimitive.Trigger>
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          data-federation-popover
+          align="start"
+          sideOffset={4}
+          className={cn(
+            "z-50 w-72 rounded-lg border bg-popover p-2 text-popover-foreground shadow-md",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        >
+          <p className="px-1 pb-1 text-xs font-medium">Federation egress allowlist</p>
+          <p className="px-1 pb-2 text-[11px] leading-snug text-muted-foreground">
+            SERVICE queries run on the native engine and may dial ONLY these endpoints
+            (host, host:port, or *.suffix). Fail-closed: an empty list refuses every
+            SERVICE endpoint.
+          </p>
+          {!nativeFederationAvailable && (
+            <p
+              className="mx-1 mb-2 rounded border border-dashed px-2 py-1 text-[11px] text-muted-foreground"
+              data-federation-web-note
+            >
+              Native-only: this browser build cannot execute SERVICE queries (CORS). The
+              setting persists with the workspace and applies in the desktop app.
+            </p>
+          )}
+          <ul className="mb-2 space-y-1" aria-label="Allowlisted endpoints">
+            {serviceAllowlist.length === 0 && (
+              <li className="px-1 text-[11px] italic text-muted-foreground" data-federation-empty>
+                No endpoints allowlisted — all SERVICE calls refused.
+              </li>
+            )}
+            {serviceAllowlist.map((entry) => (
+              <li
+                key={entry}
+                data-federation-entry={entry}
+                className="flex items-center justify-between gap-2 rounded bg-accent/30 px-2 py-0.5"
+              >
+                <code className="truncate text-[11px]">{entry}</code>
+                <button
+                  type="button"
+                  aria-label={`Remove ${entry} from the allowlist`}
+                  data-federation-remove={entry}
+                  onClick={() => remove(entry)}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <X className="size-3" aria-hidden />
+                </button>
+              </li>
+            ))}
+          </ul>
+          <div className="flex items-center gap-1">
+            <input
+              value={draft}
+              data-federation-input
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  add();
+                }
+              }}
+              placeholder="query.example.org:8890"
+              aria-label="Endpoint host to allowlist"
+              className="h-6 flex-1 rounded border bg-background px-1.5 text-[11px] outline-none focus:border-primary"
+            />
+            <button
+              type="button"
+              data-federation-add
+              onClick={add}
+              aria-label="Add endpoint to the allowlist"
+              className="flex h-6 items-center gap-0.5 rounded border px-1.5 text-[11px] text-muted-foreground hover:bg-accent/40"
+            >
+              <Plus className="size-3" aria-hidden /> Allow
+            </button>
+          </div>
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -36,7 +36,6 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { downloadText } from "@/lib/download";
 import {
@@ -61,6 +60,8 @@ import { GraphView } from "@/components/workbench/graph-view";
 // [OPUS-4.8] sq-tp1m (#757) — the per-workspace inference (RDFS / OWL 2 RL) selector, in the
 // action row so the active entailment regime is visible + controllable while querying.
 import { InferenceControl } from "@/components/workbench/inference-control";
+// [FABLE-5] sq-ixc3.14 — the federation allowlist editor + the honest run-location badge.
+import { FederationControl, RunLocationBadge } from "@/components/workbench/federation-control";
 import { useWorkspace } from "@/lib/workspace-context";
 import { DEFAULT_QUERY } from "@/data/sample-graph";
 // [OPUS-4.8] sq-ixc3.10 — the Query tool contributes its operational verbs (run / EXPLAIN /
@@ -626,12 +627,16 @@ export function QueryWorkbench() {
         {/* Action row. */}
         <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
           <span className="text-xs font-medium text-muted-foreground">SPARQL</span>
-          <Badge variant="outline" className="h-5 gap-1 text-[10px]" title="Where this query runs">
-            LOCAL · in-tab WASM
-          </Badge>
+          {/* [FABLE-5] sq-ixc3.14 — the HONEST run-location badge: in-tab WASM for a plain
+              query; the desktop's native engine (allowlist-gated) when SERVICE is detected;
+              native-only labelling on the web build instead of pretending to federate. */}
+          <RunLocationBadge query={query} />
           {/* [OPUS-4.8] sq-tp1m — the per-workspace inference regime (queries run with the chosen
               RDFS / OWL 2 RL entailment applied by the engine). */}
           <InferenceControl className="ml-2" />
+          {/* [FABLE-5] sq-ixc3.14 — the per-workspace federation egress allowlist (fail-closed:
+              SERVICE may dial ONLY these endpoints, enforced by the native engine). */}
+          <FederationControl className="ml-1" />
           <div className="ml-auto flex items-center gap-1.5">
             <Button
               size="sm"

--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -64,6 +64,8 @@ import { InferenceControl } from "@/components/workbench/inference-control";
 import { FederationControl, RunLocationBadge } from "@/components/workbench/federation-control";
 import { useWorkspace } from "@/lib/workspace-context";
 import { DEFAULT_QUERY } from "@/data/sample-graph";
+// [FABLE-5] sq-ixc3.14 — the honesty-override type for QUERY_TOOL_OVERRIDE (sq-5lyme seam).
+import type { ToolOverride } from "@/data/tools";
 // [OPUS-4.8] sq-ixc3.10 — the Query tool contributes its operational verbs (run / EXPLAIN /
 // EXPLAIN ANALYZE / re-run a recent query) to the Cmd-K spine while it is mounted.
 import { useRegisterPaletteCommands } from "@/components/workbench/command-palette";
@@ -456,6 +458,16 @@ function ResultBody({ outcome, view }: { outcome: QueryOutcome; view: ResultView
 // ---------------------------------------------------------------------------
 // The workbench.
 // ---------------------------------------------------------------------------
+
+// [FABLE-5] sq-ixc3.14 — honesty override (the sq-5lyme seam: copy flips live in the panel
+// file that earns them, never by editing data/tools.ts). The Query tool now also executes
+// federated SERVICE queries — on the DESKTOP's native engine, gated by the per-workspace
+// egress allowlist; the browser build labels that half native-only instead of pretending.
+export const QUERY_TOOL_OVERRIDE: ToolOverride = {
+  blurb:
+    "Run SPARQL 1.1/1.2 over the live store — SELECT/ASK/CONSTRUCT/DESCRIBE/UPDATE, plus " +
+    "federated SERVICE on the desktop's native engine (allowlist-gated, fail-closed).",
+};
 
 export function QueryWorkbench() {
   // [OPUS-4.8] sq-ixc3.10/.12 — EXPLAIN is the canonical run(query, { mode }) path (no standalone

--- a/gui/app/src/components/workbench/tool-panel.tsx
+++ b/gui/app/src/components/workbench/tool-panel.tsx
@@ -14,7 +14,7 @@
 // its tier/copy/group INSIDE its own panel file — never in the shared data/tools.ts.
 
 import type { ComponentType } from "react";
-import { QueryWorkbench } from "@/components/workbench/query-workbench";
+import { QueryWorkbench, QUERY_TOOL_OVERRIDE } from "@/components/workbench/query-workbench";
 import { ShaclTool } from "@/components/workbench/shacl-tool";
 import { InferenceTool } from "@/components/workbench/inference-tool";
 import {
@@ -39,7 +39,9 @@ interface ToolPanelEntry {
  * shared honest ToolStub, exactly as before.
  */
 const TOOL_PANELS: Record<string, ToolPanelEntry> = {
-  query: { Component: QueryWorkbench },
+  // [FABLE-5] sq-ixc3.14 — blurb override: the Query tool now also runs federated SERVICE
+  // (native engine on desktop, allowlist-gated fail-closed; honestly native-only in the browser).
+  query: { Component: QueryWorkbench, override: QUERY_TOOL_OVERRIDE },
   shacl: { Component: ShaclTool },
   // [OPUS-4.8] sq-tp1m — the Inference tool is a real, working panel (per-workspace RDFS /
   // OWL 2 RL entailment wired to the engine's forward-chaining reasoner), not an honest stub.

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -53,6 +53,9 @@ import {
 // workspace's persisted choice (restores it on load), mounted once regardless of the active tab.
 // [sq-glo5r] — N3RulesBridge keeps the engine's N3 rules cache in lockstep with the workspace.
 import { InferenceModeBridge, N3RulesBridge } from "@/components/workbench/inference-control";
+// [FABLE-5] sq-ixc3.14 — keeps the engine's federation egress allowlist in lockstep with the
+// active workspace's persisted setting (fail-closed until pushed), mounted once like the bridges above.
+import { FederationBridge } from "@/components/workbench/federation-control";
 // [OPUS-4.8] sq-xvj9 — the Cmd-K counterpart to the rail's "Export data…": serialise + download the
 // whole store as pretty Turtle / TriG / JSON-LD from the keyboard-first spine.
 import { downloadText } from "@/lib/download";
@@ -119,6 +122,8 @@ export function Workbench() {
         <InferenceModeBridge />
         {/* [sq-glo5r] — sync the per-workspace N3 rules into the engine's closure cache. */}
         <N3RulesBridge />
+        {/* [FABLE-5] sq-ixc3.14 — sync the per-workspace federation egress allowlist. */}
+        <FederationBridge />
         {/* (sq-eydh9) [SONNET-4.6] — global RDF file drop overlay, mounted once here. */}
         <GlobalDropOverlay />
         {/* [OPUS-4.8] sq-vw3ax (#820 redesign) — a native-feeling dark workspace. The ambient teal

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -32,12 +32,22 @@ import { basePath } from "@/lib/base-path";
 import { SAMPLE_TURTLE, SAMPLE_FORMAT } from "@/data/sample-graph";
 import { type ExportFormat } from "@/lib/rdf-format";
 import {
+  hasNativeFederation,
   hasNativeLoader,
   nativeDiskUsage,
   nativeLoadPath,
   nativeLoadText,
+  nativeServiceQuery,
   type LoadedDocument,
 } from "@/lib/tauri-ipc";
+// [FABLE-5] sq-ixc3.14 — federated SERVICE routing: the pure detector + native-result parse +
+// fail-closed refusal classifier (see lib/federation.ts for the design note).
+import {
+  describeServiceRefusal,
+  parseServiceResults,
+  queryUsesService,
+  WEB_FEDERATION_MESSAGE,
+} from "@/lib/federation";
 // [OPUS-4.8] sq-tp1m (#757) — the tier-b W-reason wasm bundle loader: the REAL forward-chaining
 // RDFS / OWL 2 RL reasoner (crates/sparq-reason via sparq-reason-wasm), lazy-loaded so the lean
 // query engine pays nothing until a workspace turns inference on.
@@ -330,6 +340,20 @@ export interface EngineContextValue {
    */
   setN3Rules: (docs: WorkspaceRulesDoc[]) => void;
   /**
+   * [FABLE-5] sq-ixc3.14 — push the active workspace's FEDERATION egress allowlist to the
+   * engine, so a SERVICE-bearing run hands the native `query_service` command exactly the
+   * endpoints the user allowlisted for THIS workspace. Kept in lockstep with the persisted
+   * workspace setting by `FederationBridge` (mirrors the inference-mode bridge). FAIL-CLOSED:
+   * until pushed (or when empty), every SERVICE endpoint is refused by the native engine.
+   */
+  setServiceAllowlist: (hosts: string[]) => void;
+  /**
+   * [FABLE-5] sq-ixc3.14 — whether the native federated-query IPC is available (inside the
+   * Tauri desktop shell). On the web build this is false and a SERVICE-bearing run degrades
+   * honestly (native-only) instead of hanging on CORS.
+   */
+  nativeFederationAvailable: boolean;
+  /**
    * [OPUS-4.8] sq-ixc3.13 — the whole-dataset N-QUADS snapshot of the live store (default graph +
    * every named graph), the save/open cache a workspace persists as its `dataSnapshot` (sq-atb0).
    * N-Quads (not the TriG `serializeStore` emits) because that is the workspace snapshot format,
@@ -582,6 +606,13 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
 
   const storeRef = React.useRef<WasmStore | null>(null);
   const ctorRef = React.useRef<WasmStoreCtor | null>(null);
+
+  // [FABLE-5] sq-ixc3.14 — the active workspace's FEDERATION egress allowlist, pushed by
+  // `setServiceAllowlist` (the FederationBridge / workspace lifecycle). A ref (not state):
+  // run() reads it imperatively at dispatch time and nothing re-renders on it. Starts EMPTY,
+  // so until a workspace pushes its setting the native engine refuses every SERVICE endpoint
+  // (fail-closed by construction).
+  const serviceAllowRef = React.useRef<string[]>([]);
 
   // [OPUS-4.8] sq-tp1m (#757) — the per-workspace inference regime + its materialised closure.
   const [inferenceMode, setInferenceModeState] = React.useState<WorkspaceInferenceMode>("off");
@@ -905,6 +936,14 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     setInferenceModeState(mode);
   }, []);
 
+  // [FABLE-5] sq-ixc3.14 — push the active workspace's federation egress allowlist. A plain
+  // ref write: the next SERVICE-bearing run() hands exactly this list to the native engine's
+  // strict fail-closed policy. Called by FederationBridge + the workspace lifecycle (switch /
+  // restore), mirroring setInferenceMode's lockstep discipline.
+  const setServiceAllowlist = React.useCallback((hosts: string[]) => {
+    serviceAllowRef.current = hosts;
+  }, []);
+
   // [sq-glo5r] — push updated N3 rules to the engine; bumps rulesEpoch so the
   // applyInferenceMode effect fires and rebuilds the N3 closure when rules change.
   const setN3Rules = React.useCallback((docs: WorkspaceRulesDoc[]) => {
@@ -1068,7 +1107,30 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       const t0 = performance.now();
       let outcome: QueryOutcome;
       try {
-        if (mode === "explain" || mode === "analyze") {
+        if (mode === "run" && (form === "select" || form === "ask") && queryUsesService(query)) {
+          // [FABLE-5] sq-ixc3.14 — FEDERATED path. The in-tab WASM engine cannot evaluate a
+          // SERVICE clause (no blocking cross-origin HTTP in a browser), so a SERVICE-bearing
+          // SELECT/ASK routes to the desktop shell's NATIVE engine over IPC: a whole-dataset
+          // N-Quads snapshot of the (possibly reasoned) target store + the query + the
+          // per-workspace egress allowlist, evaluated under the engine's STRICT fail-closed
+          // policy (an endpoint off the list is refused pre-HTTP — a typed error, never a
+          // hang). On the web build this degrades HONESTLY with the native-only message
+          // instead of running. The native call is not cooperatively cancellable; a Stop
+          // during flight surfaces as "cancelled" once the (transport-bounded) call returns.
+          if (!hasNativeFederation()) {
+            outcome = { kind: "error", message: WEB_FEDERATION_MESSAGE };
+          } else {
+            const dataset = storeToNQuads(target);
+            const json = await nativeServiceQuery(dataset, query, serviceAllowRef.current);
+            if (signal?.aborted) {
+              outcome = { kind: "cancelled" };
+            } else if (json === null) {
+              outcome = { kind: "error", message: WEB_FEDERATION_MESSAGE };
+            } else {
+              outcome = parseServiceResults(json, rowCap);
+            }
+          }
+        } else if (mode === "explain" || mode === "analyze") {
           // EXPLAIN renders the planner's chosen plan; EXPLAIN ANALYZE also EXECUTES it and
           // traces the per-operator work (the wasm `explain` / `explainAnalyze` bindings, which
           // mirror `sparq_engine::explain[_analyze]` and the server's `explain=plan|analyze`).
@@ -1135,13 +1197,15 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
           }
         }
       } catch (err) {
+        // [FABLE-5] sq-ixc3.14 — a native SERVICE egress REFUSAL (the engine's stable marker)
+        // is surfaced as the actionable fail-closed message (pointing at the per-workspace
+        // allowlist); every other error passes through unchanged. A Tauri command rejection is
+        // a plain string, so String(err) covers both shapes.
+        const raw = err instanceof Error ? err.message : String(err);
         outcome =
           err instanceof AbortError || signal?.aborted
             ? { kind: "cancelled" }
-            : {
-                kind: "error",
-                message: err instanceof Error ? err.message : String(err),
-              };
+            : { kind: "error", message: describeServiceRefusal(raw) ?? raw };
       }
       const latencyMs = performance.now() - t0;
       setLastLatencyMs(latencyMs);
@@ -1209,6 +1273,14 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     setNativeLoaderAvailable(hasNativeLoader());
   }, []);
 
+  // [FABLE-5] sq-ixc3.14 — whether the native federated-query IPC is reachable (inside the
+  // Tauri shell). Same once-on-mount discipline as nativeLoaderAvailable, so the Query tool
+  // can label the SERVICE run location honestly without re-detecting per render.
+  const [nativeFederationAvailable, setNativeFederationAvailable] = React.useState(false);
+  React.useEffect(() => {
+    setNativeFederationAvailable(hasNativeFederation());
+  }, []);
+
   const value = React.useMemo<EngineContextValue>(
     () => ({
       status,
@@ -1231,6 +1303,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       inferenceStatus,
       setInferenceMode,
       setN3Rules,
+      setServiceAllowlist,
+      nativeFederationAvailable,
     }),
     [
       status,
@@ -1253,6 +1327,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       inferenceStatus,
       setInferenceMode,
       setN3Rules,
+      setServiceAllowlist,
+      nativeFederationAvailable,
     ],
   );
 

--- a/gui/app/src/lib/federation.test.ts
+++ b/gui/app/src/lib/federation.test.ts
@@ -1,0 +1,139 @@
+// [FABLE-5] sq-ixc3.14 — unit tests for federation.ts pure helpers.
+//
+// Covers: queryUsesService (the SERVICE routing detector), describeServiceRefusal (the
+// fail-closed refusal classifier), parseServiceResults (the native-result parse + row cap).
+// The IPC round-trip itself is exercised by the Playwright mocked-IPC spec
+// (e2e-playwright/specs/federation.spec.ts) and, against the REAL engine + a live loopback
+// endpoint, by gui/src-tauri/src/federation.rs's native-lane tests.
+//
+// Run via:   npm run test:unit   (gui/app)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  queryUsesService,
+  describeServiceRefusal,
+  parseServiceResults,
+  SERVICE_EGRESS_REFUSED_MARKER,
+} from "./federation.js";
+
+// ---------------------------------------------------------------------------
+// queryUsesService
+// ---------------------------------------------------------------------------
+
+test("queryUsesService – detects a plain SERVICE clause (any case)", () => {
+  assert.equal(
+    queryUsesService(
+      "SELECT * WHERE { ?s ?p ?o . SERVICE <http://example.org/sparql> { ?s ?p2 ?o2 } }",
+    ),
+    true,
+  );
+  assert.equal(queryUsesService("select * where { service <http://e/> { ?s ?p ?o } }"), true);
+  assert.equal(queryUsesService("SELECT * WHERE { SERVICE SILENT ?ep { ?s ?p ?o } }"), true);
+});
+
+test("queryUsesService – a plain local query does not route", () => {
+  assert.equal(queryUsesService("SELECT * WHERE { ?s ?p ?o }"), false);
+});
+
+test("queryUsesService – SERVICE inside a string literal / comment / IRI is NOT a clause", () => {
+  assert.equal(
+    queryUsesService('SELECT * WHERE { ?s ?p "the SERVICE desk" }'),
+    false,
+    "double-quoted literal",
+  );
+  assert.equal(
+    queryUsesService("SELECT * WHERE { ?s ?p '''SERVICE\nmulti''' }"),
+    false,
+    "long literal",
+  );
+  assert.equal(
+    queryUsesService("# SERVICE is only mentioned here\nSELECT * WHERE { ?s ?p ?o }"),
+    false,
+    "comment",
+  );
+  assert.equal(
+    queryUsesService("SELECT * WHERE { ?s <http://example.org/service> ?o }"),
+    false,
+    "IRI containing /service",
+  );
+});
+
+test("queryUsesService – a FILTER comparison before a real SERVICE does not swallow it", () => {
+  // The `<` of `?x < 5` must NOT be treated as an IRI opener that eats the SERVICE keyword.
+  assert.equal(
+    queryUsesService(
+      "SELECT * WHERE { ?s ?p ?x . FILTER(?x < 5) SERVICE <http://e/sparql> { ?s ?q ?y } }",
+    ),
+    true,
+  );
+});
+
+test("queryUsesService – an escaped quote inside a literal does not desync the scanner", () => {
+  assert.equal(queryUsesService('SELECT * WHERE { ?s ?p "a \\" SERVICE b" }'), false);
+});
+
+// ---------------------------------------------------------------------------
+// describeServiceRefusal
+// ---------------------------------------------------------------------------
+
+test("describeServiceRefusal – classifies the engine's stable egress marker", () => {
+  const msg = describeServiceRefusal(
+    `${SERVICE_EGRESS_REFUSED_MARKER}: host "example.org" is not allowlisted`,
+  );
+  assert.ok(msg, "a marker-bearing error must classify as a refusal");
+  assert.match(msg, /fail-closed/i);
+  assert.match(msg, /allowlist/i);
+  // The engine's own message is preserved for honesty (no detail is swallowed).
+  assert.ok(msg.includes(SERVICE_EGRESS_REFUSED_MARKER));
+});
+
+test("describeServiceRefusal – any other error passes through as null", () => {
+  assert.equal(describeServiceRefusal("parse error: unexpected token"), null);
+});
+
+// ---------------------------------------------------------------------------
+// parseServiceResults
+// ---------------------------------------------------------------------------
+
+const SELECT_JSON = JSON.stringify({
+  head: { vars: ["name", "age"] },
+  results: {
+    bindings: [
+      { name: { type: "literal", value: "Alice" }, age: { type: "literal", value: "30" } },
+      { name: { type: "literal", value: "Bob" }, age: { type: "literal", value: "31" } },
+    ],
+  },
+});
+
+test("parseServiceResults – SELECT rows parse into the table outcome", () => {
+  const out = parseServiceResults(SELECT_JSON, 100);
+  assert.equal(out.kind, "select");
+  if (out.kind !== "select") return;
+  assert.equal(out.rowCount, 2);
+  assert.equal(out.totalRows, 2);
+  assert.equal(out.truncated, false);
+  assert.deepEqual(out.results.head.vars, ["name", "age"]);
+  assert.equal(out.results.results.bindings[0]?.name?.value, "Alice");
+});
+
+test("parseServiceResults – rows beyond the cap are counted but dropped (truncated)", () => {
+  const out = parseServiceResults(SELECT_JSON, 1);
+  assert.equal(out.kind, "select");
+  if (out.kind !== "select") return;
+  assert.equal(out.rowCount, 1);
+  assert.equal(out.totalRows, 2);
+  assert.equal(out.truncated, true);
+});
+
+test("parseServiceResults – an ASK document parses into the boolean outcome", () => {
+  const out = parseServiceResults('{"head":{},"boolean":true}', 100);
+  assert.equal(out.kind, "ask");
+  if (out.kind !== "ask") return;
+  assert.equal(out.value, true);
+});
+
+test("parseServiceResults – garbage is an error outcome, never a crash", () => {
+  const out = parseServiceResults("not json at all", 100);
+  assert.equal(out.kind, "error");
+});

--- a/gui/app/src/lib/federation.ts
+++ b/gui/app/src/lib/federation.ts
@@ -1,0 +1,163 @@
+// [FABLE-5] sq-ixc3.14 — pure helpers for federated SERVICE query execution in the Query tool.
+//
+// The in-tab WASM engine fundamentally cannot evaluate a SPARQL 1.1 `SERVICE` clause (the
+// browser has no blocking cross-origin HTTP — CORS), so the Query tool routes SERVICE-bearing
+// SELECT/ASK runs to the desktop shell's native engine over Tauri IPC (`query_service`,
+// gui/src-tauri/src/federation.rs), which evaluates them under the engine's STRICT fail-closed
+// egress allowlist (the per-workspace federation setting). On the hosted web build the same
+// detection produces an HONEST degradation message instead — per the tools.ts tier taxonomy
+// this half of the Query tool is native-only there (the `walkthrough` tier's framing), never a
+// silent wrong answer or a hang.
+//
+// Everything here is a PURE function (no React, no IPC) so the routing decision, the refusal
+// classification, and the native-result parse are unit-testable in the node test runner.
+
+import {
+  formatSparqlJson,
+  isAskResult,
+  askValue,
+  type SparqlResults,
+} from "@sparq/client";
+
+/**
+ * The stable marker substring every engine SERVICE egress-refusal error carries — byte-for-byte
+ * `sparq_engine::SERVICE_EGRESS_REFUSED_MARKER` (crates/sparq-engine-service/src/service.rs),
+ * the same contract sparq-server uses to classify a refusal as policy (403) rather than fault.
+ */
+export const SERVICE_EGRESS_REFUSED_MARKER = "SERVICE egress refused";
+
+/**
+ * The honest web-build degradation message (the tools.ts taxonomy's "native-only" framing):
+ * the browser cannot dial cross-origin SPARQL endpoints, and pretending otherwise would hang
+ * or silently drop the SERVICE pattern. Shown instead of running the query.
+ */
+export const WEB_FEDERATION_MESSAGE =
+  "Federated SERVICE queries are native-only: the browser build cannot dial remote SPARQL " +
+  "endpoints (cross-origin HTTP is blocked by CORS, and the in-tab WASM engine ships no " +
+  "federation client). Run this query in the sparq desktop app, where it executes on the " +
+  "native engine under the workspace's federation allowlist.";
+
+/**
+ * Strip SPARQL string literals (single/double/long), `#` comments, and IRI refs from a query,
+ * so keyword detection cannot be fooled by `"SERVICE"` inside a literal, a comment, or an IRI
+ * like `<http://example.org/service>`. A `<` is treated as an IRI opener only when a
+ * whitespace-free IRI body up to `>` follows (so a comparison `?x < 5` is untouched).
+ */
+function stripLiteralsCommentsAndIris(sparql: string): string {
+  let out = "";
+  let i = 0;
+  const n = sparql.length;
+  while (i < n) {
+    const c = sparql[i];
+    if (c === "#") {
+      // Comment: skip to end of line.
+      while (i < n && sparql[i] !== "\n") i++;
+      continue;
+    }
+    if (c === "'" || c === '"') {
+      // String literal: honour long (triple-quoted) forms and backslash escapes.
+      const quote = c;
+      const long = sparql.startsWith(quote.repeat(3), i);
+      const close = long ? quote.repeat(3) : quote;
+      i += close.length;
+      while (i < n) {
+        if (sparql[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (sparql.startsWith(close, i)) {
+          i += close.length;
+          break;
+        }
+        i++;
+      }
+      out += " ";
+      continue;
+    }
+    if (c === "<") {
+      // IRI ref: skip only a whitespace-free <...> body (IRIs cannot contain whitespace),
+      // leaving comparison operators like `?x < 5` alone.
+      const m = /^<[^<>"{}|^`\\\s]*>/.exec(sparql.slice(i));
+      if (m) {
+        i += m[0].length;
+        out += " ";
+        continue;
+      }
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/**
+ * Whether a query uses the SPARQL 1.1 `SERVICE` keyword (outside strings/comments/IRIs) and
+ * should therefore route to the native federated path (desktop) or degrade honestly (web).
+ * A pragmatic keyword scan, not a full parse: a false positive merely routes a query to the
+ * native engine (which evaluates it identically), never to a wrong answer.
+ */
+export function queryUsesService(sparql: string): boolean {
+  return /\bSERVICE\b/i.test(stripLiteralsCommentsAndIris(sparql));
+}
+
+/**
+ * Classify a native-run error: an egress REFUSAL (the engine's stable marker) becomes an
+ * actionable fail-closed message pointing at the per-workspace allowlist; anything else
+ * returns `null` (surface the engine's own message unchanged).
+ */
+export function describeServiceRefusal(message: string): string | null {
+  if (!message.includes(SERVICE_EGRESS_REFUSED_MARKER)) return null;
+  return (
+    "SERVICE endpoint refused (fail-closed): it is not on this workspace's federation " +
+    "allowlist. Add the endpoint's host (or host:port) in the Federation control to allow " +
+    `it. Engine: ${message}`
+  );
+}
+
+/** The parsed outcome of a native `query_service` run (SELECT or ASK results JSON). */
+export type ServiceResultsOutcome =
+  | {
+      kind: "select";
+      results: SparqlResults;
+      rawJson: string;
+      rowCount: number;
+      totalRows: number;
+      truncated: boolean;
+    }
+  | { kind: "ask"; value: boolean; rawJson: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Parse the SPARQL 1.1 JSON results document the native `query_service` command returns into
+ * the Query tool's outcome shape, applying the SAME row cap the streamed in-tab path applies
+ * (rows beyond `rowCap` are counted but dropped, and the outcome records `truncated`) so the
+ * result panel behaves identically wherever the query ran.
+ */
+export function parseServiceResults(json: string, rowCap: number): ServiceResultsOutcome {
+  let parsed: SparqlResults;
+  try {
+    parsed = JSON.parse(json) as SparqlResults;
+  } catch {
+    return {
+      kind: "error",
+      message: "The native engine returned an unparseable result document.",
+    };
+  }
+  if (isAskResult(parsed)) {
+    return { kind: "ask", value: askValue(parsed) ?? false, rawJson: formatSparqlJson(parsed) };
+  }
+  const bindings = parsed.results?.bindings ?? [];
+  const kept = bindings.slice(0, rowCap);
+  const capped: SparqlResults = {
+    head: { vars: parsed.head?.vars ?? [] },
+    results: { bindings: kept },
+  };
+  return {
+    kind: "select",
+    results: capped,
+    rawJson: formatSparqlJson(capped),
+    rowCount: kept.length,
+    totalRows: bindings.length,
+    truncated: bindings.length > kept.length,
+  };
+}

--- a/gui/app/src/lib/tauri-ipc.ts
+++ b/gui/app/src/lib/tauri-ipc.ts
@@ -150,6 +150,35 @@ export function hasNativeLoader(): boolean {
 }
 
 /**
+ * [FABLE-5] sq-ixc3.14 — whether the native federated-query IPC path is available (we are
+ * inside a Tauri webview). Whether the desktop build actually COMPILED the `federation`
+ * feature is only knowable at invoke time: a lean build's `query_service` stub returns a loud
+ * rebuild-hint error, which surfaces through the result panel like any other run error.
+ */
+export function hasNativeFederation(): boolean {
+  return isTauriRuntime();
+}
+
+/**
+ * [FABLE-5] sq-ixc3.14 — evaluate a SERVICE-bearing SELECT/ASK over the NATIVE engine
+ * (`query_service`, gui/src-tauri/src/federation.rs): `dataset` is the live workspace store's
+ * whole-dataset N-Quads snapshot, `allow` the per-workspace federation egress allowlist the
+ * engine enforces STRICTLY (fail-closed: an endpoint off the list is refused pre-HTTP with the
+ * stable `SERVICE egress refused` marker — see lib/federation.ts). Returns the SPARQL 1.1 JSON
+ * results document, or `null` outside the desktop shell (the web target degrades honestly in
+ * the Query tool instead). Throws the native error string on refusal / parse / HTTP failure.
+ */
+export async function nativeServiceQuery(
+  dataset: string,
+  query: string,
+  allow: string[],
+): Promise<string | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  return invoke<string>("query_service", { dataset, query, allow });
+}
+
+/**
  * [OPUS-4.8] sq-cno90 (#820 follow-up) — probe the REAL on-disk byte size of the
  * `$APPLOCALDATA/workspaces` tree through the native `disk_usage` command, or `null` outside the
  * desktop shell (the web target has no native FS — the status bar falls back to the snapshot-bytes

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -27,6 +27,7 @@ import {
   createWorkspaceStore,
   describeWorkspaceSaveError,
   newWorkspace,
+  parseServiceAllowlist,
   type SerializedWorkspaceSaver,
   type Workspace,
   type WorkspaceBackend,
@@ -109,6 +110,18 @@ export interface WorkspaceContextValue {
    * mirroring {@link recordImport}: a write failure never breaks the in-memory selection).
    */
   setInference: (mode: WorkspaceInferenceMode) => Promise<void>;
+  /**
+   * [FABLE-5] sq-ixc3.14 — the active workspace's persisted FEDERATION egress allowlist: the
+   * only SPARQL endpoints a SERVICE clause may dial when the desktop app evaluates the query
+   * natively. FAIL-CLOSED: empty means every SERVICE endpoint is refused. The federation
+   * bridge pushes this into the engine so the two stay in lockstep.
+   */
+  serviceAllowlist: string[];
+  /**
+   * [FABLE-5] sq-ixc3.14 — persist a new federation egress allowlist for the active workspace
+   * (best-effort, mirroring {@link setInference}). Entries are trimmed; empties dropped.
+   */
+  setServiceAllowlist: (hosts: string[]) => Promise<void>;
   /**
    * [sq-glo5r] The active workspace's persisted N3 rule documents (empty when none). Drives the
    * Inference tool's N3 rules panel and the engine's N3 closure cache.
@@ -299,6 +312,22 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     [applyWorkspace, persist],
   );
 
+  // [FABLE-5] sq-ixc3.14 — persist a new federation egress allowlist for the active workspace.
+  // Same best-effort discipline as setInference; normalised through the fail-closed parser
+  // (trim, drop empties) so the persisted record and the engine always see the same list.
+  // Pushed to the engine immediately (like the N3 rules), not just via the bridge.
+  const setServiceAllowlist = React.useCallback(
+    async (hosts: string[]): Promise<void> => {
+      const base = workspaceRef.current ?? newWorkspace("default workspace", STARTER_QUERY);
+      const cleaned = parseServiceAllowlist(hosts);
+      const next: Workspace = { ...base, serviceAllowlist: cleaned, updatedAt: Date.now() };
+      applyWorkspace(next);
+      engineRef.current.setServiceAllowlist(cleaned);
+      await persist(next);
+    },
+    [applyWorkspace, persist],
+  );
+
   // [sq-glo5r] — bulk-add N3 rule documents; each gets a unique addedAt (now + index offset so
   // rapid bulk adds never collide). Pushes the updated list to the engine immediately.
   const addRulesDocs = React.useCallback(
@@ -451,6 +480,9 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     engineRef.current.setInferenceMode(ws.inference ?? "off");
     // [sq-glo5r] — push the target workspace's N3 rules so the engine rebuilds the N3 closure.
     engineRef.current.setN3Rules(ws.rulesDocs ?? []);
+    // [FABLE-5] sq-ixc3.14 — push the target workspace's federation egress allowlist so a
+    // SERVICE run never dials under a PREVIOUS workspace's policy (fail-closed lockstep).
+    engineRef.current.setServiceAllowlist(ws.serviceAllowlist ?? []);
   }, [applyWorkspace]);
 
   const switchWorkspace = React.useCallback(
@@ -554,6 +586,8 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       switchWorkspace,
       inference: workspace?.inference ?? "off",
       setInference,
+      serviceAllowlist: workspace?.serviceAllowlist ?? [],
+      setServiceAllowlist,
       rulesDocs: workspace?.rulesDocs ?? [],
       addRulesDocs,
       removeRulesDoc,
@@ -572,6 +606,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       deleteWorkspace,
       switchWorkspace,
       setInference,
+      setServiceAllowlist,
       addRulesDocs,
       removeRulesDoc,
       setRulesDocEnabled,

--- a/gui/e2e-playwright/.gitignore
+++ b/gui/e2e-playwright/.gitignore
@@ -1,0 +1,1 @@
+test-results/

--- a/gui/e2e-playwright/specs/federation.spec.ts
+++ b/gui/e2e-playwright/specs/federation.spec.ts
@@ -1,0 +1,110 @@
+// [FABLE-5] sq-ixc3.14 — federated SERVICE execution journey (mocked-desktop persona).
+//
+// Exercises the Query tool's FEDERATED path end-to-end through the real frontend: SERVICE
+// detection → the honest run-location badge → the per-workspace egress-allowlist control →
+// the query_service IPC contract (dataset snapshot + query + allowlist) → the joined rows in
+// the existing multi-view result panel — and the FAIL-CLOSED refusal when the endpoint is not
+// allowlisted. The IPC layer is the tauri-mock, which mirrors the Rust command's contract
+// (strict allowlist, the stable "SERVICE egress refused" marker); the REAL engine + a LIVE
+// loopback SPARQL endpoint are covered by gui/src-tauri/src/federation.rs's native-lane tests.
+//
+// Stable selectors (declared E2E hooks):
+//   #repl-query                        — the SPARQL editor textarea
+//   button "Run query"                 — the run trigger
+//   [data-run-location="…"]            — the honest run-location badge state
+//   [data-federation-control]          — the allowlist popover trigger
+//   [data-federation-input] / [data-federation-add] / [data-federation-entry] — the editor
+//   [data-result-kind="select"|"error"] — result panel outcomes
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions; web-first assertions only.
+
+import { test, expect, readIpcLog } from "../support/index.ts";
+
+/** A SELECT that joins the seeded sample graph with a remote SERVICE endpoint. */
+const SERVICE_QUERY = `SELECT ?name ?fedRole WHERE {
+  ?s <http://xmlns.com/foaf/0.1/name> ?name .
+  SERVICE <http://fed.example.org/sparql> { ?s <http://example.org/fedRole> ?fedRole }
+}`;
+
+/** Set the React-controlled editor via the native setter + input event (see workbench-query). */
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+test.describe("federation", () => {
+  // The tauriMock auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("plain query shows the LOCAL badge; SERVICE flips it to the native federated badge", async ({
+    page,
+  }) => {
+    // The default (plain) query runs in-tab: the badge says so.
+    await expect(page.locator('[data-run-location="local-wasm"]')).toBeVisible();
+
+    // A SERVICE-bearing query flips the badge to the native federated location (desktop persona).
+    await setEditorValue(page, SERVICE_QUERY);
+    await expect(page.locator('[data-run-location="native-federated"]')).toBeVisible();
+  });
+
+  test("SERVICE endpoint off the allowlist is refused fail-closed (clean error, no hang)", async ({
+    page,
+  }) => {
+    // Fresh workspace: the allowlist is EMPTY, so the run must surface the actionable
+    // fail-closed refusal — a clean error outcome, not a hang and not an empty result.
+    await setEditorValue(page, SERVICE_QUERY);
+    await page.getByRole("button", { name: "Run query" }).click();
+
+    const error = page.locator('[data-result-kind="error"]');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/fail-closed/i);
+    await expect(error).toContainText(/allowlist/i);
+  });
+
+  test("allowlisting the endpoint runs the SERVICE join natively and renders joined rows", async ({
+    page,
+  }) => {
+    // 1. Allowlist the fixture endpoint host through the Federation control.
+    await page.locator("[data-federation-control]").click();
+    const input = page.locator("[data-federation-input]");
+    await expect(input).toBeVisible();
+    await input.fill("fed.example.org");
+    await page.locator("[data-federation-add]").click();
+    await expect(page.locator('[data-federation-entry="fed.example.org"]')).toBeVisible();
+    // Close the popover so it does not overlap the run button.
+    await page.keyboard.press("Escape");
+
+    // 2. Run the SERVICE query.
+    await setEditorValue(page, SERVICE_QUERY);
+    await page.getByRole("button", { name: "Run query" }).click();
+
+    // 3. The JOINED row renders in the existing multi-view panel: the LOCAL binding (Alice,
+    //    from the sample graph) alongside the REMOTE-only binding (remote-captain).
+    await expect(page.locator('[data-result-kind="select"]')).toBeVisible();
+    await expect(page.locator('[data-result-view="table"]')).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Alice" }).first()).toBeVisible();
+    await expect(page.getByRole("cell", { name: "remote-captain" })).toBeVisible();
+
+    // 4. IPC contract: query_service was invoked with the workspace allowlist AND a non-empty
+    //    dataset snapshot (the live store handed to the native engine).
+    const log = await readIpcLog(page);
+    const call = log.find((e) => e.cmd === "query_service");
+    expect(call, "query_service must be invoked for a SERVICE-bearing run").toBeTruthy();
+    const args = (call?.args ?? {}) as { dataset?: string; query?: string; allow?: string[] };
+    expect(args.allow).toContain("fed.example.org");
+    expect(typeof args.dataset).toBe("string");
+    expect((args.dataset ?? "").length).toBeGreaterThan(0);
+    expect(args.query ?? "").toContain("SERVICE");
+  });
+});

--- a/gui/e2e-playwright/specs/federation.web.spec.ts
+++ b/gui/e2e-playwright/specs/federation.web.spec.ts
@@ -1,0 +1,67 @@
+// [FABLE-5] sq-ixc3.14 — federated SERVICE HONEST DEGRADATION (browser persona, no Tauri).
+//
+// Runs under the chromium-web project (support/web-fixtures.ts): the Tauri globals are
+// genuinely absent, so isTauriRuntime() === false — exactly the deployed /app overlay. A
+// SERVICE-bearing query must degrade HONESTLY there: the run-location badge labels the
+// capability native-only (the tools.ts tier taxonomy's framing), the run returns a clear
+// native-only error (the browser cannot dial cross-origin SPARQL endpoints — CORS), and the
+// Federation control says the setting only applies in the desktop app. Never a hang, never a
+// silently-dropped SERVICE pattern.
+//
+// Stable selectors: #repl-query, button "Run query", [data-run-location="…"],
+// [data-federation-control], [data-federation-web-note], [data-result-kind="error"].
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions; web-first assertions only.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+const SERVICE_QUERY = `SELECT ?name ?fedRole WHERE {
+  ?s <http://xmlns.com/foaf/0.1/name> ?name .
+  SERVICE <http://fed.example.org/sparql> { ?s <http://example.org/fedRole> ?fedRole }
+}`;
+
+/** Set the React-controlled editor via the native setter + input event (see workbench-query). */
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+test.describe("federation-web", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("SERVICE query is labelled native-only and errs honestly instead of hanging", async ({
+    page,
+  }) => {
+    // The badge flips to the native-only label as soon as SERVICE is detected.
+    await setEditorValue(page, SERVICE_QUERY);
+    await expect(page.locator('[data-run-location="service-native-only"]')).toBeVisible();
+
+    // Running it surfaces the honest degradation message — a clean error outcome (CORS /
+    // native-only), NOT a hang and NOT a silently un-federated answer.
+    await page.getByRole("button", { name: "Run query" }).click();
+    const error = page.locator('[data-result-kind="error"]');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/native-only/i);
+    await expect(error).toContainText(/desktop/i);
+  });
+
+  test("the Federation control is honest about being a desktop capability", async ({ page }) => {
+    await page.locator("[data-federation-control]").click();
+    // The web note says the setting persists but SERVICE execution is native-only here.
+    const note = page.locator("[data-federation-web-note]");
+    await expect(note).toBeVisible();
+    await expect(note).toContainText(/native-only/i);
+  });
+});

--- a/gui/e2e-playwright/support/tauri-mock.ts
+++ b/gui/e2e-playwright/support/tauri-mock.ts
@@ -12,6 +12,9 @@
 //   load_text        → { nquads: "<...> .", count: 1, format: "turtle" }
 //   load_path        → same as load_text
 //   plugin:dialog|open → "/tmp/test.ttl"
+//   query_service    → [FABLE-5] sq-ixc3.14: fail-closed allowlist mirror of the Rust command —
+//                      rejects with the "SERVICE egress refused" marker unless the caller's
+//                      allow[] contains fed.example.org; else resolves a joined SELECT doc
 //   (any other cmd)  → throws Error (catches unexpected IPC surface drift)
 
 /** The script string injected via page.addInitScript before the page's own scripts run. */
@@ -30,6 +33,21 @@ export const tauriMockScript: string = `
   // The LOG accumulates every invoke call so tests can assert the IPC contract.
   var LOG = [];
 
+  // [FABLE-5] sq-ixc3.14 — the native federated-query command (query_service). The mock
+  // mirrors the Rust contract (gui/src-tauri/src/federation.rs): STRICT fail-closed
+  // allowlist — the fixture endpoint host must be ON the caller's allowlist or the call
+  // rejects with the engine's stable egress-refusal marker (a plain string, exactly like a
+  // real Tauri command Err). When allowed, it resolves a SPARQL-Results-JSON doc whose row
+  // JOINS a local sample-graph binding (Alice) with a remote-only binding (remote-captain).
+  var FED_HOST = "fed.example.org";
+  var SERVICE_FIXTURE = JSON.stringify({
+    head: { vars: ["name", "fedRole"] },
+    results: { bindings: [
+      { name:    { type: "literal", value: "Alice" },
+        fedRole: { type: "literal", value: "remote-captain" } }
+    ] }
+  });
+
   window.__TAURI__ = {
     core: {
       invoke: function (cmd, args) {
@@ -38,6 +56,20 @@ export const tauriMockScript: string = `
         if (cmd === "load_text")         return Promise.resolve(LOAD_FIXTURE);
         if (cmd === "load_path")         return Promise.resolve(LOAD_FIXTURE);
         if (cmd === "plugin:dialog|open") return Promise.resolve("/tmp/test.ttl");
+        if (cmd === "query_service") {
+          var allow = (args && args.allow) || [];
+          var permitted = false;
+          for (var i = 0; i < allow.length; i++) {
+            if (allow[i] === FED_HOST) permitted = true;
+          }
+          if (!permitted) {
+            // The stable marker substring sparq_engine::SERVICE_EGRESS_REFUSED_MARKER carries.
+            return Promise.reject(
+              'SERVICE egress refused: endpoint host "' + FED_HOST + '" is not allowlisted'
+            );
+          }
+          return Promise.resolve(SERVICE_FIXTURE);
+        }
         return Promise.reject(new Error("[tauri-mock] Unexpected IPC invoke: " + cmd));
       }
     }

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -2195,6 +2195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,7 +2422,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -2544,6 +2550,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -2758,6 +2773,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +2799,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2791,6 +2894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2849,6 +2961,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3201,6 +3336,7 @@ dependencies = [
  "spargebra",
  "sparq-core",
  "sparq-engine-serialize",
+ "sparq-engine-service",
  "sparq-substrate",
  "uuid",
 ]
@@ -3212,6 +3348,19 @@ dependencies = [
  "oxrdf",
  "sparq-core",
  "sparq-jsonld",
+]
+
+[[package]]
+name = "sparq-engine-service"
+version = "0.1.0"
+dependencies = [
+ "oxrdf",
+ "quick-xml 0.41.0",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sparq-core",
+ "ureq",
 ]
 
 [[package]]
@@ -3295,6 +3444,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sucds"
@@ -4109,6 +4264,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,6 +4328,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -4355,6 +4551,24 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4585,6 +4799,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4992,6 +5215,12 @@ dependencies = [
  "syn 2.0.118",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -54,6 +54,13 @@ tauri-build = { version = "2", features = [] }
 # cannot. The webview-target build (Pages "Try the GUI live") never links this crate at all.
 default = []
 hdt = ["dep:sparq-hdt"]
+# [FABLE-5] sq-ixc3.14 — native federated SERVICE query execution for the Query tool. OFF by
+# default for the same lean-build reasons as `hdt`: it forwards to `sparq-engine/service`, whose
+# federation client pulls a blocking HTTP/TLS stack (ureq) the default build must not carry. The
+# desktop release build turns it ON (alongside `hdt`) so SERVICE-clause queries run over the
+# native engine — the browser build fundamentally cannot (no blocking cross-origin HTTP). Every
+# `query_service` call installs the engine's STRICT fail-closed egress allowlist (federation.rs).
+federation = ["sparq-engine/service"]
 # [FABLE-5] sq-t6492 — embed + serve the frontendDist static export instead of connecting to
 # `devUrl` (http://localhost:3001). Tauri's build script sets `cfg(dev) = !custom-protocol`
 # (tauri build.rs: `let dev = !custom_protocol`), and in dev mode the webview navigates to

--- a/gui/src-tauri/src/federation.rs
+++ b/gui/src-tauri/src/federation.rs
@@ -1,0 +1,228 @@
+// [FABLE-5] sq-ixc3.14 — native federated SERVICE query execution for the Query tool.
+//
+// The GUI's query path runs in the in-tab WASM engine, which fundamentally cannot evaluate a
+// SPARQL 1.1 `SERVICE` clause: the browser has no blocking cross-origin HTTP (CORS), so the
+// engine's federation client (`sparq-engine-service`, the `service` feature) is native-only by
+// design. This module is the DELIBERATE, reviewed native query surface (see the lib.rs note on
+// the removed pre-wired commands): exactly ONE command, `query_service`, scoped to the one job
+// the webview cannot do itself — evaluate a SERVICE-bearing SELECT/ASK over a snapshot of the
+// live workspace store, joining local rows with rows fetched from remote SPARQL endpoints.
+//
+// OPT-IN: the whole capability sits behind this crate's non-default `federation` cargo feature
+// (which forwards to `sparq-engine/service`). A lean build compiles a stub that fails LOUDLY
+// with a rebuild hint — never a silent no-op — so the default build's dependency graph gains no
+// HTTP/TLS stack (the same discipline as the `hdt` feature).
+//
+// SECURITY — FAIL-CLOSED EGRESS (threat-model B4, the SERVICE SSRF primitive): every call
+// installs the engine's STRICT allowlist-only egress policy (`with_service_egress_policy(true,
+// …)` — the SAME policy the network-exposed sparq-server wires to `--service-allow`). Only the
+// endpoints on the per-workspace allowlist the user explicitly configured in the GUI are
+// reachable; EVERYTHING else — including public hosts — is refused PRE-HTTP with a typed error
+// carrying `SERVICE_EGRESS_REFUSED_MARKER` (a clean refusal, never a hang, no socket is ever
+// dialed). An empty allowlist therefore refuses every SERVICE endpoint: the default is closed.
+// The allowlist is the user's explicit per-workspace configuration (the GUI equivalent of the
+// server operator's `--service-allow`); the webview passes it per-call because the setting
+// lives with the workspace record the frontend owns.
+//
+// HONESTY: no performance number is asserted. Remote round-trips are bounded by the transport's
+// own finite default timeout (sparq-engine-service `HttpTransport`), so a slow endpoint errors
+// rather than hanging the command indefinitely.
+
+/// Evaluate a (typically SERVICE-bearing) SELECT/ASK query over a snapshot of the live
+/// workspace store, under the STRICT fail-closed egress allowlist. `dataset` is the whole
+/// workspace dataset as N-Quads (the same wire format the native loader returns); `allow` is
+/// the per-workspace egress allowlist (`host` / `host:port` / `*.suffix` entries — the same
+/// grammar as sparq-server's `--service-allow`). Returns the SPARQL 1.1 JSON results document
+/// (the same shape the in-tab WASM engine produces), so the existing multi-view result panel
+/// renders it unchanged.
+#[tauri::command]
+pub fn query_service(dataset: String, query: String, allow: Vec<String>) -> Result<String, String> {
+    run_service_query(&dataset, &query, allow)
+}
+
+/// The command body, factored out so it can be unit-tested against a real loopback SPARQL
+/// endpoint without a Tauri runtime (the same pattern as `engine::load_approved_path`).
+#[cfg(feature = "federation")]
+fn run_service_query(dataset: &str, query: &str, allow: Vec<String>) -> Result<String, String> {
+    // An empty snapshot is a legal store (a fresh workspace); parse otherwise. N-Quads is the
+    // GUI's whole-dataset wire format, so named graphs survive into the native evaluation.
+    let graph = if dataset.trim().is_empty() {
+        sparq_core::Graph::new()
+    } else {
+        sparq_core::Graph::load_dataset(dataset, "nquads")?
+    };
+    // STRICT allowlist-only egress for the whole evaluation: any SERVICE endpoint not on the
+    // user's per-workspace allowlist is refused pre-HTTP (fail-closed; empty list = refuse all).
+    sparq_engine::with_service_egress_policy(true, allow, || {
+        sparq_engine::query_json(&graph, query)
+    })
+}
+
+/// Lean-build stub: federation is compiled out, so a SERVICE run fails LOUDLY with an
+/// actionable rebuild hint instead of silently mis-reporting (the `hdt` feature's discipline).
+#[cfg(not(feature = "federation"))]
+fn run_service_query(_dataset: &str, _query: &str, _allow: Vec<String>) -> Result<String, String> {
+    Err(
+        "Federated SERVICE queries are not compiled into this build — rebuild the desktop app \
+         with `cargo build --features federation` to run SERVICE queries."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The live workspace store's snapshot: one local triple binding `?s` → `?name`.
+    const LOCAL_NQUADS: &str =
+        "<http://example.org/alice> <http://example.org/name> \"Alice\" .";
+
+    /// A SELECT that JOINS the local store with a remote SERVICE endpoint on `?s`.
+    #[cfg(feature = "federation")]
+    fn service_query(endpoint: &str) -> String {
+        format!(
+            "SELECT ?name ?age WHERE {{ ?s <http://example.org/name> ?name . \
+             SERVICE <{endpoint}> {{ ?s <http://example.org/age> ?age }} }}"
+        )
+    }
+
+    // ── the native-lane acceptance e2e (feature ON): a LIVE loopback SPARQL endpoint ──
+
+    /// Bind a loopback server that accepts one HTTP request (draining headers + body) and
+    /// answers with `body` as a SPARQL-Results-JSON 200. Returns the ephemeral port. The same
+    /// single-shot pattern as sparq-engine-service's `http_transport_tests::serve_once`.
+    #[cfg(feature = "federation")]
+    fn serve_srj_once(body: String) -> u16 {
+        use std::io::{BufRead, BufReader, Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let port = listener.local_addr().expect("local addr").port();
+        std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut reader = BufReader::new(stream);
+            // Drain the request headers, remembering Content-Length so the (POSTed) SPARQL
+            // request body can be drained too before we respond.
+            let mut content_length = 0usize;
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if reader.read_line(&mut line).is_err() || line.trim().is_empty() {
+                    break;
+                }
+                if let Some(v) = line
+                    .to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(str::trim)
+                    .and_then(|v| v.parse::<usize>().ok())
+                {
+                    content_length = v;
+                }
+            }
+            if content_length > 0 {
+                let mut body_buf = vec![0u8; content_length];
+                let _ = reader.read_exact(&mut body_buf);
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/sparql-results+json\r\n\
+                 Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = reader.get_mut().write_all(response.as_bytes());
+        });
+        port
+    }
+
+    /// ACCEPTANCE (sq-ixc3.14): a query with `SERVICE <local-test-sparq-endpoint>` returns rows
+    /// JOINED across the live workspace snapshot and the remote endpoint — through the REAL
+    /// engine federation client (HTTP transport + SRJ parse + join), with the endpoint
+    /// explicitly allowlisted.
+    #[test]
+    #[cfg(feature = "federation")]
+    fn service_query_joins_local_store_with_a_live_loopback_endpoint() {
+        // The remote half: `?s` → `?age` for the SAME subject the local store binds.
+        let srj = r#"{"head":{"vars":["s","age"]},"results":{"bindings":[
+            {"s":{"type":"uri","value":"http://example.org/alice"},
+             "age":{"type":"literal","value":"30",
+                    "datatype":"http://www.w3.org/2001/XMLSchema#integer"}}
+        ]}}"#
+            .to_string();
+        let port = serve_srj_once(srj);
+        let endpoint = format!("http://127.0.0.1:{port}/sparql");
+
+        let json = run_service_query(
+            LOCAL_NQUADS,
+            &service_query(&endpoint),
+            vec![format!("127.0.0.1:{port}")],
+        )
+        .expect("the allowlisted SERVICE join must succeed");
+
+        // The JOINED row carries the LOCAL binding ("Alice") AND the REMOTE binding ("30") —
+        // a mutation dropping either side of the join flips this red.
+        assert!(json.contains("Alice"), "local binding must survive the join: {json}");
+        assert!(json.contains("\"30\""), "remote binding must be joined in: {json}");
+    }
+
+    /// ACCEPTANCE (sq-ixc3.14): an endpoint NOT on the allowlist is refused CLEANLY — a typed
+    /// pre-HTTP refusal carrying the stable marker, not a hang (no socket is ever dialed: the
+    /// port below has no listener, so anything but a pre-HTTP refusal would surface as a
+    /// connect error or a timeout instead of the marker).
+    #[test]
+    #[cfg(feature = "federation")]
+    fn service_endpoint_off_the_allowlist_is_refused_fail_closed() {
+        let query = service_query("http://127.0.0.1:9/sparql");
+
+        // Empty allowlist (the fresh-workspace default): EVERY endpoint refused.
+        let err = run_service_query(LOCAL_NQUADS, &query, Vec::new())
+            .expect_err("an empty allowlist must refuse every SERVICE endpoint");
+        assert!(
+            err.contains(sparq_engine::SERVICE_EGRESS_REFUSED_MARKER),
+            "refusal must carry the stable egress marker, got: {err}"
+        );
+
+        // A non-empty allowlist that does NOT cover the endpoint refuses it too (strict
+        // allowlist-only, not deny-private): being on the list is the ONLY way through.
+        let err = run_service_query(
+            LOCAL_NQUADS,
+            &query,
+            vec!["query.example.org".to_string()],
+        )
+        .expect_err("a non-matching allowlist must refuse the endpoint");
+        assert!(
+            err.contains(sparq_engine::SERVICE_EGRESS_REFUSED_MARKER),
+            "refusal must carry the stable egress marker, got: {err}"
+        );
+    }
+
+    /// A refused SERVICE evaluation must not leak partial results: the refusal is an `Err`,
+    /// never an empty-but-`Ok` result set (the frontend distinguishes "no rows" from "refused").
+    #[test]
+    #[cfg(feature = "federation")]
+    fn refusal_is_an_error_not_an_empty_result() {
+        let out = run_service_query(LOCAL_NQUADS, &service_query("http://127.0.0.1:9/x"), vec![]);
+        assert!(out.is_err(), "refusal must be Err, got: {out:?}");
+    }
+
+    /// A plain (non-SERVICE) query still runs natively under the strict policy — the policy
+    /// gates egress, not local evaluation.
+    #[test]
+    #[cfg(feature = "federation")]
+    fn non_service_query_runs_under_the_strict_policy() {
+        let json = run_service_query(
+            LOCAL_NQUADS,
+            "SELECT ?name WHERE { ?s <http://example.org/name> ?name }",
+            Vec::new(),
+        )
+        .expect("a local-only query needs no egress");
+        assert!(json.contains("Alice"), "local rows must come back: {json}");
+    }
+
+    /// Lean build (feature OFF): the stub fails LOUDLY with the actionable rebuild hint —
+    /// never a silent no-op or a mis-parse.
+    #[test]
+    #[cfg(not(feature = "federation"))]
+    fn lean_build_fails_loudly_with_a_rebuild_hint() {
+        let err = run_service_query(LOCAL_NQUADS, "SELECT * WHERE { ?s ?p ?o }", Vec::new())
+            .expect_err("the lean-build stub must be an Err");
+        assert!(err.contains("--features federation"), "got: {err}");
+    }
+}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@
 
 mod disk;
 mod engine;
+mod federation;
 
 use engine::EngineState;
 
@@ -55,6 +56,14 @@ pub fn run() {
             // the resolved $APPLOCALDATA/workspaces tree and returns its REAL byte total, so the
             // status bar can show the OS-reported store footprint instead of the snapshot estimate.
             disk::disk_usage,
+            // [FABLE-5] sq-ixc3.14 — the ONE deliberate native QUERY command (the reviewed
+            // exception to the removed pre-wired surface above): evaluate a SERVICE-bearing
+            // SELECT/ASK over a snapshot of the live workspace store, because the in-tab WASM
+            // engine cannot dial remote SPARQL endpoints. Every call installs the engine's
+            // STRICT fail-closed egress allowlist (the per-workspace federation setting); the
+            // capability is gated behind the non-default `federation` cargo feature and a lean
+            // build registers a stub that fails loudly with a rebuild hint (federation.rs).
+            federation::query_service,
         ])
         .run(tauri::generate_context!())
         .expect("error while running the sparq Tauri application");

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -721,6 +721,8 @@ export {
   WORKSPACE_SCHEMA,
   WORKSPACE_INFERENCE_MODES,
   parseInferenceMode,
+  // [FABLE-5] sq-ixc3.14 — per-workspace federation egress allowlist (fail-closed parse).
+  parseServiceAllowlist,
   WebWorkspaceStore,
   MemoryWorkspaceStore,
   TauriWorkspaceStore,

--- a/packages/sparq-client/src/workspace.ts
+++ b/packages/sparq-client/src/workspace.ts
@@ -155,6 +155,15 @@ export interface Workspace {
    */
   rulesDocs?: WorkspaceRulesDoc[];
   /**
+   * [FABLE-5] sq-ixc3.14 — the per-workspace FEDERATION egress allowlist: the only SPARQL
+   * endpoints a `SERVICE` clause may dial when the desktop GUI evaluates the query over the
+   * native engine (`host` / `host:port` / `*.suffix` entries, the same grammar as
+   * sparq-server's `--service-allow`). FAIL-CLOSED: absent or empty means every SERVICE
+   * endpoint is refused. Optional + backward-compatible: an older record simply omits it
+   * (no schema bump — purely additive, like `inference`).
+   */
+  serviceAllowlist?: string[];
+  /**
    * The schema version of this persisted record. Bumped if the on-disk shape changes so a
    * loader can migrate or discard an incompatible old record rather than crash.
    */
@@ -252,8 +261,24 @@ export function parseWorkspace(value: unknown): Workspace | null {
     inference: parseInferenceMode(v.inference),
     // [sq-glo5r] — backward-compatible: an older record without `rulesDocs` → empty array.
     rulesDocs: parseRulesDocs(v.rulesDocs),
+    // [FABLE-5] sq-ixc3.14 — backward-compatible: no `serviceAllowlist` → empty (fail-closed).
+    serviceAllowlist: parseServiceAllowlist(v.serviceAllowlist),
     schema: WORKSPACE_SCHEMA,
   };
+}
+
+/**
+ * [FABLE-5] sq-ixc3.14 — validate + normalise a persisted federation egress allowlist: keep
+ * only non-empty trimmed strings, drop everything else (a hand-edited or corrupt record must
+ * degrade toward FEWER reachable endpoints, never more — fail-closed).
+ */
+export function parseServiceAllowlist(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((e) => {
+    if (typeof e !== "string") return [];
+    const trimmed = e.trim();
+    return trimmed === "" ? [] : [trimmed];
+  });
 }
 
 function parseSource(value: unknown): WorkspaceSourceMeta | null {


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous implementation of bead **sq-ixc3.14** (epic sq-ixc3). [FABLE-5]

## What

Federation was BUILT in the engine (`sparq-engine-service`: SERVICE HTTP transport, SRJ/SRX parse, bound-join, SSRF egress policy) but unreachable from the GUI. This PR wires it end-to-end:

**Native (gui/src-tauri, opt-in `federation` cargo feature → `sparq-engine/service`)**
- `query_service` — the ONE deliberate native query command (the reviewed exception to the removed pre-wired surface, sq-w2sod note): evaluates a SERVICE-bearing SELECT/ASK over an N-Quads snapshot of the live workspace store via `sparq_engine::query_json`, inside `with_service_egress_policy(strict=true, allowlist)` — the SAME allowlist-only policy sparq-server wires to `--service-allow`. **Fail-closed**: empty/absent allowlist refuses every SERVICE endpoint **pre-HTTP** with the stable `SERVICE egress refused` marker (typed refusal, never a hang; no socket dialed). Lean builds compile a loud rebuild-hint stub (the `hdt` discipline); default build's dep graph gains no HTTP/TLS stack.

**Frontend (gui/app + @sparq/client)**
- `Workspace.serviceAllowlist` — additive, backward-compatible per-workspace setting (fail-closed defensive parse; no schema bump), persisted like `inference`, pushed to the engine by a `FederationBridge` + on workspace activate.
- Query tool routes SERVICE-bearing SELECT/ASK runs (pure detector, literal/comment/IRI-safe) to the native IPC on desktop; results land in the existing multi-view panel (same row-cap/truncation semantics as the streamed in-tab path). Egress refusals classify into an actionable fail-closed message.
- **Honest web degradation**: the browser build labels SERVICE *native-only* (tools.ts taxonomy framing) — badge `SERVICE · native-only`, clear error instead of a CORS hang; the Federation control says the setting applies in the desktop app. Query tool blurb updated via the sq-5lyme per-panel override seam (never editing tools.ts).
- New `FederationControl` (allowlist editor) + honest run-location badge (`LOCAL · in-tab WASM` / `NATIVE · federated SERVICE` / `SERVICE · native-only`).

## Acceptance test (bead)

- **Native lane** (`cargo test --features federation`, now also a gui.yml matrix step): `service_query_joins_local_store_with_a_live_loopback_endpoint` runs a SERVICE query against a LIVE loopback SPARQL endpoint through the real engine federation client and asserts the row joins the LOCAL binding with the REMOTE binding (mutation on either side flips it red). `service_endpoint_off_the_allowlist_is_refused_fail_closed` proves the strict pre-HTTP refusal (empty AND non-matching allowlists) carries the stable marker — clean refusal, not a hang.
- **Playwright mock-IPC (gating lane)**: allowlist-edit → native joined rows render in the table view + IPC contract asserted (dataset snapshot, query, allowlist); off-allowlist → clean fail-closed error. **Web persona**: native-only badge + honest error + honest control note.

## Gates (run locally, both feature states)

- `cargo clippy --all-targets [-- --features federation] -- -D warnings` ✅ / `cargo test [--features federation]` ✅ (19 tests ON, 16 OFF; loopback-only, no external network)
- gui/app `lint` ✅ `typecheck` ✅ `test:unit` ✅ (46, incl. 12 new federation helper tests) `build:web` ✅ `build:tauri` ✅
- Playwright full suite **65/65** ✅ (5 new federation specs) · e2e-playwright `typecheck` + no-timeout gate ✅
- `packages/sparq-client` + `site` typecheck ✅ · `scripts/check-readme-template.py` 0 deviations ✅
- No `crates/` changes — workspace gates unaffected. gui crate stays excluded from the workspace (standalone root).

## Scope notes / follow-ups (beads filed)

- DISTINCT from sq-6v53 (federation-PLAN views) and sq-2mke (remote-endpoint store mode); this is local store + remote SERVICE join.
- sq-3w29b (P2): desktop release packaging must build with `--features federation,hdt`.
- sq-yzrjw (P3): native SERVICE for CONSTRUCT/DESCRIBE + cancellable in-flight IPC.
- Trust model documented in federation.rs: the allowlist is the user's explicit per-workspace configuration (the GUI analogue of the server operator's `--service-allow`); every call installs strict mode, so the default is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)