### PR TITLE
test(geo): property-test WKT literal round trips [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4614,6 +4614,7 @@ dependencies = [
  "i_overlay 7.0.2",
  "oxrdf 0.3.3",
  "proj4rs",
+ "proptest",
  "quick-xml 0.41.0",
  "rand 0.10.1",
  "rstar 0.13.0",

--- a/crates/sparq-geo/Cargo.toml
+++ b/crates/sparq-geo/Cargo.toml
@@ -99,6 +99,8 @@ proj4rs = { version = "0.1", optional = true }
 rustc-hash.workspace = true
 
 [dev-dependencies]
+# [GPT-5.6] Random accepted WKT geometries for parse/serialize fixpoint coverage.
+proptest = "1"
 # Deterministic random geometries for property tests + the benchmark example.
 # [OPUS-4.8] sq-8xug: rand-ecosystem 0.10. `random_range` moved from the `Rng`
 # trait to `RngExt` in 0.10, so the test/example imports use the prelude.

--- a/crates/sparq-geo/tests/wkt_roundtrip_prop.rs
+++ b/crates/sparq-geo/tests/wkt_roundtrip_prop.rs
@@ -1,0 +1,61 @@
+//! Property coverage for the accepted WKT literal domain. [GPT-5.6]
+
+use geo_types::{Coord, Geometry, LineString, Point, Polygon};
+use proptest::prelude::*;
+use sparq_geo::{parse_wkt_literal, Crs, GeoGeometry};
+
+fn coordinate() -> impl Strategy<Value = Coord<f64>> {
+    (-1_000_000.0f64..1_000_000.0, -1_000_000.0f64..1_000_000.0).prop_map(|(x, y)| Coord { x, y })
+}
+
+fn geometry() -> impl Strategy<Value = Geometry<f64>> {
+    let point = coordinate().prop_map(|c| Geometry::Point(Point(c)));
+    let line = prop::collection::vec(coordinate(), 2..=8)
+        .prop_map(|coords| Geometry::LineString(LineString::new(coords)));
+    let polygon = (
+        -1_000_000.0f64..1_000_000.0,
+        -1_000_000.0f64..1_000_000.0,
+        0.000_001f64..10_000.0,
+        0.000_001f64..10_000.0,
+    )
+        .prop_map(|(x, y, width, height)| {
+            Geometry::Polygon(Polygon::new(
+                LineString::from(vec![
+                    (x, y),
+                    (x + width, y),
+                    (x + width, y + height),
+                    (x, y + height),
+                    (x, y),
+                ]),
+                vec![],
+            ))
+        });
+
+    prop_oneof![point, line, polygon]
+}
+
+fn crs() -> impl Strategy<Value = Crs> {
+    prop_oneof![
+        Just(Crs::Crs84),
+        Just(Crs::Epsg4326),
+        Just(Crs::Other(
+            "http://www.opengis.net/def/crs/EPSG/0/27700".to_owned()
+        )),
+        Just(Crs::Other("http://example.org/crs/local".to_owned())),
+    ]
+}
+
+fn wkt_geometry() -> impl Strategy<Value = GeoGeometry> {
+    (crs(), geometry()).prop_map(|(crs, geometry)| GeoGeometry { crs, geometry })
+}
+
+proptest! {
+    #[test]
+    fn wkt_parse_serialize_roundtrip(original in wkt_geometry()) {
+        let lexical = original.to_wkt_literal();
+        let reparsed = parse_wkt_literal(&lexical)
+            .expect("to_wkt_literal must produce an accepted WKT lexical form");
+
+        prop_assert_eq!(reparsed, original);
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-4hw5u.

Adds property coverage for the WKT parse/serialize fixpoint across bounded random POINT, LINESTRING, and POLYGON geometries with CRS84, EPSG:4326, and curated other CRS IRIs. This is test-only; runtime logic is unchanged.

Gates (sparq-geo scoped):
- `cargo clippy -p sparq-geo --all-targets -- -D warnings`
- `cargo clippy -p sparq-geo --all-targets --all-features -- -D warnings`
- `cargo test -p sparq-geo`
- `cargo test -p sparq-geo --no-default-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-geo --no-deps --all-features`
- `cargo fmt -p sparq-geo` followed by restoration of pre-existing crate-wide formatting drift; the new test was formatted directly and `git diff --check` passes

Mutation spot-check: deliberately changed `to_wkt_literal` to add 1.0 to each serialized x coordinate. The property test failed and shrank to `POINT(0 0)`, reparsed as `POINT(1 0)`; reverting the mutation made the property test pass.

Not armed or merged.