### PR TITLE
build(wasm): unify +simd128 at workspace level + feature-assert guard (sq-3ul2n.2) [FABLE-5]

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,18 @@
 # getrandom 0.3 has no default backend for wasm32-unknown-unknown; select the browser backend
 # (crypto.getRandomValues) so the wasm build (oxrdf -> rand -> getrandom, for blank-node ids)
 # compiles. Pairs with `getrandom = { features = ["wasm_js"] }` in crates/sparq-wasm/Cargo.toml.
+#
+# [FABLE-5] sq-3ul2n.2: `+simd128` is set HERE at the workspace level (not in a crate-level
+# .cargo/config.toml) so EVERY wasm32 build — the shipped `wasm-pack` build, the root-invoked
+# `wasm_bundle_bytes` gate build in scripts/ci-bench.sh, and all five wasm crates — compiles
+# with WASM SIMD128 identically. cargo discovers `.cargo/config.toml` by CWD and a crate-level
+# `rustflags` REPLACES (not merges) the root one, so keeping both files would silently drop
+# getrandom_backend for a root build or simd128 for a crate build. These flags are
+# target-scoped (`[target.wasm32-unknown-unknown]`) — native builds are byte-identical.
+# NOTE: simd128 is ~speed-neutral for sparq today (no hand-written vector kernels; measured in
+# research/hardware/consumer-and-targets.md §5) and gives a small one-time bundle-size decrease;
+# the browser support floor (Chrome 91+/Firefox 89+/Safari 16.4+) is already required by the
+# shipped bundle, so this is not a support-floor change. scripts/check-wasm-features.py asserts
+# the built artifact actually carries the simd128 target_features flag.
 [target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"', '-C', 'target-feature=+simd128']

--- a/crates/sparq-wasm/.cargo/config.toml
+++ b/crates/sparq-wasm/.cargo/config.toml
@@ -1,7 +1,0 @@
-# Select getrandom's browser backend for the wasm target (see Cargo.toml), and
-# enable WASM SIMD128 — a free bundle-size win today (~-3.6% raw, no perf
-# regression; measured by research/hardware/consumer-and-targets.md). It also
-# unlocks LLVM autovectorization and is the prerequisite for the explicit
-# core::simd FILTER kernel that is the highest-reach consumer optimisation.
-[target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"', '-C', 'target-feature=+simd128']

--- a/scripts/check-wasm-features.py
+++ b/scripts/check-wasm-features.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-3ul2n.2 — assert a built .wasm artifact carries a required WASM feature.
+#
+# Parses the WebAssembly "target_features" custom section (emitted by LLVM/rustc) and checks
+# that a named feature (e.g. simd128) is present with a "used"/"required" (`+`) prefix. Used by
+# scripts/ci-bench.sh next to the wasm_bundle_bytes measurement so the root-invoked gate build
+# is proven to actually contain +simd128 — closing the gate-vs-shipped parity gap where the
+# feature previously lived only in a crate-level .cargo/config.toml that cargo discovered by CWD.
+#
+# Custom section layout we parse (WebAssembly binary format + the tool-conventions
+# target_features section):
+#   module   = magic(4) version(4) { section }*
+#   section  = id:u8 size:u32(uleb) payload[size]
+#   custom   = name_len:u32(uleb) name[name_len] contents...   (section id 0)
+#   target_features contents = count:u32(uleb) { prefix:u8 name_len:u32(uleb) name[name_len] }*
+#     prefix 0x2B '+' = feature used (required to run), 0x2D '-' = feature disallowed,
+#            0x3D '=' = feature required-and-used. We treat '+' and '=' as "present".
+#
+# stdlib only, no third-party deps.
+
+import argparse
+import sys
+
+
+def read_uleb128(buf, pos):
+    """Decode an unsigned LEB128 varint at buf[pos:]. Returns (value, new_pos)."""
+    result = 0
+    shift = 0
+    while True:
+        if pos >= len(buf):
+            raise ValueError("unexpected end of buffer while reading LEB128")
+        byte = buf[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if (byte & 0x80) == 0:
+            break
+        shift += 7
+        if shift > 63:
+            raise ValueError("LEB128 varint too long")
+    return result, pos
+
+
+def iter_sections(buf):
+    """Yield (section_id, payload_bytes) for each top-level section."""
+    if len(buf) < 8:
+        raise ValueError("file too short to be a wasm module")
+    if buf[0:4] != b"\x00asm":
+        raise ValueError("not a wasm module (bad magic %r)" % buf[0:4])
+    # buf[4:8] is the version (little-endian u32); we don't need to validate it.
+    pos = 8
+    while pos < len(buf):
+        section_id = buf[pos]
+        pos += 1
+        size, pos = read_uleb128(buf, pos)
+        payload = buf[pos:pos + size]
+        if len(payload) != size:
+            raise ValueError("truncated section (id=%d)" % section_id)
+        yield section_id, payload
+        pos += size
+
+
+def find_target_features(buf):
+    """Return the target_features section contents (bytes) or None if absent."""
+    for section_id, payload in iter_sections(buf):
+        if section_id != 0:  # 0 == custom section
+            continue
+        name_len, p = read_uleb128(payload, 0)
+        name = payload[p:p + name_len]
+        if name == b"target_features":
+            return payload[p + name_len:]
+    return None
+
+
+def parse_features(contents):
+    """Parse target_features contents into a list of (prefix_char, feature_name)."""
+    count, pos = read_uleb128(contents, 0)
+    features = []
+    for _ in range(count):
+        if pos >= len(contents):
+            raise ValueError("truncated target_features entry list")
+        prefix = chr(contents[pos])
+        pos += 1
+        name_len, pos = read_uleb128(contents, pos)
+        name = contents[pos:pos + name_len].decode("utf-8", "replace")
+        pos += name_len
+        features.append((prefix, name))
+    return features
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(
+        description="Assert a built .wasm artifact carries a required target feature."
+    )
+    ap.add_argument("wasm", help="path to the .wasm artifact")
+    ap.add_argument("--require", metavar="FEATURE",
+                    help="feature name that must be present (e.g. simd128); exit 1 if absent")
+    ap.add_argument("--list", action="store_true",
+                    help="print the parsed target_features section and exit 0")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.wasm, "rb") as fh:
+            buf = fh.read()
+    except OSError as exc:
+        print("check-wasm-features: cannot read %s: %s" % (args.wasm, exc), file=sys.stderr)
+        return 1
+
+    try:
+        contents = find_target_features(buf)
+    except ValueError as exc:
+        print("check-wasm-features: %s: %s" % (args.wasm, exc), file=sys.stderr)
+        return 1
+
+    if contents is None:
+        features = []
+    else:
+        try:
+            features = parse_features(contents)
+        except ValueError as exc:
+            print("check-wasm-features: %s: malformed target_features: %s"
+                  % (args.wasm, exc), file=sys.stderr)
+            return 1
+
+    if args.list:
+        if not features:
+            print("(no target_features custom section)")
+        for prefix, name in features:
+            print("%s%s" % (prefix, name))
+        return 0
+
+    if not args.require:
+        ap.error("one of --require or --list is required")
+
+    # A feature counts as present when prefixed '+' (used) or '=' (required+used).
+    present = {name for prefix, name in features if prefix in ("+", "=")}
+    if args.require in present:
+        print("check-wasm-features: OK — %s carries +%s" % (args.wasm, args.require))
+        return 0
+
+    have = ", ".join("%s%s" % (p, n) for p, n in features) or "(none)"
+    print("check-wasm-features: FAIL — %s does NOT carry +%s (target_features: %s)"
+          % (args.wasm, args.require, have), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -217,6 +217,32 @@ print(json.dumps([{"name": n, "unit": u, "value": float(v)} for n, u, v in rows]
 PY
 }
 
+# [FABLE-5] (sq-3ul2n.2) assert_wasm_simd128 — prove the root-invoked wasm32 gate build actually
+# carries +simd128. `+simd128` lives in the WORKSPACE .cargo/config.toml (not a crate-level file
+# cargo discovers by CWD), so every wasm32 build — this gate build AND the shipped wasm-pack build —
+# gets it identically. The `release-wasm` profile's `strip = "symbols"` REMOVES the tiny
+# `target_features` custom section that records the feature, so we cannot read it off the
+# byte-ratchet artifact directly. Instead we build ONE probe with stripping disabled
+# (CARGO_PROFILE_RELEASE_WASM_STRIP=none) — identical profile / config / target otherwise — and
+# assert its `target_features` section contains simd128. It shares the dependency compile cache with
+# the ratchet build (same target dir; only the final crate re-links), and it CLOBBERS the ratchet
+# `.wasm` at that path, so this must be called ONLY AFTER wasm_bundle_bytes (and wasm_opt) have read
+# the stripped artifact. HARD failure (exit 1) if simd128 is absent: a silent drop would ship the
+# gate build without SIMD while the crate-dir build had it (the exact parity gap this closes).
+# Skipped gracefully when the wasm target or python3 is unavailable — same posture as the byte metric.
+assert_wasm_simd128() {
+  rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  [ -f scripts/check-wasm-features.py ] || return 0
+  local probe="target/wasm32-unknown-unknown/release-wasm/sparq_wasm.wasm"
+  if CARGO_PROFILE_RELEASE_WASM_STRIP=none cargo build --profile release-wasm -q -p sparq-wasm --target wasm32-unknown-unknown 2>/dev/null; then
+    if [ -f "$probe" ] && ! python3 scripts/check-wasm-features.py "$probe" --require simd128; then
+      echo "ci-bench: FATAL — wasm gate build is missing +simd128 (workspace .cargo/config.toml regressed?)" >&2
+      exit 1
+    fi
+  fi
+}
+
 # [OPUS-4.8] (sq-dzfu) measure_parse — the TIMING metric (parse_ns_per_byte) over the FIXED corpus.
 # Factored out so BOTH the full run and the cheap `--parse-only` re-measure path use the IDENTICAL
 # measurement (min-of-5 parse timing on the deterministic byte count). Leaves $TMP/fe populated so the
@@ -285,6 +311,9 @@ if [ "$DET_ONLY" = "1" ]; then
       [ -n "${DET_WASM:-}" ] && add wasm_bundle_bytes bytes "$(wc -c < "$DET_WASM" | tr -d ' ')"
     fi
   fi
+  # [FABLE-5] (sq-3ul2n.2) assert the gate build carries +simd128 — AFTER wasm_bundle_bytes read the
+  # stripped artifact (this clobbers it with an unstripped probe; nothing below reuses it).
+  assert_wasm_simd128
   emit_json > "$OUT"
   echo "wrote $OUT (--deterministic-only):"; cat "$OUT"
   exit 0
@@ -1050,6 +1079,10 @@ if command -v wasm-opt >/dev/null 2>&1 && [ -n "${WASM_BIN:-}" ] && [ -f "${WASM
     add wasm_opt_bundle_bytes bytes "$(wc -c < "$WASM_OPT_OUT" | tr -d ' ')"
   fi
 fi
+
+# [FABLE-5] (sq-3ul2n.2) assert the gate build carries +simd128 — LAST, after wasm_bundle_bytes and
+# wasm_opt have read the stripped artifact ($WASM_BIN); this clobbers it with an unstripped probe.
+assert_wasm_simd128
 
 emit_json > "$OUT"
 echo "wrote $OUT:"; cat "$OUT"


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — recovered committed-but-unpushed epic-owner work from worktree `eo-simd-unify`; verification re-run before opening this PR.

Child bead: **sq-3ul2n.2** (browser WASM performance program, epic sq-3ul2n).

## What
- Move `-C target-feature=+simd128` from the crate-level `crates/sparq-wasm/.cargo/config.toml` (discovered only by CWD) into the workspace-root `.cargo/config.toml` under `[target.wasm32-unknown-unknown]`, merged with the existing `getrandom_backend` cfg; delete the crate-level file (a crate-level `rustflags` REPLACES the root one — keeping both silently drops a flag depending on build CWD).
- Closes a real parity gap: the root-invoked `wasm_bundle_bytes` gate build in `scripts/ci-bench.sh` (and sibling wasm crates) previously never got `+simd128`; only the crate-dir wasm-pack build did.
- Add `scripts/check-wasm-features.py` (stdlib-only): parses the `.wasm` `target_features` custom section and asserts a required feature (`--require simd128`, `--list`).
- Wire an `assert_wasm_simd128` guard into `ci-bench.sh` after both `wasm_bundle_bytes` reads (the `release-wasm` profile strips the `target_features` section, so the guard builds one unstripped probe via `CARGO_PROFILE_RELEASE_WASM_STRIP=none`).

## Verification (re-run at recovery)
- `python3 -m py_compile scripts/check-wasm-features.py` + `bash -n scripts/ci-bench.sh` — OK
- End-to-end on this branch: unstripped `release-wasm` probe build of `sparq-wasm` → guard reports `+simd128` present (full feature list: bulk-memory, multivalue, mutable-globals, nontrapping-fptoint, reference-types, sign-ext, simd128, …) — **GUARD-PASS**
- Non-vacuity: `--require relaxed-simd` (absent) exits 1 with a clear FAIL message
- No Rust source changed; rustflags are target-scoped (`wasm32-unknown-unknown`), native builds byte-identical. `scripts/` already covered by `ci/path-ownership.toml`.

## Honesty
No speed win claimed — simd128 is ~speed-neutral for sparq today (no hand-written vector kernels; research/hardware/consumer-and-targets.md §5). One small one-time DOWNWARD `wasm_bundle_bytes` shift expected; ratchet is mode=auto so it self-adjusts on merge.