### PR TITLE
fedclient: borrow SRJ result envelope [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,6 +4565,7 @@ dependencies = [
  "oxrdf 0.3.3",
  "oxttl 0.2.3",
  "rustc-hash 2.1.3",
+ "serde",
  "serde_json",
  "spargebra",
  "sparq-core",

--- a/crates/sparq-fedclient/Cargo.toml
+++ b/crates/sparq-fedclient/Cargo.toml
@@ -53,6 +53,7 @@ fedclient = [
     # tree — `fedclient` enables `sparq-engine/service`, which pulls the SAME serde_json — so
     # this adds NO new crate to the resolved dependency graph.
     "dep:serde_json",
+    "dep:serde",
 ]
 # [OPUS-4.8] sq-ij5x (epic sq-dnko, FINAL phase): Phase-7 client-side ADAPTIVE re-planning.
 # OFF by default; IMPLIES `fedclient` (it is the streaming client's execution loop) AND
@@ -81,7 +82,11 @@ rustc-hash = { workspace = true, optional = true }
 # [OPUS-4.8] sq-j27p: SPARQL-Results-JSON parsing in the Phase-3 interpreter. serde_json is
 # already resolved via `sparq-engine/service` (enabled by `fedclient`), so the default build
 # is unaffected and the `fedclient` tree gains no new crate. Version pinned to match.
-serde_json = { version = "1", optional = true }
+serde_json = { version = "1", features = ["raw_value"], optional = true }
+# [GPT-5.6] sq-1rtc2: borrowed SRJ envelopes avoid a full serde_json::Value DOM. serde is
+# already in the feature's resolved graph through serde_json; this only makes that existing
+# dependency directly usable when `fedclient` is enabled.
+serde = { version = "1", features = ["derive"], optional = true }
 # [OPUS-4.8] sq-nfxl: the discovery client's blocking HTTP GET (SSRF-guarded). Native-only;
 # the discovery module gates it out of wasm. Mirrors sparq-engine's `service` ureq config so
 # the resolved dependency is the SAME crate/version (no new tree growth on a default build).

--- a/crates/sparq-fedclient/src/operators.rs
+++ b/crates/sparq-fedclient/src/operators.rs
@@ -511,40 +511,77 @@ fn join_key(row: &[Option<Term>], shared: &[(usize, usize)], from_left: bool) ->
 /// from a solution object is UNBOUND (`None`). An ASK `boolean` body is rejected (this
 /// interpreter only joins SELECT relations). [OPUS-4.8] sq-j27p.
 pub fn parse_srj(text: &str) -> Result<Relation, String> {
-    let v: serde_json::Value =
+    // [GPT-5.6] sq-1rtc2: borrow the document envelope and each binding cell from the input.
+    // Cells outside `head.vars` remain undecoded, matching the previous parser's semantics.
+    let document: SrjDocument<'_> =
         serde_json::from_str(text).map_err(|e| format!("invalid results JSON: {}", e))?;
-    if v.get("boolean").is_some() {
+    if document.boolean.is_some() {
         return Err("endpoint returned an ASK boolean, expected SELECT bindings".to_string());
     }
-    let vars: Vec<String> = v
-        .pointer("/head/vars")
-        .and_then(|a| a.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|s| s.as_str().map(|s| s.to_string()))
-                .collect()
+    let vars = document
+        .head
+        .and_then(|head| head.vars)
+        .map(|vars| {
+            serde_json::from_str::<Vec<&serde_json::value::RawValue>>(vars.get())
+                .map_err(|_| "results JSON missing head.vars".to_string())
+        })
+        .transpose()?
+        .map(|vars| {
+            vars.into_iter()
+                .filter_map(|var| serde_json::from_str::<String>(var.get()).ok())
+                .collect::<Vec<_>>()
         })
         .ok_or_else(|| "results JSON missing head.vars".to_string())?;
 
     let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
-    for sol in v
-        .pointer("/results/bindings")
-        .and_then(|a| a.as_array())
+    for solution in document
+        .results
+        .and_then(|results| results.bindings)
+        .map(|bindings| {
+            serde_json::from_str::<Vec<&serde_json::value::RawValue>>(bindings.get())
+                .map_err(|_| "results JSON missing results.bindings".to_string())
+        })
+        .transpose()?
         .ok_or_else(|| "results JSON missing results.bindings".to_string())?
     {
-        let obj = sol
-            .as_object()
-            .ok_or_else(|| "a solution binding is not a JSON object".to_string())?;
+        let object: std::collections::HashMap<String, &serde_json::value::RawValue> =
+            serde_json::from_str(solution.get())
+                .map_err(|_| "a solution binding is not a JSON object".to_string())?;
         let mut row: Vec<Option<Term>> = Vec::with_capacity(vars.len());
         for var in &vars {
-            match obj.get(var) {
-                Some(cell) => row.push(Some(srj_term(cell)?)),
+            match object.get(var) {
+                Some(cell) => {
+                    let value: serde_json::Value = serde_json::from_str(cell.get())
+                        .map_err(|e| format!("invalid results JSON: {}", e))?;
+                    row.push(Some(srj_term(&value)?));
+                }
                 None => row.push(None),
             }
         }
         rows.push(row);
     }
     Ok(Relation { vars, rows })
+}
+
+#[derive(serde::Deserialize)]
+struct SrjDocument<'a> {
+    #[serde(borrow)]
+    head: Option<SrjHead<'a>>,
+    #[serde(borrow)]
+    results: Option<SrjResults<'a>>,
+    boolean: Option<serde_json::Value>,
+}
+
+#[derive(serde::Deserialize)]
+struct SrjHead<'a> {
+    #[serde(borrow)]
+    vars: Option<&'a serde_json::value::RawValue>,
+}
+
+#[derive(serde::Deserialize)]
+struct SrjResults<'a> {
+    #[serde(borrow)]
+    bindings: Option<&'a serde_json::value::RawValue>,
 }
 
 /// Reconstruct one `oxrdf::Term` from an SRJ binding value object — the inbound counterpart

--- a/crates/sparq-fedclient/tests/srj_parse_correctness.rs
+++ b/crates/sparq-fedclient/tests/srj_parse_correctness.rs
@@ -72,6 +72,21 @@ fn ask_boolean_body_is_rejected_for_select() {
     assert!(err.contains("ASK"), "got {}", err);
 }
 
+#[test]
+fn results_before_head_and_unused_malformed_cells_preserve_dom_semantics() {
+    // [GPT-5.6] sq-1rtc2: witnesses order-independent borrowed parsing and deferred cell
+    // decoding. Eagerly decoding every binding cell would reject `ignored`.
+    let relation = parse_srj(
+        r#"{"results":{"bindings":[{"ignored":17,"x":{"type":"literal","value":"ok"}}]},"head":{"vars":["x"]}}"#,
+    )
+    .unwrap();
+    assert_eq!(relation.vars, vec!["x"]);
+    assert_eq!(
+        relation.rows,
+        vec![vec![Some(Term::Literal(Literal::new_simple_literal("ok")))]]
+    );
+}
+
 // ─── Per-cell term-kind error paths (srj_term branches) ─────────────────────────────────
 
 #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-1rtc2.

Replaces the full-document serde_json::Value DOM with a borrowed SRJ envelope and borrowed RawValue slices. Only cells selected by head.vars are decoded, preserving ignored-cell, unbound, ASK rejection, RDF 1.2 triple, language/direction, and datatype semantics. The capability remains default-OFF and adds no new resolved dependency.

Adds a mutation-witnessing regression for results-before-head ordering and ignored malformed cells.

Gates green:
- cargo test -p sparq-fedclient
- cargo test -p sparq-fedclient --features fedclient
- cargo clippy -p sparq-fedclient --all-targets -- -D warnings
- cargo clippy -p sparq-fedclient --all-targets --features fedclient -- -D warnings
- RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-fedclient --no-deps --all-features
- cargo test -p sparq-fedclient --features fedclient --test srj_parse_correctness

A NON-CANONICAL work-box synthetic 100,000-row A/B is recorded in the bead notes; it is diagnostic only, not a canonical performance claim.

Not armed for merge.