### PR TITLE
feat(sparq-serve): retention/truncation policy for the change-stream segmented log (sq-n9s4d) [FABLE-5]

### DIFF
--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -70,12 +70,12 @@ cargo run -p sparq-server -- --format turtle data.ttl
   `sparq-server` mounts `/admin/backup` + `/admin/restore`. At-rest encryption is
   out of scope. (Same feature: `backup_delta` incremental-delta / point-in-time
   recovery between **same-lineage** generations — see rustdoc.)
-- **Durable change-data-capture stream** *(opt-in `change-stream`, OFF by default)*
-  — `change_stream::ChangeLog` persists each commit as an ordered,
-  monotonically-sequenced change record to a segmented, fsync'd append-only log
-  (Neptune-Streams shape); a consumer `poll(from_seq)`s from any offset and
-  **replays after a restart**. No new dependency, no HTTP/async; at-rest encryption
-  + authenticity out of scope. See rustdoc for the segment format.
+- **Durable change-data-capture stream** *(opt-in `change-stream`, OFF by default)* —
+  `change_stream::ChangeLog` persists each commit as an ordered, monotonically-sequenced
+  change record to a segmented, fsync'd append-only log (Neptune-Streams shape);
+  `poll(from_seq)` **replays after a restart**, and explicit retention (`apply_retention`)
+  drops whole old segments by consumer-ack / age / size (a trimmed-offset poll **fails
+  closed**). No new dependency, no HTTP/async; encryption + authenticity out of scope.
 - **Response-bytes result cache** *(opt-in `result-cache`, OFF by default)* — see
   below.
 

--- a/crates/sparq-serve/src/change_stream.rs
+++ b/crates/sparq-serve/src/change_stream.rs
@@ -48,7 +48,16 @@
 //!   acknowledged record survives a crash.
 //! - **Segmented.** Records roll into a new segment file once the active segment reaches
 //!   [`ChangeLogConfig::segment_target_bytes`], so retention/truncation can drop whole old
-//!   segments (the truncation policy is a later, separate concern — see the deferred bead).
+//!   segments.
+//! - **Retention (truncation).** [FABLE-5] (sq-n9s4d) [`ChangeLog::apply_retention`] drops
+//!   whole OLD segments — oldest-first, never the active segment, never a partial segment —
+//!   under a [`RetentionPolicy`] combining consumer-ack (a HARD safety bound: a segment
+//!   holding any unacked record is never dropped), age, and total-size pressure. Trimming
+//!   preserves the gapless order of everything retained; a [`poll`](ChangeLog::poll) from a
+//!   trimmed-away offset **fails closed** (it never silently skips dropped records) — resume
+//!   from [`first_seq`](ChangeLog::first_seq) instead. Retention is EXPLICIT (the host
+//!   decides when to call it, e.g. periodically or after commits); nothing is dropped by
+//!   default.
 //! - **Replayable after restart.** [`ChangeLog::open`] re-reads every segment in order,
 //!   validates each record's framing + digest (fail-closed on a torn tail — a half-written
 //!   trailing record is truncated, not silently replayed), and resumes appending at the next
@@ -65,7 +74,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use sparq_core::Graph;
 
@@ -181,6 +190,54 @@ impl Default for ChangeLogConfig {
     }
 }
 
+/// [FABLE-5] (sq-n9s4d) A retention/truncation policy for [`ChangeLog::apply_retention`]:
+/// which whole OLD segments may be dropped. The three criteria compose as follows:
+///
+/// - [`acked_through_seq`](Self::acked_through_seq) is a **hard safety bound**: when set, a
+///   segment is only ever droppable if EVERY record it holds has `seq <=` the watermark (a
+///   consumer has durably acknowledged it). A segment holding any unacked record — and every
+///   segment after it (prefix rule) — is retained regardless of age/size pressure.
+/// - [`max_age`](Self::max_age) / [`max_total_bytes`](Self::max_total_bytes) are **pressure
+///   criteria**: an eligible segment is dropped if its NEWEST record is older than `max_age`,
+///   OR while the log's total on-disk size still exceeds `max_total_bytes` (oldest first).
+/// - With NO pressure criterion set but an ack watermark set, ack alone drives dropping:
+///   every fully-acked old segment is dropped (the "keep only what consumers still need"
+///   shape).
+///
+/// The default policy (all `None`) is a **no-op** — nothing is ever dropped implicitly.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct RetentionPolicy {
+    /// Size pressure: drop oldest eligible segments while the total on-disk size of ALL
+    /// segment files (including the active one) exceeds this many bytes. The active segment
+    /// is never dropped, so the floor is one segment even under a `Some(0)` budget.
+    pub max_total_bytes: Option<u64>,
+    /// Age pressure: a segment whose NEWEST record's commit timestamp is at least this much
+    /// older than "now" is droppable (every record in it is stale).
+    pub max_age: Option<Duration>,
+    /// Consumer-ack watermark (hard safety bound): the highest `seq` every consumer has
+    /// durably processed. A segment holding any record with `seq >` this is never dropped.
+    pub acked_through_seq: Option<u64>,
+}
+
+impl RetentionPolicy {
+    /// `true` iff the policy can never drop anything (all criteria `None`).
+    /// [`ChangeLog::apply_retention`] short-circuits on a no-op policy.
+    pub fn is_noop(&self) -> bool {
+        self.max_total_bytes.is_none() && self.max_age.is_none() && self.acked_through_seq.is_none()
+    }
+}
+
+/// [FABLE-5] (sq-n9s4d) What one [`ChangeLog::apply_retention`] pass actually dropped.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RetentionReport {
+    /// Number of whole segment files deleted by this pass.
+    pub segments_dropped: usize,
+    /// Total on-disk bytes reclaimed by this pass.
+    pub bytes_dropped: u64,
+    /// The earliest seq still retained after this pass (== [`ChangeLog::first_seq`]).
+    pub first_retained_seq: u64,
+}
+
 /// The durable, segmented, append-only change-data-capture log over one ring's commit
 /// history. Append with [`record_commit`](Self::record_commit); read with
 /// [`poll`](Self::poll); reopen after a restart with [`open`](Self::open) and resume.
@@ -202,6 +259,10 @@ pub struct ChangeLog {
     active_bytes: u64,
     /// The seq the NEXT recorded commit will get. `0` for a fresh, empty log.
     next_seq: u64,
+    /// The earliest seq still retained on disk — `0` until retention drops a segment, then
+    /// the first seq of the oldest surviving segment. Recovered from the segment filenames
+    /// on [`open`](Self::open).
+    first_seq: u64,
     /// The generation of the last recorded commit (`None` for an empty log), used to reject
     /// a non-forward commit.
     last_generation: Option<u64>,
@@ -234,8 +295,11 @@ impl ChangeLog {
         segments.sort_by_key(|(seq, _)| *seq);
 
         // Recover the stream by reading every segment in order; the last record's seq + the
-        // recovered next-seq / last-generation drive resumed appends.
-        let mut next_seq = 0u64;
+        // recovered next-seq / last-generation drive resumed appends. A retention-trimmed
+        // log no longer starts at seq 0: the stream (and the seq validation) starts at the
+        // oldest RETAINED segment's filename key.
+        let first_seq = segments.first().map(|(seq, _)| *seq).unwrap_or(0);
+        let mut next_seq = first_seq;
         let mut last_generation: Option<u64> = None;
         let mut active_first_seq = 0u64;
         let mut active_path: Option<PathBuf> = None;
@@ -275,6 +339,7 @@ impl ChangeLog {
             active_first_seq,
             active_bytes,
             next_seq,
+            first_seq,
             last_generation,
         })
     }
@@ -288,6 +353,135 @@ impl ChangeLog {
     /// The generation of the last recorded commit, or `None` for an empty log.
     pub fn last_generation(&self) -> Option<u64> {
         self.last_generation
+    }
+
+    /// [FABLE-5] (sq-n9s4d) The earliest seq still retained on disk — `0` until
+    /// [`apply_retention`](Self::apply_retention) drops a segment. A consumer whose resume
+    /// offset was trimmed away (its [`poll`](Self::poll) fails closed) restarts from here.
+    pub fn first_seq(&self) -> u64 {
+        self.first_seq
+    }
+
+    /// [FABLE-5] (sq-n9s4d) Applies `policy` (see [`RetentionPolicy`] for how the criteria
+    /// compose) against the wall clock, dropping whole OLD segments oldest-first. Equivalent
+    /// to [`apply_retention_at`](Self::apply_retention_at) with `now` = the current time.
+    ///
+    /// Only this handle's view is mutated ([`first_seq`](Self::first_seq)); a concurrent
+    /// reader handle observes the trim through its next `poll` (which re-reads the
+    /// directory). Never touches the active segment, so appends continue unaffected.
+    pub fn apply_retention(
+        &mut self,
+        policy: &RetentionPolicy,
+    ) -> Result<RetentionReport, BackupError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        self.apply_retention_at(policy, now)
+    }
+
+    /// [FABLE-5] (sq-n9s4d) [`apply_retention`](Self::apply_retention) with an explicit
+    /// `now` (nanoseconds since the Unix epoch, the same clock as
+    /// [`ChangeRecord::timestamp_unix_nanos`]) — the deterministic core, for hosts/tests
+    /// that inject time.
+    ///
+    /// Drops a PREFIX of whole segments, oldest-first, stopping at the first segment that
+    /// must be kept (so the retained stream stays gapless) and never touching the active
+    /// segment. A segment is dropped iff:
+    /// 1. every record it holds is acked (when [`RetentionPolicy::acked_through_seq`] is
+    ///    set — the hard safety bound), AND
+    /// 2. a pressure criterion trips — its newest record is older than
+    ///    [`RetentionPolicy::max_age`], or the log's total size still exceeds
+    ///    [`RetentionPolicy::max_total_bytes`] — or NO pressure criterion is configured
+    ///    (pure-ack mode).
+    ///
+    /// A no-op policy returns immediately with nothing dropped.
+    pub fn apply_retention_at(
+        &mut self,
+        policy: &RetentionPolicy,
+        now_unix_nanos: u128,
+    ) -> Result<RetentionReport, BackupError> {
+        let mut report = RetentionReport {
+            segments_dropped: 0,
+            bytes_dropped: 0,
+            first_retained_seq: self.first_seq,
+        };
+        if policy.is_noop() {
+            return Ok(report);
+        }
+
+        let mut segments = segment_files(&self.dir)?;
+        segments.sort_by_key(|(seq, _)| *seq);
+
+        // Total on-disk size of ALL segment files (including the active one) — the quantity
+        // the `max_total_bytes` budget is checked against, updated as segments drop.
+        let mut total_bytes = 0u64;
+        for (_, path) in &segments {
+            total_bytes += fs::metadata(path)?.len();
+        }
+
+        let has_pressure = policy.max_age.is_some() || policy.max_total_bytes.is_some();
+        // `windows(2)` pairs each segment with its successor, so (a) the LAST segment — the
+        // active one — is never a drop candidate, and (b) the successor's first seq bounds
+        // the candidate's record range: a segment keyed `first` whose successor is keyed
+        // `next_first` holds exactly seqs `first..next_first` (the stream is gapless).
+        for pair in segments.windows(2) {
+            let (first, path) = &pair[0];
+            let (next_first, _) = &pair[1];
+            if *first == self.active_first_seq {
+                break; // defence-in-depth: never drop the active segment
+            }
+            let last_seq = next_first - 1;
+
+            // 1. Hard safety bound: every record in the segment must be acked.
+            if let Some(acked) = policy.acked_through_seq {
+                if last_seq > acked {
+                    break; // an unacked record: keep this segment and everything after it
+                }
+            }
+
+            // 2. Pressure: age/size when configured; pure-ack mode drops every acked prefix.
+            let drop = if has_pressure {
+                let by_size = policy
+                    .max_total_bytes
+                    .is_some_and(|budget| total_bytes > budget);
+                let by_age = match policy.max_age {
+                    None => false,
+                    Some(age) => {
+                        // Re-read the segment (validated) to find its newest record's
+                        // timestamp; retention traffic is bounded by retention itself.
+                        let (_, records) = recover_segment(path, *first)?;
+                        match records.last() {
+                            // A sealed segment always holds >= 1 record; an empty one is
+                            // anomalous — keep it (fail-safe) rather than guess its age.
+                            None => false,
+                            Some(newest) => {
+                                newest
+                                    .timestamp_unix_nanos
+                                    .saturating_add(age.as_nanos())
+                                    <= now_unix_nanos
+                            }
+                        }
+                    }
+                };
+                by_size || by_age
+            } else {
+                true
+            };
+            if !drop {
+                break; // prefix rule: the retained stream must stay gapless
+            }
+
+            let len = fs::metadata(path)?.len();
+            fs::remove_file(path)?;
+            total_bytes -= len;
+            report.segments_dropped += 1;
+            report.bytes_dropped += len;
+            self.first_seq = *next_first;
+        }
+
+        report.first_retained_seq = self.first_seq;
+        Ok(report)
     }
 
     /// Records ONE commit — the change between the same-lineage `from` and `to` generations
@@ -390,6 +584,13 @@ impl ChangeLog {
     ///
     /// This is the resume primitive: after a restart a consumer that persisted its last-seen
     /// `seq` calls `poll(last_seen + 1)` and continues exactly where it left off.
+    ///
+    /// [FABLE-5] (sq-n9s4d) If `from_seq` precedes the earliest RETAINED record (older
+    /// segments were dropped by [`apply_retention`](Self::apply_retention)), the poll
+    /// **fails closed** with [`BackupError::Format`] rather than silently skipping the
+    /// dropped records — a consumer that cannot tolerate the gap must handle it explicitly
+    /// (e.g. re-bootstrap from a [`backup`](crate::backup), then resume from
+    /// [`first_seq`](Self::first_seq)).
     pub fn poll(&self, from_seq: u64) -> Result<Vec<ChangeRecord>, BackupError> {
         read_from(&self.dir, from_seq)
     }
@@ -402,8 +603,20 @@ fn read_from(dir: &Path, from_seq: u64) -> Result<Vec<ChangeRecord>, BackupError
     let mut segments = segment_files(dir)?;
     segments.sort_by_key(|(seq, _)| *seq);
 
+    // [FABLE-5] (sq-n9s4d) The stream starts at the oldest RETAINED segment's key (0 for a
+    // never-trimmed log). Asking for records BEFORE that is fail-closed: retention dropped
+    // them, and silently resuming later would violate the gapless-replay contract.
+    let earliest = segments.first().map(|(seq, _)| *seq).unwrap_or(0);
+    if from_seq < earliest {
+        return Err(BackupError::Format(format!(
+            "poll offset {} precedes the earliest retained record {} — older segments were \
+             dropped by retention; resume at or after the earliest retained seq",
+            from_seq, earliest
+        )));
+    }
+
     let mut out = Vec::new();
-    let mut expected_seq = 0u64;
+    let mut expected_seq = earliest;
     for (_first_seq, path) in &segments {
         let (_end, recovered) = recover_segment(path, expected_seq)?;
         for rec in recovered {
@@ -1374,6 +1587,356 @@ mod tests {
         let tail = reader.poll(1).expect("reader resume");
         assert_eq!(tail.len(), 2);
         assert_eq!(tail[0].seq, 1);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    // -----------------------------------------------------------------------
+    // [FABLE-5] (sq-n9s4d) Retention/truncation coverage. Each test is mutation-
+    // witnessed: the comment names the specific regression that would turn it red.
+    // -----------------------------------------------------------------------
+
+    /// Builds a log with `n` records, ONE PER SEGMENT (`segment_target_bytes: 1`), so
+    /// retention has n segments to work with (the last is active). Returns the writer
+    /// handle, the ring, and the current (latest) generation for follow-on commits.
+    fn one_record_segments(
+        tmp: &Path,
+        n: u64,
+    ) -> (ChangeLog, GenerationRing<Graph>, std::sync::Arc<Generation<Graph>>) {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let mut prev = ring.current();
+        let config = ChangeLogConfig {
+            segment_target_bytes: 1,
+            fsync: false,
+        };
+        let mut log = ChangeLog::open_with_config(tmp, config).expect("open");
+        for i in 0..n {
+            let next = ring.publish(
+                graph_with(&format!(
+                    "<http://ex/s{}> <http://ex/p> <http://ex/o{}> .\n",
+                    i, i
+                )),
+                [],
+            );
+            log.record_commit(&prev, &next).expect("record");
+            prev = next;
+        }
+        (log, ring, prev)
+    }
+
+    /// The default policy is a NO-OP and `first_seq` starts at 0 — nothing is ever dropped
+    /// implicitly. Direct unit tests for `RetentionPolicy::is_noop`, `ChangeLog::first_seq`,
+    /// and the no-op early-return arm of `apply_retention_at`. A regression that made the
+    /// empty policy drop segments (e.g. `is_noop` inverted, or pure-ack mode firing with no
+    /// ack set) turns this red.
+    #[test]
+    fn default_retention_policy_is_noop() {
+        assert!(RetentionPolicy::default().is_noop());
+        assert!(!RetentionPolicy {
+            max_total_bytes: Some(0),
+            ..Default::default()
+        }
+        .is_noop());
+        assert!(!RetentionPolicy {
+            max_age: Some(Duration::from_secs(1)),
+            ..Default::default()
+        }
+        .is_noop());
+        assert!(!RetentionPolicy {
+            acked_through_seq: Some(0),
+            ..Default::default()
+        }
+        .is_noop());
+
+        let tmp = scratch("noop");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, _ring, _g) = one_record_segments(&tmp, 4);
+        assert_eq!(log.first_seq(), 0, "fresh log starts at seq 0");
+        let report = log
+            .apply_retention_at(&RetentionPolicy::default(), u128::MAX)
+            .expect("noop retention");
+        assert_eq!(report.segments_dropped, 0);
+        assert_eq!(report.bytes_dropped, 0);
+        assert_eq!(report.first_retained_seq, 0);
+        assert_eq!(segment_files(&tmp).expect("list").len(), 4, "all kept");
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Pure-ack retention (no pressure criteria): every FULLY-acked prefix segment is
+    /// dropped, the first partially/un-acked one stops the pass, and the report's byte
+    /// accounting equals the dropped files' actual sizes. Regressions witnessed: dropping
+    /// past the ack watermark (safety-bound check removed), off-by-one on a segment's
+    /// last seq, or bytes accounted from the wrong files.
+    #[test]
+    fn ack_retention_drops_fully_acked_prefix() {
+        let tmp = scratch("ack");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, _ring, _g) = one_record_segments(&tmp, 5); // segs 0..4, active = 4
+        let expected_bytes: u64 = (0..3)
+            .map(|s| fs::metadata(segment_path(&tmp, s)).expect("meta").len())
+            .sum();
+
+        let report = log
+            .apply_retention(&RetentionPolicy {
+                acked_through_seq: Some(2),
+                ..Default::default()
+            })
+            .expect("ack retention");
+        // Segments holding seqs 0, 1, 2 are fully acked -> dropped; seq 3 is not acked.
+        assert_eq!(report.segments_dropped, 3);
+        assert_eq!(report.bytes_dropped, expected_bytes);
+        assert_eq!(report.first_retained_seq, 3);
+        assert_eq!(log.first_seq(), 3);
+        assert_eq!(segment_files(&tmp).expect("list").len(), 2);
+        // The retained tail replays exactly (seqs 3 and 4).
+        let tail = log.poll(3).expect("poll retained tail");
+        assert_eq!(tail.len(), 2);
+        assert_eq!((tail[0].seq, tail[1].seq), (3, 4));
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A segment holding ANY unacked record is never dropped — the hard safety bound at
+    /// sub-segment granularity. Seg 0 holds seqs {0,1}; acking only seq 0 must keep it,
+    /// acking through seq 1 drops it. A regression that compared the segment's FIRST seq
+    /// to the watermark (instead of its last) would drop the half-acked segment and turn
+    /// the first phase red.
+    #[test]
+    fn ack_never_drops_partially_acked_segment() {
+        let tmp = scratch("ackpart");
+        let _ = fs::remove_dir_all(&tmp);
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let mut prev = ring.current();
+        // Phase 1: a BIG segment target packs seqs 0 and 1 into segment 0.
+        {
+            let mut log = ChangeLog::open_with_config(
+                &tmp,
+                ChangeLogConfig {
+                    segment_target_bytes: 1_000_000,
+                    fsync: false,
+                },
+            )
+            .expect("open big");
+            for i in 0..2u64 {
+                let next = ring.publish(
+                    graph_with(&format!(
+                        "<http://ex/s{}> <http://ex/p> <http://ex/o{}> .\n",
+                        i, i
+                    )),
+                    [],
+                );
+                log.record_commit(&prev, &next).expect("record");
+                prev = next;
+            }
+        }
+        // Phase 2: reopen with a TINY target so seqs 2 and 3 land in their own segments.
+        let mut log = ChangeLog::open_with_config(
+            &tmp,
+            ChangeLogConfig {
+                segment_target_bytes: 1,
+                fsync: false,
+            },
+        )
+        .expect("reopen tiny");
+        for i in 2..4u64 {
+            let next = ring.publish(
+                graph_with(&format!(
+                    "<http://ex/s{}> <http://ex/p> <http://ex/o{}> .\n",
+                    i, i
+                )),
+                [],
+            );
+            log.record_commit(&prev, &next).expect("record");
+            prev = next;
+        }
+        assert_eq!(segment_files(&tmp).expect("list").len(), 3); // {0,1} {2} {3=active}
+
+        // Ack only seq 0: segment 0 also holds the UNACKED seq 1 -> nothing droppable.
+        let report = log
+            .apply_retention(&RetentionPolicy {
+                acked_through_seq: Some(0),
+                ..Default::default()
+            })
+            .expect("partial ack");
+        assert_eq!(report.segments_dropped, 0, "half-acked segment must survive");
+        assert_eq!(log.first_seq(), 0);
+
+        // Ack through seq 1: segment 0 is now fully acked -> dropped; seq 2 is not acked.
+        let report = log
+            .apply_retention(&RetentionPolicy {
+                acked_through_seq: Some(1),
+                ..Default::default()
+            })
+            .expect("full ack");
+        assert_eq!(report.segments_dropped, 1);
+        assert_eq!(log.first_seq(), 2);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Size pressure drops oldest-first until the total is within budget, and NEVER drops
+    /// the active segment even under a zero budget; appends continue cleanly afterwards.
+    /// Regressions witnessed: budget compared against the wrong total (drops too many /
+    /// too few), or the active segment entering the candidate set (the zero-budget phase
+    /// would empty the log and the follow-on commit would fail).
+    #[test]
+    fn size_retention_drops_oldest_until_within_budget() {
+        let tmp = scratch("size");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, ring, g4) = one_record_segments(&tmp, 4); // segs 0..3, active = 3
+        let total: u64 = segment_files(&tmp)
+            .expect("list")
+            .iter()
+            .map(|(_, p)| fs::metadata(p).expect("meta").len())
+            .sum();
+
+        // Budget = total - 1: dropping ONE segment (the oldest) is enough to fit.
+        let report = log
+            .apply_retention(&RetentionPolicy {
+                max_total_bytes: Some(total - 1),
+                ..Default::default()
+            })
+            .expect("size retention");
+        assert_eq!(report.segments_dropped, 1, "one segment suffices");
+        assert_eq!(log.first_seq(), 1);
+
+        // Budget = 0: everything except the active segment goes; the log stays usable.
+        let report = log
+            .apply_retention(&RetentionPolicy {
+                max_total_bytes: Some(0),
+                ..Default::default()
+            })
+            .expect("zero budget");
+        assert_eq!(report.segments_dropped, 2);
+        assert_eq!(log.first_seq(), 3);
+        assert_eq!(
+            segment_files(&tmp).expect("list").len(),
+            1,
+            "only the active segment survives a zero budget"
+        );
+        // Appends continue after aggressive truncation.
+        let g5 = ring.publish(
+            graph_with("<http://ex/s9> <http://ex/p> <http://ex/o9> .\n"),
+            [],
+        );
+        let rec = log.record_commit(&g4, &g5).expect("append after retention");
+        assert_eq!(rec.seq, 4);
+        let tail = log.poll(3).expect("poll retained");
+        assert_eq!(tail.len(), 2);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Age pressure via the deterministic `apply_retention_at`: with `now` before every
+    /// record's cutoff nothing is dropped; with `now` far in the future every non-active
+    /// segment is dropped. A flipped age comparison turns the first phase red (everything
+    /// would be "stale" at now=0); ignoring `max_age` entirely turns the second phase red.
+    #[test]
+    fn age_retention_drops_only_stale_segments() {
+        let tmp = scratch("age");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, _ring, _g) = one_record_segments(&tmp, 3); // segs 0..2, active = 2
+        let policy = RetentionPolicy {
+            max_age: Some(Duration::from_nanos(1_000)),
+            ..Default::default()
+        };
+
+        // now = 0: no record can be 1000ns old yet (timestamps are real wall-clock nanos).
+        let report = log.apply_retention_at(&policy, 0).expect("young");
+        assert_eq!(report.segments_dropped, 0, "nothing is stale at now=0");
+
+        // now = far future: every non-active segment's newest record is long stale.
+        let report = log.apply_retention_at(&policy, u128::MAX).expect("stale");
+        assert_eq!(report.segments_dropped, 2);
+        assert_eq!(log.first_seq(), 2);
+        assert_eq!(
+            segment_files(&tmp).expect("list").len(),
+            1,
+            "the active segment is kept even when stale"
+        );
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// The ack watermark BOUNDS size pressure: a zero byte budget wants everything gone,
+    /// but only the fully-acked prefix may go. A regression that let a pressure criterion
+    /// bypass the ack safety bound would drop 2 segments here instead of 1.
+    #[test]
+    fn ack_bounds_size_pressure() {
+        let tmp = scratch("ackbound");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, _ring, _g) = one_record_segments(&tmp, 3); // segs 0..2, active = 2
+        let report = log
+            .apply_retention(&RetentionPolicy {
+                max_total_bytes: Some(0),
+                acked_through_seq: Some(0),
+                ..Default::default()
+            })
+            .expect("bounded");
+        assert_eq!(report.segments_dropped, 1, "only the acked seg 0 may go");
+        assert_eq!(log.first_seq(), 1);
+        assert_eq!(segment_files(&tmp).expect("list").len(), 2);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// Polling from a trimmed-away offset FAILS CLOSED (never a silent skip), on the
+    /// trimming handle AND on a separate reader handle over the same directory. A
+    /// regression that made `poll` silently start at the trim horizon would return Ok
+    /// here and turn both phases red.
+    #[test]
+    fn poll_before_trim_horizon_fails_closed() {
+        let tmp = scratch("horizon");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, _ring, _g) = one_record_segments(&tmp, 4);
+        log.apply_retention(&RetentionPolicy {
+            acked_through_seq: Some(1),
+            ..Default::default()
+        })
+        .expect("trim");
+        assert_eq!(log.first_seq(), 2);
+
+        let err = err_of(log.poll(0));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+        let err = err_of(log.poll(1));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+        // The horizon itself and everything after it still replay.
+        assert_eq!(log.poll(2).expect("poll horizon").len(), 2);
+
+        // A SEPARATE reader handle observes the same fail-closed horizon from disk.
+        let reader = ChangeLog::open(&tmp).expect("reader");
+        let err = err_of(reader.poll(0));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+        assert_eq!(reader.poll(2).expect("reader poll").len(), 2);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    /// A trimmed log REOPENS correctly: `open` recovers the trim horizon from the segment
+    /// filenames, resumes the seq/generation counters, replays the retained tail, and
+    /// extends the stream. A regression that kept `open`'s seq validation anchored at 0
+    /// (instead of the oldest retained segment) would reject the trimmed log outright.
+    #[test]
+    fn reopen_after_retention_resumes_and_extends() {
+        let tmp = scratch("reopen");
+        let _ = fs::remove_dir_all(&tmp);
+        let (mut log, ring, g5) = one_record_segments(&tmp, 5);
+        log.apply_retention(&RetentionPolicy {
+            acked_through_seq: Some(2),
+            ..Default::default()
+        })
+        .expect("trim");
+        drop(log); // restart
+
+        let mut reopened = ChangeLog::open(&tmp).expect("reopen trimmed log");
+        assert_eq!(reopened.first_seq(), 3, "trim horizon recovered from disk");
+        assert_eq!(reopened.next_seq(), 5, "seq counter resumed");
+        assert_eq!(reopened.last_generation(), Some(5));
+        let tail = reopened.poll(3).expect("replay retained tail");
+        assert_eq!(tail.len(), 2);
+        assert_eq!((tail[0].seq, tail[1].seq), (3, 4));
+
+        // The stream extends past the restart.
+        let g6 = ring.publish(
+            graph_with("<http://ex/s9> <http://ex/p> <http://ex/o9> .\n"),
+            [],
+        );
+        let rec = reopened.record_commit(&g5, &g6).expect("extend");
+        assert_eq!(rec.seq, 5);
+        assert_eq!(reopened.poll(3).expect("poll").len(), 3);
         let _ = fs::remove_dir_all(&tmp);
     }
 }

--- a/crates/sparq-serve/src/lib.rs
+++ b/crates/sparq-serve/src/lib.rs
@@ -100,10 +100,13 @@ pub use backup_delta::{
 // the read-back forms; `ChangeLogConfig` tunes segment size + fsync; `SEGMENT_MAGIC` is the
 // distinguishing magic line. `BackupError` (re-exported here too so a change-stream-only
 // consumer can name the error type) is the shared fail-closed error of the backup family.
+// [FABLE-5] (sq-n9s4d) `RetentionPolicy`/`RetentionReport` are the retention/truncation
+// surface: `ChangeLog::apply_retention` drops whole old segments by consumer-ack (hard
+// safety bound) / age / total-size pressure; `ChangeLog::first_seq` is the trim horizon.
 #[cfg(feature = "change-stream")]
 pub use change_stream::{
-    Change, ChangeLog, ChangeLogConfig, ChangeOp, ChangeRecord, DEFAULT_SEGMENT_TARGET_BYTES,
-    SEGMENT_MAGIC,
+    Change, ChangeLog, ChangeLogConfig, ChangeOp, ChangeRecord, RetentionPolicy,
+    RetentionReport, DEFAULT_SEGMENT_TARGET_BYTES, SEGMENT_MAGIC,
 };
 #[cfg(all(feature = "change-stream", not(feature = "backup")))]
 pub use backup::BackupError;

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -712,7 +712,13 @@ next seq) — a raw durable cross-service feed (replication / live downstream in
 distinct from the *ephemeral* in-process WebSocket/SSE subscriptions (a disconnect misses every
 change). Same N-Quads same-lineage quad-set diff + fail-closed FNV-1a digest as the backup family
 (no new dependency; no HTTP/async in the library). At-rest encryption + authenticity are out of
-scope, same as the backup family. A `ChangeSink` trait for an external broker (Kafka/NATS) is
+scope, same as the backup family. **Retention/truncation (`sq-n9s4d`)**: `ChangeLog::apply_retention`
+(and the deterministic `apply_retention_at`) drops whole OLD segments — oldest-first, never the
+active segment, never a partial segment — under a `RetentionPolicy` composing a consumer-ack
+watermark (a HARD safety bound: any unacked record keeps its segment), `max_age`, and
+`max_total_bytes` pressure; the default policy is a no-op and nothing is ever dropped implicitly.
+A `poll` from a trimmed-away offset **fails closed** (never a silent skip) — consumers resume from
+`ChangeLog::first_seq`. A `ChangeSink` trait for an external broker (Kafka/NATS) is
 tracked as a **separate later opt-in** (deferred follow-up bead `sq-l6zks`).
 
 **`GET /streams` — CDC poll endpoint (`sparq-server` feature `change-stream`, default OFF;


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — bead `sq-n9s4d`. Implemented + verified end-to-end; **not self-armed** (merge-coordinator merges).

## What

Adds the deferred **retention/truncation policy** to the opt-in `change-stream` feature's durable CDC log (`sparq-serve`, default OFF — the feature-off build is untouched, the module is `cfg`-stripped):

- **`ChangeLog::apply_retention(&RetentionPolicy)`** (+ **`apply_retention_at`**, the deterministic explicit-`now` core) drops **whole OLD segments** — oldest-first, **never the active segment, never a partial segment** (prefix rule: the retained stream stays gapless).
- **`RetentionPolicy`** composes the three criteria from the bead (*drop old segments by age/size/consumer-ack*):
  - `acked_through_seq` — **hard safety bound**: a segment holding any unacked record is never dropped (nor is anything after it); ack-only policies drop every fully-acked prefix segment;
  - `max_age` — pressure: droppable when the segment's **newest** record is older than the age;
  - `max_total_bytes` — pressure: drop oldest while the log's total on-disk size exceeds the budget.
  - The default policy (all `None`) is a **no-op** — nothing is ever dropped implicitly; retention is explicit (the host decides when to call it).
- **Trim-aware recovery + fail-closed poll**: `open` recovers the trim horizon from the segment filenames (seq validation is no longer anchored at 0), `first_seq()` exposes the horizon, and a `poll` from a trimmed-away offset **fails closed** (`BackupError::Format`) instead of silently skipping dropped records — consistent with the module's fail-closed contract; consumers resume from `first_seq()`.
- `RetentionReport` returns what a pass actually dropped (segments/bytes/new horizon).

Docs: module docs + `skills/http-server/SKILL.md` CDC paragraph + the crate README bullet (still exactly 120 lines, template-clean).

## Non-regression / behaviour notes

- **No behaviour change for existing users**: nothing in-tree calls `apply_retention` yet, and an untrimmed log has horizon 0, so every existing `poll` path (including `sparq-server`'s `/streams` `TRIM_HORIZON` = `poll(0)`) behaves identically. Wiring the server's `TRIM_HORIZON` to `first_seq()` for trimmed logs is follow-up bead **sq-iz7ag** (sparq-server is occupied by other in-flight work).
- `poll` API signature unchanged; new public surface is additive (`RetentionPolicy`, `RetentionReport`, `apply_retention`, `apply_retention_at`, `first_seq`, `RetentionPolicy::is_noop`) — each has a direct unit test.

## Tests (8 new, all mutation-witnessed)

Non-vacuity verified by actual mutations run locally:
- removing the ack safety-bound check → `ack_retention_drops_fully_acked_prefix`, `ack_never_drops_partially_acked_segment`, `ack_bounds_size_pressure` all go RED;
- disabling the trimmed-offset fail-closed guard in `read_from` → `poll_before_trim_horizon_fails_closed` goes RED.

Coverage includes: no-op default, pure-ack prefix drop + byte accounting vs real file sizes, half-acked segment survival (sub-segment ack granularity), size-budget partial + zero-budget (active-segment survival + appends continue), deterministic age at `now=0`/far-future, ack bounding size pressure, fail-closed trimmed poll on both the trimming handle and a separate reader handle, and reopen-after-trim resume + extend.

## Gates (all green locally)

- `cargo test -p sparq-serve` — feature OFF ✅ and `--features change-stream` (32 tests) ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅ and `-p sparq-serve --all-targets --features change-stream` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` ✅
- `scripts/check-readme-template.py` — 0 deviations ✅; `scripts/check-no-perf-numbers.py` — 0 findings ✅

Closes sq-n9s4d. Follow-up: sq-iz7ag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)