### PR TITLE
test(solid): cover control-document authorization vectors (sq-61uvs) [GPT-5.6]

### DIFF
--- a/crates/sparq-solid/tests/common/acp.rs
+++ b/crates/sparq-solid/tests/common/acp.rs
@@ -187,6 +187,25 @@ fn mode_independence() -> AcpScenario {
         .expect(Expect::agent(ALICE).write(ro).is(Decision::Deny))
 }
 
+/// [GPT-5.6] sq-61uvs: the ACP analogue exercises the ACR as a resource. Unlike WAC,
+/// ACP does not translate Control on the governed resource into Read/Write on its ACR;
+/// nor may a member Read policy disclose the control document.
+fn acr_document_control_gate() -> AcpScenario {
+    let container = "https://pod.example/control/";
+    let acr_doc = "https://pod.example/control/.acr";
+    let mut acr = AcrBuilder::new();
+    acr.access_control(container, |p| p.allow(Mode::Control).any_of_agent(ALICE));
+    acr.member_access_control(container, |p| p.allow(Mode::Read).any_of_agent(BOB));
+    acr.document(container);
+    AcpScenario::new("acr-document-control-gate")
+        .acr(acr)
+        .expect(Expect::agent(ALICE).control(container).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).read(acr_doc).is(Decision::Deny))
+        .expect(Expect::agent(ALICE).write(acr_doc).is(Decision::Deny))
+        .expect(Expect::agent(BOB).read(acr_doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(acr_doc).is(Decision::Deny))
+}
+
 /// ACP fail-closed: a resource with NO access control grants nobody (not even the
 /// anonymous requestor, not any authenticated agent). An unprotected resource is
 /// invisible.
@@ -233,6 +252,7 @@ pub fn acp_corpus() -> Vec<AcpScenario> {
         member_access_control_inheritance(),
         cumulative_inheritance(),
         mode_independence(),
+        acr_document_control_gate(),
         fail_closed_no_policy(),
         anyof_disjunction(),
     ]

--- a/crates/sparq-solid/tests/common/mod.rs
+++ b/crates/sparq-solid/tests/common/mod.rs
@@ -1,7 +1,7 @@
 //! [OPUS-4.8] sq-t58w.6 — the **single reusable source** for the WAC/ACP parity corpus.
 //!
 //! The scenario corpus (the `AclBuilder`/`AcrBuilder`-emitted `.acl`/`.acr` data + the
-//! `Expect` decision tables, 12 WAC + 12 ACP) lived inline in `conformance_wac.rs` /
+//! `Expect` decision tables, 13 WAC + 13 ACP) lived inline in `conformance_wac.rs` /
 //! `conformance_acp.rs`. It is extracted here, unchanged, so it is reachable by a SECOND
 //! integration-test target without copy-paste — the differential oracle (`sq-t58w.7`,
 //! `tests/differential_oracle.rs`) consumes the IDENTICAL scenarios. "One corpus, two
@@ -32,9 +32,9 @@ pub use acp::acp_corpus;
 pub use wac::wac_corpus;
 
 /// The agreed scenario floors (the guard the parity tests assert and the differential
-/// oracle inherits): 12 WAC + 12 ACP minimal-per-construct scenarios.
-pub const WAC_SCENARIO_FLOOR: usize = 12;
-pub const ACP_SCENARIO_FLOOR: usize = 12;
+/// oracle inherits): 13 WAC + 13 ACP minimal-per-construct scenarios.
+pub const WAC_SCENARIO_FLOOR: usize = 13;
+pub const ACP_SCENARIO_FLOOR: usize = 13;
 
 /// Test WebIDs / origins shared by both corpora. Kept here so the two corpus modules — and
 /// any second consumer — name the same principals.

--- a/crates/sparq-solid/tests/common/wac.rs
+++ b/crates/sparq-solid/tests/common/wac.rs
@@ -223,6 +223,23 @@ fn control_governs_acl_document() -> WacScenario {
         .expect(Expect::agent(BOB).read(acl_doc).is(Decision::Deny))
 }
 
+/// [GPT-5.6] sq-61uvs: an ACL document is never an ordinary descendant for
+/// `acl:default` inheritance. Only Control on the governed resource exposes it.
+fn acl_document_control_gate_blocks_default_and_anonymous() -> WacScenario {
+    let container = "https://pod.example/control/";
+    let acl_doc = "https://pod.example/control/.acl";
+    let mut acl = AclBuilder::new();
+    acl.access_to(container, |a| a.agent(ALICE).mode(Mode::Control));
+    acl.default_for(container, |a| a.agent(BOB).mode(Mode::Read));
+    acl.document(container);
+    WacScenario::new("acl-document-control-gate")
+        .acl(acl)
+        .expect(Expect::agent(ALICE).read(acl_doc).is(Decision::Allow))
+        .expect(Expect::agent(ALICE).write(acl_doc).is(Decision::Allow))
+        .expect(Expect::agent(BOB).read(acl_doc).is(Decision::Deny))
+        .expect(Expect::anonymous().read(acl_doc).is(Decision::Deny))
+}
+
 /// WAC fail-closed: a resource with NO applicable ACL (no own ACL, no ancestor ACL) grants
 /// nobody — not the anonymous requestor, not any authenticated agent. An unprotected
 /// resource is invisible.
@@ -268,6 +285,7 @@ pub fn wac_corpus() -> Vec<WacScenario> {
         origin_user_app_pair(),
         mode_independence(),
         control_governs_acl_document(),
+        acl_document_control_gate_blocks_default_and_anonymous(),
         fail_closed_no_acl(),
         multi_agent_union(),
     ]

--- a/crates/sparq-solid/tests/differential_oracle.rs
+++ b/crates/sparq-solid/tests/differential_oracle.rs
@@ -238,7 +238,7 @@ fn wac_differential_oracle_zero_divergence() {
         DIVERGENCE_FLOOR
     );
 
-    // Guard against a corpus that silently checks nothing: the floor is the same 12
+    // Guard against a corpus that silently checks nothing: the pinned scenario floor
     // scenarios × multiple requests the conformance suite asserts.
     assert_eq!(
         scenarios.len(),

--- a/crates/sparq-solid/tests/reference/acp.rs
+++ b/crates/sparq-solid/tests/reference/acp.rs
@@ -188,6 +188,15 @@ impl AcpModel {
     /// Decide a request, procedurally, per the ACP spec (deny-overrides over the cumulative
     /// applicable policy set).
     pub fn decide(&self, req: &Request) -> RefDecision {
+        // [GPT-5.6] sq-61uvs: an ACR is a control document, not an ordinary member
+        // resource. A member Read/Write policy must not disclose it. ACP has no WAC-style
+        // Control-to-control-document translation, so this corpus surface fails closed.
+        if req.resource.ends_with(ACR_SUFFIX)
+            && matches!(req.mode, RefMode::Read | RefMode::Write)
+        {
+            return RefDecision::Deny;
+        }
+
         let mut any_allow = false;
         let mut any_deny = false;
 


### PR DESCRIPTION
> 🤖 SPARQ agent — security fix by **GPT-5.6**, Opus-reviewed before arm

Closes bead `sq-61uvs` and closes an audit-found LOW coverage issue. Production behavior was already correct; this adds the missing regression barrier without changing runtime code.

- adds end-to-end WAC `.acl` vectors for Control-holder Read/Write allow, container-default Read deny, and anonymous deny
- adds the ACP `.acr`-as-resource analogue, including the independent reference evaluator fail-closed rule
- raises the shared WAC/ACP conformance corpus floors from 12 to 13 scenarios

Verification:
- `cargo test -p sparq-solid`
- `cargo clippy -p sparq-solid --all-targets -- -D warnings`
- `cargo test -p sparq-solid --all-features`
- `cargo clippy -p sparq-solid --all-targets --all-features -- -D warnings`
- WAC differential oracle: 51 pairs, 0 divergences
- ACP differential oracle: 45 pairs, 0 divergences

Mutation witnesses:
- replacing the WAC Control→ACL Read/Write conclusion made the oracle fail with 4 divergences
- removing the ACP reference control-document exclusion made the oracle fail on the inherited-Read disclosure vector

Not armed: Opus soundness review is required before arm.