### PR TITLE
bench(reason-dl): add tableau depth microbench [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4855,6 +4855,7 @@ dependencies = [
 name = "sparq-reason-dl"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "oxrdf 0.3.3",
  "rustc-hash 2.1.3",
  "sparq-core",

--- a/crates/sparq-reason-dl/Cargo.toml
+++ b/crates/sparq-reason-dl/Cargo.toml
@@ -53,3 +53,14 @@ rustc-hash.workspace = true
 # crates.io.
 sparq-reason = { path = "../sparq-reason", version = "0.1.0", optional = true }
 sparq-reason-el = { path = "../sparq-reason-el", version = "0.1.0", optional = true }
+
+# [GPT-5.6] sq-7ru8y: Criterion is dev-only and drives the self-relative tableau
+# microbenchmark; it does not enter the shipped opt-in reasoner crate.
+[dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
+
+# [GPT-5.6] sq-7ru8y: pinned synthetic concept expressions exercise NNF conversion and
+# tableau sat/subsumption checks at increasing nesting depths.
+[[bench]]
+name = "tableau_micro"
+harness = false

--- a/crates/sparq-reason-dl/benches/tableau_micro.rs
+++ b/crates/sparq-reason-dl/benches/tableau_micro.rs
@@ -1,0 +1,141 @@
+//! Self-relative microbenchmarks for the ALCH NNF/tableau check pipeline.
+//!
+//! The fixtures pin checker verdicts before Criterion times them. Those pins are a
+//! regression/stability oracle only; this benchmark makes no new reasoner-soundness claim.
+//! Criterion keeps measurements outside tracked files, under `target/criterion/`.
+
+// [GPT-5.6] sq-7ru8y: stability-oracle fixtures for self-relative depth scaling.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use sparq_core::dict::Id;
+use sparq_reason_dl::model::ClassExpression as CE;
+use sparq_reason_dl::nnf;
+use sparq_reason_dl::tableau::{class_satisfiability, Budget, Verdict};
+use sparq_reason_dl::Ontology;
+use std::hint::black_box;
+
+const CLASS_A: Id = 1;
+const CLASS_B: Id = 2;
+const ROLE: Id = 10;
+const DEPTHS: [usize; 4] = [1, 2, 4, 8];
+
+#[derive(Clone, Copy, Debug)]
+enum Check {
+    Satisfiable,
+    Unsatisfiable,
+    Subsumed,
+    NotSubsumed,
+}
+
+#[derive(Clone, Debug)]
+struct Fixture {
+    depth: usize,
+    check: Check,
+    expression: CE,
+    expected: bool,
+}
+
+fn nested_some(depth: usize, filler: CE) -> CE {
+    (0..depth).fold(filler, |inner, _| CE::some(ROLE, inner))
+}
+
+fn not(expression: CE) -> CE {
+    CE::ObjectComplementOf(Box::new(expression))
+}
+
+fn intersection(left: CE, right: CE) -> CE {
+    CE::ObjectIntersectionOf(vec![left, right])
+}
+
+fn fixtures() -> Vec<Fixture> {
+    let mut fixtures = Vec::with_capacity(DEPTHS.len() * 4);
+    for depth in DEPTHS {
+        let nested_a = nested_some(depth, CE::Class(CLASS_A));
+        fixtures.push(Fixture {
+            depth,
+            check: Check::Satisfiable,
+            expression: nested_a.clone(),
+            expected: true,
+        });
+        fixtures.push(Fixture {
+            depth,
+            check: Check::Unsatisfiable,
+            expression: nested_some(
+                depth,
+                intersection(CE::Class(CLASS_A), not(CE::Class(CLASS_A))),
+            ),
+            expected: false,
+        });
+
+        // C is subsumed by D iff C intersected with not-D is unsatisfiable. Keeping the
+        // reduction explicit makes both sat and subsumption fixtures use the same public
+        // NNF/tableau seam.
+        let nested_thing = nested_some(depth, CE::Thing);
+        fixtures.push(Fixture {
+            depth,
+            check: Check::Subsumed,
+            expression: intersection(nested_a.clone(), not(nested_thing)),
+            expected: true,
+        });
+        fixtures.push(Fixture {
+            depth,
+            check: Check::NotSubsumed,
+            expression: intersection(nested_a, not(nested_some(depth, CE::Class(CLASS_B)))),
+            expected: false,
+        });
+    }
+    fixtures
+}
+
+fn verdict(fixture: &Fixture) -> bool {
+    // Exercise NNF as an explicit pipeline stage as well as the tableau's internal
+    // normalization. For subsumption fixtures, an UNSAT reduction means "subsumed".
+    let normalized = nnf::nnf(&fixture.expression);
+    let result = class_satisfiability(&normalized, &Ontology::new(), Budget::default());
+    match fixture.check {
+        Check::Satisfiable | Check::Unsatisfiable => result == Verdict::Satisfiable,
+        Check::Subsumed | Check::NotSubsumed => result == Verdict::Unsatisfiable,
+    }
+}
+
+fn assert_verdicts(fixtures: &[Fixture]) {
+    for fixture in fixtures {
+        assert_eq!(
+            verdict(fixture),
+            fixture.expected,
+            "stability verdict changed for {:?} at depth {}",
+            fixture.check,
+            fixture.depth
+        );
+    }
+}
+
+#[test]
+fn verdict_matches_expected() {
+    assert_verdicts(&fixtures());
+}
+
+fn bench_tableau_checks(c: &mut Criterion) {
+    let fixtures = fixtures();
+    // Validate every pinned answer once before any timed iteration begins.
+    assert_verdicts(&fixtures);
+
+    let mut group = c.benchmark_group("tableau_check_by_depth");
+    for fixture in &fixtures {
+        let kind = match fixture.check {
+            Check::Satisfiable => "sat",
+            Check::Unsatisfiable => "unsat",
+            Check::Subsumed => "subsumed",
+            Check::NotSubsumed => "not_subsumed",
+        };
+        group.bench_with_input(
+            BenchmarkId::new(kind, fixture.depth),
+            fixture,
+            |b, fixture| b.iter(|| black_box(verdict(black_box(fixture)))),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(tableau_benches, bench_tableau_checks);
+criterion_main!(tableau_benches);

--- a/research/gap-reason-dl-micro-2026-07.md
+++ b/research/gap-reason-dl-micro-2026-07.md
@@ -1,0 +1,22 @@
+# Direct-semantics tableau microbenchmark notes
+
+<!-- [GPT-5.6] sq-7ru8y -->
+
+`sparq-reason-dl` now has a crate-local Criterion benchmark over pinned synthetic ALCH
+concept expressions. It compares the checker only with itself across increasing quantifier
+nesting depths; it has no competitor results and writes no measured values to tracked files.
+
+The fixture families cover satisfiable and contradictory existential chains plus positive
+and negative subsumption reductions. Before timing, the benchmark checks every result against
+its pinned expected Boolean. This is an answer-stability oracle, not an independent soundness
+argument; the reasoner's existing conformance tests remain responsible for that evidence.
+
+Run the quick stability lane with:
+
+```sh
+cargo bench -p sparq-reason-dl --bench tableau_micro -- --test
+```
+
+For local depth-scaling exploration, omit `--test` and compare Criterion's per-depth output.
+Criterion stores measurements below `target/criterion/`; do not copy machine-specific timing
+values into this note.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-7ru8y.

Adds a crate-local, self-relative Criterion microbenchmark for pinned ALCH satisfiability and subsumption-reduction fixtures at increasing nesting depths. Every expected verdict is asserted before timing; this is a stability oracle and does not make a new soundness claim. Adds the requested depth-scaling research note without tracked timing values.

Gates:
- `cargo clippy -p sparq-reason-dl --all-targets -- -D warnings`
- `cargo clippy -p sparq-reason-dl --all-targets --features dispatch -- -D warnings`
- `cargo test -p sparq-reason-dl`
- `cargo test -p sparq-reason-dl --features dispatch`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-reason-dl --no-deps --all-features`
- `cargo bench -p sparq-reason-dl --bench tableau_micro -- --test`

Mutation witness: flipping a pinned satisfiable verdict fails the pre-timing stability assertion; the mutation was reverted.