### PR TITLE
bench(reason-ql): add end-to-end answer gate [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4886,6 +4886,8 @@ dependencies = [
  "oxttl 0.2.3",
  "rustc-hash 2.1.3",
  "spargebra",
+ "sparq-core",
+ "sparq-engine",
 ]
 
 [[package]]

--- a/bench/reason-ql-e2e/README.md
+++ b/bench/reason-ql-e2e/README.md
@@ -1,0 +1,24 @@
+# OWL 2 QL end-to-end comparison
+
+<!-- [GPT-5.6] sq-mg1wx -->
+
+This gather-only harness compares complete query answering: sparq rewrites each CQ and then executes
+the emitted UCQ over a materialized ABox; Ontop rewrites and executes against an equivalent mapped
+store. The embedded fixtures use NPD/Requiem-class shapes, not redistributed upstream corpora.
+
+Run the hermetic smoke gate:
+
+```sh
+bash bench/reason-ql-e2e/run.sh --smoke
+```
+
+For a quiet-box sparq measurement, omit `--smoke`. To add Ontop, provide a gathered TSV whose columns
+are `case`, `answers`, and `end_to_end_ms`:
+
+```sh
+ONTOP_RESULTS=/path/to/ontop.tsv bash bench/reason-ql-e2e/run.sh
+```
+
+Both implementations must agree with `expected.tsv` before the script prints any timing row. The
+sparq rewriter-phase and end-to-end columns are deliberately distinct. Durations are non-canonical
+and must be regenerated on the intended measurement host.

--- a/bench/reason-ql-e2e/expected.tsv
+++ b/bench/reason-ql-e2e/expected.tsv
@@ -1,0 +1,5 @@
+case	answers
+npd-class	3
+npd-role	3
+requiem-inverse	2
+requiem-join	2

--- a/bench/reason-ql-e2e/run.sh
+++ b/bench/reason-ql-e2e/run.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# [GPT-5.6] sq-mg1wx: correctness-first OWL 2 QL end-to-end comparison driver.
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+mode="${1:-}"
+out="$(mktemp)"
+trap 'rm -f "$out"' EXIT
+
+cargo_args=(run -p sparq-reason-ql --example ql_endtoend_bench --features experimental)
+if [[ "$mode" != "--smoke" ]]; then
+  cargo_args+=(--release)
+fi
+(cd "$root" && cargo "${cargo_args[@]}") >"$out"
+
+# The answer gate consumes the complete output before any timing report is rendered.
+awk -F '\t' '
+  NR==FNR { if (FNR > 1) expected[$1]=$2; next }
+  FNR==1 { next }
+  { seen[$1]=1; if (!($1 in expected) || $2 != expected[$1]) bad=1 }
+  END {
+    for (id in expected) if (!(id in seen)) bad=1
+    if (bad) exit 1
+  }
+' "$here/expected.tsv" "$out" || {
+  echo "FAIL: sparq answer-set sizes differ from expected.tsv; timing suppressed" >&2
+  exit 1
+}
+
+ontop_file="${ONTOP_RESULTS:-}"
+if [[ -n "$ontop_file" ]]; then
+  awk -F '\t' '
+    NR==FNR { if (FNR > 1) expected[$1]=$2; next }
+    FNR==1 { next }
+    { seen[$1]=1; if (!($1 in expected) || $2 != expected[$1]) bad=1 }
+    END { for (id in expected) if (!(id in seen)) bad=1; if (bad) exit 1 }
+  ' "$here/expected.tsv" "$ontop_file" || {
+    echo "FAIL: Ontop answer-set sizes differ from expected.tsv; timing suppressed" >&2
+    exit 1
+  }
+fi
+
+printf 'case\tanswers\tsparq_rewriter_phase_ms\tsparq_end_to_end_ms\tontop_end_to_end_ms\n'
+awk -F '\t' -v ontop="$ontop_file" '
+  BEGIN {
+    if (ontop != "") while ((getline line < ontop) > 0) {
+      split(line, f, "\t"); if (f[1] != "case") ontop_ms[f[1]]=f[3]
+    }
+  }
+  FNR==1 { next }
+  { competitor=(($1 in ontop_ms) ? ontop_ms[$1] : "NA"); print $1 "\t" $2 "\t" $3 "\t" $4 "\t" competitor }
+' "$out"

--- a/crates/sparq-reason-ql/Cargo.toml
+++ b/crates/sparq-reason-ql/Cargo.toml
@@ -61,6 +61,8 @@ rustc-hash.workspace = true
 # `Vec<oxrdf::Triple>`. Not a runtime dependency: the rewriter takes triples from the caller,
 # which sparq already parses via sparq-core. Keeps the runtime dep surface to spargebra/oxrdf.
 oxttl.workspace = true
+sparq-core = { path = "../sparq-core" }
+sparq-engine = { path = "../sparq-engine" }
 
 # The DL-Lite-oracle differential tests are `#![cfg(feature = "experimental")]` — they exercise
 # the gated rewriter. Without `experimental` they compile empty (and the default-build archive,
@@ -74,4 +76,9 @@ oxttl.workspace = true
 # benchmark (bench/benchmarks.toml: reason-ql-rewrite).
 [[example]]
 name = "ql_rewrite_bench"
+required-features = ["experimental"]
+
+# [GPT-5.6] sq-mg1wx: hermetic rewrite-then-execute correctness/measurement harness.
+[[example]]
+name = "ql_endtoend_bench"
 required-features = ["experimental"]

--- a/crates/sparq-reason-ql/examples/ql_endtoend_bench.rs
+++ b/crates/sparq-reason-ql/examples/ql_endtoend_bench.rs
@@ -1,0 +1,93 @@
+//! [GPT-5.6] sq-mg1wx: hermetic OWL 2 QL rewrite-then-execute benchmark.
+//!
+//! The fixture shapes mirror the shallow hierarchy, inverse-role, and conjunctive-query forms
+//! found in NPD/Requiem-style OBDA suites. Every answer count is asserted before its timing row is
+//! printed, so a semantic regression cannot be hidden by a plausible duration.
+
+use oxrdf::Triple;
+use spargebra::{Query, SparqlParser};
+use sparq_core::Graph;
+use sparq_reason_ql::rewrite_production;
+use std::time::Instant;
+
+const PREFIXES: &str = "PREFIX : <http://ex/> PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> PREFIX owl: <http://www.w3.org/2002/07/owl#> PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ";
+const TURTLE_PREFIXES: &str = "@prefix : <http://ex/> . @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . @prefix owl: <http://www.w3.org/2002/07/owl#> . ";
+
+struct Case {
+    id: &'static str,
+    query: &'static str,
+    expected: usize,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        id: "npd-class",
+        query: "SELECT DISTINCT ?x WHERE { ?x a :Asset }",
+        expected: 3,
+    },
+    Case {
+        id: "npd-role",
+        query: "SELECT DISTINCT ?x ?y WHERE { ?x :relatedTo ?y }",
+        expected: 3,
+    },
+    Case {
+        id: "requiem-inverse",
+        query: "SELECT DISTINCT ?company ?worker WHERE { ?company :employs ?worker }",
+        expected: 2,
+    },
+    Case {
+        id: "requiem-join",
+        query: "SELECT DISTINCT ?x WHERE { ?x a :Employee . ?x :worksFor ?c }",
+        expected: 2,
+    },
+];
+
+fn tbox() -> Vec<Triple> {
+    let ttl = format!(
+        "{TURTLE_PREFIXES} :Platform rdfs:subClassOf :Asset . :Well rdfs:subClassOf :Asset . :connectedTo rdfs:subPropertyOf :relatedTo . :linkedTo rdfs:subPropertyOf :relatedTo . :employs owl:inverseOf :worksFor . :Manager rdfs:subClassOf :Employee ."
+    );
+    oxttl::TurtleParser::new()
+        .for_reader(ttl.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .expect("embedded TBox must parse")
+}
+
+fn abox() -> Graph {
+    Graph::load_str(
+        "@prefix : <http://ex/> . :p1 a :Platform . :w1 a :Well . :a1 a :Asset . :p1 :connectedTo :w1 . :w1 :linkedTo :a1 . :a1 :relatedTo :p1 . :alice a :Manager ; :worksFor :acme . :bob a :Employee ; :worksFor :acme . :carol a :Employee .",
+        "turtle",
+    )
+    .expect("embedded ABox must parse")
+}
+
+fn parse(body: &str) -> Query {
+    SparqlParser::new()
+        .parse_query(&format!("{PREFIXES}{body}"))
+        .expect("embedded query must parse")
+}
+
+fn main() {
+    let schema = tbox();
+    let data = abox();
+    println!("case\tanswers\trewriter_phase_ms\tend_to_end_ms");
+    for case in CASES {
+        let started = Instant::now();
+        let rewrite_started = Instant::now();
+        let rewritten = rewrite_production(&parse(case.query), &schema)
+            .unwrap_or_else(|error| panic!("{} rewrite failed: {error}", case.id));
+        let rewrite_ms = rewrite_started.elapsed().as_secs_f64() * 1_000.0;
+        let answers = sparq_engine::count(&data, &rewritten.query.to_string())
+            .unwrap_or_else(|error| panic!("{} execution failed: {error}", case.id));
+
+        assert_eq!(
+            answers, case.expected,
+            "{} answer-set-size mismatch (timing row suppressed)",
+            case.id
+        );
+        let end_to_end_ms = started.elapsed().as_secs_f64() * 1_000.0;
+        println!(
+            "{}\t{}\t{rewrite_ms:.6}\t{end_to_end_ms:.6}",
+            case.id, answers
+        );
+    }
+}

--- a/research/gap-reason-ql-e2e-2026-07.md
+++ b/research/gap-reason-ql-e2e-2026-07.md
@@ -1,0 +1,30 @@
+# OWL 2 QL end-to-end answering: first-read gap record
+
+<!-- [GPT-5.6] sq-mg1wx -->
+
+**Bead:** `sq-mg1wx`  
+**Status:** non-canonical, gather-only comparison
+
+## Fixed-vocabulary verdict
+
+**PARTIAL — local correctness gate built; external Ontop timings not gathered.** sparq now has a
+hermetic rewrite-then-execute harness over NPD/Requiem-class query shapes. It self-asserts per-query
+answer-set sizes before exposing durations. Ontop remains an external gather column and no comparative
+performance verdict is claimed until equivalent mappings, data, and a pinned Ontop build are run.
+
+## Measurement boundary
+
+The result table labels two different quantities:
+
+- **rewriter phase**: only `rewrite_production`;
+- **end to end**: query parse, rewrite, and UCQ execution over the materialized ABox.
+
+Ontop's column is end-to-end only. It must not be compared with sparq's rewriter-phase column. The
+deterministic evidence is answer-set-size agreement with `bench/reason-ql-e2e/expected.tsv`; elapsed
+times are non-canonical observations from the gathering host.
+
+## Fixture coverage and limits
+
+The hermetic corpus covers shallow class and role hierarchies, inverse roles, and a conjunctive join.
+These are representative NPD/Requiem-class shapes, not a claim of complete coverage of either corpus.
+The gate compares answer-set sizes; the `DISTINCT` queries make that an answer-set cardinality oracle.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements `sq-mg1wx`.

Adds an opt-in `experimental` rewrite-then-execute example over NPD/Requiem-class fixtures, a self-asserting answer-size gate that runs before timing output, and a gather-only Ontop end-to-end column. Rewriter-phase and end-to-end durations remain explicitly separate. The first-read research record uses a fixed-vocabulary PARTIAL verdict and makes no canonical performance claim.

Gates:
- `cargo test -p sparq-reason-ql`
- `cargo test -p sparq-reason-ql --features experimental`
- `cargo clippy -p sparq-reason-ql --all-targets -- -D warnings`
- `cargo clippy -p sparq-reason-ql --all-targets --features experimental -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-reason-ql --no-deps --all-features`
- `bash bench/reason-ql-e2e/run.sh --smoke`
- `npx --yes markdownlint-cli2@0.18.1 bench/reason-ql-e2e/README.md research/gap-reason-ql-e2e-2026-07.md`
- mutation witness: corrupting one expected count made the smoke gate fail before timing output

Not armed or merged.