### PR TITLE
bench(dashboard): feature serialize and federation suites [GPT-5.6]

### DIFF
--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -2056,6 +2056,11 @@
       aliases: ['python-bindings-bench', 'python_bindings_bench', 'pythonbindingsbench', 'python'],
       note: 'Correctness-gated binding-overhead card: result counts must agree before timing. '
           + 'Binding latency rows are non-canonical trend signals.' },
+    // [GPT-5.6] sq-l8c05: comparative serialization and FedShop-shaped federation panels.
+    { key: 'serialize-bench', title: 'Serialization throughput',
+      aliases: ['serialize-bench', 'serialize_bench', 'serializebench', 'serialize'] },
+    { key: 'federation-fedshop', title: 'Federation comparison — FedShop-shaped',
+      aliases: ['federation-fedshop', 'federation_fedshop', 'federationfedshop', 'federation'] },
     // [OPUS-4.8] sq-5o5.3: PROMOTE the ZK estate to a featured card (the maintainer treats ZK as a
     // genuine differentiator, unlike the trend-only suites). One card groups the whole estate: the
     // `zk-compose` circuit-gate counts (zk_compose_<member>_gates) + the `zk` commitment-pipeline


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-l8c05. Closes #1990. Closes #1989.

Adds exactly the two requested FEATURED_SUITES rows for the serialization-throughput and FedShop-shaped federation comparative panels. Keys use the registered benchmark IDs; titles and aliases follow the registry names, IDs, and metric-prefix spellings.

Gates:
- node --check bench/dashboard/dashboard.js
- node scripts/dashboard-smoke.js
- python3 scripts/gen-metric-labels.py --check
- python3 scripts/check-new-bench-registered.py --base main
- git diff --check

Mutation witness: direct featuredSuiteOf routing assertions pass for both underscore-prefixed metric spellings; deleting either new row from a temporary dashboard copy makes its corresponding assertion fail.