### PR TITLE
bench(lws-core): add read-path envelope harness [GPT-5.6]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -71,6 +71,10 @@ conventions first, then a per-category map that points at the registry, then a
 
 Notes on a few that need care:
 
+- **`lws-core-readpath` (`bench/lws-core-readpath`)** wraps the in-crate read-response
+  allocation example and emits validated, git-ignored JSON envelopes; see its
+  [`README.md`](./lws-core-readpath/README.md). [GPT-5.6]
+
 - **`bench/serve` + `bench/memtier` are research SPIKES, not maintained
   regression benchmarks.** Their numbers calibrate research docs; re-run on the
   target hardware before trusting any absolute value.

--- a/bench/lws-core-readpath/.gitignore
+++ b/bench/lws-core-readpath/.gitignore
@@ -1,0 +1,2 @@
+# [GPT-5.6] Local measurements are generated artifacts, never repository inputs.
+results/

--- a/bench/lws-core-readpath/README.md
+++ b/bench/lws-core-readpath/README.md
@@ -1,0 +1,17 @@
+<!-- [GPT-5.6] -->
+# lws-core read-path allocation harness
+
+This standalone harness runs the crate's `read_response_alloc_microbench` example and captures
+its deterministic allocation-operation counts in a machine-readable JSON envelope. The example
+first asserts that the before and after header sets are byte-identical; the harness refuses to
+emit a successful envelope unless both measurements and their delta are present and consistent.
+
+Run the acceptance tier from anywhere in the repository:
+
+```sh
+bash bench/lws-core-readpath/run.sh --smoke
+```
+
+Generated envelopes land under `results/`, which is ignored. They identify the source revision,
+toolchain, command, measurement kind, and raw example output. Counts remain observations produced
+by the current build and are never baked into this documentation.

--- a/bench/lws-core-readpath/emit_envelope.py
+++ b/bench/lws-core-readpath/emit_envelope.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Convert read_response_alloc_microbench output into a validated JSON envelope."""
+
+# [GPT-5.6] Keep this emitter stdlib-only so the standalone harness has no Python packages.
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import sys
+
+MEASUREMENT = re.compile(r"^(BEFORE|AFTER).*?([0-9]+) alloc ops$", re.MULTILINE)
+DELTA = re.compile(r"^DELTA\s+-([0-9]+) alloc ops \(([0-9]+)% fewer\)$", re.MULTILINE)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, type=pathlib.Path)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--rustc", required=True)
+    parser.add_argument("--profile", required=True, choices=("debug", "release"))
+    args = parser.parse_args()
+    raw = args.input.read_text(encoding="utf-8")
+    measurements = {name.lower(): int(value) for name, value in MEASUREMENT.findall(raw)}
+    delta_match = DELTA.search(raw)
+    if set(measurements) != {"before", "after"} or delta_match is None:
+        print("invalid microbench output: missing allocation measurements", file=sys.stderr)
+        return 2
+    saved, percent = (int(value) for value in delta_match.groups())
+    if saved != max(measurements["before"] - measurements["after"], 0):
+        print("invalid microbench output: inconsistent allocation delta", file=sys.stderr)
+        return 2
+    envelope = {
+        "schema_version": 1,
+        "benchmark": "lws-core-read-response-allocation-path",
+        "canonical": False,
+        "measurement_kind": "heap_alloc_or_realloc_operations",
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "source_revision": args.revision,
+        "rustc": args.rustc,
+        "profile": args.profile,
+        "command": "cargo run -p sparq-lws-core --example read_response_alloc_microbench",
+        "correctness_gate": "byte_identical_headers_asserted_by_example",
+        "measurements": {**measurements, "saved": saved, "percent_fewer": percent},
+        "raw_output": raw.splitlines(),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(envelope, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bench/lws-core-readpath/run.sh
+++ b/bench/lws-core-readpath/run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# [GPT-5.6] Standalone runner for the existing in-crate read-response allocation example.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+MODE="${1:---release}"
+case "$MODE" in
+  --smoke) PROFILE=debug; CARGO_PROFILE=() ;;
+  --release) PROFILE=release; CARGO_PROFILE=(--release) ;;
+  *) echo "usage: $0 [--smoke|--release]" >&2; exit 2 ;;
+esac
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RESULT_DIR="${LWS_CORE_READPATH_RESULTS_DIR:-$HERE/results}"
+ENVELOPE="${LWS_CORE_READPATH_ENVELOPE:-$RESULT_DIR/lws-core-readpath-$STAMP.json}"
+RAW="$(mktemp)"
+trap 'rm -f "$RAW"' EXIT
+cd "$ROOT"
+cargo run -p sparq-lws-core "${CARGO_PROFILE[@]}" --example read_response_alloc_microbench | tee "$RAW"
+python3 "$HERE/emit_envelope.py" --input "$RAW" --output "$ENVELOPE" \
+  --revision "$(git rev-parse HEAD)" --rustc "$(rustc --version)" --profile "$PROFILE"
+python3 - "$ENVELOPE" <<'PY'
+# [GPT-5.6] Mutation witness: malformed or internally inconsistent output cannot pass smoke.
+import json
+import pathlib
+import sys
+
+data = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+measurements = data["measurements"]
+assert data["correctness_gate"] == "byte_identical_headers_asserted_by_example"
+assert measurements["saved"] == max(measurements["before"] - measurements["after"], 0)
+PY
+echo "envelope: $ENVELOPE"


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-h97vj.

Adds a standalone `bench/lws-core-readpath` runner around the existing read-response allocation example, a validated machine-readable JSON envelope emitter, ignored local results, methodology documentation, and a benchmark-catalog pointer. The smoke path asserts the example output parses and that the reported delta is internally consistent.

Gates:
- `bash bench/lws-core-readpath/run.sh --smoke`
- mutation witness: inconsistent emitted delta is rejected
- `cargo test -p sparq-lws-core`
- `cargo test -p sparq-lws-core --all-features`
- `cargo clippy -p sparq-lws-core --all-targets -- -D warnings`
- `cargo clippy -p sparq-lws-core --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-lws-core --no-deps --all-features`
- `git diff --check`

No public API or crate source was changed; generated measurements remain git-ignored and no performance figures are committed to Markdown.