### PR TITLE
parse: add opt-in zlib-rs gzip backend [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,7 @@ dependencies = [
  "crc32fast",
  "libz-ng-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -6772,6 +6773,12 @@ dependencies = [
  "quote 1.0.45",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/crates/sparq-parse/Cargo.toml
+++ b/crates/sparq-parse/Cargo.toml
@@ -27,6 +27,9 @@ publish = false
 # reach the wasm bundle. The default flate2 backend stays pure-Rust miniz_oxide.
 [features]
 zlib-ng = ["flate2/zlib-ng"]
+# [GPT-5.6] (sq-98w7z.2) Pure-Rust zlib-rs encoder backend, opt-in and OFF by
+# default so the existing miniz_oxide default and lean/wasm graphs are unchanged.
+zlib-rs = ["flate2/zlib-rs"]
 
 [dependencies]
 # Multi-member gzip (one RFC 1952 member per result chunk).

--- a/crates/sparq-parse/README.md
+++ b/crates/sparq-parse/README.md
@@ -13,6 +13,10 @@ compression overlaps serialization instead of following it.
 Hard constraint: this crate must **not** enter `sparq-wasm`'s dependency graph
 (flate2 / zstd / rayon stay out of the browser bundle).
 
+<!-- [GPT-5.6] sq-98w7z.2: document the opt-in backend selection. -->
+Gzip defaults to pure-Rust `miniz_oxide`; opt-in `zlib-rs` selects flate2's
+pure-Rust zlib-rs backend, while `zlib-ng` remains available for native builds.
+
 > **Internal crate — not on crates.io** (`publish = false`). The design is gated
 > on a measured baseline; it is consumed inside the workspace, not as a
 > standalone public API.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-98w7z.2.

Adds an OFF-by-default `sparq-parse/zlib-rs` feature forwarding to flate2’s pure-Rust zlib-rs backend. The default miniz_oxide backend and lean/wasm dependency graph remain unchanged. Documents backend selection in the crate README and records the non-canonical D4 A/B results in the bead notes; the measured gzip level-6 win supports opt-in adoption, while canonical dominance remains gated by sq-98w7z.9.

Validation:
- `cargo test -p sparq-parse`
- `cargo test -p sparq-parse --features zlib-rs`
- `cargo clippy -p sparq-parse --all-targets -- -D warnings`
- `cargo clippy -p sparq-parse --all-targets --features zlib-rs -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-parse --no-deps --all-features`
- README template and no-hardcoded-performance-number gates
- mutation witness: the feature-on test command fails on unchanged main and passes on this branch

Not armed for merge.