### PR TITLE
bench(shacl-sparql): SPARQL-constraint slice sub-panel — per-shape self-asserting sh:sparql harness (sq-pymgf) [FABLE-5]

### DIFF
--- a/bench/shacl/expected-sparql.tsv
+++ b/bench/shacl/expected-sparql.tsv
@@ -1,0 +1,31 @@
+# [FABLE-5] (sq-pymgf) SPARQL-constraint SLICE deterministic golden counts for the
+# LUBM(1) seed-0 ABox (bench/shacl/gen.sh 1 0, ~103k triples) x the 3 sh:sparql shapes
+# in shapes-sparql/sparql_heavy.ttl, PER SHAPE (workload = the shape IRI local name)
+# plus the TOTAL row (all 3 shapes validated together as one model).
+# Format: <workload>\t<conforms>\t<violations>\t<focus_nodes>  (bench/shacl/expected.tsv's format).
+#   conforms     report.conforms as 0/1 (0 = does not conform).
+#   violations   report.results.len() — one result per sh:select SOLUTION (sparq does not
+#                dedup; the same PER-ENGINE caveat as expected.tsv applies to comparisons).
+#   focus_nodes  distinct focus nodes the shape's sh:targetClass selects (engine-independent).
+# Consumed ONLY by crates/sparq-shacl/examples/sparql_constraint_bench.rs, which asserts
+# every value BEFORE emitting any timing (exit 1 on drift — a correctness finding, never
+# rounded). bench/shacl/run.sh and its expected.tsv gate are untouched (they cover exactly
+# the shapes/ dir; this slice lives in shapes-sparql/ — see sparql_heavy.ttl's header).
+#
+# DERIVED by running the example on the pinned corpus, and independently CROSS-CHECKED
+# against the raw ABox (typed-edge solution counts, no SHACL engine): for sh:sparql, each
+# solution of the constraint SELECT (with $this in the target class) is one result, so
+#   GradCourseShape        1874 GraduateStudents; 3738 (this, takesCourse, o a GraduateCourse)
+#                          typed edge pairs                                          => 3738
+#   ProfessorLoadShape     125 FullProfessors; 183 (this, teacherOf, o a GraduateCourse)
+#                          typed edge pairs                                          => 183
+#   UndergradAdvisorShape  5916 UndergraduateStudents; 422 (this, advisor, o a FullProfessor)
+#                          typed edge pairs                                          => 422
+#   TOTAL                  3738 + 183 + 422 = 4343 results — the same total the 3-engine
+#                          same-box crosscheck agreed on (research/shacl-baseline-2026-07.md
+#                          §2, "sparql_heavy 4343"); the 3 target classes are disjoint in
+#                          the raw ABox, so focus nodes sum: 1874 + 125 + 5916      => 7915
+GradCourseShape	0	3738	1874
+ProfessorLoadShape	0	183	125
+UndergradAdvisorShape	0	422	5916
+TOTAL	0	4343	7915

--- a/crates/sparq-shacl/examples/sparql_constraint_bench.rs
+++ b/crates/sparq-shacl/examples/sparql_constraint_bench.rs
@@ -1,0 +1,387 @@
+//! [FABLE-5] (sq-pymgf, epic sq-hmd7l) SPARQL-constraint SLICE sub-panel runner —
+//! validates ONLY the `sh:sparql`-heavy shape set
+//! (`bench/shacl/shapes-sparql/sparql_heavy.ttl`) over the deterministic LUBM(1)
+//! ABox and reports the slice PER SHAPE, so the SHACL-SPARQL evaluation path
+//! (engine-native `sh:select` with `$this` batched into one `VALUES` execution,
+//! sq-7d3dj.33.1) is benchmarked as its own axis instead of being averaged into
+//! the whole-suite mix `scripts/bench/shacl-same-box.sh` runs.
+//!
+//! ```sh
+//! cargo run -p sparq-shacl --release --example sparql_constraint_bench -- --smoke   # iters=1
+//! cargo run -p sparq-shacl --release --example sparql_constraint_bench -- [iters]   # default 3
+//! ```
+//!
+//! HARD GATE BEFORE ANY TIMING (the sq-pymgf invariant): every shape's
+//! `conforms` / `violations` / `focus_nodes` is asserted against the pinned
+//! oracle `bench/shacl/expected-sparql.tsv` (derived from the report itself and
+//! independently cross-checked against the raw ABox — see that file's header).
+//! Any drift prints the observed-vs-pinned values and exits 1 WITHOUT emitting a
+//! single timing row: a drift is a recorded correctness finding, never rounded.
+//! Two internal consistency checks back the per-shape split: each shape's
+//! single-shape validation count must equal its `sh:sourceShape`-grouped count
+//! from the full-set validation, and the per-shape counts must sum to the
+//! full-set total.
+//!
+//! Output (stdout, only after the gate passes) is the 3-column contract
+//! `bench/shacl/run.sh` forwards for the committed suite:
+//!
+//! ```text
+//! <workload>\t<violations>\t<validate_us>
+//! ```
+//!
+//! one row per shape (workload = the shape IRI's local name, best-of-`iters`
+//! single-shape validate time) plus a `TOTAL` row (all three shapes validated
+//! together, one model). Timing is ADVISORY (non-canonical on the shared work
+//! box); correctness lives in `expected-sparql.tsv`, NOT in the binary — exactly
+//! like `bench/shacl/expected.tsv`.
+//!
+//! The external competitor column (pySHACL via
+//! `scripts/bench-adapters/shacl_report_count.py`) is a documented GATHER step —
+//! see `research/gap-shacl-sparql-2026-07.md` — so this harness stays
+//! single-crate and self-asserting.
+//!
+//! Data: `$BENCH_SHACL_DATA` (must still be the pinned LUBM(1) seed-0 ABox — the
+//! gate asserts it) or `bench/shacl/gen.sh 1 0` (cached after the first run).
+//! The shapes + oracle are read from the repo checkout via `CARGO_MANIFEST_DIR`,
+//! so the run is cwd-independent.
+
+use oxrdf::{NamedOrBlankNode, Term, Triple};
+use sparq_shacl::{count_focus_nodes, graph_from_triples, validate_with_model, ShapesModel};
+use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const SH_NODE_SHAPE: &str = "http://www.w3.org/ns/shacl#NodeShape";
+/// The whole-slice row: all three shapes validated together as ONE model.
+const TOTAL: &str = "TOTAL";
+
+/// Pinned oracle row from `bench/shacl/expected-sparql.tsv`
+/// (`<workload>\t<conforms>\t<violations>\t<focus_nodes>`).
+struct Expected {
+    conforms: u8,
+    violations: usize,
+    focus_nodes: usize,
+}
+
+/// Observed deterministic gate values + the advisory timing for one workload.
+struct Observed {
+    conforms: u8,
+    violations: usize,
+    focus_nodes: usize,
+    validate_us: f64,
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("resolve repo root from CARGO_MANIFEST_DIR")
+}
+
+/// Locate the pinned LUBM(1) seed-0 ABox: `$BENCH_SHACL_DATA` override, else
+/// `bench/shacl/gen.sh 1 0` (first stdout line; cached + deterministic).
+fn ensure_data(root: &Path) -> PathBuf {
+    if let Ok(p) = std::env::var("BENCH_SHACL_DATA") {
+        return PathBuf::from(p);
+    }
+    let gen = root.join("bench/shacl/gen.sh");
+    let out = std::process::Command::new(&gen)
+        .args(["1", "0"])
+        .output()
+        .unwrap_or_else(|e| panic!("run {}: {e}", gen.display()));
+    assert!(
+        out.status.success(),
+        "bench/shacl/gen.sh 1 0 failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let data = stdout.lines().next().unwrap_or_default().trim();
+    assert!(!data.is_empty(), "gen.sh emitted no data path");
+    PathBuf::from(data)
+}
+
+/// Parse the pinned oracle TSV (comment lines `#` and blanks skipped).
+fn parse_expected(text: &str) -> BTreeMap<String, Expected> {
+    let mut map = BTreeMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let cols: Vec<&str> = line.split('\t').collect();
+        assert!(
+            cols.len() == 4,
+            "malformed expected-sparql.tsv row: {line:?}"
+        );
+        let parse = |i: usize| -> usize {
+            cols[i]
+                .parse()
+                .unwrap_or_else(|e| panic!("bad number in expected-sparql.tsv row {line:?}: {e}"))
+        };
+        map.insert(
+            cols[0].to_string(),
+            Expected {
+                conforms: u8::try_from(parse(1)).expect("conforms is 0/1"),
+                violations: parse(2),
+                focus_nodes: parse(3),
+            },
+        );
+    }
+    map
+}
+
+/// The forward-reachable sub-graph of `triples` from the shape node `start` —
+/// the shape's own triples plus everything it references (its `sh:sparql`
+/// constraint bnode, the shared `sh:prefixes` declaration node, …). This slices
+/// the committed multi-shape file into per-shape shape graphs WITHOUT committing
+/// derived copies of it.
+fn shape_closure(triples: &[Triple], start: &str) -> Vec<Triple> {
+    // Key subjects/objects by their N-Triples form so NamedOrBlankNode and Term
+    // compare through one representation.
+    let subject_key = |s: &NamedOrBlankNode| s.to_string();
+    let mut by_subject: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (i, t) in triples.iter().enumerate() {
+        by_subject
+            .entry(subject_key(&t.subject))
+            .or_default()
+            .push(i);
+    }
+    let mut reached: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+    let start_key = format!("<{start}>");
+    reached.insert(start_key.clone());
+    queue.push_back(start_key);
+    let mut keep: Vec<usize> = Vec::new();
+    while let Some(key) = queue.pop_front() {
+        for &i in by_subject.get(&key).into_iter().flatten() {
+            keep.push(i);
+            let obj = &triples[i].object;
+            if matches!(obj, Term::NamedNode(_) | Term::BlankNode(_)) {
+                let k = obj.to_string();
+                if reached.insert(k.clone()) {
+                    queue.push_back(k);
+                }
+            }
+        }
+    }
+    keep.sort_unstable();
+    keep.dedup();
+    keep.into_iter().map(|i| triples[i].clone()).collect()
+}
+
+/// `http://…#GradCourseShape` → `GradCourseShape` (the TSV workload key).
+fn local_name(iri: &str) -> &str {
+    iri.rsplit(['#', '/']).next().unwrap_or(iri)
+}
+
+/// Best-of-`iters` validation: (violations, conforms, best µs).
+fn timed_validate(
+    data: &sparq_core::Graph,
+    model: &ShapesModel,
+    iters: usize,
+) -> (usize, bool, f64) {
+    let mut best_us = f64::INFINITY;
+    let mut violations = 0usize;
+    let mut conforms = true;
+    for _ in 0..iters {
+        let t = Instant::now();
+        let report = validate_with_model(data, model);
+        best_us = best_us.min(t.elapsed().as_secs_f64() * 1e6);
+        violations = report.results.len();
+        conforms = report.conforms;
+    }
+    (violations, conforms, best_us)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let iters: usize = match args.first().map(String::as_str) {
+        None => 3,
+        Some("--smoke") => 1,
+        Some(n) => n.parse().unwrap_or_else(|_| {
+            eprintln!(
+                "usage: sparql_constraint_bench [--smoke | iters>=1]\n\
+                 asserts bench/shacl/expected-sparql.tsv, then emits per-shape\n\
+                 <workload>\\t<violations>\\t<validate_us> (+ a TOTAL row)"
+            );
+            std::process::exit(2);
+        }),
+    };
+    if iters == 0 {
+        eprintln!("error: iters must be >= 1 (got 0); need at least one sample for finite timings");
+        std::process::exit(2);
+    }
+
+    let root = repo_root();
+    let shapes_path = root.join("bench/shacl/shapes-sparql/sparql_heavy.ttl");
+    let expected_path = root.join("bench/shacl/expected-sparql.tsv");
+
+    // ---- data graph (pinned LUBM(1) seed-0 ABox; load timing is ADVISORY) ------------
+    let data_path = ensure_data(&root);
+    let data_text = std::fs::read_to_string(&data_path)
+        .unwrap_or_else(|e| panic!("read data {}: {e}", data_path.display()));
+    let t = Instant::now();
+    let data = sparq_core::Graph::load_str(&data_text, "ntriples")
+        .unwrap_or_else(|e| panic!("parse data {}: {e}", data_path.display()));
+    let load_us = t.elapsed().as_secs_f64() * 1e6;
+    eprintln!(
+        "[shacl-sparql] data={} load_us={load_us:.1} (advisory) iters={iters}",
+        data_path.display()
+    );
+
+    // ---- shapes: full set + per-shape slices of the SAME committed file ---------------
+    let shapes_text = std::fs::read_to_string(&shapes_path)
+        .unwrap_or_else(|e| panic!("read shapes {}: {e}", shapes_path.display()));
+    let triples: Vec<Triple> = oxttl::TurtleParser::new()
+        .for_slice(shapes_text.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|e| panic!("parse shapes {}: {e}", shapes_path.display()));
+
+    // Discover the shape nodes (named subjects typed sh:NodeShape), sorted by IRI.
+    let mut shape_iris: Vec<String> = triples
+        .iter()
+        .filter_map(|t| match (&t.subject, &t.predicate, &t.object) {
+            (NamedOrBlankNode::NamedNode(s), p, Term::NamedNode(o))
+                if p.as_str() == RDF_TYPE && o.as_str() == SH_NODE_SHAPE =>
+            {
+                Some(s.as_str().to_string())
+            }
+            _ => None,
+        })
+        .collect();
+    shape_iris.sort();
+    shape_iris.dedup();
+    assert!(
+        !shape_iris.is_empty(),
+        "no sh:NodeShape found in {}",
+        shapes_path.display()
+    );
+
+    // Full-set validation (the TOTAL row) + per-source-shape grouped counts.
+    let full_graph = graph_from_triples(triples.iter().cloned());
+    let full_model = ShapesModel::parse(&full_graph);
+    let full_focus = count_focus_nodes(&data, &full_model);
+    let (total_violations, total_conforms, total_us) = timed_validate(&data, &full_model, iters);
+    let mut grouped: BTreeMap<String, usize> = BTreeMap::new();
+    {
+        // One extra (untimed) run to attribute results per sh:sourceShape.
+        let report = validate_with_model(&data, &full_model);
+        for r in &report.results {
+            let key = match &r.source_shape {
+                Term::NamedNode(n) => n.as_str().to_string(),
+                other => other.to_string(),
+            };
+            *grouped.entry(key).or_default() += 1;
+        }
+    }
+
+    // Per-shape single-shape validations.
+    let mut observed: BTreeMap<String, Observed> = BTreeMap::new();
+    let mut fail = false;
+    for iri in &shape_iris {
+        let slice = shape_closure(&triples, iri);
+        let graph = graph_from_triples(slice);
+        let model = ShapesModel::parse(&graph);
+        let focus_nodes = count_focus_nodes(&data, &model);
+        let (violations, conforms, validate_us) = timed_validate(&data, &model, iters);
+        // Internal consistency: the single-shape count must equal the
+        // sh:sourceShape-grouped count from the full-set run (two routes, one answer).
+        let from_group = grouped.get(iri).copied().unwrap_or(0);
+        if violations != from_group {
+            eprintln!(
+                "[shacl-sparql] ERROR: {} single-shape violations={violations} but \
+                 full-set sourceShape-grouped count={from_group} (per-shape split unsound)",
+                local_name(iri)
+            );
+            fail = true;
+        }
+        observed.insert(
+            local_name(iri).to_string(),
+            Observed {
+                conforms: u8::from(conforms),
+                violations,
+                focus_nodes,
+                validate_us,
+            },
+        );
+    }
+    let per_shape_sum: usize = observed.values().map(|o| o.violations).sum();
+    if per_shape_sum != total_violations {
+        eprintln!(
+            "[shacl-sparql] ERROR: per-shape violations sum {per_shape_sum} != full-set \
+             total {total_violations} (per-shape split unsound)"
+        );
+        fail = true;
+    }
+    observed.insert(
+        TOTAL.to_string(),
+        Observed {
+            conforms: u8::from(total_conforms),
+            violations: total_violations,
+            focus_nodes: full_focus,
+            validate_us: total_us,
+        },
+    );
+
+    // ---- HARD GATE: assert every workload vs the pinned oracle BEFORE any timing ------
+    let expected_text = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|e| panic!("read oracle {}: {e}", expected_path.display()));
+    let expected = parse_expected(&expected_text);
+    for (name, exp) in &expected {
+        let Some(obs) = observed.get(name) else {
+            eprintln!(
+                "[shacl-sparql] ERROR: pinned workload {name} did not run (a workload vanished)"
+            );
+            fail = true;
+            continue;
+        };
+        if obs.violations != exp.violations {
+            eprintln!(
+                "[shacl-sparql] ERROR: {name} violations={} expected={} (correctness regression)",
+                obs.violations, exp.violations
+            );
+            fail = true;
+        }
+        if obs.conforms != exp.conforms {
+            eprintln!(
+                "[shacl-sparql] ERROR: {name} conforms={} expected={} (correctness regression)",
+                obs.conforms, exp.conforms
+            );
+            fail = true;
+        }
+        if obs.focus_nodes != exp.focus_nodes {
+            eprintln!(
+                "[shacl-sparql] ERROR: {name} focus_nodes={} expected={} (target-selection regression)",
+                obs.focus_nodes, exp.focus_nodes
+            );
+            fail = true;
+        }
+    }
+    for name in observed.keys() {
+        if !expected.contains_key(name) {
+            eprintln!("[shacl-sparql] ERROR: workload {name} has no expected-sparql.tsv entry");
+            fail = true;
+        }
+    }
+    if fail {
+        eprintln!(
+            "[shacl-sparql] FAILED: divergence from bench/shacl/expected-sparql.tsv — \
+             no timings emitted (a drift is a correctness finding, never rounded)"
+        );
+        std::process::exit(1);
+    }
+
+    // ---- gate passed: emit the <workload>\t<violations>\t<us> contract ----------------
+    // Per-shape rows (sorted), then the whole-slice TOTAL row.
+    for (name, obs) in observed.iter().filter(|(n, _)| n.as_str() != TOTAL) {
+        println!("{name}\t{}\t{:.1}", obs.violations, obs.validate_us);
+    }
+    let total = &observed[TOTAL];
+    println!("{TOTAL}\t{}\t{:.1}", total.violations, total.validate_us);
+    eprintln!(
+        "[shacl-sparql] OK: all {} workloads match expected-sparql.tsv \
+         (violations + conforms + focus_nodes); timings are ADVISORY (non-canonical box)",
+        observed.len()
+    );
+}

--- a/research/gap-shacl-sparql-2026-07.md
+++ b/research/gap-shacl-sparql-2026-07.md
@@ -1,0 +1,118 @@
+<!-- [FABLE-5] sq-pymgf — per-axis gap record: the SHACL SPARQL-constraint (sh:sparql)
+SLICE, split out of the whole-suite SHACL mix as its own reported axis. Canonical
+numbers land here only from a quiet-box gather with provenance (sq-7d3dj.33.3);
+work-box readings are NON-canonical by construction and are never transcribed here. -->
+
+# Gap record — SHACL SPARQL-constraint slice (`sh:sparql`) (2026-07)
+
+**Axis:** sub-axis of the SHACL validation axis (epic `sq-hmd7l`; whole-suite record:
+`research/shacl-baseline-2026-07.md`, perf gap D8). This record covers ONLY the
+`sh:sparql` (W3C SHACL §5.2) slice — the constraint kind routed through
+`sparq-engine`'s native SPARQL evaluation, where engine-native constraint execution
+should be a differentiator, and where the pre-batching validator was honestly BEHIND
+Jena (baseline §2–§3).
+**Status:** harness + pinned oracle SHIPPED (this bead, `sq-pymgf`); canonical
+comparative numbers NOT-MEASURED (ride the quiet-box gather `sq-7d3dj.33.3`).
+**Harness:** `crates/sparq-shacl/examples/sparql_constraint_bench.rs` (single-crate,
+self-asserting) + the pinned oracle `bench/shacl/expected-sparql.tsv`.
+**Feeds:** the master table in `research/perf-dominance-gap-2026-07.md` (via
+`sq-hmd7l.27`'s successor consolidations).
+
+## 1. Why a separate slice
+
+`scripts/bench/shacl-same-box.sh` runs the whole `(data × shapes)` mix and reports
+`sparql_heavy` as ONE workload row; the per-commit suite (`bench/shacl/run.sh`)
+gates one single-constraint `sparql_constraint` workload. Neither reports the
+`sh:sparql` path per shape, so the slice's engine-native story (focus-node batching
+into one `VALUES` execution, `sq-7d3dj.33.1`; engine bind-join follow-up
+`sq-7d3dj.33.2`) had no axis of its own. This harness validates ONLY
+`bench/shacl/shapes-sparql/sparql_heavy.ttl` — three `sh:sparql` constraints over
+the three biggest LUBM target classes — and reports each shape separately plus the
+whole-slice `TOTAL`.
+
+## 2. Protocol (oracle before stopwatch — INVARIANT)
+
+1. Deterministic corpus: the LUBM(1) seed-0 ABox (`bench/shacl/gen.sh 1 0`,
+   cached), the same substrate as `bench/shacl/expected.tsv`.
+2. **Hard gate before any timing:** the runner asserts, per shape AND for the
+   total, `conforms` / `violations` / `focus_nodes` against the pinned
+   `bench/shacl/expected-sparql.tsv` (whose header carries the independent
+   raw-ABox cross-check for every count), and exits 1 on any drift WITHOUT
+   emitting a timing row. A drift is a recorded correctness finding, never
+   rounded. Two internal consistency checks back the per-shape split: each
+   single-shape count must equal the `sh:sourceShape`-grouped count from the
+   full-set validation, and the per-shape counts must sum to the total.
+3. Timing is ADVISORY and per shape (best-of-N single-shape validate on a loaded
+   graph) plus the `TOTAL` row (all three shapes, one model — the number
+   comparable to the same-box script's `sparql_heavy` row):
+
+   ```sh
+   cargo run -p sparq-shacl --release --example sparql_constraint_bench -- --smoke  # gate, iters=1
+   cargo run -p sparq-shacl --release --example sparql_constraint_bench            # best-of-3
+   ```
+
+## 3. External competitor column — documented gather step
+
+The harness itself stays single-crate and self-asserting; the pySHACL column is a
+GATHER step (never a per-commit dependency), reusing the registered adapters:
+
+```sh
+# pySHACL (Tier-1 W3C reference impl), validate-only best-of-N, same corpus:
+python3 -m venv /tmp/shacl-bench-venv && /tmp/shacl-bench-venv/bin/pip install pyshacl
+mkdir -p /tmp/shapes-sparql-only && cp bench/shacl/shapes-sparql/sparql_heavy.ttl /tmp/shapes-sparql-only/
+/tmp/shacl-bench-venv/bin/python scripts/bench/pyshacl-shacl-bench.py \
+  "$(bench/shacl/gen.sh 1 0 | head -1)" nt /tmp/shapes-sparql-only 3
+```
+
+- pySHACL emits the whole-file row only (= this harness's `TOTAL`); a per-shape
+  pySHACL split would group its report by `sh:sourceShape` — a gather-side
+  refinement, not required for the slice comparison.
+- Count reduction/cross-check uses `scripts/bench-adapters/shacl_report_count.py`
+  semantics; the per-engine dedup caveat from `bench/shacl/expected.tsv` applies
+  (these three shapes are single-route, so counts are expected to agree — the
+  baseline's `sparql_heavy` crosscheck agreed across sparq/Jena/pySHACL at both
+  scales).
+- Jena SHACL rides the existing `scripts/bench/shacl-same-box.sh` driver
+  (`JenaShaclBench.java`) unchanged.
+
+## 4. Pinned slice oracle (deterministic counts, LUBM(1) seed-0)
+
+| Workload (shape) | Target class | focus_nodes | violations |
+|---|---|---:|---:|
+| `GradCourseShape` | `ub:GraduateStudent` | 1 874 | 3 738 |
+| `ProfessorLoadShape` | `ub:FullProfessor` | 125 | 183 |
+| `UndergradAdvisorShape` | `ub:UndergraduateStudent` | 5 916 | 422 |
+| `TOTAL` | (all three, disjoint) | 7 915 | 4 343 |
+
+Each is derived from the runner AND independently cross-checked against the raw
+ABox (typed-edge solution counts, no SHACL engine — see the `expected-sparql.tsv`
+header). `TOTAL` = 4 343 equals the count all three engines agreed on for
+`sparql_heavy` in the baseline crosscheck (`research/shacl-baseline-2026-07.md` §2).
+
+## 5. Results — comparative timing
+
+> NOT-MEASURED (canonical). The pre-batching whole-mix reading
+> (`research/shacl-baseline-2026-07.md` §2: sparq BEHIND Jena on `sparql_heavy`,
+> growing with scale) predates the landed `sh:sparql` focus-node batching
+> (`sq-7d3dj.33.1`, PR #1737) and the SHACL-1.2 node-expression batching
+> (`sq-7d3dj.33.5`, PR #1754), so it must not be cited for the current validator.
+> The canonical per-shape slice numbers (sparq vs pySHACL, plus Jena from the
+> same-box harness) land in the `sq-7d3dj.33.3` quiet-box gather, which should run
+> this example alongside `scripts/bench/shacl-same-box.sh`.
+
+| Workload | count crosscheck | sparq-shacl | pySHACL | Jena SHACL | Verdict |
+|---|---|---|---|---|---|
+| `GradCourseShape` | pinned (oracle §4) | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
+| `ProfessorLoadShape` | pinned (oracle §4) | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
+| `UndergradAdvisorShape` | pinned (oracle §4) | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
+| `TOTAL` | pinned + 3-engine agreement (baseline §2) | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED | NOT-MEASURED |
+
+## 6. Verdict + plan
+
+No comparative verdict is claimable until the canonical gather runs (verdict
+vocabulary: CLEARLY-AHEAD / AHEAD-BUT-NOT-OOM / PARITY / BEHIND / NOT-MEASURED /
+NOT-COMPARABLE). Per the dominance mandate, any BEHIND or PARITY row measured
+there must carry a root cause and an immediate P1 profiling-first fix bead — the
+known engine-level lever is the bind-join/SIP follow-up `sq-7d3dj.33.2`. Action:
+`sq-7d3dj.33.3`'s quiet-box run gathers this slice in the same wave (noted on that
+bead).


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **Claude Fable 5**

Implements bead **sq-pymgf** (architect-decomposed from epic `sq-hmd7l`, comparative-benchmarking-everything): report the SPARQL-constraint (`sh:sparql`, W3C SHACL §5.2) slice — where sparq's engine-native constraint evaluation should be a differentiator — as its own axis instead of averaging it into the whole (data × shapes) mix.

## What's added (exactly the 3 files the bead scopes)

- **`crates/sparq-shacl/examples/sparql_constraint_bench.rs`** — single-crate, self-asserting runner. Validates ONLY `bench/shacl/shapes-sparql/sparql_heavy.ttl` over the deterministic LUBM(1) seed-0 ABox (`bench/shacl/gen.sh 1 0`, cached; `$BENCH_SHACL_DATA` override), **per shape**: each shape is sliced out of the committed multi-shape file by forward reachability in the shapes graph (no derived shape copies committed), so each of the 3 `sh:sparql` constraints gets its own count + best-of-N timing, plus a `TOTAL` row (all 3 as one model — the number comparable to the same-box script's `sparql_heavy` row).
- **`bench/shacl/expected-sparql.tsv`** — the pinned oracle (`<workload>\t<conforms>\t<violations>\t<focus_nodes>`, `expected.tsv`'s format). Every count independently cross-checked against the raw ABox (typed-edge solution counts, no SHACL engine — see header); `TOTAL` = 4343 equals the 3-engine (sparq/Jena/pySHACL) same-box crosscheck in `research/shacl-baseline-2026-07.md` §2.
- **`research/gap-shacl-sparql-2026-07.md`** — per-axis gap record: protocol, the **documented pySHACL gather step** (reuses the registered `scripts/bench/pyshacl-shacl-bench.py` + `scripts/bench-adapters/shacl_report_count.py`; never a per-commit dependency), comparative results honestly **NOT-MEASURED** pending the `sq-7d3dj.33.3` quiet-box canonical gather (the pre-batching baseline reading must not be cited for the current validator — `sq-7d3dj.33.1`/`33.5` batching has landed since).

## Invariant (bead): oracle before stopwatch

Per-shape + total `conforms`/`violations`/`focus_nodes` are asserted vs the pinned TSV **before any timing row is emitted** — on drift the runner prints observed-vs-pinned and exits 1 with an empty stdout (a drift is a correctness finding, never rounded). Two internal consistency checks back the per-shape split: each single-shape count must equal the `sh:sourceShape`-grouped count from the full-set validation, and the per-shape counts must sum to the full-set total.

## Acceptance + gates

- `cargo run -p sparq-shacl --release --example sparql_constraint_bench -- --smoke` exits 0 asserting the pinned counts (bead acceptance) — verified, ~0.3 s wall on the cached corpus.
- **Mutation-witnessed (non-vacuous):** flipping one pinned violation count (183→184) makes `--smoke` exit 1 with the correct `correctness regression` message and **zero stdout rows**; restoring it goes green again.
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings` — green in **both** feature states (default and `--all-features`).
- `cargo test -p sparq-shacl` — green in both feature states (incl. the W3C core ratchet).
- `rustfmt` on the new file only; `typos` clean on all three files.
- No edits to `bench/shacl/run.sh` / `scripts/bench/shacl-same-box.sh` (owned elsewhere); the per-commit `expected.tsv` gate covers exactly `shapes/` and is untouched. No crate-source changes (example only — core/engine stay lean), no new deps, no hard-coded perf numbers in markdown (deterministic counts only).

Bead: `sq-pymgf` · Epic: `sq-hmd7l` · Related: `sq-7d3dj.33` (baseline + same-box harness), `sq-7d3dj.33.3` (canonical gather this slice rides).