### PR TITLE
bench(shacl-wasm): browser SHACL same-runtime harness — sparq-shacl-wasm vs rdf-validate-shacl (sq-i858h) [FABLE-5]

### DIFF
--- a/bench/shacl-wasm/.gitignore
+++ b/bench/shacl-wasm/.gitignore
@@ -1,0 +1,4 @@
+# [FABLE-5] sq-i858h — build/gather outputs only; the harness + vendored ABox
+# + expected.tsv are committed.
+/pkg/
+/results/

--- a/bench/shacl-wasm/README.md
+++ b/bench/shacl-wasm/README.md
@@ -1,0 +1,69 @@
+# shacl-wasm — browser SHACL same-runtime comparison
+
+<!-- [FABLE-5] sq-i858h (epic sq-hmd7l) — the browser half of the SHACL
+     competitor story. The NATIVE same-box harness is
+     scripts/bench/shacl-same-box.sh (sparq vs pySHACL vs Jena); this suite
+     compares the WASM bundle against its registered JS peer instead. -->
+
+Compares **`sparq-shacl-wasm`** (the wasm-pack'd `Validator`,
+[`crates/sparq-shacl-wasm`](../../crates/sparq-shacl-wasm/README.md)) against
+**Zazuko `rdf-validate-shacl`** (`bench/competitors.json` id
+`rdf-validate-shacl`, kind `js-lib`) — **both in the same Node process**, the
+natural runtime for sparq's browser SHACL story.
+
+```sh
+bash run.sh --smoke   # acceptance: exit 0 iff the agreement gate is green
+bash run.sh           # best-of-$ITERS (default 3) + results/ envelope
+```
+
+## Workloads — the SAME (data × shapes) pairs as `bench/shacl`
+
+The **committed** shape workloads are reused verbatim (zero overlap — this
+suite adds no shapes): [`bench/shacl/shapes/*.ttl`](../shacl/shapes) +
+[`bench/shacl/shapes-sparql/sparql_heavy.ttl`](../shacl/shapes-sparql). The
+data graph is a small **vendored micro-ABox** (`data/abox.ttl`, LUBM
+vocabulary, hand-authored) so every violation constant is **hand-countable**
+(derivations in `expected.tsv`'s header) and the harness needs no LUBM
+generator / Java in a Node-only environment. Scale-tier corpora for the
+browser story are tracked separately (sq-hmd7l.40).
+
+## The gate (HARD) vs timing (ADVISORY)
+
+**INVARIANT: no timing row without a green per-workload `#violations` +
+`conforms` AGREEMENT gate** between the two engines, each ALSO matching the
+hand-derived `expected.tsv` constant (so both-engines-broken can't pass as
+"agreement"). Both engines are reduced identically — `report.results.length` /
+`report.conforms`, the `scripts/bench-adapters/js_shacl_adapter.mjs` +
+`shacl_report_count.py` contract.
+
+The two `sh:sparql` workloads (`sparql_constraint`, `sparql_heavy`) are
+**sparq-only**: `rdf-validate-shacl` implements SHACL Core only (no SHACL-SPARQL,
+W3C SHACL §5.2), so its column is **absent** there — a capability gap recorded
+honestly, never a fabricated `0`. sparq is still self-asserted vs
+`expected.tsv` on them. The four core workloads are single-route, so sparq's
+per-occurrence counting and a dedup engine agree (see the
+[`bench/shacl` README caveat](../shacl/README.md#competitors)).
+
+**Timing** is one-shot **end-to-end** (parse data + shapes + validate +
+reduce) best-of-N for BOTH engines — the stateless wasm `Validator` cannot
+hoist the parse, so the peer is charged the same work; the peer's
+validate-only time on pre-parsed datasets is an extra advisory column. All
+timings are NON-canonical on the work box (`canonical:false` in the envelope;
+`CANONICAL=1` only on a dedicated quiet EC2 box).
+
+**Bundle bytes** are the second, **deterministic** column: the
+`wasm-pack --release` nodejs-target artifact (default features — no
+`shacl-af`) byte + gzip-9 sizes, recorded per toolchain in the envelope. The
+pre-bindgen ratchet (`scripts/ci-bench.sh` `wasm_bundle_bytes`) is
+deliberately untouched.
+
+## Outputs
+
+One `bench/canonical-competitor-results`-shaped JSON envelope per run in the
+git-ignored `results/` (stdout carries the gated
+`<workload>\t<engine>\t<violations>\t<e2e_best_us>` rows). Peer npm packages
+are **gather-only** (`/tmp/shacl-wasm-deps` scratch by default — never
+committed; the exact pinned version is recorded in the envelope at gather
+time, per `bench/competitors.json`).
+
+First-read gap record: [`research/gap-shacl-wasm-2026-07.md`](../../research/gap-shacl-wasm-2026-07.md).

--- a/bench/shacl-wasm/data/abox.ttl
+++ b/bench/shacl-wasm/data/abox.ttl
@@ -7,7 +7,7 @@
 # no LUBM generator (no Java) in a Node-only environment.
 #
 # Design (every constant below is re-derived in expected.tsv's header):
-#   * 4 ub:FullProfessor  — teacherOf fan-out 2/3/2/4; all worksFor a Department;
+#   * 4 ub:FullProfessor  — teacherOf fan-out 2/3/2/3; all worksFor a Department;
 #     only prof0 is a department head (ub:headOf).
 #   * 5 ub:GraduateStudent — plain-literal names (violate sh:datatype xsd:integer),
 #     well-formed emails (sh:pattern control never fires), all memberOf dept0
@@ -42,7 +42,7 @@ d:gcourse1 a ub:GraduateCourse .
 d:gcourse2 a ub:GraduateCourse .
 
 # --- full professors (cardinality / class_nodekind focus nodes) ----------
-# teacherOf fan-out: prof0=2, prof1=3, prof2=2, prof3=4
+# teacherOf fan-out: prof0=2, prof1=3, prof2=2, prof3=3
 #   => maxCount 1 violated by ALL 4; minCount 3 violated by prof0+prof2 (2).
 # worksFor always a Department (never a University) => sh:class fires 4x;
 # always an IRI => sh:nodeKind never fires.

--- a/bench/shacl-wasm/data/abox.ttl
+++ b/bench/shacl-wasm/data/abox.ttl
@@ -1,0 +1,128 @@
+# [FABLE-5] sq-i858h — small VENDORED ABox for the browser-SHACL same-runtime
+# harness (bench/shacl-wasm/). A hand-authored, deterministic LUBM-vocabulary
+# micro-graph over which the COMMITTED bench/shacl shape workloads
+# (bench/shacl/shapes/*.ttl + bench/shacl/shapes-sparql/sparql_heavy.ttl) have
+# small, HAND-COUNTABLE violation constants — so the cross-engine
+# #violations/conforms agreement gate is checkable by eye, and the harness needs
+# no LUBM generator (no Java) in a Node-only environment.
+#
+# Design (every constant below is re-derived in expected.tsv's header):
+#   * 4 ub:FullProfessor  — teacherOf fan-out 2/3/2/4; all worksFor a Department;
+#     only prof0 is a department head (ub:headOf).
+#   * 5 ub:GraduateStudent — plain-literal names (violate sh:datatype xsd:integer),
+#     well-formed emails (sh:pattern control never fires), all memberOf dept0
+#     (dept0 subOrganizationOf univ0 => the sequence-path control never fires),
+#     advisors prof0/prof1/prof2/prof3/prof1 (only prof0 is a head).
+#   * 3 ub:GraduateCourse among the courses (the sh:sparql workloads),
+#     3 ub:UndergraduateStudent with FullProfessor advisors (sparql_heavy).
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ub:  <http://swat.cse.lehigh.edu/onto/univ-bench.owl#> .
+@prefix d:   <http://example.org/shacl-wasm-abox#> .
+
+# --- organisation --------------------------------------------------------
+d:univ0 a ub:University ;
+    ub:name "University0" .
+
+d:dept0 a ub:Department ;
+    ub:name "Department0" ;
+    ub:subOrganizationOf d:univ0 .
+
+d:dept1 a ub:Department ;
+    ub:name "Department1" ;
+    ub:subOrganizationOf d:univ0 .
+
+# --- courses -------------------------------------------------------------
+d:course0 a ub:Course .
+d:course1 a ub:Course .
+d:course2 a ub:Course .
+d:course3 a ub:Course .
+d:course4 a ub:Course .
+d:gcourse0 a ub:GraduateCourse .
+d:gcourse1 a ub:GraduateCourse .
+d:gcourse2 a ub:GraduateCourse .
+
+# --- full professors (cardinality / class_nodekind focus nodes) ----------
+# teacherOf fan-out: prof0=2, prof1=3, prof2=2, prof3=4
+#   => maxCount 1 violated by ALL 4; minCount 3 violated by prof0+prof2 (2).
+# worksFor always a Department (never a University) => sh:class fires 4x;
+# always an IRI => sh:nodeKind never fires.
+d:prof0 a ub:FullProfessor ;
+    ub:name "Professor0" ;
+    ub:emailAddress "prof0@example.org" ;
+    ub:worksFor d:dept0 ;
+    ub:headOf d:dept0 ;
+    ub:teacherOf d:course0 , d:course1 .
+
+d:prof1 a ub:FullProfessor ;
+    ub:name "Professor1" ;
+    ub:emailAddress "prof1@example.org" ;
+    ub:worksFor d:dept0 ;
+    ub:teacherOf d:gcourse0 , d:gcourse1 , d:course2 .
+
+d:prof2 a ub:FullProfessor ;
+    ub:name "Professor2" ;
+    ub:emailAddress "prof2@example.org" ;
+    ub:worksFor d:dept1 ;
+    ub:teacherOf d:course3 , d:course4 .
+
+d:prof3 a ub:FullProfessor ;
+    ub:name "Professor3" ;
+    ub:emailAddress "prof3@example.org" ;
+    ub:worksFor d:dept1 ;
+    ub:teacherOf d:gcourse2 , d:course0 , d:course1 .
+
+# --- graduate students (datatype_range / node_paths / sh:sparql) ---------
+# advisors: gs0->prof0 (a head: sh:node control passes), gs1..gs4 -> non-heads
+#   => node_paths advisor violation fires 4x.
+# takesCourse GraduateCourse solutions: gs0=1, gs1=2, gs2=0, gs3=1, gs4=0 => 4.
+d:gs0 a ub:GraduateStudent ;
+    ub:name "GradStudent0" ;
+    ub:emailAddress "gs0@example.org" ;
+    ub:memberOf d:dept0 ;
+    ub:advisor d:prof0 ;
+    ub:takesCourse d:gcourse0 .
+
+d:gs1 a ub:GraduateStudent ;
+    ub:name "GradStudent1" ;
+    ub:emailAddress "gs1@example.org" ;
+    ub:memberOf d:dept0 ;
+    ub:advisor d:prof1 ;
+    ub:takesCourse d:gcourse0 , d:gcourse1 .
+
+d:gs2 a ub:GraduateStudent ;
+    ub:name "GradStudent2" ;
+    ub:emailAddress "gs2@example.org" ;
+    ub:memberOf d:dept0 ;
+    ub:advisor d:prof2 ;
+    ub:takesCourse d:course0 .
+
+d:gs3 a ub:GraduateStudent ;
+    ub:name "GradStudent3" ;
+    ub:emailAddress "gs3@example.org" ;
+    ub:memberOf d:dept0 ;
+    ub:advisor d:prof3 ;
+    ub:takesCourse d:gcourse2 .
+
+d:gs4 a ub:GraduateStudent ;
+    ub:name "GradStudent4" ;
+    ub:emailAddress "gs4@example.org" ;
+    ub:memberOf d:dept0 ;
+    ub:advisor d:prof1 ;
+    ub:takesCourse d:course1 .
+
+# --- undergraduates (sparql_heavy UndergradAdvisorShape) -----------------
+# each has a FullProfessor advisor => 3 solutions.
+d:us0 a ub:UndergraduateStudent ;
+    ub:name "Undergrad0" ;
+    ub:advisor d:prof0 ;
+    ub:takesCourse d:course0 .
+
+d:us1 a ub:UndergraduateStudent ;
+    ub:name "Undergrad1" ;
+    ub:advisor d:prof1 ;
+    ub:takesCourse d:course2 .
+
+d:us2 a ub:UndergraduateStudent ;
+    ub:name "Undergrad2" ;
+    ub:advisor d:prof2 ;
+    ub:takesCourse d:course3 .

--- a/bench/shacl-wasm/expected.tsv
+++ b/bench/shacl-wasm/expected.tsv
@@ -1,0 +1,38 @@
+# [FABLE-5] sq-i858h — expected constants for the VENDORED micro-ABox
+# (data/abox.ttl) under the COMMITTED bench/shacl workloads. Derivation is
+# BY HAND from the ABox (each line re-derivable by eye; also confirmed by
+# RUNNING both engines AND an independent pySHACL oracle — see the PR):
+#   cardinality      (4 FullProfessor; teacherOf fan-out 2/3/2/4)
+#                    maxCount 1 fires once per focus => 4; minCount 3 fires for
+#                    the two fan-out-2 profs => 2.  TOTAL 6, conforms=false.
+#   class_nodekind   worksFor is a Department (never University) => sh:class
+#                    fires once per prof's single worksFor value => 4; all IRIs
+#                    => nodeKind 0.  TOTAL 4, conforms=false.
+#   datatype_range   5 GraduateStudent plain-literal names => sh:datatype
+#                    xsd:integer fires once per name => 5; emails all match the
+#                    pattern => 0.  TOTAL 5, conforms=false.
+#   node_paths       advisors prof0/prof1/prof2/prof3/prof1; only prof0 has
+#                    ub:headOf => sh:node fires for gs1..gs4 => 4; every grad is
+#                    memberOf dept0 subOrganizationOf univ0 => sequence-path
+#                    minCount 0 violations.  TOTAL 4, conforms=false.
+#                    (TOP-LEVEL results — the report.results contract; engines
+#                    that ALSO nest the inner minCount failure under sh:detail
+#                    keep it out of report.results.)
+#   sparql_constraint grads taking a GraduateCourse: gs0=1, gs1=2, gs2=0,
+#                    gs3=1, gs4=0 => 4 SELECT solutions.  conforms=false.
+#                    SPARQ-ONLY: rdf-validate-shacl is SHACL Core only (no
+#                    sh:sparql) — peer column ABSENT, never a fabricated 0.
+#   sparql_heavy     GradCourse 4 (as above) + ProfessorLoad prof1=2,prof3=1
+#                    => 3 + UndergradAdvisor us0/us1/us2 => 3.  TOTAL 10,
+#                    conforms=false.  SPARQ-ONLY (sh:sparql).
+#
+# All committed core shapes are SINGLE-ROUTE, so sparq's per-occurrence
+# (no-dedup) counting and a dedup engine agree (bench/shacl/README.md caveat).
+#
+# format: workload \t conforms(0|1) \t violations \t engines(both|sparq-only)
+cardinality	0	6	both
+class_nodekind	0	4	both
+datatype_range	0	5	both
+node_paths	0	4	both
+sparql_constraint	0	4	sparq-only
+sparql_heavy	0	10	sparq-only

--- a/bench/shacl-wasm/expected.tsv
+++ b/bench/shacl-wasm/expected.tsv
@@ -2,7 +2,7 @@
 # (data/abox.ttl) under the COMMITTED bench/shacl workloads. Derivation is
 # BY HAND from the ABox (each line re-derivable by eye; also confirmed by
 # RUNNING both engines AND an independent pySHACL oracle — see the PR):
-#   cardinality      (4 FullProfessor; teacherOf fan-out 2/3/2/4)
+#   cardinality      (4 FullProfessor; teacherOf fan-out 2/3/2/3)
 #                    maxCount 1 fires once per focus => 4; minCount 3 fires for
 #                    the two fan-out-2 profs => 2.  TOTAL 6, conforms=false.
 #   class_nodekind   worksFor is a Department (never University) => sh:class

--- a/bench/shacl-wasm/harness.mjs
+++ b/bench/shacl-wasm/harness.mjs
@@ -1,0 +1,348 @@
+// [FABLE-5] sq-i858h — browser-SHACL same-runtime comparison harness:
+// sparq-shacl-wasm (the wasm-pack'd `Validator`, crates/sparq-shacl-wasm) vs
+// Zazuko rdf-validate-shacl (bench/competitors.json id `rdf-validate-shacl`,
+// kind js-lib), BOTH in THIS one Node process — the natural runtime for
+// sparq's browser SHACL story.
+//
+// REDUCTION CONTRACT (identical for both engines, mirroring the shared
+// scripts/bench-adapters/js_shacl_adapter.mjs + shacl_report_count.py
+// semantics): violations = report.results.length, conforms = report.conforms.
+// Both engines expose exactly the W3C report model's sh:result set +
+// sh:conforms — sparq via `JSON.parse(Validator.validate(...))`,
+// rdf-validate-shacl via its ValidationReport object.
+//
+// GATE (the bead invariant): NO timing row for a workload unless that
+// workload's #violations AND conforms AGREE across both engines AND match the
+// hand-derived constants in expected.tsv (non-vacuity: both-engines-broken
+// cannot pass as "agreement"). Workloads whose shapes use sh:sparql (SHACL
+// §5.2) are sparq-only — rdf-validate-shacl implements SHACL Core only, so
+// its column is ABSENT there (absent capability => absent column, never a
+// fabricated 0); sparq is still self-asserted vs expected.tsv.
+//
+// TIMING (ADVISORY, canonical:false off a quiet box): one-shot END-TO-END,
+// best-of-N — parse data + shapes + validate + reduce, per iteration, for
+// BOTH engines (the sparq Validator is stateless, so parse cannot be hoisted
+// out; the peer is charged the same work for apples-to-apples). The peer's
+// validate-only time on pre-parsed datasets is recorded as an extra advisory
+// column (`peer_validate_only_us`), since RDF/JS apps typically hold a parsed
+// dataset.
+//
+// stdout : `<workload>\t<engine>\t<violations>\t<e2e_best_us>` rows (gated).
+// --out  : one canonical-competitor-results-shaped JSON envelope.
+// exit   : non-zero on any gate failure or engine error.
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { gzipSync } from 'node:zlib';
+import { basename, join } from 'node:path';
+import os from 'node:os';
+
+function parseArgs(argv) {
+  const a = { iters: 3, canonical: false, shapeDirs: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--pkg') a.pkg = argv[++i];
+    else if (k === '--modules-dir') a.modulesDir = argv[++i];
+    else if (k === '--data') a.data = argv[++i];
+    else if (k === '--shapes-dir') a.shapeDirs.push(argv[++i]);
+    else if (k === '--expected') a.expected = argv[++i];
+    else if (k === '--iters') a.iters = parseInt(argv[++i], 10);
+    else if (k === '--out') a.out = argv[++i];
+    else if (k === '--canonical') a.canonical = argv[++i] === '1';
+    else if (k === '--git-commit') a.gitCommit = argv[++i];
+    else if (k === '--allow-missing-peer') a.allowMissingPeer = true;
+    else { process.stderr.write(`harness: unknown arg ${k}\n`); process.exit(2); }
+  }
+  if (!a.pkg || !a.data || !a.shapeDirs.length || !a.expected) {
+    process.stderr.write(
+      'usage: node harness.mjs --pkg <wasm-pack out dir> --data abox.ttl ' +
+      '--shapes-dir DIR [--shapes-dir DIR2] --expected expected.tsv ' +
+      '[--modules-dir DIR] [--iters N] [--out envelope.json] [--canonical 0|1] ' +
+      '[--git-commit SHA] [--allow-missing-peer]\n');
+    process.exit(2);
+  }
+  return a;
+}
+
+// ---- expected.tsv: workload \t conforms(0|1) \t violations \t engines ------
+function readExpected(path) {
+  const rows = new Map();
+  for (const line of readFileSync(path, 'utf-8').split('\n')) {
+    if (!line || line.startsWith('#')) continue;
+    const [name, conforms, violations, engines] = line.split('\t');
+    rows.set(name, {
+      conforms: conforms === '1',
+      violations: parseInt(violations, 10),
+      engines, // 'both' | 'sparq-only'
+    });
+  }
+  return rows;
+}
+
+// ---- peer stack (adapted from scripts/bench-adapters/js_shacl_adapter.mjs —
+// that adapter is a standalone CLI, so the small factory/parser builders are
+// re-derived here with the SAME package set; the REDUCTION is byte-identical).
+function makeImporter(modulesDir) {
+  const base = modulesDir
+    ? pathToFileURL(modulesDir.replace(/\/?$/, '/') + 'package.json')
+    : pathToFileURL(process.cwd() + '/package.json');
+  return createRequire(base);
+}
+
+function makeFactory(req) {
+  const Environment = req('@rdfjs/environment').default || req('@rdfjs/environment');
+  const def = (id, sub) => {
+    const m = req(sub ? `${id}/${sub}` : id);
+    return m.default || m;
+  };
+  return new Environment([
+    def('@rdfjs/data-model', 'Factory.js'),
+    def('@rdfjs/dataset', 'Factory.js'),
+    def('@rdfjs/term-map', 'Factory.js'),
+    def('@rdfjs/namespace', 'Factory.js'),
+    def('clownface', 'Factory.js'),
+  ]);
+}
+
+async function parseTurtleToDataset(req, factory, text, baseIRI) {
+  const ParserN3 = req('@rdfjs/parser-n3').default || req('@rdfjs/parser-n3');
+  const parser = new ParserN3({ factory, baseIRI });
+  const { Readable } = await import('node:stream');
+  const stream = parser.import(Readable.from([text]));
+  const ds = factory.dataset();
+  for await (const quad of stream) ds.add(quad);
+  return ds;
+}
+
+// ---- the shared reduction, one per engine ----------------------------------
+function reduceSparqReport(jsonText) {
+  const report = JSON.parse(jsonText);
+  return { conforms: report.conforms, violations: report.results.length };
+}
+function reducePeerReport(report) {
+  return { conforms: report.conforms, violations: report.results.length };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const iters = Math.max(1, args.iters);
+
+  // sparq-shacl-wasm: the wasm-pack --target nodejs artifact (CJS entry).
+  const req = createRequire(import.meta.url);
+  const pkgEntry = join(args.pkg, 'sparq_shacl_wasm.js');
+  const { Validator } = req(pkgEntry);
+
+  // peer: rdf-validate-shacl from the gather-only modules dir.
+  let peer = null;
+  let peerVersion = null;
+  try {
+    const preq = makeImporter(args.modulesDir);
+    const SHACLValidator = preq('rdf-validate-shacl').default || preq('rdf-validate-shacl');
+    const factory = makeFactory(preq);
+    peerVersion = JSON.parse(readFileSync(
+      preq.resolve('rdf-validate-shacl/package.json'), 'utf-8')).version;
+    peer = { preq, SHACLValidator, factory };
+  } catch (e) {
+    if (!args.allowMissingPeer) {
+      process.stderr.write(
+        `harness: rdf-validate-shacl stack unavailable (${e}).\n` +
+        'harness: install the gather-only deps (see run.sh) or pass --allow-missing-peer\n' +
+        'harness: to degrade to a sparq-only self-assert (peer column ABSENT).\n');
+      process.exit(1);
+    }
+    process.stderr.write(`harness: NOTICE peer absent (${e}); peer column ABSENT.\n`);
+  }
+
+  const expected = readExpected(args.expected);
+  const dataText = readFileSync(args.data, 'utf-8');
+
+  // workloads = every *.ttl across the shape dirs; a shape using sh:sparql is
+  // sparq-only (rdf-validate-shacl is SHACL Core only — capability-absent).
+  const workloads = [];
+  for (const dir of args.shapeDirs) {
+    for (const f of readdirSync(dir).filter((f) => f.endsWith('.ttl')).sort()) {
+      const text = readFileSync(join(dir, f), 'utf-8');
+      workloads.push({
+        name: basename(f, '.ttl'),
+        text,
+        sparqlConstraint: /\bsh:sparql\b/.test(text),
+      });
+    }
+  }
+
+  const failures = [];
+  const rows = {}; // per-workload envelope rows
+  for (const wl of workloads) {
+    const exp = expected.get(wl.name);
+    if (!exp) { failures.push(`${wl.name}: no expected.tsv entry`); continue; }
+    const peerComparable = exp.engines === 'both' && !wl.sparqlConstraint;
+    if ((exp.engines === 'both') !== !wl.sparqlConstraint) {
+      failures.push(`${wl.name}: expected.tsv engines='${exp.engines}' contradicts ` +
+        `sh:sparql detection (${wl.sparqlConstraint})`);
+      continue;
+    }
+
+    // -- sparq-shacl-wasm: one-shot end-to-end, best-of-N.
+    let sparq = null, sparqBestUs = Infinity;
+    try {
+      for (let i = 0; i < iters; i++) {
+        const t0 = performance.now();
+        sparq = reduceSparqReport(Validator.validate(dataText, wl.text, 'turtle'));
+        sparqBestUs = Math.min(sparqBestUs, (performance.now() - t0) * 1000);
+      }
+    } catch (e) {
+      failures.push(`${wl.name}: sparq-shacl-wasm ERROR: ${e}`);
+      continue;
+    }
+
+    // -- rdf-validate-shacl: same one-shot end-to-end, best-of-N (+ a
+    //    validate-only advisory column on pre-parsed datasets).
+    let peerRes = null, peerBestUs = Infinity, peerValidateOnlyUs = Infinity;
+    if (peerComparable && peer) {
+      try {
+        for (let i = 0; i < iters; i++) {
+          const t0 = performance.now();
+          const dataDs = await parseTurtleToDataset(
+            peer.preq, peer.factory, dataText, pathToFileURL(args.data).href);
+          const shapesDs = await parseTurtleToDataset(
+            peer.preq, peer.factory, wl.text, 'http://example.org/shapes');
+          const validator = new peer.SHACLValidator(shapesDs, { factory: peer.factory });
+          peerRes = reducePeerReport(await validator.validate(dataDs));
+          peerBestUs = Math.min(peerBestUs, (performance.now() - t0) * 1000);
+        }
+        // validate-only advisory (datasets pre-parsed OUTSIDE the timed section).
+        const dataDs = await parseTurtleToDataset(
+          peer.preq, peer.factory, dataText, pathToFileURL(args.data).href);
+        const shapesDs = await parseTurtleToDataset(
+          peer.preq, peer.factory, wl.text, 'http://example.org/shapes');
+        for (let i = 0; i < iters; i++) {
+          const validator = new peer.SHACLValidator(shapesDs, { factory: peer.factory });
+          const t0 = performance.now();
+          const r = await validator.validate(dataDs);
+          peerValidateOnlyUs = Math.min(peerValidateOnlyUs, (performance.now() - t0) * 1000);
+          if (reducePeerReport(r).violations !== peerRes.violations) {
+            throw new Error('validate-only rerun count drift');
+          }
+        }
+      } catch (e) {
+        failures.push(`${wl.name}: rdf-validate-shacl ERROR: ${e}`);
+        continue;
+      }
+    }
+
+    // -- the GATE: counts + conforms vs expected AND engine-vs-engine.
+    const gateErrs = [];
+    if (sparq.violations !== exp.violations || sparq.conforms !== exp.conforms) {
+      gateErrs.push(`sparq-shacl-wasm ${sparq.violations}/${sparq.conforms} != ` +
+        `expected ${exp.violations}/${exp.conforms}`);
+    }
+    if (peerComparable && peer) {
+      if (peerRes.violations !== exp.violations || peerRes.conforms !== exp.conforms) {
+        gateErrs.push(`rdf-validate-shacl ${peerRes.violations}/${peerRes.conforms} != ` +
+          `expected ${exp.violations}/${exp.conforms}`);
+      }
+      if (peerRes.violations !== sparq.violations || peerRes.conforms !== sparq.conforms) {
+        gateErrs.push('engine-vs-engine DISAGREEMENT');
+      }
+    }
+
+    const row = {
+      expected_violations: exp.violations,
+      expected_conforms: exp.conforms,
+      sparq_violations: sparq.violations,
+      sparq_conforms: sparq.conforms,
+      gate: gateErrs.length ? 'FAIL' : 'green',
+    };
+    if (peerComparable) {
+      if (peer) {
+        row.peer_violations = peerRes.violations;
+        row.peer_conforms = peerRes.conforms;
+      } else {
+        row.peer = 'ABSENT (peer stack not installed; --allow-missing-peer)';
+      }
+    } else {
+      row.peer = 'not-comparable (shape uses sh:sparql — rdf-validate-shacl is SHACL Core only; column absent, not 0)';
+    }
+
+    if (gateErrs.length) {
+      failures.push(`${wl.name}: GATE: ${gateErrs.join('; ')}`);
+      rows[wl.name] = row; // counts recorded, timings withheld
+      continue;
+    }
+
+    // -- gate green: NOW (and only now) the timing rows.
+    row.sparq_e2e_best_us = Math.round(sparqBestUs);
+    process.stdout.write(`${wl.name}\tsparq-shacl-wasm\t${sparq.violations}\t${Math.round(sparqBestUs)}\n`);
+    if (peerComparable && peer) {
+      row.peer_e2e_best_us = Math.round(peerBestUs);
+      row.peer_validate_only_us = Math.round(peerValidateOnlyUs);
+      process.stdout.write(`${wl.name}\trdf-validate-shacl\t${peerRes.violations}\t${Math.round(peerBestUs)}\n`);
+    }
+    rows[wl.name] = row;
+  }
+
+  // ---- deterministic column 2: wasm-pack --release artifact bytes ----------
+  const bundle = {};
+  for (const f of readdirSync(args.pkg)) {
+    if (f.endsWith('_bg.wasm') || (f.endsWith('.js') && !f.endsWith('.d.js'))) {
+      const bytes = readFileSync(join(args.pkg, f));
+      bundle[f] = { bytes: statSync(join(args.pkg, f)).size,
+                    gzip9_bytes: gzipSync(bytes, { level: 9 }).length };
+    }
+  }
+
+  if (args.out) {
+    const envelope = {
+      gather: 'shacl-wasm-same-runtime-comparison',
+      wave: 'browser-SHACL competitor baseline (sq-i858h, epic sq-hmd7l)',
+      canonical: args.canonical,
+      canonical_note: args.canonical
+        ? 'CANONICAL: dedicated quiet box; both engines run one-shot in the same Node process, sequentially per workload.'
+        : 'NON-canonical: shared work box. Timings are directional only — do NOT bake into docs/dashboards. Bundle bytes ARE deterministic (toolchain-pinned wasm-pack --release artifact).',
+      git_commit: args.gitCommit || 'unknown',
+      suite: 'shacl-wasm',
+      scale: `vendored micro-ABox (${args.data}), hand-countable constants`,
+      iters,
+      runtime: `node ${process.version} (same process for both engines)`,
+      engines: {
+        'sparq-shacl-wasm': {
+          version: args.gitCommit || 'unknown',
+          mode: 'wasm-pack --target nodejs --release; stateless Validator.validate one-shot end-to-end best-of-N (parse+validate+reduce in the timed section)',
+        },
+        'rdf-validate-shacl': peer ? {
+          version: peerVersion,
+          mode: 'in-process RDF/JS (same one-shot end-to-end best-of-N; validate-only on pre-parsed datasets as an extra advisory column)',
+        } : { status: 'absent (gather-only npm deps not installed)' },
+      },
+      reduction: 'violations = report.results.length; conforms = report.conforms (the js_shacl_adapter.mjs / shacl_report_count.py contract)',
+      gate: 'per-workload #violations + conforms must match expected.tsv AND agree engine-vs-engine BEFORE any timing row; sh:sparql workloads are sparq-only (peer capability-absent => column absent)',
+      count_crosscheck: rows,
+      bundle_bytes: {
+        note: 'DETERMINISTIC per toolchain: the wasm-pack --release nodejs-target artifact (default features — no shacl-af). gzip-9 = the wire size a gzip-serving host ships.',
+        wasm_pack: process.env.WASM_PACK_VERSION || 'unknown',
+        artifacts: bundle,
+      },
+      env: {
+        host: os.hostname(),
+        machine: os.machine ? os.machine() : process.arch,
+        os: `${os.type()} ${os.release()}`,
+      },
+      failures,
+    };
+    writeFileSync(args.out, JSON.stringify(envelope, null, 2) + '\n');
+    process.stderr.write(`harness: envelope: ${args.out}\n`);
+  }
+
+  if (failures.length) {
+    for (const f of failures) process.stderr.write(`harness: FAIL ${f}\n`);
+    process.exit(1);
+  }
+  process.stderr.write('harness: agreement gate GREEN on every workload.\n');
+}
+
+main().catch((e) => {
+  process.stderr.write(`harness: fatal: ${e && e.stack ? e.stack : e}\n`);
+  process.exit(1);
+});

--- a/bench/shacl-wasm/run.sh
+++ b/bench/shacl-wasm/run.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# [FABLE-5] sq-i858h — browser-SHACL same-runtime comparison entry point:
+# sparq-shacl-wasm vs Zazuko rdf-validate-shacl in ONE Node process, over the
+# SAME (data x shapes) workloads as bench/shacl (the committed shapes/*.ttl +
+# shapes-sparql/sparql_heavy.ttl) on the small VENDORED micro-ABox
+# (data/abox.ttl — no LUBM generator / Java needed).
+#
+#   bash run.sh --smoke     # 1 iteration; the ACCEPTANCE entry point (exit 0
+#                           # iff the per-workload #violations+conforms
+#                           # agreement gate is green for both engines)
+#   bash run.sh             # best-of-$ITERS (default 3) + envelope
+#
+# Stages:
+#   1. wasm-pack build crates/sparq-shacl-wasm --target nodejs --release
+#      (default features — no shacl-af; artifact bytes are the DETERMINISTIC
+#      second column). Skipped when pkg/ already exists unless REBUILD=1.
+#   2. npm-install the GATHER-ONLY peer deps (never committed; AGENTS.md —
+#      engines stay out of git) into $MODULES_DIR (default /tmp scratch).
+#   3. node harness.mjs — the shared report->count reduction, the agreement
+#      gate, timing rows ONLY after the gate, one canonical-competitor-results
+#      envelope (canonical:false on the work box).
+#
+# TUNABLES (env):
+#   ITERS         best-of-N               (default 3; --smoke forces 1)
+#   MODULES_DIR   peer npm scratch        (default /tmp/shacl-wasm-deps)
+#   OUT_DIR       envelope dir            (default ./results — git-ignored)
+#   REBUILD       1 = force wasm rebuild  (default: reuse existing pkg/)
+#   CANONICAL     1 = quiet-box run       (default 0: canonical:false)
+#   ALLOW_MISSING_PEER  1 = degrade to sparq-only self-assert WITH NOTICE
+#                 (peer column ABSENT — never fabricated). Default: the peer
+#                 is REQUIRED (the whole point is the comparison).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+ITERS="${ITERS:-3}"
+MODULES_DIR="${MODULES_DIR:-/tmp/shacl-wasm-deps}"
+OUT_DIR="${OUT_DIR:-$HERE/results}"
+CANONICAL="${CANONICAL:-0}"
+
+for a in "$@"; do
+  case "$a" in
+    --smoke) ITERS=1 ;;
+    -h|--help) sed -n '2,32p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "error: unknown argument '$a' (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '[shacl-wasm] %s\n' "$*" >&2; }
+
+# ---- 1. the wasm artifact (deterministic-bytes column source) ---------------
+PKG="$HERE/pkg"
+if [ ! -f "$PKG/sparq_shacl_wasm.js" ] || [ "${REBUILD:-0}" = "1" ]; then
+  log "wasm-pack build crates/sparq-shacl-wasm (nodejs, release, default features)"
+  wasm-pack build "$ROOT/crates/sparq-shacl-wasm" --target nodejs --release \
+    --out-dir "$PKG" >&2
+else
+  log "reusing existing $PKG (REBUILD=1 to force)"
+fi
+WASM_PACK_VERSION="$(wasm-pack --version 2>/dev/null || echo unknown)"
+
+# ---- 2. gather-only peer deps (rdf-validate-shacl + its RDF/JS stack) -------
+# The exact package set from bench/competitors.json's install_recipe.
+PEER_PKGS=(rdf-validate-shacl @rdfjs/data-model @rdfjs/dataset @rdfjs/term-map
+           @rdfjs/namespace @rdfjs/parser-n3 @rdfjs/environment clownface)
+if [ ! -d "$MODULES_DIR/node_modules/rdf-validate-shacl" ]; then
+  if [ "${ALLOW_MISSING_PEER:-0}" = "1" ]; then
+    log "NOTICE: peer deps missing and ALLOW_MISSING_PEER=1 — sparq-only self-assert"
+  else
+    log "installing gather-only peer deps into $MODULES_DIR (scratch, never committed)"
+    mkdir -p "$MODULES_DIR"
+    ( cd "$MODULES_DIR" && \
+      { [ -f package.json ] || echo '{"private":true}' > package.json; } && \
+      npm install --no-save --no-audit --no-fund "${PEER_PKGS[@]}" >&2 )
+  fi
+fi
+
+# ---- 3. the harness (gate -> timing -> envelope) -----------------------------
+mkdir -p "$OUT_DIR"
+GIT_COMMIT="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$OUT_DIR/shacl-wasm-vendored-${TS}.json"
+
+EXTRA=()
+[ "${ALLOW_MISSING_PEER:-0}" = "1" ] && EXTRA+=(--allow-missing-peer)
+
+WASM_PACK_VERSION="$WASM_PACK_VERSION" node "$HERE/harness.mjs" \
+  --pkg "$PKG" \
+  --modules-dir "$MODULES_DIR" \
+  --data "$HERE/data/abox.ttl" \
+  --shapes-dir "$ROOT/bench/shacl/shapes" \
+  --shapes-dir "$ROOT/bench/shacl/shapes-sparql" \
+  --expected "$HERE/expected.tsv" \
+  --iters "$ITERS" \
+  --canonical "$CANONICAL" \
+  --git-commit "$GIT_COMMIT" \
+  --out "$OUT" \
+  ${EXTRA[@]:+"${EXTRA[@]}"}
+
+log "envelope: $OUT"
+log "scratch peer deps live in $MODULES_DIR (delete when finished)"

--- a/research/gap-shacl-wasm-2026-07.md
+++ b/research/gap-shacl-wasm-2026-07.md
@@ -1,0 +1,110 @@
+<!-- [FABLE-5] sq-i858h first-read gap record (epic sq-hmd7l). The bundle-bytes
+section is DETERMINISTIC (toolchain-pinned wasm-pack --release artifact). ALL
+latency rows are NON-CANONICAL first reads from the shared work box; a canonical
+gather sets CANONICAL=1 on a dedicated quiet EC2 box (tag sparq-bench). -->
+
+# Browser SHACL competitor gap — first-read record (2026-07-12)
+
+**Status:** harness delivered + first-read gathered. Agreement gate GREEN on
+every workload; all latency rows ADVISORY (`canonical:false`).
+**Bead:** sq-i858h. **Epic:** sq-hmd7l (comparative-benchmarking-everything).
+**Harness:** `bench/shacl-wasm/` — `run.sh --smoke` (acceptance),
+`run.sh` (best-of-N + envelope). Both engines run **in the same Node process**;
+**no timing row without a green per-workload `#violations` + `conforms`
+agreement gate**, each engine also matched against the hand-derived
+`expected.tsv` constants (both-engines-broken cannot pass as agreement).
+
+This is the **browser half** of the SHACL competitor story. The native
+same-box half (sparq vs pySHACL vs Jena SHACL) is
+`scripts/bench/shacl-same-box.sh` + `research/shacl-baseline-2026-07.md`.
+
+## Pins (recorded in the envelope at gather time)
+
+- **sparq-shacl-wasm** — `wasm-pack build --target nodejs --release`, default
+  features (no `shacl-af`), wasm-pack 0.15.0, this repo at the gather commit.
+- **rdf-validate-shacl 0.6.5** (Zazuko; `bench/competitors.json` id
+  `rdf-validate-shacl`, kind `js-lib`) + the `@rdfjs/*`/clownface stack from
+  the registry's install recipe — gather-only npm deps, never committed.
+- **Runtime** node v20.20.2, same process for both engines.
+- **Data × shapes** — the committed `bench/shacl` workloads verbatim
+  (`shapes/*.ttl` + `shapes-sparql/sparql_heavy.ttl`) over the vendored
+  hand-countable micro-ABox `bench/shacl-wasm/data/abox.ttl`.
+
+## Correctness — cross-engine agreement (deterministic)
+
+All four SHACL-Core workloads agree exactly, per-workload, on both
+`#violations` and `conforms`, and match the hand-derived constants:
+
+| workload | expected | sparq-shacl-wasm | rdf-validate-shacl | gate |
+|---|---:|---:|---:|---|
+| cardinality | 6 | 6 | 6 | green |
+| class_nodekind | 4 | 4 | 4 | green |
+| datatype_range | 5 | 5 | 5 | green |
+| node_paths | 4 | 4 | 4 | green |
+| sparql_constraint | 4 | 4 | — capability-absent | green (sparq-only) |
+| sparql_heavy | 10 | 10 | — capability-absent | green (sparq-only) |
+
+**Capability gap (sparq AHEAD):** `rdf-validate-shacl` implements SHACL Core
+only — no SHACL-SPARQL (`sh:sparql`, W3C SHACL §5.2). Its column on the two
+`sh:sparql` workloads is **absent, never a fabricated 0**; sparq is
+self-asserted against the vendored constants there. In the browser runtime,
+sparq is the only engine of this pair that can run SPARQL-constraint shapes.
+
+## DETERMINISTIC — bundle bytes (wasm-pack --release, nodejs target)
+
+Recorded per toolchain in every envelope (wasm-pack 0.15.0, 2026-07-12):
+
+| artifact | bytes | gzip-9 (wire) |
+|---|---:|---:|
+| `sparq_shacl_wasm_bg.wasm` | 2 430 436 | 884 451 |
+| `sparq_shacl_wasm.js` (glue) | 10 988 | 2 786 |
+
+**Honest read (sparq BEHIND on raw payload, by design-tradeoff):** a pure-JS
+SHACL library ships far fewer wire bytes than a wasm engine bundle. The peer's
+unpacked npm footprint for the exact registry dep set is ~10.4 MB, but that is
+**not** a wire size (no tree-shaking/minification), so this record makes **no
+byte-ratio claim** — a bundler-built minified peer bundle is the comparable
+number and is follow-up work (bead below). Mitigations already shipped: the
+SHACL bundle is a **separate, lazy-loaded** artifact (never on the landing
+page; `next/dynamic` on `/surface/shacl` only), built `-Oz`, `shacl-af` off by
+default.
+
+## ADVISORY — same-runtime latency, first read (NON-canonical, shared work box)
+
+One-shot end-to-end (parse data + shapes + validate + reduce), best-of-3,
+micro-ABox (envelope `shacl-wasm-vendored-20260712T023932Z.json`; directional
+only — do NOT bake into docs/dashboards):
+
+- sparq-shacl-wasm one-shot e2e: ~0.6–1.0 ms per core workload.
+- rdf-validate-shacl one-shot e2e: ~15–23 ms (dominated by the RDF/JS
+  streaming-parser setup per document).
+- rdf-validate-shacl **validate-only** on pre-parsed datasets (the steady-state
+  an RDF/JS app sees): ~1.1–2.1 ms — i.e. even the peer's parse-free
+  steady-state is slower than sparq's parse-included one-shot on this corpus.
+
+Directionally sparq LEADS on every timed workload at this (micro) scale.
+Caveats before any dominance claim: the corpus is deliberately tiny (the gate
+substrate, not a load test), the box is shared, and the peer's e2e is
+parser-bound. A scale-tier browser corpus + quiet-box gather is where a citable
+number would come from (sq-hmd7l.39/40 wasm-compare wave; SHACL can join it).
+
+## Surface gap noted (sparq)
+
+`sparq-shacl-wasm`'s `Validator` is deliberately **stateless one-shot** — there
+is no pre-parsed/persistent-graph validate on this bundle, so a validate-only
+column for sparq is structurally absent (the lean `sparq-wasm` bundle's
+`Store.validate` behind its `shacl` feature is that shape). At micro scale the
+one-shot still wins; at scale-tier corpora repeat-validation without re-parse
+may matter. Follow-up bead filed (below) rather than widening this bundle now.
+
+## Follow-ups filed
+
+- **sq-c6c2s** — minified browser-bundle byte comparison (esbuild-built
+  rdf-validate-shacl bundle vs the wasm artifact) + evaluate further size-trim
+  for `sparq-shacl-wasm`.
+- **sq-01xlp** — evaluate a pre-parsed/stateful `Validator` variant (or bless
+  the lean bundle's `Store.validate` as the stateful path) for scale-tier
+  repeat validation.
+- Scale-tier + quiet-box canonical gather rides the existing wasm-compare wave
+  (sq-hmd7l.39 / sq-hmd7l.40) — the harness here accepts any data file via
+  its `--data` seam.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **Claude Fable 5**

Implements bead **sq-i858h** (epic sq-hmd7l, comparative-benchmarking-everything): the **browser half of the SHACL competitor story** — `sparq-shacl-wasm` (the wasm-pack'd `Validator`) vs Zazuko **`rdf-validate-shacl` 0.6.5** (already registered in `bench/competitors.json`, kind `js-lib`), **both in the same Node process**.

Only new files under `bench/shacl-wasm/` + `research/gap-shacl-wasm-2026-07.md` — zero overlap with the native `bench/shacl` harness or `scripts/bench/shacl-same-box.sh`, no crate changes.

## What's in it

- **`bench/shacl-wasm/run.sh`** — entry point. `--smoke` is the acceptance path: wasm-pack builds `crates/sparq-shacl-wasm` (nodejs target, release, default features), npm-installs the **gather-only** peer deps into `/tmp` scratch (never committed), runs the harness. Exit 0 iff the gate is green.
- **`bench/shacl-wasm/harness.mjs`** — the SAME `(data × shapes)` workloads as `bench/shacl` (committed `shapes/*.ttl` + `shapes-sparql/sparql_heavy.ttl`, reused verbatim) over a small **vendored micro-ABox** (`data/abox.ttl`, LUBM vocabulary, hand-countable constants). Both engines reduced identically: `violations = report.results.length`, `conforms = report.conforms` (the `js_shacl_adapter.mjs` / `shacl_report_count.py` contract).
- **GATE (the bead invariant):** *no timing row without a green per-workload `#violations` + `conforms` agreement gate*, each engine ALSO matched against the hand-derived `expected.tsv` constants — both-engines-broken cannot pass as "agreement". The two `sh:sparql` workloads are **sparq-only** (rdf-validate-shacl is SHACL Core only): capability-absent ⇒ **column absent, never a fabricated 0**.
- **Envelope:** one `bench/canonical-competitor-results`-shaped JSON per run, `canonical:false` on the work box; **bundle bytes** (wasm-pack `--release` artifact + gzip-9) as the second, deterministic column; peer version pinned at gather time.
- **`research/gap-shacl-wasm-2026-07.md`** — first-read gap record: 4/4 core workloads agree exactly; sparq AHEAD on capability (SHACL-SPARQL runs in-browser, the peer can't); honest byte-payload caveat (no byte-ratio claim vs an unminified npm footprint); advisory latency read clearly marked NON-canonical.

## Verification

- **Acceptance:** `bash bench/shacl-wasm/run.sh --smoke` → **exit 0**, agreement gate green on every workload (cardinality 6, class_nodekind 4, datatype_range 5, node_paths 4 — both engines + expected; sparql_constraint 4 / sparql_heavy 10 sparq-only self-asserted). Constants hand-re-verified against the ABox line by line.
- **Non-vacuous / mutation-witnessed:** (1) corrupting an `expected.tsv` constant (6→7) → exit 1 with `GATE: … != expected`; (2) skewing the sparq reduction by +1 → exit 1 with `engine-vs-engine DISAGREEMENT`; restored → exit 0 again. Timing rows verified withheld on gate failure.
- **Fresh-build proof:** `REBUILD=1` full run from a clean `pkg/` at this commit — wasm-pack build + best-of-3 gather green.
- No Rust source touched (crate gates unaffected); typos/shellcheck clean; readme-template gate scopes to `crates/*/README.md` only; the bench README carries no hard-coded perf numbers (measured first-reads live in the dated research gap record, per repo precedent).

## Follow-ups (beads filed)

- **sq-c6c2s** — minified browser-bundle byte comparison (esbuild peer bundle vs the wasm artifact) + size-trim evaluation.
- **sq-01xlp** — pre-parsed/stateful `Validator` variant question for scale-tier repeat validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)