### PR TITLE
bench: add Tier-B WASM size envelope [GPT-5.6]

### DIFF
--- a/bench/wasm-tierb-size/size.mjs
+++ b/bench/wasm-tierb-size/size.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// [GPT-5.6] sq-3k4rp — deterministic shipped Tier-B WASM size envelope.
+
+import path from "node:path";
+import { createHash } from "node:crypto";
+import { gzipSync, constants as zlibConstants } from "node:zlib";
+import { spawnSync } from "node:child_process";
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import process from "node:process";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, "..", "..");
+const OUT = path.resolve(process.argv[2] ?? path.join(HERE, "envelope.json"));
+
+const BUNDLES = [
+  ["sparq-rsp-wasm", "sparq_rsp_wasm_bg.wasm"],
+  ["sparq-text-wasm", "sparq_text_wasm_bg.wasm"],
+  ["sparq-reason-wasm", "sparq_reason_wasm_bg.wasm"],
+  ["sparq-shacl-wasm", "sparq_shacl_wasm_bg.wasm"],
+];
+
+function commandVersion(command, args = ["--version"]) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  return result.stdout.trim() || result.stderr.trim() || null;
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function measure(crate, filename) {
+  const relativePath = path.join("crates", crate, "pkg", filename);
+  try {
+    const bytes = await readFile(path.join(REPO, relativePath));
+    return {
+      crate,
+      artifact: relativePath,
+      status: "present",
+      raw_bytes: bytes.length,
+      gzip_level_9_bytes_advisory: gzipSync(bytes, {
+        level: 9,
+        // Pin fields that can otherwise vary between gzip producers.
+        mtime: 0,
+      }).length,
+      sha256: sha256(bytes),
+    };
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    console.error(`[wasm-tierb-size] notice: ${relativePath} is missing; build ${crate} first`);
+    return {
+      crate,
+      artifact: relativePath,
+      status: "missing",
+      notice: "artifact was not built; no size or digest was recorded",
+    };
+  }
+}
+
+const git = spawnSync("git", ["-C", REPO, "rev-parse", "HEAD"], { encoding: "utf8" });
+const envelope = {
+  schema_version: 1,
+  suite: "wasm-tierb-size",
+  bead: "sq-3k4rp",
+  deterministic_metric: "raw_bytes",
+  git_commit: git.status === 0 ? git.stdout.trim() : null,
+  toolchain: {
+    wasm_pack: commandVersion("wasm-pack"),
+    binaryen: commandVersion("wasm-opt"),
+    node_zlib: process.versions.zlib,
+    gzip_level: zlibConstants.Z_BEST_COMPRESSION,
+  },
+  bundles: await Promise.all(BUNDLES.map(([crate, filename]) => measure(crate, filename))),
+};
+
+await writeFile(OUT, `${JSON.stringify(envelope, null, 2)}\n`);
+
+for (const bundle of envelope.bundles) {
+  if (bundle.status === "present") {
+    console.log(
+      `${bundle.crate}: ${bundle.raw_bytes} raw bytes; ` +
+        `${bundle.gzip_level_9_bytes_advisory} gzip-9 advisory bytes; sha256 ${bundle.sha256}`,
+    );
+  } else {
+    console.log(`${bundle.crate}: missing-with-notice`);
+  }
+}
+console.log(`wrote ${path.relative(process.cwd(), OUT)}`);

--- a/bench/wasm-tierb-size/size.test.mjs
+++ b/bench/wasm-tierb-size/size.test.mjs
@@ -1,0 +1,41 @@
+// [GPT-5.6] sq-3k4rp — mutation witness for present and absent bundle accounting.
+
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, "..", "..");
+const artifact = path.join(REPO, "crates", "sparq-rsp-wasm", "pkg", "sparq_rsp_wasm_bg.wasm");
+const tmp = await mkdtemp(path.join(os.tmpdir(), "wasm-tierb-size-test-"));
+const out = path.join(tmp, "envelope.json");
+
+try {
+  await mkdir(path.dirname(artifact), { recursive: true });
+  const original = await readFile(artifact).catch(() => null);
+  try {
+    await writeFile(artifact, Buffer.from("deterministic-fixture"));
+    const run = spawnSync(process.execPath, [path.join(HERE, "size.mjs"), out], { encoding: "utf8" });
+    assert.equal(run.status, 0, run.stderr);
+    const envelope = JSON.parse(await readFile(out, "utf8"));
+    assert.equal(envelope.bundles.length, 4);
+    const present = envelope.bundles.find((row) => row.crate === "sparq-rsp-wasm");
+    assert.deepEqual(
+      { status: present.status, raw_bytes: present.raw_bytes, sha256: present.sha256 },
+      {
+        status: "present",
+        raw_bytes: 21,
+        sha256: "d05270b97c3ebfff4627da61d16ef5a480fab6f967cefebcac14b079aa01be10",
+      },
+    );
+    assert.ok(envelope.bundles.some((row) => row.status === "missing"));
+  } finally {
+    if (original === null) await rm(artifact, { force: true });
+    else await writeFile(artifact, original);
+  }
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-3k4rp.

Adds a deterministic shipped-artifact size aggregator for the four Tier-B WASM bundles. Present artifacts record canonical raw bytes, advisory gzip level-9 bytes, SHA-256, and toolchain versions; absent artifacts are explicitly reported missing-with-notice.

Validation:
- `npm run build:rsp-wasm`
- `npm run build:text-wasm`
- `node --test bench/wasm-tierb-size/size.test.mjs`
- two aggregator runs compared byte-for-byte with `cmp`
- mutation witness: replacing SHA-256 computation made the test fail
- `node --check bench/wasm-tierb-size/size.mjs`
- `git diff --check`

Rust crate gates are not applicable: this changes only standalone Node benchmark tooling and no Rust crate or public API.

The PR is intentionally not armed or merged.