### PR TITLE
feat(nlq): classify generated SPARQL policy (sq-9zs3g) [GPT-5.6]

### DIFF
--- a/crates/sparq-nlq/Cargo.toml
+++ b/crates/sparq-nlq/Cargo.toml
@@ -45,6 +45,9 @@ nlq-endpoint = ["dep:reqwest"]
 # `sparq-core`. Citations are emitted from in-graph `prov:wasDerivedFrom`/`dcterms:source`
 # provenance ONLY — never guessed; absent provenance yields "no source recorded".
 citations = []
+# [GPT-5.6] sq-9zs3g: generated-query policy inspection is opt-in so the
+# default NLQ surface remains unchanged.
+query-policy = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-nlq/src/lib.rs
+++ b/crates/sparq-nlq/src/lib.rs
@@ -29,6 +29,10 @@ pub mod constrain;
 pub mod eval;
 pub mod link;
 
+/// Read-only versus mutating classification for parsed SPARQL algebra.
+#[cfg(feature = "query-policy")]
+pub mod policy;
+
 // [OPUS-4.8] sq-2489d.1 (GenAI-KB Phase 1): the cross-cutting provenance-join primitive
 // and the PKG-native citation renderer, behind the opt-in `citations` feature so the lean
 // NL→SPARQL loop carries zero provenance machinery in the default build.

--- a/crates/sparq-nlq/src/policy.rs
+++ b/crates/sparq-nlq/src/policy.rs
@@ -1,0 +1,104 @@
+//! Policy classification for generated SPARQL algebra.
+//!
+//! Classify only after parsing. A [`spargebra::Query`] is always read-only, while every
+//! [`spargebra::Update`] is mutating, including update requests containing multiple
+//! operations. This algebra-level split avoids keyword scanning and therefore
+//! cannot be confused by comments, string literals, or prefixes.
+
+// [GPT-5.6] sq-9zs3g: policy is decided from typed parser output, not source text.
+
+use spargebra::{Query, Update};
+
+/// The graph-access policy required by parsed SPARQL algebra.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum QueryPolicy {
+    /// The algebra can inspect a dataset but cannot change it.
+    ReadOnly,
+    /// The algebra can change a dataset.
+    Mutating,
+}
+
+/// Classifies parsed query algebra.
+///
+/// All SPARQL query result forms (`SELECT`, `ASK`, `CONSTRUCT`, and
+/// `DESCRIBE`) are read-only. The exhaustive match intentionally makes a new
+/// upstream query variant a compile-time decision instead of silently granting
+/// it read-only access.
+#[must_use]
+pub fn classify_query(query: &Query) -> QueryPolicy {
+    match query {
+        Query::Select { .. }
+        | Query::Ask { .. }
+        | Query::Construct { .. }
+        | Query::Describe { .. } => QueryPolicy::ReadOnly,
+    }
+}
+
+/// Classifies a parsed SPARQL Update request.
+///
+/// An update request is mutating regardless of which operation it contains or
+/// how many operations are combined in the request. Callers should reject it
+/// whenever only read access was authorized.
+#[must_use]
+pub const fn classify_update(_update: &Update) -> QueryPolicy {
+    QueryPolicy::Mutating
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_query, classify_update, QueryPolicy};
+    use spargebra::SparqlParser;
+
+    #[test]
+    fn read_only_algebra_classified() {
+        for sparql in [
+            "SELECT * WHERE { ?s ?p ?o }",
+            "ASK WHERE { ?s ?p ?o }",
+            "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+            "DESCRIBE ?s WHERE { ?s ?p ?o }",
+        ] {
+            let query = SparqlParser::new()
+                .parse_query(sparql)
+                .expect("valid query fixture");
+            assert_eq!(classify_query(&query), QueryPolicy::ReadOnly, "{sparql}");
+        }
+    }
+
+    #[test]
+    fn mutating_algebra_classified() {
+        for sparql in [
+            "INSERT DATA { <http://example/s> <http://example/p> <http://example/o> }",
+            "DELETE DATA { <http://example/s> <http://example/p> <http://example/o> }",
+            "LOAD <http://example/data>",
+            "CLEAR DEFAULT",
+            "DROP DEFAULT",
+            "CREATE GRAPH <http://example/g>",
+            "ADD DEFAULT TO GRAPH <http://example/g>",
+            "MOVE DEFAULT TO GRAPH <http://example/g>",
+            "COPY DEFAULT TO GRAPH <http://example/g>",
+        ] {
+            let update = SparqlParser::new()
+                .parse_update(sparql)
+                .expect("valid update fixture");
+            assert_eq!(classify_update(&update), QueryPolicy::Mutating, "{sparql}");
+        }
+    }
+
+    #[test]
+    fn mixed_update_is_mutating() {
+        let update = SparqlParser::new()
+            .parse_update(
+                "DELETE { ?s <http://example/old> ?o } \
+                 INSERT { ?s <http://example/new> ?o } \
+                 WHERE { ?s <http://example/old> ?o }; \
+                 CLEAR GRAPH <http://example/staging>",
+            )
+            .expect("valid mixed update fixture");
+
+        assert!(
+            update.operations.len() > 1,
+            "fixture must contain mixed operations"
+        );
+        assert_eq!(classify_update(&update), QueryPolicy::Mutating);
+    }
+}

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -128,6 +128,22 @@ sparq_introspect::facets(graph: &Graph, request: &FacetRequest) -> FacetResponse
 
 `sparq-nlq`:
 
+With the default-off `query-policy` feature, classify generated SPARQL after
+parsing its algebra (never by scanning keywords):
+
+```rust
+use spargebra::SparqlParser;
+use sparq_nlq::policy::{classify_query, classify_update, QueryPolicy};
+
+let parser = SparqlParser::new();
+let query = parser.parse_query("SELECT * WHERE { ?s ?p ?o }")?;
+assert_eq!(classify_query(&query), QueryPolicy::ReadOnly);
+
+let update = parser.parse_update("CLEAR DEFAULT")?;
+assert_eq!(classify_update(&update), QueryPolicy::Mutating);
+# Ok::<(), spargebra::SparqlSyntaxError>(())
+```
+
 ```rust
 // The single seam to any model — synchronous, stateless (the whole prompt is in `prompt`).
 pub trait Llm { fn complete(&self, prompt: &str) -> Result<String, String>; }


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements bead `sq-9zs3g`.

- adds the default-off `query-policy` feature and gated public `policy` module
- classifies all parsed query forms as read-only and parsed update requests as mutating
- covers SELECT/ASK/CONSTRUCT/DESCRIBE, all requested update spellings, and a multi-operation update
- updates the matching genai-retrieval skill for the new public API

Gates (all green):
- `cargo test -p sparq-nlq`
- `cargo test -p sparq-nlq --features query-policy`
- `cargo clippy -p sparq-nlq --all-targets -- -D warnings`
- `cargo clippy -p sparq-nlq --all-targets --features query-policy -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-nlq --no-deps --all-features`

Mutation witness: temporarily returning `ReadOnly` from `classify_update` made `mixed_update_is_mutating` fail; restoring the implementation made it pass.