### PR TITLE
feat(gui): ODRL policy tool — author/evaluate a policy + fail-closed gated two-pane preview over the native engine (sq-ixc3.15)

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -465,6 +465,17 @@ jobs:
       - name: Test (federated SERVICE, native lane)
         run: cargo test --features federation
 
+      # [FABLE-5] sq-ixc3.15 — the OPT-IN odrl feature state: clippy + the native-lane ODRL
+      # policy-tool tests (odrl.rs), which drive the REAL sparq-policy evaluator + sparq-solid
+      # PodStore/odrl-bridge gating: a prohibition flips a previously visible named graph to
+      # hidden, a malformed policy denies everything with a visible reason, and a grant-less
+      # requester sees zero rows (fail-closed). Keeps BOTH feature states green.
+      - name: Clippy (odrl, -D warnings)
+        run: cargo clippy --all-targets --features odrl -- -D warnings
+
+      - name: Test (ODRL policy tool, native lane)
+        run: cargo test --features odrl
+
   # [SONNET-4.6] sq-ymr2e.6 — SHRUNK tauri-driver smoke: max-3-assertion real-IPC test.
   #
   # Shrunk from the multi-step sq-pnnl harness to exactly 3 meaningful assertions:

--- a/gui/README.md
+++ b/gui/README.md
@@ -115,6 +115,18 @@ dial ONLY the per-workspace `Federation` control's entries (host / host:port / `
 same grammar as sparq-server's `--service-allow`); everything else, including public hosts, is
 refused pre-HTTP. The browser build labels SERVICE **native-only** (CORS) instead of pretending.
 
+For **usage control** (`sq-ixc3.15`), the **Policies (ODRL) tool** runs its whole round-trip in
+one native command (`odrl_preview`, behind the crate's opt-in `odrl` feature, pulling the
+research-track `sparq-policy` evaluator + `sparq-solid` enforcement store): author/validate a
+Turtle ODRL policy, evaluate a (party, action, target) request — decision + matched rules + unmet
+constraints — then run the SAME SPARQL query ungated AND per requester through `PodStore`'s
+**fail-closed** per-session named-graph gating (the one-shot `odrl-bridge` materialization path;
+the `*_conditional` variants with the bare-assignee widening hazard, bead `sq-9n1q4`, are not
+wired). A malformed policy materializes **nothing** — deny-everything with the parser's verbatim
+reason — and an `odrl:prohibition` visibly flips a previously visible named graph to hidden in
+that requester's pane. The browser build labels the tool **native-only** (the ODRL stack is not
+in the wasm bundle) instead of pretending.
+
 ## File ingest library (`lib/file-ingest.ts`, sq-vnh1v)
 
 The **file ingest library** is a shared zero-server multi-file upload harness for the RDF import (sq-eydh9), SHACL shapes (sq-txrui), and N3 rules (sq-glo5r) surfaces. It operates on a single `IngestResult` contract: every file is `accepted[]` (name, text, bytes) or `rejected[]` (name, reason) — **no silent drops**. 

--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -16,7 +16,7 @@
     "start": "npx --yes serve out",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/federation.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts"
+    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/federation.test.ts src/lib/odrl.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/gui/app/src/components/workbench/odrl-tool.tsx
+++ b/gui/app/src/components/workbench/odrl-tool.tsx
@@ -1,0 +1,484 @@
+"use client";
+
+// [FABLE-5] sq-ixc3.15 — the ODRL policy tool: author/validate a policy, evaluate a request,
+// and preview the access-controlled result set per requester NEXT TO the ungated rows.
+//
+// The whole round-trip runs in ONE native command (`odrl_preview`, gui/src-tauri/src/odrl.rs):
+// parse the Turtle ODRL policy → evaluate the (party, action, target) request per requester →
+// materialize through the odrl-bridge → run the SAME SPARQL query ungated AND per requester
+// through PodStore's fail-closed per-session named-graph gating. NATIVE-ONLY: the ODRL stack
+// is not in the in-tab wasm bundle, so the hosted web build degrades honestly (WEB_ODRL_MESSAGE,
+// run disabled) — never a fabricated decision.
+//
+// Follows the GUI workbench translation rule (research/gui-design.md §A.4/§A.5): marketing
+// chrome CUT, live-result rendering only, honest error messaging. FAIL-CLOSED UX invariants:
+//   - A malformed policy renders the deny-everything banner with the parser's verbatim reason;
+//     every gated pane shows the REAL zero-row result the empty auth index produced.
+//   - A requester's pane lists the named graphs the policy HID versus the ungated pane, so a
+//     prohibition visibly flips a previously visible graph to hidden.
+//   - No result is ever synthesized in the webview; every row comes from the native engine.
+
+import * as React from "react";
+import { Scale, Loader2, Play } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { toolById, TIER_META, type ToolOverride } from "@/data/tools";
+import { useEngine } from "@/lib/engine-context";
+import { isTauriRuntime, nativeOdrlPreview } from "@/lib/tauri-ipc";
+import {
+  WEB_ODRL_MESSAGE,
+  ODRL_ACTIONS,
+  SAMPLE_DATASET_TRIG,
+  SAMPLE_POLICY_TTL,
+  SAMPLE_TARGET,
+  SAMPLE_REQUESTERS,
+  SAMPLE_QUERY,
+  hiddenGraphs,
+  describeMalformedPolicy,
+  type OdrlPreviewResult,
+  type OdrlPane,
+} from "@/lib/odrl";
+import { isAskResult, type SparqlResults } from "@sparq/client";
+
+// ---------------------------------------------------------------------------
+// Honesty-metadata override — flips this tool to a working panel (sq-ixc3.15).
+// The tier stays `live-native`: live on the desktop's native engine, honestly
+// unavailable in the hosted web build. Never edit data/tools.ts.
+// ---------------------------------------------------------------------------
+
+export const ODRL_TOOL_OVERRIDE: ToolOverride = {
+  built: true,
+  group: "working",
+};
+
+// ---------------------------------------------------------------------------
+// State shapes.
+// ---------------------------------------------------------------------------
+
+type RunState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "result"; preview: OdrlPreviewResult }
+  | { kind: "error"; message: string };
+
+type DatasetSource = "sample" | "store";
+
+/** Parse a pane's SPARQL-JSON, or `null` when it is not a SELECT document. */
+function parseSelect(json: string): SparqlResults | null {
+  try {
+    const parsed = JSON.parse(json) as SparqlResults;
+    return isAskResult(parsed) ? null : parsed;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small render helpers.
+// ---------------------------------------------------------------------------
+
+function LabeledTextarea({
+  label,
+  value,
+  onChange,
+  hook,
+  rows,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  hook: string;
+  rows: number;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs font-medium text-muted-foreground">{label}</span>
+      <textarea
+        {...{ [hook]: "" }}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={rows}
+        spellCheck={false}
+        aria-label={label}
+        className="w-full resize-y rounded-md border bg-background p-2 font-mono text-xs outline-none focus:ring-2 focus:ring-ring"
+      />
+    </div>
+  );
+}
+
+/** A compact bindings table for one pane (fail-closed: renders exactly what came back). */
+function PaneTable({ results }: { results: SparqlResults }) {
+  const vars = results.head?.vars ?? [];
+  const rows = results.results?.bindings ?? [];
+  if (rows.length === 0) {
+    return <p className="px-2 py-1.5 text-xs text-muted-foreground">(0 rows)</p>;
+  }
+  return (
+    <table className="w-full text-left text-xs">
+      <thead className="border-b bg-card">
+        <tr>
+          {vars.map((v) => (
+            <th key={v} className="px-2 py-1 font-medium text-muted-foreground">
+              ?{v}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, ri) => (
+          <tr key={ri} className="border-b">
+            {vars.map((v) => (
+              <td key={v} className="px-2 py-1 font-mono">
+                {row[v]?.value ?? ""}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** One requester's gated pane: decision, hidden-graph diff, and the gated rows. */
+function RequesterPane({
+  pane,
+  ungated,
+  index,
+}: {
+  pane: OdrlPane;
+  ungated: SparqlResults | null;
+  index: number;
+}) {
+  const gated = parseSelect(pane.results_json);
+  const hidden = ungated && gated ? hiddenGraphs(ungated, gated) : [];
+  const suffix = index === 0 ? "a" : index === 1 ? "b" : String(index);
+  return (
+    <div
+      className="flex min-w-0 flex-1 flex-col rounded-md border"
+      {...{ [`data-odrl-pane-${suffix}`]: "" }}
+    >
+      <div className="flex items-center gap-2 border-b bg-card px-2 py-1.5">
+        <span className="min-w-0 flex-1 truncate font-mono text-xs" title={pane.requester}>
+          {pane.requester}
+        </span>
+        <Badge
+          variant={pane.allow ? "success" : "muted"}
+          {...{ [`data-odrl-decision-${suffix}`]: pane.allow ? "allow" : "deny" }}
+        >
+          {pane.allow ? "Allow" : "Deny"}
+        </Badge>
+      </div>
+      {(pane.matched_rules.length > 0 || pane.unmet_constraints.length > 0) && (
+        <div className="space-y-0.5 border-b px-2 py-1.5 text-[11px] text-muted-foreground">
+          {pane.matched_rules.map((r) => (
+            <p key={r} className="truncate" title={r}>
+              matched: <span className="font-mono">{r}</span>
+            </p>
+          ))}
+          {pane.unmet_constraints.map((c) => (
+            <p key={c}>unmet: {c}</p>
+          ))}
+        </div>
+      )}
+      {hidden.length > 0 && (
+        <p
+          className="border-b px-2 py-1.5 text-[11px] text-[var(--warning)]"
+          {...{ [`data-odrl-hidden-${suffix}`]: "" }}
+        >
+          Hidden vs ungated: {hidden.map((g) => `<${g}>`).join(", ")}
+        </p>
+      )}
+      <div className="min-h-0 overflow-auto">
+        {gated ? (
+          <PaneTable results={gated} />
+        ) : (
+          <pre className="whitespace-pre-wrap p-2 font-mono text-[11px]">{pane.results_json}</pre>
+        )}
+      </div>
+      {pane.bridge_notes.length > 0 && (
+        <details className="border-t px-2 py-1 text-[11px] text-muted-foreground">
+          <summary className="cursor-pointer">Bridge notes ({pane.bridge_notes.length})</summary>
+          <ul className="space-y-0.5 pt-1">
+            {pane.bridge_notes.map((n, i) => (
+              <li key={i} className="break-all font-mono">
+                {n}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel.
+// ---------------------------------------------------------------------------
+
+export function OdrlTool() {
+  const native = isTauriRuntime();
+  const { snapshotStore } = useEngine();
+
+  const [policy, setPolicy] = React.useState(SAMPLE_POLICY_TTL);
+  const [datasetSource, setDatasetSource] = React.useState<DatasetSource>("sample");
+  const [sampleDataset, setSampleDataset] = React.useState(SAMPLE_DATASET_TRIG);
+  const [action, setAction] = React.useState(ODRL_ACTIONS[0].iri);
+  const [target, setTarget] = React.useState(SAMPLE_TARGET);
+  const [requesterA, setRequesterA] = React.useState<string>(SAMPLE_REQUESTERS[0]);
+  const [requesterB, setRequesterB] = React.useState<string>(SAMPLE_REQUESTERS[1]);
+  const [query, setQuery] = React.useState(SAMPLE_QUERY);
+  const [run, setRun] = React.useState<RunState>({ kind: "idle" });
+
+  // toolById (not tool-panel's resolveTool) to avoid an import cycle with the registry; the
+  // override does not change the tier, so the base read is the honest one.
+  const tool = toolById("odrl");
+  const tier = tool ? TIER_META[tool.tier] : null;
+
+  const onRun = React.useCallback(() => {
+    // The live-store snapshot is N-Quads; the editable sample is TriG.
+    const dataset =
+      datasetSource === "sample" ? sampleDataset : (snapshotStore() ?? "");
+    const format = datasetSource === "sample" ? "trig" : "nquads";
+    setRun({ kind: "running" });
+    void nativeOdrlPreview({
+      dataset,
+      format,
+      policy,
+      action,
+      target,
+      requesters: [requesterA, requesterB],
+      query,
+    }).then(
+      (preview) => {
+        // `null` = not in the desktop shell (the button is disabled there, but stay honest).
+        if (preview === null) setRun({ kind: "error", message: WEB_ODRL_MESSAGE });
+        else setRun({ kind: "result", preview });
+      },
+      (err) =>
+        setRun({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        }),
+    );
+  }, [
+    datasetSource,
+    sampleDataset,
+    snapshotStore,
+    policy,
+    action,
+    target,
+    requesterA,
+    requesterB,
+    query,
+  ]);
+
+  return (
+    <div className="flex h-full flex-col overflow-auto">
+      {/* Operational header: icon + verb + the honesty tier dot. */}
+      <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
+        <Scale className="size-4 text-primary" aria-hidden />
+        <h2 className="text-sm font-semibold">Policies (ODRL)</h2>
+        {tier && (
+          <span
+            className="flex items-center gap-1.5 text-[11px] text-muted-foreground"
+            data-odrl-tier=""
+          >
+            <span className={cn("size-2 rounded-full", tier.dot)} aria-hidden />
+            {tier.label}
+          </span>
+        )}
+        <Button
+          size="sm"
+          onClick={onRun}
+          disabled={!native || run.kind === "running"}
+          data-odrl-run=""
+          className="ml-auto"
+        >
+          {run.kind === "running" ? <Loader2 className="animate-spin" /> : <Play />}
+          Evaluate + preview
+        </Button>
+      </div>
+
+      {/* Honest web-build degradation: the ODRL stack is not in the wasm bundle. */}
+      {!native && (
+        <p
+          data-odrl-web-note=""
+          className="border-b bg-card px-3 py-2 text-xs text-[var(--warning)]"
+        >
+          {WEB_ODRL_MESSAGE}
+        </p>
+      )}
+
+      {/* Authoring: policy + dataset. */}
+      <div className="grid gap-3 p-3 md:grid-cols-2">
+        <LabeledTextarea
+          label="ODRL policy (Turtle)"
+          value={policy}
+          onChange={setPolicy}
+          hook="data-odrl-policy"
+          rows={12}
+        />
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3 text-xs">
+            <span className="font-medium text-muted-foreground">Dataset</span>
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="odrl-dataset-source"
+                checked={datasetSource === "sample"}
+                onChange={() => setDatasetSource("sample")}
+                data-odrl-source-sample=""
+              />
+              Sample (two named graphs)
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="odrl-dataset-source"
+                checked={datasetSource === "store"}
+                onChange={() => setDatasetSource("store")}
+                data-odrl-source-store=""
+              />
+              Live store snapshot
+            </label>
+          </div>
+          {datasetSource === "sample" ? (
+            <LabeledTextarea
+              label="Sample dataset (TriG)"
+              value={sampleDataset}
+              onChange={setSampleDataset}
+              hook="data-odrl-dataset"
+              rows={9}
+            />
+          ) : (
+            <p className="rounded-md border bg-card p-2 text-xs text-muted-foreground">
+              The whole live workspace store (every named graph) is snapshotted to the native
+              engine at run time. Gating decides per NAMED graph — data in the default graph is
+              not addressable by an ODRL target.
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Request form: action / target / the two requesters. */}
+      <div className="grid gap-3 px-3 pb-3 md:grid-cols-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="odrl-action" className="text-xs font-medium text-muted-foreground">
+            Action
+          </label>
+          <select
+            id="odrl-action"
+            data-odrl-action=""
+            value={action}
+            onChange={(e) => setAction(e.target.value)}
+            className="rounded-md border bg-background px-2 py-1.5 font-mono text-xs outline-none focus:ring-2 focus:ring-ring"
+          >
+            {ODRL_ACTIONS.map((a) => (
+              <option key={a.iri} value={a.iri}>
+                odrl:{a.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        {(
+          [
+            ["Target (named graph IRI)", target, setTarget, "data-odrl-target"],
+            ["Requester A (WebID)", requesterA, setRequesterA, "data-odrl-requester-a"],
+            ["Requester B (WebID)", requesterB, setRequesterB, "data-odrl-requester-b"],
+          ] as const
+        ).map(([label, value, set, hook]) => (
+          <div key={hook} className="flex flex-col gap-1">
+            <span className="text-xs font-medium text-muted-foreground">{label}</span>
+            <input
+              {...{ [hook]: "" }}
+              value={value}
+              onChange={(e) => set(e.target.value)}
+              spellCheck={false}
+              aria-label={label}
+              className="rounded-md border bg-background px-2 py-1.5 font-mono text-xs outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* The SAME query every pane runs. */}
+      <div className="px-3 pb-3">
+        <LabeledTextarea
+          label="SPARQL query (run ungated + per requester through the gated view)"
+          value={query}
+          onChange={setQuery}
+          hook="data-odrl-query"
+          rows={4}
+        />
+      </div>
+
+      {/* Results. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-3 border-t p-3">
+        {run.kind === "idle" && (
+          <p className="text-sm text-muted-foreground">
+            Evaluate the request and preview the gated result set per requester.
+          </p>
+        )}
+        {run.kind === "running" && <p className="text-sm text-muted-foreground">Running…</p>}
+        {run.kind === "error" && (
+          <pre
+            data-odrl-error=""
+            className="whitespace-pre-wrap font-mono text-xs text-destructive"
+          >
+            {run.message}
+          </pre>
+        )}
+        {run.kind === "result" && <PreviewResult preview={run.preview} />}
+      </div>
+    </div>
+  );
+}
+
+function PreviewResult({ preview }: { preview: OdrlPreviewResult }) {
+  const ungated = parseSelect(preview.ungated_json);
+  return (
+    <>
+      {/* Policy validation status — malformed ⇒ the deny-everything banner, reason verbatim. */}
+      {preview.policy_ok ? (
+        <p className="text-xs text-muted-foreground" data-odrl-policy-ok="">
+          Policy OK — {preview.permissions} permission(s), {preview.prohibitions}{" "}
+          prohibition(s).
+          {preview.refused &&
+            " REFUSED: the policy's odrl:conflict strategy cannot be honored — nothing was materialized (fail-closed)."}
+        </p>
+      ) : (
+        <pre
+          data-odrl-policy-error=""
+          className="whitespace-pre-wrap rounded-md border border-destructive/50 bg-card p-2 font-mono text-xs text-destructive"
+        >
+          {describeMalformedPolicy(preview.policy_error ?? "unknown parse error")}
+        </pre>
+      )}
+
+      {/* The two gated panes, side by side. */}
+      <div className="flex flex-col gap-3 lg:flex-row">
+        {preview.panes.map((pane, i) => (
+          <RequesterPane key={pane.requester + i} pane={pane} ungated={ungated} index={i} />
+        ))}
+      </div>
+
+      {/* The ungated pane: what the raw dataset answers with no gating at all. */}
+      <div className="rounded-md border" data-odrl-pane-ungated="">
+        <p className="border-b bg-card px-2 py-1.5 text-xs font-medium text-muted-foreground">
+          Ungated (no access control)
+        </p>
+        <div className="overflow-auto">
+          {ungated ? (
+            <PaneTable results={ungated} />
+          ) : (
+            <pre className="whitespace-pre-wrap p-2 font-mono text-[11px]">
+              {preview.ungated_json}
+            </pre>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/gui/app/src/components/workbench/tool-panel.tsx
+++ b/gui/app/src/components/workbench/tool-panel.tsx
@@ -24,6 +24,7 @@ import {
 import { FullTextTool, FULL_TEXT_TOOL_OVERRIDE } from "@/components/workbench/full-text-tool";
 import { StreamingTool, STREAMING_TOOL_OVERRIDE } from "@/components/workbench/streaming-tool";
 import { ServerTool, SERVER_TOOL_OVERRIDE } from "@/components/workbench/server-tool";
+import { OdrlTool, ODRL_TOOL_OVERRIDE } from "@/components/workbench/odrl-tool";
 import { ToolStub } from "@/components/workbench/tool-stub";
 import { applyToolOverride, toolById, type ToolDef, type ToolOverride } from "@/data/tools";
 
@@ -50,6 +51,10 @@ const TOOL_PANELS: Record<string, ToolPanelEntry> = {
   "full-text": { Component: FullTextTool, override: FULL_TEXT_TOOL_OVERRIDE },
   streaming: { Component: StreamingTool, override: STREAMING_TOOL_OVERRIDE },
   server: { Component: ServerTool, override: SERVER_TOOL_OVERRIDE },
+  // [FABLE-5] sq-ixc3.15 — the ODRL policy tool: a working panel over the desktop's NATIVE
+  // engine (evaluate + fail-closed gated preview); the hosted web build degrades honestly
+  // inside the panel (the `live-native` tier's framing).
+  odrl: { Component: OdrlTool, override: ODRL_TOOL_OVERRIDE },
 };
 
 /**

--- a/gui/app/src/data/tools.ts
+++ b/gui/app/src/data/tools.ts
@@ -25,6 +25,7 @@ import {
   Lock,
   Users,
   Server,
+  Scale,
 } from "lucide-react";
 
 /**
@@ -32,6 +33,8 @@ import {
  * (site/src/data/surfaces.ts) so the GUI inherits the same honest "what runs where" framing.
  *   live           — shipped wasm, in-tab today
  *   live-new-wasm  — a new wasm bundle (portability spike first)
+ *   live-native    — LIVE on the desktop app's native engine; honestly unavailable in the
+ *                    hosted web build (the capability is not in the wasm bundle)
  *   live-bbjs      — 3rd-party WASM (bb.js UltraHonk proving); NOT externally audited
  *   live-sim       — faithful in-tab JS simulation; NOT the native protocol
  *   walkthrough    — captured-I/O replay (native-only / different host)
@@ -40,6 +43,7 @@ import {
 export type Tier =
   | "live"
   | "live-new-wasm"
+  | "live-native"
   | "live-bbjs"
   | "live-sim"
   | "walkthrough"
@@ -183,6 +187,19 @@ export const TOOLS: ToolDef[] = [
     group: "coming-soon",
   },
   {
+    id: "odrl",
+    label: "Policies",
+    // [FABLE-5] sq-ixc3.15 — the ODRL usage-control tool. NATIVE-ONLY: the sparq-policy
+    // evaluator + sparq-solid enforcement store are not in the in-tab wasm bundle, so the
+    // hosted web build degrades honestly (the panel shows the native-only message).
+    blurb:
+      "Author + evaluate an ODRL policy; preview the access-gated result set per requester next to the ungated rows.",
+    tier: "live-native",
+    icon: Scale,
+    built: false,
+    group: "coming-soon",
+  },
+  {
     id: "server",
     label: "Server",
     blurb:
@@ -198,6 +215,7 @@ export const TOOLS: ToolDef[] = [
 export const TIER_META: Record<Tier, { dot: string; label: string }> = {
   live: { dot: "bg-[var(--success)]", label: "Live in-tab" },
   "live-new-wasm": { dot: "bg-[var(--success)]", label: "Live (new wasm)" },
+  "live-native": { dot: "bg-primary", label: "Live (desktop native only)" },
   "live-bbjs": { dot: "bg-primary", label: "Live (bb.js); not audited" },
   "live-sim": { dot: "bg-[var(--warning)]", label: "In-tab simulation" },
   walkthrough: { dot: "bg-muted-foreground", label: "Walkthrough (native-only)" },

--- a/gui/app/src/lib/odrl.test.ts
+++ b/gui/app/src/lib/odrl.test.ts
@@ -1,0 +1,99 @@
+// [FABLE-5] sq-ixc3.15 — unit tests for odrl.ts pure helpers.
+//
+// Covers: boundValues / hiddenGraphs (the pane-diff logic that reports which named graphs a
+// policy hid from a requester) and describeMalformedPolicy (the fail-closed banner). The IPC
+// round-trip is exercised by the Playwright mocked-IPC spec (e2e-playwright/specs/
+// odrl-tool.spec.ts) and, against the REAL evaluator + enforcement store, by
+// gui/src-tauri/src/odrl.rs's native-lane tests.
+//
+// Run via:   npm run test:unit   (gui/app)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { SparqlResults } from "@sparq/client";
+
+import {
+  boundValues,
+  hiddenGraphs,
+  describeMalformedPolicy,
+  SAMPLE_DATASET_TRIG,
+  SAMPLE_POLICY_TTL,
+  SAMPLE_QUERY,
+} from "./odrl.js";
+
+/** Build a SELECT results doc binding `?g` (and `?title`) per row. */
+function results(rows: Array<{ g: string; title?: string }>): SparqlResults {
+  return {
+    head: { vars: ["g", "title"] },
+    results: {
+      bindings: rows.map((r) => ({
+        g: { type: "uri", value: r.g },
+        ...(r.title ? { title: { type: "literal", value: r.title } } : {}),
+      })),
+    },
+  } as SparqlResults;
+}
+
+const PUBLIC_G = "http://example.org/public";
+const SECRET_G = "http://example.org/secret";
+
+// ---------------------------------------------------------------------------
+// boundValues
+// ---------------------------------------------------------------------------
+
+test("boundValues – distinct values in first-seen order", () => {
+  const r = results([{ g: SECRET_G }, { g: PUBLIC_G }, { g: SECRET_G }]);
+  assert.deepEqual(boundValues(r, "g"), [SECRET_G, PUBLIC_G]);
+});
+
+test("boundValues – unbound variable / empty results yield an empty list", () => {
+  assert.deepEqual(boundValues(results([]), "g"), []);
+  assert.deepEqual(boundValues(results([{ g: PUBLIC_G }]), "nope"), []);
+});
+
+// ---------------------------------------------------------------------------
+// hiddenGraphs — the "what did the policy hide?" diff
+// ---------------------------------------------------------------------------
+
+test("hiddenGraphs – a prohibition-hidden graph shows up in the diff", () => {
+  const ungated = results([
+    { g: PUBLIC_G, title: "Public report" },
+    { g: SECRET_G, title: "Secret memo" },
+  ]);
+  const alicePane = results([{ g: PUBLIC_G, title: "Public report" }]);
+  assert.deepEqual(hiddenGraphs(ungated, alicePane), [SECRET_G]);
+});
+
+test("hiddenGraphs – an ungated-equal pane hides nothing (honest empty diff)", () => {
+  const both = results([{ g: PUBLIC_G }, { g: SECRET_G }]);
+  assert.deepEqual(hiddenGraphs(both, both), []);
+});
+
+test("hiddenGraphs – deny-everything (empty pane) hides every ungated graph", () => {
+  const ungated = results([{ g: PUBLIC_G }, { g: SECRET_G }]);
+  assert.deepEqual(hiddenGraphs(ungated, results([])), [PUBLIC_G, SECRET_G]);
+});
+
+// ---------------------------------------------------------------------------
+// describeMalformedPolicy — the fail-closed banner
+// ---------------------------------------------------------------------------
+
+test("describeMalformedPolicy – states deny-everything AND carries the verbatim reason", () => {
+  const msg = describeMalformedPolicy("expected '.' at line 3");
+  assert.match(msg, /fail-closed/i);
+  assert.match(msg, /denying everything/i);
+  assert.ok(msg.includes("expected '.' at line 3"), "the parser reason must be verbatim");
+});
+
+// ---------------------------------------------------------------------------
+// Sample fixtures — the out-of-the-box demo must stay coherent
+// ---------------------------------------------------------------------------
+
+test("sample fixtures – the policy targets the sample graphs and the query is graph-scoped", () => {
+  // The prohibition demo only works if the policy targets the graphs the dataset defines
+  // and the query iterates named graphs (PodStore's default graph is EMPTY by design).
+  assert.ok(SAMPLE_DATASET_TRIG.includes("ex:public {"));
+  assert.ok(SAMPLE_DATASET_TRIG.includes("ex:secret {"));
+  assert.ok(SAMPLE_POLICY_TTL.includes("odrl:prohibition"));
+  assert.ok(SAMPLE_POLICY_TTL.includes("odrl:target ex:secret"));
+  assert.match(SAMPLE_QUERY, /GRAPH \?g/);
+});

--- a/gui/app/src/lib/odrl.ts
+++ b/gui/app/src/lib/odrl.ts
@@ -61,7 +61,7 @@ export const ODRL_ACTIONS: ReadonlyArray<{ label: string; iri: string }> = [
 ];
 
 /**
- * The self-contained sample dataset (TriG, TWO named graphs) the tool prefils so the gating
+ * The self-contained sample dataset (TriG, TWO named graphs) the tool prefills so the gating
  * demo works out of the box: per-session visibility is decided PER NAMED GRAPH, so the data
  * must be graph-structured and the sample policy must target these graph IRIs.
  */

--- a/gui/app/src/lib/odrl.ts
+++ b/gui/app/src/lib/odrl.ts
@@ -1,0 +1,149 @@
+"use client";
+
+// [FABLE-5] sq-ixc3.15 — pure helpers + fixtures for the ODRL policy tool.
+//
+// The ODRL usage-control stack (the sparq-policy evaluator + sparq-solid's PodStore/odrl-bridge
+// enforcement) is NOT in the in-tab wasm bundle, so the tool is NATIVE-ONLY: the desktop shell
+// runs the whole round-trip in one Rust command (`odrl_preview`, gui/src-tauri/src/odrl.rs) and
+// the hosted web build degrades HONESTLY with the message below — never a fabricated decision.
+//
+// Everything here is a PURE function or a constant (no React, no IPC) so the pane-diff logic
+// and the fail-closed messaging are unit-testable in the node test runner.
+
+import type { SparqlResults } from "@sparq/client";
+
+/**
+ * One requester's pane — byte-for-byte the Rust `OdrlPane` (gui/src-tauri/src/odrl.rs): the
+ * ODRL decision for the explicit request, the bridge's materialization notes, and the gated
+ * result set (SPARQL 1.1 JSON) from `PodStore::query_json_as` under that requester's session.
+ */
+export interface OdrlPane {
+  requester: string;
+  allow: boolean;
+  matched_rules: string[];
+  unmet_constraints: string[];
+  bridge_notes: string[];
+  results_json: string;
+}
+
+/**
+ * The whole preview — byte-for-byte the Rust `OdrlPreview`. `policy_ok === false` means the
+ * policy did not parse: NOTHING was materialized (deny-everything, fail-closed) and
+ * `policy_error` carries the verbatim parse error as the visible reason.
+ */
+export interface OdrlPreviewResult {
+  policy_ok: boolean;
+  policy_error: string | null;
+  permissions: number;
+  prohibitions: number;
+  refused: boolean;
+  ungated_json: string;
+  panes: OdrlPane[];
+}
+
+/**
+ * The honest web-build degradation message (the tools.ts taxonomy's "native-only" framing):
+ * the ODRL evaluator + enforcement store are not in the in-tab wasm bundle, and pretending
+ * otherwise would fabricate an access decision. Shown instead of running.
+ */
+export const WEB_ODRL_MESSAGE =
+  "The ODRL policy tool is native-only: the in-tab WASM bundle ships neither the ODRL " +
+  "evaluator (sparq-policy) nor the usage-control enforcement store (sparq-solid). Run this " +
+  "tool in the sparq desktop app, where the whole evaluate-and-preview round-trip executes " +
+  "on the native engine with fail-closed named-graph gating.";
+
+/** The ODRL actions the request form offers (label → full IRI). */
+export const ODRL_ACTIONS: ReadonlyArray<{ label: string; iri: string }> = [
+  { label: "read", iri: "http://www.w3.org/ns/odrl/2/read" },
+  { label: "modify", iri: "http://www.w3.org/ns/odrl/2/modify" },
+  { label: "append", iri: "http://www.w3.org/ns/odrl/2/append" },
+  { label: "delete", iri: "http://www.w3.org/ns/odrl/2/delete" },
+];
+
+/**
+ * The self-contained sample dataset (TriG, TWO named graphs) the tool prefils so the gating
+ * demo works out of the box: per-session visibility is decided PER NAMED GRAPH, so the data
+ * must be graph-structured and the sample policy must target these graph IRIs.
+ */
+export const SAMPLE_DATASET_TRIG = `@prefix ex: <http://example.org/> .
+ex:public {
+  ex:doc1 ex:title "Public report" .
+}
+ex:secret {
+  ex:doc2 ex:title "Secret memo" .
+}
+`;
+
+/**
+ * The sample Turtle ODRL policy: read permitted on BOTH graphs for anyone, with a prohibition
+ * scoped to alice on the secret graph — so the prohibition VISIBLY flips a previously visible
+ * named graph to hidden in alice's preview pane while bob keeps it.
+ */
+export const SAMPLE_POLICY_TTL = `@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix ex: <http://example.org/> .
+
+ex:policy1 a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target ex:public ] ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target ex:secret ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target ex:secret ;
+                     odrl:assignee ex:alice ] .
+`;
+
+/** The default explicit request target (the graph the sample prohibition contests). */
+export const SAMPLE_TARGET = "http://example.org/secret";
+
+/** The two default requesters the two-pane preview compares. */
+export const SAMPLE_REQUESTERS: readonly [string, string] = [
+  "http://example.org/alice",
+  "http://example.org/bob",
+];
+
+/**
+ * The SAME query every pane runs. `GRAPH ?g` because PodStore's default graph is EMPTY by
+ * design (spec-conformant fail-closed default) — gating decides per named graph.
+ */
+export const SAMPLE_QUERY = `SELECT ?g ?s ?title WHERE {
+  GRAPH ?g { ?s <http://example.org/title> ?title }
+}`;
+
+/**
+ * The distinct values a variable binds in a SPARQL results document, in first-seen order.
+ * Used to list the named graphs (`?g`) each pane can see.
+ */
+export function boundValues(results: SparqlResults, variable: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const row of results.results?.bindings ?? []) {
+    const value = row[variable]?.value;
+    if (typeof value === "string" && !seen.has(value)) {
+      seen.add(value);
+      out.push(value);
+    }
+  }
+  return out;
+}
+
+/**
+ * The named graphs visible UNGATED but hidden in a requester's gated pane — the tool's
+ * headline diff ("what did the policy hide from this requester?"). Pure set difference over
+ * the `?g` bindings, so an empty result honestly means "nothing was hidden".
+ */
+export function hiddenGraphs(
+  ungated: SparqlResults,
+  gated: SparqlResults,
+  variable = "g",
+): string[] {
+  const visible = new Set(boundValues(gated, variable));
+  return boundValues(ungated, variable).filter((g) => !visible.has(g));
+}
+
+/**
+ * The visible fail-closed banner for a malformed policy: the deny-everything consequence
+ * FIRST, then the parser's verbatim reason (never paraphrased, never hidden).
+ */
+export function describeMalformedPolicy(reason: string): string {
+  return (
+    "Malformed policy — denying everything (fail-closed). Nothing was materialized; every " +
+    `requester sees zero rows. Parser: ${reason}`
+  );
+}

--- a/gui/app/src/lib/tauri-ipc.ts
+++ b/gui/app/src/lib/tauri-ipc.ts
@@ -179,6 +179,34 @@ export async function nativeServiceQuery(
 }
 
 /**
+ * [FABLE-5] sq-ixc3.15 — run the ODRL policy tool's whole native round-trip (`odrl_preview`,
+ * gui/src-tauri/src/odrl.rs): parse/validate the Turtle `policy`, evaluate the (action,
+ * target, requester) request per requester, materialize the policy through the odrl-bridge,
+ * and evaluate `query` once UNGATED over the raw `dataset` (TriG/N-Quads per `format`) plus
+ * once PER REQUESTER through PodStore's fail-closed per-session named-graph gating. Returns
+ * the preview object (see lib/odrl.ts for the mirrored shape), or `null` outside the desktop
+ * shell (the web target degrades honestly — the ODRL stack is not in the wasm bundle).
+ * Whether the desktop build compiled the `odrl` feature is only knowable at invoke time: a
+ * lean build's stub throws a loud rebuild-hint error, surfaced through the panel's error
+ * state. Throws the native error string on a dataset/query failure — but NEVER for a
+ * malformed policy or a missing grant, which are in-band fail-closed outcomes (deny-
+ * everything with a visible reason / zero rows).
+ */
+export async function nativeOdrlPreview(args: {
+  dataset: string;
+  format: string;
+  policy: string;
+  action: string;
+  target: string;
+  requesters: string[];
+  query: string;
+}): Promise<import("./odrl").OdrlPreviewResult | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  return invoke<import("./odrl").OdrlPreviewResult>("odrl_preview", args);
+}
+
+/**
  * [OPUS-4.8] sq-cno90 (#820 follow-up) — probe the REAL on-disk byte size of the
  * `$APPLOCALDATA/workspaces` tree through the native `disk_usage` command, or `null` outside the
  * desktop shell (the web target has no native FS — the status bar falls back to the snapshot-bytes

--- a/gui/e2e-playwright/specs/odrl-tool.spec.ts
+++ b/gui/e2e-playwright/specs/odrl-tool.spec.ts
@@ -1,0 +1,114 @@
+// [FABLE-5] sq-ixc3.15 — ODRL policy tool journey (mocked-desktop persona).
+//
+// Exercises the tool end-to-end through the real frontend: open the tab → run the prefilled
+// sample (policy + two-named-graph dataset + graph-scoped query) → the two-pane preview where
+// the PROHIBITION visibly flips a previously visible named graph to hidden in alice's pane
+// while bob's and the ungated pane keep it → the malformed-policy DENY-EVERYTHING banner with
+// the visible reason. The IPC layer is the tauri-mock, which mirrors the Rust command's
+// fail-closed contract (gui/src-tauri/src/odrl.rs); the REAL evaluator + PodStore gating are
+// covered by that module's native-lane tests.
+//
+// Stable selectors (declared E2E hooks):
+//   [data-tool="odrl"]                — the rail entry
+//   [data-odrl-policy]                — the policy editor textarea
+//   [data-odrl-run]                   — the run trigger
+//   [data-odrl-decision-a|b]          — the per-requester decision badge (allow|deny)
+//   [data-odrl-pane-a|b]              — the per-requester gated pane
+//   [data-odrl-hidden-a]              — the hidden-vs-ungated graph diff line
+//   [data-odrl-pane-ungated]          — the ungated pane
+//   [data-odrl-policy-error]          — the malformed-policy fail-closed banner
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { test, expect, readIpcLog } from "../support/index.ts";
+
+/** Set a React-controlled textarea via the native setter + input event. */
+async function setTextareaValue(
+  page: import("@playwright/test").Page,
+  selector: string,
+  value: string,
+): Promise<void> {
+  await page.evaluate(
+    ({ selector, text }) => {
+      const el = document.querySelector<HTMLTextAreaElement>(selector);
+      if (!el) throw new Error(`Textarea ${selector} not found`);
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      if (!setter) throw new Error("Could not access native value setter");
+      setter.call(el, text);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    { selector, text: value },
+  );
+}
+
+test.describe("odrl tool", () => {
+  // The tauriMock auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("a prohibition flips a previously visible named graph to hidden in the preview pane", async ({
+    page,
+  }) => {
+    await page.locator('[data-tool="odrl"]').click();
+
+    // The prefilled sample carries the prohibition scoped to alice on the secret graph.
+    await page.locator("[data-odrl-run]").click();
+
+    // Policy validated: permissions + the prohibition counted.
+    await expect(page.locator("[data-odrl-policy-ok]")).toBeVisible();
+    await expect(page.locator("[data-odrl-policy-ok]")).toContainText(/prohibition/i);
+
+    // Alice: DENIED, her pane HIDES the secret graph (previously visible ungated) but keeps
+    // the still-permitted public one — the visible flip the bead's acceptance test names.
+    await expect(page.locator('[data-odrl-decision-a="deny"]')).toBeVisible();
+    const paneA = page.locator("[data-odrl-pane-a]");
+    await expect(paneA).toContainText("Public report");
+    await expect(paneA).not.toContainText("Secret memo");
+    await expect(page.locator("[data-odrl-hidden-a]")).toContainText(
+      "http://example.org/secret",
+    );
+
+    // Bob: ALLOWED, his pane keeps both graphs.
+    await expect(page.locator('[data-odrl-decision-b="allow"]')).toBeVisible();
+    await expect(page.locator("[data-odrl-pane-b]")).toContainText("Secret memo");
+
+    // The ungated pane always shows the raw data — the honest baseline of the diff.
+    await expect(page.locator("[data-odrl-pane-ungated]")).toContainText("Secret memo");
+
+    // IPC contract: odrl_preview got the policy, both requesters, and the query.
+    const log = await readIpcLog(page);
+    const call = log.find((e) => e.cmd === "odrl_preview");
+    expect(call, "odrl_preview must be invoked").toBeTruthy();
+    const args = (call?.args ?? {}) as {
+      policy?: string;
+      requesters?: string[];
+      query?: string;
+    };
+    expect(args.policy ?? "").toContain("odrl:prohibition");
+    expect(args.requesters).toHaveLength(2);
+    expect(args.query ?? "").toContain("GRAPH");
+  });
+
+  test("a malformed policy denies everything (fail-closed) with a visible reason", async ({
+    page,
+  }) => {
+    await page.locator('[data-tool="odrl"]').click();
+
+    await setTextareaValue(page, "[data-odrl-policy]", "this is @@ not turtle ;;");
+    await page.locator("[data-odrl-run]").click();
+
+    // The deny-everything banner: consequence first, parser reason verbatim.
+    const banner = page.locator("[data-odrl-policy-error]");
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(/fail-closed/i);
+    await expect(banner).toContainText(/denying everything/i);
+    await expect(banner).toContainText(/parse error/i);
+
+    // Both gated panes are empty (nothing materialized), while the ungated pane still
+    // proves the data exists — deny-everything is a GATING outcome, not missing data.
+    await expect(page.locator("[data-odrl-pane-a]")).toContainText("(0 rows)");
+    await expect(page.locator("[data-odrl-pane-b]")).toContainText("(0 rows)");
+    await expect(page.locator("[data-odrl-pane-ungated]")).toContainText("Secret memo");
+  });
+});

--- a/gui/e2e-playwright/specs/odrl-tool.web.spec.ts
+++ b/gui/e2e-playwright/specs/odrl-tool.web.spec.ts
@@ -1,0 +1,36 @@
+// [FABLE-5] sq-ixc3.15 — ODRL policy tool spec (web persona).
+//
+// Runs under the chromium-web project (*.web.spec.ts pattern): NO Tauri globals, pure browser
+// persona. The ODRL stack (sparq-policy evaluator + sparq-solid enforcement store) is NOT in
+// the in-tab wasm bundle, so in the browser the tool must degrade HONESTLY: the native-only
+// message is shown and the run trigger is disabled — never a fabricated decision, never a
+// silent no-op. The tier chip carries the `live-native` framing.
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only; stable selectors.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+test.describe("odrl-tool (web persona)", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("degrades honestly in the browser: native-only note shown, run disabled", async ({
+    page,
+  }) => {
+    await page.locator('[data-tool="odrl"]').click();
+
+    // The honest degradation note names the native-only reality.
+    const note = page.locator("[data-odrl-web-note]");
+    await expect(note).toBeVisible();
+    await expect(note).toContainText(/native-only/i);
+    await expect(note).toContainText(/desktop/i);
+
+    // The run trigger is disabled — the browser cannot produce a real decision.
+    await expect(page.locator("[data-odrl-run]")).toBeDisabled();
+
+    // The honesty tier chip carries the live-native framing (dot + label).
+    await expect(page.locator("[data-odrl-tier]")).toContainText(/native/i);
+
+    // The authoring surfaces still render (author in the browser, run on desktop).
+    await expect(page.locator("[data-odrl-policy]")).toBeVisible();
+  });
+});

--- a/gui/e2e-playwright/support/tauri-mock.ts
+++ b/gui/e2e-playwright/support/tauri-mock.ts
@@ -15,6 +15,11 @@
 //   query_service    → [FABLE-5] sq-ixc3.14: fail-closed allowlist mirror of the Rust command —
 //                      rejects with the "SERVICE egress refused" marker unless the caller's
 //                      allow[] contains fed.example.org; else resolves a joined SELECT doc
+//   odrl_preview     → [FABLE-5] sq-ixc3.15: fail-closed mirror of the Rust command — a policy
+//                      that does not look like Turtle ODRL resolves the DENY-EVERYTHING shape
+//                      (policy_ok:false + verbatim-style reason + zero-row panes); a well-formed
+//                      one resolves the sample preview (alice's pane hides the secret graph the
+//                      prohibition flipped, bob's + the ungated pane keep it)
 //   (any other cmd)  → throws Error (catches unexpected IPC surface drift)
 
 /** The script string injected via page.addInitScript before the page's own scripts run. */
@@ -48,6 +53,38 @@ export const tauriMockScript: string = `
     ] }
   });
 
+  // [FABLE-5] sq-ixc3.15 — the ODRL policy tool's native round-trip (odrl_preview). The mock
+  // mirrors the Rust contract (gui/src-tauri/src/odrl.rs): the SAME SPARQL-JSON docs the real
+  // PodStore gating produces, with alice's pane HIDING the secret graph her prohibition flips
+  // and bob's pane keeping it; a malformed policy resolves the fail-closed deny-everything
+  // shape (nothing materialized, zero-row panes, the parse reason surfaced verbatim).
+  var G_PUBLIC = "http://example.org/public";
+  var G_SECRET = "http://example.org/secret";
+  function odrlRows(rows) {
+    return JSON.stringify({
+      head: { vars: ["g", "s", "title"] },
+      results: { bindings: rows.map(function (r) {
+        return {
+          g: { type: "uri", value: r[0] },
+          s: { type: "uri", value: r[1] },
+          title: { type: "literal", value: r[2] }
+        };
+      }) }
+    });
+  }
+  var ODRL_PUBLIC_ROW = [G_PUBLIC, "http://example.org/doc1", "Public report"];
+  var ODRL_SECRET_ROW = [G_SECRET, "http://example.org/doc2", "Secret memo"];
+  function odrlPane(requester, allow, rows, matched, notes) {
+    return {
+      requester: requester,
+      allow: allow,
+      matched_rules: matched,
+      unmet_constraints: [],
+      bridge_notes: notes,
+      results_json: odrlRows(rows)
+    };
+  }
+
   window.__TAURI__ = {
     core: {
       invoke: function (cmd, args) {
@@ -69,6 +106,46 @@ export const tauriMockScript: string = `
             );
           }
           return Promise.resolve(SERVICE_FIXTURE);
+        }
+        if (cmd === "odrl_preview") {
+          var policyText = (args && args.policy) || "";
+          var reqs = (args && args.requesters) || [];
+          var reqA = reqs[0] || "http://example.org/alice";
+          var reqB = reqs[1] || "http://example.org/bob";
+          if (policyText.indexOf("@prefix") === -1) {
+            // Malformed policy: NOTHING materialized — deny-everything, reason verbatim.
+            return Promise.resolve({
+              policy_ok: false,
+              policy_error: "Turtle parse error: unexpected token at line 1",
+              permissions: 0,
+              prohibitions: 0,
+              refused: false,
+              ungated_json: odrlRows([ODRL_PUBLIC_ROW, ODRL_SECRET_ROW]),
+              panes: [
+                odrlPane(reqA, false, [], [],
+                  ["policy malformed — nothing materialized (deny-everything)"]),
+                odrlPane(reqB, false, [], [],
+                  ["policy malformed — nothing materialized (deny-everything)"])
+              ]
+            });
+          }
+          // The sample policy: alice's prohibition hides the secret graph; bob keeps it.
+          return Promise.resolve({
+            policy_ok: true,
+            policy_error: null,
+            permissions: 2,
+            prohibitions: 1,
+            refused: false,
+            ungated_json: odrlRows([ODRL_PUBLIC_ROW, ODRL_SECRET_ROW]),
+            panes: [
+              odrlPane(reqA, false, [ODRL_PUBLIC_ROW],
+                ["http://example.org/policy1#prohibition1"],
+                ["deny: " + reqA + " read " + G_SECRET]),
+              odrlPane(reqB, true, [ODRL_PUBLIC_ROW, ODRL_SECRET_ROW],
+                ["http://example.org/policy1#permission2"],
+                ["grant: " + reqB + " read " + G_SECRET])
+            ]
+          });
         }
         return Promise.reject(new Error("[tauri-mock] Unexpected IPC invoke: " + cmd));
       }

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -3374,6 +3374,8 @@ dependencies = [
  "sparq-core",
  "sparq-engine",
  "sparq-hdt",
+ "sparq-policy",
+ "sparq-solid",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -3397,6 +3399,39 @@ dependencies = [
 [[package]]
 name = "sparq-jsonld"
 version = "0.1.0"
+
+[[package]]
+name = "sparq-policy"
+version = "0.1.0"
+dependencies = [
+ "oxrdf",
+ "sparq-core",
+ "sparq-engine",
+]
+
+[[package]]
+name = "sparq-reason"
+version = "0.1.0"
+dependencies = [
+ "oxrdf",
+ "regex",
+ "rustc-hash",
+ "sparq-core",
+ "sparq-substrate",
+]
+
+[[package]]
+name = "sparq-solid"
+version = "0.1.0"
+dependencies = [
+ "oxrdf",
+ "rustc-hash",
+ "spargebra",
+ "sparq-core",
+ "sparq-engine",
+ "sparq-policy",
+ "sparq-reason",
+]
 
 [[package]]
 name = "sparq-substrate"

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -61,6 +61,15 @@ hdt = ["dep:sparq-hdt"]
 # native engine — the browser build fundamentally cannot (no blocking cross-origin HTTP). Every
 # `query_service` call installs the engine's STRICT fail-closed egress allowlist (federation.rs).
 federation = ["sparq-engine/service"]
+# [FABLE-5] sq-ixc3.15 — the ODRL policy tool's native backing: author/validate a Turtle ODRL
+# policy, evaluate a request, and preview the access-controlled result set (PodStore::query_as
+# via the odrl-bridge, fail-closed per-session named-graph gating) next to the ungated results.
+# OFF by default for the same lean-build reasons as `hdt`/`federation`: it pulls the optional
+# research-track sparq-policy evaluator + sparq-solid enforcement store. The desktop release
+# build turns it ON; the webview/wasm target never links these crates (the tool degrades
+# honestly to a native-only message in the browser). Lean builds register a stub that fails
+# loudly with a rebuild hint (odrl.rs).
+odrl = ["dep:sparq-policy", "dep:sparq-solid"]
 # [FABLE-5] sq-t6492 — embed + serve the frontendDist static export instead of connecting to
 # `devUrl` (http://localhost:3001). Tauri's build script sets `cfg(dev) = !custom-protocol`
 # (tauri build.rs: `let dev = !custom_protocol`), and in dev mode the webview navigates to
@@ -98,6 +107,13 @@ sparq-engine = { path = "../../crates/sparq-engine", features = ["serialize-rdf"
 # [OPUS-4.8] sq-ixc3.13 — opt-in native-only HDT reader (loads .hdt[.gz] straight into a
 # sparq Graph; the wasm read-replica cannot). Pulled in only under this crate's `hdt` feature.
 sparq-hdt = { path = "../../crates/sparq-hdt", optional = true }
+
+# [FABLE-5] sq-ixc3.15 — opt-in native-only ODRL usage-control stack for the ODRL policy tool:
+# the sparq-policy evaluator (parse/validate a Turtle policy + evaluate a request) and the
+# sparq-solid enforcement store (`PodStore::query_json_as` fail-closed named-graph gating, fed
+# by the `odrl-bridge` materialization). Pulled in only under this crate's `odrl` feature.
+sparq-policy = { path = "../../crates/sparq-policy", optional = true }
+sparq-solid = { path = "../../crates/sparq-solid", features = ["odrl-bridge"], optional = true }
 
 # [OPUS-4.8] sq-ixc3.13 — streaming decompression for the native disk loader: gzip + bzip2 +
 # zstd, the SAME codec matrix the CLI's `open_reader` handles (crates/sparq-cli/src/main.rs).

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@
 mod disk;
 mod engine;
 mod federation;
+mod odrl;
 
 use engine::EngineState;
 
@@ -64,6 +65,14 @@ pub fn run() {
             // capability is gated behind the non-default `federation` cargo feature and a lean
             // build registers a stub that fails loudly with a rebuild hint (federation.rs).
             federation::query_service,
+            // [FABLE-5] sq-ixc3.15 — the ODRL policy tool's ONE native command: parse/validate
+            // a Turtle ODRL policy, evaluate the (party, action, target) request, materialize
+            // the policy through the odrl-bridge, and run the SAME query per requester through
+            // PodStore's fail-closed per-session named-graph gating next to the ungated run.
+            // Gated behind the non-default `odrl` cargo feature; a lean build registers a stub
+            // that fails loudly with a rebuild hint (odrl.rs). Malformed policy ⇒ nothing
+            // materializes ⇒ deny-everything with the parse error as the visible reason.
+            odrl::odrl_preview,
         ])
         .run(tauri::generate_context!())
         .expect("error while running the sparq Tauri application");

--- a/gui/src-tauri/src/odrl.rs
+++ b/gui/src-tauri/src/odrl.rs
@@ -1,0 +1,410 @@
+// [FABLE-5] sq-ixc3.15 — the ODRL policy tool's native command: author/validate a policy,
+// evaluate a request, and preview the access-controlled result set next to the ungated one.
+//
+// The GUI's in-tab WASM engine ships neither the ODRL evaluator (sparq-policy) nor the
+// usage-control enforcement store (sparq-solid's `PodStore` + odrl-bridge), so this whole
+// tool is NATIVE-ONLY: exactly ONE command, `odrl_preview`, scoped to the one round-trip the
+// webview cannot do itself — parse a Turtle ODRL policy, evaluate the user's request
+// (party/action/target), materialize the policy through the odrl-bridge into a `PodStore`,
+// and run the SAME SPARQL query as each requester through `query_json_as` (fail-closed
+// per-session named-graph gating) alongside the ungated evaluation over the raw dataset.
+//
+// OPT-IN: the capability sits behind this crate's non-default `odrl` cargo feature (pulling
+// the optional `sparq-policy` + `sparq-solid`/odrl-bridge crates). A lean build compiles a
+// stub that fails LOUDLY with a rebuild hint — never a silent no-op — the same discipline as
+// the `hdt` and `federation` features.
+//
+// FAIL-CLOSED INVARIANTS (mirrored in the frontend and asserted by the tests below):
+//   - A malformed policy materializes NOTHING: every requester sees ZERO rows (an empty
+//     authorized-graph set is the PodStore default), and the parse error is returned verbatim
+//     as the visible reason. Deny-everything, never a guess.
+//   - A policy whose `odrl:conflict` strategy the bridge cannot honor is REFUSED whole
+//     (`BridgeOutcome::refused`): again nothing materializes, and the reasons are surfaced.
+//   - A requester with no applicable grant gets an `Ok` result with zero rows (authorization
+//     never errors) — indistinguishable from the graphs being absent.
+//
+// WIDENING HAZARD deliberately avoided: this command uses ONLY the one-shot
+// `materialize_odrl_policy` path, which honors a bare `odrl:assignee` rule attribute. The
+// `*_conditional` bridge variants drop a bare assignee to `auth:Public` (bead sq-9n1q4) and
+// are NOT wired here.
+
+/// One requester's pane in the two-pane preview: the ODRL decision for the explicit request,
+/// the bridge's materialization notes, and the gated result set (SPARQL 1.1 JSON) produced by
+/// `PodStore::query_json_as` under that requester's session.
+#[derive(Debug, serde::Serialize)]
+pub struct OdrlPane {
+    /// The requester's WebID (echoed so the frontend can label the pane).
+    pub requester: String,
+    /// The ODRL decision for the explicit (action, target, this-party) request.
+    pub allow: bool,
+    /// Rule ids that produced the decision (granting permission / overriding prohibition).
+    pub matched_rules: Vec<String>,
+    /// Human-readable reasons each permission did NOT grant (unmet constraints).
+    pub unmet_constraints: Vec<String>,
+    /// The bridge's materialization notes for this requester across every rule target —
+    /// which auth grants/denies were written, or why nothing was.
+    pub bridge_notes: Vec<String>,
+    /// The gated result set: the SAME query, evaluated through the fail-closed per-session
+    /// named-graph view. SPARQL 1.1 JSON results document.
+    pub results_json: String,
+}
+
+/// The whole preview: policy validation status, the ungated evaluation, and one pane per
+/// requester. `policy_ok == false` ⇒ deny-everything (every pane has zero rows) with
+/// `policy_error` as the visible reason.
+#[derive(Debug, serde::Serialize)]
+pub struct OdrlPreview {
+    /// Whether the policy parsed as Turtle ODRL. False ⇒ NOTHING was materialized.
+    pub policy_ok: bool,
+    /// The verbatim parse error when `policy_ok` is false (the visible fail-closed reason).
+    pub policy_error: Option<String>,
+    /// Parsed rule counts (0 when the policy is malformed).
+    pub permissions: usize,
+    pub prohibitions: usize,
+    /// True when the policy's `odrl:conflict` strategy is one the bridge cannot honor: the
+    /// WHOLE policy is refused and nothing materializes (fail-closed, reasons in the panes).
+    pub refused: bool,
+    /// The ungated evaluation of the same query over the raw dataset (SPARQL 1.1 JSON).
+    pub ungated_json: String,
+    /// One pane per requester, in the order given.
+    pub panes: Vec<OdrlPane>,
+}
+
+/// Author/validate → evaluate → preview, in one native round-trip. `dataset` is TriG or
+/// N-Quads (`format`), `policy` is Turtle ODRL, `action`/`target` are IRIs and `requesters`
+/// WebIDs; `query` is the SPARQL SELECT/ASK run once ungated and once per requester through
+/// the fail-closed gated view.
+#[tauri::command]
+pub fn odrl_preview(
+    dataset: String,
+    format: String,
+    policy: String,
+    action: String,
+    target: String,
+    requesters: Vec<String>,
+    query: String,
+) -> Result<OdrlPreview, String> {
+    run_odrl_preview(&dataset, &format, &policy, &action, &target, requesters, &query)
+}
+
+/// The command body, factored out so it is unit-testable without a Tauri runtime (the same
+/// pattern as `federation::run_service_query`).
+#[cfg(feature = "odrl")]
+fn run_odrl_preview(
+    dataset: &str,
+    format: &str,
+    policy_text: &str,
+    action: &str,
+    target: &str,
+    requesters: Vec<String>,
+    query: &str,
+) -> Result<OdrlPreview, String> {
+    use sparq_policy::{evaluate, parse_policy_str, Request};
+    use sparq_solid::{Mode, PodStore, Session};
+
+    // An empty dataset is a legal store (author a policy before loading data).
+    let graph = if dataset.trim().is_empty() {
+        sparq_core::Graph::new()
+    } else {
+        sparq_core::Graph::load_dataset(dataset, format)?
+    };
+
+    // The UNGATED pane: the same query over the raw dataset, before any gating. Evaluated
+    // first because `PodStore::new` takes ownership of the graph.
+    let ungated_json = sparq_engine::query_json(&graph, query)?;
+
+    // The enforcement store: strips reserved graphs, starts with an EMPTY auth index — the
+    // fail-closed default every requester keeps unless the policy grants otherwise.
+    let mut store = PodStore::new(graph);
+
+    // (a) Parse/validate. Malformed ⇒ deny-everything: materialize NOTHING and surface the
+    // parse error verbatim; the gated queries below then run against the empty auth index.
+    let (policy, policy_error) = match parse_policy_str(policy_text, "turtle") {
+        Ok(p) => (Some(p), None),
+        Err(e) => (None, Some(e)),
+    };
+
+    // (b)+(c) Evaluate the explicit request per requester, then materialize the policy for
+    // every (requester × rule-target) pair so the preview reflects the WHOLE policy — a rule
+    // targeting another graph still shapes that requester's view. Grants/denies written by
+    // the one-shot bridge are strictly per-principal, so requesters cannot widen each other.
+    let mut refused = false;
+    let mut panes: Vec<OdrlPane> = Vec::with_capacity(requesters.len());
+    for webid in &requesters {
+        let mut pane = OdrlPane {
+            requester: webid.clone(),
+            allow: false, // fail-closed default (empty/malformed policy denies)
+            matched_rules: Vec::new(),
+            unmet_constraints: Vec::new(),
+            bridge_notes: Vec::new(),
+            results_json: String::new(),
+        };
+        if let Some(policy) = &policy {
+            let request = Request::new(action).on(target).by(webid.as_str());
+            let decision = evaluate(policy, &request);
+            pane.allow = decision.allow;
+            pane.matched_rules = decision.matched_rules;
+            pane.unmet_constraints = decision.unmet_constraints;
+
+            // Every distinct rule target, with the explicit request target included — sorted
+            // (BTreeSet) so the notes are deterministic.
+            let mut targets: std::collections::BTreeSet<String> = policy
+                .permissions
+                .iter()
+                .chain(policy.prohibitions.iter())
+                .filter_map(|r| r.target.clone())
+                .collect();
+            targets.insert(target.to_owned());
+            for t in &targets {
+                let req = Request::new(action).on(t.as_str()).by(webid.as_str());
+                let outcome = store.materialize_odrl_policy(policy, &req);
+                if outcome.refused {
+                    refused = true;
+                }
+                if let Some((p, m, g)) = &outcome.grant_triple {
+                    pane.bridge_notes.push(format!("grant: {p} {m} {g}"));
+                }
+                if let Some((p, m, g)) = &outcome.deny_triple {
+                    pane.bridge_notes.push(format!("deny: {p} {m} {g}"));
+                }
+                for reason in outcome.reasons {
+                    pane.bridge_notes.push(format!("{t}: {reason}"));
+                }
+            }
+        } else if let Some(err) = &policy_error {
+            pane.bridge_notes
+                .push(format!("policy malformed — nothing materialized (deny-everything): {err}"));
+        }
+        panes.push(pane);
+    }
+
+    // The GATED panes: the SAME query per requester through the fail-closed per-session
+    // named-graph view. Run AFTER all materialization so every pane sees the final auth
+    // state. Authorization never errors: no grant ⇒ zero rows, not an Err.
+    for pane in &mut panes {
+        let session = Session {
+            agent: Some(pane.requester.as_str()),
+            ..Session::default()
+        };
+        pane.results_json = store.query_json_as(&session, Mode::Read, query)?;
+    }
+
+    let (permissions, prohibitions) = policy
+        .as_ref()
+        .map(|p| (p.permissions.len(), p.prohibitions.len()))
+        .unwrap_or((0, 0));
+    Ok(OdrlPreview {
+        policy_ok: policy_error.is_none(),
+        policy_error,
+        permissions,
+        prohibitions,
+        refused,
+        ungated_json,
+        panes,
+    })
+}
+
+/// Lean-build stub: the ODRL evaluator + enforcement store are compiled out, so the tool
+/// fails LOUDLY with an actionable rebuild hint instead of silently mis-reporting (the same
+/// discipline as the `hdt` / `federation` features).
+#[cfg(not(feature = "odrl"))]
+fn run_odrl_preview(
+    _dataset: &str,
+    _format: &str,
+    _policy: &str,
+    _action: &str,
+    _target: &str,
+    _requesters: Vec<String>,
+    _query: &str,
+) -> Result<OdrlPreview, String> {
+    Err(
+        "The ODRL policy tool is not compiled into this build — rebuild the desktop app with \
+         `cargo build --features odrl` to evaluate policies and preview gated results."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two named graphs: one public report, one secret memo.
+    const DATASET_TRIG: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:public { ex:doc1 ex:title "Public report" . }
+        ex:secret { ex:doc2 ex:title "Secret memo" . }
+    "#;
+
+    /// The SAME query every pane runs: everything, per named graph.
+    const QUERY: &str =
+        "SELECT ?g ?s ?title WHERE { GRAPH ?g { ?s <http://example.org/title> ?title } }";
+
+    const ODRL_READ: &str = "http://www.w3.org/ns/odrl/2/read";
+    const ALICE: &str = "http://example.org/alice";
+    const BOB: &str = "http://example.org/bob";
+
+    /// Permissions on BOTH graphs for anyone (no assignee).
+    #[cfg(feature = "odrl")]
+    const POLICY_PERMIT_ALL: &str = r#"
+        @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        @prefix ex: <http://example.org/> .
+        ex:policy1 a odrl:Set ;
+          odrl:permission [ odrl:action odrl:read ; odrl:target ex:public ] ;
+          odrl:permission [ odrl:action odrl:read ; odrl:target ex:secret ] .
+    "#;
+
+    /// The same permissions PLUS a prohibition scoped to alice on the secret graph.
+    #[cfg(feature = "odrl")]
+    const POLICY_PROHIBIT_ALICE_SECRET: &str = r#"
+        @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        @prefix ex: <http://example.org/> .
+        ex:policy1 a odrl:Set ;
+          odrl:permission [ odrl:action odrl:read ; odrl:target ex:public ] ;
+          odrl:permission [ odrl:action odrl:read ; odrl:target ex:secret ] ;
+          odrl:prohibition [ odrl:action odrl:read ; odrl:target ex:secret ;
+                             odrl:assignee ex:alice ] .
+    "#;
+
+    #[cfg(feature = "odrl")]
+    fn preview(policy: &str) -> OdrlPreview {
+        run_odrl_preview(
+            DATASET_TRIG,
+            "trig",
+            policy,
+            ODRL_READ,
+            "http://example.org/secret",
+            vec![ALICE.to_string(), BOB.to_string()],
+            QUERY,
+        )
+        .expect("preview must succeed")
+    }
+
+    /// ACCEPTANCE (sq-ixc3.15): an `odrl:prohibition` flips a PREVIOUSLY VISIBLE named graph
+    /// to hidden in the requester's preview pane — while the other requester (and the ungated
+    /// pane) still see it. Mutating the bridge to skip the deny triple flips this red.
+    #[test]
+    #[cfg(feature = "odrl")]
+    fn prohibition_flips_a_previously_visible_graph_to_hidden() {
+        // WITHOUT the prohibition: alice sees the secret memo (previously visible)…
+        let before = preview(POLICY_PERMIT_ALL);
+        assert!(before.policy_ok);
+        assert!(
+            before.panes[0].results_json.contains("Secret memo"),
+            "alice must see the secret graph before the prohibition: {}",
+            before.panes[0].results_json
+        );
+        assert!(before.panes[0].allow, "the explicit request must be permitted");
+
+        // …WITH the prohibition: alice's pane hides it, bob's and the ungated pane keep it.
+        let after = preview(POLICY_PROHIBIT_ALICE_SECRET);
+        assert!(after.policy_ok);
+        assert_eq!(after.prohibitions, 1);
+        assert!(
+            !after.panes[0].results_json.contains("Secret memo"),
+            "the prohibition must hide the secret graph from alice: {}",
+            after.panes[0].results_json
+        );
+        assert!(
+            after.panes[0].results_json.contains("Public report"),
+            "the prohibition must NOT hide the still-permitted public graph: {}",
+            after.panes[0].results_json
+        );
+        assert!(!after.panes[0].allow, "the explicit request must now be denied");
+        assert!(
+            after.panes[1].results_json.contains("Secret memo"),
+            "bob is not the prohibition's assignee — his pane keeps the graph: {}",
+            after.panes[1].results_json
+        );
+        assert!(after.panes[1].allow);
+        assert!(
+            after.ungated_json.contains("Secret memo"),
+            "the ungated pane is never gated: {}",
+            after.ungated_json
+        );
+    }
+
+    /// ACCEPTANCE (sq-ixc3.15): a MALFORMED policy denies everything (fail-closed) with the
+    /// parse error as the visible reason — zero rows in every gated pane even though the
+    /// ungated pane proves the data is there.
+    #[test]
+    #[cfg(feature = "odrl")]
+    fn malformed_policy_denies_everything_with_a_visible_reason() {
+        let out = preview("this is @@ not turtle ;;");
+        assert!(!out.policy_ok);
+        let reason = out.policy_error.as_deref().expect("the parse error must be visible");
+        assert!(!reason.is_empty());
+        assert_eq!((out.permissions, out.prohibitions), (0, 0));
+        for pane in &out.panes {
+            assert!(
+                !pane.allow,
+                "a malformed policy must deny {}",
+                pane.requester
+            );
+            assert!(
+                !pane.results_json.contains("Public report")
+                    && !pane.results_json.contains("Secret memo"),
+                "a malformed policy must materialize NOTHING — got rows for {}: {}",
+                pane.requester,
+                pane.results_json
+            );
+        }
+        assert!(
+            out.ungated_json.contains("Secret memo"),
+            "the ungated pane must prove the data exists: {}",
+            out.ungated_json
+        );
+    }
+
+    /// Fail-closed default: a requester with NO applicable grant gets zero rows (`Ok`, never
+    /// an error) — a permission scoped to bob alone leaves alice's pane empty.
+    #[test]
+    #[cfg(feature = "odrl")]
+    fn requester_without_a_grant_sees_nothing() {
+        let out = run_odrl_preview(
+            DATASET_TRIG,
+            "trig",
+            r#"
+              @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+              @prefix ex: <http://example.org/> .
+              ex:policy1 a odrl:Set ;
+                odrl:permission [ odrl:action odrl:read ; odrl:target ex:secret ;
+                                  odrl:assignee ex:bob ] .
+            "#,
+            ODRL_READ,
+            "http://example.org/secret",
+            vec![ALICE.to_string(), BOB.to_string()],
+            QUERY,
+        )
+        .expect("preview must succeed");
+        assert!(!out.panes[0].allow, "alice is not the assignee");
+        assert!(
+            !out.panes[0].results_json.contains("Secret memo"),
+            "no grant ⇒ no rows for alice: {}",
+            out.panes[0].results_json
+        );
+        assert!(out.panes[1].allow, "bob is the assignee");
+        assert!(
+            out.panes[1].results_json.contains("Secret memo"),
+            "bob's grant must surface the graph: {}",
+            out.panes[1].results_json
+        );
+    }
+
+    /// Lean build (feature OFF): the stub fails LOUDLY with the actionable rebuild hint —
+    /// never a silent no-op or a fabricated preview.
+    #[test]
+    #[cfg(not(feature = "odrl"))]
+    fn lean_build_fails_loudly_with_a_rebuild_hint() {
+        let err = run_odrl_preview(
+            DATASET_TRIG,
+            "trig",
+            "",
+            ODRL_READ,
+            "http://example.org/secret",
+            vec![ALICE.to_string(), BOB.to_string()],
+            QUERY,
+        )
+        .expect_err("the lean-build stub must be an Err");
+        assert!(err.contains("--features odrl"), "got: {err}");
+    }
+}

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -249,6 +249,8 @@ assert!(!store.accessible(&Session { agent: Some("https://alice.ex/card#me"), cl
 
 **Fail-closed:** a grant is materialized only on a *definite Permit* AND a *mappable action* AND a *concrete party (WebID) + target graph*. A Deny, unsatisfied constraint, undischarged duty, unmapped action, or partyless/targetless request materializes **nothing**.
 
+**Interactive surface** — [FABLE-5] sq-ixc3.15: the desktop GUI's **Policies (ODRL) tool** (`gui/`, opt-in `odrl` cargo feature on `gui/src-tauri`) drives exactly this one-shot bridge path end-to-end: author/validate a policy, evaluate a request, and preview the same SPARQL query per requester through `query_json_as` next to the ungated rows (`gui/src-tauri/src/odrl.rs`).
+
 ### Prohibitions → explicit `auth:deny*` (deny-overrides) — [OPUS-4.8] sq-w693
 
 A matched ODRL **Prohibition** is materialized as the dual triple — `principal auth:deny<Mode> target` — via `materialize_odrl_prohibition` (or `materialize_odrl_policy`, which does both sides at once). The **same** action→mode mapping picks the mode, so the deny predicate is `auth:denyRead` / `auth:denyWrite` / `auth:denyAppend` / `auth:denyControl`.


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — autonomous implementation of bead `sq-ixc3.15`.

## What

The **Policies (ODRL) tool**: a new GUI workbench tab that makes the built-but-invisible usage-control estate (`sparq-policy` evaluator + `sparq-solid` odrl-bridge + `PodStore::query_as`) reachable from `gui/` — author/validate a Turtle ODRL policy, evaluate a (party, action, target) request, and preview the SAME SPARQL query per requester through the fail-closed per-session named-graph gated view **next to the ungated results**.

## How

- **Native backend (opt-in, core stays lean):** ONE new command `odrl_preview` (`gui/src-tauri/src/odrl.rs`) behind the non-default `odrl` cargo feature (`dep:sparq-policy` + `dep:sparq-solid`/odrl-bridge). Lean builds compile a stub that fails loudly with a rebuild hint (the `hdt`/`federation` discipline). The command parses the policy, evaluates the request per requester, materializes via the **one-shot** bridge path — deliberately NOT the `*_conditional` variants carrying the bare-assignee → `auth:Public` widening hazard (bead `sq-9n1q4`) — and runs the query ungated + per requester through `PodStore::query_json_as`.
- **Frontend:** `odrl` ToolDef with an honest new `live-native` tier (live on the desktop's native engine; the browser build shows the native-only message and disables the run — the ODRL stack is not in the wasm bundle), panel with policy/dataset editors + request form + two gated panes with a hidden-vs-ungated graph diff, pure helpers + node unit tests, tauri-mock mirror + mocked-IPC and web-persona Playwright specs.
- **CI:** `gui.yml` tauri-build gains the `odrl` feature state (clippy + tests), keeping both states green.

## Acceptance (bead) → evidence

| Criterion | Evidence |
|---|---|
| prohibition flips a previously visible named graph to hidden | native test `prohibition_flips_a_previously_visible_graph_to_hidden` (real evaluator + PodStore, before/after) + `odrl-tool.spec.ts` UI journey |
| malformed policy ⇒ deny-everything (fail-closed) with visible reason | native test `malformed_policy_denies_everything_with_a_visible_reason` (zero rows, verbatim parser reason) + UI spec |
| tier dot honest (native-only, wasm not shipped) | `live-native` tier + `odrl-tool.web.spec.ts` (browser persona: note shown, run disabled) |
| gui gates green | see below |

## Gates (run locally to completion)

- `cargo clippy --all-targets -- -D warnings` — lean ✅ and `--features odrl` ✅
- `cargo test` — lean ✅ (17, incl. loud-stub test) and `--features odrl` ✅ (19)
- gui/app: `typecheck` ✅ · `lint` ✅ · `test:unit` 53/53 ✅ · `build:web` + `build:tauri` ✅
- Playwright deterministic lane: **68/68** ✅
- `scripts/check-readme-template.py` — 0 deviations ✅

## Non-vacuity

The native tests assert row-level content both ways (secret memo present for bob/ungated, absent for alice) across a before/after policy pair; mutating the bridge deny path or the fail-closed default flips them red. The lean-stub test fails if the stub silently no-ops.

## Discovered work (beaded)

- Filed: desktop **release** bundle builds with no opt-in features (`hdt`/`federation`/`odrl` compiled OUT of shipped installers despite the Cargo.toml comments) — P2 bug.

Complements `sq-6v53` (conflict/containment views). **Not armed** — merge-coordinator merges verified branches.