### PR TITLE
feat(reason/datalog): semi-naive per-stratum evaluation + deterministic EvalStats (sq-8sve7) [FABLE-5]

### DIFF
--- a/crates/sparq-reason/src/datalog/eval.rs
+++ b/crates/sparq-reason/src/datalog/eval.rs
@@ -1,16 +1,40 @@
-//! [FABLE-5] sq-6tykl.3 — the **non-incremental per-stratum evaluator** (Phase 1).
+//! [FABLE-5] sq-6tykl.3 / sq-8sve7 — the **semi-naive per-stratum evaluator** (Phase 2).
 //!
-//! Strata run in ascending order; within a stratum, rules iterate to fixpoint in
-//! naive rounds (derivations de-duplicate at store insertion — semi-naive delta
-//! restriction is a beaded follow-up phase, see the design record §6). Because the
-//! checker guarantees every `NOT`-negated / `AGGREGATE`-read predicate is complete
-//! before its stratum runs:
+//! Strata run in ascending order; within a stratum, rules iterate to fixpoint with
+//! **semi-naive delta restriction** — the exact round discipline
+//! [`crate::n3::compiled`]'s eval loop implements:
+//!
+//! * **round 0**: every fact in the store (inputs + lower-strata derivations) is the
+//!   delta, so the first round is equivalent to a full run;
+//! * **each later round**: a monotonic rule re-runs once per positive-atom index `k`
+//!   with atom `k` restricted to the previous round's newly-derived delta (all other
+//!   atoms read the full store; duplicates de-duplicate at store insertion). Any new
+//!   derivation must use at least one delta fact in some positive position, so the
+//!   union over `k` is complete; instantiations entirely inside the older store were
+//!   produced in an earlier round.
+//! * rules with **no positive atoms** draw only on relations that are constant within
+//!   the stratum (aggregate tables, `NOT` over completed lower strata), so they fire
+//!   in round 0 only — the n3 `join_steps.is_empty()` discipline;
+//! * rules carrying **`NOT`** keep the full re-run every round ([`needs_full`], the n3
+//!   discipline for scoped negation). The stratification checker already guarantees
+//!   every negated relation is complete before its stratum runs (so delta restriction
+//!   would remain sound); the full re-run is deliberate defence-in-depth for this
+//!   soundness-sensitive path — it can only cost work, never correctness.
+//!
+//! Because the checker guarantees every `NOT`-negated / `AGGREGATE`-read predicate is
+//! complete before its stratum runs:
 //!
 //! * `AGGREGATE` tables are computed **once at stratum entry** (their bodies read
 //!   strictly-lower strata, which no longer change) and then joined like positive
-//!   relations;
+//!   relations — they are constant within the stratum, so they never gate delta
+//!   restriction of the positive atoms;
 //! * `NOT` is a per-row absence check against the store's predicate index —
 //!   the indexed relation is final, so no retraction can ever be needed.
+//!
+//! [`EvalStats`] counts rounds and the candidate rows fed into positive-atom join
+//! steps — a DETERMINISTIC work measure (no wall-clock; work-box timings are
+//! non-canonical). The differential suite asserts the semi-naive closure equals both
+//! the forced-full (naive) closure and the independent oracle on every battery input.
 //!
 //! Positive-atom and aggregate-table joins drive the SHARED
 //! [`sparq_substrate::join`] kernels via the same thin layout-adapter pattern as
@@ -28,6 +52,20 @@ use sparq_substrate::rows::{Row, NO_ID};
 
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 
+/// Deterministic evaluation counters (sq-8sve7): fixpoint `rounds` summed across
+/// strata and the number of candidate rows (`tuples_considered`) fed into
+/// positive-atom join steps during rule firing. Aggregate-table construction is
+/// excluded — it runs once per stratum in both the semi-naive and the forced-full
+/// mode, so it cancels out of any comparison. A pure work measure: NO wall-clock.
+#[cfg(any(test, feature = "datalog"))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EvalStats {
+    /// Fixpoint rounds run, summed over all strata.
+    pub(crate) rounds: usize,
+    /// Candidate rows fed into positive-atom join steps (delta-restricted or full).
+    pub(crate) tuples_considered: u64,
+}
+
 /// Evaluate `program` (already checked by [`super::stratify`]) over `facts` and
 /// return the full closure (inputs + derivations, de-duplicated; treat as a set).
 pub(super) fn eval_stratified(
@@ -35,6 +73,22 @@ pub(super) fn eval_stratified(
     facts: &[[Id; 3]],
     program: &Program,
     strat: &Stratification,
+) -> Vec<[Id; 3]> {
+    let mut stats = EvalStats::default();
+    eval_stratified_with_stats(dict, facts, program, strat, &mut stats, false)
+}
+
+/// The instrumented engine behind [`eval_stratified`]. `force_full` disables the
+/// delta restriction so every rule re-runs against the full store each round —
+/// exactly the Phase-1 naive discipline; the differential and stats tests use it as
+/// the in-engine baseline (the independent `oracle` stays the external reference).
+pub(super) fn eval_stratified_with_stats(
+    dict: &mut Dict,
+    facts: &[[Id; 3]],
+    program: &Program,
+    strat: &Stratification,
+    stats: &mut EvalStats,
+    force_full: bool,
 ) -> Vec<[Id; 3]> {
     let mut store = FactStore::default();
     for f in facts {
@@ -61,42 +115,69 @@ pub(super) fn eval_stratified(
                     .collect()
             })
             .collect();
+        // Round 0: everything derived so far (inputs + lower strata) is the delta.
+        let mut delta: Vec<[Id; 3]> = store.list.clone();
+        let mut first_round = true;
         loop {
+            stats.rounds += 1;
             let mut produced: Vec<[Id; 3]> = Vec::new();
             for (r, tables) in rules.iter().zip(&agg_tables) {
-                run_rule(dict, r, tables, &store, &mut produced);
+                if force_full || needs_full(r) || r.positive.is_empty() {
+                    // Full re-run (non-monotonic-conservative), or a rule with no
+                    // positive atoms whose inputs are constant within the stratum:
+                    // the latter fires in round 0 only.
+                    if force_full || needs_full(r) || first_round {
+                        run_rule(dict, r, tables, &store, None, stats, &mut produced);
+                    }
+                } else {
+                    // Semi-naive: once per positive-atom position, with that atom
+                    // restricted to the delta (dedup happens at store insertion).
+                    for k in 0..r.positive.len() {
+                        run_rule(dict, r, tables, &store, Some((&delta, k)), stats, &mut produced);
+                    }
+                }
             }
-            let mut any_new = false;
+            let mut new_delta: Vec<[Id; 3]> = Vec::new();
             for f in produced {
-                any_new |= store.insert(f);
+                if store.insert(f) {
+                    new_delta.push(f);
+                }
             }
-            if !any_new {
+            first_round = false;
+            if new_delta.is_empty() {
                 break;
             }
+            delta = new_delta;
         }
     }
     store.list
 }
 
+/// Conservative non-monotonicity flag, mirroring the n3 compiled path's
+/// `needs_full`: a rule carrying `NOT` re-runs against the full store every round.
+/// The stratification checker already guarantees the negated relations are complete
+/// (strictly-lower strata) before the stratum runs — so this is defence-in-depth,
+/// not a soundness requirement; see the module docs.
+fn needs_full(rule: &Rule) -> bool {
+    !rule.negated.is_empty()
+}
+
 /// `(binding slot, candidate column)` pairs mapping variable slots to the atom's
 /// triple positions — used for equi-join keys and write-back slots alike.
 type SlotCols = Vec<(usize, usize)>;
-/// Per-position constants pinned for an atom's join probe (`s`, `p`, `o`).
-type AtomConsts = [Option<Id>; 3];
-/// The join plan for one atom: `(key_cols, new_writes, consts)`.
-type AtomPlan = (SlotCols, SlotCols, AtomConsts);
+/// The join plan for one atom: `(key_cols, new_writes)`.
+type AtomPlan = (SlotCols, SlotCols);
 
 /// The join plan for one atom given the running bound-slot set: equi-join key
-/// column pairs `(binding slot, candidate column)` for already-bound variables,
-/// write-back slots for new ones, and per-position constants. Marks the atom's
-/// new variables as bound.
+/// column pairs `(binding slot, candidate column)` for already-bound variables and
+/// write-back slots for new ones (constants are pre-filtered by [`atom_admits`]).
+/// Marks the atom's new variables as bound.
 fn plan_atom(atom: &Atom, bound: &mut FxHashSet<u32>) -> AtomPlan {
     let mut key_cols = Vec::new();
     let mut new_writes = Vec::new();
-    let mut consts = [None, None, None];
     for (i, t) in atom.t.iter().enumerate() {
         match t {
-            DTerm::Const(id) => consts[i] = Some(*id),
+            DTerm::Const(_) => {}
             DTerm::Var(v) => {
                 if bound.contains(v) {
                     key_cols.push((*v as usize, i));
@@ -109,22 +190,33 @@ fn plan_atom(atom: &Atom, bound: &mut FxHashSet<u32>) -> AtomPlan {
     for &(v, _) in &new_writes {
         bound.insert(v as u32);
     }
-    (key_cols, new_writes, consts)
+    (key_cols, new_writes)
 }
 
-/// Candidate facts for one atom: the store's predicate index narrowed by the
-/// constant pre-filters, as substrate probe rows `[s, p, o]`.
-fn candidates(consts: &[Option<Id>; 3], pred: Id, store: &FactStore) -> Vec<Row> {
-    let keep = |t: &[Id; 3]| {
-        consts[0].is_none_or(|c| t[0] == c)
-            && consts[2].is_none_or(|c| t[2] == c)
+/// Does the fact pass the atom's constant pre-filters (predicate + any constant
+/// subject/object positions)?
+fn atom_admits(atom: &Atom, f: &[Id; 3]) -> bool {
+    f[1] == atom.pred
+        && atom.t.iter().zip(f).all(|(t, id)| match t {
+            DTerm::Const(c) => c == id,
+            DTerm::Var(_) => true,
+        })
+}
+
+/// Candidate facts for one atom, as substrate probe rows `[s, p, o]`: drawn from
+/// the store's predicate index — or from `delta` when this atom is the semi-naive
+/// restricted position — and narrowed by the constant pre-filters.
+fn candidates(atom: &Atom, store: &FactStore, delta: Option<&[[Id; 3]]>) -> Vec<Row> {
+    let source: &[[Id; 3]] = match delta {
+        Some(d) => d,
+        None => store
+            .by_pred
+            .get(&atom.pred)
+            .map_or(&[][..], |v| v.as_slice()),
     };
-    store
-        .by_pred
-        .get(&pred)
-        .map_or(&[][..], |v| v.as_slice())
+    source
         .iter()
-        .filter(|t| keep(t))
+        .filter(|t| atom_admits(atom, t))
         .map(|t| Row::from_slice(t))
         .collect()
 }
@@ -177,8 +269,8 @@ fn aggregate_table(dict: &mut Dict, agg: &AggAtom, store: &FactStore) -> Vec<Row
     let mut rows: Vec<Row> = vec![empty];
     let mut bound: FxHashSet<u32> = FxHashSet::default();
     for atom in &agg.body {
-        let (key_cols, new_writes, consts) = plan_atom(atom, &mut bound);
-        let cands = candidates(&consts, atom.pred, store);
+        let (key_cols, new_writes) = plan_atom(atom, &mut bound);
+        let cands = candidates(atom, store, None);
         rows = join_rows(&rows, &key_cols, &new_writes, &cands, agg.n_slots, 3);
     }
     // Distinct full tuples, then count per ON-group. (`COUNT(?v)` counts distinct
@@ -202,19 +294,38 @@ fn aggregate_table(dict: &mut Dict, agg: &AggAtom, store: &FactStore) -> Vec<Row
 
 /// Fire one rule against the current store, appending (possibly duplicate)
 /// conclusions to `out` — the caller's store insertion de-duplicates.
+///
+/// `delta`: `Some((delta_facts, k))` restricts positive atom `k` to the delta (the
+/// semi-naive run for position `k`); `None` is a full run. When the restricted
+/// atom admits no delta fact the whole conjunction is empty, so the run is skipped
+/// up front — this keeps `stats.tuples_considered` an honest work measure (the
+/// other atoms' candidates are never materialised for a run that cannot fire).
+#[allow(clippy::too_many_arguments)]
 fn run_rule(
     dict: &Dict,
     rule: &Rule,
     agg_tables: &[Vec<Row>],
     store: &FactStore,
+    delta: Option<(&[[Id; 3]], usize)>,
+    stats: &mut EvalStats,
     out: &mut Vec<[Id; 3]>,
 ) {
+    if let Some((d, k)) = delta {
+        if !d.iter().any(|f| atom_admits(&rule.positive[k], f)) {
+            return;
+        }
+    }
     let empty: Row = std::iter::repeat_n(NO_ID, rule.n_slots).collect();
     let mut rows: Vec<Row> = vec![empty];
     let mut bound: FxHashSet<u32> = FxHashSet::default();
-    for atom in &rule.positive {
-        let (key_cols, new_writes, consts) = plan_atom(atom, &mut bound);
-        let cands = candidates(&consts, atom.pred, store);
+    for (idx, atom) in rule.positive.iter().enumerate() {
+        let (key_cols, new_writes) = plan_atom(atom, &mut bound);
+        let restricted = match delta {
+            Some((d, k)) if k == idx => Some(d),
+            _ => None,
+        };
+        let cands = candidates(atom, store, restricted);
+        stats.tuples_considered += cands.len() as u64;
         rows = join_rows(&rows, &key_cols, &new_writes, &cands, rule.n_slots, 3);
         if rows.is_empty() {
             return;

--- a/crates/sparq-reason/src/datalog/mod.rs
+++ b/crates/sparq-reason/src/datalog/mod.rs
@@ -4,10 +4,10 @@
 //! This is Phase 1 of the stratified-Datalog program (design record
 //! `research/stratified-datalog-rules.md`): a small **native rule dialect** modelled on
 //! RDFox's Datalog surface (the maintainer's open question 4 — see the record §2 for the
-//! decision), a **stratification checker**, and a **non-incremental per-stratum
-//! evaluator** supporting `NOT` (store-scoped negation as failure) and
-//! `AGGREGATE … BIND COUNT(?v) AS ?c` atoms plus a minimal numeric `FILTER`. Semi-naive
-//! per-stratum evaluation, the remaining aggregate functions (`SUM`/`MIN`/`MAX`/`AVG`)
+//! decision), a **stratification checker**, and a **semi-naive per-stratum evaluator**
+//! (Phase 2, sq-8sve7 — delta-restricted positive joins; see `eval`) supporting `NOT`
+//! (store-scoped negation as failure) and `AGGREGATE … BIND COUNT(?v) AS ?c` atoms plus
+//! a minimal numeric `FILTER`. The remaining aggregate functions (`SUM`/`MIN`/`MAX`/`AVG`)
 //! and incremental maintenance under insert/delete are **later phases**, beaded from the
 //! design record — this module is honest about being the fixture-scale foundation.
 //!
@@ -211,9 +211,10 @@ pub fn parse_program(dict: &mut Dict, src: &str) -> Result<Program, String> {
 /// Check stratifiability and evaluate `program` over `facts`: run the per-stratum
 /// forward fixpoint to completion and return the full ground closure — input facts
 /// plus every derivation, de-duplicated. Treat the result as a SET (order is
-/// unspecified). Non-incremental Phase-1 evaluation (naive rounds per stratum);
-/// `dict` is needed mutably because aggregation MINTS `xsd:integer` count literals
-/// into the caller's id space.
+/// unspecified). Non-incremental semi-naive evaluation (delta-restricted rounds per
+/// stratum — identical derived-fact sets to the naive discipline, by differential
+/// test); `dict` is needed mutably because aggregation MINTS `xsd:integer` count
+/// literals into the caller's id space.
 ///
 /// # Errors
 ///

--- a/crates/sparq-reason/src/datalog/tests.rs
+++ b/crates/sparq-reason/src/datalog/tests.rs
@@ -609,3 +609,143 @@ fn differential_multi_head_and_global_count() {
         0..25,
     );
 }
+
+// ---------------------------------------------------------------------------
+// Semi-naive vs naive (sq-8sve7): SET-identical closures + strictly less work
+// ---------------------------------------------------------------------------
+
+/// Three-way differential on one (program, facts) input: the semi-naive engine,
+/// the same engine forced to full (naive) re-runs, and the independent oracle
+/// must produce the SAME closure set.
+fn assert_semi_naive_equals_naive(src: &str, facts_of: &dyn Fn(&mut Dict) -> Vec<[Id; 3]>) {
+    let mut d = Dict::new();
+    let program = parse_program(&mut d, src).expect("parse");
+    let strat = stratify(&d, &program).expect("stratifiable");
+    let facts = facts_of(&mut d);
+    let mut semi_stats = eval::EvalStats::default();
+    let semi: FxHashSet<[Id; 3]> =
+        eval::eval_stratified_with_stats(&mut d, &facts, &program, &strat, &mut semi_stats, false)
+            .into_iter()
+            .collect();
+    let mut naive_stats = eval::EvalStats::default();
+    let naive: FxHashSet<[Id; 3]> =
+        eval::eval_stratified_with_stats(&mut d, &facts, &program, &strat, &mut naive_stats, true)
+            .into_iter()
+            .collect();
+    assert_eq!(
+        semi, naive,
+        "semi-naive/naive closure divergence ({} facts) program:\n{src}",
+        facts.len()
+    );
+    let reference = oracle::eval_naive(&mut d, &facts, &program, &strat);
+    assert_eq!(
+        semi, reference,
+        "engine/oracle closure divergence ({} facts) program:\n{src}",
+        facts.len()
+    );
+}
+
+/// The sq-8sve7 soundness invariant, as a battery: recursive, NAF, aggregate and
+/// multi-stratum programs × {empty graph, single fact, seeded random graphs} —
+/// semi-naive output == naive output as SET equality on every input.
+///
+/// NON-VACUITY (verified by hand-run mutation, see the PR body): restricting the
+/// semi-naive loop to `k = 0` only — or starting the delta empty instead of
+/// all-facts — flips this test red on the recursive programs.
+#[test]
+fn differential_semi_naive_equals_naive_battery() {
+    let programs = [
+        // Pure positive recursion (transitive closure).
+        format!(
+            "{P}[?x, ex:reach, ?y] :- [?x, ex:edge, ?y] .\n\
+             [?x, ex:reach, ?z] :- [?x, ex:reach, ?y], [?y, ex:edge, ?z] ."
+        ),
+        // Transitive closure with the RECURSIVE atom in the SECOND body position —
+        // the delta restriction must cover every positive-atom index k, not just
+        // k = 0 (a k=0-only mutation goes red exactly here).
+        format!(
+            "{P}[?x, ex:reach, ?y] :- [?x, ex:edge, ?y] .\n\
+             [?x, ex:reach, ?z] :- [?y, ex:edge, ?z], [?x, ex:reach, ?y] ."
+        ),
+        // Recursion + NAF across strata (needs_full path + delta path together).
+        format!(
+            "{P}[?x, ex:reach, \"y\"] :- [?x, ex:seed, \"y\"] .\n\
+             [?y, ex:reach, \"y\"] :- [?x, ex:reach, \"y\"], [?x, ex:edge, ?y] .\n\
+             [?x, ex:unreach, \"y\"] :- [?x, a, ex:Node], NOT [?x, ex:reach, \"y\"] ."
+        ),
+        // Aggregate + threshold FILTER + NAF over a derived class (3 strata).
+        format!(
+            "{P}[?x, ex:deg, ?c] :- AGGREGATE([?x, ex:edge, ?y] ON ?x BIND COUNT(?y) AS ?c) .\n\
+             [?x, a, ex:Hub] :- [?x, ex:deg, ?c], FILTER(?c >= 2) .\n\
+             [?x, a, ex:Leaf] :- [?x, a, ex:Node], NOT [?x, a, ex:Hub] ."
+        ),
+        // Multi-head + recursion over a derived predicate + global count over the
+        // recursive closure + a wildcard-NAF constant rule.
+        format!(
+            "{P}[?x, ex:out, ?y], [?y, ex:in, ?x] :- [?x, ex:edge, ?y] .\n\
+             [?x, ex:reach, ?y] :- [?x, ex:out, ?y] .\n\
+             [?x, ex:reach, ?z] :- [?x, ex:reach, ?y], [?y, ex:out, ?z] .\n\
+             [ex:world, ex:nreach, ?c] :- AGGREGATE([?x, ex:reach, ?y] BIND COUNT(?x) AS ?c) .\n\
+             [ex:world, ex:quiet, \"y\"] :- [ex:world, a, ex:Nothing], NOT [?z, ex:edge, ?z] ."
+        ),
+    ];
+    for src in &programs {
+        // Empty input graph.
+        assert_semi_naive_equals_naive(src, &|_| Vec::new());
+        // Single fact.
+        assert_semi_naive_equals_naive(src, &|d| {
+            let (a, e, b) = (iri(d, "a"), iri(d, "edge"), iri(d, "b"));
+            vec![[a, e, b]]
+        });
+        // Seed-randomised graphs (typed nodes + random edges + one seed).
+        for seed in 0..10 {
+            assert_semi_naive_equals_naive(src, &move |d| random_graph(d, seed, 6, 9));
+        }
+    }
+}
+
+/// sq-8sve7 acceptance: on a 30-node linear-chain transitive closure, semi-naive
+/// delta restriction feeds STRICTLY fewer candidate tuples into the join steps
+/// than the forced-full (naive) discipline — while deriving the identical set,
+/// cross-checked against the independent oracle. Deterministic counters only.
+#[test]
+fn semi_naive_considers_fewer_tuples_than_naive() {
+    let mut d = Dict::new();
+    let src = format!(
+        "{P}[?x, ex:reach, ?y] :- [?x, ex:edge, ?y] .\n\
+         [?x, ex:reach, ?z] :- [?x, ex:reach, ?y], [?y, ex:edge, ?z] ."
+    );
+    let program = parse_program(&mut d, &src).expect("parse");
+    let strat = stratify(&d, &program).expect("stratifiable");
+    let edge = iri(&mut d, "edge");
+    let nodes: Vec<Id> = (0..30).map(|i| iri(&mut d, &format!("c{i}"))).collect();
+    let facts: Vec<[Id; 3]> = nodes.windows(2).map(|w| [w[0], edge, w[1]]).collect();
+
+    let mut semi_stats = eval::EvalStats::default();
+    let semi: FxHashSet<[Id; 3]> =
+        eval::eval_stratified_with_stats(&mut d, &facts, &program, &strat, &mut semi_stats, false)
+            .into_iter()
+            .collect();
+    let mut naive_stats = eval::EvalStats::default();
+    let naive: FxHashSet<[Id; 3]> =
+        eval::eval_stratified_with_stats(&mut d, &facts, &program, &strat, &mut naive_stats, true)
+            .into_iter()
+            .collect();
+
+    // Identical derived sets, and both equal the independent oracle.
+    let reference = oracle::eval_naive(&mut d, &facts, &program, &strat);
+    assert_eq!(semi, reference);
+    assert_eq!(naive, reference);
+    // 30-node chain: 29 input edges + C(30,2) = 435 reach facts.
+    assert_eq!(semi.len(), 29 + 435);
+
+    // The point of the phase: strictly less join work, same fixpoint depth order.
+    assert!(
+        semi_stats.tuples_considered < naive_stats.tuples_considered,
+        "semi-naive must consider strictly fewer tuples: semi={} naive={}",
+        semi_stats.tuples_considered,
+        naive_stats.tuples_considered
+    );
+    assert!(semi_stats.rounds >= 2, "chain TC needs multiple rounds");
+    assert!(semi_stats.tuples_considered > 0, "counter must be live");
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — implements bead **sq-8sve7** (Datalog Phase 2: semi-naive per-stratum evaluation), parent epic sq-6tykl.3. REASONER-SOUNDNESS-SENSITIVE: left **unarmed** for the Opus soundness review of the invariant.

## What

Replaces the Phase-1 naive per-stratum rounds in `sparq-reason/src/datalog/eval.rs` (feature `datalog`, single crate) with **semi-naive delta-restricted positive joins**, mirroring the exact round discipline `n3/compiled.rs` already implements at its eval loop:

- **Round 0**: every fact in the store (inputs + lower-strata derivations) is the delta → equivalent to a full run.
- **Later rounds**: each monotonic rule re-runs once per positive-atom index `k` with atom `k` restricted to the previous round's newly-derived delta; all other atoms read the full store; dedup at store insertion. A run whose delta atom admits no delta fact is skipped up front.
- **`needs_full`** (mirrors n3): rules carrying `NOT` keep the full re-run every round. The stratification checker already guarantees every negated relation is complete (strictly-lower stratum) before the stratum runs, so delta restriction would remain sound — the full re-run is deliberate **defence-in-depth** on this soundness-sensitive path (costs work, never correctness).
- Rules with **no positive atoms** draw only on within-stratum-constant relations (aggregate tables, completed-lower-strata `NOT`) → fire in round 0 only (the n3 `join_steps.is_empty()` discipline).
- **`AGGREGATE` tables unchanged**: computed once at stratum entry; constant within the stratum, so they never gate delta restriction.

Adds `pub(crate) EvalStats { rounds: usize, tuples_considered: u64 }` behind `#[cfg(any(test, feature = "datalog"))]` — a **deterministic** counter of candidate rows fed into positive-atom join steps (aggregate-table construction excluded: it runs once per stratum in both modes and cancels out of any comparison). **No wall-clock / perf numbers claimed anywhere** — work-box timings are non-canonical.

## Completeness argument (why the delta restriction derives the same set)

Any new instantiation at round *r* must use ≥1 fact from Δᵣ in some positive position — that instantiation appears in the run for that position `k` (other atoms read the full store ⊇ everything). Instantiations entirely inside the older store were produced in an earlier round (induction; round 0's delta is everything). NAF/aggregate reads are stratum-constant by the checker's guarantee, so per-row `NOT`/table joins cannot change mid-stratum.

## Soundness invariant + tests

**INVARIANT: identical derived-fact SETS to naive on every input.** Verified three ways per input:

- `differential_semi_naive_equals_naive_battery` — battery of programs (pure recursion; **right-recursive body order** with the growing relation in the SECOND atom position; recursion+NAF across strata; aggregate+FILTER+NAF over a derived class; multi-head + recursion over derived + global count + wildcard NAF) × fact sets (**empty**, **single fact**, seeded random graphs ×10): asserts `semi == forced_full == independent oracle` as set equality. `force_full` reproduces the exact old naive discipline in-engine; the substitution-based `oracle` stays the shared-nothing external reference.
- `semi_naive_considers_fewer_tuples_than_naive` — 30-node linear-chain transitive closure: `tuples_considered(semi) < tuples_considered(forced_full)` **strictly**, with the identical 29+435-fact closure, cross-checked against the oracle.
- All pre-existing fixtures + `assert_differential` seeds 0..25 pass unchanged.

**Non-vacuity — verified by hand-run mutations (both reverted):**
1. Restricting the semi-naive loop to `k = 0` only → battery RED (caught precisely by the right-recursive program — the first battery draft lacked it and did NOT flip; I added the position-1-recursion program specifically to close that vacuity gap before claiming non-vacuity).
2. Starting the round-0 delta empty instead of all-facts → battery RED.

## Gates (all run locally, both feature states)

- `cargo clippy -p sparq-reason --all-targets -- -D warnings` — green default AND `--features datalog`
- `cargo test -p sparq-reason` — green default (module compiled out) AND `--features datalog` (all suites, 0 failed)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-reason --all-features --no-deps` — green (module docs updated to Phase-2 semi-naive)

No public-API change (`eval()` signature unchanged; `EvalStats` is `pub(crate)`) → no SKILL.md/README delta. Design refs: `research/stratified-datalog-rules.md` item 1, gpt56-decomp step 2.

**DO NOT ARM** — awaiting the Opus reviewer's verification of the soundness invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)