### PR TITLE
fix(ci): family_curve schema-drift guard tolerates lockfile drift (sq-q134e) [FABLE-5]

### DIFF
--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -288,13 +288,33 @@ jobs:
       # compiled above, so a plain `cargo build` of the harness here is near-free and
       # makes that schema drift a visible RED check on the PR that introduces it. (Build
       # only — no `cargo run`: catching the compile/API break needs no real bb proving.)
-      # `--locked` so the build honours family_curve's OWN committed Cargo.lock and
-      # FAILS if it has drifted from Cargo.toml (rather than silently rewriting it),
-      # keeping the schema-drift guard reproducible. [OPUS-4.8] sq-kep2
+      #
+      # [FABLE-5] sq-q134e — deliberately NOT `--locked`. The harness path-deps on
+      # in-repo crates (sparq-zk → … → sparq-substrate) whose manifests bump
+      # dependencies on lanes that do NOT trigger this zk lane, so the committed
+      # harness Cargo.lock drifts SILENTLY on main and `--locked` then spuriously
+      # failed the NEXT zk-touching PR (bit #1962 via a main-side hashbrown bump the
+      # ZK PR never made). A plain `cargo build` keeps every still-compatible pin
+      # from the committed lock (cargo re-resolves MINIMALLY) and only absorbs the
+      # in-repo manifest bumps — so the guard still goes RED on a real schema/API
+      # break in the harness, while pure lock drift becomes an advisory notice (with
+      # the lock diff in the step summary) asking for a refresh commit instead of a
+      # spurious failure on an innocent PR. [FABLE-5] sq-q134e
       - name: Build the standalone family_curve harness (schema-drift guard)
         if: steps.changes.outputs.zk == 'true'
         working-directory: bench/zk-compose/family_curve
-        run: cargo build --locked
+        run: |
+          set -euo pipefail
+          cargo build
+          if ! git diff --quiet -- Cargo.lock; then
+            echo "::notice file=bench/zk-compose/family_curve/Cargo.lock::family_curve Cargo.lock drifted from an in-repo dep bump that landed on a lane which does not run this guard. The build used the minimally refreshed lock; commit the refreshed Cargo.lock to re-pin (sq-q134e)."
+            {
+              echo '### family_curve Cargo.lock drift (sq-q134e) — commit this refresh to re-pin'
+              echo '```diff'
+              git diff -- Cargo.lock
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # The load-bearing step: run EVERY `#[ignore]`d test in the ZK crates. With the
       # toolchain on PATH the forge tests do a REAL bb prove and assert every forgery is

--- a/bench/zk-compose/README.md
+++ b/bench/zk-compose/README.md
@@ -96,7 +96,7 @@ snapshot) and then re-run the catalog generator to re-join the new numbers.
 pattern as `bench/zk`) that drives the `sparq-zk-compose` prover (nargo + bb
 subprocesses) once per circuit-family member and emits the full **(k, n, r, d)
 cost curve** — prove time, verify time, proof size, vk size. CI **builds** the
-harness (a `--locked` compile-only schema-drift guard, see the blockquote below)
+harness (a compile-only schema-drift guard, see the blockquote below)
 but never **runs** it: each row is a real `bb prove` (~1-2 s) so the curve is
 generated manually, not in CI. It is a plain timing harness, not criterion
 (criterion's repeated sampling over ~1-2 s proofs would take hours).
@@ -121,6 +121,15 @@ raw `Prover.toml`. ([OPUS-4.8] sq-kep2 ported the harness to that schema.)
 > triggers on `crates/sparq-zk-compose/**`), so such drift is a visible red check.
 > **When you change a `CircuitId`/`ProofInputs` variant or `prover_toml_for`,
 > update this harness too.**
+>
+> The CI build is deliberately **not** `--locked` ([FABLE-5] sq-q134e): the
+> harness path-deps on in-repo crates whose manifests bump dependencies on lanes
+> that never run this guard, so the committed `family_curve/Cargo.lock` drifts
+> silently on main and `--locked` then spuriously failed the *next* zk-touching
+> PR (#1962, a main-side `hashbrown` bump). A plain `cargo build` keeps every
+> still-compatible pin from the committed lock (cargo re-resolves minimally) and
+> only absorbs the in-repo manifest bumps; if the lock did drift, CI emits an
+> advisory notice + lock diff asking for a refresh commit instead of failing.
 
 ### Run
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — automated contribution; bead **sq-q134e**.

## Bug (sq-q134e, bit #1962)

The standalone `bench/zk-compose/family_curve` harness (schema-drift guard, sq-kep2) was built with `cargo build --locked`, but its committed `Cargo.lock` path-deps on in-repo crates (`sparq-zk` → … → `sparq-substrate`) whose manifests bump dependencies on lanes that do **not** trigger the zk lane. The pinned lock therefore drifts **silently on main**, and `--locked` then spuriously fails the *next* zk-touching PR — bit #1962 via a main-side `hashbrown 0.17.1` bump the ZK PR never made.

## Fix (minimal, determinism preserved)

Drop `--locked` from the guard step. Cargo re-resolves **minimally**: every still-compatible pin in the committed lock is kept, and only the in-repo manifest bumps are absorbed. So:

- a **real schema/API break** in the harness still turns the check **RED** (the guard's actual purpose — a compile break);
- **pure lock drift** now produces a `::notice` annotation + the lock diff in the step summary asking for a refresh commit, instead of failing an innocent PR.

README guard blockquote updated to match.

## Verification

- **Drift reproduced against the real pre-#1962 stale lock** (`git show 2b5d07397~1:…/Cargo.lock`): old `cargo … --locked` fails (`cannot update the lock file … --locked was passed`, exit 101).
- **New step body run end-to-end on the same stale lock**: `cargo build` finishes clean, refreshes exactly the +1 `hashbrown 0.17.1` dep edge that #1962 had to hand-commit, emits the notice, writes the step-summary diff, exits 0.
- **Determinism**: with the stale working-copy lock, minimal re-resolution converges **byte-for-byte** to the committed post-#1962 lock (empty `git diff` vs HEAD) — no floating of unrelated pins.
- `actionlint` + YAML parse clean on `.github/workflows/zk-toolchain.yml`.

No Rust source changes; the current committed harness lock is already in sync with main, so no lock refresh is needed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)