### PR TITLE
bench(dashboard): feature five comparative suites [GPT-5.6]

### DIFF
--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -2031,6 +2031,31 @@
     // like-for-like axis (query-over-HDT is a NON-goal — different data structure); the
     // hdt-cpp competitor (bench/competitors.json) is decode-only, gather-only via docker.
     { key: 'HDT',           title: 'HDT load-and-decode', aliases: ['hdt', 'snikmeta'] },
+    // [GPT-5.6] sq-g3n7h: comparative suites added in #1887/#1908/#1916/#1926/#1929.
+    // These cards deliberately say what they measure: several are correctness, quality, or size
+    // panels rather than speed claims, and their wall-clock rows remain non-canonical trends.
+    { key: 'Browser / WASM', title: 'Browser / WASM comparison',
+      aliases: ['wasm-compare', 'wasm_compare', 'wasmcompare'],
+      note: 'Bundle-SIZE and compatibility card: bundle bytes are deterministic artifact-size '
+          + 'measurements, not speed. Browser and Node latency rows are correctness-gated, '
+          + 'non-canonical trend signals.' },
+    { key: 'RDFC-1.0 canonicalization', title: 'RDFC-1.0 canonicalization',
+      aliases: ['canon-bench', 'canon_bench', 'canonbench', 'canon'],
+      note: 'Correctness and DoS-resistance card: canonical bytes must match the W3C oracle; '
+          + 'poison-graph rows report guard/cap outcomes, not speed. Sane-set timings are '
+          + 'non-canonical trend signals.' },
+    { key: 'KGE quality', title: 'KGE link-prediction quality',
+      aliases: ['kge-quality-comparison', 'kge_quality_comparison', 'kgequalitycomparison', 'kge'],
+      note: 'QUALITY card: filtered MRR and Hits@k are matched-model link-prediction quality '
+          + 'measurements, not throughput or training-speed claims.' },
+    { key: 'Graph Store Protocol', title: 'Graph Store Protocol',
+      aliases: ['gsp-bench', 'gsp_bench', 'gspbench', 'gsp'],
+      note: 'Correctness-gated protocol card: round-trip RDF content must agree before timing. '
+          + 'Loopback latency rows are non-canonical trend signals.' },
+    { key: 'Python bindings', title: 'Python binding overhead',
+      aliases: ['python-bindings-bench', 'python_bindings_bench', 'pythonbindingsbench', 'python'],
+      note: 'Correctness-gated binding-overhead card: result counts must agree before timing. '
+          + 'Binding latency rows are non-canonical trend signals.' },
     // [OPUS-4.8] sq-5o5.3: PROMOTE the ZK estate to a featured card (the maintainer treats ZK as a
     // genuine differentiator, unlike the trend-only suites). One card groups the whole estate: the
     // `zk-compose` circuit-gate counts (zk_compose_<member>_gates) + the `zk` commitment-pipeline
@@ -2073,7 +2098,8 @@
         var a = f.aliases[j];
         // label-map suite match (exact, normalised) OR a name-token prefix like `deeptax_…`.
         if (suite === a) return f;
-        if (lowerName.indexOf(a.replace(/[ -]/g, '')) === 0 ||
+        if (lowerName.indexOf(a) === 0 ||
+            lowerName.indexOf(a.replace(/[ -]/g, '')) === 0 ||
             lowerName.indexOf(a.replace(/[ -]/g, '_')) === 0) return f;
       }
     }

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -164,6 +164,25 @@ eq(D.featuredSuiteOf('vectors_hnsw_recall_at10') && D.featuredSuiteOf('vectors_h
    'vector ANN recall metric is featured under Vector / ANN');
 eq(D.featuredSuiteOf('vectors_diskann_query_us') && D.featuredSuiteOf('vectors_diskann_query_us').key, 'Vector / ANN',
    'vector ANN advisory-latency metric is featured under Vector / ANN');
+// [GPT-5.6] sq-g3n7h: every newly implemented comparative suite must resolve from both its
+// registry spelling and the underscore-prefixed metric spelling emitted into benchmark feeds.
+[
+  ['wasm-compare/bundle', 'Browser / WASM'],
+  ['wasm_compare_bundle_bytes', 'Browser / WASM'],
+  ['canon-bench', 'RDFC-1.0 canonicalization'],
+  ['canon_poison_guard_count', 'RDFC-1.0 canonicalization'],
+  ['kge-quality-comparison', 'KGE quality'],
+  ['kge_filtered_mrr', 'KGE quality'],
+  ['gsp-bench', 'Graph Store Protocol'],
+  ['gsp_put_p50_ms', 'Graph Store Protocol'],
+  ['python-bindings-bench', 'Python bindings'],
+  ['python_query_floor_us', 'Python bindings']
+].forEach(function (c) {
+  const suite = D.featuredSuiteOf(c[0]);
+  eq(suite && suite.key, c[1], c[0] + ' is routed to its featured comparative suite');
+  ok(suite && typeof suite.note === 'string' && suite.note.length > 0,
+     c[1] + ' carries an honesty note');
+});
 
 // buildFeatured: groups by suite, latest value per metric, competitor SEAM present.
 const featEntries = [{
@@ -173,13 +192,22 @@ const featEntries = [{
     { name: 'op_q01_bgp_count_us', value: 5, unit: 'us' },      // NOT featured
     { name: 'watdiv_sf1_S1_count_us', value: 30, unit: 'µs' },
     { name: 'lubm_q06_count_us', value: 99, unit: 'µs' },
-    { name: 'sp2b_q1_count_us', value: 50, unit: 'µs' }
+    { name: 'sp2b_q1_count_us', value: 50, unit: 'µs' },
+    { name: 'wasm_compare_bundle_bytes', value: 1, unit: 'bytes' },
+    { name: 'canon_poison_guard_count', value: 1, unit: 'count' },
+    { name: 'kge_filtered_mrr', value: 1, unit: 'ratio' },
+    { name: 'gsp_put_p50_ms', value: 1, unit: 'ms' },
+    { name: 'python_query_floor_us', value: 1, unit: 'µs' }
   ]
 }];
 const feat = D.buildFeatured(featEntries, null);
 const featSuites = feat.groups.map(function (g) { return g.suite; });
 ok(featSuites.indexOf('WatDiv') !== -1 && featSuites.indexOf('LUBM') !== -1 &&
    featSuites.indexOf('SP2Bench') !== -1, 'buildFeatured surfaces WatDiv/LUBM/SP2Bench');
+['Browser / WASM', 'RDFC-1.0 canonicalization', 'KGE quality',
+ 'Graph Store Protocol', 'Python bindings'].forEach(function (suite) {
+  ok(featSuites.indexOf(suite) !== -1, 'buildFeatured surfaces ' + suite);
+});
 ok(featSuites.indexOf('Operators') === -1 && featSuites.indexOf('Pipeline') === -1,
    'buildFeatured excludes non-featured (engine) suites');
 // the SEAM: no competitor file -> empty engine list, every row has a competitors:{} object.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements bead `sq-g3n7h`.

Adds featured dashboard cards for wasm-compare, canon, KGE, GSP, and Python bindings, with suite aliases and explicit honesty notes distinguishing artifact size, correctness/DoS resistance, quality, and non-canonical timing signals. Extends the Node dashboard smoke test to cover registry and emitted-metric spellings plus featured-view construction.

Verification:
- `node scripts/dashboard-smoke.js`
- mutation witness: removing the KGE row makes the focused routing/build assertions fail
- `python3 -m unittest scripts.tests.test_drift_scan scripts.tests.test_check_new_bench_registered`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- Rust crate test states: N/A (dashboard-only JS change; no crate or feature changed)

Closes #1936.
Closes #1935.
Closes #1922.
Closes #1914.
Closes #1894.