### PR TITLE
perf(canon): add low-copy bridge writer [GPT-5.6]

### DIFF
--- a/crates/sparq-canon/Cargo.toml
+++ b/crates/sparq-canon/Cargo.toml
@@ -64,6 +64,9 @@ sha2 = { version = "0.10", optional = true }
 # for native; a wasm consumer disables it via `default-features = false`.
 default = ["parallel"]
 parallel = ["sparq-core/parallel"]
+# [GPT-5.6] sq-occip: reuse one N-Quads bridge buffer instead of allocating a
+# temporary String for every serialized quad. OFF by default; text is identical.
+bridge-lowcopy = []
 # NON-STANDARD, OFF BY DEFAULT. RDF-1.2 triple-term canonicalization: a native
 # RDFC-1.0 re-implementation over oxrdf-0.3 whose Hash-N-Degree-Quads descent
 # reaches blank nodes nested inside `Term::Triple` objects. This is NOT W3C

--- a/crates/sparq-canon/src/lib.rs
+++ b/crates/sparq-canon/src/lib.rs
@@ -398,6 +398,17 @@ pub fn graph_triples(g: &Graph) -> Result<Vec<Triple>, CanonError> {
 /// literal word `DEFAULT`, so the default graph is emitted explicitly as a
 /// 3-term line.
 fn bridge_to_02(dataset: &[Quad]) -> Result<Vec<oxrdf02::Quad>, CanonError> {
+    let doc = serialize_quads(dataset)?;
+    parse_02(&doc)
+}
+
+#[cfg(not(feature = "bridge-lowcopy"))]
+fn serialize_quads(dataset: &[Quad]) -> Result<String, CanonError> {
+    serialize_quads_default(dataset)
+}
+
+#[cfg(any(not(feature = "bridge-lowcopy"), test))]
+fn serialize_quads_default(dataset: &[Quad]) -> Result<String, CanonError> {
     let mut doc = String::new();
     for q in dataset {
         if matches!(q.object, oxrdf::Term::Triple(_)) {
@@ -415,13 +426,44 @@ fn bridge_to_02(dataset: &[Quad]) -> Result<Vec<oxrdf02::Quad>, CanonError> {
             }
         }
     }
-    parse_02(&doc)
+    Ok(doc)
+}
+
+/// [GPT-5.6] sq-occip: serialize directly into one reusable buffer. `String`'s
+/// `fmt::Write` implementation is infallible, so the expectation cannot fire.
+#[cfg(feature = "bridge-lowcopy")]
+fn serialize_quads(dataset: &[Quad]) -> Result<String, CanonError> {
+    use std::fmt::Write as _;
+
+    let mut doc = String::new();
+    for q in dataset {
+        if matches!(q.object, oxrdf::Term::Triple(_)) {
+            return Err(CanonError::TripleTerm);
+        }
+        match &q.graph_name {
+            GraphName::DefaultGraph => {
+                writeln!(doc, "{} {} {} .", q.subject, q.predicate, q.object)
+                    .expect("writing to a String cannot fail");
+            }
+            g => {
+                writeln!(doc, "{} {} {} {} .", q.subject, q.predicate, q.object, g)
+                    .expect("writing to a String cannot fail");
+            }
+        }
+    }
+    Ok(doc)
 }
 
 fn bridge_triples_to_02(triples: &[Triple]) -> Result<Vec<oxrdf02::Quad>, CanonError> {
     let mut doc = String::new();
+    #[cfg(feature = "bridge-lowcopy")]
+    use std::fmt::Write as _;
     for t in triples {
+        #[cfg(not(feature = "bridge-lowcopy"))]
         doc.push_str(&format!("{} {} {} .\n", t.subject, t.predicate, t.object));
+        #[cfg(feature = "bridge-lowcopy")]
+        writeln!(doc, "{} {} {} .", t.subject, t.predicate, t.object)
+            .expect("writing to a String cannot fail");
     }
     parse_02(&doc)
 }
@@ -483,6 +525,36 @@ mod tests {
 
     fn iri(s: &str) -> NamedNode {
         NamedNode::new(s).unwrap()
+    }
+
+    /// [GPT-5.6] sq-occip: witnesses that the opt-in writer preserves every
+    /// interchange byte and therefore the canonical result, including blank
+    /// nodes, escaped literals, default graphs, and named graphs.
+    #[cfg(feature = "bridge-lowcopy")]
+    #[test]
+    fn lowcopy_bridge_is_byte_identical_to_default() {
+        let datasets = [
+            parse_nquads_03("<http://ex/s> <http://ex/p> \"plain\" .\n").unwrap(),
+            parse_nquads_03(
+                "_:a <http://ex/p> _:b .\n_:b <http://ex/q> \"line\\nquote\\\"\"@en .\n",
+            )
+            .unwrap(),
+            parse_nquads_03(
+                "_:a <http://ex/p> <http://ex/o> <http://ex/g> .\n\
+                 <http://ex/s> <http://ex/p> _:a <http://ex/g> .\n",
+            )
+            .unwrap(),
+        ];
+
+        for dataset in datasets {
+            let default_doc = serialize_quads_default(&dataset).unwrap();
+            let lowcopy_doc = serialize_quads(&dataset).unwrap();
+            assert_eq!(lowcopy_doc.as_bytes(), default_doc.as_bytes());
+
+            let default_quads = parse_02(&default_doc).unwrap();
+            let default_canonical = rdf_canon::canonicalize_quads(&default_quads).unwrap();
+            assert_eq!(canonicalize(&dataset).unwrap(), default_canonical);
+        }
     }
 
     // [OPUS-4.8] sq-qcnn.14 — direct unit tests per public fn, asserting exact values.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes bead `sq-occip`.

Adds the OFF-by-default `bridge-lowcopy` feature. When enabled, the oxrdf 0.3 → N-Quads bridge writes terms directly into one reused `String`; the default serialization path and oxrdf 0.2 parse side remain unchanged.

The feature-only equivalence test covers default/named graphs, blank nodes, and escaped literals, asserting byte-identical bridge text and identical final canonical output. A deliberate one-byte mutation made this test fail before restoration.

Gates:
- `cargo test -p sparq-canon`
- `cargo test -p sparq-canon --features bridge-lowcopy`
- `cargo clippy -p sparq-canon --all-targets -- -D warnings`
- `cargo clippy -p sparq-canon --all-targets --features bridge-lowcopy -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-canon --no-deps --all-features`
- `git diff --check`