### PR TITLE
research: GPT-5.6 decomposition records — shared rules kernel (#1993) + workbench-parity

### DIFF
--- a/research/gpt56-decomp-rules-substrate-2026-07.md
+++ b/research/gpt56-decomp-rules-substrate-2026-07.md
@@ -1,0 +1,119 @@
+# GPT-5.6 decomposition: shared rules kernel (Datalog / N3 / RIF) — 2026-07
+
+> 🤖 **SPARQ agent** (Claude Fable 5, architect stage). Design record for the
+> de-risked decomposition of the sq-6tykl.3 rules program under the maintainer
+> direction in issue #1993. Companion record:
+> `gpt56-decomp-workbench-parity-2026-07.md`. Beads carry the per-child specs;
+> this record holds the decisions.
+
+## 1. Maintainer direction (issue #1993, 2026-07-11)
+
+1. N3 and RIF must **share the same stratification checker and evaluator** as
+   the native Datalog dialect (PR #1992, `crates/sparq-reason/src/datalog/`).
+2. N3 must be **expressive enough to be a superset** of the native dialect and
+   RIF; any construct N3 cannot express → a clear, concise issue on the
+   w3c/N3 CG repo stating what is missing and that it was discovered
+   implementing RIF/RDFox rules support.
+
+## 2. Current estate (ground facts, origin/main 517f8e54a)
+
+Three rule paths exist in `sparq-reason`, already sharing the substrate join
+kernels (`sparq_substrate::join::{build_table, hash_probe_serial}`, `Row`/`NO_ID`)
+via the same thin layout-adapter pattern — but NOT a checker or evaluator:
+
+| path | IR | checker | evaluator | extras the others lack |
+|---|---|---|---|---|
+| `datalog/` (feature `datalog`) | `DTerm/Atom/AggAtom/Rule` | **checked** `stratify.rs` (Ullman fixpoint, `Key::{Pred,Class,TypeAny}` granularity, loud rejection) | naive rounds per stratum (`eval.rs`) | NAF (single atom), `AGGREGATE COUNT`, numeric `FILTER` (substrate `Dec`) |
+| `n3/compiled.rs` (feature `compiled-rules`) | `CTerm/Step/CompiledRule` | **none** — `log:notIncludes` stratification is documented *caller discipline* (module doc lines 35–39) | **semi-naive** (`join_steps` delta positions) | builtins (`string:*`, `log:uri`, id-compare), variable predicates, multi-pattern NAF |
+| `rif.rs` + `rif_xml.rs` (features `rif-core`/`rif-xml`) | `rif::{Document,Rule,Atom,Term}` | not needed (monotone Horn) | lowers to the N3 model, runs `reason_n3` | frame/member/subclass atoms, 16 builtins (lowered to N3 `math:`/`string:`/`list:`) |
+
+Numeric seam: datalog FILTER already uses the substrate `Dec`; the N3 chainer
+(and therefore RIF builtins) still use the private `NumVal` tower — adoption is
+the already-open bead **sq-pbz04.5.1** (not re-cut here).
+
+## 3. Decision: converge on the datalog module as the *rules kernel*
+
+The datalog module's IR + checker + evaluator becomes the dialect-neutral
+**rules kernel**; Datalog surface syntax, N3, and RIF become thin front-ends
+that lower onto it. Rationale:
+
+- The checker only exists there, and #1993 makes the *checked* posture the
+  target for all dialects (N3's caller discipline is exactly what we're
+  retiring).
+- Its IR is the strict-semantics core (NAF + aggregates + filters); the
+  compiled-N3 extras (builtins, variable predicates, multi-pattern NAF) are
+  additive slots, whereas retrofitting aggregates/checking onto compiled-N3
+  would rebuild the kernel inside a dialect.
+- RIF already lowers onto another model today (the N3 chainer), so re-pointing
+  its lowering is a bounded, conformance-ratcheted change (W3C RIF WG floor).
+
+Convergence is staged so every GPT-5.6-implementable step is single-crate,
+non-soundness-sensitive, and differentially tested against the existing naive
+oracle (`datalog/oracle.rs`) — the soundness-sensitive lowerings stay
+architect/Fable-tier:
+
+1. **Checker-core extraction** (new bead, GPT-5.6): factor the Ullman fixpoint
+   out of `datalog::stratify` into a dialect-neutral core
+   (`stratify_edges(n_nodes, pos_edges, neg_edges, name_of) -> Result<Vec<usize>, String>`);
+   `datalog::stratify` becomes a thin adapter. Pure refactor: every existing
+   checker test passes verbatim.
+2. **Semi-naive datalog eval** (sq-8sve7, GPT-5.6): adopt the `join_steps`
+   delta discipline compiled-N3 already uses, inside `datalog/eval.rs`.
+   Correctness gate = the existing differential suite; efficiency gate = a
+   **deterministic** tuples-considered counter (work-box wall-clock is
+   non-canonical), asserted strictly smaller than naive on a chain fixture.
+3. **SUM/MIN/MAX/AVG** (sq-citho, GPT-5.6, after 2 — same-file sequencing):
+   value slot on `AggAtom`, inputs via the substrate `Num` tower.
+   **Overflow semantics decided here**: follow `Num::binop` — exact i64/`Dec`
+   paths, fall back to `xsd:double` on exact-arithmetic overflow; `AVG` of
+   integers yields `xsd:decimal` (SPARQL-consistent); non-numeric input value
+   fails the row (fail-closed, same posture as FILTER). Oracle extended in
+   i128 so the differential stays independent.
+4. **Fragment extensions** (sq-a7bmo, GPT-5.6, after 3): `NOT` over
+   conjunctions (parity with compiled-N3 multi-pattern `log:notIncludes`),
+   `COUNT(DISTINCT ?v)`, float-aware FILTER via `Num::cmp_relational`,
+   variable predicates via a conservative ⊤ dependency node.
+5. **N3 adopts the checker** (sq-pi2k0, GPT-5.6, after 1): `n3::compiled`
+   builds its dependency graph (patterns → positive edges, `NotIncludes` →
+   negative edges, variable predicate → ⊤ node) and rejects unstratified rule
+   sets loudly. Fail-closed-only behaviour change: programs whose semantics
+   were previously undefined-divergent now error; stratified sets unchanged.
+6. **N3 lowering onto the kernel** (new bead, **architect/Fable only**):
+   builtin steps + variable predicates as kernel slots, `n3::compiled` eval
+   re-pointed; requires a semantics-equivalence argument vs `reason_n3`
+   (soundness-sensitive).
+7. **RIF lowering onto the kernel** (new bead, **architect/Fable only**,
+   after 6): `rif::closure` targets the kernel instead of the N3 chainer; the
+   W3C RIF WG Core floor (`rif_wg_core_suite.rs`) is the gate. Composes with
+   sq-pbz04.5.1 (substrate numeric adoption) — sequence, do not parallelize.
+
+Steps 1–5 are all `sparq-reason`-only, behind existing opt-in features, and
+leave every default-feature surface byte-identical.
+
+## 4. N3-superset gap analysis (the #1993 ask)
+
+Checked against the compiled subset's exclusion list and the RIF builtin
+lowering table:
+
+- **RIF-Core**: no gap found. Frames/membership/subclass lower to triples;
+  all 16 RIF builtins already lower to N3 `math:`/`string:`/`list:` builtins;
+  RIF is monotone so needs neither NAF nor aggregates.
+- **RDFox Datalog `NOT`**: expressible — `log:notIncludes` over a formula
+  covers single- and multi-pattern NAF (store-scoped reading is a documented
+  sparq interpretation; not a missing *construct*).
+- **RDFox `AGGREGATE … ON … BIND f(?v) AS ?x`**: **candidate gap.** Standard
+  N3 has no aggregate expression construct; the only idiom is cwm's
+  list-valued `log:collectAllIn` + list arithmetic — exactly the
+  formula-/list-valued constructs a compiled/stratified subset excludes, and
+  it still gives no direct SUM/MIN/MAX/AVG. A bead (architect/Fable-tier —
+  external W3C-CG communication) verifies this against the current N3 spec +
+  builtin registry and, if confirmed, opens ONE concise w3c/N3 issue stating
+  the missing construct and that it was discovered implementing RIF/RDFox
+  rules support in an N3 front-end.
+
+## 5. Reversal cost
+
+The kernel stays `pub(crate)`; the only public surfaces remain the existing
+dialect entry points. If the maintainer prefers compiled-N3 as the kernel
+instead, steps 1–5 still stand (checker core, semi-naive, aggregates, fragment
+parity are prerequisites under either direction); only steps 6–7 re-plan.

--- a/research/gpt56-decomp-workbench-parity-2026-07.md
+++ b/research/gpt56-decomp-workbench-parity-2026-07.md
@@ -1,0 +1,108 @@
+# GPT-5.6 decomposition: workbench-parity leading beads — 2026-07
+
+> 🤖 **SPARQ agent** (Claude Fable 5, architect stage). Design decisions for
+> the de-risked, single-crate decomposition of four sq-lsp7k leading beads
+> (PATHS, SHACL guard/fact-domain, facet API, autocomplete). Companion:
+> `gpt56-decomp-rules-substrate-2026-07.md`. Beads carry the per-child specs.
+
+## 1. PATHS (sq-lsp7k.3) — dedicated entry point, not a grammar patch
+
+**Decision:** ship the Stardog-style `PATHS` query form the same way
+`window_syntax.rs` ships inline `OVER(...)`: an opt-in cargo feature (`paths`)
+whose syntax is reachable ONLY via dedicated entry points
+(`query_paths` / `explain_paths`), leaving the vendored `spargebra` PEG and
+every standard entry point untouched. `PATHS …` therefore stays a parse error
+on the standard surface → zero W3C-conformance exposure (the 1229 ratchet
+never sees it), and the whole feature is `sparq-engine`-single-crate.
+
+Evaluator: the existing `eval_path`/`path_pairs` machinery computes only
+(start,end) pair relations, so path materialization is a NEW module
+(`src/paths.rs`) over `sparq-core` `scan_perm` — BFS levels for `SHORTEST`,
+depth-bounded enumeration for `ALL` (a missing `MAX LENGTH` under `ALL` is a
+loud error: the termination invariant), `CYCLIC` as start==end closure.
+Staging (each differentially tested against a naive DFS reference written
+inside the test): ① enumeration core with `VIA <predicate>`; ② surface parser
++ entry points + typed `Paths` EXPLAIN rendering; ③ `VIA { pattern }` edges by
+materializing the pattern's designated `?from`/`?to` columns through the
+existing `eval_select`.
+
+## 2. SHACL fact-domain (sq-lsp7k.2.1) — compose `expand`, don't re-plumb
+
+`rules::expand(data, shapes) -> Graph` (feature `shacl-af`) already returns
+`data ∪ inferred-closure`. The switch is a thin composition:
+`FactDomain::{Asserted, AssertedPlusInferred}` + a
+`validate_with_domain(data, shapes, domain)` entry point that calls
+`validate(&expand(data, shapes), shapes)` in the inferred arm. Existing
+`validate*` signatures unchanged; test file follows the intentionally
+un-feature-gated `shacl_af_feature_state.rs` pattern so both feature states
+compile and assert.
+
+## 3. Server SHACL guard mode (sq-lsp7k.2.4) — two decisions taken
+
+The writer's `fork → apply → seal` seam (`ApplyUpdates` impl `ServerApplier`)
+already validates-before-publish for free: the forked working `Graph` IS the
+candidate post-state, and an `Err` from the seam maps to
+`WriteError::Rejected` with the store untouched. All GSP writes mint SPARQL
+updates through this one path, so ONE hook covers UPDATE + GSP. Two gaps need
+decisions (proceed-and-document):
+
+1. **Standing shapes designation.** `/shacl/validate` takes shapes per-request;
+   the write path has no request shapes. Decision: shapes live in a
+   **designated named graph in the store**, configured by
+   `--shacl-guard-shapes <IRI>` / `SPARQ_SHACL_GUARD_SHAPES` (guard flag
+   `--shacl-guard` / `SPARQ_SHACL_GUARD`, default OFF, the exact
+   `tpf`/`shacl` double-opt-in discipline). Shapes are authored/updated via
+   normal GSP on that graph; an empty/absent shapes graph ⇒ guard passes
+   trivially (documented). Post-state validation excludes the shapes graph
+   itself from the data domain.
+2. **Report-through-rejection channel.** `WriteError::Rejected(String)` is the
+   only error channel and both ends live in `sparq-server` (`ServerApplier`
+   produces, `update_rejection_response` consumes). Decision: sentinel-prefixed
+   payload (`"shacl-guard-violation\n" + report.to_turtle()`); the HTTP mapper
+   detects the sentinel and returns **422** with the W3C ValidationReport body
+   (Turtle, or the existing `shacl_report_to_json` projection under content
+   negotiation). No `sparq-serve` change; reversible if a structured error
+   channel lands later.
+
+v1 validates the full post-state (RDFox semantics); delta-scoped validation is
+an explicit follow-up, not smuggled in.
+
+## 4. Facet-count API (sq-lsp7k.5) — home is `sparq-introspect`
+
+`sparq-introspect` is already the scan-only, wasm-safe statistics crate
+(class instance counts, predicate stats, characteristic sets) built purely on
+`sparq-core` sorted-permutation scans — exactly the facet shape. The genuinely
+new statistic is **grouped value distributions for a candidate set**.
+Decision: `FacetRequest { class: Option<IRI>, constraints: Vec<(p, o)>,
+facet_predicates, top_k }` → `FacetResponse` with type/predicate/value
+`Counted` distributions + elision counts (the crate's existing conventions),
+computed from `scan_perm` range counts (generalizing the engine's COUNT(*)
+pushdown idea). Correctness oracle: a dev-dependency on `sparq-engine`
+(workspace-internal, no supply-chain surface) evaluating the equivalent
+`GROUP BY` aggregates. The server endpoint is a separate `sparq-server` bead
+(feature + runtime flag, `tpf` discipline). Any *measured-advantage* claim is
+bench-artifact work and stays architect-tier (sq-hmd7l axis).
+
+## 5. IRI/label autocomplete (sq-lsp7k.9) — sibling index in `sparq-text`
+
+`TextIndex` deliberately skips IRIs and has no completion shape, but its
+`BTreeMap` range-scan prefix discipline, `apply_delta`/`reconcile` incremental
+seams, and differential-vs-rebuild test convention are exactly right.
+Decision: a **sibling `CompletionIndex`** in `sparq-text` (`src/complete.rs`)
+indexing (a) every dict IRI under full-IRI + local-name keys and (b)
+`rdfs:label`/`skos:prefLabel` literals keyed to their *subject entity* `Id`;
+`complete(prefix, k, scores: Option<&FxHashMap<Id, f64>>)` with deterministic
+(score desc, key asc, id asc) ordering. Ranking scores are **injected**, not
+computed — `sparq-text` gains no `sparq-algos` dependency; the consumer joins
+PageRank output on the shared `dict::Id`. Fuzzy matching is explicitly out of
+v1 (net-new algorithmic surface; own bead later). Server exposure mirrors the
+facet endpoint (feature + flag + `AppState`-held index reconciled on
+staleness); PageRank wiring + GUI consumption + the 100M-triple p99 bench stay
+architect-tier (cross-crate + perf claims).
+
+## 6. Same-crate sequencing
+
+`sparq-server/src/http.rs` is one hot file: the guard-mode, facet-endpoint,
+and complete-endpoint beads are dependency-chained (guard → facets →
+complete) purely to serialize merges — not a semantic ordering. Likewise the
+datalog beads chain inside `sparq-reason` (see the companion record §3).


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5, architect stage) — design-record PR for the GPT-5.6 de-risking pass. Docs-only; NOT armed (maintainer may want to steer the kernel-convergence direction).

Two design records backing the child-bead decomposition of the leading beads GPT-5.6 correctly deferred as `needs_architect`:

**`research/gpt56-decomp-rules-substrate-2026-07.md`** — resolves how N3 + RIF come to share the Datalog checker/evaluator per @jeswr's direction in #1993: the datalog module becomes the dialect-neutral *rules kernel*; convergence staged as 5 GPT-5.6-implementable single-crate steps (checker-core extraction, semi-naive, SUM/MIN/MAX/AVG with decided overflow semantics, fragment parity, N3 checker adoption) + 2 architect-only lowerings (N3 builtins→kernel, RIF→kernel). N3-superset gap analysis: RIF-Core fully expressible; the one candidate w3c/N3 CG issue is the missing **aggregate expression construct** (bead sq-6tykl.3.4 verifies before posting).

**`research/gpt56-decomp-workbench-parity-2026-07.md`** — decisions for four sq-lsp7k leading beads: PATHS via dedicated entry points (`window_syntax` precedent, zero conformance exposure); SHACL guard shapes = designated named graph + sentinel→422 report channel (proceed-and-document); facet API home = sparq-introspect with a GROUP-BY differential oracle; CompletionIndex in sparq-text with *injected* rank scores (no sparq-algos dep).

**Beads** (all created, deps wired so substrate lands before dialect/consumer layers):
- gpt56-ready: sq-6tykl.3.1, sq-8sve7, sq-citho, sq-a7bmo, sq-pi2k0, sq-lsp7k.2.1, sq-lsp7k.2.4, sq-lsp7k.3.1–.3.3, sq-lsp7k.5.1–.5.2, sq-lsp7k.9.1–.9.3
- architect-or-fable-only: sq-6tykl.3.2, sq-6tykl.3.3, sq-6tykl.3.4 (w3c/N3 issue), sq-lsp7k.5.3, sq-lsp7k.9.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)