### PR TITLE
bench(hdt): add self-asserting direct decoder A/B [GPT-5.6]

### DIFF
--- a/bench/hdt/direct-vs-upstream.sh
+++ b/bench/hdt/direct-vs-upstream.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# [GPT-5.6] (sq-wzzxg) Self-relative HDT decode A/B. The Rust example performs
+# the hard direct-vs-upstream graph-agreement assertion before printing timings;
+# this wrapper preserves its nonzero exit and exposes the benchmark TSV contract.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+triples=1000000
+if [ "${1:-}" = "--smoke" ]; then
+  triples=100
+elif [ "$#" -ne 0 ]; then
+  echo "usage: $0 [--smoke]" >&2
+  exit 2
+fi
+
+BIN="${HDT_DIRECT_AB_BIN:-$ROOT/target/release/examples/bench_direct_vs_upstream}"
+if [ -z "${HDT_DIRECT_AB_BIN:-}" ]; then
+  cargo build --release -p sparq-hdt --example bench_direct_vs_upstream >&2
+fi
+if [ ! -x "$BIN" ]; then
+  echo "[hdt-direct-ab] ERROR: runner is not executable: $BIN" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# A panic or any other failure (including graph divergence) stops here before TSV
+# is emitted. Thus machine-sensitive timings can never be reported after a failed
+# correctness gate.
+if ! "$BIN" "$triples" >"$TMP/raw.stdout" 2>"$TMP/raw.stderr"; then
+  cat "$TMP/raw.stderr" >&2
+  echo "[hdt-direct-ab] ERROR: graph-agreement gate or benchmark run failed" >&2
+  exit 1
+fi
+cat "$TMP/raw.stderr" >&2
+
+loaded="$(awk '/^loaded [0-9]+ triples / { print $2 }' "$TMP/raw.stdout")"
+direct_s="$(awk '/^  direct / { print $3 }' "$TMP/raw.stdout" | sed 's/s$//')"
+upstream_s="$(awk '/^  upstream / { print $3 }' "$TMP/raw.stdout" | sed 's/s$//')"
+
+if ! [[ "$loaded" =~ ^[0-9]+$ ]] || [ "$loaded" != "$triples" ]; then
+  echo "[hdt-direct-ab] ERROR: expected $triples agreed triples, got '${loaded:-missing}'" >&2
+  exit 1
+fi
+if ! [[ "$direct_s" =~ ^[0-9]+([.][0-9]+)?$ ]] || ! [[ "$upstream_s" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  echo "[hdt-direct-ab] ERROR: benchmark timing rows were missing or malformed" >&2
+  exit 1
+fi
+
+direct_us="$(awk -v seconds="$direct_s" 'BEGIN { printf "%.0f", seconds * 1000000 }')"
+upstream_us="$(awk -v seconds="$upstream_s" 'BEGIN { printf "%.0f", seconds * 1000000 }')"
+printf 'direct_decode\t%s\t%s\n' "$loaded" "$direct_us"
+printf 'upstream_decode\t%s\t%s\n' "$loaded" "$upstream_us"
+echo "[hdt-direct-ab] OK: direct and upstream paths produced agreeing graphs" >&2

--- a/research/gap-hdt-direct-2026-07.md
+++ b/research/gap-hdt-direct-2026-07.md
@@ -1,0 +1,18 @@
+# HDT direct-decoder self-relative A/B
+
+<!-- [GPT-5.6] sq-wzzxg -->
+
+This runner compares sparq-hdt's direct decoder with its upstream-backed oracle
+using identical in-memory HDT bytes. It is an internal structural comparison,
+not an external competitor result and not a source of headline performance
+claims.
+
+Run `bash bench/hdt/direct-vs-upstream.sh --smoke` for the smallest correctness
+check, or omit `--smoke` for the normal synthetic workload. Standard output is
+restricted to `<workload>\t<triples>\t<us>` rows so automation can collect it.
+Diagnostics go to standard error.
+
+The direct and upstream paths must agree before either timing is emitted. Any
+decoder failure or triple-count divergence exits nonzero, making correctness a
+hard gate. Timing values are advisory and non-canonical on a work box; canonical
+comparisons require a quiet-box rerun.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-wzzxg.

- adds bench/hdt/direct-vs-upstream.sh with --smoke and the workload/triples/us TSV stdout contract
- preserves the example graph-agreement assertion as a hard pre-timing gate
- records the self-relative, advisory/non-canonical scope in the HDT gap note

Gates:
- cargo clippy default and all-features
- cargo test default and all-features
- rustdoc all-features with warnings denied
- crate formatting
- smoke acceptance
- mutation witness: injected failing runner exits 1 before emitting TSV

Not armed for merge.