### PR TITLE
perf(site): halve most routes' first-load JS — tree-shake the radix-ui barrel + keep the benchmark snapshot server-only (sq-qgkwy.1)

### DIFF
--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -44,6 +44,16 @@ const nextConfig: NextConfig = {
   trailingSlash: true,
   // Static export cannot run the Next.js image optimiser.
   images: { unoptimized: true },
+  // [FABLE-5] sq-qgkwy.1 — tree-shake the MONOLITHIC `radix-ui` barrel. The site imports a
+  // handful of primitives (Slot, Dialog, Tooltip, …) via `import { X } from "radix-ui"`, but
+  // webpack does not shake the package's namespace re-export barrel: the ENTIRE primitive set
+  // (Select, Menu, NavigationMenu, ScrollArea, Toast, Slider, Form, Menubar, …) was bundled
+  // into a ~170 KB raw commons chunk shipped on almost every route's first load (measured via
+  // source-map attribution — see PR). `optimizePackageImports` rewrites the barrel imports to
+  // direct per-primitive imports at compile time, so only primitives actually used are bundled.
+  // Purely mechanical (same symbols, same behaviour); lucide-react is already on Next's
+  // built-in default list, radix-ui (the monolith) is not.
+  experimental: { optimizePackageImports: ["radix-ui"] },
   // [FABLE-5] sq-ymr2e.10 — the visual-regression suite (SPARQ_VR=1, set only by scripts/vr.sh
   // inside the pinned Playwright container) screenshots pages served by `next dev`, and the dev
   // indicator badge would otherwise appear in — and destabilise — every baseline. Scoped to the

--- a/site/scripts/check-bundle.mjs
+++ b/site/scripts/check-bundle.mjs
@@ -27,7 +27,7 @@
 //      (routes-manifest.basePath, images-manifest), so the check adapts to BOTH build modes
 //      (the default `/sparq` sub-path and the `NEXT_PUBLIC_BASE_PATH=''` root-relative export).
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -194,9 +194,50 @@ export function analyzeBundle({ loadable, app, routes, images, htmlByLabel }) {
   return { errors, summary: { basePath, unoptimized, heavyReport, routeReport } };
 }
 
+/**
+ * [FABLE-5] sq-qgkwy.1 — 4. DATA ISOLATION: the ~1.3 MB benchmark snapshot
+ * (src/data/benchmarks.generated.json) is SERVER-ONLY. It renders into the prerendered
+ * HTML/RSC payload; no emitted client JS chunk may embed it. A "use client" module (or
+ * anything transitively imported by one — the subtle case: metric-table.tsx has no
+ * directive yet is client-bundled via suite-group) importing a VALUE from
+ * src/data/benchmarks.ts folds the whole snapshot into a chunk — that double-shipped
+ * /benchmarks/[type]'s data as a ~762 KB raw first-load page chunk on top of the already
+ * prerendered HTML. Client code imports display helpers from src/lib/fmt-num.ts instead.
+ *
+ * Detection is by FINGERPRINT, not size threshold: `latest.commit` from the snapshot is a
+ * full commit sha — long, unique, and by construction present in any chunk that embeds the
+ * JSON. Pure (fs-free) for unit-testing; main() supplies the chunk texts.
+ *
+ * @param {string} fingerprint          distinctive string from the server-only snapshot
+ * @param {Array<{file: string, text: string}>} chunks  emitted client JS chunks
+ * @returns {string[]} offending chunk file names
+ */
+export function findSnapshotLeaks(fingerprint, chunks) {
+  if (!fingerprint || fingerprint.length < 8) {
+    throw new Error(
+      `DATA-ISOLATION: unusable snapshot fingerprint ${JSON.stringify(fingerprint)} — ` +
+        `did benchmarks.generated.json lose latest.commit?`,
+    );
+  }
+  return chunks.filter((c) => c.text.includes(fingerprint)).map((c) => c.file);
+}
+
 /** Read + JSON-parse a build manifest, or return null if it does not exist. */
 function readJson(path) {
   return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : null;
+}
+
+/** Every emitted client JS chunk under .next/static/chunks, recursively. */
+function readClientChunks(dir, prefix = "") {
+  const chunks = [];
+  if (!existsSync(dir)) return chunks;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) chunks.push(...readClientChunks(join(dir, entry.name), rel));
+    else if (entry.name.endsWith(".js"))
+      chunks.push({ file: rel, text: readFileSync(join(dir, entry.name), "utf8") });
+  }
+  return chunks;
 }
 
 function main() {
@@ -224,12 +265,33 @@ function main() {
 
   const { errors, summary } = analyzeBundle({ loadable, app, routes, images, htmlByLabel });
 
+  // 4. DATA ISOLATION — the server-only benchmark snapshot must not appear in ANY client chunk.
+  const snapshot = readJson(join(siteRoot, "src", "data", "benchmarks.generated.json"));
+  const fingerprint = snapshot?.latest?.commit;
+  let leakReport = "skipped (no snapshot)";
+  if (snapshot) {
+    const leaked = findSnapshotLeaks(
+      fingerprint,
+      readClientChunks(join(nextDir, "static", "chunks")),
+    );
+    for (const file of leaked) {
+      errors.push(
+        `DATA-ISOLATION: client chunk ${file} embeds the server-only benchmark snapshot ` +
+          `(fingerprint: latest.commit ${fingerprint}). A client-bundled module imports a ` +
+          `VALUE from src/data/benchmarks.ts — import display helpers from ` +
+          `"@/lib/fmt-num" instead (see that file's header).`,
+      );
+    }
+    leakReport = leaked.length === 0 ? "no client chunk embeds it" : `${leaked.length} LEAK(S)`;
+  }
+
   console.log("[check-bundle] wasm-free main-bundle guard (sq-vw3ax.9)");
   console.log(`  basePath (resolved): "${summary.basePath}"   images.unoptimized: ${summary.unoptimized}`);
   console.log("  heavy modules kept code-split (lazy on expand):");
   for (const line of summary.heavyReport) console.log(`    - ${line}`);
   console.log("  guarded route first-load payloads:");
   for (const line of summary.routeReport) console.log(`    - ${line}`);
+  console.log(`  server-only benchmark snapshot: ${leakReport}`);
 
   if (errors.length > 0) {
     console.error(`\n[check-bundle] FAIL — ${errors.length} problem(s):`);
@@ -239,7 +301,8 @@ function main() {
 
   console.log(
     "\n[check-bundle] PASS — no engine wasm / ZK prover / demo / lazy-codec chunk in any " +
-      "guarded route's first-load bundle; basePath + images.unoptimized preserved.",
+      "guarded route's first-load bundle; server-only benchmark snapshot in no client chunk; " +
+      "basePath + images.unoptimized preserved.",
   );
 }
 

--- a/site/src/components/benchmarks/http-panel-table.tsx
+++ b/site/src/components/benchmarks/http-panel-table.tsx
@@ -18,11 +18,11 @@
 import * as React from "react";
 
 import { Badge } from "@/components/ui/badge";
-import {
-  fmtNum,
-  type CompetitiveSummary,
-  type SameBoxComparison,
-  type SameBoxRow,
+import { fmtNum } from "@/lib/fmt-num";
+import type {
+  CompetitiveSummary,
+  SameBoxComparison,
+  SameBoxRow,
 } from "@/data/benchmarks";
 
 type Regime = "keep-alive" | "fresh-connect";

--- a/site/src/components/benchmarks/metric-table.tsx
+++ b/site/src/components/benchmarks/metric-table.tsx
@@ -1,7 +1,8 @@
 // [OPUS-4.8] sq-vjn4 — the per-suite metrics table (sparq absolute numbers, smaller is
 // better). Pure presentational; no fabricated competitor columns — same-box competitor
 // numbers are surfaced via the same-box table + the live summary, references separately.
-import { fmtNum, type MetricRow } from "@/data/benchmarks";
+import { fmtNum } from "@/lib/fmt-num";
+import type { MetricRow } from "@/data/benchmarks";
 
 export function MetricTable({ rows }: { rows: MetricRow[] }) {
   return (

--- a/site/src/components/benchmarks/references-note.tsx
+++ b/site/src/components/benchmarks/references-note.tsx
@@ -2,7 +2,8 @@
 // cited competitor numbers at their OWN scale/machine (e.g. QLever on a 2020 M1, EYE
 // DeepTaxonomy on an M1) — shown SEPARATELY and CLEARLY LABELLED, never divided into a
 // same-box speedup. A null value renders "n/a (not gathered)".
-import { fmtNum, type ReferenceBaseline } from "@/data/benchmarks";
+import { fmtNum } from "@/lib/fmt-num";
+import type { ReferenceBaseline } from "@/data/benchmarks";
 
 export function ReferencesNote({ references }: { references: ReferenceBaseline[] }) {
   if (references.length === 0) return null;

--- a/site/src/components/benchmarks/same-box-table.tsx
+++ b/site/src/components/benchmarks/same-box-table.tsx
@@ -5,7 +5,8 @@
 //   * a whole-engine failure (e.g. Fuseki load timeout) renders "failed", never blank;
 //   * per-query solution COUNT cross-check (✓ agree / DIFF) is shown;
 //   * canonical vs non-canonical provenance (host / scale / commit) is labelled.
-import { fmtNum, type SameBoxComparison } from "@/data/benchmarks";
+import { fmtNum } from "@/lib/fmt-num";
+import type { SameBoxComparison } from "@/data/benchmarks";
 
 export function SameBoxTable({ comparison }: { comparison: SameBoxComparison }) {
   const engines = comparison.engines;

--- a/site/src/components/benchmarks/scaling-charts.tsx
+++ b/site/src/components/benchmarks/scaling-charts.tsx
@@ -13,7 +13,8 @@ import { ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 import { LineChart, type ChartPoint } from "@/components/benchmarks/line-chart";
-import { fmtNum, type ScalingFamily } from "@/data/benchmarks";
+import { fmtNum } from "@/lib/fmt-num";
+import type { ScalingFamily } from "@/data/benchmarks";
 
 const CHART_VARS = ["--chart-2", "--chart-4", "--chart-1", "--chart-5", "--chart-3"];
 

--- a/site/src/data/benchmarks.ts
+++ b/site/src/data/benchmarks.ts
@@ -841,14 +841,12 @@ export function sameBoxComparison(suite: string): SameBoxComparison | undefined 
 }
 
 // Number-formatter matching dashboard.js fmtNum (no fabrication, just display).
-export function fmtNum(v: number | null | undefined): string {
-  if (v == null) return "—";
-  if (v === 0) return "0";
-  const abs = Math.abs(v);
-  if (abs >= 1000) return v.toLocaleString("en-US", { maximumFractionDigits: 0 });
-  if (abs >= 1) return (Math.round(v * 100) / 100).toLocaleString("en-US");
-  return (Math.round(v * 10000) / 10000).toString();
-}
+// [FABLE-5] sq-qgkwy.1 — moved to src/lib/fmt-num.ts and RE-EXPORTED here for server-side
+// callers only. "use client" components must import it from "@/lib/fmt-num" directly:
+// importing any VALUE from THIS module drags the full ~1.3 MB generated snapshot into the
+// browser bundle (it double-shipped /benchmarks/[type]'s data as a ~762 KB raw page chunk
+// on top of the prerendered HTML). Guarded by test/benchmarks-data-server-only.test.mjs.
+export { fmtNum } from "@/lib/fmt-num";
 
 // ---- TREND series (sq-hsyg; mirror of dashboard.js trendPoints) -----------------------
 // Per-metric history points {date, value} across the committed window, oldest → newest.

--- a/site/src/lib/fmt-num.ts
+++ b/site/src/lib/fmt-num.ts
@@ -1,0 +1,20 @@
+// [FABLE-5] sq-qgkwy.1 — the benchmark number-formatter, in its OWN dependency-free module.
+//
+// It used to live in src/data/benchmarks.ts, but that module imports the full
+// benchmarks.generated.json snapshot (~1.3 MB raw). Client components ("use client":
+// metric-table, same-box-table, http-panel-table, references-note, scaling-charts) imported
+// the VALUE `fmtNum` from there, which pulled the entire snapshot into the browser bundle —
+// /benchmarks/[type]'s first-load page chunk was ~762 KB raw (~72 kB gz) of mostly JSON the
+// server component had ALREADY rendered into the static HTML (double-shipped). Client code
+// must import `fmtNum` from HERE; server-side code may keep using the re-export in
+// src/data/benchmarks.ts. Guarded by test/benchmarks-data-server-only.test.mjs.
+//
+// Matches dashboard.js fmtNum (no fabrication, just display).
+export function fmtNum(v: number | null | undefined): string {
+  if (v == null) return "—";
+  if (v === 0) return "0";
+  const abs = Math.abs(v);
+  if (abs >= 1000) return v.toLocaleString("en-US", { maximumFractionDigits: 0 });
+  if (abs >= 1) return (Math.round(v * 100) / 100).toLocaleString("en-US");
+  return (Math.round(v * 10000) / 10000).toString();
+}

--- a/site/test/benchmarks-data-server-only.test.mjs
+++ b/site/test/benchmarks-data-server-only.test.mjs
@@ -1,0 +1,58 @@
+// [FABLE-5] sq-qgkwy.1 — unit tests for the DATA-ISOLATION invariant of the bundle guard
+// (scripts/check-bundle.mjs `findSnapshotLeaks`): the ~1.3 MB benchmark snapshot
+// (src/data/benchmarks.generated.json) is SERVER-ONLY — it reaches the browser only as
+// prerendered HTML/RSC, never embedded in a client JS chunk. Before this bead, client-bundled
+// modules (metric-table & co., pulled in by the "use client" suite-group) imported the VALUE
+// `fmtNum` from src/data/benchmarks.ts, folding the whole snapshot into /benchmarks/[type]'s
+// first-load page chunk (~762 KB raw) on top of the already-prerendered HTML.
+//
+// A source-level "use client" scan is NOT sufficient — the leak came from modules with no
+// directive at all, client-bundled transitively — so the guard fingerprints the BUILT chunks:
+// `latest.commit` (a full commit sha) is by construction embedded in any chunk that inlines
+// the JSON. These tests feed synthetic chunks; `npm run check:bundle` / postbuild runs the
+// same function against the real .next artifacts.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { findSnapshotLeaks } from "../scripts/check-bundle.mjs";
+
+const SHA = "0123456789abcdef0123456789abcdef01234567";
+
+test("clean chunks pass", () => {
+  const chunks = [
+    { file: "static/chunks/3131-aa.js", text: "self.webpackChunk=[]" },
+    { file: "static/chunks/app/benchmarks/[type]/page-bb.js", text: "render(tables)" },
+  ];
+  assert.deepEqual(findSnapshotLeaks(SHA, chunks), []);
+});
+
+test("a chunk embedding the snapshot is flagged (the real pre-fix regression shape)", () => {
+  // A minified chunk inlining the JSON carries the latest.commit sha as a string literal.
+  const chunks = [
+    { file: "static/chunks/3131-aa.js", text: "self.webpackChunk=[]" },
+    {
+      file: "static/chunks/app/benchmarks/[type]/page-bb.js",
+      text: `JSON.parse('{"latest":{"commit":"${SHA}","benches":[]}}')`,
+    },
+  ];
+  assert.deepEqual(findSnapshotLeaks(SHA, chunks), [
+    "static/chunks/app/benchmarks/[type]/page-bb.js",
+  ]);
+});
+
+test("every offending chunk is reported, not just the first", () => {
+  const chunks = [
+    { file: "a.js", text: `x="${SHA}"` },
+    { file: "b.js", text: "clean" },
+    { file: "c.js", text: `y="${SHA}"` },
+  ];
+  assert.deepEqual(findSnapshotLeaks(SHA, chunks), ["a.js", "c.js"]);
+});
+
+test("an unusable fingerprint is a loud error, never a silent pass", () => {
+  // If benchmarks.generated.json ever loses latest.commit, the guard must fail closed —
+  // a missing/short fingerprint would otherwise make the scan vacuously green.
+  for (const bad of [undefined, null, "", "abc1234"]) {
+    assert.throws(() => findSnapshotLeaks(bad, [{ file: "a.js", text: "x" }]), /fingerprint/);
+  }
+});


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — implements bead **sq-qgkwy.1** (epic sq-qgkwy, website performance optimisation). Measurement-first; zero behaviour change intended. **Not self-armed** — the merge-coordinator merges.

## What was found (source-map attribution over the static export)

1. **The monolithic `radix-ui` barrel was not tree-shaken.** The site imports only `Slot`, `Dialog`, `Tooltip` from `radix-ui`, but webpack bundled the ENTIRE primitive set — Select, Menu, NavigationMenu, ScrollArea, Toast, Slider, OTP field, Form, Menubar, ContextMenu, DropdownMenu, Popover… — into a ~170 KB raw commons chunk (`3507-*`) shipped on nearly every route's first load.
2. **The ~1.3 MB benchmark snapshot double-shipped to the client.** Benchmark table/chart components (client-bundled *transitively* via the `"use client"` suite-group — most have no directive themselves) imported the **value** `fmtNum` from `src/data/benchmarks.ts`, which imports `benchmarks.generated.json`. That folded the whole snapshot into `/benchmarks/[type]`'s first-load page chunk (~762 KB raw / ~72 kB gz) **on top of the same data already prerendered into the static HTML**.

## Fixes (both mechanical, no behaviour change)

- `next.config.ts`: `experimental.optimizePackageImports: ["radix-ui"]` — compile-time rewrite of barrel imports to per-primitive imports; only primitives actually used are bundled. (lucide-react is already on Next's built-in default list; the radix-ui monolith is not — **upstream bead sq-w728o** filed to propose it upstream per the upstream-contribution protocol.)
- `fmtNum` moved to dependency-free `src/lib/fmt-num.ts`; `src/data/benchmarks.ts` re-exports it for server-side callers; the five client-graph importers now import from the lib module. The snapshot stays server-only (HTML/RSC).

## Measured before → after

**Next route table (first-load JS, gz):**

| route | before | after |
|---|---|---|
| most content routes (`/papers`, `/specs`, `/surface/sparql`, …) | 178 kB | **106 kB** |
| `/` | 189 kB | **117 kB** |
| `/benchmarks/[type]` | 258 kB | **123 kB** |
| `/capabilities` | 199 kB | **128 kB** |
| `/showcase/zk-car-hire` | 215 kB | **144 kB** |

**Real transfer (every `<script>` referenced by the exported HTML, incl. layout + polyfills, gz — measured on this box from the build artifacts):**

| route | before | after | Δ |
|---|---|---|---|
| `/` | 251.2 K | 203.8 K | −18.9 % |
| `/capabilities` | 255.4 K | 208.0 K | −18.6 % |
| `/papers` | 249.0 K | 201.6 K | −19.0 % |
| `/benchmarks/sparql` | 321.5 K (1580.7 K raw) | 212.5 K (677.7 K raw) | −33.9 % gz / −57 % raw |
| `/surface/sparql` | 249.0 K | 201.6 K | −19.0 % |
| `/showcase/zk-car-hire` | 267.3 K | 220.8 K | −17.4 % |
| `/about` | 202.5 K | 202.1 K | −0.2 % |
| `/download` | 210.6 K | 210.2 K | −0.2 % |

No sampled route regressed. (Byte counts are build-artifact facts — deterministic per build — not wall-clock timings; nothing here is a canonical performance number.)

## The other two levers (assessed honestly)

- **Cacheability:** assets are already content-hashed immutable URLs; **28 shared chunks (framework, Next runtime, polyfills, every lazy demo chunk, bb.js/noir-js) keep byte-identical hashes across the baseline → optimised builds**, so unchanged code keeps caching across deploys. GitHub Pages does not allow custom `Cache-Control` (platform constraint — it serves `max-age=600` + ETag revalidation); nothing further is actionable there.
- **Parallelise:** the exported HTML already loads all chunks `async` in head, the Inter woff2 is preloaded, the polyfills chunk is `noModule` (modern browsers skip it), and `next/link` prefetches on viewport. No waterfall found to fix; the hero-runner/demo chunks intentionally load post-paint (sq-vw3ax.9 guard).

## Guard hardening

`scripts/check-bundle.mjs` gains **invariant 4 — DATA ISOLATION**: no emitted client chunk may embed the server-only benchmark snapshot (fingerprint = `latest.commit`, a full sha that is by construction inside any chunk inlining the JSON; fails closed if the fingerprint ever goes missing). A source-level `"use client"` scan is provably insufficient — the regression came from modules with no directive, client-bundled transitively. Unit tests: `test/benchmarks-data-server-only.test.mjs` (incl. the fail-closed case; the leak shape is exercised synthetically).

## Zero-regression proof

- `npm run build` (static export) ✅ — incl. `postbuild` `check-bundle` **PASS** (all prior invariants intact + new data-isolation line: "server-only benchmark snapshot: no client chunk embeds it")
- `npm run lint` ✅ · `tsc --noEmit` ✅
- unit: **334/334** ✅ · e2e (chromium, per-PR lane): **124/124** ✅
- visual-regression (pinned container, this box): 7/9 — the 2 home-first-fold shots differ by 9–12 px in the stat-band digit **identically on the pre-change control run** (same tests, same magnitude, with my diff fully reverted), i.e. pre-existing/environmental in this worktree, not introduced by this PR. CI's hermetic `site-visual` lane adjudicates.

## Upstream

Root cause 1 is framework-level: Next's default `optimizePackageImports` list lacks the `radix-ui` monolith that shadcn/ui now recommends. Beaded as **sq-w728o** (minimal draft PR upstream per protocol, @jeswr to review first) rather than worked around silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)