### PR TITLE
feat(lws-core): harden Solid read content negotiation — JSON-LD profile param + Turtle fallback (sq-ah3oj) [FABLE-5]

### DIFF
--- a/crates/sparq-lws-core/src/ldp/content.rs
+++ b/crates/sparq-lws-core/src/ldp/content.rs
@@ -10,6 +10,9 @@
 //! M2: content negotiation (an `Accept`-driven serialisation choice) + re-serialisation between the
 //! two RDF formats now land here ([`negotiate_accept`] + [`serialize_triples`]). The JSON-LD
 //! `noRemoteContextLoader` SSRF posture (oxjsonld is local-only by construction) ports favourably.
+//! The Solid read path is hardened via [`negotiate_accept_with_profile`]: q-values, the JSON-LD
+//! `profile` parameter (expanded vs compacted, surfaced in [`NegotiatedFormat`]), and an `Accept`
+//! naming no producible type degrading to `text/turtle` (the Solid default) instead of a 406.
 //! Still M2-next: N-Triples/N-Quads/N3 read formats.
 
 use oxjsonld::{JsonLdParser, JsonLdSerializer};
@@ -145,21 +148,96 @@ pub fn serialize_triples(format: RdfFormat, triples: &[Triple]) -> Result<Vec<u8
     }
 }
 
-/// Negotiate the response RDF format from an `Accept` header against the formats this server can
-/// produce (Turtle + JSON-LD).
+/// A JSON-LD document form requested via the `Accept` header's `profile` media-type parameter
+/// ([JSON-LD 1.1 IANA registration](https://www.w3.org/TR/json-ld11/#iana-considerations)).
 ///
-/// Returns the best acceptable [`RdfFormat`], or `None` when the client explicitly accepts neither
-/// (the caller then responds 406). An ABSENT or `*/*` Accept defaults to the resource's stored
-/// format (`stored`) — the most faithful, zero-cost response. Quality values (`q=`) are honoured:
-/// the highest-q acceptable type wins, ties broken in the header's order.
+/// Only the two READ-relevant document forms are honoured: `expanded` and `compacted`. Other
+/// registered profile IRIs (`flattened`, `framed`, …) are ignored — per the registration a profile
+/// parameter is a client *preference* a server may decline, never an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsonLdProfileParam {
+    /// `http://www.w3.org/ns/json-ld#expanded`
+    Expanded,
+    /// `http://www.w3.org/ns/json-ld#compacted`
+    Compacted,
+}
+
+impl JsonLdProfileParam {
+    /// Extract the first honoured document form from a `profile` parameter VALUE (the part after
+    /// `profile=`), deterministically.
+    ///
+    /// The value is a (usually quoted) whitespace-separated list of profile IRIs; the FIRST one
+    /// that names an honoured form wins (client order = client preference). Unknown IRIs are
+    /// skipped. IRIs match the canonical registration exactly (IRIs are case-sensitive) — matched
+    /// via [`oxjsonld::JsonLdProfile::from_iri`] so the accepted spellings stay pinned to the
+    /// vendored JSON-LD implementation, not a hand-copied string.
+    fn from_param_value(value: &str) -> Option<Self> {
+        value
+            .trim()
+            .trim_matches('"')
+            .split_ascii_whitespace()
+            .find_map(|iri| match oxjsonld::JsonLdProfile::from_iri(iri) {
+                Some(oxjsonld::JsonLdProfile::Expanded) => Some(Self::Expanded),
+                Some(oxjsonld::JsonLdProfile::Compacted) => Some(Self::Compacted),
+                _ => None,
+            })
+    }
+}
+
+/// The outcome of [`negotiate_accept_with_profile`]: the chosen response format, plus — when that
+/// format is JSON-LD and the winning explicit `application/ld+json` range carried a recognised
+/// `profile` parameter — the requested document form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NegotiatedFormat {
+    /// The RDF format the response body should be serialised in.
+    pub format: RdfFormat,
+    /// The JSON-LD document form the client asked for, when [`Self::format`] is
+    /// [`RdfFormat::JsonLd`] and an explicit `application/ld+json` range carried one. `None`
+    /// otherwise (including a JSON-LD choice reached via an `application/*` / `*/*` wildcard —
+    /// wildcard ranges carry no honoured profile). The serialiser currently emits the streaming
+    /// (expanded-compatible) document form regardless; this field lets the handler echo the
+    /// selected profile and honour `compacted` output once the serialiser can produce it.
+    pub jsonld_profile: Option<JsonLdProfileParam>,
+}
+
+/// Negotiate the response RDF format from an `Accept` header against the formats this server can
+/// produce (Turtle + JSON-LD). Thin wrapper over [`negotiate_accept_with_profile`] (the single
+/// `Accept` decision point) that drops the JSON-LD profile detail.
+pub fn negotiate_accept(accept: Option<&str>, stored: RdfFormat) -> Option<RdfFormat> {
+    negotiate_accept_with_profile(accept, stored).map(|n| n.format)
+}
+
+/// Negotiate the response RDF format (and JSON-LD document form) from an `Accept` header against
+/// the formats this server can produce (Turtle + JSON-LD).
+///
+/// - An ABSENT `Accept` means "no preference": the resource's stored format (`stored`) — the most
+///   faithful, zero-cost response (as does `*/*`, which covers both producible types).
+/// - Quality values (`q=`) are honoured: the highest-q acceptable type wins; a q-tie prefers the
+///   stored format (cheapest); range ties break in the header's order.
+/// - The `application/ld+json` `profile` parameter is honoured deterministically: the profile of
+///   the best-q explicit `ld+json` range is surfaced (first-listed range wins q-ties), reduced to
+///   the first honoured document form in its value.
+/// - A PRESENT header that names/covers NO producible type (blank, or only unrecognised types like
+///   `text/html`) falls back to `text/turtle` — the Solid default representation — rather than
+///   failing the read (never a 406, never a 500).
+/// - `None` (⇒ the caller's 406) is returned ONLY when the client EXPLICITLY refused every
+///   producible type it covered (all applicable ranges at `q=0`) — serving a representation the
+///   client q=0-refused would violate RFC 7231 §5.3.1.
 ///
 /// This is a deliberately small, dependency-free `Accept` parser sufficient for the two RDF media
-/// types the server serves; it is NOT a general RFC 7231 content-negotiation engine.
-pub fn negotiate_accept(accept: Option<&str>, stored: RdfFormat) -> Option<RdfFormat> {
-    let raw = match accept {
-        None => return Some(stored),
-        Some(s) if s.trim().is_empty() => return Some(stored),
-        Some(s) => s,
+/// types the server serves; it is NOT a general RFC 7231 content-negotiation engine (in
+/// particular, parameters are split on `;`, so a quoted parameter value containing `;` — which no
+/// registered profile IRI does — would mis-parse).
+pub fn negotiate_accept_with_profile(
+    accept: Option<&str>,
+    stored: RdfFormat,
+) -> Option<NegotiatedFormat> {
+    // ABSENT header — "no preference": the stored format, byte-identical to the stored bytes.
+    let Some(raw) = accept else {
+        return Some(NegotiatedFormat {
+            format: stored,
+            jsonld_profile: None,
+        });
     };
 
     // Track the best q for each producible type, plus the matching type-range wildcards. A `text/*`
@@ -172,6 +250,11 @@ pub fn negotiate_accept(accept: Option<&str>, stored: RdfFormat) -> Option<RdfFo
     let mut q_app_star: Option<f32> = None; // covers JSON-LD only
     let mut q_any: Option<f32> = None; // covers both
 
+    // The profile carried by the BEST explicit `application/ld+json` range seen so far. Updated
+    // only on a STRICTLY greater q, so the first-listed range wins q-ties — deterministic, and
+    // consistent with `bump`, under which a later equal-q range changes nothing.
+    let mut jsonld_profile: Option<JsonLdProfileParam> = None;
+
     fn bump(slot: &mut Option<f32>, q: f32) {
         *slot = Some(slot.unwrap_or(0.0).max(q));
     }
@@ -179,23 +262,48 @@ pub fn negotiate_accept(accept: Option<&str>, stored: RdfFormat) -> Option<RdfFo
     for part in raw.split(',') {
         let mut it = part.split(';');
         let media = it.next().unwrap_or("").trim().to_ascii_lowercase();
-        // Parse an optional q-value; default 1.0; clamp to [0,1]; a malformed q is treated as 0
-        // (RFC 7231 §5.3.1 — an unparseable weight is not "accepted").
+        // Parse the parameters: an optional q-value (default 1.0; clamp to [0,1]; a malformed q is
+        // treated as 0 — RFC 7231 §5.3.1, an unparseable weight is not "accepted") and an optional
+        // `profile` (media-type parameter names are case-insensitive; the IRI value is not).
         let mut q: f32 = 1.0;
+        let mut profile: Option<JsonLdProfileParam> = None;
         for param in it {
-            let p = param.trim();
-            if let Some(v) = p.strip_prefix("q=").or_else(|| p.strip_prefix("Q=")) {
-                q = v.trim().parse::<f32>().unwrap_or(0.0).clamp(0.0, 1.0);
+            let Some((name, value)) = param.split_once('=') else {
+                continue;
+            };
+            match name.trim().to_ascii_lowercase().as_str() {
+                "q" => q = value.trim().parse::<f32>().unwrap_or(0.0).clamp(0.0, 1.0),
+                "profile" => profile = JsonLdProfileParam::from_param_value(value),
+                _ => {}
             }
         }
         match media.as_str() {
             "text/turtle" => bump(&mut q_turtle, q),
-            "application/ld+json" => bump(&mut q_jsonld, q),
+            "application/ld+json" => {
+                if q_jsonld.is_none_or(|cur| q > cur) {
+                    jsonld_profile = profile;
+                }
+                bump(&mut q_jsonld, q);
+            }
             "text/*" => bump(&mut q_text_star, q),
             "application/*" => bump(&mut q_app_star, q),
             "*/*" => bump(&mut q_any, q),
             _ => {}
         }
+    }
+
+    // A header that named/covered NO producible type — blank, or only unrecognised media types
+    // (`text/html`, `application/xml`, …). Solid default: degrade to Turtle, don't fail the read.
+    if q_turtle.is_none()
+        && q_jsonld.is_none()
+        && q_text_star.is_none()
+        && q_app_star.is_none()
+        && q_any.is_none()
+    {
+        return Some(NegotiatedFormat {
+            format: RdfFormat::Turtle,
+            jsonld_profile: None,
+        });
     }
 
     // Resolve each concrete type's effective weight: an explicit q wins; else the most specific
@@ -204,14 +312,23 @@ pub fn negotiate_accept(accept: Option<&str>, stored: RdfFormat) -> Option<RdfFo
     let jsonld = q_jsonld.or(q_app_star).or(q_any).unwrap_or(0.0);
 
     if turtle <= 0.0 && jsonld <= 0.0 {
-        return None; // 406 — the client accepts neither producible type.
+        return None; // 406 — the client EXPLICITLY refused (q=0) every covered producible type.
     }
     // Highest q wins; on a tie prefer the resource's stored format (cheapest, most faithful).
-    Some(match stored {
+    let format = match stored {
         RdfFormat::Turtle if turtle >= jsonld => RdfFormat::Turtle,
         RdfFormat::JsonLd if jsonld >= turtle => RdfFormat::JsonLd,
         _ if turtle >= jsonld => RdfFormat::Turtle,
         _ => RdfFormat::JsonLd,
+    };
+    Some(NegotiatedFormat {
+        format,
+        // The profile is only meaningful for a JSON-LD response, and only when JSON-LD won via an
+        // explicit `application/ld+json` range (a wildcard win carries no honoured profile).
+        jsonld_profile: match format {
+            RdfFormat::JsonLd => jsonld_profile,
+            RdfFormat::Turtle => None,
+        },
     })
 }
 
@@ -230,11 +347,25 @@ mod tests {
             Some(RdfFormat::Turtle)
         );
         assert_eq!(
-            negotiate_accept(Some(""), RdfFormat::JsonLd),
+            negotiate_accept(None, RdfFormat::JsonLd),
             Some(RdfFormat::JsonLd)
         );
         assert_eq!(
             negotiate_accept(Some("*/*"), RdfFormat::Turtle),
+            Some(RdfFormat::Turtle)
+        );
+    }
+
+    #[test]
+    fn blank_accept_falls_back_to_turtle_the_solid_default() {
+        // A PRESENT-but-blank Accept is treated as naming no producible type: the Solid default
+        // (text/turtle), even when the stored format is JSON-LD.
+        assert_eq!(
+            negotiate_accept(Some(""), RdfFormat::JsonLd),
+            Some(RdfFormat::Turtle)
+        );
+        assert_eq!(
+            negotiate_accept(Some("   "), RdfFormat::JsonLd),
             Some(RdfFormat::Turtle)
         );
     }
@@ -280,12 +411,31 @@ mod tests {
     }
 
     #[test]
-    fn unacceptable_accept_is_none_406() {
+    fn unrecognised_accept_falls_back_to_turtle_not_406() {
+        // An Accept naming only types the server can't produce degrades to the Solid default
+        // (text/turtle) — the read never fails over an exotic Accept.
         assert_eq!(
             negotiate_accept(Some("application/xml"), RdfFormat::Turtle),
+            Some(RdfFormat::Turtle)
+        );
+        assert_eq!(
+            negotiate_accept(Some("text/html"), RdfFormat::JsonLd),
+            Some(RdfFormat::Turtle)
+        );
+    }
+
+    #[test]
+    fn explicit_q_zero_refusal_of_every_covered_type_is_none_406() {
+        // The ONLY remaining 406: the client covered our producible types and explicitly refused
+        // them all with q=0 — serving one anyway would violate the client's stated refusal.
+        assert_eq!(
+            negotiate_accept(
+                Some("text/turtle;q=0, application/ld+json;q=0"),
+                RdfFormat::Turtle
+            ),
             None
         );
-        assert_eq!(negotiate_accept(Some("text/html"), RdfFormat::JsonLd), None);
+        assert_eq!(negotiate_accept(Some("*/*;q=0"), RdfFormat::JsonLd), None);
     }
 
     #[test]

--- a/crates/sparq-lws-core/src/ldp/handler.rs
+++ b/crates/sparq-lws-core/src/ldp/handler.rs
@@ -741,8 +741,10 @@ pub(crate) async fn serve_read<S: Store>(
     //   read-304 fast path). A client holding the Turtle tag but asking for JSON-LD therefore gets a
     //   fresh 200, never a 304 for a representation it doesn't hold; the write path accepts either
     //   tag's STATE part for If-Match (the GET → PUT round-trip — see `conditional`'s module doc).
-    //   An Accept that matches NO producible type is a 406 here, BEFORE the precondition check (a
-    //   conditional applies to the selected representation; with none selectable there is no 304).
+    //   An Accept that EXPLICITLY refuses (q=0) every producible type it covers is a 406 here,
+    //   BEFORE the precondition check (a conditional applies to the selected representation; with
+    //   none selectable there is no 304). An Accept merely naming no producible type instead falls
+    //   back to text/turtle, the Solid default (see `content::negotiate_accept_with_profile`).
     let (rendered, etag): (Option<(Bytes, String)>, String) = if target.is_container {
         let (body, content_type) = render_container(
             state,
@@ -1702,7 +1704,8 @@ fn validate_writable(
 ///
 /// The two sets are de-duplicated (a stored triple identical to a generated one is not repeated). The
 /// negotiated format honours the `Accept` header (Turtle / JSON-LD), defaulting to the container's
-/// stored format when it is RDF (else Turtle); an Accept that admits neither is a 406.
+/// stored format when it is RDF (else Turtle); an Accept naming no producible type falls back to
+/// Turtle (the Solid default), and only an explicit q=0 refusal of every covered type is a 406.
 async fn render_container<S: Store>(
     state: &Arc<LdpState<S>>,
     container_iri: &str,
@@ -1959,7 +1962,8 @@ fn write_response(existed: bool, meta: &ResourceMeta, iri: &str) -> Response {
 
 /// Content-negotiate the response body for an RDF resource. For a non-RDF stored type the body is
 /// returned verbatim. For an RDF type, the stored bytes are re-serialised into the negotiated format
-/// when it differs from the stored one. A client that accepts NEITHER producible type ⇒ 406.
+/// when it differs from the stored one. A client that EXPLICITLY refuses (q=0) every producible
+/// type it covers ⇒ 406; an Accept naming no producible type falls back to Turtle (Solid default).
 fn negotiate_body(
     stored_body: &Bytes,
     stored_content_type: &str,
@@ -1994,7 +1998,8 @@ fn negotiate_body(
 ///   `"<state>+<variant>"` tag, distinct per negotiated media type and derived from the stored
 ///   state — so the tag a 200 carries for each negotiated type is exactly the tag that later 304s
 ///   for that type, and the write path can round-trip its state part (`conditional` module doc);
-/// - an `Accept` matching NO producible type ⇒ 406 (no selected representation, no validator).
+/// - an `Accept` that explicitly refuses (q=0) every producible type it covers ⇒ 406 (no selected
+///   representation, no validator); one merely naming no producible type falls back to Turtle.
 ///
 /// The format decision is the same [`negotiate_accept`] call [`negotiate_body`] makes, so the
 /// validator and the body it labels can never disagree.
@@ -5844,7 +5849,9 @@ mod tests {
     #[tokio::test]
     async fn get_unacceptable_accept_is_406_even_with_matching_if_none_match() {
         // With no selectable representation there is nothing a conditional can apply to: the 406
-        // wins over a matching If-None-Match (no 304 for an unproducible representation).
+        // wins over a matching If-None-Match (no 304 for an unproducible representation). Since
+        // the Solid-default fallback landed, the only unacceptable Accept is an EXPLICIT q=0
+        // refusal of every producible type (a merely-unknown type now degrades to Turtle).
         let state = state_with_owner_resource("/alice/doc", COND_DOC).await;
         let turtle_tag =
             etag_of(&get_with(&state, owner_token(), "/alice/doc", HeaderMap::new()).await);
@@ -5853,7 +5860,10 @@ mod tests {
             header::IF_NONE_MATCH,
             HeaderValue::from_str(&turtle_tag).unwrap(),
         );
-        cond.insert(header::ACCEPT, HeaderValue::from_static("text/html"));
+        cond.insert(
+            header::ACCEPT,
+            HeaderValue::from_static("text/turtle;q=0, application/ld+json;q=0"),
+        );
         let uri: axum::http::Uri = "/alice/doc".parse().unwrap();
         let err = get_handler(State(state), Extension(owner_token()), uri, cond)
             .await

--- a/crates/sparq-lws-core/tests/identity_http.rs
+++ b/crates/sparq-lws-core/tests/identity_http.rs
@@ -191,10 +191,28 @@ async fn id_doc_negotiates_jsonld() {
 }
 
 #[tokio::test]
-async fn id_doc_unacceptable_accept_is_406() {
+async fn id_doc_unknown_accept_falls_back_to_turtle() {
+    // An Accept naming no producible type degrades to the Solid default (text/turtle) — the
+    // id-doc read never 406s over an exotic Accept.
     let h = Harness::new(true).await;
     let resp = h
         .anon("GET", ID_HOST, "/alice", &[("accept", "text/html")])
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("content-type").unwrap(), "text/turtle");
+}
+
+#[tokio::test]
+async fn id_doc_explicit_q_zero_refusal_is_406() {
+    // The only remaining 406: the client explicitly refused (q=0) every producible type.
+    let h = Harness::new(true).await;
+    let resp = h
+        .anon(
+            "GET",
+            ID_HOST,
+            "/alice",
+            &[("accept", "text/turtle;q=0, application/ld+json;q=0")],
+        )
         .await;
     assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
 }

--- a/crates/sparq-lws-core/tests/ldp_conneg.rs
+++ b/crates/sparq-lws-core/tests/ldp_conneg.rs
@@ -1,0 +1,228 @@
+// AUTHORED-BY Claude Fable 5
+//! Acceptance tests for the hardened Solid read content negotiation (bead sq-ah3oj):
+//! `negotiate_accept` / `negotiate_accept_with_profile` in `ldp::content`.
+//!
+//! Covers, per the bead's acceptance criteria:
+//! - q-value ordering picks the highest acceptable format;
+//! - the `application/ld+json` `profile` parameter deterministically selects expanded vs
+//!   compacted (surfaced in [`NegotiatedFormat::jsonld_profile`]);
+//! - a blank/unknown `Accept` falls back to `text/turtle` (the Solid default), never an error;
+//! - the JSON-LD path stays LOCAL-ONLY: a document whose `@context` is a remote IRI fails to
+//!   parse (no remote context loader is reachable from any code path).
+
+use sparq_lws_core::ldp::content::{
+    negotiate_accept, negotiate_accept_with_profile, parse_to_triples, serialize_triples,
+    JsonLdProfileParam, RdfFormat,
+};
+
+const EXPANDED: &str = "http://www.w3.org/ns/json-ld#expanded";
+const COMPACTED: &str = "http://www.w3.org/ns/json-ld#compacted";
+
+/// Shorthand: the negotiated format for `accept` over a stored-Turtle resource.
+fn fmt(accept: &str) -> Option<RdfFormat> {
+    negotiate_accept(Some(accept), RdfFormat::Turtle)
+}
+
+/// Shorthand: the negotiated JSON-LD profile for `accept` over a stored-Turtle resource.
+fn profile(accept: &str) -> Option<JsonLdProfileParam> {
+    negotiate_accept_with_profile(Some(accept), RdfFormat::Turtle)
+        .expect("acceptable")
+        .jsonld_profile
+}
+
+// --- q-value ordering ----------------------------------------------------------------------
+
+#[test]
+fn q_value_ordering_picks_the_highest_acceptable_format() {
+    // JSON-LD outweighs Turtle although listed second…
+    assert_eq!(
+        fmt("text/turtle;q=0.5, application/ld+json;q=0.9"),
+        Some(RdfFormat::JsonLd)
+    );
+    // …and vice versa.
+    assert_eq!(
+        fmt("application/ld+json;q=0.2, text/turtle;q=0.8"),
+        Some(RdfFormat::Turtle)
+    );
+    // An explicit type outweighs a wildcard at lower q.
+    assert_eq!(
+        fmt("*/*;q=0.1, application/ld+json;q=0.9"),
+        Some(RdfFormat::JsonLd)
+    );
+    // A q-tie prefers the STORED format (cheapest, most faithful).
+    assert_eq!(
+        negotiate_accept(
+            Some("text/turtle;q=0.7, application/ld+json;q=0.7"),
+            RdfFormat::JsonLd
+        ),
+        Some(RdfFormat::JsonLd)
+    );
+}
+
+#[test]
+fn q_zero_excludes_a_type_and_the_other_still_wins() {
+    assert_eq!(
+        fmt("text/turtle;q=0, application/ld+json;q=0.1"),
+        Some(RdfFormat::JsonLd)
+    );
+}
+
+// --- the ld+json `profile` parameter --------------------------------------------------------
+
+#[test]
+fn profile_param_selects_expanded() {
+    assert_eq!(
+        profile(&format!("application/ld+json;profile=\"{EXPANDED}\"")),
+        Some(JsonLdProfileParam::Expanded)
+    );
+}
+
+#[test]
+fn profile_param_selects_compacted() {
+    assert_eq!(
+        profile(&format!("application/ld+json;profile=\"{COMPACTED}\"")),
+        Some(JsonLdProfileParam::Compacted)
+    );
+}
+
+#[test]
+fn profile_param_accepts_unquoted_value_and_case_insensitive_name() {
+    assert_eq!(
+        profile(&format!("application/ld+json;PROFILE={COMPACTED}")),
+        Some(JsonLdProfileParam::Compacted)
+    );
+}
+
+#[test]
+fn profile_value_first_honoured_iri_wins_deterministically() {
+    // A multi-IRI profile value: the FIRST honoured document form wins (client order).
+    assert_eq!(
+        profile(&format!(
+            "application/ld+json;profile=\"http://www.w3.org/ns/json-ld#flattened {COMPACTED} {EXPANDED}\""
+        )),
+        Some(JsonLdProfileParam::Compacted)
+    );
+}
+
+#[test]
+fn unknown_profile_iris_are_ignored_not_an_error() {
+    assert_eq!(
+        profile("application/ld+json;profile=\"http://www.w3.org/ns/json-ld#framed\""),
+        None
+    );
+    assert_eq!(profile("application/ld+json"), None);
+}
+
+#[test]
+fn profile_of_the_best_q_ldjson_range_wins() {
+    // The higher-q explicit ld+json range's profile is the one surfaced…
+    assert_eq!(
+        profile(&format!(
+            "application/ld+json;profile=\"{COMPACTED}\";q=0.4, application/ld+json;profile=\"{EXPANDED}\";q=0.9"
+        )),
+        Some(JsonLdProfileParam::Expanded)
+    );
+    // …and a q-tie keeps the FIRST-listed range's profile (deterministic).
+    assert_eq!(
+        profile(&format!(
+            "application/ld+json;profile=\"{COMPACTED}\";q=0.9, application/ld+json;profile=\"{EXPANDED}\";q=0.9"
+        )),
+        Some(JsonLdProfileParam::Compacted)
+    );
+}
+
+#[test]
+fn profile_is_none_when_turtle_wins_or_jsonld_won_via_wildcard() {
+    // Turtle wins ⇒ no JSON-LD profile, even though one was sent.
+    let n = negotiate_accept_with_profile(
+        Some(&format!(
+            "text/turtle;q=0.9, application/ld+json;profile=\"{EXPANDED}\";q=0.4"
+        )),
+        RdfFormat::Turtle,
+    )
+    .expect("acceptable");
+    assert_eq!(n.format, RdfFormat::Turtle);
+    assert_eq!(n.jsonld_profile, None);
+
+    // JSON-LD reached ONLY via a wildcard range carries no honoured profile.
+    let n = negotiate_accept_with_profile(Some("application/*"), RdfFormat::Turtle)
+        .expect("acceptable");
+    assert_eq!(n.format, RdfFormat::JsonLd);
+    assert_eq!(n.jsonld_profile, None);
+}
+
+// --- Solid-default fallback + the remaining 406 ---------------------------------------------
+
+#[test]
+fn blank_accept_falls_back_to_turtle() {
+    assert_eq!(
+        negotiate_accept(Some(""), RdfFormat::JsonLd),
+        Some(RdfFormat::Turtle)
+    );
+    assert_eq!(
+        negotiate_accept(Some("   "), RdfFormat::JsonLd),
+        Some(RdfFormat::Turtle)
+    );
+}
+
+#[test]
+fn unknown_accept_falls_back_to_turtle_never_an_error() {
+    for accept in ["text/html", "image/png", "application/xml, text/html;q=0.5"] {
+        assert_eq!(
+            negotiate_accept(Some(accept), RdfFormat::JsonLd),
+            Some(RdfFormat::Turtle),
+            "Accept: {accept}"
+        );
+    }
+}
+
+#[test]
+fn absent_accept_keeps_the_stored_format() {
+    // The absent-Accept path is unchanged (byte-identical invariant): stored format, verbatim.
+    assert_eq!(
+        negotiate_accept(None, RdfFormat::JsonLd),
+        Some(RdfFormat::JsonLd)
+    );
+    assert_eq!(
+        negotiate_accept(None, RdfFormat::Turtle),
+        Some(RdfFormat::Turtle)
+    );
+}
+
+#[test]
+fn only_an_explicit_q_zero_refusal_of_every_covered_type_is_406() {
+    assert_eq!(fmt("text/turtle;q=0, application/ld+json;q=0"), None);
+    assert_eq!(fmt("*/*;q=0"), None);
+}
+
+// --- SSRF posture: JSON-LD stays local-only --------------------------------------------------
+
+#[test]
+fn jsonld_remote_context_is_rejected_not_fetched() {
+    // A JSON-LD body whose @context is a REMOTE IRI must fail to parse: the parser has no remote
+    // document loader (local-only by construction), so no code path can be induced to fetch it.
+    let body = br#"{
+        "@context": "https://schema.org",
+        "@id": "https://pod.example/alice/data#me",
+        "name": "Alice"
+    }"#;
+    let err = parse_to_triples(RdfFormat::JsonLd, body, "https://pod.example/alice/data");
+    assert!(
+        err.is_err(),
+        "a remote @context must be rejected, got: {err:?}"
+    );
+}
+
+#[test]
+fn jsonld_serialisation_round_trips_locally() {
+    // The re-serialisation path emits self-contained (context-free) JSON-LD that parses back
+    // locally — no context resolution, remote or otherwise, is involved.
+    let turtle =
+        b"<https://pod.example/alice/data#me> <http://xmlns.com/foaf/0.1/name> \"Alice\" .";
+    let triples =
+        parse_to_triples(RdfFormat::Turtle, turtle, "https://pod.example/alice/data").unwrap();
+    let jsonld = serialize_triples(RdfFormat::JsonLd, &triples).unwrap();
+    let reparsed =
+        parse_to_triples(RdfFormat::JsonLd, &jsonld, "https://pod.example/alice/data").unwrap();
+    assert_eq!(reparsed, triples);
+}

--- a/crates/sparq-lws-core/tests/ldp_http.rs
+++ b/crates/sparq-lws-core/tests/ldp_http.rs
@@ -354,7 +354,9 @@ async fn get_negotiates_jsonld_from_stored_turtle() {
 }
 
 #[tokio::test]
-async fn get_with_unacceptable_accept_is_406() {
+async fn get_with_unknown_accept_falls_back_to_turtle() {
+    // An Accept naming no producible type degrades to the Solid default (text/turtle) rather than
+    // failing the read with a 406.
     let h = Harness::new().await;
     h.request(
         "PUT",
@@ -369,6 +371,33 @@ async fn get_with_unacceptable_accept_is_406() {
             "/alice/data",
             None,
             &[("accept", "image/png")],
+            Body::empty(),
+        )
+        .await;
+    assert_eq!(get.status(), StatusCode::OK);
+    assert_eq!(
+        get.headers().get(axum::http::header::CONTENT_TYPE).unwrap(),
+        "text/turtle"
+    );
+}
+
+#[tokio::test]
+async fn get_with_explicit_q_zero_refusal_is_406() {
+    // The only remaining 406: the client explicitly refused (q=0) every producible type.
+    let h = Harness::new().await;
+    h.request(
+        "PUT",
+        "/alice/data",
+        Some("text/turtle"),
+        Body::from(TURTLE),
+    )
+    .await;
+    let get = h
+        .request_with(
+            "GET",
+            "/alice/data",
+            None,
+            &[("accept", "text/turtle;q=0, application/ld+json;q=0")],
             Body::empty(),
         )
         .await;


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **Claude Fable 5**

Implements bead **sq-ah3oj** (lws-core: JSON-LD read content-negotiation profile handling in `ldp::content`).

## What

Hardens the Solid read path's single `Accept` decision point in `crates/sparq-lws-core/src/ldp/content.rs`:

- **New** `negotiate_accept_with_profile()` — the full negotiation seam. `negotiate_accept()` is now a thin wrapper over it (unchanged signature, all existing call sites untouched).
- **q-values** honoured as before (highest acceptable wins; q-tie prefers the stored format; range-tie breaks in header order).
- **`application/ld+json` `profile` parameter** honoured deterministically: the best-q explicit `ld+json` range's profile is surfaced in the new `NegotiatedFormat.jsonld_profile` (`Expanded` / `Compacted`); first-listed range wins q-ties; within a multi-IRI profile value the first honoured form wins; unknown profile IRIs are ignored (per the JSON-LD IANA registration, profile is a preference, never an error). IRI spellings are pinned via `oxjsonld::JsonLdProfile::from_iri` — no hand-copied strings. The serialiser currently emits the streaming (expanded-compatible) form regardless; the surfaced profile is the seam for echoing/honouring it in the handler (follow-up bead sq-10ty4).
- **Solid-default fallback**: a present `Accept` naming/covering NO producible type (blank, `text/html`, `image/png`, …) now degrades to `text/turtle` instead of a 406 — the read never fails over an exotic Accept. The **only remaining 406** is an explicit `q=0` refusal of every covered producible type (serving one anyway would violate RFC 7231 §5.3.1).

## Invariants (bead)

- **Byte-identical paths**: absent-`Accept`, `*/*`, and `text/turtle` negotiation results are unchanged (tested).
- **SSRF posture preserved verbatim**: no new dependency, no `Cargo.toml` change, oxjsonld stays local-only — a JSON-LD body with a remote `@context` is rejected, not fetched (tested: `jsonld_remote_context_is_rejected_not_fetched`).
- Unsupported `Accept` degrades to Turtle, never a 500.

## Ripple (doc/tests only)

The 406→fallback semantic change required updating three tests that asserted the OLD unknown-Accept-is-406 behaviour (`ldp_http.rs`, `identity_http.rs`, one in-handler conditional-request test) — each now asserts the Turtle fallback AND keeps end-to-end 406 coverage via an explicit q=0-refusal variant — plus four stale doc comments in `handler.rs`. No handler/store/app code paths changed.

## Tests

New `crates/sparq-lws-core/tests/ldp_conneg.rs` (15 tests) per the bead's acceptance: q-value ordering, expanded/compacted profile selection (quoted/unquoted/case-insensitive name/multi-IRI/best-q/tie), blank+unknown→Turtle, absent→stored, q=0-all→406, wildcard/Turtle wins carry no profile, remote-context rejection, local round-trip.

**Non-vacuity mutation-witnessed**: knocking out the Turtle fallback → 2 tests red; knocking out profile extraction → 5 tests red (both reverted).

## Gates (all green, both feature states)

- `cargo clippy -p sparq-lws-core --all-targets -- -D warnings` (default AND `--all-features`)
- `cargo test -p sparq-lws-core` (default AND `--all-features`) — 577 unit + all integration suites
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-lws-core --no-deps --all-features`
- No README change; no perf numbers in markdown; core crates untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
