### PR TITLE
test(vectors): property-test codebook algebra [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5124,6 +5124,7 @@ dependencies = [
  "instant-distance",
  "memmap2",
  "oxrdf 0.3.3",
+ "proptest",
  "rayon",
  "reqwest",
  "rustc-hash 2.1.3",

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -217,6 +217,7 @@ getrandom = { version = "0.3", features = ["wasm_js"] }
 # closures, so the LIBRARY stays decoupled — `sparq-sim` is a test/example dependency
 # only and never enters the published dependency graph.
 [dev-dependencies]
+proptest = "1"
 sparq-sim = { path = "../sparq-sim" }
 # [OPUS-4.8] sq-wlzi: DEV-only. The id-keyed-staleness-contract test (tests/staleness_contract.rs)
 # demonstrates the SOUND serving path — persist the build graph with `Graph::save`, reopen it with
@@ -240,6 +241,12 @@ rayon = { workspace = true }
 # OPTIONAL runtime dep (the `provider`/`embeddings` features) — listing it here makes it
 # available to the test targets in BOTH feature states, independent of those features.
 serde_json = "1"
+
+# [GPT-5.6] sq-lyf31: the codebook algebra property test exercises the opt-in
+# structure surface, so Cargo must skip that integration target in lean builds.
+[[test]]
+name = "proptest_quant"
+required-features = ["structure"]
 
 # [OPUS-4.8] sq-ip3a: the bench example measures HNSW (`VectorIndex`) recall/build, so it needs the
 # approximate backend. Gating it on `approx-ann` keeps `cargo build --all-targets` (default features)

--- a/crates/sparq-vectors/tests/proptest_quant.rs
+++ b/crates/sparq-vectors/tests/proptest_quant.rs
@@ -1,0 +1,107 @@
+//! Property tests for the categorical codebook's lossless member algebra.
+
+use std::collections::BTreeSet;
+
+use oxrdf::{Literal, NamedNode, Term};
+use proptest::collection::btree_set;
+use proptest::prelude::*;
+use proptest::strategy::ValueTree;
+use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+use sparq_vectors::{Codebook, INVALID_SLOT};
+
+// [GPT-5.6] sq-lyf31: retain the term kind in the generated identity so the
+// corpus exercises both RDF IRIs and literals while remaining distinct.
+fn term(kind: bool, id: u16) -> Term {
+    if kind {
+        Term::NamedNode(NamedNode::new_unchecked(format!(
+            "https://example.test/member/{id}"
+        )))
+    } else {
+        Term::Literal(Literal::new_simple_literal(format!("member-{id}")))
+    }
+}
+
+fn member_sets() -> impl Strategy<Value = (BTreeSet<u16>, BTreeSet<u16>)> {
+    (
+        btree_set(any::<u16>(), 1..12),
+        btree_set(any::<u16>(), 1..12),
+    )
+}
+
+#[test]
+fn codebook_member_algebra_holds_for_distinct_rdf_terms() {
+    let config = Config {
+        cases: 256,
+        ..Config::default()
+    };
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &[0x56; 32]);
+    let mut runner = TestRunner::new_with_rng(config, rng);
+
+    runner
+        .run(&member_sets(), |(iri_ids, literal_ids)| {
+            let members: Vec<Term> = iri_ids
+                .into_iter()
+                .map(|id| term(true, id))
+                .chain(literal_ids.into_iter().map(|id| term(false, id)))
+                .collect();
+            let codebook = Codebook::new(members.clone());
+
+            prop_assert_eq!(codebook.member_count(), members.len());
+            prop_assert_eq!(codebook.dim(), members.len() + 1);
+
+            let mut slots = BTreeSet::new();
+            for member in &members {
+                prop_assert!(codebook.is_member(member));
+                let slot = codebook.slot(member);
+                prop_assert!((1..codebook.dim()).contains(&slot));
+                prop_assert!(slots.insert(slot), "distinct members shared slot {slot}");
+                prop_assert_eq!(codebook.slot(member), slot, "slot was not stable");
+
+                let encoded = codebook.encode(member);
+                prop_assert_eq!(encoded.len(), codebook.dim());
+                prop_assert_eq!(codebook.decode(&encoded), Some(member.clone()));
+
+                let mut into = vec![f32::NAN; codebook.dim()];
+                codebook.encode_into(member, &mut into).unwrap();
+                prop_assert_eq!(
+                    into.iter().map(|value| value.to_bits()).collect::<Vec<_>>(),
+                    encoded
+                        .iter()
+                        .map(|value| value.to_bits())
+                        .collect::<Vec<_>>()
+                );
+            }
+            prop_assert_eq!(slots.len(), codebook.member_count());
+
+            let outsider = Term::NamedNode(NamedNode::new_unchecked(
+                "https://example.test/definitely-not-a-member",
+            ));
+            prop_assert!(!codebook.is_member(&outsider));
+            prop_assert_eq!(codebook.slot(&outsider), INVALID_SLOT);
+            let invalid_block = codebook.encode(&outsider);
+            prop_assert!(members
+                .iter()
+                .all(|member| codebook.encode(member) != invalid_block));
+            prop_assert_eq!(codebook.decode(&invalid_block), None);
+            prop_assert_eq!(codebook.decode(&vec![0.0; codebook.dim()]), None);
+            Ok(())
+        })
+        .expect("deterministically generated codebook must satisfy its algebra");
+}
+
+#[test]
+fn deterministic_generator_is_non_vacuous() {
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &[0x56; 32]);
+    let mut runner = TestRunner::new_with_rng(Config::default(), rng);
+    let (iri_ids, literal_ids) = member_sets().new_tree(&mut runner).unwrap().current();
+
+    assert!(!iri_ids.is_empty(), "IRI member path must be exercised");
+    assert!(
+        !literal_ids.is_empty(),
+        "literal member path must be exercised"
+    );
+    assert!(
+        iri_ids.len() + literal_ids.len() >= 2,
+        "slot injectivity needs two members"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-lyf31.

Adds deterministic property coverage for the structure-gated categorical Codebook:
- member encode/decode identity and membership
- stable, in-range, injective slots
- dimension and byte-exact encode_into equivalence
- reserved and all-zero non-member decode paths
- explicit IRI/literal generator non-vacuity

Mutation witness: forcing Codebook::slot to return INVALID_SLOT makes proptest_quant fail on the in-range member-slot assertion; restoring the implementation makes it green.

Gates:
- cargo clippy -p sparq-vectors --all-targets -- -D warnings
- cargo clippy -p sparq-vectors --all-targets --features structure -- -D warnings
- cargo test -p sparq-vectors
- cargo test -p sparq-vectors --features structure
- RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-vectors --no-deps --all-features
- cargo test -p sparq-vectors --features structure --test proptest_quant