### PR TITLE
test(sim): property-check metric axioms (sq-3f1u6) [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5002,6 +5002,7 @@ name = "sparq-sim"
 version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
+ "proptest",
  "rustc-hash 2.1.3",
  "serde_json",
  "sparq-core",

--- a/crates/sparq-sim/Cargo.toml
+++ b/crates/sparq-sim/Cargo.toml
@@ -37,4 +37,5 @@ rustc-hash.workspace = true
 # (hand-built `format!`, mirroring `mpc_net_bench::cell_json`); serde_json is a
 # dev-dependency so it never enters the crate's published graph.
 [dev-dependencies]
+proptest = "1"
 serde_json = "1"

--- a/crates/sparq-sim/tests/proptest_metric.rs
+++ b/crates/sparq-sim/tests/proptest_metric.rs
@@ -1,0 +1,112 @@
+// [GPT-5.6] sq-3f1u6: property witnesses for the structural-similarity metric axioms.
+
+use std::collections::HashSet;
+
+use oxrdf::{NamedNode, Term};
+use proptest::prelude::*;
+use sparq_core::Graph;
+use sparq_sim::{weighted_jaccard, SignatureMode, Sim, SimConfig};
+
+const FEATURES: usize = 8;
+
+fn entity(name: &str) -> Term {
+    Term::NamedNode(NamedNode::new(format!("http://example.com/{name}")).unwrap())
+}
+
+fn graph_for_masks(masks: &[u8]) -> Graph {
+    let mut triples = String::new();
+    for (entity_index, mask) in masks.iter().enumerate() {
+        for feature in 0..FEATURES {
+            if mask & (1 << feature) != 0 {
+                triples.push_str(&format!(
+                    "<http://example.com/e{entity_index}> <http://example.com/p{feature}> \"value\" .\n"
+                ));
+            }
+        }
+    }
+    Graph::load_str(&triples, "ntriples").unwrap()
+}
+
+fn unweighted(graph: &Graph, mode: SignatureMode) -> Sim<'_> {
+    Sim::with_config(
+        graph,
+        SimConfig {
+            mode,
+            idf: false,
+            profile_fallback: false,
+            max_pair_frequency: usize::MAX,
+            ..SimConfig::default()
+        },
+    )
+}
+
+proptest! {
+    #[test]
+    fn term_similarity_is_reflexive_symmetric_and_bounded(a in 1_u8..=u8::MAX, b in any::<u8>()) {
+        let graph = graph_for_masks(&[a, b]);
+        let sim = unweighted(&graph, SignatureMode::PredicateNeighbor);
+        let ea = entity("e0");
+        let eb = entity("e1");
+        let ab = sim.similarity(&ea, &eb);
+
+        prop_assert_eq!(sim.similarity(&ea, &ea), 1.0);
+        prop_assert_eq!(ab, sim.similarity(&eb, &ea));
+        prop_assert!((0.0..=1.0).contains(&ab), "similarity out of range: {ab}");
+    }
+
+    #[test]
+    fn disjoint_term_signatures_have_zero_similarity(
+        a in 1_u8..=u8::MAX,
+        b in 1_u8..=u8::MAX,
+    ) {
+        let left = a & !b;
+        let right = b & !a;
+        prop_assume!(left != 0 && right != 0);
+        let graph = graph_for_masks(&[left, right]);
+        let sim = unweighted(&graph, SignatureMode::PredicateNeighbor);
+
+        prop_assert_eq!(sim.similarity(&entity("e0"), &entity("e1")), 0.0);
+    }
+
+    #[test]
+    fn weighted_jaccard_obeys_metric_axioms(a in 1_u8..=u8::MAX, b in 1_u8..=u8::MAX) {
+        let graph = graph_for_masks(&[a, b]);
+        let sim = Sim::new(&graph);
+        let sa = sim.signature(&entity("e0")).unwrap();
+        let sb = sim.signature(&entity("e1")).unwrap();
+        let ab = weighted_jaccard(&sa, &sb);
+
+        prop_assert_eq!(weighted_jaccard(&sa, &sa), 1.0);
+        prop_assert_eq!(ab, weighted_jaccard(&sb, &sa));
+        prop_assert!((0.0..=1.0).contains(&ab), "weighted Jaccard out of range: {ab}");
+        if a & b == 0 {
+            prop_assert_eq!(ab, 0.0);
+        }
+    }
+
+    #[test]
+    fn most_similar_is_sorted_bounded_and_deduplicated(
+        query in 1_u8..=u8::MAX,
+        candidates in prop::collection::vec(any::<u8>(), 1..16),
+        k in 0_usize..20,
+    ) {
+        let mut masks = Vec::with_capacity(candidates.len() + 1);
+        masks.push(query);
+        masks.extend(candidates);
+        let graph = graph_for_masks(&masks);
+        let sim = unweighted(&graph, SignatureMode::Predicates);
+        let query_term = entity("e0");
+        let results = sim.most_similar(&query_term, k);
+        let mut seen = HashSet::new();
+
+        prop_assert!(results.len() <= k);
+        for pair in results.windows(2) {
+            prop_assert!(pair[0].1 >= pair[1].1, "ranking is not non-increasing: {results:?}");
+        }
+        for (term, score) in results {
+            prop_assert_ne!(&term, &query_term);
+            prop_assert!((0.0..=1.0).contains(&score), "ranked score out of range: {score}");
+            prop_assert!(seen.insert(term), "duplicate ranked entity");
+        }
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-3f1u6.

Adds randomized, test-only coverage for structural similarity:
- term-level self-identity, symmetry, boundedness, and disjointness
- direct weighted-Jaccard axioms over generated signatures
- sorted, bounded, self-excluding, duplicate-free most_similar rankings

Mutation witness: temporarily changed inter / union to union / inter; weighted_jaccard_obeys_metric_axioms failed immediately on the boundedness assertion (a = 1, b = 2, score inf). The production implementation was restored before commit.

Gates:
- cargo clippy -p sparq-sim --all-targets -- -D warnings
- cargo clippy -p sparq-sim --all-targets --all-features -- -D warnings
- cargo test -p sparq-sim
- cargo test -p sparq-sim --all-features
- RUSTDOCFLAGS=-D warnings cargo doc -p sparq-sim --no-deps --all-features
- cargo test -p sparq-sim --test proptest_metric