### PR TITLE
fix(shacl): per-statement message/severity override survives recursing-component evaluation (sq-1jemy) [FABLE-5]

### DIFF
--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -457,6 +457,20 @@ impl<'a> Validator<'a> {
         if shape.deactivated {
             return;
         }
+        // [FABLE-5] (sq-1jemy) Make nested shape evaluation TRANSPARENT to the
+        // caller's per-statement annotation override. Every recursing composite
+        // (`sh:node` / `sh:not` / `sh:and|or|xone` / qualified / member /
+        // reifier-shape / `sh:property`) re-enters this function via
+        // `conforms*()` / `validate_shape*()`, and the component loop below
+        // resets `self.active_meta` per component — which used to CLOBBER the
+        // outer occurrence's `{| sh:message |}` / `{| sh:severity |}` override
+        // to `None` before the composite arm's `result()` read it (a silent
+        // no-op). Saving the caller's meta here (take: the nested frame starts
+        // clean, so an outer override can never leak INTO nested results — those
+        // carry the nested shape's own metas, the reading recorded in
+        // research/shacl12-conformance-gap.md §6) and restoring it on exit lets
+        // the override survive the recursion for the composite's OWN result.
+        let caller_meta = self.active_meta.take();
         #[cfg(test)]
         let focus_id = if FORCE_NO_IDFAST.with(Cell::get) {
             Some(None) // pretend the focus is unresolved → full Term-level route
@@ -533,6 +547,10 @@ impl<'a> Validator<'a> {
             self.eval_component(sid, focus, &mut values, comp, out);
             self.active_meta = None;
         }
+        // [FABLE-5] (sq-1jemy) Hand the caller's per-statement override back
+        // (see the take() above): the composite arm that recursed into this
+        // frame reads it in `result()` after we return.
+        self.active_meta = caller_meta;
     }
 
     /// A result owned by shape `sid` for `focus`. [OPUS-4.8] (sq-pb0wm) When a

--- a/crates/sparq-shacl/tests/constraints.rs
+++ b/crates/sparq-shacl/tests/constraints.rs
@@ -1282,3 +1282,180 @@ fn per_statement_severity_is_occurrence_scoped() {
         "un-annotated occurrence keeps the default Violation"
     );
 }
+
+// ----------------------------------------------------------------------------
+// [FABLE-5] (sq-1jemy) Per-statement overrides on RECURSING components. A
+// `{| sh:message … |}` / `{| sh:severity … |}` on a shape-referencing constraint
+// statement (`sh:node` / `sh:not`) governs the COMPOSITE component's OWN result
+// (the SHACL-1.2 severity precedence keys on the reifier of "the triples
+// containing the parameters of the constraint that caused the result"). Before
+// this fix the nested `conforms()` / `validate_shape()` recursion reset
+// `active_meta` to `None` before the composite arm's `result()` read it, so the
+// override was silently dropped. Conversely, the override does NOT govern the
+// NESTED shape's results (they are caused by the nested shape's own constraint
+// statements) — the reading recorded in research/shacl12-conformance-gap.md §6.
+// ----------------------------------------------------------------------------
+
+/// `{| sh:severity sh:Warning |}` on a `sh:node` statement survives the nested
+/// `conforms()` recursion: the NodeConstraintComponent's own result carries the
+/// override. Term-level route (literal focus, no path ⇒ `ValueNodes::Terms`).
+#[test]
+fn per_statement_severity_override_survives_sh_node_recursion() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "hello" ;
+          sh:node ex:N {| sh:severity sh:Warning |} .
+        ex:N a sh:NodeShape ; sh:nodeKind sh:IRI .
+    "#;
+    let r = run("ex:x ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "NodeConstraintComponent"), 1, "{}", r.to_text());
+    let node_res = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("NodeConstraintComponent"))
+        .expect("node result");
+    assert_eq!(
+        node_res.severity, SH_WARNING,
+        "the sh:node occurrence's severity override must survive the nested \
+         shape evaluation: {}",
+        r.to_text()
+    );
+}
+
+/// The `sh:node` override on the ID-FAST route (pathed property shape ⇒ value
+/// nodes stay dictionary ids and the id-level `Component::Node` arm calls
+/// `conforms_id`). Same invariant as the Term-level twin above.
+#[test]
+fn per_statement_severity_override_survives_sh_node_recursion_idfast() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ; sh:property ex:P .
+        ex:P a sh:PropertyShape ; sh:path ex:q ;
+          sh:node ex:N {| sh:severity sh:Warning |} .
+        ex:N a sh:NodeShape ; sh:datatype xsd:integer .
+    "#;
+    // ex:v is an IRI in the data graph (id-resolvable), not an xsd:integer.
+    let r = run("ex:n ex:q ex:v .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "NodeConstraintComponent"), 1, "{}", r.to_text());
+    let node_res = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("NodeConstraintComponent"))
+        .expect("node result");
+    assert_eq!(
+        node_res.severity, SH_WARNING,
+        "the id-level sh:node arm must also see the surviving override: {}",
+        r.to_text()
+    );
+}
+
+/// `{| sh:message … |}` on a `sh:node` statement: the composite result's
+/// message is the per-statement override, not the (absent) shape-level one.
+#[test]
+fn per_statement_message_override_survives_sh_node_recursion() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "hello" ;
+          sh:node ex:N {| sh:message "node override"@en |} .
+        ex:N a sh:NodeShape ; sh:nodeKind sh:IRI .
+    "#;
+    let r = run("ex:x ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    let node_res = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("NodeConstraintComponent"))
+        .expect("node result");
+    let want = Term::Literal(oxrdf::Literal::new_language_tagged_literal_unchecked(
+        "node override",
+        "en",
+    ));
+    assert!(
+        node_res.effective_messages().contains(&want),
+        "the sh:node occurrence's message override must survive the nested \
+         shape evaluation, got {:?}",
+        node_res.effective_messages()
+    );
+}
+
+/// `{| sh:severity sh:Warning |}` on a `sh:not` statement (the other
+/// single-statement recursing composite) survives its `conforms()` recursion.
+#[test]
+fn per_statement_severity_override_survives_sh_not_recursion() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+          sh:not ex:N {| sh:severity sh:Warning |} .
+        ex:N a sh:NodeShape ; sh:nodeKind sh:IRI .
+    "#;
+    // ex:n IS an IRI, so it conforms to the negated shape → sh:not fires.
+    let r = run("ex:n ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "NotConstraintComponent"), 1, "{}", r.to_text());
+    let not_res = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("NotConstraintComponent"))
+        .expect("not result");
+    assert_eq!(
+        not_res.severity, SH_WARNING,
+        "the sh:not occurrence's severity override must survive the nested \
+         shape evaluation: {}",
+        r.to_text()
+    );
+}
+
+/// Occurrence scoping still holds around a recursing component: the annotated
+/// `sh:node` result carries the override while an un-annotated SIBLING
+/// constraint evaluated AFTER it keeps the default sh:Violation (the restore
+/// must not bleed the override into later loop iterations).
+#[test]
+fn per_statement_override_on_sh_node_is_occurrence_scoped() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "hello" ;
+          sh:node ex:N {| sh:severity sh:Warning |} ;
+          sh:minLength 99 .
+        ex:N a sh:NodeShape ; sh:nodeKind sh:IRI .
+    "#;
+    let r = run("ex:x ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 2, "{}", r.to_text());
+    let node_res = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("NodeConstraintComponent"))
+        .expect("node result");
+    let ml = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("MinLengthConstraintComponent"))
+        .expect("minLength result");
+    assert_eq!(node_res.severity, SH_WARNING, "annotated sh:node → Warning");
+    assert_eq!(
+        ml.severity, SH_VIOLATION,
+        "un-annotated sibling keeps the default Violation: {}",
+        r.to_text()
+    );
+}
+
+/// A `{| sh:severity |}` on a `sh:property` statement does NOT govern the
+/// NESTED property shape's results: those are caused by the nested shape's own
+/// constraint statements (here its `sh:minCount`), whose reifiers — not the
+/// outer `sh:property` statement's — drive the severity precedence. Deactivation
+/// on `sh:property` (the pre-recursion skip) is covered above; message/severity
+/// on it have no composite result to govern in this implementation.
+#[test]
+fn per_statement_override_on_sh_property_does_not_govern_nested_results() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+          sh:property ex:P {| sh:severity sh:Warning |} .
+        ex:P a sh:PropertyShape ; sh:path ex:q ; sh:minCount 1 .
+    "#;
+    let r = run("ex:n ex:other ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "MinCountConstraintComponent"), 1, "{}", r.to_text());
+    assert_eq!(
+        r.results[0].severity, SH_VIOLATION,
+        "the nested shape's result keeps the nested shape's own severity — the \
+         outer sh:property annotation must not leak in: {}",
+        r.to_text()
+    );
+}

--- a/research/shacl12-conformance-gap.md
+++ b/research/shacl12-conformance-gap.md
@@ -253,6 +253,18 @@ draft; the W3C suite pins only the cases above. Two readings had to be chosen:
    list-/path-valued operands (e.g. the disjunctive `sh:datatype ( … )`, an
    RDF-list comparand) are multi-triple and are NOT annotated.
 
+   *[FABLE-5] (sq-1jemy)* This reading was initially only PARTIALLY implemented:
+   the nested `conforms()` / `validate_shape()` recursion reset the active
+   per-statement meta before the composite arm's `result()` read it, silently
+   dropping the override on every recursing composite (`sh:node`, `sh:not`,
+   `sh:someValue`, `sh:memberShape`, …). Fixed by saving the caller's meta at
+   the single recursion entry (`validate_shape_at`) and restoring it on exit —
+   nested evaluation is now transparent to the caller's override, and a take()
+   keeps an outer override from leaking INTO nested results (pinned by
+   `per_statement_override_on_sh_property_does_not_govern_nested_results`).
+   On `sh:property` — which reports the nested shape's results directly and has
+   no composite result — only deactivation is observable, as decided above.
+
 ### oxttl / oxrdf upgrade assessment (the item-6 question)
 
 The original gap note assumed the `{| … |}` annotation syntax was unparseable

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -329,6 +329,13 @@ the override resolves per occurrence from that reifier (`misc/{deactivated-003,m
 severity-003}`). Supported on single-statement Core constraints (`sh:datatype`, `sh:nodeKind`,
 `sh:class`, `sh:hasValue`, `sh:rootClass`, `sh:node`, `sh:property`, `sh:not`, `sh:someValue`,
 `sh:memberShape`); list-/path-valued operands are not single statements and carry no override.
+On a RECURSING composite (`sh:node` / `sh:not` / `sh:someValue` / `sh:memberShape`) the
+message/severity override governs the composite component's OWN result and survives the
+nested shape evaluation (sq-1jemy); it does NOT govern the nested shape's results — those
+carry the nested shape's own metas (the 1.2 severity precedence keys on the reifier of the
+constraint statement that caused each result). On `sh:property` — which reports the nested
+property shape's results directly, with no composite result — only `{| sh:deactivated |}`
+is observable.
 
 **SHACL-1.2 targets & SPARQL node expressions (always on, no feature flag, sq-rnkdh).**
 Beyond `sh:targetNode`/`Class`/`SubjectsOf`/`ObjectsOf` + implicit class targets:


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — implements bead `sq-1jemy`.

## What

A `{| sh:message … |}` / `{| sh:severity … |}` RDF-1.2 reified-annotation override on a **shape-referencing constraint statement** (`sh:node` / `sh:not` / `sh:someValue` / `sh:memberShape`) was a silent **no-op**: the nested `conforms()` / `validate_shape()` recursion re-entered the component loop, which reset `self.active_meta` per nested component and left it `None` — so the composite arm's `result()` read a clobbered value and the override was dropped (research/shacl12-conformance-gap.md §6 latent limitation, bead `sq-1jemy`).

## Fix

One seam, at the single recursion entry `validate_shape_at`:

- **`take()` the caller's `active_meta` on entry** — the nested frame starts clean, so an outer override can never leak INTO the nested shape's results (they carry the nested shape's own metas — the reading recorded in §6, matching the SHACL 1.2 draft's severity precedence, which keys on the reifier of the triples of *the constraint that caused the result*).
- **Restore it on exit** — the override survives the recursion for the composite component's OWN result (`NodeConstraintComponent`, `NotConstraintComponent`, …).

This covers every recursing composite (Term-level and id-fast `conforms_id` routes, `member_details`, and the `sh:property` direct recursion) at one choke point, so a future arm can't re-introduce the bug.

**`sh:property` boundary (honest scope):** it reports the *nested* property shape's results directly and emits no composite result, so a message/severity annotation on the `sh:property` statement has nothing to govern — only `{| sh:deactivated |}` is observable there (the pre-recursion skip, unchanged). That reading is now pinned by a test and documented in the SKILL + design record.

## Tests (TDD — all six written first; five were red pre-fix)

- `per_statement_severity_override_survives_sh_node_recursion` (Term-level route)
- `per_statement_severity_override_survives_sh_node_recursion_idfast` (id-fast `conforms_id` route)
- `per_statement_message_override_survives_sh_node_recursion`
- `per_statement_severity_override_survives_sh_not_recursion`
- `per_statement_override_on_sh_node_is_occurrence_scoped` (no bleed into later loop iterations)
- `per_statement_override_on_sh_property_does_not_govern_nested_results` (green pre-fix — guards against over-fixing/leak-in)

## Gates (both feature states)

- `cargo build` / `cargo test -p sparq-shacl` — GREEN default AND `--all-features` (`shacl-af`,`scs`); W3C shacl12 baselines unchanged
- `cargo clippy --workspace --all-targets -- -D warnings` — GREEN
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — GREEN
- typos (repo config) + markdownlint (0 errors) on touched markdown; `check-readme-template.py --enforce` — 0 deviations (no README touched)
- No public-API change; no new deps; behavior change is scoped to previously-dropped annotation overrides

## Docs

- `skills/shacl-validation/SKILL.md` — recursing-composite override semantics + the `sh:property` boundary
- `research/shacl12-conformance-gap.md` §6 — records the fix against the decided reading

NOT arming — merge-coordinator handles merge.