### PR TITLE
test(geo): add geof metamorphic algebra laws [GPT-5.6]

### DIFF
--- a/crates/sparq-geo/tests/geof_metamorph.rs
+++ b/crates/sparq-geo/tests/geof_metamorph.rs
@@ -1,0 +1,97 @@
+//! Metamorphic laws for the pure Simple Features operations. [GPT-5.6]
+
+use geo_types::{Coord, Geometry, LineString, Point, Polygon};
+use proptest::prelude::*;
+use sparq_geo::geof::{
+    distance, envelope, sf_contains, sf_disjoint, sf_equals, sf_intersects, sf_overlaps, sf_within,
+    Unit,
+};
+use sparq_geo::{Crs, GeoGeometry};
+
+fn coordinate() -> impl Strategy<Value = Coord<f64>> {
+    (-1_000_000.0f64..1_000_000.0, -1_000_000.0f64..1_000_000.0).prop_map(|(x, y)| Coord { x, y })
+}
+
+fn geometry() -> impl Strategy<Value = Geometry<f64>> {
+    let point = coordinate().prop_map(|c| Geometry::Point(Point(c)));
+    let line = prop::collection::vec(coordinate(), 2..=8)
+        .prop_map(|coords| Geometry::LineString(LineString::new(coords)));
+    let polygon = (
+        -1_000_000.0f64..1_000_000.0,
+        -1_000_000.0f64..1_000_000.0,
+        0.000_001f64..10_000.0,
+        0.000_001f64..10_000.0,
+    )
+        .prop_map(|(x, y, width, height)| {
+            Geometry::Polygon(Polygon::new(
+                LineString::from(vec![
+                    (x, y),
+                    (x + width, y),
+                    (x + width, y + height),
+                    (x, y + height),
+                    (x, y),
+                ]),
+                vec![],
+            ))
+        });
+
+    prop_oneof![point, line, polygon]
+}
+
+fn geo_geometry() -> impl Strategy<Value = GeoGeometry> {
+    geometry().prop_map(|geometry| GeoGeometry {
+        crs: Crs::Crs84,
+        geometry,
+    })
+}
+
+proptest! {
+    #[test]
+    fn symmetric_relations_and_negation(
+        a in geo_geometry(),
+        b in geo_geometry(),
+    ) {
+        let intersects_ab = sf_intersects(&a, &b)?;
+        let intersects_ba = sf_intersects(&b, &a)?;
+        let disjoint_ab = sf_disjoint(&a, &b)?;
+
+        prop_assert_eq!(intersects_ab, intersects_ba);
+        prop_assert_eq!(disjoint_ab, sf_disjoint(&b, &a)?);
+        prop_assert_eq!(sf_equals(&a, &b)?, sf_equals(&b, &a)?);
+        prop_assert_eq!(sf_overlaps(&a, &b)?, sf_overlaps(&b, &a)?);
+        prop_assert_eq!(disjoint_ab, !intersects_ab);
+    }
+
+    #[test]
+    fn within_and_contains_are_dual(a in geo_geometry(), b in geo_geometry()) {
+        prop_assert_eq!(sf_within(&a, &b)?, sf_contains(&b, &a)?);
+        prop_assert_eq!(sf_contains(&a, &b)?, sf_within(&b, &a)?);
+    }
+
+    #[test]
+    fn equality_and_disjointness_are_reflexive_laws(a in geo_geometry()) {
+        prop_assert!(sf_equals(&a, &a)?);
+        prop_assert!(!sf_disjoint(&a, &a)?);
+    }
+
+    #[test]
+    fn distance_is_symmetric_and_non_negative(
+        a in geo_geometry(),
+        b in geo_geometry(),
+    ) {
+        let ab = distance(&a, &b, Unit::Degree)?;
+        let ba = distance(&b, &a, Unit::Degree)?;
+
+        prop_assert_eq!(ab, ba);
+        prop_assert!(ab >= 0.0);
+    }
+
+    #[test]
+    fn envelope_is_idempotent(g in geo_geometry()) {
+        let once = envelope(&g)?;
+        prop_assume!(sf_equals(&once, &once)?);
+        let twice = envelope(&once)?;
+
+        prop_assert!(sf_equals(&once, &twice)?);
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-ojg3q.

Adds algebraic property coverage for the pure GeoSPARQL Simple Features functions:

- symmetric intersection, disjointness, equality, and overlap
- disjoint/intersects negation and within/contains duality
- equality/disjointness reflexive laws
- symmetric, non-negative distance
- topologically idempotent envelopes, excluding degenerate envelopes rejected by the topology predicate

The geometry generator mirrors the existing bounded point/line/polygon proptest strategy. This is an internal metamorphic mechanism, independent of the existing differential-oracle and fixed-corpus tests.

Gates:

- `cargo clippy -p sparq-geo --all-targets -- -D warnings`
- `cargo clippy -p sparq-geo --all-targets --all-features -- -D warnings`
- `cargo test -p sparq-geo`
- `cargo test -p sparq-geo --all-features`
- `cargo test -p sparq-geo --no-default-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-geo --no-deps --all-features`
- mutation witness: inverting the disjoint/intersects negation assertion makes the targeted property fail and minimize immediately
