### PR TITLE
site: publish JSON-LD 1.1 conformance floors [GPT-5.6]

### DIFF
--- a/site/src/app/assurance/jsonld-conformance/page.tsx
+++ b/site/src/app/assurance/jsonld-conformance/page.tsx
@@ -1,0 +1,75 @@
+// [GPT-5.6] sq-ztdez — static public scoreboard for the six JSON-LD lanes.
+import type { Metadata } from "next";
+import { CheckCircle2, FlaskConical } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { jsonLdConformanceLanes } from "@/data/jsonld-conformance";
+
+export const metadata: Metadata = {
+  title: "JSON-LD 1.1 conformance floors",
+  description: "Measured, rise-only W3C JSON-LD 1.1 conformance floors for sparq.",
+};
+
+export default function JsonLdConformancePage() {
+  return (
+    <div className="space-y-10">
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <FlaskConical className="size-5" aria-hidden />
+          </span>
+          <div>
+            <h1 className="text-2xl font-semibold">JSON-LD 1.1 conformance floors</h1>
+            <p className="text-sm text-muted-foreground">
+              Six independently ratcheted lanes against pinned W3C test suites.
+            </p>
+          </div>
+        </div>
+        <Badge variant="outline">W3C JSON-LD 1.1</Badge>
+      </header>
+
+      <p className="max-w-3xl rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-muted-foreground">
+        <strong className="text-foreground">Measured floors, not conformance claims.</strong>{" "}
+        Each pass/total value is a rise-only measured minimum at the pinned suite revision.
+        A lane below its total is not claimed conformant; uncounted cases remain documented
+        failures or skips in the test harness.
+      </p>
+
+      <section aria-labelledby="lanes-heading" className="space-y-4">
+        <h2 id="lanes-heading" className="text-lg font-semibold">
+          Ratcheted lanes
+        </h2>
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {jsonLdConformanceLanes.map((lane) => {
+            const complete = lane.floor === lane.total;
+            return (
+              <li key={lane.id} className="rounded-xl border bg-card p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="font-semibold">{lane.label}</h3>
+                    <code className="text-xs text-muted-foreground">{lane.id}</code>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-xl font-semibold tabular-nums" aria-label={`${lane.floor} passes out of ${lane.total}`}>
+                      {lane.floor}/{lane.total}
+                    </p>
+                    <p className="text-xs text-muted-foreground">measured floor</p>
+                  </div>
+                </div>
+                {complete ? (
+                  <p className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <CheckCircle2 className="size-3.5 text-[var(--success)]" aria-hidden />
+                    Full score at the pinned revision
+                  </p>
+                ) : (
+                  <p className="mt-3 text-xs text-muted-foreground">Not claimed conformant</p>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </div>
+  );
+}
+

--- a/site/src/data/jsonld-conformance.ts
+++ b/site/src/data/jsonld-conformance.ts
@@ -1,0 +1,20 @@
+// [GPT-5.6] sq-ztdez — public, hand-authored snapshot of the six ratcheted
+// W3C JSON-LD 1.1 lanes. These are measured conformance floors, not targets or
+// performance results. Keep the denominators paired with their pinned suites.
+// TODO(sq-oy1f follow-up): wire generated feed
+
+export interface JsonLdConformanceLane {
+  id: "toRdf" | "expand" | "flatten" | "compact" | "frame" | "fromRdf";
+  label: string;
+  floor: number;
+  total: number;
+}
+
+export const jsonLdConformanceLanes = [
+  { id: "toRdf", label: "JSON-LD to RDF", floor: 413, total: 467 },
+  { id: "expand", label: "Expansion", floor: 276, total: 385 },
+  { id: "flatten", label: "Flattening", floor: 53, total: 58 },
+  { id: "compact", label: "Compaction", floor: 228, total: 246 },
+  { id: "frame", label: "Framing", floor: 92, total: 92 },
+  { id: "fromRdf", label: "RDF to JSON-LD", floor: 52, total: 53 },
+] as const satisfies readonly JsonLdConformanceLane[];

--- a/site/test/jsonld-conformance-page.test.mjs
+++ b/site/test/jsonld-conformance-page.test.mjs
@@ -1,0 +1,28 @@
+// [GPT-5.6] sq-ztdez — mutation witness for all six ratios and the honesty caveat.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const root = new URL("../", import.meta.url);
+
+test("JSON-LD scoreboard renders every measured floor and the qualifying caveat", async () => {
+  const [page, data] = await Promise.all([
+    readFile(new URL("src/app/assurance/jsonld-conformance/page.tsx", root), "utf8"),
+    import("../src/data/jsonld-conformance.ts"),
+  ]);
+
+  assert.deepEqual(
+    data.jsonLdConformanceLanes.map(({ id, floor, total }) => [id, floor, total]),
+    [
+      ["toRdf", 413, 467],
+      ["expand", 276, 385],
+      ["flatten", 53, 58],
+      ["compact", 228, 246],
+      ["frame", 92, 92],
+      ["fromRdf", 52, 53],
+    ],
+  );
+  assert.match(page, /Measured floors, not conformance claims/);
+  assert.match(page, /A lane below its total is not claimed conformant/);
+  assert.match(page, /jsonLdConformanceLanes\.map/);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-ztdez.

Adds the public static JSON-LD 1.1 assurance scoreboard with six hand-authored, rise-only measured floor ratios and an explicit non-conformance caveat for incomplete lanes. Adds a mutation-witnessed unit check covering every ratio and the qualifying copy.

Frontend dependency classification: no dependency added; this static page uses existing shared UI and icon code, so no optional chunk or dynamic import boundary is introduced.

Gates:
- npm run test:unit — 335/335 green
- npm run typecheck — green
- npm run build — green; emitted site/out/assurance/jsonld-conformance/index.html
- built HTML grep — all six lane ratios and honesty caveat present
- mutation witness — changing toRdf 413 to 412 makes the focused test fail