### PR TITLE
chore(supply-chain): pre-attest the solid-server-rs import dependency tree (sq-gg0qq.1)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -55,7 +55,16 @@ yanked = "deny"
 # (its code moved into `rustls-pki-types`' `PemObject`). The crate is now absent
 # from Cargo.lock, so the ignore is removed and the gate re-flags any regression
 # that reintroduces it.
+# RUSTSEC-2025-0134 (unmaintained `rustls-pemfile`) is RE-ADDED (it was removed by
+# sq-g2xs when ureq 3 dropped the crate from the tree): the solid-server-rs import
+# (epic sq-gg0qq, supply-chain pre-flight sq-gg0qq.1) reintroduces `rustls-pemfile 2`
+# for its mTLS serve path (PEM cert-chain/key parse into the DER types
+# `with_client_cert_verifier(..).with_single_cert(..)` needs). "Unmaintained" here
+# means ARCHIVED-BUT-STABLE — the crate's functionality moved into `rustls-pki-types`'
+# `PemObject`; there is no vulnerability. Follow-up bead sq-5ah3p (migration to
+# rustls-pki-types' PemObject during the import) removes this ignore again.
 ignore = [
+  { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is archived/unmaintained (functionality moved into rustls-pki-types PemObject) — an informational advisory, not a vulnerability. Re-added for the solid-server-rs import pre-flight (sq-gg0qq.1): the imported mTLS serve path parses PEM cert-chain/key via rustls-pemfile 2, exactly as upstream jeswr/solid-server-rs ships. Remove by migrating the imported code to rustls-pki-types PemObject (follow-up bead sq-5ah3p)." },
   # quick-xml 0.37.5 (oxigraph 0.5.x transitive) — see the justification above.
   { id = "RUSTSEC-2026-0194", reason = "quick-xml <0.41 quadratic-time duplicate-attribute DoS. Our own crates are on the patched 0.41; this tolerates ONLY the transitive quick-xml 0.37.5 pinned by the oxigraph 0.5.x stack (oxrdfxml/sparesults/spareval), for which no fixed upstream release exists yet. Availability-only, not memory-unsafety. Remove when oxigraph bumps quick-xml >=0.41. https://github.com/tafia/quick-xml/issues/969" },
   { id = "RUSTSEC-2026-0195", reason = "quick-xml <0.41 unbounded namespace-declaration allocation in NsReader — memory-exhaustion DoS. Same fix (>=0.41.0) and same scope as RUSTSEC-2026-0194: our own crates are on the patched 0.41; this tolerates ONLY the transitive quick-xml 0.37.5 pinned by the oxigraph 0.5.x stack (oxrdfxml/sparesults/spareval), for which no fixed upstream release exists yet. Availability-only, not memory-unsafety. Remove when oxigraph bumps quick-xml >=0.41. https://github.com/tafia/quick-xml/issues/970" },
@@ -121,6 +130,11 @@ exceptions = [
   #     (already allowed). Scoped per-crate so the broad allowlist stays
   #     permissive-only. [OPUS-4.8] PR #700 (dependabot bzip2 0.5 -> 0.6).
   { crate = "libbz2-rs-sys@0.2.5", allow = ["bzip2-1.0.6"] },
+  # --- xxhash-rust (BSL-1.0 — the Boost Software License, OSI-approved + FSF-Free,
+  #     permissive; no copyleft). Transitive of the `redis` client (solid-server-rs
+  #     import pre-flight, sq-gg0qq.1) behind the opt-in `redis-replay` feature of the
+  #     incoming crates. Scoped per-crate so the broad allowlist stays as-is. [FABLE-5]
+  { crate = "xxhash-rust@0.8.16", allow = ["BSL-1.0"] },
 ]
 
 [bans]
@@ -141,4 +155,12 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # (vendor/spargebra). A path patch is not a registry/git source, so it does not
 # trip unknown-registry/unknown-git; this block documents the boundary and is
 # the hook for any future git source we deliberately allow.
-allow-git = []
+# [FABLE-5] sq-gg0qq.1 (solid-server-rs import pre-flight): `solid-oidc-verifier` is
+# the maintainer's standalone, security-audited DPoP/Solid-OIDC verifier crate
+# (github.com/jeswr — the SAME owner as this repo's upstream). It is consumed as a
+# GIT dependency pinned to an exact rev (89c8962…, Cargo.lock committed) because no
+# crates.io release exists yet; the handover (jeswr/solid-server-rs#14) directs
+# "depend on it, don't absorb it". cargo-deny allows the ORIGIN here; the exact-rev
+# pin lives in the consuming crate's Cargo.toml + the committed lockfile. Re-pin to
+# a tagged release (and drop this entry for a registry dep) once the verifier cuts one.
+allow-git = ["https://github.com/jeswr/solid-oidc-verifier"]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -50,6 +50,10 @@ criteria = "safe-to-deploy"
 version = "1.9.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.arcstr]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.ark-bn254]]
 version = "0.6.0"
 criteria = "safe-to-deploy"
@@ -108,11 +112,22 @@ criteria = "safe-to-deploy"
 
 [[exemptions.async-trait]]
 version = "0.1.89"
-criteria = "safe-to-run"
+criteria = "safe-to-deploy"
+notes = "was safe-to-run (dev-only); promoted to safe-to-deploy for the solid-server-rs import pre-flight (sq-gg0qq.1) - solid-oidc-verifier + the lws Store/BlobStore seams use it in non-dev deps [FABLE-5]"
 
 [[exemptions.autocfg]]
 version = "1.5.1"
 criteria = "safe-to-deploy"
+
+[[exemptions.aws-lc-rs]]
+version = "1.17.1"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): the house FIPS-capable rustls crypto backend of the incoming server (HKDF/HMAC primitives, process-wide provider). AWS-maintained, formally-verified core (AWS-LC). [FABLE-5]"
+
+[[exemptions.aws-lc-sys]]
+version = "0.42.0"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): -sys crate for aws-lc-rs — vendors + compiles the AWS-LC C/asm source at build time via cc/cmake (build-time code execution, same class as libmimalloc-sys already in tree). AWS-maintained. [FABLE-5]"
 
 [[exemptions.axum]]
 version = "0.8.9"
@@ -121,6 +136,11 @@ criteria = "safe-to-deploy"
 [[exemptions.axum-core]]
 version = "0.5.6"
 criteria = "safe-to-deploy"
+
+[[exemptions.axum-server]]
+version = "0.8.0"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): TLS-serving path of the incoming server; consumed with default-features=false + tls-rustls-no-provider so it reuses the process-wide aws-lc-rs provider (no second provider). [FABLE-5]"
 
 [[exemptions.base16ct]]
 version = "0.2.0"
@@ -234,6 +254,10 @@ version = "0.4.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.core-foundation]]
+version = "0.9.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.core-foundation]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
 
@@ -258,6 +282,14 @@ version = "0.5.1"
 criteria = "safe-to-run"
 notes = "LOAD-BEARING trust anchor, NOT the in-tree version. The tree has criterion 0.8.2 (dev-only bench dep, not in the shipped/wasm build), which is certified via the isrg upstream safe-to-run DELTA-audit chain 0.5.1 -> 0.6.0 -> 0.7.0 -> 0.8.0 -> 0.8.1 -> 0.8.2 (supply-chain/imports.lock). That chain needs a base at 0.5.1; this exemption is that base. Removing it un-vets criterion 0.8.2 and fails `cargo vet --frozen` — verified 2026-07-07 (sq-57zih). Keep until a full audit of a later criterion base lands upstream. [OPUS-4.8]"
 
+[[exemptions.critical-section]]
+version = "1.2.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.crossbeam-channel]]
+version = "0.5.16"
+criteria = "safe-to-deploy"
+
 [[exemptions.crossbeam-deque]]
 version = "0.8.6"
 criteria = "safe-to-deploy"
@@ -274,6 +306,10 @@ notes = "advisory-fix release for RUSTSEC-2026-0204 (unsound epoch pinning); del
 [[exemptions.crossbeam-utils]]
 version = "0.8.21"
 criteria = "safe-to-deploy"
+
+[[exemptions.crypto-bigint]]
+version = "0.5.5"
+criteria = "safe-to-run"
 
 [[exemptions.crypto-common]]
 version = "0.1.7"
@@ -299,6 +335,10 @@ criteria = "safe-to-deploy"
 version = "2.11.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.deranged]]
+version = "0.5.8"
+criteria = "safe-to-deploy"
+
 [[exemptions.digest]]
 version = "0.10.7"
 criteria = "safe-to-deploy"
@@ -319,9 +359,17 @@ criteria = "safe-to-deploy"
 version = "0.5.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.dunce]]
+version = "1.0.5"
+criteria = "safe-to-deploy"
+
 [[exemptions.earcut]]
 version = "0.4.5"
 criteria = "safe-to-deploy"
+
+[[exemptions.ecdsa]]
+version = "0.16.9"
+criteria = "safe-to-run"
 
 [[exemptions.ed25519]]
 version = "2.2.3"
@@ -335,6 +383,10 @@ criteria = "safe-to-deploy"
 version = "0.6.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.elliptic-curve]]
+version = "0.13.8"
+criteria = "safe-to-run"
+
 [[exemptions.enum-ordinalize]]
 version = "4.3.2"
 criteria = "safe-to-deploy"
@@ -345,6 +397,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fastrand]]
 version = "2.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.ff]]
+version = "0.13.1"
 criteria = "safe-to-run"
 
 [[exemptions.find-msvc-tools]]
@@ -359,6 +415,14 @@ criteria = "safe-to-deploy"
 version = "2.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.fs-err]]
+version = "3.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.fs_extra]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.futures-channel]]
 version = "0.3.32"
 criteria = "safe-to-deploy"
@@ -368,6 +432,10 @@ version = "0.3.32"
 criteria = "safe-to-deploy"
 
 [[exemptions.futures-io]]
+version = "0.3.32"
+criteria = "safe-to-deploy"
+
+[[exemptions.futures-macro]]
 version = "0.3.32"
 criteria = "safe-to-deploy"
 
@@ -431,6 +499,14 @@ criteria = "safe-to-deploy"
 version = "0.2.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.group]]
+version = "0.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.h2]]
+version = "0.4.15"
+criteria = "safe-to-deploy"
+
 [[exemptions.half]]
 version = "2.7.1"
 criteria = "safe-to-deploy"
@@ -459,6 +535,23 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.hickory-net]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hickory-proto]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.hickory-resolver]]
+version = "0.26.1"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): transitive of solid-oidc-verifier — its DNS-pinned SSRF-guarded async resolver (0.26.1 carries the GHSA-q2qq-hmj6-3wpp hickory-proto fix). [FABLE-5]"
+
+[[exemptions.hmac]]
+version = "0.12.1"
+criteria = "safe-to-run"
+
 [[exemptions.http]]
 version = "1.4.2"
 criteria = "safe-to-deploy"
@@ -469,6 +562,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.httparse]]
 version = "1.10.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.humantime]]
+version = "2.4.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.hybrid-array]]
@@ -571,6 +668,10 @@ criteria = "safe-to-deploy"
 version = "0.6.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.ipconfig]]
+version = "0.3.4"
+criteria = "safe-to-deploy"
+
 [[exemptions.ipnet]]
 version = "2.12.0"
 criteria = "safe-to-deploy"
@@ -581,6 +682,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.itoa]]
 version = "1.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni]]
+version = "0.22.4"
+criteria = "safe-to-deploy"
+
+[[exemptions.jni-macros]]
+version = "0.22.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.jni-sys]]
@@ -606,6 +715,11 @@ criteria = "safe-to-deploy"
 [[exemptions.json-event-parser]]
 version = "0.2.3"
 criteria = "safe-to-deploy"
+
+[[exemptions.jsonwebtoken]]
+version = "10.4.0"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): transitive of solid-oidc-verifier — JWS verification for DPoP/Solid-OIDC access tokens. [FABLE-5]"
 
 [[exemptions.khronos-egl]]
 version = "6.0.0"
@@ -699,6 +813,10 @@ criteria = "safe-to-run"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.moka]]
+version = "0.12.15"
+criteria = "safe-to-deploy"
+
 [[exemptions.mownstr]]
 version = "0.3.1"
 criteria = "safe-to-deploy"
@@ -709,6 +827,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.naga-types]]
 version = "30.0.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.ndk-context]]
+version = "0.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.ndk-sys]]
@@ -735,6 +857,10 @@ criteria = "safe-to-deploy"
 version = "0.4.6"
 criteria = "safe-to-deploy"
 
+[[exemptions.num-conv]]
+version = "0.2.2"
+criteria = "safe-to-deploy"
+
 [[exemptions.num_cpus]]
 version = "1.17.0"
 criteria = "safe-to-deploy"
@@ -750,6 +876,11 @@ criteria = "safe-to-deploy"
 [[exemptions.objc2-io-surface]]
 version = "0.3.2"
 criteria = "safe-to-deploy"
+
+[[exemptions.object_store]]
+version = "0.13.2"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): Apache Arrow's blob-store trait (S3/GCS/Azure/local) — backup/bytes-only seam of the incoming server, never authoritative. [FABLE-5]"
 
 [[exemptions.once_cell]]
 version = "1.21.4"
@@ -807,6 +938,11 @@ criteria = "safe-to-deploy"
 version = "0.2.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.p256]]
+version = "0.13.2"
+criteria = "safe-to-run"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): DEV-ONLY (safe-to-run) — mints test JWS access tokens + DPoP proofs in the incoming server's auth-middleware unit tests; RustCrypto ES256 stack, never in the shipped build. [FABLE-5]"
+
 [[exemptions.parking_lot]]
 version = "0.12.5"
 criteria = "safe-to-deploy"
@@ -829,6 +965,14 @@ criteria = "safe-to-deploy"
 
 [[exemptions.peg-runtime]]
 version = "0.8.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem]]
+version = "3.0.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.pem-rfc7468]]
+version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.pin-project-lite]]
@@ -874,13 +1018,25 @@ criteria = "safe-to-deploy"
 version = "0.1.5"
 criteria = "safe-to-deploy"
 
+[[exemptions.powerfmt]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.ppv-lite86]]
 version = "0.2.21"
+criteria = "safe-to-deploy"
+
+[[exemptions.prefix-trie]]
+version = "0.8.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.prettyplease]]
 version = "0.2.37"
 criteria = "safe-to-deploy"
+
+[[exemptions.primeorder]]
+version = "0.13.6"
+criteria = "safe-to-run"
 
 [[exemptions.profiling]]
 version = "1.0.18"
@@ -943,6 +1099,11 @@ criteria = "safe-to-deploy"
 version = "6.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.r2d2]]
+version = "0.8.10"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): blocking connection pool for the opt-in redis-replay feature (distributed DPoP jti replay store); dedicated-OS-thread pattern, no async runtime features. [FABLE-5]"
+
 [[exemptions.rand_core]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
@@ -962,6 +1123,11 @@ criteria = "safe-to-deploy"
 [[exemptions.rdf-canon]]
 version = "0.15.3"
 criteria = "safe-to-deploy"
+
+[[exemptions.redis]]
+version = "1.3.0"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): SYNC-only client (default-features=false, features=[r2d2]) behind the incoming server's opt-in redis-replay feature; BSD-3-Clause. [FABLE-5]"
 
 [[exemptions.redox_syscall]]
 version = "0.5.18"
@@ -990,6 +1156,14 @@ criteria = "safe-to-deploy"
 [[exemptions.resiter]]
 version = "0.5.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.resolv-conf]]
+version = "0.7.6"
+criteria = "safe-to-deploy"
+
+[[exemptions.rfc6979]]
+version = "0.4.0"
+criteria = "safe-to-run"
 
 [[exemptions.ring]]
 version = "0.17.14"
@@ -1031,6 +1205,11 @@ criteria = "safe-to-deploy"
 version = "0.8.4"
 criteria = "safe-to-deploy"
 
+[[exemptions.rustls-pemfile]]
+version = "2.2.0"
+criteria = "safe-to-deploy"
+notes = "solid-server-rs import pre-flight (sq-gg0qq.1): PEM cert-chain/key parse for the incoming mTLS serve path; archived-but-stable (see the deny.toml RUSTSEC-2025-0134 ignore + VEX entry); follow-up migrates to rustls-pki-types PemObject. [FABLE-5]"
+
 [[exemptions.rustls-pki-types]]
 version = "1.14.1"
 criteria = "safe-to-deploy"
@@ -1068,9 +1247,17 @@ criteria = "safe-to-deploy"
 version = "0.1.29"
 criteria = "safe-to-deploy"
 
+[[exemptions.scheduled-thread-pool]]
+version = "0.2.7"
+criteria = "safe-to-deploy"
+
 [[exemptions.scopeguard]]
 version = "1.2.0"
 criteria = "safe-to-deploy"
+
+[[exemptions.sec1]]
+version = "0.7.3"
+criteria = "safe-to-run"
 
 [[exemptions.security-framework]]
 version = "3.7.0"
@@ -1096,6 +1283,10 @@ criteria = "safe-to-deploy"
 version = "0.7.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.serdect]]
+version = "0.2.0"
+criteria = "safe-to-run"
+
 [[exemptions.sha1]]
 version = "0.11.0"
 criteria = "safe-to-deploy"
@@ -1118,6 +1309,18 @@ criteria = "safe-to-deploy"
 
 [[exemptions.simd-adler32]]
 version = "0.3.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.simd_cesu8]]
+version = "1.1.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.simdutf8]]
+version = "0.1.5"
+criteria = "safe-to-deploy"
+
+[[exemptions.simple_asn1]]
+version = "0.6.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.siphasher]]
@@ -1220,6 +1423,18 @@ criteria = "safe-to-deploy"
 version = "1.0.2"
 criteria = "safe-to-deploy"
 
+[[exemptions.system-configuration]]
+version = "0.7.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.system-configuration-sys]]
+version = "0.6.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.tagptr]]
+version = "0.2.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.target-lexicon]]
 version = "0.13.5"
 criteria = "safe-to-deploy"
@@ -1234,6 +1449,18 @@ criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
 version = "2.0.18"
+criteria = "safe-to-deploy"
+
+[[exemptions.time]]
+version = "0.3.53"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-core]]
+version = "0.1.9"
+criteria = "safe-to-deploy"
+
+[[exemptions.time-macros]]
+version = "0.2.31"
 criteria = "safe-to-deploy"
 
 [[exemptions.tiny-keccak]]
@@ -1314,6 +1541,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.unicode-ident]]
 version = "1.0.24"
+criteria = "safe-to-deploy"
+
+[[exemptions.untrusted]]
+version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.untrusted]]
@@ -1436,6 +1667,10 @@ criteria = "safe-to-deploy"
 version = "30.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.widestring]]
+version = "1.2.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-run"
@@ -1476,6 +1711,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.windows-numerics]]
 version = "0.3.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.windows-registry]]
+version = "0.6.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.windows-result]]
@@ -1620,6 +1859,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.xml-rs]]
 version = "0.8.28"
+criteria = "safe-to-deploy"
+
+[[exemptions.xxhash-rust]]
+version = "0.8.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.yoke]]

--- a/supply-chain/vex.cdx.json
+++ b/supply-chain/vex.cdx.json
@@ -37,6 +37,36 @@
   ],
   "vulnerabilities": [
     {
+      "id": "RUSTSEC-2025-0134",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2025-0134"
+      },
+      "ratings": [
+        {
+          "source": {
+            "name": "RustSec"
+          },
+          "severity": "none"
+        }
+      ],
+      "description": "rustls-pemfile is unmaintained (archived): its PEM-parsing functionality moved into rustls-pki-types' PemObject API. This is an informational 'unmaintained' advisory - there is no vulnerability, no CVE, and no known exploit; the crate is a small, stable PEM decoder.",
+      "detail": "Re-added for the solid-server-rs import pre-flight (bead sq-gg0qq.1, epic sq-gg0qq): the imported server's mTLS serve path parses the PEM certificate chain + private key via rustls-pemfile 2 into the DER types that rustls' with_client_cert_verifier(..).with_single_cert(..) builder needs, exactly as upstream jeswr/solid-server-rs ships it. The crate was previously in the tree via ureq 2 and this same advisory was tolerated until sq-g2xs removed it (ureq 3 dropped the dep); this statement restores the same justification for the incoming crates.",
+      "analysis": {
+        "state": "not_affected",
+        "justification": "code_not_reachable",
+        "response": [
+          "will_not_fix"
+        ],
+        "detail": "Honest scope: 'unmaintained' is an advisory ABOUT maintenance status, not an exploitable flaw - there is no vulnerable code path to reach. The parser handles operator-supplied local PEM files (TLS cert/key material), not untrusted network input. Planned remediation: migrate the imported mTLS path to rustls-pki-types' PemObject (the maintained successor API, already in the tree) in follow-up bead sq-5ah3p, then remove this statement AND the matching deny.toml [advisories].ignore entry together. Mirrors the deny.toml ignore entry (same reason)."
+      },
+      "affects": [
+        {
+          "ref": "pkg:cargo/sparq"
+        }
+      ]
+    },
+    {
       "id": "RUSTSEC-2026-0194",
       "source": {
         "name": "RustSec",


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous implementation of bead `sq-gg0qq.1` (supply-chain pre-flight for epic `sq-gg0qq`, the jeswr/solid-server-rs migration per handover jeswr/solid-server-rs#14). Authored by Claude Fable 5 `[FABLE-5]`.

## What

Attests **ALL** new dependencies of the incoming `solid-server-rs` crates in ONE PR — **before any code lands** — so the subsequent crate-import beads (`sq-gg0qq.2+`) are disjoint and never touch the shared, gating cargo-vet/deny.toml surface (the new-dep collision class of #1893/#1898). **NO functional code: only `deny.toml` + `supply-chain/` config. `Cargo.toml`/`Cargo.lock` are untouched.**

## How the set was derived (empirically, not guessed)

Declared the 8 new top-level deps exactly as upstream `jeswr/solid-server-rs` ships them (versions + features) in a scratch workspace member off current main, resolved, and diffed the lockfile against main → **59 new crates** (58 crates.io + 1 git):

- `axum-server 0.8` (`default-features=false`, `tls-rustls-no-provider` — reuses the process-wide aws-lc-rs provider)
- `object_store 0.13`, `redis 1` (sync-only, `features=["r2d2"]`), `r2d2 0.8`
- `aws-lc-rs 1` (+ `aws-lc-sys` build-time C/asm compile — trust-surface delta noted in the exemption)
- `rustls-pemfile 2`, dev-only `p256 0.13`
- `solid-oidc-verifier` **git dep** pinned rev `89c8962` (`network` feature) + its transitives (hickory DNS-pinning SSRF resolver stack, jsonwebtoken, moka, …)

## Changes

| File | Change |
|---|---|
| `supply-chain/config.toml` | 58 new `[[exemptions]]` at the resolved versions — dev-only p256/RustCrypto stack at `safe-to-run`, rest `safe-to-deploy`; `async-trait` promoted `safe-to-run` → `safe-to-deploy` (the verifier uses it non-dev). `imports.lock` untouched. |
| `deny.toml` `[sources]` | `allow-git` for `https://github.com/jeswr/solid-oidc-verifier` — the maintainer's standalone, security-audited DPoP/Solid-OIDC verifier; handover directive is depend-don't-absorb; exact-rev pin lives with the consuming crate. |
| `deny.toml` `[licenses]` | per-crate exception `xxhash-rust@0.8.16` **BSL-1.0** (OSI-approved, permissive; via `redis`). |
| `deny.toml` `[advisories]` + `supply-chain/vex.cdx.json` | `RUSTSEC-2025-0134` (unmaintained `rustls-pemfile`) re-added with justification + matching VEX statement (`not_affected`/`code_not_reachable` — informational advisory, operator-supplied PEM only). Follow-up bead **sq-5ah3p** migrates the imported mTLS path to `rustls-pki-types` `PemObject` and removes both together. |

## Acceptance (bead: "a scratch branch adding the dep declarations passes the supply-chain CI lane")

Ran the exact CI-lane commands locally in **both** states:

1. **Scratch state** (deps declared, lockfile resolved): `cargo deny check bans sources licenses advisories` → all ok; `cargo fetch --locked && cargo vet --locked --frozen` → Vetting Succeeded (462 exempted).
2. **This PR's committed state** (config-only): all four deny checks ok — the not-yet-used allow/exception/ignore entries surface as *warnings* only (verified, matching the documented cargo-deny/vet ratchet semantics); `cargo vet --locked --frozen` → Vetting Succeeded; `check-vex-deny-drift.py` → 3 ids in sync 1:1; VEX drift self-test 11/11.

Reproduce the scratch state with a workspace member declaring exactly the deps listed above (upstream `Cargo.toml` lines 20–125).

## Not in scope

- `mimalloc` (upstream's global allocator) is **already** in sparq's lock — no attestation needed.
- `oxrdf`/`oxttl`/`oxjsonld`, `tokio-rustls`, hyper/axum/rustls stack — already in tree.
- Whether the import keeps `rustls-pemfile` vs migrating to `PemObject` at import time → `sq-5ah3p` (blocked on `sq-gg0qq.2`).

Beads: implements `sq-gg0qq.1`; unblocks `sq-gg0qq.2`; created `sq-5ah3p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)