### PR TITLE
test(sparq-nlq): cover dictionary constraint invariants [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4829,6 +4829,7 @@ name = "sparq-nlq"
 version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
+ "proptest",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/sparq-nlq/Cargo.toml
+++ b/crates/sparq-nlq/Cargo.toml
@@ -75,3 +75,7 @@ serde_json = "1"
 # The live Anthropic client (non-default `live` feature only). Blocking: the loop is
 # synchronous by design and this crate must not drag an async runtime into the tree.
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"], optional = true }
+
+[dev-dependencies]
+# [GPT-5.6] sq-lxw27: metric-law coverage for deterministic dictionary ranking.
+proptest = "1"

--- a/crates/sparq-nlq/src/constrain.rs
+++ b/crates/sparq-nlq/src/constrain.rs
@@ -33,6 +33,10 @@ use spargebra::Query;
 use sparq_core::dict::TermParts;
 use sparq_core::Graph;
 
+mod distance;
+
+use distance::edit_distance;
+
 /// `rdf:type` — the predicate whose *object* is a class IRI, the one object position
 /// we treat as a vocabulary term (every other object is data, not schema).
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -182,30 +186,6 @@ fn nearest_known(graph: &Graph, iri: &str) -> Vec<String> {
     scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
     scored.truncate(MAX_SUGGESTIONS);
     scored.into_iter().map(|(_, iri)| iri).collect()
-}
-
-/// Levenshtein edit distance (two rolling rows). Local names are short, so the
-/// quadratic cost is trivial; no allocation beyond the two rows.
-fn edit_distance(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    if a.is_empty() {
-        return b.len();
-    }
-    if b.is_empty() {
-        return a.len();
-    }
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut cur = vec![0usize; b.len() + 1];
-    for (i, &ca) in a.iter().enumerate() {
-        cur[0] = i + 1;
-        for (j, &cb) in b.iter().enumerate() {
-            let cost = usize::from(ca != cb);
-            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
-        }
-        std::mem::swap(&mut prev, &mut cur);
-    }
-    prev[b.len()]
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sparq-nlq/src/constrain/distance.rs
+++ b/crates/sparq-nlq/src/constrain/distance.rs
@@ -1,0 +1,27 @@
+/// Levenshtein edit distance (two rolling rows). Local names are short, so the
+/// quadratic cost is trivial; no allocation beyond the two rows.
+///
+/// Kept crate-private: this is an implementation detail of dictionary suggestion
+/// ranking, shared with its property tests without widening the public API.
+/// [GPT-5.6] sq-lxw27
+pub(crate) fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}

--- a/crates/sparq-nlq/tests/constrain_unknown_terms.rs
+++ b/crates/sparq-nlq/tests/constrain_unknown_terms.rs
@@ -1,0 +1,144 @@
+//! Determinism and metric-law coverage for dictionary-grounded query repair.
+
+// Import the crate-private production implementation so the metric laws mutation-test
+// the exact function used for suggestion ranking without widening sparq-nlq's API.
+// [GPT-5.6] sq-lxw27
+#[path = "../src/constrain/distance.rs"]
+mod distance;
+
+use distance::edit_distance;
+use proptest::prelude::*;
+use spargebra::{Query, SparqlParser};
+use sparq_core::Graph;
+use sparq_nlq::constrain::{dictionary_repair_message, unknown_terms, TermRole};
+
+const DBO: &str = "http://dbpedia.org/ontology/";
+
+fn graph() -> Graph {
+    Graph::load_str(
+        r#"
+            @prefix dbo: <http://dbpedia.org/ontology/> .
+            <http://example.org/film> a dbo:Movie ;
+                dbo:director <http://example.org/director> ;
+                dbo:directedBy <http://example.org/director> ;
+                dbo:writer <http://example.org/writer> ;
+                dbo:producer <http://example.org/producer> .
+        "#,
+        "turtle",
+    )
+    .expect("fixture graph parses")
+}
+
+fn parse(query: &str) -> Query {
+    SparqlParser::new()
+        .parse_query(query)
+        .expect("test query parses")
+}
+
+fn short_string() -> impl Strategy<Value = String> {
+    prop::collection::vec(any::<char>(), 0..=8)
+        .prop_map(|characters| characters.into_iter().collect())
+}
+
+#[test]
+fn unknown_terms_are_deterministic_for_multiple_unknown_iris() {
+    let graph = graph();
+    let query = parse(
+        "PREFIX dbo: <http://dbpedia.org/ontology/>\n\
+         SELECT ?film WHERE {\n\
+           ?film dbo:directr ?director ; dbo:writr ?writer ; a dbo:Movi .\n\
+         }",
+    );
+
+    let first = unknown_terms(&graph, &query);
+    assert_eq!(first, unknown_terms(&graph, &query));
+    assert_eq!(first, unknown_terms(&graph, &query));
+    assert_eq!(first.len(), 3);
+    assert_eq!(first[0].iri, format!("{DBO}directr"));
+    assert_eq!(first[0].role, TermRole::Predicate);
+    assert_eq!(first[1].iri, format!("{DBO}writr"));
+    assert_eq!(first[1].role, TermRole::Predicate);
+    assert_eq!(first[2].iri, format!("{DBO}Movi"));
+    assert_eq!(first[2].role, TermRole::Class);
+}
+
+proptest! {
+    #[test]
+    fn edit_distance_is_symmetric(a in short_string(), b in short_string()) {
+        prop_assert_eq!(edit_distance(&a, &b), edit_distance(&b, &a));
+    }
+
+    #[test]
+    fn edit_distance_satisfies_triangle_inequality(
+        a in short_string(),
+        b in short_string(),
+        c in short_string(),
+    ) {
+        let direct = edit_distance(&a, &c);
+        let via_b = edit_distance(&a, &b) + edit_distance(&b, &c);
+        prop_assert!(direct <= via_b, "d(a,c)={direct} > d(a,b)+d(b,c)={via_b}");
+    }
+}
+
+#[test]
+fn nearest_known_ranks_the_closest_typo_first_and_distances_ascend() {
+    let graph = graph();
+    let query = parse(
+        "PREFIX dbo: <http://dbpedia.org/ontology/>\n\
+         SELECT ?film WHERE { ?film dbo:directr ?director }",
+    );
+
+    let unknowns = unknown_terms(&graph, &query);
+    assert_eq!(unknowns.len(), 1);
+    let suggestions = &unknowns[0].suggestions;
+    assert_eq!(
+        suggestions.first().map(String::as_str),
+        Some("http://dbpedia.org/ontology/director")
+    );
+
+    let distances: Vec<_> = suggestions
+        .iter()
+        .map(|suggestion| {
+            edit_distance(
+                "directr",
+                suggestion
+                    .strip_prefix(DBO)
+                    .expect("suggestions stay in the typo's namespace"),
+            )
+        })
+        .collect();
+    assert!(
+        distances.windows(2).all(|pair| pair[0] <= pair[1]),
+        "suggestions must have ascending edit distance: {suggestions:?} -> {distances:?}"
+    );
+}
+
+#[test]
+fn empty_graph_reports_unknown_term_without_suggestions() {
+    let graph = Graph::default();
+    let query = parse(
+        "PREFIX dbo: <http://dbpedia.org/ontology/>\n\
+         SELECT ?film WHERE { ?film dbo:directr ?director }",
+    );
+
+    let unknowns = unknown_terms(&graph, &query);
+    assert_eq!(unknowns.len(), 1);
+    assert!(unknowns[0].suggestions.is_empty());
+}
+
+#[test]
+fn dictionary_repair_message_is_byte_stable() {
+    let graph = graph();
+    let query = parse(
+        "PREFIX dbo: <http://dbpedia.org/ontology/>\n\
+         SELECT ?film WHERE { ?film dbo:directr ?director ; a dbo:Movi }",
+    );
+    let unknowns = unknown_terms(&graph, &query);
+
+    let first = dictionary_repair_message(&unknowns);
+    assert_eq!(first, dictionary_repair_message(&unknowns));
+    assert_eq!(first, dictionary_repair_message(&unknowns));
+    assert!(first.contains("predicate <http://dbpedia.org/ontology/directr>"));
+    assert!(first.contains("class <http://dbpedia.org/ontology/Movi>"));
+    assert!(first.contains("did you mean <http://dbpedia.org/ontology/director>"));
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes bead `sq-lxw27`.

Summary:
- add deterministic integration coverage for repeated `unknown_terms` and `dictionary_repair_message` calls
- verify nearest-known suggestions are ordered by ascending Levenshtein distance and empty dictionaries produce no suggestions
- property-test Levenshtein symmetry and the triangle inequality with short random Unicode strings
- keep the distance helper crate-private by extracting the existing implementation into a shared private source module

Non-vacuity:
- temporarily reversed the production suggestion comparator; the nearest-known ordering test failed, then passed after restoring ascending order

Gates:
- `cargo test -p sparq-nlq`
- `cargo test -p sparq-nlq --all-features`
- `cargo clippy -p sparq-nlq --all-targets -- -D warnings`
- `cargo clippy -p sparq-nlq --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-nlq --no-deps --all-features`
- changed-file rustfmt and `git diff --check`

No public API or README/skill surface changed.