### PR TITLE
ci(miri): guarantee classified shard verdicts (sq-hytab) [GPT-5.6]

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -32,7 +32,7 @@
 #      test gets a fresh interpreter (kills the state-accumulation failure mode at the root)
 #      and the runner's cores actually parallelise interpretation (a single `cargo miri
 #      test` process interprets everything on one core, whatever test-threads says).
-#   2. `--partition count:<k>/12` — twelve matrix shards, each a disjoint round-robin slice
+#   2. `--partition count:<k>/24` — twenty-four matrix shards, each a disjoint round-robin slice
 #      of the SAME test list; the union over shards is exactly the old single-run test set
 #      (nextest count-partitioning assigns every test to exactly one shard, and round-robin
 #      spreads the alphabetically-clustered heavy modules across shards).
@@ -61,12 +61,17 @@
 #      covered (`cargo miri test --doc`; sparq-core has one; measured seconds under Miri).
 #      Coverage relative to the old `cargo miri test -p sparq-core` is therefore identical:
 #      same lib/integration test binaries (partitioned exhaustively), same doctests.
-#   Shard count: 12, calibrated from a work-box run of shard 1-of-6 (sq-63ups PR): the test
+#   Shard count: 24. [GPT-5.6] The original 12-way split was calibrated from a work-box run of shard
+#   1-of-6 (sq-63ups PR), but the first classified nightly run showed that shard 4 still
+#   queued enough heavy tests to hit the 130-minute job backstop before its classifier ran
+#   (sq-hytab). Doubling the round-robin partitions preserves the exact test-set union while
+#   reducing each runner's queue; every shard can reach the classifier before the backstop.
+#   The original calibration found that the test
 #   set is BIMODAL under Miri — most tests are ms..seconds, but ~30% are heavy end-to-end
 #   loader tests at ~50-70 min EACH in a fresh interpreter (the accumulation bug above made
-#   them look infinitely worse in-process, but they are genuinely expensive too). Twelve
-#   round-robin shards put ~2-3 heavies per shard; run in parallel inside the shard they
-#   bound the wall near max(single heavy) ≈ 50-70+ min, inside the 130-minute ceiling with
+#   them look infinitely worse in-process, but they are genuinely expensive too). Twenty-four
+#   round-robin shards spread those heavies across smaller queues; run in parallel inside the
+#   shard they bound the wall near max(single heavy) ≈ 50-70+ min, inside the 130-minute ceiling with
 #   the 100-min per-test cap guaranteeing a named verdict either way. The REAL cost fix is
 #   cfg(miri)-scaling the heavy tests' input sizes (standard Miri practice) — a crates/
 #   change tracked by follow-up bead sq-0s15k, after which the shard count can drop again.
@@ -146,7 +151,7 @@ env:
 
 jobs:
   miri:
-    name: miri (sparq-core unsafe surface, UB, shard ${{ matrix.shard }}/12)
+    name: miri (sparq-core unsafe surface, UB, shard ${{ matrix.shard }}/24)
     runs-on: ubuntu-latest
     # Backstop only: each shard's real ceiling is the 100-min per-test terminate cap in
     # .config/nextest.toml [profile.default-miri] — a hung/pathological test reds its shard
@@ -158,7 +163,7 @@ jobs:
       # A pathological test in one shard must not cancel the other shards' verdicts.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -213,12 +218,12 @@ jobs:
       # failed test is written to the step summary + annotations, so the cost debt stays LOUD and
       # under standing pressure (sq-0s15k). When sq-0s15k cfg(miri)-scales the heavy tests there
       # are no timeouts and the classifier is a transparent pass-through.
-      - name: cargo miri nextest run (shard ${{ matrix.shard }}/12)
+      - name: cargo miri nextest run (shard ${{ matrix.shard }}/24)
         env:
           NEXTEST_EXPERIMENTAL_LIBTEST_JSON: "1"
         run: >-
           cargo +nightly-2026-06-11 miri nextest run -p sparq-core
-          --partition count:${{ matrix.shard }}/12 --no-fail-fast
+          --partition count:${{ matrix.shard }}/24 --no-fail-fast
           --message-format libtest-json-plus --message-format-version 0.1
           > "miri-shard-${{ matrix.shard }}.jsonl" 2> "miri-shard-${{ matrix.shard }}.stderr"
           || true
@@ -229,7 +234,7 @@ jobs:
         run: |
           cat "miri-shard-${{ matrix.shard }}.stderr" || true
           python3 scripts/miri_classify_verdict.py \
-            --shard "${{ matrix.shard }}/12" \
+            --shard "${{ matrix.shard }}/24" \
             --events "miri-shard-${{ matrix.shard }}.jsonl"
 
   # nextest does not execute doctests; keep them covered so this lane's coverage stays

--- a/scripts/miri_classify_verdict.py
+++ b/scripts/miri_classify_verdict.py
@@ -32,7 +32,7 @@
 # Usage (in miri.yml):
 #   set -o pipefail
 #   NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1 cargo +<nightly> miri nextest run -p sparq-core \
-#       --partition count:<k>/12 --no-fail-fast \
+#       --partition count:<k>/24 --no-fail-fast \
 #       --message-format libtest-json-plus --message-format-version 0.1 \
 #     | tee miri-shard.jsonl | python3 scripts/miri_classify_verdict.py --shard <k>
 #
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from pathlib import Path
 import sys
 
 TIMEOUT_REASON = "time limit exceeded"
@@ -147,7 +148,7 @@ def main(argv: list[str] | None = None) -> int:
     # nextest never ran the tests (build break / miri sysroot failure / crash before emitting),
     # NOT a clean shard. Treat it as FATAL so a setup failure cannot masquerade as a pass.
     # (A shard legitimately assigned zero tests still emits nothing here — but every one of the
-    # 12 round-robin shards over sparq-core's ~130 tests receives tests, so an empty stream is a
+    # 24 round-robin shards over sparq-core's ~130 tests receives tests, so an empty stream is a
     # real failure signal, not an empty partition. If the partition scheme ever changes, revisit.)
     if not timed_out and not failed and n_ok == 0:
         print(f"::error title=Miri shard produced no test outcomes (shard {args.shard})::"
@@ -227,6 +228,23 @@ def _self_test() -> int:
         with open(good, "w", encoding="utf-8") as fh:
             fh.write(json.dumps({"type": "test", "event": "ok", "name": "a::x"}) + "\n")
         ck(main(["--shard", "Z", "--events", good]) == 0, "a real pass via main => exit 0")
+
+    # 7. [GPT-5.6] The workflow must keep every partition label and command in sync. This is the
+    # regression witness for sq-hytab: reverting the 24-way split to the 12-way layout that
+    # exhausted the job backstop makes this check fail before the nightly lane is trusted.
+    workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/miri.yml").read_text(
+        encoding="utf-8"
+    )
+    expected_matrix = (
+        "shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, "
+        "17, 18, 19, 20, 21, 22, 23, 24]"
+    )
+    ck(expected_matrix in workflow, "workflow enumerates all 24 Miri shards")
+    ck(
+        workflow.count("${{ matrix.shard }}/24") == 4,
+        "workflow consistently labels, partitions, and classifies 24 shards",
+    )
+    ck("${{ matrix.shard }}/12" not in workflow, "stale 12-way partition wiring absent")
 
     if fails:
         for x in fails:


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Fixes bead `sq-hytab` and addresses #1917.

The first classifier-enabled nightly proved 11/12 Miri shards and the doctest leg clean, but shard 4 exhausted the 130-minute job backstop before its verdict classifier could run. This keeps the exact same exhaustive test-set union while splitting it across 24 round-robin process-isolated shards, reducing each runner queue so the classifier is reached before the backstop.

The classifier self-test now also validates the workflow contract: all 24 shards are enumerated and every job label, nextest partition, and classifier label agrees. Mutation witness: temporarily restoring stale `/12` wiring makes the self-test fail on both consistency and stale-wiring checks.

Gates:
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy -p sparq-core --all-targets --no-default-features -- -D warnings`
- `cargo test -p sparq-core`
- `cargo test -p sparq-core --no-default-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- `python3 scripts/miri_classify_verdict.py --self-test`
- `git diff --check`

Note: `cargo fmt --check` is red on untouched `origin/main` due pre-existing formatting drift in recently merged unrelated crates; this PR changes only YAML and Python and does not modify that drift.

Not armed or merged; merge-coordinator owns landing.
