### PR TITLE
bench: reason-deletion — FBF/DRed-style deletion-workload correctness+timing suite (sq-31fza) [FABLE-5]

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -670,6 +670,26 @@ records_to  = "stdout; bench/inference/incremental-bench.md"
 featured    = false
 status      = "ok"
 
+# [FABLE-5] sq-31fza (parent sq-6tykl.4; sq-hmd7l deletion-workload axis) — the SELF-ASSERTING
+# deletion-ratio sibling of inference-incremental: same UNMODIFIED driver example, but on a
+# deterministic committed-generator corpus with HARD closure fixtures, so it runs hermetically
+# (no gitignored olympics.nt fetch) and correctness regressions fail LOUDLY.
+[[benchmark]]
+id          = "reason-deletion"
+name        = "Deletion-workload incremental reasoning (FBF/DRed-style retraction) correctness + timing"
+category    = "inference"
+measures    = "per tier (small+medium per-commit; large nightly/EC2): randomized ABox insert/delete batch times at several deletion ratios (delta {1,100,10000} / ABox size) for RDFS + OWL-RL CountingMono/Fixpoint, vs from-scratch re-materialization. HARD gates: the driver's built-in differential asserts (incremental closure set-equal to from-scratch after the randomized sequence; full_rebuilds()==0 on ABox deltas) panic->red, AND expected.tsv pins every tier's ABox + closure triple-counts (deterministic; catches silent under/over-derivation + generator drift)"
+invoke      = "bash bench/reason-deletion/run.sh   # REASONDEL_TIERS=\"small medium large\" adds the nightly tier"
+source      = "bench/reason-deletion/{run.sh,gen.sh,gen_reason_deletion.py,parse_and_assert.py,expected.tsv,README.md}; crates/sparq-reason/examples/incremental_olympics_bench.rs (driver, UNMODIFIED)"
+dataset     = "deterministic LUBM-class synthetic ABox over the driver's TBox vocabulary (gen_reason_deletion.py, fixed-seed LCG, 8 triples/unit; cached under /tmp/reason-deletion, never committed); tier unit counts pinned in expected.tsv (chosen so the driver's fixed-seed delete-sampler never draws the one axiom-typing triple — see README.md honesty notes)"
+quiet_box_sensitive = true  # delta timings are single-shot wall-clock trend-only, NOT perf-gated; the differential asserts + closure fixtures ARE a hard deterministic correctness gate (load-robust)
+pinning     = "generator is a pure function of the units column; driver delta seeds fixed in-source (0xBEEF_0001/0xBEEF_0002); expected.tsv re-validated whenever driver or generator changes"
+records_to  = "stdout (metric TSV lines) + JSON results envelope (default /tmp/reason-deletion/reason-deletion-<UTC>.json; host block marks work-box timings NON-canonical)"
+# Correctness+measurement half only (bead sq-31fza); the RDFox-FBF/GraphDB-smooth-delete
+# competitor comparison + any incremental.rs optimization are follow-up beads under sq-6tykl.4.
+featured    = false
+status      = "ok"
+
 [[benchmark]]
 id          = "solid-wac-bench"
 name        = "sparq-solid WAC/ACP auth-view materialization"

--- a/bench/reason-deletion/README.md
+++ b/bench/reason-deletion/README.md
@@ -1,0 +1,69 @@
+# reason-deletion — deletion-workload correctness + timing for incremental reasoning
+
+> 🤖 SPARQ agent — written by **Claude Fable 5** (bead `sq-31fza`; parent `sq-6tykl.4`;
+> comparative axis registered under `sq-hmd7l` in `bench/benchmarks.toml`).
+
+The CORRECTNESS + MEASUREMENT half of the FBF/DRed-grade retraction program: randomized
+insert/**delete** batches at several deletion ratios over a LUBM-class materialized
+closure, with a **differential-correctness gate** — after the randomized sequence the
+incrementally-maintained closure must be set-equal to a from-scratch re-materialization
+(and ABox deltas must never have triggered a full rebuild). This is what separates real
+incremental deletion (RDFox FBF/DRed/B-F; GraphDB smooth-delete) from a demo reasoner.
+Any `incremental.rs` OPTIMIZATION found wanting here goes to a follow-up sparq-reason
+bead — this suite is bench-dir-only by design (the crate was in-flight).
+
+## How it works
+
+```
+bash bench/reason-deletion/run.sh                       # per-commit tiers (small medium)
+REASONDEL_TIERS="small medium large" bash bench/reason-deletion/run.sh   # + nightly tier
+```
+
+1. `gen.sh <units>` → a deterministic LUBM-class synthetic ABox (`gen_reason_deletion.py`;
+   1 unit = 1 athlete + 1 result = 8 triples; shared teams/games/events scale
+   sub-linearly, like LUBM's departments-per-university).
+2. The **existing, unmodified** driver
+   `crates/sparq-reason/examples/incremental_olympics_bench.rs` runs on that corpus. The
+   driver itself performs the randomized (fixed-seed xorshift) insert/delete batches over
+   three workloads — RDFS (`MaterializedGraph`), OWL 2 RL mono + fixpoint
+   (`MaterializedOwlGraph`) — and carries the load-bearing built-in asserts:
+   incremental == from-scratch closure after the sequence, zero full rebuilds on ABox
+   deltas, plus the N3/WAC section's own asserts. A violated assert panics → non-zero
+   exit → `run.sh` is RED.
+3. `parse_and_assert.py` additionally pins every tier's parsed ABox count and all three
+   closure sizes to `expected.tsv` (deterministic; catches silent under/over-derivation
+   and generator drift), emits `<metric>\t<value>\t<unit>` TSV timing lines, and writes
+   the standard JSON results envelope (default under `/tmp/reason-deletion/`, git-ignored
+   territory; `REASONDEL_JSON_OUT` overrides). The envelope's host block marks work-box
+   timings NON-canonical (`quiet_box: false`) — timings are trend-only, never perf-gated
+   and never baked into docs.
+
+## Deletion ratios
+
+The driver's batch sizes are fixed (1 / 100 / 10,000 triples), so the ratio axis comes
+from varying the base size per tier: a 10,000-triple delete batch is ~41% of the small
+tier's ABox (24,160 triples), ~8.3% of medium (120,000), ~1.7% of large (600,000). The
+envelope records `delete_ratio = delta / abox_triples` per cell. Ratios here are dataset
+geometry (fixture constants), not measured performance.
+
+## Honesty notes
+
+- **Why not literal LUBM data:** the driver synthesizes its TBox over the olympics
+  vocabulary (`foaf:Person`/`dbo:team`/`oly:athlete`/…), and this bead forbids touching
+  sparq-reason source. Feeding it univ-bench IRIs would make every rule a no-op and the
+  deletion workload vacuous. The generator is LUBM-**class** (deterministic,
+  scale-parameterized instance generator over a fixed schema with class hierarchies and
+  domain/range/subPropertyOf/inverseOf-typed properties) bound to the vocabulary the
+  driver's TBox actually ranges over, so the closure is materially larger than the ABox
+  and deletion has real re-derivation work.
+- **Pinned tier sizes:** the driver's delete-sampler excludes the six TBox *predicates*
+  but not the `[locatedIn, rdf:type, owl:TransitiveProperty]` axiom-typing triple; if
+  drawn, deleting it legitimately takes the documented rebuild path and fails the
+  no-rebuild assert. Tier unit counts are pinned to values where the fixed-seed draw
+  sequence never hits it (fully deterministic — see `expected.tsv`). The driver-side fix
+  (exclude axiom-typing triples from ABox sampling) is a sparq-reason change, tracked as
+  follow-up bead `sq-x58ow`.
+- **Timing scope:** delta timings are single-shot (the driver measures one batch per
+  size) and machine-dependent — comparative claims belong in envelope-carrying gathers
+  on a quiet box, per `bench/CATALOG.md`. The RDFox/GraphDB competitor comparison is the
+  parent bead's follow-up, not part of this suite.

--- a/bench/reason-deletion/expected.tsv
+++ b/bench/reason-deletion/expected.tsv
@@ -1,0 +1,17 @@
+# [FABLE-5] bench/reason-deletion fixtures (bead sq-31fza) — DETERMINISTIC structural
+# counts: fixed generator (gen_reason_deletion.py, pure function of units) + the driver's
+# fixed seeds. Columns (TAB-separated):
+#   tier  units  abox_triples  rdfs_closure  owl_mono_closure  owl_fixpoint_closure
+# abox_triples = units*8 (generator-drift gate). Closure columns are the incremental
+# closure sizes; the driver already asserts each equals the from-scratch closure, so
+# pinning them here pins BOTH maintenance and batch materialization.
+# UNIT COUNTS ARE PINNED (3020, not 3000): the driver's delete-sampler excludes only the
+# six TBox PREDICATES, so on the fixpoint workload it can draw the single
+# [locatedIn, rdf:type, owl:TransitiveProperty] axiom-typing triple, which legitimately
+# triggers the documented rebuild path and fails the "ABox deltas must not rebuild"
+# assert. Tier sizes are chosen so the fixed-seed draw sequence never hits it
+# (deterministic; re-validate with run.sh if the driver or generator changes).
+# Driver-side fix tracked as follow-up bead sq-x58ow — see README.md.
+small	3020	24160	42662	48734	49348
+medium	15000	120000	211792	241824	242438
+large	75000	600000	1058842	1208874	1209488

--- a/bench/reason-deletion/gen.sh
+++ b/bench/reason-deletion/gen.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# [FABLE-5] bench/reason-deletion corpus wrapper (bead sq-31fza) — cache-backed entry point
+# mirroring bench/deep-taxonomy/gen.sh + bench/lubm/gen.sh.
+#
+#   bench/reason-deletion/gen.sh [units=15000] [out=$REASONDEL_CACHE/rd-<units>.nt]
+#
+# Emits ONE path on stdout: the deterministic N-Triples ABox for the requested UNITS tier
+# (1 unit = 1 athlete + 1 result = 8 triples; see gen_reason_deletion.py for the schema).
+#
+# HERMETICITY: python3 stdlib only, no network. Output cached under $REASONDEL_CACHE
+# (default /tmp/reason-deletion), gitignored + regenerable; byte-identical per <units>,
+# so the cache makes steady-state runs skip generation. Caller cleans up.
+set -euo pipefail
+
+UNITS="${1:-15000}"
+CACHE="${REASONDEL_CACHE:-/tmp/reason-deletion}"
+OUT="${2:-$CACHE/rd-${UNITS}.nt}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GEN="$ROOT/bench/reason-deletion/gen_reason_deletion.py"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[reasondel] ERROR: 'python3' not found (needed to run gen_reason_deletion.py)." >&2
+  exit 1
+fi
+if [ ! -f "$GEN" ]; then
+  echo "[reasondel] ERROR: generator missing at $GEN" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+# Deterministic: same bytes every run for a given <units>; regenerate only if absent.
+if [ ! -s "$OUT" ]; then
+  python3 "$GEN" "$UNITS" > "$OUT.tmp"
+  mv "$OUT.tmp" "$OUT"
+fi
+
+echo "$OUT"

--- a/bench/reason-deletion/gen_reason_deletion.py
+++ b/bench/reason-deletion/gen_reason_deletion.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# [FABLE-5] Deletion-workload corpus generator for bench/reason-deletion (bead sq-31fza,
+# parent sq-6tykl.4). Emits a DETERMINISTIC LUBM-class synthetic ABox as N-Triples on stdout.
+#
+#   gen_reason_deletion.py <units>
+#
+# "LUBM-class" = the same benchmark genre as LUBM's UBA generator: a deterministic,
+# scale-parameterized instance generator over a FIXED schema with class hierarchies and
+# typed (domain/range/subPropertyOf/inverseOf) properties, so an RDFS / OWL 2 RL closure
+# is materially larger than the ABox and deletion maintenance has real re-derivation work.
+#
+# WHY the OLYMPICS vocabulary (not LUBM's univ-bench IRIs): the driver for this suite is
+# the EXISTING, unmodified example crates/sparq-reason/examples/incremental_olympics_bench.rs
+# (the bead forbids touching sparq-reason source), and that example SYNTHESIZES its TBox
+# over the olympics vocabulary (foaf:Person / dbo:team / oly:athlete / ...). Feeding it
+# actual univ-bench IRIs would make every rule a no-op and the deletion workload vacuous.
+# So the generator emits LUBM-class DATA SHAPE bound to the vocabulary the driver's TBox
+# actually ranges over. See README.md ("Why not literal LUBM data").
+#
+# Schema exercised per unit (1 unit = 1 athlete + 1 result = 8 ABox triples):
+#   athlete  rdf:type foaf:Person          -> subClassOf chain Person->Agent->Entity
+#                                             (+ owl:equivalentClass Human in the OWL runs)
+#   athlete  dbo:team team_k               -> domain/range + subPropertyOf affiliatedWith
+#                                             (+ owl:inverseOf hasMember in the OWL runs)
+#   athlete  foaf:age  "N"^^xsd:integer    -> domain Person
+#   athlete  foaf:gender "..."             -> domain Person
+#   result   oly:athlete athlete           -> domain Result->Entity, range Person
+#   result   oly:games   games_g           -> range dbo:Olympics->Event->Entity
+#   result   oly:event   event_e           -> range dbo:SportsEvent->Event->Entity
+#   result   oly:medal   medal_m           -> range syn:Medal, subPropertyOf award
+#
+# Shared entities (teams/games/events/medals) scale sub-linearly with units, like LUBM's
+# departments-per-university, so the closure has both per-unit and amortized derivations.
+#
+# DETERMINISM: pure function of <units> — no RNG state beyond a fixed-seed LCG used only
+# to vary ages/genders/assignments; byte-identical output for a given <units> every run.
+# The RANDOMIZED insert/delete batches come from the driver example's own fixed-seed
+# xorshift sampler, NOT from this generator. Instance IRIs live under their own namespace
+# (rd:) so they can never collide with the driver's fresh-insert IRIs (syn:newAthlete_*).
+#
+# stdlib-only; no network.
+import sys
+
+RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+FOAF = "http://xmlns.com/foaf/0.1/"
+DBO = "http://dbpedia.org/ontology/"
+OLY = "http://wallscope.co.uk/ontology/olympics/"
+XSD_INT = "http://www.w3.org/2001/XMLSchema#integer"
+# Instance namespace DISTINCT from the driver's syn: (http://sparq.dev/bench/olympics#)
+# so generated instances never collide with the example's fresh_inserts IRIs.
+RD = "http://sparq.dev/bench/reason-deletion#"
+
+GENDERS = ("female", "male", "nonbinary")
+MEDALS = ("Gold", "Silver", "Bronze")
+
+
+def main() -> int:
+    if len(sys.argv) != 2 or not sys.argv[1].isdigit() or int(sys.argv[1]) < 1:
+        print("usage: gen_reason_deletion.py <units>=positive int", file=sys.stderr)
+        return 2
+    units = int(sys.argv[1])
+    # Shared-entity pools: sub-linear in units (LUBM-style shared structure).
+    teams = max(1, units // 50)
+    games = max(1, units // 400)
+    events = max(1, units // 100)
+
+    # Fixed-seed LCG (MMIX constants) — deterministic variation only.
+    state = 0x5DEECE66D
+    def lcg() -> int:
+        nonlocal state
+        state = (state * 6364136223846793005 + 1442695040888963407) % (1 << 64)
+        return state >> 33
+
+    out = sys.stdout
+    w = out.write
+    for i in range(units):
+        a = f"<{RD}athlete{i}>"
+        r = f"<{RD}result{i}>"
+        team = f"<{RD}team{lcg() % teams}>"
+        game = f"<{RD}games{lcg() % games}>"
+        event = f"<{RD}event{lcg() % events}>"
+        medal = f"<{RD}medal{MEDALS[lcg() % 3]}>"
+        age = 16 + lcg() % 40
+        gender = GENDERS[lcg() % 3]
+        w(f"{a} <{RDF_TYPE}> <{FOAF}Person> .\n")
+        w(f"{a} <{DBO}team> {team} .\n")
+        w(f'{a} <{FOAF}age> "{age}"^^<{XSD_INT}> .\n')
+        w(f'{a} <{FOAF}gender> "{gender}" .\n')
+        w(f"{r} <{OLY}athlete> {a} .\n")
+        w(f"{r} <{OLY}games> {game} .\n")
+        w(f"{r} <{OLY}event> {event} .\n")
+        w(f"{r} <{OLY}medal> {medal} .\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/reason-deletion/parse_and_assert.py
+++ b/bench/reason-deletion/parse_and_assert.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# [FABLE-5] Output parser + fixture gate + envelope writer for bench/reason-deletion
+# (bead sq-31fza). Invoked by run.sh with:
+#   RD_TMP        dir holding <tier>.out driver transcripts
+#   RD_EXP        expected.tsv path
+#   RD_TIERS      space-separated tier names that ran green (driver exit 0)
+#   RD_JSON_OUT   envelope output path
+#   RD_SPARQ_REV  short git rev (provenance)
+#
+# Asserts, per tier (all DETERMINISTIC — fixed generator + fixed driver seeds):
+#   parsed ABox triple-count == units*8            (generator drift gate)
+#   RDFS / OWL-mono / OWL-fixpoint incremental closure sizes == expected.tsv
+#     (silent under/over-derivation gate; the driver ALREADY asserted each equals the
+#      from-scratch closure, so pinning the incremental size pins both sides)
+# Exit 1 on any mismatch. Timings are parsed into the envelope but NEVER asserted
+# (work-box wall-clock is non-canonical; see bench/CATALOG.md QUIET-BOX).
+#
+# stdlib-only.
+import json
+import os
+import platform
+import re
+import sys
+import time
+
+TMP = os.environ["RD_TMP"]
+EXP = os.environ["RD_EXP"]
+TIERS = os.environ["RD_TIERS"].split()
+JSON_OUT = os.environ["RD_JSON_OUT"]
+
+# Driver output shapes (crates/sparq-reason/examples/incremental_olympics_bench.rs):
+RE_PARSED = re.compile(r"^parsed (\d+) triples in ")
+RE_SECTION = re.compile(r"^== (RDFS \(MaterializedGraph\)|OWL 2 RL \(MaterializedOwlGraph, (?:mono|fixpoint)\)|N3 / WAC) ")
+RE_INCR = re.compile(r"^initial incremental build:\s+([0-9.]+)s\s+closure (\d+) \(base (\d+)")
+RE_FULL = re.compile(r"^full materialize\S*(?: \(v1 path\))?:\s*([0-9.]+)s\s+closure (\d+)")
+RE_DELTA = re.compile(
+    r"^delta\s+(\d+): insert\s+([0-9.]+)s \(\s*(\S+)x vs full\)\s+delete\s+([0-9.]+)s \(\s*(\S+)x vs full\)"
+)
+
+WL_OF_SECTION = {
+    "RDFS (MaterializedGraph)": "rdfs",
+    "OWL 2 RL (MaterializedOwlGraph, mono)": "owlmono",
+    "OWL 2 RL (MaterializedOwlGraph, fixpoint)": "owlfix",
+}
+
+
+def parse_tier(path):
+    """-> {abox, workloads: {wl: {closure, base, incr_build_s, full_s, full_closure,
+    deltas: [{n, insert_s, delete_s}]}}}"""
+    out = {"abox": None, "workloads": {}}
+    wl = None
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            m = RE_PARSED.match(line)
+            if m:
+                out["abox"] = int(m.group(1))
+                continue
+            m = RE_SECTION.match(line)
+            if m:
+                wl = WL_OF_SECTION.get(m.group(1))  # None for the N3/WAC section
+                if wl:
+                    out["workloads"][wl] = {"deltas": []}
+                continue
+            if not wl:
+                continue
+            w = out["workloads"][wl]
+            m = RE_INCR.match(line)
+            if m:
+                w["incr_build_s"] = float(m.group(1))
+                w["closure"] = int(m.group(2))
+                w["base"] = int(m.group(3))
+                continue
+            m = RE_FULL.match(line)
+            if m:
+                w["full_s"] = float(m.group(1))
+                w["full_closure"] = int(m.group(2))
+                continue
+            m = RE_DELTA.match(line)
+            if m:
+                w["deltas"].append(
+                    {"n": int(m.group(1)), "insert_s": float(m.group(2)), "delete_s": float(m.group(4))}
+                )
+    return out
+
+
+def main():
+    expected = {}
+    with open(EXP, encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("#") or not line.strip():
+                continue
+            tier, units, abox, rdfs, mono, fix = line.rstrip("\n").split("\t")
+            expected[tier] = {
+                "units": int(units),
+                "abox": int(abox),
+                "rdfs": int(rdfs),
+                "owlmono": int(mono),
+                "owlfix": int(fix),
+            }
+
+    fail = 0
+    tiers_json = []
+    for tier in TIERS:
+        exp = expected.get(tier)
+        if exp is None:
+            print(f"[reasondel] ERROR: tier {tier} missing from expected.tsv", file=sys.stderr)
+            fail = 1
+            continue
+        parsed = parse_tier(os.path.join(TMP, f"{tier}.out"))
+        if parsed["abox"] != exp["abox"]:
+            print(
+                f"[reasondel] ERROR: tier {tier} ABox={parsed['abox']} expected={exp['abox']}"
+                " (generator or parser drift)",
+                file=sys.stderr,
+            )
+            fail = 1
+        for wl in ("rdfs", "owlmono", "owlfix"):
+            w = parsed["workloads"].get(wl)
+            got = w.get("closure") if w else None
+            if got != exp[wl]:
+                print(
+                    f"[reasondel] ERROR: tier {tier} {wl} closure={got} expected={exp[wl]}"
+                    " (derivation regression)",
+                    file=sys.stderr,
+                )
+                fail = 1
+                continue
+            # Metric TSV (harvest-friendly; deterministic count + trend-only timings).
+            print(f"reasondel_{tier}_{wl}_closure_triples\t{w['closure']}\ttriples")
+            if "full_s" in w:
+                print(f"reasondel_{tier}_{wl}_full_s\t{w['full_s']}\ts")
+            for d in w["deltas"]:
+                print(f"reasondel_{tier}_{wl}_ins{d['n']}_s\t{d['insert_s']}\ts")
+                print(f"reasondel_{tier}_{wl}_del{d['n']}_s\t{d['delete_s']}\ts")
+                d["delete_ratio"] = round(d["n"] / parsed["abox"], 6) if parsed["abox"] else None
+        tiers_json.append({"tier": tier, "units": exp["units"], **parsed})
+
+    envelope = {
+        "suite": "reason-deletion",
+        "bead": "sq-31fza",
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "sparq_rev": os.environ.get("RD_SPARQ_REV", "unknown"),
+        "driver": "crates/sparq-reason/examples/incremental_olympics_bench.rs (UNMODIFIED; fixed-seed randomized ABox insert/delete batches)",
+        "corpus": {
+            "generator": "bench/reason-deletion/gen_reason_deletion.py (deterministic LCG; LUBM-class shape over the driver's TBox vocabulary)",
+            "triples_per_unit": 8,
+        },
+        "correctness": {
+            "differential": "pass" if not fail else "fail",
+            "meaning": "driver exit 0 == built-in asserts held: incremental closure set-equal to from-scratch re-materialization after the randomized insert/delete sequence, zero full rebuilds on ABox deltas, in all three workloads; closure sizes additionally pinned to expected.tsv",
+        },
+        "host": {
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "nproc": os.cpu_count(),
+            "quiet_box": False,  # flip only on a dedicated quiet gather box
+            "note": "work-box timings are NON-canonical; see bench/CATALOG.md QUIET-BOX",
+        },
+        "tiers": tiers_json,
+        "timing_note": "delta timings are single-shot wall-clock (the driver measures one batch per size); trend-only, never perf-gated; delete_ratio = delta / ABox triples",
+    }
+    os.makedirs(os.path.dirname(JSON_OUT) or ".", exist_ok=True)
+    with open(JSON_OUT, "w", encoding="utf-8") as f:
+        json.dump(envelope, f, indent=2)
+        f.write("\n")
+    return fail
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/reason-deletion/run.sh
+++ b/bench/reason-deletion/run.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# [FABLE-5] Deletion-workload correctness + timing runner for incremental reasoning
+# (bead sq-31fza; parent sq-6tykl.4 "FBF-grade retraction benchmark"; axis under sq-hmd7l).
+# A self-contained, self-asserting entry point mirroring bench/owl-sameas/run.sh /
+# bench/deep-taxonomy/run.sh. For EACH requested TIER it:
+#
+#   1. ensures the corpus exists (gen.sh -> gen_reason_deletion.py): a deterministic
+#      LUBM-class synthetic ABox at the tier's unit count (units column of expected.tsv).
+#   2. runs the EXISTING, UNMODIFIED driver example
+#        crates/sparq-reason/examples/incremental_olympics_bench.rs
+#      on that corpus. The example itself performs the randomized insert/delete batches
+#      (fixed-seed xorshift; ABox-only sampling) across three workloads — RDFS
+#      (MaterializedGraph), OWL 2 RL mono + OWL 2 RL fixpoint (MaterializedOwlGraph) —
+#      and carries the LOAD-BEARING built-in asserts: after the randomized
+#      insert/delete/restore sequence the incrementally-maintained closure must be
+#      set-EQUAL to a from-scratch re-materialization, and ABox deltas must never have
+#      triggered a full rebuild. A violated assert panics -> non-zero exit -> this
+#      runner fails LOUDLY. (Differential correctness is the POINT of the suite.)
+#   3. parses the closure sizes and ASSERTS them against expected.tsv (deterministic
+#      structural counts — catches silent under/over-derivation AND generator drift).
+#   4. emits timing metric TSV lines and wraps everything in the standard JSON results
+#      envelope (host block marks work-box timings NON-canonical; quiet_box=false).
+#
+# DELETION RATIOS: the driver's delta sizes are fixed ({1, 100, 10000} triples), so the
+# suite gets its ratio axis by varying the BASE size per tier — e.g. a 10,000-triple
+# delete batch is a large fraction of the small tier's ABox and a small fraction of the
+# large tier's. The envelope records delete_ratio = delta / abox_triples per cell.
+#
+# Usage: bench/reason-deletion/run.sh    (run from anywhere; honours these env knobs)
+#   REASONDEL_TIERS="small medium"  tier names (rows of expected.tsv; default per-commit
+#                                   pair; add "large" for the nightly/EC2 tier)
+#   BIN=<path>                      driver binary (default:
+#                                   target/release/examples/incremental_olympics_bench;
+#                                   built automatically if absent)
+#   REASONDEL_CACHE=<dir>           corpus + envelope cache (default /tmp/reason-deletion)
+#   REASONDEL_JSON_OUT=<path>       envelope path (default $REASONDEL_CACHE/
+#                                   reason-deletion-<UTC>.json; git-ignored territory)
+#
+# stdout: one TSV line per metric:  <metric_name>\t<value>\t<unit>
+#   reasondel_<tier>_<wl>_closure_triples   incremental closure size (DETERMINISTIC)
+#   reasondel_<tier>_<wl>_full_s            from-scratch re-materialization seconds
+#   reasondel_<tier>_<wl>_ins<delta>_s      incremental insert-batch seconds
+#   reasondel_<tier>_<wl>_del<delta>_s      incremental delete-batch seconds
+#   (<wl> in {rdfs, owlmono, owlfix}; timings are wall-clock trend-only — NOT perf-gated)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+BIN="${BIN:-$ROOT/target/release/examples/incremental_olympics_bench}"
+GEN="$ROOT/bench/reason-deletion/gen.sh"
+EXP="$ROOT/bench/reason-deletion/expected.tsv"
+CACHE="${REASONDEL_CACHE:-/tmp/reason-deletion}"
+TIERS="${REASONDEL_TIERS:-small medium}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+JSON_OUT="${REASONDEL_JSON_OUT:-$CACHE/reason-deletion-$STAMP.json}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[reasondel] driver not found at $BIN — building (release)..." >&2
+  cargo build --release -p sparq-reason --example incremental_olympics_bench >&2
+fi
+if [ ! -x "$BIN" ]; then
+  echo "[reasondel] ERROR: driver still missing at $BIN" >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+ran_tiers=""
+for TIER in $TIERS; do
+  UNITS="$(awk -F'\t' -v t="$TIER" '$1==t{print $2}' "$EXP")"
+  if [ -z "$UNITS" ]; then
+    echo "[reasondel] ERROR: tier '$TIER' has no expected.tsv row" >&2
+    fail=1; continue
+  fi
+  echo "[reasondel] === tier $TIER (units=$UNITS) ===" >&2
+  CORPUS="$("$GEN" "$UNITS")"
+
+  # Run the driver. A built-in differential-correctness assert failing PANICS the
+  # example -> non-zero exit here -> the suite is RED. That exit-code coupling is the
+  # acceptance-critical wiring: run.sh green <=> incremental==from-scratch held on the
+  # whole randomized sequence in all three workloads (plus the N3/WAC section's own
+  # asserts, which the example always runs).
+  if ! "$BIN" "$CORPUS" > "$TMP/$TIER.out" 2> "$TMP/$TIER.err"; then
+    echo "[reasondel] ERROR: driver FAILED on tier $TIER (differential-correctness" >&2
+    echo "[reasondel]        assert or crash). Last lines:" >&2
+    tail -n 25 "$TMP/$TIER.out" "$TMP/$TIER.err" >&2 || true
+    fail=1; continue
+  fi
+  if grep -q "skipping RDFS/OWL workloads" "$TMP/$TIER.out"; then
+    echo "[reasondel] ERROR: driver skipped the corpus (parse/path problem?)" >&2
+    fail=1; continue
+  fi
+  ran_tiers="$ran_tiers $TIER"
+done
+
+# Parse every tier's output, assert closure fixtures, emit metric TSV + the envelope.
+if ! RD_TMP="$TMP" RD_EXP="$EXP" RD_TIERS="$ran_tiers" RD_JSON_OUT="$JSON_OUT" \
+     RD_SPARQ_REV="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)" \
+     python3 "$ROOT/bench/reason-deletion/parse_and_assert.py"; then
+  fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[reasondel] OK: differential correctness + closure fixtures green ($ran_tiers )" >&2
+  echo "[reasondel] envelope: $JSON_OUT" >&2
+else
+  echo "[reasondel] FAILED: see errors above" >&2
+fi
+exit "$fail"


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **Claude Fable 5**

Implements bead **sq-31fza** (parent **sq-6tykl.4**, deletion-heavy incremental reasoning; axis registered under **sq-hmd7l**): a new self-contained `bench/reason-deletion/` realizing the CORRECTNESS+MEASUREMENT half of the FBF-grade retraction program. **Bench-dir + registry only — zero crate files touched** (file-disjoint from all in-flight sparq-reason work, per the bead).

## What it does
- **Driver**: the EXISTING, UNMODIFIED `crates/sparq-reason/examples/incremental_olympics_bench.rs` — it already performs fixed-seed randomized ABox insert/delete batches over RDFS + OWL-RL CountingMono/CountingFixpoint and carries the load-bearing built-in asserts (incremental closure set-equal to a from-scratch re-materialization after the randomized sequence; `full_rebuilds()==0` on ABox deltas). An assert violation panics → `run.sh` RED. This is exactly the bead's invariant wiring.
- **Corpus**: `gen_reason_deletion.py` — deterministic LUBM-class synthetic ABox (scale-parameterized instance generator over a fixed schema with class hierarchies + domain/range/subPropertyOf/inverseOf-typed properties), bound to the driver's TBox vocabulary so the rules genuinely fire (closure materially larger than the ABox). README documents honestly why literal univ-bench IRIs would make the workload vacuous.
- **Deletion ratios**: driver deltas are fixed {1, 100, 10000}, so the ratio axis comes from tier base sizes (small/medium per-commit, large nightly/EC2 opt-in); the envelope records `delete_ratio` per cell.
- **Fixtures**: `expected.tsv` pins every tier's parsed ABox count + all three closure sizes (deterministic) — catches silent under/over-derivation and generator drift on top of the driver's differential asserts.
- **Envelope**: standard JSON results envelope (host block marks work-box timings NON-canonical, `quiet_box:false`); timings trend-only, never perf-gated, none baked into markdown.
- **Registry**: `bench/benchmarks.toml` `[[benchmark]] id=reason-deletion` (`featured=false`; the RDFox-FBF/GraphDB-smooth-delete competitor half + any `incremental.rs` optimization stay follow-up beads under sq-6tykl.4, per the bead's scope).

## Honest seam note
The driver's delete-sampler excludes the six TBox *predicates* but can draw the one `[locatedIn, rdf:type, owl:TransitiveProperty]` axiom-typing triple on the fixpoint workload, which legitimately rebuilds and fails its no-rebuild assert (reproduced: units=3000 → exit 134). Tier unit counts are therefore pinned to draw-safe values (fully deterministic; documented in `expected.tsv` + README). Driver-side fix filed as bead **sq-x58ow**.

## Verification (acceptance criteria)
- `bash bench/reason-deletion/run.sh` **green** (small+medium; large tier verified green too) — and the driver's built-in asserts prove incremental==from-scratch on the randomized sequence (exit-code coupled).
- **Mutation-witnessed, non-vacuous**: (1) corrupting one `expected.tsv` closure count → run RED (`derivation regression`); (2) pointing the small tier at the known-bad unit count 3000 → driver panic path RED (`driver FAILED on tier small`). Both reverted.
- `scripts/check-no-perf-numbers.py --enforce bench/reason-deletion/README.md` → **0 findings** (only fixture-geometry constants in the dir).
- `scripts/check-new-bench-registered.py --base main` → G3 **PASS**; `benchmarks.toml` parses (tomllib).
- shellcheck + `bash -n` clean on `run.sh`/`gen.sh`; typos clean.

Bead: sq-31fza · Follow-ups: sq-x58ow (driver sampler seam), competitor comparison + optimization under sq-6tykl.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)