### PR TITLE
feat(reason-dl): SubObjectPropertyOf conclusion refutation encoding + L1 datatype-map-IRI refusal (sq-pbz04.4.9) [FABLE-5]

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -1115,11 +1115,15 @@ pub const SUITES: &[Suite] = &[
             feature: "dl-direct",
         },
         ci_job: "inference-conformance",
-        ratchet_floor: 95,
+        ratchet_floor: 94,
         floor_basis: "positive-tag membership passes, EXACT-pinned (sparq EXTENSION over the \
                       L1/L2 ALCH-fragment checker — scoped fragment, NOT full OWL 2 DL and NOT \
                       a W3C ProfileIdentificationTest conformance claim); re-pinned by \
-                      sq-pbz04.4.16 (M7 singleton-intersection normalization: +27, 68 -> 95)",
+                      sq-pbz04.4.16 (M7 singleton-intersection normalization: +27, 68 -> 95); \
+                      re-pinned by sq-pbz04.4.9 (L1 datatype-map-IRI refusal: -1, 95 -> 94 — the \
+                      WebOnt-I5.3-015 EL profile row whose premise carries xsd:integer/xsd:string \
+                      ranges now refuses extraction and honestly abstains, was a pass under the \
+                      old opaque-datatype reading)",
         note: "EXTENSION ratchet — the DIRECT-arm ProfileIdentificationTest cases whose \
                POSITIVE test:profile tags the L2 syntactic checker reproduces through the \
                REAL fail-closed L1 extraction + grammar walk; abstentions are never passes. \
@@ -1127,10 +1131,11 @@ pub const SUITES: &[Suite] = &[
                normalizes a 1-ary owl:intersectionOf to its member) and now pass; the \
                positive PROFILE_DIVERGENCES pin is empty. The EXPLICIT-NEGATIVE direction is \
                a SEPARATE lane (sq-pbz04.4.16): the export's owl:NegativePropertyAssertion \
-               profile negations refuted where L2 can (139), with an honest measured In-gap \
-               (180 of 319 checkable) where axiom-grammar membership over the ALCH shadow \
-               cannot refute full-profile membership (deferred restrictions); species \
-               assertions remain unchecked (documented)",
+               profile negations refuted where L2 can (137 after sq-pbz04.4.9's L1 \
+               datatype-map-IRI refusal moved 2 datatype rows out of the checkable set), with \
+               an honest measured In-gap (180 of 317 checkable) where axiom-grammar membership \
+               over the ALCH shadow cannot refute full-profile membership (deferred \
+               restrictions); species assertions remain unchecked (documented)",
     },
     Suite {
         label: "OWL 2 Direct-Semantics consistency + entailment (scoped fragment)",
@@ -1150,7 +1155,10 @@ pub const SUITES: &[Suite] = &[
                       +1, 189 -> 190); re-pinned by sq-pbz04.4.16 (M7 singleton-intersection \
                       normalization: -8, 190 -> 182 — 8 consistency cases re-route from the \
                       ALCH tableau to the RL branch and honestly abstain via the documented \
-                      disjointWith divergence guard, never a wrong verdict; fail set unchanged)",
+                      disjointWith divergence guard, never a wrong verdict; fail set unchanged); \
+                      unchanged at 182 by sq-pbz04.4.9 (SubObjectPropertyOf conclusion encoding \
+                      + L1 datatype-map-IRI refusal net to zero on the pass total, composition \
+                      97+69 -> 96+70; fail set still 5, M3/M5/M6)",
         note: "EXTENSION ratchet — the DIRECT-arm consistency / inconsistency / positive- / \
                negative-entailment tests decided by the REAL sparq-reason-dl L4 dispatch \
                (RL guarded / EL guarded / QL deferred / ALCH tableau) under a pinned \

--- a/crates/sparq-conformance/tests/dl_suite.rs
+++ b/crates/sparq-conformance/tests/dl_suite.rs
@@ -136,13 +136,28 @@ mod gated {
     /// The 27 pinned M7 rows (`WebOnt-I5.26-002`/`-005`, `WebOnt-disjointWith-003`…`-009`,
     /// each EL/QL/RL) whose singleton `owl:intersectionOf ( :A )` L1 now normalizes to its
     /// member all PASS; `PROFILE_DIVERGENCES` is now empty. [FABLE-5]
-    pub const DL_PROFILE_FLOOR: usize = 95;
+    /// Re-pinned by sq-pbz04.4.9 (datatype-map IRI refusal at L1): −1 (95 → 94). One
+    /// positively-tagged profile row (`WebOnt-I5.3-015`, tagged EL — the same case whose
+    /// premise carries `xsd:integer`/`xsd:string` ranges) previously EXTRACTED under the
+    /// opaque-datatype reading and passed the L2 grammar walk; L1 now refuses the datatype
+    /// IRI as a `DataConstruct`, so its profile set is `Unknown` → the row moves to the
+    /// abstained bucket (`DL_PROFILE_ABSTAINED` 117 → 118). Honest fail-closed shift — a
+    /// pass under a wrong opaque-datatype reading becomes an honest abstention (the M4
+    /// precedent). [FABLE-5]
+    pub const DL_PROFILE_FLOOR: usize = 94;
 
     /// EXPLICIT-NEGATIVE profile lane REFUTED (pass) count — checkable
     /// `owl:NegativePropertyAssertion(case, test:profile, {EL|QL|RL})` rows the L2 checker
-    /// DEFINITIVELY refuted (`NotIn`), driven `expect_in = false`. RISE-only: a genuine new
-    /// full-profile restriction only ADDS refutations. [FABLE-5] sq-pbz04.4.16
-    pub const DL_PROFILE_NEGATIVE_REFUTED: usize = 139;
+    /// DEFINITIVELY refuted (`NotIn`), driven `expect_in = false`. RISE-only in the ABSENCE
+    /// of an extraction-boundary change: a genuine new full-profile restriction only ADDS
+    /// refutations. [FABLE-5] sq-pbz04.4.16
+    /// Re-pinned by sq-pbz04.4.9 (datatype-map IRI refusal at L1): −2 (139 → 137). Two
+    /// explicit-negation rows whose input carries a bare datatype IRI in a class position now
+    /// REFUSE extraction (`DataConstruct`), so L2 can no longer answer `NotIn` on them — they
+    /// move from refuted to abstained (`DL_PROFILE_NEGATIVE_ABSTAINED` 615 → 617; checkable
+    /// denominator 319 → 317). Not a refutation regression: the rows became honestly
+    /// out-of-fragment, exactly the fail-closed L1 boundary. [FABLE-5]
+    pub const DL_PROFILE_NEGATIVE_REFUTED: usize = 137;
 
     /// EXPLICIT-NEGATIVE profile lane In-GAP — checkable explicit-negation rows where L2
     /// answered `In` (could not refute full-profile membership from axiom-grammar membership
@@ -151,13 +166,17 @@ mod gated {
     /// sq-1ivw7-style follow-ups). The In-vs-negative gap is `IN_GAP` of
     /// `REFUTED + IN_GAP` = 180 of 319 (improved from the pre-lane measurement 211/322 — the
     /// M7 normalization moved the 27 singleton cases into the checkable set on BOTH sides).
+    /// Unchanged by sq-pbz04.4.9: the two datatype rows that left the checkable set were
+    /// REFUTED (not In-gap), so IN_GAP stays 180 while the denominator drops 319 → 317.
     /// [FABLE-5] sq-pbz04.4.16
     pub const DL_PROFILE_NEGATIVE_IN_GAP: usize = 180;
 
     /// EXPLICIT-NEGATIVE profile lane ABSTAINED — explicit-negation rows where L1 extraction
     /// refused (out-of-fragment input), so L2 abstained (`Unknown`) rather than answering
     /// either direction. Pinned so the tri-state accounting closes. [FABLE-5] sq-pbz04.4.16
-    pub const DL_PROFILE_NEGATIVE_ABSTAINED: usize = 615;
+    /// Re-pinned by sq-pbz04.4.9 (datatype-map IRI refusal at L1): +2 (615 → 617) — the two
+    /// datatype rows that left [`DL_PROFILE_NEGATIVE_REFUTED`] land here. [FABLE-5]
+    pub const DL_PROFILE_NEGATIVE_ABSTAINED: usize = 617;
 
     /// EXPLICIT-NEGATIVE profile lane OUT-OF-SCOPE — explicit-negation rows excluded at
     /// selection (owl:imports / functional-syntax-only input). [FABLE-5] sq-pbz04.4.16
@@ -169,8 +188,9 @@ mod gated {
     /// `tests/scoreboard_floors.rs`. A sparq EXTENSION measurement over the scoped
     /// fragment — NOT full OWL 2 DL.
     ///
-    /// COMPOSITION: 97 consistency + 14 inconsistency + 69 positive-entailment +
+    /// COMPOSITION: 96 consistency + 14 inconsistency + 70 positive-entailment +
     /// 2 negative-entailment = 182. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.12/.13
+    /// (was 97+14+69+2 before sq-pbz04.4.9 — see the sq-pbz04.4.9 re-pin note below.)
     /// Re-pinned by sq-pbz04.4.11 (M1 named-composite fix): +8 net.
     /// Re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix): −3 (192 → 189) — three graphs with
     /// an unconsumed anonymous composite (`WebOnt-I5.26-001`/`-006` consistency; `WebOnt-I5.5-005`
@@ -197,6 +217,22 @@ mod gated {
     /// there. Honest routing to a guarded branch, not a lost capability — the tableau would
     /// still decide these if reached; graduating them back is a deliberate future re-pin once
     /// the RL divergence guard is narrowed or a tableau fallback is added. [FABLE-5]
+    /// UNCHANGED at 182 by sq-pbz04.4.9, but COMPOSITION shifted (97+69 → 96+70 across the
+    /// consistency/positive-entailment split). TWO independent effects net to zero on the pass
+    /// total AND leave the audited fail set (M3/M5/M6, 5 rows) exactly unchanged:
+    ///   (a) the new `SubObjectPropertyOf` conclusion refutation encoding (the sq-pbz04.4.9
+    ///       feature) graduates one property-axiom-conclusion positive-entailment row from a
+    ///       (previously `UnencodedConclusion`) abstention to a definitive PASS: +1 pos-ent;
+    ///   (b) the datatype-map IRI refusal at L1 (`extract.rs` `datatype_iri_name`) makes the
+    ///       `WebOnt-I5.3-015` consistency-lane row (its premise carries `xsd:integer`/
+    ///       `xsd:string` ranges) refuse extraction, so it moves from a definitive `Consistent`
+    ///       PASS to an honest `OutOfFragment` abstention: −1 consistency. Crucially, that same
+    ///       L1 refusal is what REMOVES the would-be NEW positive-entailment divergence
+    ///       `WebOnt-I5.3-015` (whose conclusion `p ⊑ q` the RBox encoding would otherwise have
+    ///       decided `NotEntailed` — sound-as-scoped under opaque datatypes, but a wrong-looking
+    ///       definitive verdict on an input the fragment cannot actually reason about; the
+    ///       escalated soundness verdict directed refusing at L1 rather than pinning it). Net:
+    ///       DIRECT pass total 182 → 182, fail set unchanged. [FABLE-5] sq-pbz04.4.9
     pub const DL_DIRECT_FLOOR: usize = 182;
 
     /// Abstained (fail-closed OutOfFragment / guard / deferred / budget) row totals,
@@ -209,7 +245,11 @@ mod gated {
     /// set is `Unknown` → abstain (previously it extracted and answered a wrong `NotIn`, the
     /// M7 singleton-intersection divergence — now superseded by the honest abstention).
     /// [OPUS-4.8] sq-pbz04.4.12
-    pub const DL_PROFILE_ABSTAINED: usize = 117;
+    /// Re-pinned by sq-pbz04.4.9 (datatype-map IRI refusal at L1): +1 (117 → 118). The
+    /// `WebOnt-I5.3-015` positive profile row (EL-tagged; its premise carries `xsd:integer`/
+    /// `xsd:string` ranges) now REFUSES extraction, moving from a pass to an abstention (see
+    /// [`DL_PROFILE_FLOOR`]). [FABLE-5]
+    pub const DL_PROFILE_ABSTAINED: usize = 118;
     /// See [`DL_PROFILE_ABSTAINED`].
     /// Re-pinned by sq-pbz04.4.11: +4 from the 4 consistency cases that shifted from
     /// Pass to OutOfFragment (budget exhaustion on the now-more-complete model).
@@ -229,6 +269,12 @@ mod gated {
     /// M7 fix re-routes from the ALCH tableau (Pass) to the RL branch move to a fail-closed
     /// `RlDivergenceGuard("owl:disjointWith")` abstention — see [`DL_DIRECT_FLOOR`] for the full
     /// mechanism (honest routing to a guarded branch, never a wrong verdict). [FABLE-5]
+    /// UNCHANGED at 472 by sq-pbz04.4.9 (measured), composition-shifted: the new
+    /// `SubObjectPropertyOf` conclusion encoding graduates property-axiom-conclusion rows OUT
+    /// of abstention (−N), while the L1 datatype-map refusal moves the `WebOnt-I5.3-015`
+    /// consistency row plus its would-be positive-entailment divergence INTO OutOfFragment
+    /// abstention (+N) — the two effects net to zero on the total; see [`DL_DIRECT_FLOOR`].
+    /// [FABLE-5] sq-pbz04.4.9
     pub const DL_DIRECT_ABSTAINED: usize = 472;
 
     /// Audited, PINNED divergence rows (module docs — mechanisms M3/M5/M6): every row
@@ -308,10 +354,19 @@ mod gated {
     /// extractor refuses) — fixed by always emitting the explicit
     /// `A owl:equivalentClass _:b` shape (see `render.rs`), which moved those 15 from
     /// violations to passes (278 → 293). [FABLE-5] sq-pbz04.4.17
-    pub const DL_RENDER_ROUNDTRIP_FLOOR: usize = 293;
+    /// Re-pinned by sq-pbz04.4.9 (datatype-map IRI refusal at L1): −2 (293 → 291). Two
+    /// DIRECT-arm documents carried a bare `xsd:*` datatype IRI in a class-expression
+    /// position (an `rdfs:range`/`rdfs:domain` object) and had been round-tripping through
+    /// the OLD opaque-object-class reading; L1 now refuses that as a `DataConstruct`
+    /// (`extract.rs` `datatype_iri_name`), so they move from round-tripped to
+    /// extraction-refused (`DL_RENDER_ROUNDTRIP_REFUSED` 378 → 380). Honest shift — a
+    /// coincidental round-trip under a wrong reading becomes an honest refusal; `violations`
+    /// stays 0 (no fidelity bug). [FABLE-5]
+    pub const DL_RENDER_ROUNDTRIP_FLOOR: usize = 291;
     /// See [`DL_RENDER_ROUNDTRIP_FLOOR`] — documents the L1 extractor refused
     /// (out-of-ALCH-fragment; the renderer contract is scoped to successful extractions).
-    pub const DL_RENDER_ROUNDTRIP_REFUSED: usize = 378;
+    /// Re-pinned by sq-pbz04.4.9: +2 (378 → 380) — see [`DL_RENDER_ROUNDTRIP_FLOOR`].
+    pub const DL_RENDER_ROUNDTRIP_REFUSED: usize = 380;
     /// See [`DL_RENDER_ROUNDTRIP_FLOOR`] — documents whose RDF/XML literal oxrdfxml
     /// rejects (the M6 mechanism, `FS2RDF-literals-ar`); they reach no lane's extraction.
     pub const DL_RENDER_ROUNDTRIP_PARSE_FAILED: usize = 1;

--- a/crates/sparq-reason-dl/README.md
+++ b/crates/sparq-reason-dl/README.md
@@ -96,8 +96,8 @@ classification; verdicts only for a pure ⊤-free EL+⊥ TBox with zero skipped 
 (always `Unknown` — DL-Lite_R consistency is the QL workstream's, not duplicated), or the
 **ALCH tableau** (complete for the fragment). `check::DirectChecker::entailment` decides
 premise ⊨ conclusion per conclusion-axiom by sound refutation encodings on the tableau
-(GCI / class-assertion / the fresh-class role-assertion trick + the record's desugarings);
-unencoded kinds abstain. A **blank-node individual in the conclusion is read EXISTENTIALLY**
+(GCI / class-assertion / the fresh-class trick, its sq-pbz04.4.9 role-subsumption lift for
+`SubObjectPropertyOf`, + the record's desugarings); a future unencoded kind abstains. A **blank-node individual in the conclusion is read EXISTENTIALLY**
 (sq-pbz04.4.13): a tree-shaped anonymous assertion set rolls up into an `∃`-class assertion
 decided soundly, and a non-rollable shape (shared / cyclic / nominal / free-root) abstains
 `ConclusionAnonymousIndividual` — never a skolem-constant `NotEntailed`. Every verdict carries its producing `Branch`; every guard fails

--- a/crates/sparq-reason-dl/src/check.rs
+++ b/crates/sparq-reason-dl/src/check.rs
@@ -88,8 +88,18 @@
 //! - `DisjointClasses(C, D)` — `O ∪ {(C ⊓ D)(x)}`, `x` fresh: the `C ⊓ D ⊑ ⊥` desugaring.
 //! - `ObjectPropertyDomain(R, C)` / `ObjectPropertyRange(R, C)` — the `∃R.⊤ ⊑ C` /
 //!   `⊤ ⊑ ∀R.C` desugarings (record §3), then the GCI refutation.
-//! - `SubObjectPropertyOf` — [`UnknownReason::UnencodedConclusion`]: the record defers
-//!   property-axiom conclusions (no argued encoding is composed here).
+//! - `SubObjectPropertyOf(R, S)` — `O ∪ {R(a,b), B(b), (∀S.¬B)(a)}` with `a`, `b` FRESH
+//!   individuals and `B` a FRESH class name ([FABLE-5] sq-pbz04.4.9; record §4 as amended —
+//!   the role-subsumption lift of the fresh-class trick). Sound AND complete: if every
+//!   model of `O` has `Rᴵ ⊆ Sᴵ`, then in any model of the union `(a,b) ∈ R ⊆ S` makes `b`
+//!   an `S`-successor of `a`, so `a ∈ ∀S.¬B` forces `b ∈ ¬B`, clashing with `B(b)` — the
+//!   union is inconsistent. Conversely a model `I` of `O` with some `(u,v) ∈ Rᴵ ∖ Sᴵ`
+//!   extends to a model of the union via `aᴵ = u`, `bᴵ = v`, `Bᴵ = {v}` (`a`/`b`/`B` occur
+//!   nowhere in `O`; `(u,v) ∉ Sᴵ` means no `S`-successor of `u` is `v`, the sole member of
+//!   `B`, so `(∀S.¬B)(a)` holds) — non-entailment yields consistency. The tableau side
+//!   holds because its `∀`-rule fires modulo the role hierarchy (`System::is_subrole`,
+//!   reflexive-transitive), so the `R`-edge `a → b` is seen by `∀S` exactly when
+//!   `O ⊢ R ⊑* S`. All three additions stay inside the L1 fragment.
 //!
 //! `Entailed` needs every conclusion axiom's refutation(s) unsatisfiable; a single
 //! definitively-satisfiable refutation is `NotEntailed` (sound because the tableau is
@@ -179,8 +189,11 @@ pub enum UnknownReason {
     QlConsistencyPending,
     /// The ALCH tableau exhausted its deterministic count budget mid-search.
     ResourceBudget(ExhaustedBudget),
-    /// Entailment only: the conclusion-axiom kind has no argued refutation encoding
-    /// (property-axiom conclusions are deferred by the design record).
+    /// Entailment only: the conclusion-axiom kind has no argued refutation encoding.
+    /// Every axiom kind the L1 model can currently express HAS an argued encoding
+    /// (`SubObjectPropertyOf` gained one under sq-pbz04.4.9), so this reason is not
+    /// produced today — it is RETAINED fail-closed for future model growth (a new axiom
+    /// kind abstains here until its encoding is argued in the design record). [FABLE-5]
     UnencodedConclusion(String),
     /// Entailment only: the CONCLUSION ontology mentions a blank-node individual in a shape
     /// that does NOT roll up into a tree-shaped existential class assertion (it is shared
@@ -837,8 +850,33 @@ fn refutation_checks(conclusion: &Axiom, fresh: &mut FreshNames) -> Option<Vec<V
                 },
             ]])
         }
-        // Property-axiom conclusions are deferred by the record (§4): no encoding here.
-        Axiom::SubObjectPropertyOf { .. } => None,
+        // The fresh-individual-pair role-subsumption trick (module docs; record §4 as
+        // amended by sq-pbz04.4.9 — sound AND complete). [FABLE-5]
+        Axiom::SubObjectPropertyOf { sub, sup } => {
+            let a = fresh.mint();
+            let b = fresh.mint();
+            let witness = fresh.mint();
+            Some(vec![vec![
+                Axiom::ObjectPropertyAssertion {
+                    property: sub.clone(),
+                    source: a,
+                    target: b,
+                },
+                Axiom::ClassAssertion {
+                    class: ClassExpression::Class(witness),
+                    individual: b,
+                },
+                Axiom::ClassAssertion {
+                    class: ClassExpression::only(
+                        sup.named(),
+                        ClassExpression::ObjectComplementOf(Box::new(ClassExpression::Class(
+                            witness,
+                        ))),
+                    ),
+                    individual: a,
+                },
+            ]])
+        }
     }
 }
 

--- a/crates/sparq-reason-dl/src/extract.rs
+++ b/crates/sparq-reason-dl/src/extract.rs
@@ -728,6 +728,20 @@ fn decode_class_inner(
             "RDF 1.2 triple term in a class-expression position".to_string(),
         ));
     }
+    // [FABLE-5] sq-pbz04.4.9: a bare OWL 2 datatype-map IRI (`xsd:integer`, `rdfs:Literal`, …)
+    // in a class-expression position — including an `rdfs:range` / `rdfs:domain` object — carries
+    // concrete-domain meaning the datatype-free ALCH fragment cannot model. Reading it as an
+    // opaque object class would silently drop that meaning (e.g. `p rdfs:range xsd:integer` +
+    // `p rdfs:range xsd:string` are only jointly unsatisfiable because the value spaces are
+    // DISJOINT — invisible under an opaque-class reading, WebOnt-I5.3-015). Refuse fail-closed,
+    // the same discipline as the literal / `owl:onDatatype` / declared-datatype-property
+    // refusals; datatypes are the design-record §5 deferral pending a concrete-domain oracle.
+    if let Some(dt) = datatype_iri_name(dict, id) {
+        return Err(ExtractError::DataConstruct(format!(
+            "datatype IRI {} in a class-expression position (no concrete domain in L1)",
+            dt
+        )));
+    }
     if id == v.thing {
         return Ok(ClassExpression::Thing);
     }
@@ -1459,6 +1473,40 @@ fn term_iri(dict: &Dict, id: Id) -> String {
     }
 }
 
+/// The XSD namespace: every IRI under it is an OWL 2 datatype-map datatype ([FABLE-5]
+/// sq-pbz04.4.9, per the escalated soundness verdict).
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+/// The non-XSD members of the OWL 2 datatype map recognised by name (design record §5): the
+/// datatypes whose IRIs live outside the XSD namespace.
+const NON_XSD_DATATYPE_IRIS: &[&str] = &[
+    "http://www.w3.org/2000/01/rdf-schema#Literal",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral",
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral",
+    "http://www.w3.org/2002/07/owl#real",
+    "http://www.w3.org/2002/07/owl#rational",
+];
+
+/// `Some(display)` when `id` names a well-known OWL 2 datatype-map datatype (an `xsd:*` IRI or
+/// one of the [`NON_XSD_DATATYPE_IRIS`]). A bare datatype IRI carries CONCRETE-DOMAIN meaning
+/// (a fixed value space) that the datatype-free ALCH fragment cannot model; reading it as an
+/// opaque object class would SILENTLY DROP that meaning (design record §5 defers datatypes
+/// pending a concrete-domain oracle). Detected by IRI identity, so a datatype reaching ANY
+/// class-expression position fails closed uniformly — the same discipline as the literal /
+/// `owl:onDatatype` / declared-datatype-property refusals. [FABLE-5] sq-pbz04.4.9
+fn datatype_iri_name(dict: &Dict, id: Id) -> Option<String> {
+    if is_inline(id) {
+        return None;
+    }
+    if let TermParts::Iri { prefix, suffix } = dict.term_parts(id) {
+        let iri = format!("{}{}", prefix, suffix);
+        if iri.starts_with(XSD) || NON_XSD_DATATYPE_IRIS.contains(&iri.as_str()) {
+            return Some(iri);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1527,6 +1575,73 @@ mod tests {
         assert!(!is_triple_term(&dict, s));
         assert!(term_iri(&dict, s).contains("ex/s"));
         assert!(term_iri(&dict, lit).contains("lit"));
+    }
+
+    /// Direct unit test of `datatype_iri_name` ([FABLE-5] sq-pbz04.4.9): `xsd:*` IRIs and the
+    /// named non-XSD datatype-map members are recognised; an ordinary class IRI, a literal, and
+    /// `owl:Thing` are NOT.
+    #[test]
+    fn datatype_iri_name_recognises_the_datatype_map() {
+        let (dict, _t) = Graph::parse_to_triples(
+            "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+             @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+             @prefix owl: <http://www.w3.org/2002/07/owl#> .\n\
+             <http://ex/s> <http://ex/p> xsd:integer , xsd:string , rdfs:Literal , owl:real .\n\
+             <http://ex/s> <http://ex/q> <http://ex/A> , owl:Thing , \"lit\" .",
+            "turtle",
+        )
+        .expect("parse");
+        use oxrdf::{Literal, NamedNode, Term as OTerm};
+        let look = |iri: &str| dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(iri)));
+        // Recognised datatype-map members.
+        for iri in [
+            "http://www.w3.org/2001/XMLSchema#integer",
+            "http://www.w3.org/2001/XMLSchema#string",
+            "http://www.w3.org/2000/01/rdf-schema#Literal",
+            "http://www.w3.org/2002/07/owl#real",
+        ] {
+            assert_eq!(datatype_iri_name(&dict, look(iri)).as_deref(), Some(iri));
+        }
+        // NOT datatypes: an ordinary class IRI, owl:Thing, a literal.
+        assert_eq!(datatype_iri_name(&dict, look("http://ex/A")), None);
+        assert_eq!(
+            datatype_iri_name(&dict, look("http://www.w3.org/2002/07/owl#Thing")),
+            None
+        );
+        let lit = dict.lookup(&OTerm::Literal(Literal::new_simple_literal("lit")));
+        assert_eq!(datatype_iri_name(&dict, lit), None);
+    }
+
+    /// End-to-end fail-closed refusal ([FABLE-5] sq-pbz04.4.9): a datatype IRI reaching a
+    /// class-expression position (an `rdfs:range` object here, but the check is position-uniform)
+    /// refuses extraction as a `DataConstruct` — it is NOT read as an opaque object class. This
+    /// is the WebOnt-I5.3-015 mechanism (two disjoint datatype ranges must not silently extract
+    /// to two unrelated opaque classes).
+    #[test]
+    fn datatype_range_object_refuses_extraction() {
+        let (dict, triples) = Graph::parse_to_triples(
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+             @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+             <http://ex/p> rdfs:range xsd:integer .",
+            "turtle",
+        )
+        .expect("parse");
+        assert!(
+            matches!(extract(&dict, &triples), Err(ExtractError::DataConstruct(_))),
+            "a datatype range object must refuse extraction (DataConstruct)"
+        );
+        // A datatype as a subClassOf super-CE refuses just the same (position-uniform).
+        let (dict, triples) = Graph::parse_to_triples(
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+             @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+             <http://ex/A> rdfs:subClassOf xsd:string .",
+            "turtle",
+        )
+        .expect("parse");
+        assert!(matches!(
+            extract(&dict, &triples),
+            Err(ExtractError::DataConstruct(_))
+        ));
     }
 
     /// Direct unit test of `normalize_intersection` (sq-pbz04.4.16 / M7): a one-member

--- a/crates/sparq-reason-dl/tests/check.rs
+++ b/crates/sparq-reason-dl/tests/check.rs
@@ -411,22 +411,89 @@ fn entailment_disjointness_domain_range_desugarings() {
     assert_eq!(v, EntailmentVerdict::Entailed);
 }
 
+// -------------------------------------------------------------------------------------------
+// SubObjectPropertyOf conclusions — the fresh-individual-pair encoding ([FABLE-5] sq-pbz04.4.9)
+// -------------------------------------------------------------------------------------------
+
 #[test]
-fn entailment_unencoded_conclusion_kind_abstains() {
-    // Property-axiom conclusions are deferred by the design record: no encoding, no guess.
-    let (v, b) = entail(
-        ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .",
-        ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .",
-    );
-    assert!(
-        matches!(
-            v,
-            EntailmentVerdict::Unknown(UnknownReason::UnencodedConclusion(_))
-        ),
-        "expected UnencodedConclusion, got {:?}",
-        v
-    );
+fn entailment_subproperty_direct_and_converse() {
+    // BEAD ACCEPTANCE CASE (sq-pbz04.4.9): a SubObjectPropertyOf CONCLUSION now gets a
+    // definitive verdict via {R(a,b), B(b), (∀S.¬B)(a)} with fresh a/b/B — previously an
+    // UnencodedConclusion abstention. r ⊑ s entails r ⊑ s...
+    let premise = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .";
+    let conclusion = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::Entailed);
     assert_eq!(b, Branch::AlchTableau);
+    // ...and the CONVERSE s ⊑ r is definitively NOT entailed (completeness half: the model
+    // interpreting B = {b} with an s-edge outside r certifies satisfiability). A mutation
+    // that quantifies ∀ over the SUB role instead of the SUPER role makes this refutation
+    // unsatisfiable and flips it to a WRONG Entailed — this assertion is the witness.
+    let (v, b) = entail(
+        premise,
+        ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :s rdfs:subPropertyOf :r .",
+    );
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_subproperty_transitivity() {
+    // Role-hierarchy transitivity flows through the tableau's reflexive-transitive
+    // `is_subrole` closure: r ⊑ s ⊑ t entails r ⊑ t.
+    let premise = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :t a owl:ObjectProperty . \
+                   :r rdfs:subPropertyOf :s . :s rdfs:subPropertyOf :t .";
+    let (v, b) = entail(
+        premise,
+        ":r a owl:ObjectProperty . :t a owl:ObjectProperty . :r rdfs:subPropertyOf :t .",
+    );
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+    // t ⊑ r is not entailed by the chain.
+    let (v, _) = entail(
+        premise,
+        ":r a owl:ObjectProperty . :t a owl:ObjectProperty . :t rdfs:subPropertyOf :r .",
+    );
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+}
+
+#[test]
+fn entailment_subproperty_reflexivity_from_empty_premise() {
+    // R ⊑ R holds in EVERY interpretation, so even an (axiom-)empty premise entails it —
+    // the refutation {r(a,b), B(b), (∀r.¬B)(a)} clashes on the r-edge itself (the
+    // reflexive base of `is_subrole`). A mutation that drops B(b) or the role assertion
+    // from the encoding leaves the refutation satisfiable and flips this to NotEntailed.
+    let (v, b) = entail(
+        ":x a :A .",
+        ":r a owl:ObjectProperty . :r rdfs:subPropertyOf :r .",
+    );
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+    // Two UNRELATED roles from the same premise: definitively not entailed (freshness: the
+    // fresh B/a/b must not capture anything in the premise).
+    let (v, _) = entail(
+        ":x a :A .",
+        ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .",
+    );
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+}
+
+#[test]
+fn entailment_subproperty_mixed_conclusion_aggregates() {
+    // A conclusion mixing the NEW RBox encoding with an ABox one: r ⊑ s AND s(x,y) both
+    // follow from {r ⊑ s, r(x,y)} — the per-axiom conjunction aggregates to Entailed.
+    let premise = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . \
+                   :r rdfs:subPropertyOf :s . :x :r :y .";
+    let conclusion = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . \
+                      :r rdfs:subPropertyOf :s . :x :s :y .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+    // Flip ONE conjunct (t ⊑ r not entailed): the whole conclusion set fails definitively.
+    let conclusion = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . \
+                      :t a owl:ObjectProperty . :t rdfs:subPropertyOf :r . :x :s :y .";
+    let (v, _) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
 }
 
 #[test]

--- a/research/owl2-direct-semantics-scoping.md
+++ b/research/owl2-direct-semantics-scoping.md
@@ -212,8 +212,19 @@ conclusion-axiom, each with an explicit sound encoding into a consistency questi
 `O ∪ {(¬C)(a)}` inconsistent; `ObjectPropertyAssertion(R,a,b)` → `O ∪ {B(b), (∀R.¬B)(a)}`
 inconsistent with `B` a **fresh** class name (sound *and* complete: a model of `O` lacking
 `R(a,b)` extends to one interpreting `B` as `{b}`, and conversely `b ∈ B` forces the clash
-exactly when every model has `R(a,b)`). Conclusion-axiom kinds without an argued encoding
-(property-axiom conclusions, keys, …) → `Unknown`. **Negative entailment** verdicts are
+exactly when every model has `R(a,b)`); `SubObjectPropertyOf(R,S)` →
+`O ∪ {R(a,b), B(b), (∀S.¬B)(a)}` inconsistent with `a`, `b` **fresh** individuals and `B` a
+**fresh** class name (**§4 amendment, sq-pbz04.4.9** — the role-subsumption lift of the
+fresh-class trick; the original record deferred property-axiom conclusions). Soundness: if
+`O ⊨ R ⊑ S`, any model of the union has `(a,b) ∈ R ⊆ S`, so `b` is an `S`-successor of `a`
+and `(∀S.¬B)(a)` forces `b ∈ ¬B`, clashing with `B(b)` — no model exists. Completeness: a
+model `I` of `O` with `(u,v) ∈ Rᴵ ∖ Sᴵ` extends to the union via `aᴵ = u`, `bᴵ = v`,
+`Bᴵ = {v}` — the fresh names occur nowhere in `O`, and `(u,v) ∉ Sᴵ` means no `S`-successor
+of `u` is `v` (the sole member of `B`), so `(∀S.¬B)(a)` holds. The decision procedure is
+faithful to this semantics because the L3 tableau's `∀`-rule fires modulo the
+reflexive-transitive role hierarchy, and all three additions stay inside the §3 fragment.
+Conclusion-axiom kinds without an argued encoding (keys, …; none currently expressible in
+the L1 model) → `Unknown`. **Negative entailment** verdicts are
 emitted only when the refutation check lands in a branch that is *complete* (EL-guarded,
 ALCH, or RL-with-guard) — a definitive "consistent" is what certifies non-entailment.
 
@@ -241,7 +252,7 @@ wrong species check would poison the lane. Untagged species assertions are not c
 | Transitive roles (S) | kept out of v1 to keep the §3 argument minimal — note: this is the **first-in-line** extension (the ∀₊-propagation rule needs *no* blocking change absent inverses, per Horrocks & Sattler) | small follow-up bead once v1's floor is pinned |
 | Cardinalities / functionality (N/Q/F) | need the choose-rule + node merging; merging + blocking interaction is the classic unsoundness trap; with inverses added later this escalates to pairwise blocking | post-v1, only with a written argument |
 | Nominals in class expressions (`oneOf`, `hasValue`, O) | the O+I+Q interaction is where NEXPTIME bites and where naive blocking is unsound; a "fresh-concept" approximation is sound but **incomplete** and would blur the completeness ledger | revisit only after I and Q are argued |
-| Datatypes / data properties (D) | a datatype-aware tableau needs a concrete-domain satisfiability oracle; sparq already has the seam (`sparq-substrate` numeric tower; `dtype.rs`; EL `cdomain`) but wiring it into a tableau is its own design problem | future record; reuse the shared tower, never a private one |
+| Datatypes / data properties (D) | a datatype-aware tableau needs a concrete-domain satisfiability oracle; sparq already has the seam (`sparq-substrate` numeric tower; `dtype.rs`; EL `cdomain`) but wiring it into a tableau is its own design problem. **sq-pbz04.4.9 hardened the L1 boundary here:** a bare OWL 2 datatype-map IRI (`xsd:*`, `rdfs:Literal`, `rdf:PlainLiteral`/`XMLLiteral`, `owl:real`/`rational`) reaching ANY class-expression position — including an `rdfs:range`/`rdfs:domain` object — now refuses extraction as a `DataConstruct` rather than reading as an opaque object class (which silently dropped the value-space meaning; two disjoint datatype ranges were invisibly unrelated, e.g. WebOnt-I5.3-015). Uniform position check, same discipline as the literal / `owl:onDatatype` refusals. | future record; reuse the shared tower, never a private one |
 | `sameAs` / `differentFrom` in the tableau path | equality reasoning = merging (see cardinalities); RL branch already covers them for RL ontologies | with N/Q |
 | Keys, property chains, `hasSelf`, property disjointness/(a)symmetry/(ir)reflexivity | outside ALCH; RL branch handles their assertional consequences for RL ontologies | per-construct evaluation later |
 | OWL 2 DL species validation (global restrictions) | needs regularity/simple-role machinery; wrong checks poison the profile lane | post-v1 bead if the lane's value warrants it |

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -321,7 +321,9 @@ returning `ConsistencyOutcome` / `EntailmentOutcome`: a tri-state verdict PLUS t
 that produced it (traceability). `entailment()` checks `O ⊨ α` per conclusion axiom by an
 argued refutation encoding onto the tableau (`SubClassOf`, `ClassAssertion`,
 `ObjectPropertyAssertion` via a fresh-class encoding, `EquivalentClasses`, `DisjointClasses`,
-domain/range; property-axiom conclusions abstain). Every guard fails CLOSED — uncertainty is a
+domain/range, and — since sq-pbz04.4.9 — `SubObjectPropertyOf(R,S)` via the
+fresh-individual-pair lift `{R(a,b), B(b), (∀S.¬B)(a)}`, sound and complete because the
+tableau's ∀-rule fires modulo the role hierarchy). Every guard fails CLOSED — uncertainty is a
 typed `UnknownReason`, never a guessed verdict. **Conclusion anonymous individuals
 (sq-pbz04.4.13):** a blank-node individual in the CONCLUSION is read EXISTENTIALLY (per the
 official Direct-Semantics tests) — L1's skolem-constant reading is entailment-preserving on the
@@ -368,7 +370,7 @@ the whole graph, never a partial extraction):
 | Cardinality (min/max/exact/qualified) | Refused | `OutOfFragment` |
 | Nominals (`owl:oneOf`, `owl:hasValue`, `owl:hasSelf`); inverse properties (`owl:inverseOf`); property characteristics (Transitive/Functional/IFP/Sym/Asym/Refl/Irr) | Refused | `OutOfFragment` |
 | `owl:sameAs` / `owl:differentFrom`; property chains; keys; `owl:disjointUnionOf` | Refused | `OutOfFragment` |
-| Datatypes / data properties / data-range restrictions | Refused | `DataConstruct` |
+| Datatypes / data properties / data-range restrictions; a bare datatype-map IRI (`xsd:*`, `rdfs:Literal`, `owl:real`/`rational`) in ANY class position incl. an `rdfs:range`/`rdfs:domain` object (sq-pbz04.4.9) | Refused | `DataConstruct` |
 | Malformed RDF list (unterminated, cyclic, branching, empty, orphan cell, `rdf:nil` as list cell) | Refused | `MalformedList` |
 | Malformed class expression (missing filler/property, conflicting shapes, cyclic, bare blank) | Refused | `MalformedClassExpression` |
 | Undeclared predicate (role-vs-annotation ambiguous); RDF 1.2 triple term | Refused | `Unclassifiable` |
@@ -389,9 +391,10 @@ the whole graph, never a partial extraction):
 |---|---|---|
 | `SubClassOf`, `ClassAssertion`, `EquivalentClasses`, `DisjointClasses`, `ObjectPropertyDomain` / `ObjectPropertyRange` | Yes (sound + complete via refutation encoding) | — |
 | `ObjectPropertyAssertion` (fresh-class encoding — sound and complete, `check.rs` §4) | Yes | — |
+| `SubObjectPropertyOf` (fresh-individual-pair encoding `{R(a,b), B(b), (∀S.¬B)(a)}` — sound and complete; sq-pbz04.4.9) | Yes | — |
 | Tree-shaped conclusion blank node (rolls up to an existential class assertion; sq-pbz04.4.13) | Yes | — |
 | Non-tree conclusion blank node (shared / cyclic / named-successor / free-existential root) | Never | `ConclusionAnonymousIndividual` |
-| `SubObjectPropertyOf` conclusion | Never | `UnencodedConclusion` |
+| A future axiom kind without an argued encoding (none expressible today) | Never | `UnencodedConclusion` |
 | Deterministic count budget exhausted mid-search | Never | `ResourceBudget` |
 
 Deferred constructs — inverse roles, cardinality/functionality, nominals, transitivity,


### PR DESCRIPTION
> 🤖 SPARQ agent. Bead **sq-pbz04.4.9** (epic sq-pbz04.4 — OWL 2 Direct-Semantics workstream; design record `research/owl2-direct-semantics-scoping.md` §4). Opt-in throughout; the lean default build carries ZERO of this.

## What

A `SubObjectPropertyOf(R,S)` **conclusion** now receives a definitive Direct-Semantics entailment verdict — previously it abstained (`UnencodedConclusion`). Refutation encoding (record §4, amended by this bead):

```
O ⊨ R ⊑ S   iff   O ∪ { R(a,b), B(b), (∀S.¬B)(a) }   is inconsistent      (a, b, B fresh)
```

the role-subsumption lift of the existing fresh-class trick. **Sound AND complete** (argued in `check.rs` module docs + the record): if every model has `Rᴵ ⊆ Sᴵ` the union clashes; a model with `(u,v) ∈ Rᴵ∖Sᴵ` extends via `Bᴵ={v}`. The decision procedure is faithful because the L3 tableau's `∀`-rule fires modulo the reflexive-transitive role hierarchy, so the `R`-edge `a→b` is seen by `∀S` exactly when `O ⊢ R ⊑* S`. All three additions stay inside the L1 ALCH fragment.

## L1 soundness fix (escalated verdict)

The new encoding **exposed a pre-existing L1 fidelity gap**: a bare OWL 2 datatype-map IRI (`xsd:*`, `rdfs:Literal`, `rdf:PlainLiteral`/`XMLLiteral`, `owl:real`/`rational`) in a class-expression position — including an `rdfs:range`/`rdfs:domain` object — was read as an **opaque object class**, silently dropping value-space meaning. On `WebOnt-I5.3-015` (two *disjoint* datatype ranges → `p` necessarily empty → `p ⊑ q` vacuous) that opaque reading made the RBox encoding return a definitive `NotEntailed` contradicting the export's `Entailed`.

A sparq-reviewer soundness escalation ruled this **not sound-as-scoped** (the checker's contract promises `Unknown` outside the argued fragment, and datatypes are the record §5 deferral). Fix: `extract.rs` now **refuses a datatype-map IRI in ANY class position as `DataConstruct`** (uniform position check) — the same fail-closed discipline as the existing literal / `owl:onDatatype` / declared-datatype-property refusals. So `WebOnt-I5.3-015` honestly abstains (extraction-refused) instead of yielding a wrong-looking definitive verdict.

## Tests (mutation-witnessed, REAL pipeline)

- 4 new `SubObjectPropertyOf` entailment tests (direct/converse, transitivity, reflexivity-from-empty-premise, mixed-conclusion). **Mutating `∀` from the super-role to the sub-role in the encoding flips all 4 red** (verified), then reverted — non-vacuous.
- `datatype_iri_name` direct unit test + a datatype-in-class-position **extraction-refusal** integration test for the L1 fix.

## Conformance re-pin (measured — DIRECT arm + both profile lanes + render round-trip)

| Floor | Before | After | Why |
|---|---|---|---|
| `DL_DIRECT_FLOOR` | 182 | **182** (unchanged) | composition 97+69 → 96+70: **+1** pos-ent (the encoding) − **1** consistency (I5.3-015 datatype refusal); **fail set still 5, M3/M5/M6** — I5.3-015 leaves the fail set as an honest abstention, NOT a new pin |
| `DL_PROFILE_FLOOR` | 95 | 94 | I5.3-015 EL profile row refuses extraction |
| `DL_PROFILE_ABSTAINED` | 117 | 118 | ″ |
| `DL_PROFILE_NEGATIVE_REFUTED` | 139 | 137 | 2 datatype rows leave the checkable set |
| `DL_PROFILE_NEGATIVE_ABSTAINED` | 615 | 617 | ″ (In-gap 180 of 319 → 317) |
| `DL_RENDER_ROUNDTRIP_FLOOR` | 293 | 291 | 2 documents refuse (was round-tripping opaquely) |
| `DL_RENDER_ROUNDTRIP_REFUSED` | 378 | 380 | ″; violations still **0** |

Every moved row is a coincidental-pass-under-a-wrong-datatype-reading becoming an honest refusal (the M4 precedent), never a lost capability. Scoreboard mirrors + `scoreboard_floors` test synced.

## Gates (both feature states)

`cargo clippy --all-targets -D warnings` (reason-dl + conformance, default AND feature-ON) ✅ · tests both states ✅ · `cargo doc --workspace --no-deps --all-features` `RUSTDOCFLAGS=-D warnings` ✅ · `check-readme-template.py --enforce` 0 deviations ✅ · typos clean ✅ · `scoreboard_floors` in sync ✅. (Deterministic COUNT-budget conformance — no wall-clock, per policy.)

## Deferred

`sq-pbz04.4.19` (P4) — datatype-map-aware L1 + concrete-domain satisfiability oracle for the ALCH tableau (the §5 deferral unlock path that would graduate the abstained datatype cases to definitive verdicts).

**Do not arm** — the merge-coordinator merges.