### PR TITLE
feat(lws): observe notification backlog overflow [GPT-5.6]

### DIFF
--- a/crates/sparq-lws-core/README.md
+++ b/crates/sparq-lws-core/README.md
@@ -37,6 +37,8 @@ module docs on `src/main.rs`.
   tiered PoP: RFC 8705 mTLS cert-bound tokens and HKDF/HMAC DPoP-SK attestation.
 - **Storage seams** — `Store` / `SparqClient` / `BlobStore` traits: in-memory
   double, live SPARQ HTTP client, and `object_store` blob backends.
+- **Notification observability** — [GPT-5.6] process-wide backlog-overflow totals
+  are available through `notifications::ws::NotificationMetrics::snapshot()`.
 - **Transport hardening** — HTTP/2 rapid-reset + slowloris guards, request
   timeouts, body limits, per-connection max-requests, rate limiting, overload
   shedding.

--- a/crates/sparq-lws-core/src/notifications/ws.rs
+++ b/crates/sparq-lws-core/src/notifications/ws.rs
@@ -21,7 +21,8 @@
 //!    (Attaching them to the LDP responses is a one-line wire in the handler; this module owns the
 //!    values so the discovery contract lives in one place.)
 
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, LazyLock};
 
 use axum::extract::ws::rejection::WebSocketUpgradeRejection;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
@@ -45,6 +46,45 @@ pub const SUBSCRIPTION_PATH: &str = "/.notifications/WebSocketChannel2023/";
 pub const RECEIVE_PATH: &str = "/.notifications/WebSocketChannel2023/receive";
 /// The storage-description / well-known discovery document path.
 pub const WELL_KNOWN_SOLID_PATH: &str = "/.well-known/solid";
+
+// [GPT-5.6] Keep the hot-path counters private so callers can observe but cannot mutate them.
+struct NotificationMetricCounters {
+    dropped_subscribers_total: AtomicU64,
+    lagged_events_total: AtomicU64,
+}
+
+static NOTIFICATION_METRICS: LazyLock<NotificationMetricCounters> =
+    LazyLock::new(|| NotificationMetricCounters {
+        dropped_subscribers_total: AtomicU64::new(0),
+        lagged_events_total: AtomicU64::new(0),
+    });
+
+/// Process-wide WebSocket notification overflow counters.
+///
+/// Obtain the current values with [`NotificationMetrics::snapshot`]. Counts are monotonic for the
+/// lifetime of the process and use relaxed atomic ordering because they are observability-only.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct NotificationMetrics {
+    /// Subscribers closed after falling behind the per-topic broadcast buffer.
+    pub dropped_subscribers_total: u64,
+    /// Notification events skipped by lagged subscribers before they were closed.
+    pub lagged_events_total: u64,
+}
+
+impl NotificationMetrics {
+    /// Returns a point-in-time snapshot of the process-wide notification overflow counters.
+    #[must_use]
+    pub fn snapshot() -> Self {
+        Self {
+            dropped_subscribers_total: NOTIFICATION_METRICS
+                .dropped_subscribers_total
+                .load(Ordering::Relaxed),
+            lagged_events_total: NOTIFICATION_METRICS
+                .lagged_events_total
+                .load(Ordering::Relaxed),
+        }
+    }
+}
 
 /// State for the notification routes: the hub + the server's public base URL (for building the
 /// absolute `receiveFrom` / subscription-service URLs in discovery + subscribe responses).
@@ -273,7 +313,13 @@ async fn stream_notifications(mut socket: WebSocket, hub: NotificationHub, topic
                     }
                     // The buffer overran for this slow client: a frame was dropped. Tell the client to
                     // reconcile by closing — it should re-subscribe + re-read (missed-update safety).
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        NOTIFICATION_METRICS
+                            .dropped_subscribers_total
+                            .fetch_add(1, Ordering::Relaxed);
+                        NOTIFICATION_METRICS
+                            .lagged_events_total
+                            .fetch_add(skipped, Ordering::Relaxed);
                         let _ = socket
                             .send(Message::Close(Some(axum::extract::ws::CloseFrame {
                                 code: 1011, // "internal error" / server overload — client reconnects

--- a/crates/sparq-lws-core/tests/notifications_http.rs
+++ b/crates/sparq-lws-core/tests/notifications_http.rs
@@ -21,6 +21,9 @@ use solid_oidc_verifier::verifier::Verifier;
 use sparq_lws_core::app::{build_router, AppState};
 use sparq_lws_core::auth::AuthContext;
 use sparq_lws_core::ldp::handler::LdpState;
+use sparq_lws_core::notifications::activity::ActivityType;
+use sparq_lws_core::notifications::ws::NotificationMetrics;
+use sparq_lws_core::notifications::NotificationHub;
 use sparq_lws_core::store::{CompositeStore, InMemoryBlobStore, InMemorySparqClient};
 use tower::ServiceExt;
 
@@ -309,7 +312,7 @@ async fn receive_with_valid_token_for_wrong_topic_is_rejected() {
 
 /// A really-bound server whose base URL matches the bound address, so DPoP htu + the WS upgrade work
 /// against `127.0.0.1:<port>`. Returns the base URL + the keys.
-async fn bind_live_server() -> (String, KeyKit, KeyKit) {
+async fn bind_live_server() -> (String, KeyKit, KeyKit, NotificationHub) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let base_url = format!("http://{addr}");
@@ -343,6 +346,7 @@ async fn bind_live_server() -> (String, KeyKit, KeyKit) {
             .expect("seed live root owner acl");
     }
     let ldp = LdpState::new(store, base_url.clone());
+    let notification_hub = ldp.notifications.clone();
     let app = build_router(AppState {
         auth: Arc::new(ctx),
         ldp: Arc::new(ldp),
@@ -353,7 +357,81 @@ async fn bind_live_server() -> (String, KeyKit, KeyKit) {
         axum::serve(listener, app).await.unwrap();
     });
 
-    (base_url, issuer_key, client_key)
+    (base_url, issuer_key, client_key, notification_hub)
+}
+
+// [GPT-5.6] A current-thread runtime makes the burst deterministic: the receive task cannot drain
+// the broadcast channel until this task yields after filling it beyond its fixed capacity.
+#[tokio::test(flavor = "current_thread")]
+async fn live_websocket_overflow_closes_and_increments_metrics() {
+    use futures_util::StreamExt;
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    let before = NotificationMetrics::snapshot();
+    let (base_url, issuer_key, client_key, hub) = bind_live_server().await;
+    let topic = format!("{base_url}/alice/overflow");
+    let access = mint_access_token(&issuer_key, &client_key.thumbprint);
+    let htu = format!("{base_url}/.notifications/WebSocketChannel2023/");
+    let proof = mint_dpop_proof(&client_key, "POST", &htu, &access);
+    let sub = reqwest_like_client()
+        .post(htu)
+        .header("authorization", format!("DPoP {access}"))
+        .header("dpop", proof)
+        .header("content-type", "application/ld+json")
+        .body(
+            serde_json::json!({
+                "type": WS_TYPE,
+                "topic": topic,
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(sub.status(), 200);
+    let channel: serde_json::Value = sub.json().await.unwrap();
+    let receive_from = channel["receiveFrom"].as_str().unwrap();
+    let (mut ws, _) = tokio_tungstenite::connect_async(receive_from)
+        .await
+        .expect("ws connects");
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while hub.subscriber_count(&topic).await != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("subscriber registered");
+
+    for _ in 0..65 {
+        hub.notify(&topic, ActivityType::Update, None).await;
+    }
+
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(5), ws.next())
+        .await
+        .expect("overflow close arrived")
+        .expect("websocket stream yielded a frame")
+        .expect("close frame is valid");
+    match frame {
+        WsMessage::Close(Some(close)) => {
+            assert_eq!(
+                close.code,
+                tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode::Error
+            );
+            assert_eq!(
+                close.reason,
+                "notification backlog overflow; reconnect and reconcile"
+            );
+        }
+        other => panic!("expected overflow close frame, got {other:?}"),
+    }
+
+    let after = NotificationMetrics::snapshot();
+    assert_eq!(
+        after.dropped_subscribers_total,
+        before.dropped_subscribers_total + 1
+    );
+    assert_eq!(after.lagged_events_total, before.lagged_events_total + 1);
 }
 
 /// Default-ignored: a full subscribe → connect WebSocket → PUT → receive an AS2.0 Update over the
@@ -365,7 +443,7 @@ async fn live_websocket_delivers_update_on_put() {
     use futures_util::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 
-    let (base_url, issuer_key, client_key) = bind_live_server().await;
+    let (base_url, issuer_key, client_key, _hub) = bind_live_server().await;
     let topic = format!("{base_url}/alice/data");
 
     let auth = |method: &str, path: &str| {


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes bead `sq-7q7rt`.

Adds process-wide, relaxed-atomic WebSocket notification overflow counters exposed through `NotificationMetrics::snapshot()`. The existing overflow close code, reason, timing, and reconnect/reconcile behavior are unchanged.

Adds a non-ignored real-WebSocket regression test that deterministically overruns the broadcast buffer and asserts the unchanged close frame plus exact metric deltas. Mutation witness: removing the dropped-subscriber increment makes the test fail (`0 != 1`).

Gates green:
- `cargo clippy -p sparq-lws-core --all-targets -- -D warnings`
- `cargo clippy -p sparq-lws-core --all-targets --all-features -- -D warnings`
- `cargo test -p sparq-lws-core`
- `cargo test -p sparq-lws-core --all-features`
- `cargo test -p sparq-lws-core --test notifications_http`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-lws-core --no-deps --all-features`
- `cargo check --workspace`
- `cargo check --workspace --all-features`
- `python3 scripts/check-readme-template.py --enforce`
- `cargo fmt -p sparq-lws-core`