### PR TITLE
fix(site): link canonical documentation from primary nav [GPT-5.6]

### DIFF
--- a/site/e2e/site-nav.spec.ts
+++ b/site/e2e/site-nav.spec.ts
@@ -28,7 +28,7 @@ async function gotoSettled(page: Page, route: string): Promise<void> {
   await gotoAppReady(page, route);
 }
 
-test("the slim top bar shows the 6 destinations (no Try item) and no full sidebar tree", async ({
+test("the slim top bar shows the destinations (no Try item) and no full sidebar tree", async ({
   page,
 }) => {
   await gotoSettled(page, "");
@@ -37,6 +37,7 @@ test("the slim top bar shows the 6 destinations (no Try item) and no full sideba
   // [OPUS-4.8] sq-1scgk — "Papers" is now a first-class bar destination alongside the rest.
   for (const label of [
     "Home",
+    "Docs",
     "Capabilities",
     "App",
     "Benchmarks",
@@ -45,6 +46,12 @@ test("the slim top bar shows the 6 destinations (no Try item) and no full sideba
   ]) {
     await expect(primary.getByRole("link", { name: label, exact: true })).toBeVisible();
   }
+  // [GPT-5.6] sq-f8ufg — mutation witness: removing Docs or pointing it at the nonexistent
+  // /docs route makes this assertion fail. The Skills router is the canonical live docs index.
+  await expect(primary.getByRole("link", { name: "Docs", exact: true })).toHaveAttribute(
+    "href",
+    "https://github.com/sparq-org/sparq/blob/main/skills/SKILL.md",
+  );
   // [OPUS-4.8] sq-4hiqe — the "Try" nav item is REMOVED (the /try playground is gone). The bar
   // must expose NO "Try" destination now.
   await expect(primary.getByRole("link", { name: "Try", exact: true })).toHaveCount(0);

--- a/site/src/components/layout/app-shell.tsx
+++ b/site/src/components/layout/app-shell.tsx
@@ -55,6 +55,10 @@ import {
 import { PaletteCommandsProvider } from "@/components/palette-commands";
 
 const REPO_URL = "https://github.com/jeswr/sparq";
+// [GPT-5.6] sq-f8ufg — the published documentation surface currently lives in the repository's
+// Agent Skills router. The mdBook build is validation-only (not deployed at /docs or /guide), so
+// link to this canonical, live index rather than presenting a dead route on the marketing site.
+const DOCS_URL = "https://github.com/sparq-org/sparq/blob/main/skills/SKILL.md";
 
 // The slim top bar's content destinations. Capabilities is the single gallery that replaces
 // the collapsed /surface/* tree; App is the live operational GUI destination (the single
@@ -67,6 +71,7 @@ const REPO_URL = "https://github.com/jeswr/sparq";
 // a hard, full-page navigation — see NavLink — not a next/link soft nav (sq-vw3ax.11).
 const NAV_ITEMS: { href: string; label: string; external?: boolean }[] = [
   { href: "/", label: "Home" },
+  { href: DOCS_URL, label: "Docs", external: true },
   { href: "/capabilities", label: "Capabilities" },
   { href: "/app", label: "App", external: true },
   { href: "/benchmarks", label: "Benchmarks" },
@@ -77,7 +82,11 @@ const NAV_ITEMS: { href: string; label: string; external?: boolean }[] = [
 function useIsActive() {
   const pathname = usePathname();
   return (href: string) =>
-    href === "/" ? pathname === "/" : pathname.startsWith(href);
+    href.startsWith("http")
+      ? false
+      : href === "/"
+        ? pathname === "/"
+        : pathname.startsWith(href);
 }
 
 function NavLink({
@@ -108,9 +117,12 @@ function NavLink({
   // /sparq (Pages) vs "" (Tauri) hosts — Next does NOT auto-prefix a plain <a>. The trailing
   // slash matches `trailingSlash: true` so the static export's directory index resolves.
   if (external) {
+    const resolvedHref = href.startsWith("http")
+      ? href
+      : withBasePath(href.endsWith("/") ? href : `${href}/`);
     return (
       <a
-        href={withBasePath(href.endsWith("/") ? href : `${href}/`)}
+        href={resolvedHref}
         onClick={onNavigate}
         aria-current={active ? "page" : undefined}
         className={className}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes #2018.
Closes bead `sq-f8ufg`.

## Summary

- add a visible, nav-styled **Docs** destination to the shared desktop/mobile primary navigation
- point it at the canonical live Agent Skills documentation router (`skills/SKILL.md`)
- preserve hard navigation for documentation outside the Next.js export while leaving `/app` base-path behavior intact
- add a regression assertion for both visibility and the exact canonical URL

The repository mdBook is currently build-validation-only: live checks confirmed `/docs`, `/guide`, the legacy Pages URL, and a plausible docs subdomain are not deployed. The Skills router is therefore the working public documentation index rather than a guessed dead route.

## Gates

- `npm run lint` — green
- `npm run typecheck` — green
- `npm run test:unit` — green (334 tests)
- `NEXT_PUBLIC_BASE_PATH= npm run build` — green (static export 65/65; bundle guard PASS)
- `npm run test:e2e -- e2e/site-nav.spec.ts` — green (9 tests)
- mutation witness: removed the Docs nav item and ran the focused slim-top-bar test; it failed, then the item was restored and the full spec passed
- `git diff --check` — green

No `.beads/` files are included.