### PR TITLE
site: add captured CLI walkthrough [GPT-5.6]

### DIFF
--- a/site/src/components/cli-walkthrough.tsx
+++ b/site/src/components/cli-walkthrough.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+// [GPT-5.6] sq-j4woz — the CLI surface walkthrough. The site is static and has no
+// backend, so this component REPLAYS real, verbatim sparq-cli captures rather than
+// pretending to execute commands. See src/lib/cli.ts for the declared fixture and the
+// stdout/stderr honesty contract; site/test/cli.test.mjs pins their exact serialization.
+
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CLI_CAPTURES } from "@/lib/cli";
+
+export function CliWalkthrough() {
+  const [selected, setSelected] = React.useState(0);
+  const capture = CLI_CAPTURES[selected];
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="text-xl font-semibold">sparq CLI walkthrough</h2>
+          <Badge variant="success" className="text-[10px] uppercase">
+            real captured output
+          </Badge>
+        </div>
+        <p className="measure text-sm text-muted-foreground">
+          Pick a subcommand to replay its recorded stdout and stderr over the
+          declared four-triple fixture. Nothing runs in your browser.
+        </p>
+      </div>
+
+      <div
+        className="flex flex-wrap gap-2"
+        role="group"
+        aria-label="CLI subcommand"
+      >
+        {CLI_CAPTURES.map((item, index) => (
+          <Button
+            key={item.id}
+            size="sm"
+            variant={index === selected ? "default" : "outline"}
+            aria-pressed={index === selected}
+            onClick={() => setSelected(index)}
+          >
+            {item.label}
+          </Button>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader className="space-y-1">
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="font-mono text-base">
+              {capture.label}
+            </CardTitle>
+            <Badge
+              variant="outline"
+              className="font-mono text-[10px] uppercase"
+            >
+              captured replay
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">{capture.description}</p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div>
+            <div className="mb-1 text-xs font-medium text-muted-foreground">
+              command
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed">
+              <span className="select-none text-muted-foreground">$ </span>
+              {capture.command}
+            </pre>
+          </div>
+          {capture.stdout && (
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">
+                stdout
+              </div>
+              <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed">
+                {capture.stdout}
+              </pre>
+            </div>
+          )}
+          {capture.stderr && (
+            <div>
+              <div className="mb-1 text-xs font-medium text-muted-foreground">
+                stderr
+              </div>
+              <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12px] leading-relaxed text-muted-foreground">
+                {capture.stderr}
+              </pre>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/site/src/lib/cli.ts
+++ b/site/src/lib/cli.ts
@@ -1,0 +1,74 @@
+// [GPT-5.6] sq-j4woz — framework-free captured CLI data for the static site.
+//
+// HONESTY CONTRACT: GitHub Pages has no sparq backend. Every stdout/stderr string below
+// was captured verbatim by running its exact `command` from the repository root against
+// CLI_FIXTURE. The two streams remain separate so the UI cannot blur diagnostics into
+// query results. Re-run the commands and replace the captures; never invent output.
+
+export const CLI_FIXTURE =
+  `<http://example.org/Researcher> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/Person> .
+<http://example.org/alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://example.org/Researcher> .
+<http://example.org/alice> <http://example.org/knows> <http://example.org/bob> .
+<http://example.org/bob> <http://example.org/knows> <http://example.org/carol> .
+` as const;
+
+export interface CliCapture {
+  id: "query" | "reason" | "build" | "query-mmap";
+  label: string;
+  description: string;
+  command: string;
+  stdout: string;
+  stderr: string;
+}
+
+export const CLI_CAPTURES: readonly CliCapture[] = [
+  {
+    id: "query",
+    label: "query",
+    description: "Load N-Triples in memory and emit W3C TSV bindings.",
+    command:
+      'cargo run -q -p sparq-cli -- query site/cli-demo.nt ntriples "SELECT ?person WHERE { ?person a <http://example.org/Researcher> }" --format tsv',
+    stdout: `?person
+<http://example.org/alice>
+`,
+    stderr:
+      "loaded 4 triples in 0.016s (0.00 M/s) | store ~0.00 GB (271 B/triple), dict ~0.00 GB (8 terms, 92 B/term)\n",
+  },
+  {
+    id: "reason",
+    label: "reason",
+    description:
+      "Materialize the RDFS closure, including Alice's inferred Person type.",
+    command:
+      "cargo run -q -p sparq-cli -- reason site/cli-demo.nt ntriples rdfs",
+    stdout: "5 triples after rdfs reasoning\n",
+    stderr: "reasoned [Rdfs]: 4 -> 5 triples (+1 entailed) in 0.000s\n",
+  },
+  {
+    id: "build",
+    label: "build",
+    description: "Build external-memory indexes for mmap-backed querying.",
+    command:
+      "cargo run -q -p sparq-cli -- build site/cli-demo.nt ntriples /tmp/sparq-cli-demo-index 1",
+    stdout: "",
+    stderr:
+      "built on-disk indexes in /tmp/sparq-cli-demo-index in 0.0s (external-memory, 1M-triple runs)\n",
+  },
+  {
+    id: "query-mmap",
+    label: "query-mmap",
+    description:
+      "Open the persisted indexes with mmap and run the same SELECT.",
+    command:
+      'cargo run -q -p sparq-cli -- query-mmap /tmp/sparq-cli-demo-index "SELECT ?person WHERE { ?person a <http://example.org/Researcher> }" --format tsv',
+    stdout: `?person
+<http://example.org/alice>
+`,
+    stderr:
+      "opened 4 triples (indexes MEMORY-MAPPED) in 0.005s | store-heap ~0.00 GB (mmap'd perms not counted), dict ~0.00 GB\n",
+  },
+] as const;
+
+export function captureById(id: CliCapture["id"]): CliCapture | undefined {
+  return CLI_CAPTURES.find((capture) => capture.id === id);
+}

--- a/site/test/cli.test.mjs
+++ b/site/test/cli.test.mjs
@@ -1,0 +1,60 @@
+// [GPT-5.6] sq-j4woz — pins the real sparq-cli transcripts used by the static walkthrough.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { CLI_CAPTURES, CLI_FIXTURE, captureById } from "../src/lib/cli.ts";
+
+test("the declared fixture is the exact four-triple capture input", () => {
+  assert.equal(CLI_FIXTURE.split("\n").filter(Boolean).length, 4);
+  assert.match(CLI_FIXTURE, /rdf-schema#subClassOf/);
+  assert.match(CLI_FIXTURE, /rdf-syntax-ns#type/);
+});
+
+test("the four exact cargo-run command shapes are pinned", () => {
+  assert.deepEqual(
+    CLI_CAPTURES.map(({ id, command }) => [id, command]),
+    [
+      [
+        "query",
+        'cargo run -q -p sparq-cli -- query site/cli-demo.nt ntriples "SELECT ?person WHERE { ?person a <http://example.org/Researcher> }" --format tsv',
+      ],
+      [
+        "reason",
+        "cargo run -q -p sparq-cli -- reason site/cli-demo.nt ntriples rdfs",
+      ],
+      [
+        "build",
+        "cargo run -q -p sparq-cli -- build site/cli-demo.nt ntriples /tmp/sparq-cli-demo-index 1",
+      ],
+      [
+        "query-mmap",
+        'cargo run -q -p sparq-cli -- query-mmap /tmp/sparq-cli-demo-index "SELECT ?person WHERE { ?person a <http://example.org/Researcher> }" --format tsv',
+      ],
+    ],
+  );
+  for (const capture of CLI_CAPTURES) {
+    assert.match(capture.command, /^cargo run -q -p sparq-cli -- /);
+    assert.ok(
+      !capture.command.includes("\n"),
+      `${capture.id}: command must be one shell line`,
+    );
+  }
+});
+
+test("stdout and stderr serialization is byte-for-byte pinned", () => {
+  assert.equal(
+    JSON.stringify(
+      CLI_CAPTURES.map(({ id, stdout, stderr }) => ({ id, stdout, stderr })),
+    ),
+    '[{"id":"query","stdout":"?person\\n<http://example.org/alice>\\n","stderr":"loaded 4 triples in 0.016s (0.00 M/s) | store ~0.00 GB (271 B/triple), dict ~0.00 GB (8 terms, 92 B/term)\\n"},{"id":"reason","stdout":"5 triples after rdfs reasoning\\n","stderr":"reasoned [Rdfs]: 4 -> 5 triples (+1 entailed) in 0.000s\\n"},{"id":"build","stdout":"","stderr":"built on-disk indexes in /tmp/sparq-cli-demo-index in 0.0s (external-memory, 1M-triple runs)\\n"},{"id":"query-mmap","stdout":"?person\\n<http://example.org/alice>\\n","stderr":"opened 4 triples (indexes MEMORY-MAPPED) in 0.005s | store-heap ~0.00 GB (mmap\'d perms not counted), dict ~0.00 GB\\n"}]',
+  );
+});
+
+test("captures preserve stream shape and mmap/query result parity", () => {
+  for (const capture of CLI_CAPTURES) {
+    assert.ok(capture.stdout.endsWith("\n") || capture.stdout === "");
+    assert.ok(capture.stderr.endsWith("\n") || capture.stderr === "");
+  }
+  assert.equal(captureById("query").stdout, captureById("query-mmap").stdout);
+  assert.equal(captureById("build").stdout, "");
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements sq-j4woz.

Adds the three-file CLI content cluster: framework-free verbatim sparq-cli captures for query, reason, build, and query-mmap; a static-site replay component; and byte-exact serialization tests. The four commands were run against the declared four-triple fixture, with stdout and stderr preserved separately.

Gates:
- npm run test:unit -- test/cli.test.mjs (340 passing)
- focused cli.test.mjs (4 passing)
- npm run typecheck
- scoped next lint
- Prettier and git diff --check
- mutation witness: changing one captured timing byte fails the serialization pin

No IA wiring is included, per the parallel-safe bead scope.