### PR TITLE
feat(engine): support PATHS VIA graph patterns [GPT-5.6]

### DIFF
--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -43,7 +43,7 @@ pub mod params;
 #[cfg(feature = "paths")]
 pub mod paths;
 #[cfg(feature = "paths")]
-pub use paths::{enumerate_paths, PathMode, PathSolution, PathSpec};
+pub use paths::{enumerate_paths, PathMode, PathSolution, PathSpec, Via};
 // [GPT-5.6] (sq-lsp7k.3.2) Dedicated non-standard PATHS syntax. The ordinary
 // SPARQL parser remains untouched, so this surface is available only by explicit opt-in.
 #[cfg(feature = "paths")]

--- a/crates/sparq-engine/src/paths.rs
+++ b/crates/sparq-engine/src/paths.rs
@@ -1,6 +1,9 @@
-//! Full-path enumeration over a single RDF predicate.
+//! Full-path enumeration over an RDF predicate or materialized graph pattern.
 
-use oxrdf::{NamedNode, Term};
+use oxrdf::vocab::xsd;
+use oxrdf::{Literal, NamedNode, Term};
+use spargebra::algebra::GraphPattern;
+use spargebra::{Query, SparqlParser};
 use sparq_core::{dict::Id, store::Perm, Graph};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
@@ -13,7 +16,20 @@ pub enum PathMode {
     All,
 }
 
-/// Parameters for path enumeration over one predicate.
+/// Defines the directed edge relation used for path enumeration.
+///
+/// [GPT-5.6] `sq-lsp7k.3.3`: pattern relations are materialized once, then
+/// consumed by the same deterministic T1 enumerator as predicate relations.
+#[derive(Clone, Debug)]
+pub enum Via {
+    /// Every triple using this predicate is one directed edge.
+    Predicate(NamedNode),
+    /// A SPARQL group graph pattern whose reserved `?from` and `?to` variables
+    /// designate each directed edge's endpoints.
+    Pattern(String),
+}
+
+/// Parameters for path enumeration over an edge relation.
 #[derive(Clone, Debug)]
 pub struct PathSpec {
     /// Enumeration mode.
@@ -24,8 +40,8 @@ pub struct PathSpec {
     pub start: Option<Term>,
     /// Optional fixed ending node; otherwise every edge object is considered.
     pub end: Option<Term>,
-    /// Predicate defining the directed edge relation.
-    pub via: NamedNode,
+    /// Predicate or graph pattern defining the directed edge relation.
+    pub via: Via,
     /// Maximum edge count. Required for [`PathMode::All`].
     pub max_length: Option<usize>,
 }
@@ -35,7 +51,8 @@ pub struct PathSpec {
 pub struct PathSolution {
     /// Path nodes, including both endpoints.
     pub nodes: Vec<Term>,
-    /// Edge terms, one fewer than `nodes`; currently each is `PathSpec::via`.
+    /// Edge terms, one fewer than `nodes`. Pattern edges use the pattern source
+    /// as a canonical, blank-node-free `xsd:string` marker.
     pub edges: Vec<Term>,
 }
 
@@ -48,24 +65,12 @@ pub fn enumerate_paths(graph: &Graph, spec: &PathSpec) -> Result<Vec<PathSolutio
         return Err("PATHS ALL requires MAX LENGTH".to_owned());
     }
 
-    let Some(via_id) = graph.id_of(&Term::NamedNode(spec.via.clone())) else {
-        return Ok(Vec::new());
-    };
-    let scan = graph
-        .store
-        .scan_perm(&[None, Some(via_id), None], Perm::Pso)
-        .or_else(|| {
-            graph
-                .store
-                .scan_perm(&[None, Some(via_id), None], Perm::Pos)
-        })
-        .expect("a predicate-leading permutation is always built");
+    let (edge_pairs, edge) = edge_relation(graph, &spec.via)?;
     let mut adjacency: BTreeMap<Id, Vec<Id>> = BTreeMap::new();
     let mut sinks = BTreeSet::new();
-    for row in scan.rows.iter() {
-        let [subject, _, object] = scan.to_spo(row);
-        adjacency.entry(subject).or_default().push(object);
-        sinks.insert(object);
+    for (from, to) in edge_pairs {
+        adjacency.entry(from).or_default().push(to);
+        sinks.insert(to);
     }
     for next in adjacency.values_mut() {
         next.sort_unstable();
@@ -93,7 +98,6 @@ pub fn enumerate_paths(graph: &Graph, spec: &PathSpec) -> Result<Vec<PathSolutio
     }
 
     paths.sort_by(|left, right| left.len().cmp(&right.len()).then_with(|| left.cmp(right)));
-    let edge = Term::NamedNode(spec.via.clone());
     Ok(paths
         .into_iter()
         .map(|ids| PathSolution {
@@ -101,6 +105,90 @@ pub fn enumerate_paths(graph: &Graph, spec: &PathSpec) -> Result<Vec<PathSolutio
             nodes: ids.into_iter().map(|id| graph.dict.term(id)).collect(),
         })
         .collect())
+}
+
+fn edge_relation(graph: &Graph, via: &Via) -> Result<(Vec<(Id, Id)>, Term), String> {
+    match via {
+        Via::Predicate(predicate) => {
+            let edge = Term::NamedNode(predicate.clone());
+            let Some(via_id) = graph.id_of(&edge) else {
+                return Ok((Vec::new(), edge));
+            };
+            let scan = graph
+                .store
+                .scan_perm(&[None, Some(via_id), None], Perm::Pso)
+                .or_else(|| {
+                    graph
+                        .store
+                        .scan_perm(&[None, Some(via_id), None], Perm::Pos)
+                })
+                .expect("a predicate-leading permutation is always built");
+            let pairs = scan
+                .rows
+                .iter()
+                .map(|row| {
+                    let [subject, _, object] = scan.to_spo(row);
+                    (subject, object)
+                })
+                .collect();
+            Ok((pairs, edge))
+        }
+        Via::Pattern(pattern) => {
+            let source = format!("SELECT ?from ?to WHERE {{ {pattern} }}");
+            let parsed = SparqlParser::new()
+                .parse_query(&source)
+                .map_err(|error| format!("invalid PATHS VIA pattern: {error}"))?;
+            let Query::Select {
+                pattern: GraphPattern::Project { inner, .. },
+                ..
+            } = parsed
+            else {
+                return Err("invalid SELECT projection for PATHS VIA pattern".to_owned());
+            };
+            let mut binds_from = false;
+            let mut binds_to = false;
+            inner.on_in_scope_variable(|variable| match variable.as_str() {
+                "from" => binds_from = true,
+                "to" => binds_to = true,
+                _ => {}
+            });
+            if !binds_from {
+                return Err("PATHS VIA pattern must bind ?from".to_owned());
+            }
+            if !binds_to {
+                return Err("PATHS VIA pattern must bind ?to".to_owned());
+            }
+            let result = crate::query(graph, &source)?;
+            let from = result
+                .vars
+                .iter()
+                .position(|var| var.as_str() == "from")
+                .ok_or_else(|| "PATHS VIA pattern must bind ?from".to_owned())?;
+            let to = result
+                .vars
+                .iter()
+                .position(|var| var.as_str() == "to")
+                .ok_or_else(|| "PATHS VIA pattern must bind ?to".to_owned())?;
+            let mut pairs = Vec::with_capacity(result.rows.len());
+            for row in result.rows {
+                let from_term = row[from].as_ref().ok_or_else(|| {
+                    "PATHS VIA pattern must bind ?from in every solution".to_owned()
+                })?;
+                let to_term = row[to].as_ref().ok_or_else(|| {
+                    "PATHS VIA pattern must bind ?to in every solution".to_owned()
+                })?;
+                let Some(from_id) = graph.id_of(from_term) else {
+                    continue;
+                };
+                let Some(to_id) = graph.id_of(to_term) else {
+                    continue;
+                };
+                pairs.push((from_id, to_id));
+            }
+            let marker = Term::Literal(Literal::new_typed_literal(pattern.clone(), xsd::STRING));
+            Ok((pairs, marker))
+        }
+    }
 }
 
 fn selected_ids(graph: &Graph, fixed: Option<&Term>, all: impl Iterator<Item = Id>) -> Vec<Id> {

--- a/crates/sparq-engine/src/paths_syntax.rs
+++ b/crates/sparq-engine/src/paths_syntax.rs
@@ -16,7 +16,7 @@ use spargebra::term::NamedNodePattern;
 use spargebra::{Query, SparqlParser};
 use sparq_core::Graph;
 
-use crate::{enumerate_paths, PathMode, PathSpec, QueryResult};
+use crate::{enumerate_paths, PathMode, PathSpec, QueryResult, Via};
 
 #[derive(Debug)]
 struct ParsedPaths {
@@ -26,7 +26,7 @@ struct ParsedPaths {
     start: Option<Term>,
     end_var: Variable,
     end: Option<Term>,
-    via: NamedNode,
+    via: Via,
     max_length: Option<usize>,
 }
 
@@ -89,9 +89,9 @@ pub fn explain_paths(_graph: &Graph, src: &str) -> Result<String, String> {
         .max_length
         .map_or_else(|| "none".to_owned(), |n| n.to_string());
     Ok(format!(
-        "Paths mode={mode} cyclic={} via=<{}> maxLength={maximum}",
+        "Paths mode={mode} cyclic={} via={} maxLength={maximum}",
         parsed.cyclic,
-        parsed.via.as_str()
+        display_via(&parsed.via)
     ))
 }
 
@@ -124,7 +124,12 @@ fn parse_paths(src: &str) -> Result<ParsedPaths, String> {
     let end_var = parser.variable()?;
     let end = parser.optional_bound_iri(&prologue)?;
     parser.keyword("VIA")?;
-    let via = resolve_iri(&prologue, parser.next("IRI after VIA")?)?;
+    let via_token = parser.next("IRI or graph pattern after VIA")?;
+    let via = if via_token.starts_with('{') {
+        Via::Pattern(canonical_pattern(&prologue, via_token)?)
+    } else {
+        Via::Predicate(resolve_iri(&prologue, via_token)?)
+    };
     let max_length = if parser.consume_keyword("MAX") {
         parser.keyword("LENGTH")?;
         Some(
@@ -155,6 +160,31 @@ fn parse_paths(src: &str) -> Result<ParsedPaths, String> {
         via,
         max_length,
     })
+}
+
+fn display_via(via: &Via) -> String {
+    match via {
+        Via::Predicate(predicate) => format!("<{}>", predicate.as_str()),
+        Via::Pattern(pattern) => format!("{{ {pattern} }}"),
+    }
+}
+
+fn canonical_pattern(prologue: &str, token: &str) -> Result<String, String> {
+    let source = token
+        .strip_prefix('{')
+        .and_then(|value| value.strip_suffix('}'))
+        .ok_or_else(|| "unterminated graph pattern after VIA".to_owned())?
+        .trim();
+    let query = SparqlParser::new()
+        .parse_query(&format!("{prologue} SELECT ?from ?to WHERE {{ {source} }}"))
+        .map_err(|error| format!("invalid graph pattern after VIA: {error}"))?;
+    let Query::Select { pattern, .. } = query else {
+        unreachable!()
+    };
+    let GraphPattern::Project { inner, .. } = pattern else {
+        return Err("invalid SELECT projection for PATHS VIA pattern".to_owned());
+    };
+    Ok(inner.to_string())
 }
 
 fn validate_prologue(prologue: &str) -> Result<(), String> {
@@ -216,6 +246,14 @@ fn tokenize(src: &str) -> Result<Vec<String>, String> {
             tokens.push(src[start..end].to_owned());
             continue;
         }
+        if ch == '{' {
+            let end = braced_group_end(src, start)?;
+            while chars.peek().is_some_and(|(index, _)| *index < end) {
+                chars.next();
+            }
+            tokens.push(src[start..end].to_owned());
+            continue;
+        }
         let mut end = start + ch.len_utf8();
         while let Some(&(index, c)) = chars.peek() {
             if c.is_whitespace() || c == '=' || c == '#' || c == '<' {
@@ -227,6 +265,52 @@ fn tokenize(src: &str) -> Result<Vec<String>, String> {
         tokens.push(src[start..end].to_owned());
     }
     Ok(tokens)
+}
+
+fn braced_group_end(src: &str, start: usize) -> Result<usize, String> {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut iri = false;
+    let mut comment = false;
+    for (offset, ch) in src[start..].char_indices() {
+        if comment {
+            if ch == '\n' {
+                comment = false;
+            }
+            continue;
+        }
+        if let Some(delimiter) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == delimiter {
+                quote = None;
+            }
+            continue;
+        }
+        if iri {
+            if ch == '>' {
+                iri = false;
+            }
+            continue;
+        }
+        match ch {
+            '#' => comment = true,
+            '<' => iri = true,
+            '\'' | '"' => quote = Some(ch),
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok(start + offset + ch.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+    Err("unterminated graph pattern after VIA".to_owned())
 }
 
 struct Tokens<'a> {

--- a/crates/sparq-engine/tests/paths_core.rs
+++ b/crates/sparq-engine/tests/paths_core.rs
@@ -2,7 +2,7 @@
 
 use oxrdf::{NamedNode, Term};
 use sparq_core::Graph;
-use sparq_engine::{enumerate_paths, PathMode, PathSolution, PathSpec};
+use sparq_engine::{enumerate_paths, PathMode, PathSolution, PathSpec, Via};
 use std::collections::{BTreeMap, BTreeSet};
 
 const EX: &str = "http://example/";
@@ -29,7 +29,7 @@ fn spec(mode: PathMode, start: &str, end: Option<&str>, max_length: Option<usize
         cyclic: end.is_none(),
         start: Some(iri(start)),
         end: end.map(iri),
-        via: via(),
+        via: Via::Predicate(via()),
         max_length,
     }
 }
@@ -185,7 +185,7 @@ fn seeded_random_graph_agrees_with_recursive_reference() {
             cyclic: false,
             start: None,
             end: None,
-            via: via(),
+            via: Via::Predicate(via()),
             max_length: (mode == PathMode::All).then_some(4),
         };
         let got: BTreeSet<Vec<usize>> = enumerate_paths(&g, &request)

--- a/crates/sparq-engine/tests/paths_via.rs
+++ b/crates/sparq-engine/tests/paths_via.rs
@@ -1,0 +1,83 @@
+#![cfg(feature = "paths")]
+
+// [GPT-5.6] sq-lsp7k.3.3 acceptance and mutation-witnessed VIA-pattern coverage.
+
+use sparq_core::Graph;
+use sparq_engine::query_paths;
+
+fn fixture() -> Graph {
+    Graph::load_str(
+        r#"@prefix ex: <http://ex/> .
+            ex:a ex:knows ex:b .
+            ex:b ex:memberOf ex:c .
+            ex:c ex:knows ex:d .
+            ex:d ex:memberOf ex:e .
+            ex:a ex:p ex:c .
+            ex:c ex:p ex:e ."#,
+        "turtle",
+    )
+    .unwrap()
+}
+
+#[test]
+fn composed_graph_pattern_materializes_the_expected_paths() {
+    let result = query_paths(
+        &fixture(),
+        "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s = ex:a END ?e = ex:e \
+         VIA { ?from ex:knows/ex:memberOf ?to }",
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.rows.len(),
+        2,
+        "the fixture contains one two-edge path"
+    );
+    assert_eq!(
+        result.rows[0][4].as_ref().unwrap().to_string(),
+        "<http://ex/c>"
+    );
+    assert_eq!(
+        result.rows[1][4].as_ref().unwrap().to_string(),
+        "<http://ex/e>"
+    );
+    let edge_markers = result
+        .rows
+        .iter()
+        .map(|row| row[5].as_ref().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(edge_markers[0], edge_markers[1]);
+    assert!(edge_markers[0].is_literal());
+}
+
+#[test]
+fn single_predicate_pattern_is_byte_identical_to_predicate_via() {
+    let predicate = query_paths(
+        &fixture(),
+        "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s = ex:a END ?e = ex:e VIA ex:p",
+    )
+    .unwrap();
+    let pattern = query_paths(
+        &fixture(),
+        "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s = ex:a END ?e = ex:e \
+         VIA { ?from ex:p ?to }",
+    )
+    .unwrap();
+
+    assert_eq!(predicate.vars, pattern.vars);
+    assert_eq!(predicate.rows.len(), pattern.rows.len());
+    for (predicate_row, pattern_row) in predicate.rows.iter().zip(&pattern.rows) {
+        assert_eq!(&predicate_row[..5], &pattern_row[..5]);
+    }
+}
+
+#[test]
+fn pattern_missing_reserved_to_binding_is_a_loud_error() {
+    let error = query_paths(
+        &fixture(),
+        "PREFIX ex: <http://ex/> PATHS SHORTEST START ?s END ?e \
+         VIA { ?from ex:p ex:c }",
+    )
+    .unwrap_err();
+    assert!(error.contains("must bind ?to"), "unexpected error: {error}");
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -196,19 +196,25 @@ paths up to that bound. Set `cyclic: true` to request only non-empty paths retur
 ```rust
 // Cargo.toml: sparq-engine = { version = "0.1", features = ["paths"] }
 use oxrdf::{NamedNode, Term};
-use sparq_engine::{enumerate_paths, PathMode, PathSpec};
+use sparq_engine::{enumerate_paths, PathMode, PathSpec, Via};
 
 let paths = enumerate_paths(&g, &PathSpec {
     mode: PathMode::Shortest,
     cyclic: false,
     start: Some(Term::NamedNode(NamedNode::new("http://ex/alice")?)),
     end: Some(Term::NamedNode(NamedNode::new("http://ex/bob")?)),
-    via: NamedNode::new("http://ex/knows")?,
+    via: Via::Predicate(NamedNode::new("http://ex/knows")?),
     max_length: None,
 })?;
 assert!(paths.iter().all(|path| path.nodes.len() == path.edges.len() + 1));
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+`PathSpec::via` also accepts `Via::Pattern`, whose SPARQL group graph pattern must bind the
+reserved `?from` and `?to` endpoint variables. The pattern is evaluated once to materialize the
+edge relation. In the dedicated syntax, write `VIA { ?from ex:knows/ex:memberOf ?to }`. Because a
+pattern has no single predicate term, each returned `?edge` is the canonicalized pattern source as
+an `xsd:string` literal (and therefore contains no blank nodes).
 
 The same feature exposes a dedicated non-standard query form through `query_paths` and
 `explain_paths`. It is intentionally rejected by the ordinary `query` entry point:


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-lsp7k.3.3.

- Extends the opt-in paths API with Via::Predicate and Via::Pattern.
- Parses VIA { ... } through the dedicated PATHS surface, canonicalizes the standard SPARQL graph pattern, evaluates it once, and reuses the existing deterministic path enumerator.
- Rejects patterns that do not bind reserved ?from and ?to endpoints.
- Binds pattern edges to a canonical blank-node-free xsd:string marker and updates the public usage skill.
- Adds composed-property-path, predicate differential, and loud-error coverage.

Gates:
- cargo test -p sparq-engine (default): green
- cargo test -p sparq-engine --features paths: green
- cargo clippy -p sparq-engine --all-targets -- -D warnings: green
- cargo clippy -p sparq-engine --all-targets --features paths -- -D warnings: green
- RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-engine --no-deps --all-features: green
- mutation witness: clearing the materialized pattern-edge relation makes composed_graph_pattern_materializes_the_expected_paths fail (0 rows vs 2 expected)

Note: predicate and equivalent graph-pattern forms are byte-identical for endpoint/path/node columns. Their ?edge columns intentionally differ per the bead contract: predicate IRI versus canonical xsd:string pattern marker.