### PR TITLE
bench(federation): first comparative federation harness — FedShop-shaped vs Comunica + Jena SERVICE over local member endpoints (sq-hmd7l.12)

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -1628,20 +1628,20 @@ records_to  = "bench/competitor-results/gsp-<UTC>.json via GSP_JSON_OUT (git-ign
 featured    = false  # external-competitor differential harness, not a dashboard-promoted capability suite
 status      = "ok"  # smoke (sparq loopback) is self-contained; competitor columns are gather-time external cost
 
-# [SONNET-4.6] sq-hmd7l.12 — federation harness (FedShop vs Comunica + Jena SERVICE)
+# [FABLE-5] sq-hmd7l.12 — federation harness (FedShop-shaped vs Comunica + Jena SERVICE)
 [[benchmark]]
 id          = "federation-fedshop"
-name        = "Federation comparison — FedShop vs Comunica + Jena SERVICE over local member endpoints"
+name        = "Federation comparison — FedShop-shaped vs Comunica + Jena SERVICE over local member endpoints"
 category    = "query"
-measures    = "per-query result count + federation latency (ms) for FedShop-shaped queries over local member SPARQL endpoints; source-selection precision (members contacted vs correct members); result-count oracle before timing"
-invoke      = "TBD — implementing bead sq-hmd7l.12"
-source      = "TBD — bench/federation-fedshop/; scripts/bench-adapters/comunica_adapter.mjs + http_sparql_adapter.py"
-dataset     = "TBD — FedShop-shaped corpus split across local member endpoints; member data generated in-repo"
+measures    = "per-query canonical RESULT-SET agreement oracle (asserted BEFORE any timing) + federation wall time (best-of-N) for FedShop-shaped queries over 2 local sparq-server member endpoints; per-member HTTP REQUEST COUNTS via a counting reverse proxy (uniform across engines); source-selection precision/recall vs measured per-member block-relevance ground truth; explicit-SERVICE regime (sparq/comunica/jena) + virtual source-selection regime (comunica)"
+invoke      = "bash bench/federation/run.sh [--smoke]  # --smoke = acceptance: one query, sparq-vs-Comunica result-set agreement"
+source      = "bench/federation/{run.sh,compare.py,comunica_runner.mjs}"
+dataset     = "FedShop-shaped vendor+ratingsite shop federation, generated in-repo by compare.py (deterministic seed; per-member sha256 recorded in the results JSON); LargeRDFBench's public endpoints are dead — local replicas only"
 quiet_box_sensitive = true
-pinning     = "TBD — corpus sha256 + Comunica + Jena pinned versions at gather time"
-records_to  = "TBD — bench/competitor-results/<engine>-federation-<UTC>.json (git-ignored)"
-featured    = false  # registry stub; implementing bead sq-hmd7l.12
-status      = "planning"
+pinning     = "per-member corpus sha256 + the RESOLVED @comunica/query-sparql npm version recorded in the results JSON at every gather (FED_COMUNICA_SPEC pins the install; Jena optional via FED_JENA_ARQ)"
+records_to  = "bench/competitor-results/federation-fedshop-<UTC>.json (git-ignored)"
+featured    = false  # comparative harness; smoke (sparq + gather-time Comunica) is the committed self-test
+status      = "ok"
 
 # [SONNET-4.6] sq-hmd7l.13 — LDBC Graphalytics comparison
 [[benchmark]]

--- a/bench/federation/README.md
+++ b/bench/federation/README.md
@@ -1,0 +1,60 @@
+# bench/federation — comparative federation panel (FedShop-shaped)
+
+[FABLE-5] sq-hmd7l.12 — the first comparative END-TO-END federation harness
+(registry id `federation-fedshop`; the fedplan criterion micro is NOT comparative).
+
+## What it measures
+
+A FedShop-shaped shop federation — a **vendor** member (offers) + a **ratingsite**
+member (reviews), sharing product IRIs — is generated in-repo (deterministic seed,
+per-member sha256 recorded) and served by **2 local sparq-server member endpoints**
+(same-box replicas: network variance controlled; LargeRDFBench's public endpoints
+are dead, so local replicas are the only honest option). A request-**counting
+reverse proxy** sits in front of each member so every engine's per-member HTTP
+request counts are measured uniformly.
+
+Engines, over the SAME FedShop-shaped federated queries:
+
+| column | what runs | regime |
+|---|---|---|
+| `sparq` | sparq-server `--features service` (SERVICE eval + bound-join) | explicit SERVICE |
+| `comunica` | `@comunica/query-sparql` (reference federated-SPARQL engine) | explicit SERVICE **and** virtual (`sources=[all members]`, engine-side source selection) |
+| `jena` | Apache Jena `arq` (naive SERVICE baseline) | explicit SERVICE — optional: `FED_JENA_ARQ=/path/to/arq` |
+
+**Invariant (never wall time alone):** per query, the canonical **result-set
+multisets must agree across engines BEFORE any timing is reported**; per-member
+request counts + source-selection precision/recall (vs *measured* per-member
+block-relevance ground truth) are always reported alongside wall time.
+
+Timing regimes differ by engine nature and are recorded in the results JSON, not
+hidden: sparq = HTTP round-trip to the federator; comunica = engine-internal exec
+(process startup excluded); jena = process wall including JVM startup.
+
+## Run it
+
+```sh
+cargo build --release -p sparq-server --features service
+bash bench/federation/run.sh --smoke   # acceptance: one query, sparq-vs-Comunica agreement
+bash bench/federation/run.sh           # full panel: 5 queries, timed, explicit + virtual
+```
+
+Comunica is installed **at gather time** into `bench/federation/node_modules`
+(git-ignored, never a committed dependency); the resolved npm version is recorded
+in the results JSON. Default spec `@comunica/query-sparql@^4` (v5 needs Node ≥ 22).
+Results: `bench/competitor-results/federation-fedshop-<UTC>.json` (git-ignored).
+Tunables (`FED_SCALE`, `FED_ITERS`, `FED_PORT_BASE`, …): see the `run.sh` header.
+Hermetic unit layer: `python3 bench/federation/compare.py --self-test`.
+
+## Honest scope (v1)
+
+- The corpus is FedShop-**shaped** (BSBM-style shop federation, cross-member joins
+  on product IRIs), generated in-repo — not the upstream dockerized FedShop
+  distribution. Same-box local replicas are the variance-controlled equivalent.
+- sparq has **no server-exposed virtual-federation endpoint** (sparq-fedclient is
+  a library) — the sparq virtual-regime cell is an honest `n/a`; a fedclient
+  runner column is tracked as follow-up bead sq-hmd7l.47.
+- SolidBench (pod-shaped federation over many small sources) is a follow-up
+  candidate suite, not covered here.
+- Numbers gathered on a shared work box are **NON-canonical** (bench/CATALOG.md
+  rules); first-read observations live in `research/gap-federation-2026-07.md`,
+  flagged as such.

--- a/bench/federation/compare.py
+++ b/bench/federation/compare.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-hmd7l.12 — first comparative FEDERATION harness (FedShop-shaped).
+#
+# Drives a same-box federation panel: a FedShop-shaped shop federation (vendor +
+# ratingsite member datasets, generated in-repo, deterministic) is served by LOCAL
+# sparq-server member endpoints; three federating engines execute the SAME
+# FedShop-shaped federated queries over them:
+#
+#   sparq    — sparq-server built `--features service` (the engine's SPARQL 1.1
+#              SERVICE eval + bound-join pushdown), queried over HTTP /sparql.
+#   comunica — @comunica/query-sparql (the reference federated-SPARQL JS engine),
+#              via comunica_runner.mjs (gather-time npm install, never committed).
+#   jena     — Apache Jena `arq` executing the same explicit-SERVICE query over an
+#              empty default graph (the naive SERVICE baseline). OPTIONAL column:
+#              set FED_JENA_ARQ=/path/to/apache-jena/bin/arq; honest n/a when unset.
+#
+# INVARIANT (bead sq-hmd7l.12): per query, the engines' RESULT SETS (canonical
+# binding multisets, not just counts) must AGREE before ANY timing is reported;
+# per-member HTTP REQUEST COUNTS and SOURCE-SELECTION precision/recall are always
+# reported alongside wall time — never wall time alone.
+#
+# Request counts come from an in-process counting reverse proxy in front of EACH
+# member endpoint (every engine is pointed at the proxies, so the counts are
+# uniform across engines). Source-selection ground truth is measured, not assumed:
+# a member is RELEVANT to a query iff at least one of the query's member-block
+# patterns yields >=1 row when executed directly against that member (probed on
+# the member's REAL port, so ground-truth probes never pollute the proxy counts).
+#
+# Two federation regimes:
+#   explicit — the federated query names each member in a SERVICE <proxy-url>
+#              clause (all three engines). Source selection is trivially bounded
+#              by the query text; the counts still expose join strategy (e.g.
+#              bound-join batching vs per-binding requests).
+#   virtual  — the SERVICE-free conjunction of the same blocks, executed by
+#              Comunica over sources=[all members] (its native federated mode:
+#              the engine does source selection). sparq has no server-exposed
+#              virtual-federation endpoint today (sparq-fedclient is a library)
+#              — that column is an honest n/a (follow-up bead).
+#
+# Timing regimes differ by engine NATURE and are recorded, not hidden:
+#   sparq: HTTP round-trip to the federator (server regime, includes result
+#          serialisation); comunica: engine-internal exec time reported by the
+#          runner (library regime, process startup excluded); jena: arq process
+#          wall time INCLUDING JVM startup (flagged jvm_included in the JSON).
+#
+# NON-goals (v1, honest): no dockerized upstream FedShop distribution (the corpus
+# is FedShop-SHAPED, generated in-repo — upstream FedShop RUNS its members in
+# docker; same-box local replicas are the variance-controlled equivalent this
+# panel wants); LargeRDFBench's public endpoints are DEAD (local replicas only);
+# SolidBench is a follow-up note in bench/federation/README.md.
+#
+# Exit contract: 0 = every attempted query's oracle agreed (engines that cannot
+# execute a construct record an honest per-query "error" cell and are excluded
+# from that query's oracle — but sparq-vs-comunica agreement on >=1 query is
+# REQUIRED, and any executed-but-DISAGREEING pair is a hard failure).
+#
+# --self-test runs the hermetic unit layer (no HTTP, no node, no server binary).
+from __future__ import annotations
+
+import argparse
+import http.client
+import http.server
+import json
+import os
+import random
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import urllib.request
+
+FS = "http://sparq.dev/fedshop#"
+PREFIXES = (
+    "PREFIX fs: <http://sparq.dev/fedshop#>\n"
+    "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n"
+    "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>\n"
+)
+XSD_INTEGER = "http://www.w3.org/2001/XMLSchema#integer"
+XSD_STRING = "http://www.w3.org/2001/XMLSchema#string"
+
+MEMBERS = ["vendor", "ratingsite"]
+
+# ─── FedShop-shaped federated queries ────────────────────────────────────────────────
+# Each query is a list of member BLOCKS; the harness renders the explicit-SERVICE
+# form (SERVICE <member-proxy> { block } per block) and the virtual SERVICE-free
+# form ({ block } conjunction) from the same manifest — one source of truth, so the
+# two regimes are the same algebra modulo federation.
+QUERIES = [
+    {
+        "id": "q01-offer-review-join",
+        "desc": "cheap well-rated products: offers (vendor) join reviews (ratingsite) on ?product",
+        "select": "?product ?price ?rating",
+        "blocks": [
+            {
+                "member": "vendor",
+                "pattern": "?offer fs:product ?product ; fs:price ?price . FILTER(?price <= 40)",
+            },
+            {
+                "member": "ratingsite",
+                "pattern": "?review fs:reviewFor ?product ; fs:rating ?rating . FILTER(?rating >= 8)",
+            },
+        ],
+    },
+    {
+        "id": "q02-product-detail",
+        "desc": "every offer + every review of one product (highly selective cross-member star)",
+        "select": "?offer ?price ?review ?rating",
+        "blocks": [
+            {
+                "member": "vendor",
+                "pattern": "?offer fs:product fs:Product1 ; fs:price ?price .",
+            },
+            {
+                "member": "ratingsite",
+                "pattern": "?review fs:reviewFor fs:Product1 ; fs:rating ?rating .",
+            },
+        ],
+    },
+    {
+        "id": "q03-unreviewed-offers",
+        "desc": "cheap offered products with NO review (OPTIONAL SERVICE + !bound anti-join)",
+        "select": "?product ?price",
+        "blocks": [
+            {
+                "member": "vendor",
+                "pattern": "?offer fs:product ?product ; fs:price ?price . FILTER(?price <= 30)",
+            },
+            {
+                "member": "ratingsite",
+                "pattern": "?review fs:reviewFor ?product .",
+                "optional": True,
+            },
+        ],
+        "outer_filter": "FILTER(!bound(?review))",
+    },
+    {
+        "id": "q04-vendor-only",
+        "desc": "single-member query (only the vendor member is relevant — source-selection probe)",
+        "select": "?offer ?product ?price",
+        "blocks": [
+            {
+                "member": "vendor",
+                "pattern": "?offer fs:product ?product ; fs:price ?price ; fs:vendor fs:Vendor0 . FILTER(?price <= 20)",
+            },
+        ],
+    },
+    {
+        "id": "q05-vendor0-reviews",
+        "desc": "reviews of Vendor0's products (selective left side -> bound-join request-count probe)",
+        "select": "?product ?review ?rating",
+        "blocks": [
+            {
+                "member": "vendor",
+                "pattern": "?offer fs:product ?product ; fs:vendor fs:Vendor0 .",
+            },
+            {
+                "member": "ratingsite",
+                "pattern": "?review fs:reviewFor ?product ; fs:rating ?rating . FILTER(?rating <= 3)",
+            },
+        ],
+    },
+]
+
+
+# ─── Deterministic FedShop-shaped member data ───────────────────────────────────────
+def gen_member_data(member: str, n_products: int, seed: int = 42) -> list[str]:
+    """N-Triples lines for one member of the shop federation. Deterministic in
+    (member, n_products, seed). Product IRIs are SHARED across members (the join
+    keys); offer/review subjects are member-local. ~10% of products have no offer
+    and ~1/7 have no review, so exclusive-to-one-member products exist (q03/q04
+    are non-empty) alongside the joinable overlap (q01/q02/q05 are non-empty)."""
+    # str seeding is hash-stable (seeded via sha512, PYTHONHASHSEED-independent).
+    rng = random.Random(f"{seed}:{member}")
+    out: list[str] = []
+
+    def t(s: str, p: str, o: str) -> None:
+        out.append(f"{s} {p} {o} .")
+
+    def product(i: int) -> str:
+        return f"<{FS}Product{i}>"
+
+    if member == "vendor":
+        n_offer = 0
+        for i in range(n_products):
+            if i % 10 == 9 and i != 1:  # ~10% offer-less (Product1 always offered: q02)
+                continue
+            for _ in range(1 + (rng.random() < 0.5)):  # 1-2 offers per offered product
+                offer = f"<{FS}Offer{n_offer}>"
+                n_offer += 1
+                vendor = f"<{FS}Vendor{rng.randrange(2)}>"
+                price = rng.randrange(5, 100)
+                t(offer, f"<{FS}product>", product(i))
+                t(offer, f"<{FS}price>", f'"{price}"^^<{XSD_INTEGER}>')
+                t(offer, f"<{FS}vendor>", vendor)
+            t(product(i), "<http://www.w3.org/2000/01/rdf-schema#label>", f'"product {i}"')
+    elif member == "ratingsite":
+        n_review = 0
+        for i in range(n_products):
+            if i % 7 == 6 and i != 1:  # ~1/7 review-less (Product1 always reviewed: q02)
+                continue
+            for _ in range(1 + rng.randrange(3)):  # 1-3 reviews per reviewed product
+                review = f"<{FS}Review{n_review}>"
+                n_review += 1
+                t(review, f"<{FS}reviewFor>", product(i))
+                t(review, f"<{FS}rating>", f'"{rng.randrange(1, 11)}"^^<{XSD_INTEGER}>')
+                t(review, f"<{FS}reviewer>", f"<{FS}Reviewer{rng.randrange(20)}>")
+    else:
+        raise ValueError(f"unknown member: {member}")
+    return out
+
+
+# ─── Query rendering (explicit-SERVICE vs virtual) ───────────────────────────────────
+def render_query(query: dict, mode: str, member_urls: dict[str, str] | None = None) -> str:
+    """Render one manifest query. mode='explicit' wraps each block in
+    SERVICE <member_urls[member]> {...}; mode='virtual' emits the SERVICE-free
+    group conjunction (each block keeps its own group braces, so FILTER scope is
+    identical across the two renderings)."""
+    parts: list[str] = []
+    for block in query["blocks"]:
+        if mode == "explicit":
+            if member_urls is None or block["member"] not in member_urls:
+                raise ValueError(f"no endpoint URL for member {block['member']!r}")
+            group = f"SERVICE <{member_urls[block['member']]}> {{ {block['pattern']} }}"
+        elif mode == "virtual":
+            group = f"{{ {block['pattern']} }}"
+        else:
+            raise ValueError(f"unknown mode: {mode}")
+        if block.get("optional"):
+            group = f"OPTIONAL {{ {group} }}"
+        parts.append(group)
+    if query.get("outer_filter"):
+        parts.append(query["outer_filter"])
+    body = "\n  ".join(parts)
+    return f"{PREFIXES}SELECT {query['select']} WHERE {{\n  {body}\n}}"
+
+
+def block_probe_query(block: dict) -> str:
+    """Standalone probe for source-selection ground truth: does this member hold
+    ANY solution to this block's pattern?"""
+    return f"{PREFIXES}SELECT * WHERE {{ {block['pattern']} }} LIMIT 1"
+
+
+# ─── Canonical result-set agreement (the oracle) ─────────────────────────────────────
+def canon_term(term: dict) -> tuple:
+    """Canonical comparable form of one SPARQL-results-JSON term. RDF 1.1: a plain
+    literal IS an xsd:string literal, so a missing datatype and an explicit
+    xsd:string datatype canonicalise identically. bnode labels are NOT comparable
+    across engines — the harness's queries never project bnodes; a projected bnode
+    canonicalises to a fixed marker so agreement stays label-independent."""
+    kind = term.get("type", "")
+    if kind in ("uri", "iri"):
+        return ("iri", term["value"])
+    if kind in ("bnode", "blank"):
+        return ("bnode", "_")
+    if kind in ("literal", "typed-literal"):
+        dt = term.get("datatype") or XSD_STRING
+        lang = (term.get("xml:lang") or term.get("lang") or "").lower()
+        if lang:
+            return ("literal", term["value"], "", lang)
+        return ("literal", term["value"], dt, "")
+    raise ValueError(f"unknown term kind in results: {term!r}")
+
+
+def canon_rows(bindings: list[dict]) -> list[tuple]:
+    """Canonical MULTISET (sorted list) of solution rows; each row is the sorted
+    tuple of (var, canonical-term). Unbound vars are simply absent, matching
+    SPARQL-results-JSON semantics in every engine."""
+    rows = []
+    for b in bindings:
+        rows.append(tuple(sorted((var, canon_term(term)) for var, term in b.items())))
+    return sorted(rows)
+
+
+def rows_agree(a: list[dict], b: list[dict]) -> bool:
+    return canon_rows(a) == canon_rows(b)
+
+
+def precision_recall(contacted: set[str], relevant: set[str]) -> tuple[float | None, float | None]:
+    p = len(contacted & relevant) / len(contacted) if contacted else None
+    r = len(contacted & relevant) / len(relevant) if relevant else None
+    return p, r
+
+
+# ─── Counting reverse proxy (uniform per-member request counts) ──────────────────────
+class _CountingProxyHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    HOP_BY_HOP = {
+        "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+        "te", "trailers", "transfer-encoding", "upgrade",
+    }
+
+    def _forward(self) -> None:
+        srv = self.server  # CountingProxy
+        with srv.lock:
+            srv.count += 1
+        body = b""
+        length = self.headers.get("Content-Length")
+        if length:
+            body = self.rfile.read(int(length))
+        conn = http.client.HTTPConnection("127.0.0.1", srv.target_port, timeout=60)
+        try:
+            headers = {}
+            for k, v in self.headers.items():
+                lk = k.lower()
+                # Strip hop-by-hop headers; strip accept-encoding so the upstream
+                # answers identity-encoded and the raw body forwards verbatim;
+                # rewrite Host to the real member authority.
+                if lk in self.HOP_BY_HOP or lk in ("accept-encoding", "host", "content-length"):
+                    continue
+                headers[k] = v
+            headers["Host"] = f"127.0.0.1:{srv.target_port}"
+            if body:
+                headers["Content-Length"] = str(len(body))
+            conn.request(self.command, self.path, body=body or None, headers=headers)
+            resp = conn.getresponse()
+            payload = resp.read()
+            self.send_response(resp.status)
+            for k, v in resp.getheaders():
+                if k.lower() in self.HOP_BY_HOP or k.lower() == "content-length":
+                    continue
+                self.send_header(k, v)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except (OSError, http.client.HTTPException) as e:
+            try:
+                self.send_error(502, f"upstream member unreachable: {e}")
+            except OSError:
+                pass
+        finally:
+            conn.close()
+
+    do_GET = do_POST = do_HEAD = do_OPTIONS = _forward
+
+    def log_message(self, *args):  # quiet
+        pass
+
+
+class CountingProxy(http.server.ThreadingHTTPServer):
+    """Reverse proxy 127.0.0.1:port -> 127.0.0.1:target_port counting every request."""
+
+    daemon_threads = True
+
+    def __init__(self, port: int, target_port: int):
+        self.target_port = target_port
+        self.count = 0
+        self.lock = threading.Lock()
+        super().__init__(("127.0.0.1", port), _CountingProxyHandler)
+        self._thread = threading.Thread(target=self.serve_forever, daemon=True)
+        self._thread.start()
+
+    def reset(self) -> None:
+        with self.lock:
+            self.count = 0
+
+    def snapshot(self) -> int:
+        with self.lock:
+            return self.count
+
+
+# ─── Engine runners ───────────────────────────────────────────────────────────────────
+def sparql_json_request(endpoint: str, query: str, timeout: float = 120.0) -> dict:
+    data = urllib.parse.urlencode({"query": query}).encode()
+    req = urllib.request.Request(
+        endpoint,
+        data=data,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/sparql-results+json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def run_sparq(endpoint: str, query: str, timeout: float) -> tuple[list[dict], float]:
+    """Execute on the sparq federator; returns (bindings, wall_us of the HTTP round trip)."""
+    t0 = time.perf_counter()
+    doc = sparql_json_request(endpoint, query, timeout)
+    wall_us = (time.perf_counter() - t0) * 1e6
+    return doc["results"]["bindings"], wall_us
+
+
+def run_comunica(
+    runner: str, query: str, sources: list[str], timeout: float
+) -> tuple[list[dict], float, str]:
+    """Execute via comunica_runner.mjs; returns (bindings, engine exec_us, version)."""
+    proc = subprocess.run(
+        ["node", runner, *(f"--source={s}" for s in sources)],
+        input=query.encode(),
+        capture_output=True,
+        timeout=timeout,
+        cwd=os.path.dirname(os.path.abspath(runner)),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"comunica runner failed (exit {proc.returncode}): "
+            f"{proc.stderr.decode(errors='replace')[-2000:]}"
+        )
+    doc = json.loads(proc.stdout.decode("utf-8"))
+    return doc["bindings"], doc["exec_ms"] * 1000.0, doc.get("engine_version", "unknown")
+
+
+def run_jena(arq: str, query: str, timeout: float, workdir: str) -> tuple[list[dict], float]:
+    """Execute via Jena arq over an empty default graph (naive SERVICE baseline).
+    Wall time INCLUDES JVM startup — flagged jvm_included in the results JSON."""
+    qfile = os.path.join(workdir, "jena-query.rq")
+    with open(qfile, "w") as f:
+        f.write(query)
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        [arq, "--query", qfile, "--results", "JSON"],
+        capture_output=True,
+        timeout=timeout,
+    )
+    wall_us = (time.perf_counter() - t0) * 1e6
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"arq failed (exit {proc.returncode}): {proc.stderr.decode(errors='replace')[-2000:]}"
+        )
+    doc = json.loads(proc.stdout.decode("utf-8"))
+    return doc["results"]["bindings"], wall_us
+
+
+# ─── Server lifecycle ────────────────────────────────────────────────────────────────
+def wait_ready(endpoint: str, proc: subprocess.Popen, timeout_s: float, what: str) -> None:
+    deadline = time.monotonic() + timeout_s
+    probe = f"{PREFIXES}SELECT * WHERE {{ ?s ?p ?o }} LIMIT 1"
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"{what} exited during startup (code {proc.returncode})")
+        try:
+            sparql_json_request(endpoint, probe, timeout=5)
+            return
+        except OSError:
+            time.sleep(0.25)
+    raise RuntimeError(f"{what} not ready within {timeout_s}s")
+
+
+def free_port_check(port: int) -> None:
+    with socket.socket() as s:
+        # SO_REUSEADDR matches the servers' own bind semantics — a previous run's
+        # TIME_WAIT connections must not fail the check (only a live LISTENer should).
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("127.0.0.1", port))
+        except OSError as e:
+            raise RuntimeError(f"port {port} not free (set --port-base): {e}") from e
+
+
+# ─── The panel ────────────────────────────────────────────────────────────────────────
+def run_panel(args) -> int:
+    queries = QUERIES[:1] if args.smoke else QUERIES
+    n_products = args.scale
+    iters = args.iters
+    workdir = args.workdir
+    os.makedirs(workdir, exist_ok=True)
+
+    member_port = {m: args.port_base + i for i, m in enumerate(MEMBERS)}
+    proxy_port = {m: args.port_base + 10 + i for i, m in enumerate(MEMBERS)}
+    fed_port = args.port_base + 20
+    for p in [*member_port.values(), *proxy_port.values(), fed_port]:
+        free_port_check(p)
+
+    corpus_sha = {}
+    import hashlib
+
+    for m in MEMBERS:
+        path = os.path.join(workdir, f"{m}.nt")
+        data = "\n".join(gen_member_data(m, n_products)) + "\n"
+        with open(path, "w") as f:
+            f.write(data)
+        corpus_sha[m] = hashlib.sha256(data.encode()).hexdigest()
+        log(f"member {m}: {data.count(chr(10))} triples -> {path} (sha256 {corpus_sha[m][:16]}…)")
+
+    procs: list[subprocess.Popen] = []
+    proxies: dict[str, CountingProxy] = {}
+    results: dict = {
+        "suite": "federation-fedshop",
+        "mode": "smoke" if args.smoke else "full",
+        "scale_products": n_products,
+        "iters": iters,
+        "corpus_sha256": corpus_sha,
+        "members": {
+            m: {"endpoint": f"http://127.0.0.1:{proxy_port[m]}/sparql", "backing": "sparq-server"}
+            for m in MEMBERS
+        },
+        "engines": {},
+        "queries": [],
+        "notes": [
+            "NON-canonical unless gathered on a quiet dedicated box (bench/CATALOG.md rules).",
+            "timing regimes: sparq=HTTP round-trip to federator; comunica=engine-internal exec"
+            " (process startup excluded); jena=arq process wall INCLUDING JVM startup.",
+            "explicit mode: SERVICE clauses name the members — source selection is bounded by"
+            " the query text; request counts still expose join strategy. virtual mode"
+            " (comunica only): engine-side source selection over sources=[all members].",
+        ],
+    }
+    exit_code = 0
+    try:
+        # 1. members (real sparq-server instances) + counting proxies in front.
+        for m in MEMBERS:
+            logf = open(os.path.join(workdir, f"{m}.server.log"), "wb")
+            proc = subprocess.Popen(
+                [
+                    args.sparq_server_bin,
+                    "--addr",
+                    f"127.0.0.1:{member_port[m]}",
+                    "--format",
+                    "ntriples",
+                    "--query-timeout",
+                    str(int(args.query_timeout)),
+                    os.path.join(workdir, f"{m}.nt"),
+                ],
+                stdout=logf,
+                stderr=logf,
+            )
+            procs.append(proc)
+        for m in MEMBERS:
+            wait_ready(
+                f"http://127.0.0.1:{member_port[m]}/sparql",
+                procs[MEMBERS.index(m)],
+                args.ready_timeout,
+                f"member {m}",
+            )
+            proxies[m] = CountingProxy(proxy_port[m], member_port[m])
+        log(f"members up: {', '.join(f'{m}:{member_port[m]} (proxy :{proxy_port[m]})' for m in MEMBERS)}")
+
+        # 2. the sparq federator: EMPTY graph, service feature, members allowlisted.
+        fed_logf = open(os.path.join(workdir, "federator.server.log"), "wb")
+        fed_proc = subprocess.Popen(
+            [
+                args.sparq_server_bin,
+                "--addr",
+                f"127.0.0.1:{fed_port}",
+                "--query-timeout",
+                str(int(args.query_timeout)),
+                "--service-allow",
+                "127.0.0.1",
+            ],
+            stdout=fed_logf,
+            stderr=fed_logf,
+        )
+        procs.append(fed_proc)
+        fed_endpoint = f"http://127.0.0.1:{fed_port}/sparql"
+        wait_ready(fed_endpoint, fed_proc, args.ready_timeout, "sparq federator")
+        log(f"sparq federator up at {fed_endpoint} (SERVICE allow: 127.0.0.1)")
+
+        member_urls = {m: f"http://127.0.0.1:{proxy_port[m]}/sparql" for m in MEMBERS}
+        engines = ["sparq", "comunica"] + (["jena"] if args.jena_arq else [])
+        results["engines"] = {
+            "sparq": {"kind": "server", "column": "SERVICE eval + bound-join (sparq-engine/service)"},
+            "comunica": {"kind": "js-lib", "column": "@comunica/query-sparql"},
+            **(
+                {"jena": {"kind": "jvm-cli", "column": "arq explicit SERVICE (naive baseline)", "jvm_included": True}}
+                if args.jena_arq
+                else {}
+            ),
+        }
+        if not args.jena_arq:
+            results["notes"].append("jena column n/a: FED_JENA_ARQ unset (optional naive baseline).")
+
+        agreed_any = False
+        for q in queries:
+            qres: dict = {"id": q["id"], "desc": q["desc"], "explicit": {}, "virtual": {}}
+            results["queries"].append(qres)
+            explicit_q = render_query(q, "explicit", member_urls)
+            virtual_q = render_query(q, "virtual")
+
+            # Source-selection ground truth: probe each block against EVERY member
+            # directly (real ports — the proxies never see the probes).
+            relevant: set[str] = set()
+            for m in MEMBERS:
+                for block in q["blocks"]:
+                    doc = sparql_json_request(
+                        f"http://127.0.0.1:{member_port[m]}/sparql",
+                        block_probe_query(block),
+                        args.query_timeout,
+                    )
+                    if doc["results"]["bindings"]:
+                        relevant.add(m)
+                        break
+            qres["relevant_members"] = sorted(relevant)
+
+            # ORACLE pass (one counted execution per engine) — BEFORE any timing.
+            oracle: dict[str, list[dict]] = {}
+            for eng in engines:
+                for proxy in proxies.values():
+                    proxy.reset()
+                cell: dict = {}
+                qres["explicit"][eng] = cell
+                try:
+                    if eng == "sparq":
+                        bindings, _ = run_sparq(fed_endpoint, explicit_q, args.query_timeout)
+                    elif eng == "comunica":
+                        bindings, _, ver = run_comunica(
+                            args.comunica_runner, explicit_q, [], args.query_timeout
+                        )
+                        results["engines"]["comunica"]["version"] = ver
+                    else:
+                        bindings, _ = run_jena(args.jena_arq, explicit_q, args.query_timeout, workdir)
+                except (RuntimeError, OSError, subprocess.TimeoutExpired, KeyError, ValueError) as e:
+                    cell["status"] = "error"
+                    cell["error"] = str(e)[-500:]
+                    log(f"{q['id']} [{eng}] ERROR: {str(e)[-200:]}")
+                    continue
+                oracle[eng] = bindings
+                cell["rows"] = len(bindings)
+                cell["requests"] = {m: proxies[m].snapshot() for m in MEMBERS}
+                contacted = {m for m, c in cell["requests"].items() if c > 0}
+                p, r = precision_recall(contacted, relevant)
+                cell["contacted_members"] = sorted(contacted)
+                cell["source_selection"] = {"precision": p, "recall": r}
+
+            # Agreement: every pair of engines that EXECUTED must agree.
+            ok_engines = sorted(oracle)
+            disagree = []
+            for i, a in enumerate(ok_engines):
+                for b in ok_engines[i + 1 :]:
+                    if not rows_agree(oracle[a], oracle[b]):
+                        disagree.append((a, b))
+            qres["oracle"] = {
+                "executed": ok_engines,
+                "agreed": not disagree and len(ok_engines) >= 2,
+                "disagreements": [f"{a} vs {b}" for a, b in disagree],
+            }
+            if disagree:
+                exit_code = 1
+                log(f"{q['id']}: ORACLE DISAGREEMENT: {qres['oracle']['disagreements']} — no timing reported")
+                continue
+            if "sparq" in oracle and "comunica" in oracle:
+                agreed_any = True
+            if len(ok_engines) < 2:
+                log(f"{q['id']}: <2 engines executed — no cross-check possible, no timing reported")
+                continue
+            log(
+                f"{q['id']}: oracle AGREED across {ok_engines} "
+                f"({len(canon_rows(oracle[ok_engines[0]]))} rows); relevant={sorted(relevant)}"
+            )
+
+            # TIMED pass (only after agreement; counts already recorded above).
+            if not args.smoke:
+                for eng in ok_engines:
+                    walls = []
+                    for _ in range(iters):
+                        try:
+                            if eng == "sparq":
+                                _, w = run_sparq(fed_endpoint, explicit_q, args.query_timeout)
+                            elif eng == "comunica":
+                                _, w, _ = run_comunica(
+                                    args.comunica_runner, explicit_q, [], args.query_timeout
+                                )
+                            else:
+                                _, w = run_jena(args.jena_arq, explicit_q, args.query_timeout, workdir)
+                        except (RuntimeError, OSError, subprocess.TimeoutExpired) as e:
+                            qres["explicit"][eng]["timing_error"] = str(e)[-300:]
+                            break
+                        walls.append(w)
+                    if walls:
+                        qres["explicit"][eng]["best_us"] = round(min(walls))
+                        qres["explicit"][eng]["iters"] = len(walls)
+
+                # VIRTUAL regime: comunica-native source selection; sparq honest n/a.
+                for proxy in proxies.values():
+                    proxy.reset()
+                vcell: dict = {}
+                qres["virtual"]["comunica"] = vcell
+                qres["virtual"]["sparq"] = {
+                    "status": "n/a",
+                    "reason": "no server-exposed virtual-federation endpoint (sparq-fedclient is a library; follow-up bead)",
+                }
+                try:
+                    vbindings, _, _ = run_comunica(
+                        args.comunica_runner, virtual_q, list(member_urls.values()), args.query_timeout
+                    )
+                    vcell["rows"] = len(vbindings)
+                    vcell["requests"] = {m: proxies[m].snapshot() for m in MEMBERS}
+                    contacted = {m for m, c in vcell["requests"].items() if c > 0}
+                    p, r = precision_recall(contacted, relevant)
+                    vcell["contacted_members"] = sorted(contacted)
+                    vcell["source_selection"] = {"precision": p, "recall": r}
+                    vcell["agrees_with_explicit_oracle"] = rows_agree(
+                        vbindings, oracle[ok_engines[0]]
+                    )
+                    if not vcell["agrees_with_explicit_oracle"]:
+                        # Honest: virtual-mode divergence is REPORTED, not fatal —
+                        # engine-side source selection over a SERVICE-free conjunction
+                        # is a different query regime (bnode/dedup semantics can differ).
+                        log(f"{q['id']} [comunica virtual]: result set differs from explicit oracle (reported)")
+                    walls = []
+                    for _ in range(iters):
+                        _, w, _ = run_comunica(
+                            args.comunica_runner, virtual_q, list(member_urls.values()), args.query_timeout
+                        )
+                        walls.append(w)
+                    vcell["best_us"] = round(min(walls))
+                except (RuntimeError, OSError, subprocess.TimeoutExpired) as e:
+                    vcell["status"] = "error"
+                    vcell["error"] = str(e)[-500:]
+
+        if not agreed_any:
+            log("FAIL: no query achieved sparq-vs-comunica result-set agreement")
+            exit_code = 1
+    finally:
+        for proxy in proxies.values():
+            proxy.shutdown()
+        for proc in procs:
+            proc.terminate()
+        for proc in procs:
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    if args.json_out:
+        os.makedirs(os.path.dirname(args.json_out) or ".", exist_ok=True)
+        with open(args.json_out, "w") as f:
+            json.dump(results, f, indent=2)
+        log(f"results JSON -> {args.json_out}")
+    print_table(results)
+    return exit_code
+
+
+def print_table(results: dict) -> None:
+    print(f"\nfederation-fedshop panel ({results['mode']}, scale={results['scale_products']} products)")
+    print(f"{'query':28} {'engine':10} {'rows':>6} {'best_us':>10} {'requests':20} {'src-sel P/R':12} oracle")
+    for q in results["queries"]:
+        agreed = q.get("oracle", {}).get("agreed")
+        for eng, cell in q.get("explicit", {}).items():
+            if cell.get("status") == "error":
+                print(f"{q['id']:28} {eng:10} {'ERROR':>6}")
+                continue
+            reqs = ",".join(f"{m}:{c}" for m, c in cell.get("requests", {}).items())
+            ss = cell.get("source_selection", {})
+            fmt = lambda v: "-" if v is None else f"{v:.2f}"
+            print(
+                f"{q['id']:28} {eng:10} {cell.get('rows', '-'):>6} "
+                f"{cell.get('best_us', '-'):>10} {reqs:20} "
+                f"{fmt(ss.get('precision')):>5}/{fmt(ss.get('recall')):<6} "
+                f"{'AGREED' if agreed else 'NO'}"
+            )
+        vc = q.get("virtual", {}).get("comunica")
+        if vc and "rows" in vc:
+            reqs = ",".join(f"{m}:{c}" for m, c in vc.get("requests", {}).items())
+            ss = vc.get("source_selection", {})
+            fmt = lambda v: "-" if v is None else f"{v:.2f}"
+            print(
+                f"{q['id']:28} {'comunica*':10} {vc.get('rows', '-'):>6} "
+                f"{vc.get('best_us', '-'):>10} {reqs:20} "
+                f"{fmt(ss.get('precision')):>5}/{fmt(ss.get('recall')):<6} "
+                f"{'=explicit' if vc.get('agrees_with_explicit_oracle') else 'DIFFERS'}"
+            )
+    print("(* = virtual regime: engine-side source selection over sources=[all members])\n")
+
+
+def log(msg: str) -> None:
+    print(f"[federation] {msg}", file=sys.stderr)
+
+
+# ─── Hermetic self-test (no HTTP, no node, no server binary) ─────────────────────────
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(name: str, cond: bool) -> None:
+        if not cond:
+            failures.append(name)
+
+    # Generator: deterministic + member-disjoint local subjects + shared products.
+    v1, v2 = gen_member_data("vendor", 50), gen_member_data("vendor", 50)
+    r1 = gen_member_data("ratingsite", 50)
+    check("gen deterministic", v1 == v2)
+    check("gen nonempty", len(v1) > 50 and len(r1) > 50)
+    check("gen vendor has offers", any("Offer0>" in line for line in v1))
+    check("gen ratingsite has reviews", any("Review0>" in line for line in r1))
+    check("gen shares product iris", any("Product1>" in l for l in v1) and any("Product1>" in l for l in r1))
+    check(
+        "gen scale changes data",
+        gen_member_data("vendor", 10) != gen_member_data("vendor", 20),
+    )
+
+    # Rendering: explicit names both proxies; virtual names none; FILTER scope kept.
+    urls = {"vendor": "http://127.0.0.1:1/sparql", "ratingsite": "http://127.0.0.1:2/sparql"}
+    q1 = QUERIES[0]
+    exp = render_query(q1, "explicit", urls)
+    vir = render_query(q1, "virtual")
+    check("explicit has both services", exp.count("SERVICE <") == 2 and urls["vendor"] in exp)
+    check("virtual is service-free", "SERVICE" not in vir)
+    check("virtual keeps filter scope", vir.count("{") == vir.count("}") and "FILTER" in vir)
+    q3 = next(q for q in QUERIES if q["id"].startswith("q03"))
+    exp3 = render_query(q3, "explicit", urls)
+    check("q03 optional wraps service", "OPTIONAL { SERVICE" in exp3)
+    check("q03 outer filter rendered", "!bound(?review)" in exp3)
+
+    # Canonicalisation: RDF 1.1 plain-vs-xsd:string; datatype significance; multiset.
+    lit_plain = {"type": "literal", "value": "a"}
+    lit_str = {"type": "literal", "value": "a", "datatype": XSD_STRING}
+    lit_int = {"type": "literal", "value": "a", "datatype": XSD_INTEGER}
+    check("plain == xsd:string", canon_term(lit_plain) == canon_term(lit_str))
+    check("datatype significant", canon_term(lit_plain) != canon_term(lit_int))
+    check(
+        "lang tag case-insensitive",
+        canon_term({"type": "literal", "value": "a", "xml:lang": "EN"})
+        == canon_term({"type": "literal", "value": "a", "xml:lang": "en"}),
+    )
+    row_a = {"x": {"type": "uri", "value": "http://e/1"}}
+    row_b = {"x": {"type": "uri", "value": "http://e/2"}}
+    check("agreement order-insensitive", rows_agree([row_a, row_b], [row_b, row_a]))
+    check("agreement is multiset", not rows_agree([row_a], [row_a, row_a]))
+    check("agreement value-sensitive", not rows_agree([row_a], [row_b]))
+    check(
+        "bnode labels not compared",
+        rows_agree(
+            [{"x": {"type": "bnode", "value": "b0"}}],
+            [{"x": {"type": "bnode", "value": "genid-77"}}],
+        ),
+    )
+
+    # Source-selection math.
+    check("precision/recall", precision_recall({"a", "b"}, {"a"}) == (0.5, 1.0))
+    check("precision empty contacted", precision_recall(set(), {"a"}) == (None, 0.0))
+
+    # Probe query shape.
+    check("probe has limit 1", block_probe_query(q1["blocks"][0]).rstrip().endswith("LIMIT 1"))
+
+    if failures:
+        print(f"[federation] self-test FAILED: {failures}", file=sys.stderr)
+        return 1
+    print("[federation] self-test OK", file=sys.stderr)
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--self-test", action="store_true", help="hermetic unit layer; no HTTP/node/server")
+    ap.add_argument("--smoke", action="store_true", help="2 members, one query, oracle only (acceptance)")
+    ap.add_argument("--scale", type=int, default=None, help="products in the shop corpus")
+    ap.add_argument("--iters", type=int, default=5, help="timed iterations per engine per query")
+    ap.add_argument("--port-base", type=int, default=int(os.environ.get("FED_PORT_BASE", "7141")))
+    ap.add_argument("--sparq-server-bin", default=os.environ.get("SPARQ_SERVER_BIN", "target/release/sparq-server"))
+    ap.add_argument("--comunica-runner", default=os.path.join(os.path.dirname(os.path.abspath(__file__)), "comunica_runner.mjs"))
+    ap.add_argument("--jena-arq", default=os.environ.get("FED_JENA_ARQ", ""), help="path to Jena arq (optional column)")
+    ap.add_argument("--workdir", default=os.environ.get("FED_WORKDIR", "/tmp/sparq-federation-bench"))
+    ap.add_argument("--json-out", default="", help="results JSON path (suggest bench/competitor-results/, git-ignored)")
+    ap.add_argument("--ready-timeout", type=float, default=120.0)
+    ap.add_argument("--query-timeout", type=float, default=120.0)
+    args = ap.parse_args()
+    if args.self_test:
+        return self_test()
+    if args.scale is None:
+        args.scale = 40 if args.smoke else 500
+    return run_panel(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/federation/comunica_runner.mjs
+++ b/bench/federation/comunica_runner.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+// [FABLE-5] sq-hmd7l.12 — Comunica column runner for the federation panel.
+//
+// Reads ONE SPARQL query on stdin, executes it with @comunica/query-sparql (the
+// reference federated-SPARQL JS engine, gather-time `npm install` into
+// bench/federation/node_modules — NEVER a committed dependency), and prints a
+// single JSON document on stdout:
+//
+//   { ok, exec_ms, engine_version, bindings: [ { var: {type,value,datatype?,"xml:lang"?} } ] }
+//
+// bindings mirror the SPARQL 1.1 Query Results JSON term shape, so bench/
+// federation/compare.py canonicalises sparq and Comunica rows through the SAME
+// code path (the result-set-agreement oracle).
+//
+// Sources:
+//   --source=<url>   repeatable; each becomes {type:'sparql', value:url} — the
+//                    VIRTUAL federation regime (Comunica does source selection).
+//                    The explicit type skips Comunica's format-probe requests, so
+//                    the proxy request counts measure query execution, not
+//                    detection.
+//   (none)           an empty in-memory RDF/JS store is the sole source — the
+//                    EXPLICIT regime, where the query names members via
+//                    SERVICE <url> clauses and the outer join happens client-side.
+//
+// exec_ms measures queryBindings() start -> stream end (engine-internal
+// execution; Node process startup is EXCLUDED — compare.py records this timing
+// regime in the results JSON).
+import { QueryEngine } from '@comunica/query-sparql';
+import { Store } from 'n3';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+function termToJson(term) {
+  switch (term.termType) {
+    case 'NamedNode':
+      return { type: 'uri', value: term.value };
+    case 'BlankNode':
+      return { type: 'bnode', value: term.value };
+    case 'Literal': {
+      const out = { type: 'literal', value: term.value };
+      if (term.language) out['xml:lang'] = term.language;
+      else if (term.datatype && term.datatype.value !== 'http://www.w3.org/2001/XMLSchema#string')
+        out.datatype = term.datatype.value;
+      return out;
+    }
+    default:
+      throw new Error(`unsupported term type in results: ${term.termType}`);
+  }
+}
+
+async function main() {
+  const sources = [];
+  for (const arg of process.argv.slice(2)) {
+    if (arg.startsWith('--source=')) sources.push({ type: 'sparql', value: arg.slice('--source='.length) });
+    else throw new Error(`unknown arg: ${arg}`);
+  }
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const query = Buffer.concat(chunks).toString('utf8');
+  if (!query.trim()) throw new Error('empty query on stdin');
+
+  const engine = new QueryEngine();
+  const context = { sources: sources.length ? sources : [new Store()] };
+
+  const t0 = process.hrtime.bigint();
+  const stream = await engine.queryBindings(query, context);
+  const bindings = [];
+  for await (const b of stream) {
+    const row = {};
+    for (const [variable, term] of b) row[variable.value] = termToJson(term);
+    bindings.push(row);
+  }
+  const execMs = Number(process.hrtime.bigint() - t0) / 1e6;
+
+  let version = 'unknown';
+  try {
+    version = require('@comunica/query-sparql/package.json').version;
+  } catch {
+    /* version stays 'unknown' — compare.py records it as such */
+  }
+  process.stdout.write(
+    JSON.stringify({ ok: true, exec_ms: execMs, engine_version: version, bindings }) + '\n',
+  );
+}
+
+main().catch((e) => {
+  process.stderr.write(`comunica_runner: ${e && e.stack ? e.stack : e}\n`);
+  process.exit(1);
+});

--- a/bench/federation/run.sh
+++ b/bench/federation/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# [FABLE-5] sq-hmd7l.12 — comparative FEDERATION panel entry point (FedShop-shaped).
+#
+# Stands up 2 LOCAL sparq-server member endpoints (a FedShop-shaped vendor +
+# ratingsite shop federation, corpus generated in-repo, deterministic), puts a
+# request-COUNTING reverse proxy in front of each member, and executes the same
+# FedShop-shaped federated queries with three engines:
+#
+#   sparq    — sparq-server `--features service` (SERVICE eval + bound-join)
+#   comunica — @comunica/query-sparql (reference federated-SPARQL engine;
+#              gather-time npm install into bench/federation/node_modules,
+#              git-ignored — NEVER a committed dependency)
+#   jena     — Apache Jena `arq` naive SERVICE baseline (OPTIONAL: FED_JENA_ARQ)
+#
+# INVARIANT: per query, canonical RESULT-SET agreement across engines is asserted
+# BEFORE any timing; per-member HTTP request counts + source-selection
+# precision/recall are reported alongside wall time — never wall time alone.
+#
+# USAGE
+#   bench/federation/run.sh --smoke   # acceptance: 2 local member endpoints, one
+#                                     # FedShop-shaped query, sparq-vs-Comunica
+#                                     # result-set agreement; exit 0 = green
+#   bench/federation/run.sh           # full panel: 5 queries, timed iters,
+#                                     # explicit + virtual regimes, JSON results
+#
+# TUNABLES (env; safe defaults):
+#   SPARQ_SERVER_BIN   server binary (default target/release/sparq-server; MUST be
+#                      built `--features service` — probed via --help)
+#   FED_PORT_BASE      first port of the panel's loopback block (default 7141)
+#   FED_SCALE          products in the generated corpus (default 40 smoke / 500 full)
+#   FED_ITERS          timed iterations per engine per query (default 5)
+#   FED_JENA_ARQ       path to Jena `arq` -> enables the naive-baseline column
+#   FED_COMUNICA_SPEC  npm spec to install (default @comunica/query-sparql; the
+#                      RESOLVED version is recorded in the results JSON — pin here
+#                      for a canonical gather, e.g. @comunica/query-sparql@4.4.0)
+#   FED_JSON_OUT       results JSON path (default, full mode only:
+#                      bench/competitor-results/federation-fedshop-<UTC>.json, git-ignored)
+#   FED_WORKDIR        scratch dir for corpora + server logs (default /tmp/sparq-federation-bench)
+#
+# Same contract as the sibling panels (bench/gsp/run.sh, scripts/*-same-box.sh):
+# bounded waits everywhere, compare.py owns spawn + EXIT-safe teardown of every
+# server/proxy, non-zero exit = the panel is NOT green.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+SMOKE=0
+for arg in "$@"; do
+  case "$arg" in
+    --smoke) SMOKE=1 ;;
+    *) echo "[federation] unknown arg: $arg (usage: bench/federation/run.sh [--smoke])" >&2; exit 2 ;;
+  esac
+done
+
+SPARQ_SERVER_BIN="${SPARQ_SERVER_BIN:-$ROOT/target/release/sparq-server}"
+# v4 major by default: v5 pulls undici@8 (Node >= 22.19) — v4 runs on Node 18/20.
+# The RESOLVED version is recorded in the results JSON at every gather.
+FED_COMUNICA_SPEC="${FED_COMUNICA_SPEC:-@comunica/query-sparql@^4}"
+
+log() { printf '[federation] %s\n' "$*" >&2; }
+die() { printf '[federation] ERROR: %s\n' "$*" >&2; exit 1; }
+
+command -v python3 >/dev/null 2>&1 || die "python3 required"
+command -v node >/dev/null 2>&1 || die "node required (the Comunica column; install Node.js >= 18)"
+command -v npm >/dev/null 2>&1 || die "npm required (gather-time Comunica install)"
+
+if [ ! -x "$SPARQ_SERVER_BIN" ]; then
+  log "sparq-server not found at $SPARQ_SERVER_BIN"
+  die "build it first: cargo build --release -p sparq-server --features service (or set SPARQ_SERVER_BIN)"
+fi
+# The federator needs the engine's SERVICE eval compiled in; a stock (feature-off)
+# binary's --help carries no --service-allow flag — fail fast + loud, not at query time.
+if ! "$SPARQ_SERVER_BIN" --help 2>&1 | grep -q -- '--service-allow'; then
+  die "this sparq-server build has no SERVICE federation — rebuild: cargo build --release -p sparq-server --features service"
+fi
+
+# ---- 1. hermetic self-test of the driver (no HTTP, no node; fails fast + loud) --------
+python3 "$ROOT/bench/federation/compare.py" --self-test || die "compare.py self-test failed"
+
+# ---- 2. gather-time Comunica install (git-ignored node_modules; never committed) ------
+if ! node -e "require.resolve('@comunica/query-sparql/package.json', {paths:['$ROOT/bench/federation']}); require.resolve('n3/package.json', {paths:['$ROOT/bench/federation']})" >/dev/null 2>&1; then
+  log "installing $FED_COMUNICA_SPEC + n3 into bench/federation/node_modules (gather-only)"
+  npm install --no-save --no-audit --no-fund --prefix "$ROOT/bench/federation" \
+    "$FED_COMUNICA_SPEC" n3 >/dev/null \
+    || die "npm install failed (network needed once; the dep is gather-only, never committed)"
+fi
+
+# ---- 3. drive the panel (oracle-before-timing lives in compare.py) --------------------
+ARGS=( --sparq-server-bin "$SPARQ_SERVER_BIN" )
+[ "$SMOKE" = 1 ] && ARGS+=( --smoke )
+[ -n "${FED_SCALE:-}" ] && ARGS+=( --scale "$FED_SCALE" )
+[ -n "${FED_ITERS:-}" ] && ARGS+=( --iters "$FED_ITERS" )
+[ -n "${FED_JENA_ARQ:-}" ] && ARGS+=( --jena-arq "$FED_JENA_ARQ" )
+[ -n "${FED_WORKDIR:-}" ] && ARGS+=( --workdir "$FED_WORKDIR" )
+if [ -n "${FED_JSON_OUT:-}" ]; then
+  ARGS+=( --json-out "$FED_JSON_OUT" )
+elif [ "$SMOKE" = 0 ]; then
+  ARGS+=( --json-out "$ROOT/bench/competitor-results/federation-fedshop-$(date -u +%Y%m%dT%H%M%SZ).json" )
+fi
+
+exec python3 "$ROOT/bench/federation/compare.py" "${ARGS[@]}"

--- a/research/gap-federation-2026-07.md
+++ b/research/gap-federation-2026-07.md
@@ -1,0 +1,88 @@
+<!-- [FABLE-5] sq-hmd7l.12 — per-axis gap record: comparative SPARQL federation.
+First-read only; work-box WALL-TIME readings are NON-canonical by construction and are
+never transcribed here. Per-member HTTP request counts ARE transcribed: they are
+deterministic engine-behaviour facts (identical on every box for a fixed corpus seed),
+not timings. -->
+
+# Gap record — SPARQL federation (2026-07)
+
+**Axis:** federation (epic `sq-hmd7l`, bead `sq-hmd7l.12`).
+**Status:** harness DELIVERED + smoke green (sparq + gather-time Comunica); Jena naive
+column implemented but NOT-MEASURED (needs a Jena install: `FED_JENA_ARQ`); no canonical
+run yet (§4).
+**Harness:** `bench/federation/` (`run.sh` + `compare.py` + `comunica_runner.mjs`),
+registered as `federation-fedshop`.
+**Feeds:** the master table in `research/perf-dominance-gap-2026-07.md` once a canonical
+run exists.
+
+## 1. Engines and honest scope
+
+| Engine | Federation surface | Comparability |
+|---|---|---|
+| sparq | sparq-server `--features service`: SPARQL 1.1 SERVICE eval + on-by-default bound-join pushdown | subject (server regime: HTTP round-trip timed) |
+| Comunica (`@comunica/query-sparql@^4`) | explicit SERVICE **and** virtual `sources=[members]` (engine-side source selection) | reference federated-SPARQL engine (library regime: engine-internal exec timed; both regimes recorded in the results JSON) |
+| Jena `arq` | explicit SERVICE over an empty default graph | naive baseline (JVM startup included, flagged) |
+
+Scope caveats:
+
+- **Correctness before stopwatch (INVARIANT):** per query the canonical result-set
+  MULTISETS (not counts) must agree across every engine that executed, BEFORE any
+  timing; an executed-but-disagreeing pair is a hard red. The oracle is hermetically
+  regression-tested (`compare.py --self-test`: order-insensitive, multiset-sensitive,
+  datatype-sensitive, RDF 1.1 plain≡xsd:string, bnode-label-independent).
+- **Corpus is FedShop-SHAPED, not upstream FedShop:** a deterministic in-repo
+  vendor+ratingsite shop federation (shared product IRIs = join keys). Upstream
+  FedShop's dockerized members are replaced by same-box sparq-server replicas —
+  variance-controlled, and the only honest option (LargeRDFBench's public endpoints
+  are dead). Per-member corpus sha256 + resolved Comunica version are recorded in
+  every results JSON.
+- **Request counts are uniform:** every engine is pointed at a counting reverse proxy
+  per member; ground-truth member relevance is MEASURED (block probes against the
+  members' real ports), never assumed.
+- **sparq virtual-regime cell is n/a:** sparq-fedclient (the source-selecting
+  federation client) is a library with no server-exposed endpoint; the harness reports
+  an honest n/a and a fedclient runner column is a follow-up bead (sq-hmd7l.47).
+- **SolidBench** (many small pod-shaped sources) is a follow-up suite candidate.
+
+## 2. First-read findings (work box — request counts transcribed as deterministic facts; wall times NOT)
+
+Full panel, 500-product corpus, seed 42 (5 queries, all oracles AGREED sparq↔Comunica):
+
+1. **Bound-join dominance in requests (deterministic):** on the offer⋈review join (q01)
+   sparq answers with **vendor:1 + ratingsite:5** member requests (VALUES-batched
+   bound-join) vs Comunica-explicit **vendor:2 + ratingsite:248** (per-binding
+   requests) and Comunica-virtual **vendor:7 + ratingsite:38**. The selective
+   bind-join probe (q05) reads sparq **1+6** vs Comunica-explicit **2+318**. Request
+   count is the axis's structural lever: sparq issues 1–2 orders of magnitude fewer
+   member requests on join-heavy shapes.
+2. **Wall-time ordering (ordinal only, NON-canonical):** sparq's HTTP round-trip was
+   consistently 1–2 orders of magnitude below Comunica's engine-internal exec on every
+   query — directionally consistent with the request-count gap, but the two timing
+   regimes differ (server vs library) and the box is shared: a canonical quiet-box run
+   must confirm before any dominance claim enters the master table.
+3. **Source-selection signal is real in the virtual regime:** Comunica-virtual contacts
+   both members on the single-member query (q04: precision 0.50 — 4 requests to the
+   irrelevant ratingsite member) where the explicit regime is precision 1.0 by query
+   text. This validates the precision/recall instrumentation; sparq cannot enter this
+   comparison until a fedclient runner exists (sq-hmd7l.47).
+4. **OPTIONAL-SERVICE anti-join agrees cross-engine (q03):** `OPTIONAL { SERVICE … } +
+   FILTER(!bound)` produces identical multisets on sparq and Comunica — a semantics
+   corner worth locking in as a conformance fact independent of timing.
+5. **Comunica v5 requires Node ≥ 22** (undici@8); the harness pins `@^4` by default and
+   records the resolved version — a canonical gather on a newer box may bump the major
+   deliberately.
+
+## 3. Gap verdict (per the dominance mandate)
+
+- **Requests/join-strategy: CLEARLY-AHEAD (deterministic).** No fix bead needed.
+- **Wall time: LIKELY-AHEAD, NOT-CANONICAL.** Instrument bead = run the panel on the
+  canonical quiet box (§4); no P1 fix bead — no dimension read behind.
+- **Virtual-regime source selection: NOT-COMPARABLE yet** (sparq column missing, not
+  behind) — follow-up bead sq-hmd7l.47 (sparq-fedclient runner column).
+
+## 4. What a canonical run needs
+
+Quiet dedicated box; `bash bench/federation/run.sh` with `FED_COMUNICA_SPEC` pinned to
+an exact version; optionally `FED_JENA_ARQ` for the naive baseline; archive the results
+JSON (corpus sha256s + versions are embedded) under the canonical results store, then
+promote the verdicts into `research/perf-dominance-gap-2026-07.md`.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous implementation of bead `sq-hmd7l.12` (epic `sq-hmd7l`). [FABLE-5]

## bench(federation): first comparative federation harness — FedShop-shaped vs Comunica + Jena SERVICE over local member endpoints

No comparative end-to-end federation harness existed (only the fedplan criterion micro). This adds `bench/federation/` (registry id `federation-fedshop`, dep `sq-hmd7l.1` ✓ — the Comunica registry entry + toml stub land-filled here).

### What it does
- **2 local sparq-server member endpoints** serve a FedShop-shaped shop federation (vendor offers + ratingsite reviews, shared product IRIs as join keys) **generated in-repo** by `compare.py` — deterministic seed, per-member sha256 recorded in every results JSON. LargeRDFBench's public endpoints are dead → local replicas only (consistent with the sq-6tykl in-process/mock-endpoint federation design).
- A **request-counting reverse proxy** fronts each member, so per-member HTTP request counts are measured **uniformly across engines**.
- Columns: **sparq** (sparq-server `--features service`: SERVICE eval + bound-join) vs **Comunica** `@comunica/query-sparql@^4` (gather-time `npm install` into git-ignored `node_modules` — never a committed dep; resolved version recorded; `^4` because v5 needs Node ≥ 22) vs **Jena `arq`** naive SERVICE baseline (optional, `FED_JENA_ARQ`).
- Two regimes from ONE query manifest: **explicit SERVICE** (all engines) and **virtual** source selection (`sources=[all members]`, Comunica-native; the sparq cell is an honest n/a — sparq-fedclient is a library; follow-up bead `sq-hmd7l.47`).

### Invariant (bead spec)
Per query, canonical **result-set MULTISET agreement** across engines is asserted **BEFORE any timing**; request counts + source-selection precision/recall (vs **measured** per-member block-relevance ground truth, probed on the members' real ports so probes never pollute proxy counts) are always reported alongside wall time — never wall time alone. Disagreement between two engines that both executed = hard red.

### Acceptance (verified green on this box)
- `bash bench/federation/run.sh --smoke` → 2 local sparq-server members, one FedShop-shaped query, **sparq-vs-Comunica result-set agreement, exit 0** ✓
- Full 5-query panel also green: all oracles AGREED (incl. the `OPTIONAL { SERVICE … } + FILTER(!bound)` anti-join corner), virtual regime matches the explicit oracle, and Comunica-virtual's q04 precision 0.50 shows the source-selection instrumentation carries real signal.
- Hermetic unit layer `compare.py --self-test` (no HTTP/node/binary): generator determinism, oracle multiset/datatype/lang/bnode semantics (mutation-flippable: dropping datatype significance or multiset-ness goes red), precision math, explicit/virtual rendering.

### Honesty
- First-read gap record `research/gap-federation-2026-07.md` — flagged **NON-canonical**; wall times NOT transcribed (ordinal statements only), deterministic request counts transcribed as engine-behaviour facts (e.g. q01: sparq `vendor:1 + ratingsite:5` vs Comunica-explicit `2 + 248`).
- Timing regimes differ by engine nature and are recorded in the JSON, not hidden (sparq = HTTP round-trip; Comunica = engine-internal exec; Jena = wall incl. JVM).
- Corpus is FedShop-**shaped**, not the upstream dockerized distribution (noted in README + gap record). SolidBench = follow-up note.

### Gates
- Zero Rust changes (`sparq-fedclient`/`fedplan` read-only, per bead) — `cargo clippy --workspace --all-targets -- -D warnings` run to completion: GREEN.
- `scripts/check-new-bench-registered.py` (G3) ✓, `scripts/check-no-perf-numbers.py` 0 findings ✓, `scripts/check-readme-template.py` 0 deviations ✓, `benchmarks.toml` parses (99 entries) ✓, drift-scan clean ✓, py/mjs/sh syntax ✓.

**Do not merge manually** — the merge-coordinator arms verified branches.
