### PR TITLE
bench: add scalar builtin-cost micro-suite [GPT-5.6]

### DIFF
--- a/bench/builtins/README.md
+++ b/bench/builtins/README.md
@@ -1,0 +1,30 @@
+<!-- [GPT-5.6] sq-xngad — standing builtin-cost micro-benchmark. -->
+
+# Builtin-cost micro-benchmark
+
+This suite measures scalar builtins whose setup cost can accidentally become a per-row cost:
+constant-pattern `REGEX` and `REPLACE`, `RAND`, and query-constant `NOW`. It generates a fixed
+N-Triples corpus outside the checkout, runs the release `sparq-cli` query-suite driver, checks the
+result cardinality of every probe, and prints a Markdown throughput table.
+
+```sh
+cargo build --release -p sparq-cli
+bench/builtins/run.sh
+```
+
+Useful knobs are `ROWS` (generated input rows), `ITERS` (minimum-of repetitions), `CLI` (binary
+path), and `BUILTINS_CACHE` (generated-data directory). For a cheap harness check:
+
+```sh
+ROWS=100 ITERS=1 bench/builtins/run.sh
+```
+
+Every elapsed-time and throughput value is a work-box measurement and **NON-CANONICAL**. The
+canonical rerun belongs to sq-98w7z.9; in particular, it reruns the REGEX-heavy FILTER probe here.
+The optimized `after` implementation is current main. There is no feature or environment toggle
+for the old behavior, so a true `before` run must build the parent of commit `85a54650f` and invoke
+this same script with `CLI` pointing at that binary. The memoization is unconditional.
+
+The table's `rows/s` is derived from the CLI's minimum query time. It is a trend aid, not a
+committed performance claim. Generated corpora and raw results remain under `BUILTINS_CACHE`
+(default `/tmp/sparq-builtin-cost`) and are safe to delete after a run.

--- a/bench/builtins/queries/now_query_constant.rq
+++ b/bench/builtins/queries/now_query_constant.rq
@@ -1,0 +1,5 @@
+# [GPT-5.6] NOW must remain equal across calls and rows within one query execution.
+SELECT ?s (NOW() AS ?instant) WHERE {
+  ?s <urn:value> ?value .
+  FILTER(NOW() = NOW())
+}

--- a/bench/builtins/queries/rand_projection.rq
+++ b/bench/builtins/queries/rand_projection.rq
@@ -1,0 +1,4 @@
+# [GPT-5.6] Forces one RAND evaluation for every input binding.
+SELECT ?s (RAND() AS ?random) WHERE {
+  ?s <urn:value> ?value .
+}

--- a/bench/builtins/queries/regex_constant.rq
+++ b/bench/builtins/queries/regex_constant.rq
@@ -1,0 +1,5 @@
+# [GPT-5.6] Constant pattern: regression witness for per-row regex compilation.
+SELECT ?s WHERE {
+  ?s <urn:value> ?value .
+  FILTER(REGEX(STR(?value), "^row-[0-9]{8}-alpha$"))
+}

--- a/bench/builtins/queries/replace_constant.rq
+++ b/bench/builtins/queries/replace_constant.rq
@@ -1,0 +1,5 @@
+# [GPT-5.6] Constant pattern and replacement: regression witness for cached REPLACE setup.
+SELECT ?s WHERE {
+  ?s <urn:value> ?value .
+  FILTER(REPLACE(STR(?value), "-alpha$", "-omega") != STR(?value))
+}

--- a/bench/builtins/run.sh
+++ b/bench/builtins/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# [GPT-5.6] sq-xngad — reproducible scalar-builtin cost probes.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLI="${CLI:-$ROOT/target/release/sparq-cli}"
+ROWS="${ROWS:-100000}"
+ITERS="${ITERS:-5}"
+CACHE="${BUILTINS_CACHE:-/tmp/sparq-builtin-cost}"
+DATA="$CACHE/rows-${ROWS}.nt"
+RAW="$CACHE/results.tsv"
+QUERIES="$ROOT/bench/builtins/queries"
+
+case "$ROWS:$ITERS" in
+  *[!0-9:]*|0:*|*:0) echo "ERROR: ROWS and ITERS must be positive integers" >&2; exit 2 ;;
+esac
+[ -x "$CLI" ] || {
+  echo "ERROR: sparq-cli not found at $CLI; run: cargo build --release -p sparq-cli" >&2
+  exit 2
+}
+
+mkdir -p "$CACHE"
+if [ ! -f "$DATA" ] || [ "$(wc -l < "$DATA")" -ne "$ROWS" ]; then
+  tmp="$DATA.tmp.$$"
+  trap 'rm -f "${tmp:-}"' EXIT
+  awk -v n="$ROWS" 'BEGIN {
+    for (i = 0; i < n; i++) {
+      printf "<urn:row:%d> <urn:value> \"row-%08d-alpha\" .\n", i, i
+    }
+  }' > "$tmp"
+  mv "$tmp" "$DATA"
+  tmp=""
+fi
+
+"$CLI" bench "$DATA" ntriples "$QUERIES" "$ITERS" count > "$RAW"
+
+expected_for() {
+  case "$1" in
+    regex_constant|replace_constant|rand_projection|now_query_constant) printf '%s\n' "$ROWS" ;;
+    *) return 1 ;;
+  esac
+}
+
+fail=0
+seen=0
+while IFS=$'\t' read -r name rows micros; do
+  expected="$(expected_for "$name")" || {
+    echo "ERROR: unexpected result row: $name" >&2; fail=1; continue
+  }
+  seen=$((seen + 1))
+  if [ "$rows" != "$expected" ]; then
+    echo "ERROR: $name returned $rows rows; expected $expected" >&2
+    fail=1
+  fi
+  case "$micros" in
+    ''|*[!0-9.]*) echo "ERROR: $name emitted invalid microseconds: $micros" >&2; fail=1 ;;
+  esac
+done < "$RAW"
+[ "$seen" -eq 4 ] || { echo "ERROR: expected 4 probes, saw $seen" >&2; fail=1; }
+[ "$fail" -eq 0 ] || exit 1
+
+printf '%s\n\n' '> Work-box timings — NON-CANONICAL; canonical rerun: sq-98w7z.9.'
+printf '| probe | result rows | min us | rows/s |\n'
+printf '|---|---:|---:|---:|\n'
+awk -F'\t' '{
+  rate = ($3 > 0) ? ($2 * 1000000 / $3) : 0
+  printf "| `%s` | %d | %.3f | %.0f |\n", $1, $2, $3, rate
+}' "$RAW"


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-xngad.

Adds a self-contained `bench/builtins/` suite for constant-pattern REGEX/REPLACE, per-row RAND projection, and query-constant NOW. The runner generates its corpus under `/tmp`, validates every probe cardinality, and emits a work-box NON-CANONICAL Markdown throughput table. The README records that the unconditional before state is reconstructed from the parent of commit `85a54650f`; sq-98w7z.9 owns the canonical rerun.

Gates:
- `cargo build --release -p sparq-cli`
- `ROWS=100 ITERS=1 bench/builtins/run.sh`
- mutation witness: impossible REGEX made the runner fail on 0 vs expected rows
- `shellcheck bench/builtins/run.sh`
- markdownlint-cli2 (0 errors)
- `python3 scripts/check-no-perf-numbers.py --enforce bench/builtins/README.md`
- `git diff --check`

No crate code, public API, feature, or README template changed, so crate clippy/test/doc feature-state gates are not applicable. PR is intentionally unarmed.