### PR TITLE
bench(reason-el): real-ontology EL classification vs ELK harness + pinned smoke (sq-hmd7l.8)

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -1664,14 +1664,14 @@ id          = "reason-el-real"
 name        = "OWL 2 EL classification on real ontologies (GO / OpenGALEN) vs ELK"
 category    = "inference"
 measures    = "EL classification wall time + subsumption count on the Gene Ontology (GO) and OpenGALEN ontologies vs ELK; subsumption-count oracle before timing"
-invoke      = "TBD — implementing bead sq-hmd7l.8"
-source      = "TBD — bench/reason-el-real/; scripts/bench-adapters/ (ELK adapter)"
-dataset     = "TBD — Gene Ontology OWL release (sha256-pinned) + OpenGALEN OWL (sha256-pinned); downloaded at gather time"
+invoke      = "ONLY=sparq bash scripts/bench/reason-el-same-box.sh --smoke   # hermetic acceptance (pinned vendored fixture). Full gather: bash scripts/bench/reason-el-same-box.sh"
+source      = "scripts/bench/reason-el-same-box.sh (harness); crates/sparq-reason-el/examples/reason_el_real_bench.rs (sparq leg + smoke); crates/sparq-reason-el/examples/data/el_smoke.ttl (vendored fixture); ELK invoked via its standalone CLI jar (gather-only /tmp)"
+dataset     = "Gene Ontology (go-basic.owl, CC-BY-4.0) + OpenGALEN 8 (OWL); sha256 recorded per envelope at gather time; converted OWL->NT via Jena riot. gather-only /tmp, NOT committed"
 quiet_box_sensitive = true
-pinning     = "TBD — GO + OpenGALEN release SHA or URL + sha256; ELK jar pinned version"
-records_to  = "TBD — bench/competitor-results/elk-reason-el-<UTC>.json (git-ignored); research/gap-reason-el-2026-07.md"
-featured    = false  # registry stub; implementing bead sq-hmd7l.8
-status      = "planning"
+pinning     = "ontology_sha256 recorded per gather envelope; ELK_VERSION (default 0.6.0) + JENA_VERSION (default 5.4.0) pinned in the harness; the committed smoke fixture pins a subsumption COUNT (not a timing)"
+records_to  = "bench/competitor-results/ (git-ignored envelopes: reason-el-<ontology>-<UTC>.json); research/gap-reason-el-2026-07.md"
+featured    = false  # opt-in reasoner crate; non-canonical until a quiet-box gather
+status      = "harness-ready"
 
 # [SONNET-4.6] sq-hmd7l.9 — QL rewriting vs Ontop on NPD + Requiem suites
 [[benchmark]]

--- a/crates/sparq-reason-el/examples/data/el_smoke.ttl
+++ b/crates/sparq-reason-el/examples/data/el_smoke.ttl
@@ -1,0 +1,31 @@
+# [FABLE-5] sq-hmd7l.8 — small VENDORED OWL 2 EL smoke ontology for the real-ontology
+# classification bench (crates/sparq-reason-el/examples/reason_el_real_bench.rs).
+#
+# This is a hand-built, hermetic EL+⊥ fixture (NOT a slice of GO/OpenGALEN — those are
+# large, fetched gather-only by scripts/bench/reason-el-same-box.sh and are NOT committed
+# per AGENTS.md). It is shaped like a biomedical anatomy/finding sub-hierarchy so the
+# example exercises the SAME classification path the real gather drives, but with a
+# closed-form, hand-verified subsumption count that can be PINNED as an oracle in CI.
+#
+# It deliberately includes a CR4 existential derivation that OWL 2 RL CANNOT reach
+# (Neuron ⊑ NucleatedCell, derived only through ∃hasPart.Nucleus), so the pinned count is
+# NON-VACUOUS: disabling the consequence-based rules would drop the count and fail loudly.
+# Uses only is-a + role-EQUALITY existentials (no property chains / transitivity), so the
+# complete closure is identical with or without the `rbox` feature — the pinned assertion
+# holds in BOTH feature states.
+
+@prefix :    <http://sparq.dev/bench/reason-el/smoke#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+# --- A. is-a taxonomy ---------------------------------------------------------------------
+:Cell          rdfs:subClassOf :AnatomicalEntity .
+:Neuron        rdfs:subClassOf :Cell .
+:CellComponent rdfs:subClassOf :AnatomicalEntity .
+:Nucleus       rdfs:subClassOf :CellComponent .
+:NucleatedCell rdfs:subClassOf :Cell .
+
+# --- B. existential (CR4) — the RL-unreachable subsumption --------------------------------
+# Neuron ⊑ ∃hasPart.Nucleus ,  ∃hasPart.Nucleus ⊑ NucleatedCell   ⊨   Neuron ⊑ NucleatedCell
+:Neuron rdfs:subClassOf [ owl:onProperty :hasPart ; owl:someValuesFrom :Nucleus ] .
+[ owl:onProperty :hasPart ; owl:someValuesFrom :Nucleus ] rdfs:subClassOf :NucleatedCell .

--- a/crates/sparq-reason-el/examples/reason_el_real_bench.rs
+++ b/crates/sparq-reason-el/examples/reason_el_real_bench.rs
@@ -1,0 +1,162 @@
+//! [FABLE-5] sq-hmd7l.8 (epic sq-hmd7l) — real-ontology OWL 2 EL classification bench.
+//!
+//! The crate's other bench (`snomed_go_scale_bench`) is a SYNTHETIC, closed-form scaling
+//! probe. This example instead classifies an ONTOLOGY FILE end-to-end (parse → extract →
+//! CR1–CR5 saturate → project) and reports the ORACLE METRIC used to cross-check sparq
+//! against ELK on real ontologies: the number of PROPER NAMED SUBSUMPTION PAIRS
+//! (`C ⊑ D`, both named IRIs, `C ≠ D`, `D ≠ owl:Thing`) in the complete classification.
+//!
+//! TWO MODES
+//! ---------
+//!   * SMOKE (no path arg, or the sole arg `--smoke`): classify the small VENDORED EL
+//!     fixture `examples/data/el_smoke.ttl` (compiled in via `include_str!`, so the run is
+//!     hermetic and cwd-independent) and ASSERT its pinned oracle counts. This is the
+//!     acceptance gate: `cargo run -p sparq-reason-el --release --example
+//!     reason_el_real_bench` exits 0 iff classification still derives exactly the pinned
+//!     lattice. The pinned count includes a CR4 existential subsumption OWL 2 RL cannot
+//!     reach, so a classifier regression flips it red (non-vacuous).
+//!
+//!   * GATHER (`<path> [format]`): classify an arbitrary ontology converted to RDF
+//!     (`format` defaults to `turtle`; pass `ntriples` for a riot-converted GO/OpenGALEN
+//!     dump) and PRINT `classes=<n> subsumptions=<n> emitted=<n> skipped_axioms=<n>
+//!     classify_s=<t>` — NO assertion (real-ontology counts are recorded + cross-checked
+//!     vs ELK by scripts/bench/reason-el-same-box.sh, never baked in here). The
+//!     subsumption count is emitted BEFORE any timing claim so the harness can enforce the
+//!     "no timing row without a subsumption-count agreement" invariant.
+//!
+//! The fixture uses only is-a + role-EQUALITY existentials (no property chains), so its
+//! complete closure is identical with or without the `rbox` feature; the same example
+//! built `--features rbox` (as the GO/OpenGALEN gather does, for part-of role chains)
+//! gets role reasoning for free via `Classifier::classify` and the pinned smoke count is
+//! unchanged. Work-box wall-clock is non-canonical — printed as a trend only.
+
+use sparq_core::dict::{Id, TermParts};
+use sparq_core::Graph;
+use sparq_reason_el::classify_graph;
+use std::time::Instant;
+
+const RDFS_SUBCLASSOF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+const OWL_THING: &str = "http://www.w3.org/2002/07/owl#Thing";
+
+/// The vendored EL smoke ontology, compiled in for a hermetic, cwd-independent smoke run.
+const SMOKE_TTL: &str = include_str!("data/el_smoke.ttl");
+
+// --- pinned smoke oracle (hand-verified; see examples/data/el_smoke.ttl) -----------------
+// Named classes participating in the subsumption lattice (an endpoint of some proper named
+// C ⊑ D): AnatomicalEntity, Cell, Neuron, CellComponent, Nucleus, NucleatedCell = 6.
+const SMOKE_LATTICE_CLASSES: usize = 6;
+// Proper named subsumption pairs in the complete closure (C ⊑ D, both named, C≠D, D≠Thing):
+//   Cell⊑AnatomicalEntity, Neuron⊑Cell, CellComponent⊑AnatomicalEntity,
+//   Nucleus⊑CellComponent, NucleatedCell⊑Cell                            (5 told)
+//   Nucleus⊑AnatomicalEntity, NucleatedCell⊑AnatomicalEntity,
+//   Neuron⊑AnatomicalEntity, Neuron⊑NucleatedCell                        (4 derived; the
+//   last is the CR4 existential edge OWL 2 RL cannot reach)              → 9 total.
+const SMOKE_SUBSUMPTIONS: usize = 9;
+
+/// Classification metrics for one ontology — the ORACLE the ELK cross-check compares on.
+struct Metrics {
+    /// Distinct named classes that are an ENDPOINT of some proper named subsumption pair
+    /// (self-consistent with `subsumptions`; excludes anonymous restriction classes and
+    /// ⊤/⊥, unlike the extractor's raw `Report::named_classes`).
+    lattice_classes: usize,
+    /// PROPER NAMED subsumption pairs (`C ⊑ D`, both named IRIs, `C ≠ D`, `D ≠ owl:Thing`)
+    /// in the COMPLETE classification (told + derived). The engine-vs-ELK oracle metric.
+    subsumptions: usize,
+    /// NEW `rdfs:subClassOf` triples `classify_graph` materialised (`Report::emitted_subsumptions`).
+    emitted: usize,
+    /// Class-axioms outside the recognised EL fragment that were IGNORED (`Report::skipped_axioms`).
+    /// A non-zero value is the honest "the lattice may be incomplete for those axioms" signal.
+    skipped_axioms: usize,
+    /// Wall-clock of `classify_graph` only (parse excluded). Non-canonical on a shared box.
+    classify_s: f64,
+}
+
+/// Parses `text` as `format`, runs the full classifier, and reads off the oracle metrics.
+fn classify_text(text: &str, format: &str) -> Result<Metrics, String> {
+    let (mut dict, mut triples) = Graph::parse_to_triples(text, format)?;
+    let sco = dict.lookup(&oxrdf::Term::NamedNode(
+        oxrdf::NamedNode::new_unchecked(RDFS_SUBCLASSOF),
+    ));
+    let thing = dict.lookup(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(OWL_THING)));
+
+    let t = Instant::now();
+    let report = classify_graph(&mut dict, &mut triples);
+    let classify_s = t.elapsed().as_secs_f64();
+
+    // Count PROPER NAMED subsumption pairs from the materialised closure. classify_graph has
+    // appended every derived named edge, so a scan of the subClassOf triples with named-IRI
+    // endpoints (dropping self-loops, owl:Thing supers, and edges to anonymous restriction
+    // bnodes) is exactly the engine-vs-ELK oracle metric. A set dedupes told∩derived overlap.
+    let named = |id: Id| matches!(dict.term_parts(id), TermParts::Iri { .. });
+    let mut pairs: rustc_hash::FxHashSet<(Id, Id)> = rustc_hash::FxHashSet::default();
+    let mut classes: rustc_hash::FxHashSet<Id> = rustc_hash::FxHashSet::default();
+    for &[s, p, o] in &triples {
+        if p == sco && s != o && o != thing && named(s) && named(o) {
+            pairs.insert((s, o));
+            classes.insert(s);
+            classes.insert(o);
+        }
+    }
+
+    Ok(Metrics {
+        lattice_classes: classes.len(),
+        subsumptions: pairs.len(),
+        emitted: report.emitted_subsumptions,
+        skipped_axioms: report.skipped_axioms,
+        classify_s,
+    })
+}
+
+fn run_smoke() {
+    let m = classify_text(SMOKE_TTL, "turtle").expect("smoke fixture parses");
+    println!(
+        "smoke (examples/data/el_smoke.ttl): lattice_classes={} subsumptions={} emitted={} \
+         skipped_axioms={} classify_s={:.6}",
+        m.lattice_classes, m.subsumptions, m.emitted, m.skipped_axioms, m.classify_s
+    );
+    assert_eq!(
+        m.lattice_classes, SMOKE_LATTICE_CLASSES,
+        "lattice class count {} != pinned {SMOKE_LATTICE_CLASSES} (classification changed)",
+        m.lattice_classes
+    );
+    assert_eq!(
+        m.subsumptions, SMOKE_SUBSUMPTIONS,
+        "proper named subsumption count {} != pinned {SMOKE_SUBSUMPTIONS} — a classification \
+         regression (e.g. the CR4 existential edge Neuron ⊑ NucleatedCell no longer derives)",
+        m.subsumptions
+    );
+    assert_eq!(
+        m.skipped_axioms, 0,
+        "smoke fixture is pure EL — {} axioms unexpectedly skipped",
+        m.skipped_axioms
+    );
+    println!(
+        "OK: pinned oracle held — {SMOKE_LATTICE_CLASSES} lattice classes, {SMOKE_SUBSUMPTIONS} \
+         proper named subsumptions (incl. the RL-unreachable CR4 edge). Wall-clock is \
+         trend-only (non-canonical shared box)."
+    );
+}
+
+fn run_gather(path: &str, format: &str) {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("cannot read ontology {path}: {e}"));
+    let m = classify_text(&text, format)
+        .unwrap_or_else(|e| panic!("cannot classify {path} as {format}: {e}"));
+    // Subsumption count FIRST (the cross-check oracle), timing after — the harness records the
+    // count per ontology before it trusts any wall-clock (the sq-hmd7l.8 invariant).
+    println!(
+        "ontology={path} lattice_classes={} subsumptions={} emitted={} skipped_axioms={} classify_s={:.6}",
+        m.lattice_classes, m.subsumptions, m.emitted, m.skipped_axioms, m.classify_s
+    );
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        None | Some("--smoke") => run_smoke(),
+        Some(path) => {
+            let format = args.get(1).map(String::as_str).unwrap_or("turtle");
+            run_gather(path, format);
+        }
+    }
+}

--- a/research/gap-reason-el-2026-07.md
+++ b/research/gap-reason-el-2026-07.md
@@ -1,0 +1,124 @@
+<!-- [FABLE-5] sq-hmd7l.8 — OWL 2 EL classification competitor gap record.
+Harness description + first-read methodology for the sparq-reason-el vs ELK same-box
+comparison on real ontologies. No fabricated numbers; NO hard-coded performance numbers
+presented as canonical. Every timing row this harness collects is flagged NON-canonical
+(canonical:false) until a dedicated quiet EC2 run re-measures it. -->
+
+# OWL 2 EL classification competitor gap — 2026-07
+
+**Status:** harness record / first-read methodology description (NON-canonical).
+**Date:** 2026-07-07.
+**Bead:** sq-hmd7l.8.
+**Epic:** sq-hmd7l (comparative-benchmarking-everything).
+**Competitor:** `elk` — ELK, the reference consequence-based OWL 2 EL classifier
+(Apache-2.0; `bench/competitors.json`, suite `reason-el-real`).
+**Canonical run:** deferred to a dedicated quiet-box wave (`quiet_box_sensitive = true`).
+
+---
+
+## 0. Prior state
+
+`sparq-reason-el`'s only bench was `examples/snomed_go_scale_bench.rs` — a **synthetic**,
+in-process, closed-form scaling probe (a no-hidden-quadratic doubling-ratio assertion on a
+generated SNOMED/GO-shaped slice). It never touches a real ontology and has no competitor
+column. `bench/benchmarks.toml` carried a `reason-el-real` registry stub (from sq-hmd7l.1)
+with every field `TBD`. This bead delivers the durable comparison harness + a real-ontology
+classification example + a pinned hermetic acceptance fixture, and fills the stub in.
+
+---
+
+## 1. Metric — the subsumption-count ORACLE
+
+The comparison metric is **proper named subsumption pairs**: the *complete transitive
+closure* of `C ⊑ D` over **named** classes, with `C ≠ D`, `D ≠ owl:Thing`, and both
+endpoints named IRIs (anonymous restriction classes and `⊤`/`⊥` excluded). It is the
+classification's observable content that both engines can produce and that is invariant to
+internal representation.
+
+- **sparq** reports it directly: `examples/reason_el_real_bench` runs `classify_graph`
+  (which materialises the *complete* closure as `rdfs:subClassOf` triples) and counts the
+  distinct named-endpoint `subClassOf` pairs.
+- **ELK** emits an inferred **direct** taxonomy; the harness transitively closes ELK's
+  named `subClassOf` edges in the count step so both engines are compared on the *same*
+  closure notion.
+
+**ORACLE-BEFORE-TIMING (the sq-hmd7l.8 invariant).** For every ontology both counts are
+recorded and cross-checked **before** any timing row is emitted; a timing row is emitted
+only when a count is present. **Neither engine is ground truth** — a disagreement is
+recorded as `counts_agree=false` and investigated, **never adjusted** to match. A missing
+count (engine error/absent) records `counts_agree=n/a`, and the timing carries no agreement
+flag. This is enforced structurally in `scripts/bench/reason-el-same-box.sh` (§3) and in the
+envelope's `oracle_before_timing` block.
+
+---
+
+## 2. Corpora
+
+Real ontologies are **gather-only** (fetched to `/tmp`, NOT committed — large corpora +
+engines stay out of git per AGENTS.md). Both are freely licensed so the numbers are
+publishable:
+
+- **Gene Ontology** (`go-basic.owl`, CC-BY 4.0) — the canonical large biomedical EL
+  ontology. `GO_OWL_URL` overridable; the release SHA-256 is recorded into each envelope at
+  gather time (`ontology_sha256`).
+- **OpenGALEN** (OpenGALEN 8, GALEN open-source licence) — a large clinical-terminology EL
+  ontology with deep part-of role structure.
+- **SNOMED CT is LICENSE-GATED — skipped** (free subsets only, if any).
+- **ORE 2014/2015 EL track** — a stretch goal, not implemented here.
+
+Each OWL is converted to N-Triples offline via Apache Jena `riot` at gather time
+(`Classifier::classify` / `classify_graph` consume RDF triples). The sparq leg is built
+`--features rbox` so real part-of role chains (GO's `part_of` transitivity, SNOMED-style
+right-identity) are classified faithfully; the metric is unchanged in feature-OFF, `rbox`
+only *adds* the edges the ontology's role axioms entail.
+
+---
+
+## 3. Harness (`scripts/bench/reason-el-same-box.sh`)
+
+Built on the `scripts/bench/shacl-same-box.sh` template; emits one competitor-results-shaped
+envelope JSON per ontology.
+
+- **`--smoke` (ONLY=sparq)** — the fast, hermetic **acceptance path**: build + run
+  `examples/reason_el_real_bench --smoke` on the small **vendored** fixture
+  `crates/sparq-reason-el/examples/data/el_smoke.ttl`, asserting its pinned subsumption
+  count. No network, no JVM, no downloads. This is the CI-runnable gate.
+- **Full mode** — for each ontology: download OWL → `riot` OWL→NT → sparq classify (count +
+  time) and ELK classify (taxonomy → transitively-closed count + time) → record both counts
+  + agreement → emit envelope. ELK/Jena/OWL are gather-only `/tmp` deps. An engine failure
+  or timeout degrades to an honest ERROR row, never a fabricated number.
+
+### 3.1 The vendored acceptance fixture
+
+`examples/data/el_smoke.ttl` is a **hand-built, hermetic EL+⊥ fixture** shaped like a
+biomedical anatomy sub-hierarchy — it is **NOT** a slice of GO/OpenGALEN (those are fetched
+gather-only). It exists so the acceptance path has a closed-form, hand-verified count to
+pin. It deliberately includes a **CR4 existential subsumption OWL 2 RL cannot reach**
+(`Neuron ⊑ NucleatedCell`, derived only through `∃hasPart.Nucleus`), so the pinned count is
+**non-vacuous**: a consequence-based-rule regression drops the count 9→8 and fails loudly.
+Pinned oracle (hand-derived in `examples/data/el_smoke.ttl` + the example's constants):
+**6 lattice classes, 9 proper named subsumptions** (5 told + 4 derived, incl. the CR4 edge).
+Using only is-a + role-*equality* existentials (no chains), the closure is identical with
+or without `rbox`, so the pinned assertion holds in **both** feature states.
+
+---
+
+## 4. Canonicity
+
+**Every** row this harness collects on the shared work box is **NON-canonical**
+(`canonical:false` in the envelope, always). Work-box timings are directional only — do NOT
+bake them into docs/dashboards. The harness is the durable deliverable; a future
+`CANONICAL=1` run on a dedicated quiet EC2 box produces citable numbers. No wall-clock
+number is pinned or asserted anywhere in this bead — only the dimensionless subsumption
+**count** is an oracle.
+
+---
+
+## 5. Follow-ups
+
+- Canonical quiet-box gather (GO + OpenGALEN, both engines) → publish the first
+  sparq-vs-ELK subsumption-count agreement + timing envelope.
+- ORE 2014/2015 EL-track corpus columns (stretch).
+- If a real ontology's sparq/ELK counts **disagree**, investigate the cause (fragment
+  coverage: a construct sparq's extractor skips — `skipped_axioms > 0` is the honest signal —
+  vs an ELK-specific normalisation) and file a bead; never adjust either count to match.

--- a/scripts/bench/reason-el-same-box.sh
+++ b/scripts/bench/reason-el-same-box.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# [FABLE-5] sq-hmd7l.8 (epic sq-hmd7l) — same-box OWL 2 EL CLASSIFICATION comparison:
+# sparq-reason-el vs ELK (the canonical consequence-based EL classifier, Apache-2.0) on
+# real ontologies (Gene Ontology + OpenGALEN), emitting one competitor-results ENVELOPE
+# per ontology. Mirrors scripts/bench/shacl-same-box.sh (the SHACL gather recipe) and the
+# canonical-competitor-results JSON shape.
+#
+# ORACLE-BEFORE-TIMING (the sq-hmd7l.8 INVARIANT). For every ontology BOTH engines' proper
+# named subsumption COUNT is recorded and cross-checked FIRST; a timing row is emitted ONLY
+# when both counts are present. NEITHER engine is ground truth — a disagreement is recorded
+# with `counts_agree=false` and investigated, NEVER silently adjusted. Work-box timings are
+# NON-canonical (canonical:false always) — the harness is the durable deliverable; a future
+# dedicated quiet-box run sets CANONICAL=1.
+#
+# METRIC. "proper named subsumption pairs" = the COMPLETE transitive closure of C ⊑ D over
+# named classes (C ≠ D, D ≠ owl:Thing, both named IRIs). sparq reports it directly
+# (examples/reason_el_real_bench GATHER mode); ELK's inferred DIRECT taxonomy is transitively
+# closed in the count step so both engines are compared on the SAME closure notion.
+#
+# --smoke  (ONLY=sparq): the fast, hermetic ACCEPTANCE path — build + run the sparq example
+#          on the small VENDORED fixture (crates/sparq-reason-el/examples/data/el_smoke.ttl),
+#          asserting its pinned subsumption count. NO downloads, NO JVM, NO network.
+#              ONLY=sparq bash scripts/bench/reason-el-same-box.sh --smoke
+#
+# FULL MODE (gather; needs network + a JRE + riot for OWL→NT):
+#              bash scripts/bench/reason-el-same-box.sh            # GO + OpenGALEN, both engines
+#              REASON_EL_ONTOLOGIES=go ONLY=sparq  bash scripts/bench/reason-el-same-box.sh
+#
+# TUNABLES (env; all have safe defaults):
+#   REASON_EL_ONTOLOGIES  space list of ontology keys        (default "go opengalen")
+#   ONLY                  engine subset of "sparq elk"       (default "sparq elk")
+#   OUT_DIR               envelope dir (default /tmp/reason-el-same-box-results; a canonical
+#                         run points this at bench/canonical-competitor-results/<date>/)
+#   CANONICAL             1 = dedicated quiet-box run        (default 0: NON-canonical)
+#   TIMEOUT_S             per-engine classify cap, seconds   (default 1800)
+#   ELK_VERSION           ELK CLI distribution version       (default 0.6.0)
+#   ELK_JAR               path to elk.jar (auto-downloaded to /tmp if unset)
+#   JENA_VERSION          apache-jena for `riot` OWL→NT      (default 5.4.0)
+#   JENA_HOME             jena dist root (auto-downloaded to /tmp if unset)
+#   GO_OWL_URL            Gene Ontology OWL URL              (default go-basic.owl release)
+#   OPENGALEN_OWL_URL     OpenGALEN OWL URL                  (default OpenGALEN 8 full)
+#
+# Ontology OWL + the ELK/Jena jars are gather-only deps under /tmp — NOT committed (engines
+# + big corpora stay out of git per AGENTS.md). Delete when done:
+#   rm -rf /tmp/reason-el-gather /tmp/elk-cli /tmp/jena-riot
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$ROOT"
+
+ONLY="${ONLY:-sparq elk}"
+OUT_DIR="${OUT_DIR:-/tmp/reason-el-same-box-results}"
+CANONICAL="${CANONICAL:-0}"
+TIMEOUT_S="${TIMEOUT_S:-1800}"
+REASON_EL_ONTOLOGIES="${REASON_EL_ONTOLOGIES:-go opengalen}"
+ELK_VERSION="${ELK_VERSION:-0.6.0}"
+JENA_VERSION="${JENA_VERSION:-5.4.0}"
+JENA_HOME="${JENA_HOME:-/tmp/jena-riot/apache-jena-$JENA_VERSION}"
+GO_OWL_URL="${GO_OWL_URL:-http://purl.obolibrary.org/obo/go/go-basic.owl}"
+OPENGALEN_OWL_URL="${OPENGALEN_OWL_URL:-https://www.opengalen.org/download/OpenGALEN8-OWL.zip}"
+
+log() { printf '[reason-el-same-box] %s\n' "$*" >&2; }
+want() { [[ " $ONLY " == *" $1 "* ]]; }
+
+# ---- --smoke: the hermetic, sparq-only acceptance path -----------------------
+if [[ "${1:-}" == "--smoke" ]]; then
+  log "SMOKE: sparq-only, pinned vendored fixture (no network/JVM)"
+  cargo build --release -p sparq-reason-el --example reason_el_real_bench
+  "$ROOT/target/release/examples/reason_el_real_bench" --smoke
+  log "SMOKE OK"
+  exit 0
+fi
+
+mkdir -p "$OUT_DIR"
+GATHER="/tmp/reason-el-gather"
+mkdir -p "$GATHER"
+GIT_COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+# ---- 0. engines --------------------------------------------------------------
+SPARQ_BIN="$ROOT/target/release/examples/reason_el_real_bench"
+if want sparq; then
+  log "building sparq reason_el_real_bench (--features rbox for real role chains)"
+  # rbox: real biomedical ontologies (GO part_of, SNOMED-style chains) need the role box for a
+  # complete closure. The example's metric is unchanged in feature-OFF; rbox only ADDS edges the
+  # ontology's role axioms entail. Built with rbox so the real-ontology count is faithful.
+  cargo build --release -p sparq-reason-el --features rbox --example reason_el_real_bench
+fi
+
+if want elk; then
+  ELK_JAR="${ELK_JAR:-/tmp/elk-cli/elk-standalone.jar}"
+  if [ ! -f "$ELK_JAR" ]; then
+    mkdir -p /tmp/elk-cli
+    log "downloading ELK $ELK_VERSION CLI to /tmp/elk-cli (Apache-2.0, gather-only)"
+    curl -sSL -o /tmp/elk-cli/elk.zip \
+      "https://github.com/liveontologies/elk-reasoner/releases/download/v$ELK_VERSION/elk-distribution-cli-$ELK_VERSION.zip" || {
+        log "ELK download failed — set ELK_JAR to a local elk-standalone.jar and rerun"; }
+    if [ -f /tmp/elk-cli/elk.zip ]; then
+      unzip -oq /tmp/elk-cli/elk.zip -d /tmp/elk-cli || true
+      found_jar="$(find /tmp/elk-cli -name 'elk-standalone*.jar' | head -1 || true)"
+      [ -n "$found_jar" ] && cp "$found_jar" "$ELK_JAR"
+    fi
+  fi
+  if [ ! -f "$ELK_JAR" ]; then
+    log "ELK jar unavailable ($ELK_JAR) — ELK columns will record an honest ERROR"
+  else
+    ELK_VER="$(java -jar "$ELK_JAR" --version 2>/dev/null | head -1 || echo "elk-$ELK_VERSION")"
+    log "ELK: $ELK_VER"
+  fi
+fi
+
+# riot (Apache Jena) converts each OWL ontology → N-Triples for sparq's parser.
+if [ ! -x "$JENA_HOME/bin/riot" ]; then
+  log "downloading apache-jena $JENA_VERSION to /tmp/jena-riot (for riot OWL→NT, gather-only)"
+  mkdir -p /tmp/jena-riot
+  curl -sSL -o "/tmp/jena-riot/apache-jena-$JENA_VERSION.tar.gz" \
+    "https://archive.apache.org/dist/jena/binaries/apache-jena-$JENA_VERSION.tar.gz"
+  tar xzf "/tmp/jena-riot/apache-jena-$JENA_VERSION.tar.gz" -C /tmp/jena-riot
+fi
+RIOT="$JENA_HOME/bin/riot"
+
+# ---- 1. resolve each ontology to a local OWL file ----------------------------
+resolve_owl() {
+  case "$1" in
+    go)        echo "$GO_OWL_URL" ;;
+    opengalen) echo "$OPENGALEN_OWL_URL" ;;
+    *)         echo "" ;;
+  esac
+}
+
+for ONT in $REASON_EL_ONTOLOGIES; do
+  URL="$(resolve_owl "$ONT")"
+  [ -z "$URL" ] && { log "unknown ontology key '$ONT' — skipping"; continue; }
+  log "=== ontology: $ONT ($URL) ==="
+
+  OWL="$GATHER/$ONT.owl"
+  NT="$GATHER/$ONT.nt"
+  if [ ! -f "$OWL" ]; then
+    log "downloading $ONT OWL (gather-only)"
+    if [[ "$URL" == *.zip ]]; then
+      curl -sSL -o "$GATHER/$ONT.zip" "$URL"
+      (cd "$GATHER" && unzip -oq "$ONT.zip" && \
+        find . -maxdepth 2 -iname '*.owl' | head -1 | xargs -I{} cp {} "$OWL")
+    else
+      curl -sSL -o "$OWL" "$URL"
+    fi
+  fi
+  if [ ! -f "$OWL" ]; then log "$ONT OWL unavailable — skipping"; continue; fi
+  OWL_SHA="$(sha256sum "$OWL" | cut -d' ' -f1)"
+
+  if want sparq && [ ! -f "$NT" ]; then
+    log "riot: converting $ONT OWL → N-Triples"
+    "$RIOT" --output=ntriples "$OWL" > "$NT" 2>"$GATHER/$ONT.riot.err" || {
+      log "riot conversion failed (see $GATHER/$ONT.riot.err) — skipping $ONT"; continue; }
+  fi
+
+  # -- 2a. sparq: subsumption count + classify time (count printed FIRST) -------
+  SPARQ_ROW=""; SPARQ_COUNT=""; SPARQ_S=""
+  if want sparq; then
+    log "sparq: classify $ONT (cap ${TIMEOUT_S}s)"
+    if timeout "$TIMEOUT_S" "$SPARQ_BIN" "$NT" ntriples > "$GATHER/$ONT.sparq.out" 2>&1; then
+      SPARQ_ROW="$(cat "$GATHER/$ONT.sparq.out")"
+      SPARQ_COUNT="$(sed -n 's/.*subsumptions=\([0-9]*\).*/\1/p' "$GATHER/$ONT.sparq.out")"
+      SPARQ_S="$(sed -n 's/.*classify_s=\([0-9.]*\).*/\1/p' "$GATHER/$ONT.sparq.out")"
+    else
+      log "sparq FAILED/timeout on $ONT"; SPARQ_ROW="ERROR: timeout/failure"
+    fi
+  fi
+
+  # -- 2b. ELK: classify → inferred taxonomy → transitively-closed named count --
+  ELK_ROW=""; ELK_COUNT=""; ELK_S=""
+  if want elk && [ -f "${ELK_JAR:-/nonexistent}" ]; then
+    log "elk: classify $ONT (cap ${TIMEOUT_S}s)"
+    ELK_OUT="$GATHER/$ONT.elk-taxonomy.owl"
+    START="$(python3 -c 'import time;print(f"{time.time():.6f}")')"
+    if timeout "$TIMEOUT_S" java -jar "$ELK_JAR" \
+        --input "$OWL" --output "$ELK_OUT" classify 2>"$GATHER/$ONT.elk.err"; then
+      END="$(python3 -c 'import time;print(f"{time.time():.6f}")')"
+      ELK_S="$(python3 -c "print(f'{$END-$START:.6f}')")"
+      # Transitively close ELK's inferred DIRECT SubClassOf taxonomy over named classes and count
+      # proper pairs — aligning ELK's metric with sparq's complete-closure count.
+      "$RIOT" --output=ntriples "$ELK_OUT" > "$GATHER/$ONT.elk.nt" 2>/dev/null || true
+      ELK_COUNT="$(ELK_NT="$GATHER/$ONT.elk.nt" python3 - <<'PYEOF'
+import os, sys
+sco = "<http://www.w3.org/2000/01/rdf-schema#subClassOf>"
+thing = "<http://www.w3.org/2002/07/owl#Thing>"
+sup = {}
+path = os.environ["ELK_NT"]
+if not os.path.exists(path):
+    print(""); sys.exit(0)
+for line in open(path):
+    p = line.rstrip(" .\n").split(" ", 2)
+    if len(p) == 3 and p[1] == sco and p[0].startswith("<") and p[2].startswith("<"):
+        s, o = p[0], p[2]
+        if s != o and o != thing:
+            sup.setdefault(s, set()).add(o)
+# transitive closure over the direct taxonomy
+closure = {c: set(v) for c, v in sup.items()}
+changed = True
+while changed:
+    changed = False
+    for c in list(closure):
+        add = set()
+        for d in closure[c]:
+            add |= sup.get(d, set())
+        add -= closure[c]; add.discard(c)
+        if add:
+            closure[c] |= add; changed = True
+print(sum(len(v) for v in closure.values()))
+PYEOF
+)"
+    else
+      log "elk FAILED/timeout on $ONT"; ELK_ROW="ERROR: timeout/failure"
+    fi
+  elif want elk; then
+    ELK_ROW="ERROR: elk jar unavailable"
+  fi
+
+  # -- 3. ORACLE-BEFORE-TIMING: record counts + agreement, THEN timing ---------
+  COUNTS_AGREE="n/a"
+  if [ -n "$SPARQ_COUNT" ] && [ -n "$ELK_COUNT" ]; then
+    [ "$SPARQ_COUNT" = "$ELK_COUNT" ] && COUNTS_AGREE="true" || COUNTS_AGREE="false"
+    log "$ONT subsumptions — sparq=$SPARQ_COUNT elk=$ELK_COUNT agree=$COUNTS_AGREE"
+    [ "$COUNTS_AGREE" = "false" ] && \
+      log "DISAGREEMENT recorded (neither engine is ground truth; INVESTIGATE — not adjusted)"
+  else
+    log "$ONT: one or both subsumption counts missing — timing recorded WITHOUT an agreement flag"
+  fi
+
+  TS="$(python3 -c 'import time;print(time.strftime("%Y%m%dT%H%M%SZ", time.gmtime()))')"
+  OUT="$OUT_DIR/reason-el-${ONT}-${TS}.json"
+  CANONICAL="$CANONICAL" ONT="$ONT" URL="$URL" OWL_SHA="$OWL_SHA" GIT_COMMIT="$GIT_COMMIT" \
+  ONLY="$ONLY" TIMEOUT_S="$TIMEOUT_S" OUT="$OUT" \
+  SPARQ_ROW="$SPARQ_ROW" SPARQ_COUNT="$SPARQ_COUNT" SPARQ_S="$SPARQ_S" \
+  ELK_ROW="$ELK_ROW" ELK_COUNT="$ELK_COUNT" ELK_S="$ELK_S" ELK_VER="${ELK_VER:-}" \
+  COUNTS_AGREE="$COUNTS_AGREE" \
+  python3 - <<'PYEOF'
+import json, os, platform
+
+canonical = os.environ["CANONICAL"] == "1"
+only = os.environ["ONLY"].split()
+sparq_count = os.environ["SPARQ_COUNT"] or None
+elk_count = os.environ["ELK_COUNT"] or None
+agree = os.environ["COUNTS_AGREE"]
+
+engines = {}
+if "sparq" in only:
+    engines["sparq"] = {
+        "version": os.environ["GIT_COMMIT"],
+        "mode": "in-process (examples/reason_el_real_bench GATHER: parse once, classify_graph); --features rbox",
+        "subsumptions": sparq_count,
+        "classify_s": os.environ["SPARQ_S"] or None,
+        "raw": os.environ["SPARQ_ROW"],
+    }
+if "elk" in only:
+    engines["elk"] = {
+        "version": os.environ.get("ELK_VER", ""),
+        "mode": "ELK CLI classify → inferred taxonomy → riot NT → transitively-closed named count",
+        "subsumptions": elk_count,
+        "classify_s": os.environ["ELK_S"] or None,
+        "raw": os.environ["ELK_ROW"],
+    }
+
+note = (
+    "CANONICAL: dedicated quiet box, one engine active at a time, SAME ontology OWL."
+    if canonical else
+    "NON-canonical FIRST READ: shared work box (not a dedicated quiet instance). Timings are "
+    "directional only — do NOT bake into docs/dashboards. The harness "
+    "(scripts/bench/reason-el-same-box.sh) is the durable deliverable; rerun CANONICAL=1 on a "
+    "dedicated EC2 box for citable numbers."
+)
+
+envelope = {
+    "gather": "reason-el-same-box-comparison",
+    "wave": "reason-el competitor baseline (sq-hmd7l.8)",
+    "canonical": canonical,
+    "canonical_note": note,
+    "git_commit": os.environ["GIT_COMMIT"],
+    "suite": "reason-el-real",
+    "ontology": os.environ["ONT"],
+    "ontology_url": os.environ["URL"],
+    "ontology_sha256": os.environ["OWL_SHA"],
+    "metric": ("proper named subsumption pairs = complete transitive closure of C ⊑ D over named "
+               "classes (C≠D, D≠owl:Thing, both named IRIs); ELK's direct taxonomy is transitively "
+               "closed to match sparq's closure count"),
+    "oracle_before_timing": {
+        "sparq_subsumptions": sparq_count,
+        "elk_subsumptions": elk_count,
+        "counts_agree": agree,
+        "policy": ("NEITHER engine is ground truth. A recorded count is required per ontology before "
+                   "any timing is trusted; a disagreement (counts_agree=false) is INVESTIGATED, never "
+                   "adjusted. counts_agree=n/a means a count was missing (engine error/absent)."),
+    },
+    "engines": engines,
+    "env": {
+        "host": platform.node(),
+        "machine": platform.machine(),
+        "os": platform.platform(),
+        "timeout_s": int(os.environ["TIMEOUT_S"]),
+    },
+}
+with open(os.environ["OUT"], "w") as fh:
+    json.dump(envelope, fh, indent=2)
+    fh.write("\n")
+print(os.environ["OUT"])
+PYEOF
+  log "envelope: $OUT"
+done
+
+log "done. Gather deps live under /tmp/reason-el-gather + /tmp/elk-cli + /tmp/jena-riot (delete when finished)."


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated contribution for bead `sq-hmd7l.8` (epic `sq-hmd7l`, comparative-benchmarking-everything).

## What

`sparq-reason-el`'s only bench was **synthetic** (`snomed_go_scale_bench` — a closed-form scaling probe). This adds the durable **same-box comparison vs ELK** (the reference consequence-based OWL 2 EL classifier, Apache-2.0) on **real ontologies** (Gene Ontology / OpenGALEN), with a **subsumption-count oracle recorded BEFORE any timing**.

## Deliverables

- **`crates/sparq-reason-el/examples/reason_el_real_bench.rs`** — classifies an ontology file end-to-end and reports **proper named subsumption pairs** (complete transitive closure of `C ⊑ D` over named classes). Two modes:
  - `--smoke` (default): assert the pinned vendored-fixture count.
  - `<path> [format]`: print `subsumptions=… classify_s=…` for the GO/OpenGALEN cross-check (count first, timing after).
  - No `required-features`; identical count in feature-OFF and `--features rbox` (fixture uses role-*equality* existentials only, so `rbox` adds nothing here — but the same binary built `--features rbox` classifies real part-of role chains faithfully).
- **`crates/sparq-reason-el/examples/data/el_smoke.ttl`** — small **vendored** hermetic EL+⊥ fixture. Pins **6 lattice classes / 9 proper named subsumptions**, including a **CR4 existential edge OWL 2 RL cannot reach** (`Neuron ⊑ NucleatedCell`). **Non-vacuous:** removing that axiom drops the count 9→8 (verified) and fails the pinned assertion.
- **`scripts/bench/reason-el-same-box.sh`** — `--smoke` acceptance path (sparq-only, **no network/JVM**) + full gather (OWL→NT via Jena `riot`, sparq vs ELK, both counts + agreement recorded, honest ERROR degradation, one competitor-results envelope per ontology). **Neither engine is ground truth** — a disagreement is recorded (`counts_agree=false`), never adjusted. All work-box rows are **NON-canonical**.
- **`research/gap-reason-el-2026-07.md`** — methodology + provenance (NON-canonical flagged; no hard-coded perf numbers).
- **`bench/benchmarks.toml`** — fill the pre-registered `reason-el-real` stub with the delivered artifacts.

SNOMED CT is license-gated → **skipped** (free subsets only). ORE EL-track is a documented stretch follow-up.

## Acceptance (both pass)

- `cargo run -p sparq-reason-el --release --example reason_el_real_bench` → exits 0, asserts the pinned count.
- `ONLY=sparq bash scripts/bench/reason-el-same-box.sh --smoke` → exits 0.

## Gates

clippy `-D warnings` (default + `--all-features`, `--all-targets`); tests both states; `RUSTDOCFLAGS=-D warnings cargo doc --all-features`; `check-new-bench-registered.py` + `check-no-perf-numbers.py` PASS. No README touched.

*Not armed — leaving merge to the coordinator.*