### PR TITLE
bench(trust): add deterministic admission cost harness [GPT-5.6]

### DIFF
--- a/bench/trust-admission/.gitignore
+++ b/bench/trust-admission/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!sample.json

--- a/bench/trust-admission/README.md
+++ b/bench/trust-admission/README.md
@@ -1,0 +1,33 @@
+# Trust-admission deterministic metrics
+
+This directory holds regenerable evidence from the opt-in `sparq-trust` certification
+graph and unchanged admission gate. Generate the sample from the repository root:
+
+```sh
+cargo run -p sparq-trust --features cert-graph --example admission_cost -- \
+  --emit bench/trust-admission/sample.json
+```
+
+The document is a JSON object with `schema_version` (currently `1`) and `cases`, an
+ordered array. Every case contains these integer fields:
+
+- `fixture_size`: synthetic rules and certification edges constructed for the case.
+- `depth_bound`: closure bound supplied to `derive_effective_rules`.
+- `direct_rule_count`: anchor rules supplied to closure and admission.
+- `certification_edges_considered`: edges inspected by the evidence harness.
+- `edges_rejected`: counts keyed by every public `EdgeRejection` reason:
+  `no_anchor`, `signature_invalid`, `out_of_window`, `cyclic`, `broadening`, and
+  `over_depth`.
+- `max_closure_depth_reached`: actual closure rounds reached. The current implementation
+  is intentionally depth-1, so this is either zero or one.
+- `visited_set_size`: unique certifier and certified-issuer identities observed. This is
+  the deterministic visited-set input size for evaluating cycle handling; it does not
+  claim that the current depth-1 library implementation allocates such a set.
+- `derived_rule_count`: effective rules minus direct rules.
+
+All values are deterministic functions of fixed fixtures. The schema excludes clock,
+elapsed-time, host, platform, and allocator measurements. Such measurements are not
+canonical evidence for this repository.
+
+[GPT-5.6] `sq-r78pf`; evidence substrate for `sq-pfae.9` only. It does not close that
+cost/decidability spike or make a complexity/soundness claim.

--- a/bench/trust-admission/sample.json
+++ b/bench/trust-admission/sample.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": 1,
+  "cases": [
+    {
+      "fixture_size": 1,
+      "depth_bound": 0,
+      "direct_rule_count": 1,
+      "certification_edges_considered": 1,
+      "edges_rejected": {
+        "no_anchor": 0,
+        "signature_invalid": 0,
+        "out_of_window": 0,
+        "cyclic": 0,
+        "broadening": 0,
+        "over_depth": 1
+      },
+      "max_closure_depth_reached": 0,
+      "visited_set_size": 2,
+      "derived_rule_count": 0
+    },
+    {
+      "fixture_size": 1,
+      "depth_bound": 1,
+      "direct_rule_count": 1,
+      "certification_edges_considered": 1,
+      "edges_rejected": {
+        "no_anchor": 0,
+        "signature_invalid": 0,
+        "out_of_window": 0,
+        "cyclic": 0,
+        "broadening": 0,
+        "over_depth": 0
+      },
+      "max_closure_depth_reached": 1,
+      "visited_set_size": 2,
+      "derived_rule_count": 1
+    },
+    {
+      "fixture_size": 4,
+      "depth_bound": 1,
+      "direct_rule_count": 4,
+      "certification_edges_considered": 4,
+      "edges_rejected": {
+        "no_anchor": 1,
+        "signature_invalid": 1,
+        "out_of_window": 1,
+        "cyclic": 0,
+        "broadening": 0,
+        "over_depth": 0
+      },
+      "max_closure_depth_reached": 1,
+      "visited_set_size": 8,
+      "derived_rule_count": 1
+    },
+    {
+      "fixture_size": 16,
+      "depth_bound": 1,
+      "direct_rule_count": 16,
+      "certification_edges_considered": 16,
+      "edges_rejected": {
+        "no_anchor": 3,
+        "signature_invalid": 3,
+        "out_of_window": 3,
+        "cyclic": 2,
+        "broadening": 2,
+        "over_depth": 0
+      },
+      "max_closure_depth_reached": 1,
+      "visited_set_size": 28,
+      "derived_rule_count": 3
+    },
+    {
+      "fixture_size": 64,
+      "depth_bound": 1,
+      "direct_rule_count": 64,
+      "certification_edges_considered": 64,
+      "edges_rejected": {
+        "no_anchor": 11,
+        "signature_invalid": 11,
+        "out_of_window": 11,
+        "cyclic": 10,
+        "broadening": 10,
+        "over_depth": 0
+      },
+      "max_closure_depth_reached": 1,
+      "visited_set_size": 108,
+      "derived_rule_count": 11
+    }
+  ]
+}

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -15,6 +15,10 @@ readme = "README.md"
 # signature but does NOT deliver unlinkable/anonymous presentation. NOT published.
 publish = false
 
+[[example]]
+name = "admission_cost"
+required-features = ["cert-graph"]
+
 # [OPUS-4.8] docs.rs: build with all features + the `docsrs` cfg.
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/sparq-trust/examples/admission_cost.rs
+++ b/crates/sparq-trust/examples/admission_cost.rs
@@ -1,0 +1,211 @@
+//! Deterministic admission and certification-closure cost evidence (`sq-r78pf`).
+//!
+//! [GPT-5.6] This example deliberately records operation-independent counts only. It
+//! contains no clock sampling, elapsed duration, allocator telemetry, or host metadata.
+
+use oxrdf::{BlankNode, Literal, NamedNode, Term, Triple};
+use sparq_trust::admit::{admit, PresentedCredential, Session};
+use sparq_trust::graph::{
+    certification_message, derive_effective_rules, explain_edge, CertScope, Certification,
+    EdgeRejection,
+};
+use sparq_trust::policy::{ShapeRef, TrustRule};
+use sparq_zk::sig::{PublicKey, SecretKey};
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+const NOW: i64 = 1_700_000_000;
+const FRESH: i64 = 86_400;
+const TARGET: &str = "https://pod.example/resource";
+const PREDICATE: &str = "https://schema.org/age";
+
+fn iri(value: &str) -> NamedNode {
+    NamedNode::new(value).expect("fixture IRIs are valid")
+}
+
+fn predicate_shape(predicate: &str, suffix: &str) -> ShapeRef {
+    let root = BlankNode::new(format!("shape{suffix}")).expect("valid fixture blank node");
+    let property = BlankNode::new(format!("property{suffix}")).expect("valid fixture blank node");
+    ShapeRef {
+        root: Term::BlankNode(root.clone()),
+        triples: vec![
+            Triple::new(
+                root.clone(),
+                iri("http://www.w3.org/ns/shacl#targetSubjectsOf"),
+                iri(predicate),
+            ),
+            Triple::new(
+                root,
+                iri("http://www.w3.org/ns/shacl#property"),
+                property.clone(),
+            ),
+            Triple::new(
+                property.clone(),
+                iri("http://www.w3.org/ns/shacl#path"),
+                iri(predicate),
+            ),
+            Triple::new(
+                property,
+                iri("http://www.w3.org/ns/shacl#minCount"),
+                Literal::new_simple_literal("1"),
+            ),
+        ],
+    }
+}
+
+fn anchor(index: usize, key: PublicKey) -> TrustRule {
+    TrustRule {
+        source: iri(&format!("https://authority.example/{index}")),
+        issuer_key: key,
+        shape: predicate_shape(PREDICATE, &index.to_string()),
+        scope: iri(TARGET),
+        fresh_within_secs: FRESH,
+    }
+}
+
+fn signed_cert(index: usize, signer: &SecretKey, certified_key: PublicKey) -> Certification {
+    let mut cert = Certification {
+        certifier: iri(&format!("https://authority.example/{index}")),
+        certifier_key: signer.public_key(),
+        certified_issuer: iri(&format!("https://issuer.example/{index}")),
+        certified_key,
+        scope: CertScope::AnyService,
+        valid_from_unix_secs: NOW - 1,
+        valid_until_unix_secs: NOW + FRESH,
+        signature_hex: String::new(),
+    };
+    cert.signature_hex = signer.sign_commitment(&certification_message(&cert));
+    cert
+}
+
+fn fixture(size: usize) -> (Vec<TrustRule>, Vec<Certification>) {
+    let mut rules = Vec::with_capacity(size);
+    let mut certifications = Vec::with_capacity(size);
+    for index in 0..size {
+        let signer = SecretKey::from_seed(index as u64 + 1);
+        let certified_key = SecretKey::from_seed(index as u64 + 10_001).public_key();
+        rules.push(anchor(index, signer.public_key()));
+        let mut cert = signed_cert(index, &signer, certified_key);
+        // Deterministically exercise each fail-closed reason reachable at depth one.
+        match index % 6 {
+            1 => cert.certifier = iri("https://unanchored.example/authority"),
+            2 => cert.signature_hex = "00".to_owned(),
+            3 => cert.valid_until_unix_secs = NOW - 1,
+            4 => cert.certified_issuer = cert.certifier.clone(),
+            5 => cert.scope = CertScope::Shape(predicate_shape("https://schema.org/name", "broad")),
+            _ => {}
+        }
+        if index % 6 != 2 {
+            cert.signature_hex = signer.sign_commitment(&certification_message(&cert));
+        }
+        certifications.push(cert);
+    }
+    (rules, certifications)
+}
+
+#[derive(Default)]
+struct Rejections {
+    no_anchor: usize,
+    signature_invalid: usize,
+    out_of_window: usize,
+    cyclic: usize,
+    broadening: usize,
+    over_depth: usize,
+}
+
+impl Rejections {
+    fn record(&mut self, reason: EdgeRejection) {
+        match reason {
+            EdgeRejection::NoAnchor => self.no_anchor += 1,
+            EdgeRejection::SignatureInvalid => self.signature_invalid += 1,
+            EdgeRejection::OutOfWindow => self.out_of_window += 1,
+            EdgeRejection::Cyclic => self.cyclic += 1,
+            EdgeRejection::Broadening => self.broadening += 1,
+            EdgeRejection::OverDepth => self.over_depth += 1,
+        }
+    }
+}
+
+/// Render the fixed fixture suite as canonical, deterministic JSON.
+///
+/// Public solely so the integration test can include this example and mutation-witness
+/// byte stability without adding anything to the `sparq-trust` library API.
+pub fn render_fixture_suite() -> String {
+    let mut output = String::from("{\n  \"schema_version\": 1,\n  \"cases\": [\n");
+    let cases = [(1, 0_u32), (1, 1), (4, 1), (16, 1), (64, 1)];
+    for (case_index, (size, depth_bound)) in cases.into_iter().enumerate() {
+        let (rules, certifications) = fixture(size);
+        let effective = derive_effective_rules(&rules, &certifications, NOW, depth_bound);
+        let mut rejections = Rejections::default();
+        for cert in &certifications {
+            if let Err(reason) = explain_edge(&rules, cert, NOW, depth_bound) {
+                rejections.record(reason);
+            }
+        }
+
+        let visited_set_size = certifications
+            .iter()
+            .flat_map(|cert| [cert.certifier.as_str(), cert.certified_issuer.as_str()])
+            .collect::<BTreeSet<_>>()
+            .len();
+
+        // Exercise the unchanged admission gate once per effective rule. The deliberately
+        // malformed signature fails closed after canonicalisation; its result is not a
+        // metric because this harness counts policy/closure work, not authorisation facts.
+        let credential = PresentedCredential {
+            graph: vec![Triple::new(
+                iri("https://agent.example/alice"),
+                iri(PREDICATE),
+                Literal::from(42),
+            )],
+            issuer_signature_hex: "00".to_owned(),
+            salt: [7; 32],
+            issued_at_unix_secs: NOW,
+            revoked: false,
+        };
+        let session = Session {
+            agent: iri("https://agent.example/alice"),
+            now_unix_secs: NOW,
+        };
+        let _ = admit(&credential, &effective, &session, &iri(TARGET));
+
+        let derived_rule_count = effective.len().saturating_sub(rules.len());
+        let max_closure_depth_reached = usize::from(depth_bound > 0 && !certifications.is_empty());
+        write!(
+            output,
+            "    {{\n      \"fixture_size\": {size},\n      \"depth_bound\": {depth_bound},\n      \"direct_rule_count\": {},\n      \"certification_edges_considered\": {},\n      \"edges_rejected\": {{\n        \"no_anchor\": {},\n        \"signature_invalid\": {},\n        \"out_of_window\": {},\n        \"cyclic\": {},\n        \"broadening\": {},\n        \"over_depth\": {}\n      }},\n      \"max_closure_depth_reached\": {max_closure_depth_reached},\n      \"visited_set_size\": {visited_set_size},\n      \"derived_rule_count\": {derived_rule_count}\n    }}{}\n",
+            rules.len(),
+            certifications.len(),
+            rejections.no_anchor,
+            rejections.signature_invalid,
+            rejections.out_of_window,
+            rejections.cyclic,
+            rejections.broadening,
+            rejections.over_depth,
+            if case_index + 1 == cases.len() { "" } else { "," },
+        )
+        .expect("writing to String is infallible");
+    }
+    output.push_str("  ]\n}\n");
+    output
+}
+
+fn output_path(args: impl IntoIterator<Item = String>) -> Result<String, String> {
+    let mut args = args.into_iter();
+    match (args.next().as_deref(), args.next(), args.next()) {
+        (Some("--emit"), Some(path), None) => Ok(path),
+        _ => Err("usage: admission_cost --emit PATH".to_owned()),
+    }
+}
+
+fn main() {
+    let path = output_path(std::env::args().skip(1)).unwrap_or_else(|message| {
+        eprintln!("{message}");
+        std::process::exit(2);
+    });
+    if let Some(parent) = Path::new(&path).parent() {
+        std::fs::create_dir_all(parent).expect("create output directory");
+    }
+    std::fs::write(path, render_fixture_suite()).expect("write deterministic metrics JSON");
+}

--- a/crates/sparq-trust/tests/admission_cost_determinism.rs
+++ b/crates/sparq-trust/tests/admission_cost_determinism.rs
@@ -1,0 +1,23 @@
+//! [GPT-5.6] Mutation witness for deterministic admission-cost evidence (`sq-r78pf`).
+
+#![cfg(feature = "cert-graph")]
+
+#[allow(dead_code)]
+#[path = "../examples/admission_cost.rs"]
+mod admission_cost;
+
+#[test]
+fn identical_fixture_runs_are_byte_identical_and_have_no_environment_metrics() {
+    let first = admission_cost::render_fixture_suite();
+    let second = admission_cost::render_fixture_suite();
+
+    assert_eq!(first.as_bytes(), second.as_bytes());
+    assert!(first.contains("\"certification_edges_considered\""));
+    assert!(first.contains("\"derived_rule_count\""));
+    for forbidden in ["timing", "duration", "elapsed", "hostname", "platform"] {
+        assert!(
+            !first.contains(forbidden),
+            "forbidden metric key: {forbidden}"
+        );
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-r78pf.

Adds an opt-in `cert-graph` example that runs certification closure and the unchanged admission gate over fixed growing fixtures, emitting canonical JSON counts only. Documents and commits the schema/sample, with regenerable-output hygiene.

The integration test renders the same suite twice and checks byte identity plus absence of environment-dependent metric keys. Mutation witness: a temporary per-call counter made the determinism test fail; restoring the pure renderer made it pass.

Gates:
- `cargo clippy -p sparq-trust --all-targets -- -D warnings`
- `cargo clippy -p sparq-trust --all-targets --features cert-graph -- -D warnings`
- `cargo test -p sparq-trust`
- `cargo test -p sparq-trust --features cert-graph`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-trust --no-deps --all-features`
- `cargo build -p sparq-trust`
- documented JSON-schema validation with `jq`

No library behavior or public library API changes; the example target requires the default-OFF `cert-graph` feature. No runtime, host, or allocator measurements are emitted.