### PR TITLE
bench(policy): add correctness-gated decision harness [GPT-5.6]

### DIFF
--- a/crates/sparq-policy/examples/policy_bench.rs
+++ b/crates/sparq-policy/examples/policy_bench.rs
@@ -1,0 +1,184 @@
+//! Correctness-gated, self-relative policy-evaluation micro-benchmark.
+//!
+//! [GPT-5.6] sq-gpdwc. The WAC and ACP lanes model their characteristic
+//! allow/deny shapes in ODRL so that all lanes exercise the same evaluator.
+//! This is not an external comparison or a security/soundness claim.
+
+use sparq_policy::{evaluate, parse_policy_str, Policy, Request, Value, ODRL_NS};
+use std::hint::black_box;
+use std::time::Instant;
+
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+struct Case {
+    request: Request,
+    allow: bool,
+}
+
+struct Mix {
+    name: &'static str,
+    policy: Policy,
+    cases: Vec<Case>,
+}
+
+fn request(action: &str, target: &str, assignee: &str) -> Request {
+    Request::new(format!("{ODRL_NS}{action}"))
+        .on(target)
+        .by(assignee)
+}
+
+fn parse(ttl: &str) -> Policy {
+    parse_policy_str(ttl, "turtle").expect("vendored policy fixture must parse")
+}
+
+fn mixes() -> Vec<Mix> {
+    let wac = parse(&format!(
+        "@prefix odrl: <{ODRL_NS}> .\n\
+         <urn:policy:wac> a odrl:Set ;\n\
+           odrl:permission [ odrl:action odrl:read ; odrl:target <urn:doc:public> ] ;\n\
+           odrl:permission [ odrl:action odrl:write ; odrl:target <urn:doc:private> ;\n\
+                             odrl:assignee <urn:agent:owner> ] ."
+    ));
+    let acp = parse(&format!(
+        "@prefix odrl: <{ODRL_NS}> .\n\
+         <urn:policy:acp> a odrl:Set ;\n\
+           odrl:permission [ odrl:action odrl:read ; odrl:target <urn:resource:team> ;\n\
+                             odrl:assignee <urn:group:editors> ] ;\n\
+           odrl:prohibition [ odrl:action odrl:write ; odrl:target <urn:resource:team> ;\n\
+                              odrl:assignee <urn:agent:suspended> ] ."
+    ));
+    let odrl = parse(&format!(
+        "@prefix odrl: <{ODRL_NS}> .\n\
+         @prefix xsd: <{XSD}> .\n\
+         <urn:policy:odrl> a odrl:Set ;\n\
+           odrl:permission [ odrl:action odrl:use ; odrl:target <urn:data:study> ;\n\
+             odrl:assignee <urn:agent:researcher> ;\n\
+             odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;\n\
+                               odrl:rightOperand <urn:purpose:research> ] ;\n\
+             odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;\n\
+                               odrl:rightOperand \"2030-01-01T00:00:00Z\"^^xsd:dateTime ] ] ."
+    ));
+
+    vec![
+        Mix {
+            name: "wac",
+            policy: wac,
+            cases: vec![
+                Case {
+                    request: request("read", "urn:doc:public", "urn:agent:anyone"),
+                    allow: true,
+                },
+                Case {
+                    request: request("write", "urn:doc:private", "urn:agent:owner"),
+                    allow: true,
+                },
+                Case {
+                    request: request("write", "urn:doc:private", "urn:agent:other"),
+                    allow: false,
+                },
+                Case {
+                    request: request("read", "urn:doc:private", "urn:agent:owner"),
+                    allow: false,
+                },
+            ],
+        },
+        Mix {
+            name: "acp",
+            policy: acp,
+            cases: vec![
+                Case {
+                    request: request("read", "urn:resource:team", "urn:group:editors"),
+                    allow: true,
+                },
+                Case {
+                    request: request("read", "urn:resource:team", "urn:agent:outsider"),
+                    allow: false,
+                },
+                Case {
+                    request: request("write", "urn:resource:team", "urn:agent:suspended"),
+                    allow: false,
+                },
+                Case {
+                    request: request("read", "urn:resource:other", "urn:group:editors"),
+                    allow: false,
+                },
+            ],
+        },
+        Mix {
+            name: "odrl",
+            policy: odrl,
+            cases: vec![
+                Case {
+                    request: odrl_request("urn:purpose:research", "2028-01-01T00:00:00Z"),
+                    allow: true,
+                },
+                Case {
+                    request: odrl_request("urn:purpose:marketing", "2028-01-01T00:00:00Z"),
+                    allow: false,
+                },
+                Case {
+                    request: odrl_request("urn:purpose:research", "2031-01-01T00:00:00Z"),
+                    allow: false,
+                },
+                Case {
+                    request: request("use", "urn:data:study", "urn:agent:other"),
+                    allow: false,
+                },
+            ],
+        },
+    ]
+}
+
+fn odrl_request(purpose: &str, time: &str) -> Request {
+    request("use", "urn:data:study", "urn:agent:researcher")
+        .with(format!("{ODRL_NS}purpose"), Value::Iri(purpose.into()))
+        .with(format!("{ODRL_NS}dateTime"), Value::DateTime(time.into()))
+}
+
+fn assert_oracle(mixes: &[Mix]) {
+    for mix in mixes {
+        for (index, case) in mix.cases.iter().enumerate() {
+            let actual = evaluate(&mix.policy, &case.request).allow;
+            assert_eq!(actual, case.allow, "{} oracle row {index}", mix.name);
+        }
+    }
+}
+
+fn main() {
+    let smoke = match std::env::args().nth(1).as_deref() {
+        None => false,
+        Some("--smoke") => true,
+        Some(arg) => panic!("unknown argument {arg:?}; expected --smoke"),
+    };
+    let mixes = mixes();
+
+    // No timing row may be emitted unless the complete pinned table is green.
+    assert_oracle(&mixes);
+    let rounds = if smoke { 100 } else { 25_000 };
+
+    println!("=== SPARQ_POLICY_BENCH ===");
+    println!(
+        "# correctness=green oracle_rows={}",
+        mixes.iter().map(|m| m.cases.len()).sum::<usize>()
+    );
+    println!("# policy-mix\tdecisions\tus");
+    for mix in &mixes {
+        let start = Instant::now();
+        let mut allowed = 0usize;
+        for _ in 0..rounds {
+            for case in &mix.cases {
+                allowed +=
+                    usize::from(black_box(evaluate(&mix.policy, black_box(&case.request))).allow);
+            }
+        }
+        black_box(allowed);
+        let decisions = rounds * mix.cases.len();
+        println!(
+            "{}\t{}\t{}",
+            mix.name,
+            decisions,
+            start.elapsed().as_micros()
+        );
+    }
+    println!("=== END SPARQ_POLICY_BENCH ===");
+}

--- a/research/gap-policy-2026-07.md
+++ b/research/gap-policy-2026-07.md
@@ -1,0 +1,41 @@
+# Policy-evaluation benchmark gap record — 2026-07
+
+<!-- [GPT-5.6] sq-gpdwc. Do not put benchmark measurements in this record. -->
+
+**Axis:** access-control policy evaluation (WAC-, ACP-, and ODRL-shaped decisions)  
+**Epic:** sq-hmd7l  
+**Bead:** sq-gpdwc
+
+## Disposition
+
+External throughput comparison is **NOT-COMPARABLE**. There is no pinned peer that
+offers the same in-process decision surface across this WAC/ACP/ODRL mix. Selecting
+an unrelated policy engine would produce an apples-to-oranges result rather than a
+defensible competitor column.
+
+The crate therefore has a self-relative micro-harness at
+`crates/sparq-policy/examples/policy_bench.rs`. It evaluates a deterministic request
+corpus against vendored policy fixtures. Before starting a timer or printing any
+throughput row, the harness checks every result against a pinned allow/deny table.
+Failure is fail-fast. Its machine-readable rows are:
+
+```text
+<policy-mix>\t<decisions>\t<us>
+```
+
+Run the acceptance tier with:
+
+```sh
+cargo run -p sparq-policy --release --example policy_bench -- --smoke
+```
+
+The WAC and ACP lanes reproduce their characteristic public/owner and group/deny
+decision shapes using ODRL rules, so all lanes measure the same `sparq-policy`
+evaluation path. This harness measures evaluation mechanics only. It makes no claim
+about the soundness or security of an access-control deployment.
+
+## Gap status
+
+There is no peer-performance gap to report under the honest NOT-COMPARABLE
+disposition. Future measurements may be stored by the benchmark infrastructure, but
+timings are deliberately not committed to this Markdown record.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-gpdwc.

Adds a deterministic WAC/ACP/ODRL-shaped policy-decision micro-harness. The complete pinned allow/deny oracle is asserted before the timing envelope or any throughput row is emitted. Output follows the policy-mix, decisions, microseconds TSV contract. The accompanying gap record preserves the honest NOT-COMPARABLE-externally disposition and makes no access-control soundness or security claim.

Gates:
- cargo clippy -p sparq-policy --all-targets -- -D warnings
- cargo clippy -p sparq-policy --all-targets --all-features -- -D warnings
- cargo test -p sparq-policy
- cargo test -p sparq-policy --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-policy --no-deps --all-features
- cargo run -p sparq-policy --release --example policy_bench -- --smoke
- mutation witness: flipping pinned WAC row 0 made the acceptance command fail before timing output

All scoped gates green. Not armed for merge.