### PR TITLE
engine: add dedicated PATHS query surface [GPT-5.6]

### DIFF
--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -44,6 +44,12 @@ pub mod params;
 pub mod paths;
 #[cfg(feature = "paths")]
 pub use paths::{enumerate_paths, PathMode, PathSolution, PathSpec};
+// [GPT-5.6] (sq-lsp7k.3.2) Dedicated non-standard PATHS syntax. The ordinary
+// SPARQL parser remains untouched, so this surface is available only by explicit opt-in.
+#[cfg(feature = "paths")]
+mod paths_syntax;
+#[cfg(feature = "paths")]
+pub use paths_syntax::{explain_paths, query_paths};
 // [OPUS-4.8] (sq-7d3dj.30.1) Pre-execution SPARQL algebra rewrite pass (result-equivalent
 // FILTER `?v = <iri>` constant-substitution + `OPTIONAL … !bound` → anti-join). NON-DEFAULT
 // `algebra-rewrite` feature; when off, zero of this code compiles, `PreparedQuery::parse`

--- a/crates/sparq-engine/src/paths_syntax.rs
+++ b/crates/sparq-engine/src/paths_syntax.rs
@@ -1,0 +1,295 @@
+//! Dedicated syntax front end for materialized full-path queries.
+//!
+//! This module deliberately does not extend `spargebra`: [`query_paths`] is the
+//! only query entry point accepting `PATHS`, leaving the standard SPARQL surface
+//! and its conformance behavior unchanged.
+//!
+//! The result follows a row-per-hop shape. Every row binds the requested start
+//! and end variables, `?pathIndex` (zero-based within the result), `?hopIndex`
+//! (zero-based within the path), `?node` (the node reached by that hop), and
+//! `?edge` (the predicate traversed by that hop).
+
+use oxrdf::vocab::xsd;
+use oxrdf::{Literal, NamedNode, Term, Variable};
+use spargebra::algebra::GraphPattern;
+use spargebra::term::NamedNodePattern;
+use spargebra::{Query, SparqlParser};
+use sparq_core::Graph;
+
+use crate::{enumerate_paths, PathMode, PathSpec, QueryResult};
+
+#[derive(Debug)]
+struct ParsedPaths {
+    mode: PathMode,
+    cyclic: bool,
+    start_var: Variable,
+    start: Option<Term>,
+    end_var: Variable,
+    end: Option<Term>,
+    via: NamedNode,
+    max_length: Option<usize>,
+}
+
+/// Parses and evaluates the opt-in `PATHS` query form.
+pub fn query_paths(graph: &Graph, src: &str) -> Result<QueryResult, String> {
+    let parsed = parse_paths(src)?;
+    let solutions = enumerate_paths(
+        graph,
+        &PathSpec {
+            mode: parsed.mode,
+            cyclic: parsed.cyclic,
+            start: parsed.start,
+            end: parsed.end,
+            via: parsed.via,
+            max_length: parsed.max_length,
+        },
+    )?;
+    let vars = vec![
+        parsed.start_var,
+        parsed.end_var,
+        Variable::new_unchecked("pathIndex"),
+        Variable::new_unchecked("hopIndex"),
+        Variable::new_unchecked("node"),
+        Variable::new_unchecked("edge"),
+    ];
+    let mut rows = Vec::new();
+    for (path_index, path) in solutions.into_iter().enumerate() {
+        let start = path
+            .nodes
+            .first()
+            .cloned()
+            .expect("enumerated paths are non-empty");
+        let end = path
+            .nodes
+            .last()
+            .cloned()
+            .expect("enumerated paths are non-empty");
+        for (hop_index, edge) in path.edges.into_iter().enumerate() {
+            rows.push(vec![
+                Some(start.clone()),
+                Some(end.clone()),
+                Some(integer(path_index)),
+                Some(integer(hop_index)),
+                Some(path.nodes[hop_index + 1].clone()),
+                Some(edge),
+            ]);
+        }
+    }
+    Ok(QueryResult { vars, rows })
+}
+
+/// Renders the typed operator represented by an opt-in `PATHS` query.
+pub fn explain_paths(_graph: &Graph, src: &str) -> Result<String, String> {
+    let parsed = parse_paths(src)?;
+    let mode = match parsed.mode {
+        PathMode::Shortest => "shortest",
+        PathMode::All => "all",
+    };
+    let maximum = parsed
+        .max_length
+        .map_or_else(|| "none".to_owned(), |n| n.to_string());
+    Ok(format!(
+        "Paths mode={mode} cyclic={} via=<{}> maxLength={maximum}",
+        parsed.cyclic,
+        parsed.via.as_str()
+    ))
+}
+
+fn integer(value: usize) -> Term {
+    Term::Literal(Literal::new_typed_literal(value.to_string(), xsd::INTEGER))
+}
+
+fn parse_paths(src: &str) -> Result<ParsedPaths, String> {
+    let tokens = tokenize(src)?;
+    let paths_at = tokens
+        .iter()
+        .position(|token| token.eq_ignore_ascii_case("PATHS"))
+        .ok_or_else(|| "expected PATHS query form".to_owned())?;
+    let prologue = tokens[..paths_at].join(" ");
+    validate_prologue(&prologue)?;
+    let mut parser = Tokens::new(&tokens[paths_at..]);
+    parser.keyword("PATHS")?;
+    let mode = if parser.consume_keyword("SHORTEST") {
+        PathMode::Shortest
+    } else if parser.consume_keyword("ALL") {
+        PathMode::All
+    } else {
+        return Err("PATHS requires SHORTEST or ALL".to_owned());
+    };
+    let cyclic = parser.consume_keyword("CYCLIC");
+    parser.keyword("START")?;
+    let start_var = parser.variable()?;
+    let start = parser.optional_bound_iri(&prologue)?;
+    parser.keyword("END")?;
+    let end_var = parser.variable()?;
+    let end = parser.optional_bound_iri(&prologue)?;
+    parser.keyword("VIA")?;
+    let via = resolve_iri(&prologue, parser.next("IRI after VIA")?)?;
+    let max_length = if parser.consume_keyword("MAX") {
+        parser.keyword("LENGTH")?;
+        Some(
+            parser
+                .next("integer after MAX LENGTH")?
+                .parse::<usize>()
+                .map_err(|_| "MAX LENGTH must be a non-negative integer".to_owned())?,
+        )
+    } else {
+        None
+    };
+    if parser.remaining() {
+        return Err(format!(
+            "unexpected token `{}` after PATHS query",
+            parser.peek().unwrap()
+        ));
+    }
+    if mode == PathMode::All && max_length.is_none() {
+        return Err("PATHS ALL requires MAX LENGTH".to_owned());
+    }
+    Ok(ParsedPaths {
+        mode,
+        cyclic,
+        start_var,
+        start,
+        end_var,
+        end,
+        via,
+        max_length,
+    })
+}
+
+fn validate_prologue(prologue: &str) -> Result<(), String> {
+    if prologue.is_empty() {
+        return Ok(());
+    }
+    SparqlParser::new()
+        .parse_query(&format!("{prologue} ASK {{ }}"))
+        .map(|_| ())
+        .map_err(|error| format!("invalid PATHS prologue: {error}"))
+}
+
+fn resolve_iri(prologue: &str, token: &str) -> Result<NamedNode, String> {
+    let query = SparqlParser::new()
+        .parse_query(&format!(
+            "{prologue} SELECT * WHERE {{ <urn:sparq:source> {token} <urn:sparq:target> }}"
+        ))
+        .map_err(|error| format!("invalid IRI `{token}`: {error}"))?;
+    let Query::Select { pattern, .. } = query else {
+        unreachable!()
+    };
+    let pattern = match pattern {
+        GraphPattern::Project { inner, .. } => *inner,
+        other => other,
+    };
+    let GraphPattern::Bgp { patterns } = pattern else {
+        unreachable!()
+    };
+    let NamedNodePattern::NamedNode(node) = &patterns[0].predicate else {
+        return Err(format!("expected IRI, found `{token}`"));
+    };
+    Ok(node.clone())
+}
+
+fn tokenize(src: &str) -> Result<Vec<String>, String> {
+    let mut tokens = Vec::new();
+    let mut chars = src.char_indices().peekable();
+    while let Some((start, ch)) = chars.next() {
+        if ch.is_whitespace() {
+            continue;
+        }
+        if ch == '#' {
+            while chars.next().is_some_and(|(_, c)| c != '\n') {}
+            continue;
+        }
+        if ch == '=' {
+            tokens.push("=".to_owned());
+            continue;
+        }
+        if ch == '<' {
+            let mut end = None;
+            for (index, c) in chars.by_ref() {
+                if c == '>' {
+                    end = Some(index + 1);
+                    break;
+                }
+            }
+            let end = end.ok_or_else(|| "unterminated IRI reference".to_owned())?;
+            tokens.push(src[start..end].to_owned());
+            continue;
+        }
+        let mut end = start + ch.len_utf8();
+        while let Some(&(index, c)) = chars.peek() {
+            if c.is_whitespace() || c == '=' || c == '#' || c == '<' {
+                break;
+            }
+            chars.next();
+            end = index + c.len_utf8();
+        }
+        tokens.push(src[start..end].to_owned());
+    }
+    Ok(tokens)
+}
+
+struct Tokens<'a> {
+    tokens: &'a [String],
+    position: usize,
+}
+
+impl<'a> Tokens<'a> {
+    fn new(tokens: &'a [String]) -> Self {
+        Self {
+            tokens,
+            position: 0,
+        }
+    }
+    fn peek(&self) -> Option<&str> {
+        self.tokens.get(self.position).map(String::as_str)
+    }
+    fn next(&mut self, expected: &str) -> Result<&'a str, String> {
+        let token = self
+            .tokens
+            .get(self.position)
+            .ok_or_else(|| format!("expected {expected}"))?;
+        self.position += 1;
+        Ok(token)
+    }
+    fn keyword(&mut self, expected: &str) -> Result<(), String> {
+        let found = self.next(expected)?;
+        if found.eq_ignore_ascii_case(expected) {
+            Ok(())
+        } else {
+            Err(format!("expected {expected}, found `{found}`"))
+        }
+    }
+    fn consume_keyword(&mut self, keyword: &str) -> bool {
+        if self
+            .peek()
+            .is_some_and(|token| token.eq_ignore_ascii_case(keyword))
+        {
+            self.position += 1;
+            true
+        } else {
+            false
+        }
+    }
+    fn variable(&mut self) -> Result<Variable, String> {
+        let token = self.next("variable")?;
+        let name = token
+            .strip_prefix('?')
+            .or_else(|| token.strip_prefix('$'))
+            .ok_or_else(|| format!("expected variable, found `{token}`"))?;
+        Variable::new(name).map_err(|error| error.to_string())
+    }
+    fn optional_bound_iri(&mut self, prologue: &str) -> Result<Option<Term>, String> {
+        if self.peek() != Some("=") {
+            return Ok(None);
+        }
+        self.position += 1;
+        Ok(Some(Term::NamedNode(resolve_iri(
+            prologue,
+            self.next("IRI after =")?,
+        )?)))
+    }
+    fn remaining(&self) -> bool {
+        self.position < self.tokens.len()
+    }
+}

--- a/crates/sparq-engine/tests/paths_surface.rs
+++ b/crates/sparq-engine/tests/paths_surface.rs
@@ -1,0 +1,94 @@
+#![cfg(feature = "paths")]
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_engine::{explain_paths, query, query_paths};
+
+const PATHS: &str = "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s = ex:a END ?e = ex:d VIA ex:p";
+
+fn diamond() -> Graph {
+    Graph::load_str(
+        "@prefix ex: <http://ex/> . ex:a ex:p ex:b, ex:c . ex:b ex:p ex:d . ex:c ex:p ex:d .",
+        "turtle",
+    )
+    .unwrap()
+}
+
+fn lexical(term: &Option<Term>) -> String {
+    term.as_ref().unwrap().to_string()
+}
+
+#[test]
+fn shortest_diamond_returns_exact_row_per_hop_bindings() {
+    let result = query_paths(&diamond(), PATHS).unwrap();
+    assert_eq!(
+        result.vars.iter().map(|v| v.as_str()).collect::<Vec<_>>(),
+        ["s", "e", "pathIndex", "hopIndex", "node", "edge"]
+    );
+    let rows = result
+        .rows
+        .iter()
+        .map(|row| row.iter().map(lexical).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rows,
+        vec![
+            vec![
+                "<http://ex/a>",
+                "<http://ex/d>",
+                "\"0\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "\"0\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "<http://ex/b>",
+                "<http://ex/p>"
+            ],
+            vec![
+                "<http://ex/a>",
+                "<http://ex/d>",
+                "\"0\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "\"1\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "<http://ex/d>",
+                "<http://ex/p>"
+            ],
+            vec![
+                "<http://ex/a>",
+                "<http://ex/d>",
+                "\"1\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "\"0\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "<http://ex/c>",
+                "<http://ex/p>"
+            ],
+            vec![
+                "<http://ex/a>",
+                "<http://ex/d>",
+                "\"1\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "\"1\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+                "<http://ex/d>",
+                "<http://ex/p>"
+            ],
+        ]
+    );
+}
+
+#[test]
+fn standard_surface_still_rejects_paths() {
+    assert!(query(&diamond(), PATHS).is_err());
+}
+
+#[test]
+fn malformed_paths_are_loud() {
+    assert!(query_paths(&diamond(), "PATHS SHORTEST START ?s END ?e")
+        .unwrap_err()
+        .contains("VIA"));
+    assert_eq!(
+        query_paths(&diamond(), "PATHS ALL START ?s END ?e VIA <http://ex/p>").unwrap_err(),
+        "PATHS ALL requires MAX LENGTH"
+    );
+}
+
+#[test]
+fn explain_contains_typed_paths_operator() {
+    assert_eq!(
+        explain_paths(&diamond(), PATHS).unwrap(),
+        "Paths mode=shortest cyclic=false via=<http://ex/p> maxLength=none"
+    );
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -210,6 +210,19 @@ assert!(paths.iter().all(|path| path.nodes.len() == path.edges.len() + 1));
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+The same feature exposes a dedicated non-standard query form through `query_paths` and
+`explain_paths`. It is intentionally rejected by the ordinary `query` entry point:
+
+```rust
+let result = sparq_engine::query_paths(&g,
+    "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s = ex:alice END ?e = ex:bob VIA ex:knows")?;
+// Columns: ?s ?e ?pathIndex ?hopIndex ?node ?edge; one row per traversed hop.
+let plan = sparq_engine::explain_paths(&g,
+    "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s = ex:alice END ?e = ex:bob VIA ex:knows")?;
+assert!(plan.starts_with("Paths mode=shortest"));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 **RDF 1.2 triple terms** (`<<( s p o )>>`) — stored structurally; patterns with variables
 inside the triple term match. Load with the `rdf-12` feature enabled on oxrdf/oxttl (default in
 this workspace). In Turtle/TriG you can write the reified triple `<< s p o >>` (the


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-lsp7k.3.2.

Adds the opt-in, dedicated `query_paths` and `explain_paths` entry points without extending the standard SPARQL parser. PATHS results use deterministic row-per-hop bindings for the endpoint variables plus `?pathIndex`, `?hopIndex`, `?node`, and `?edge`. Prefix/base resolution is delegated to the existing SPARQL parser, and the public query skill is updated in the same change.

Tests cover exact diamond-graph rows, standard-surface rejection, malformed input, typed EXPLAIN output, and a witnessed mutation of hop-node selection.

Gates:
- `cargo test -p sparq-engine`
- `cargo test -p sparq-engine --features paths`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo clippy --workspace --all-targets --features paths -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`
- W3C conformance: 1225 pass, 0 fail, 4 documented divergences, 0 skip (1229 in scope)