### PR TITLE
test(rsp): cover sparse count-window R2S diffs [GPT-5.6]

### DIFF
--- a/crates/sparq-rsp/tests/rsp.rs
+++ b/crates/sparq-rsp/tests/rsp.rs
@@ -417,6 +417,43 @@ fn continuous_query_over_count_window() {
     assert_eq!(sums, vec![sum(1), sum(3), sum(6)]);
 }
 
+/// [GPT-5.6] sq-f0v71: count-window R2S diffs compare consecutive
+/// *reported* windows when the slide skips arrivals. The transient window
+/// after `v3` would be `{v2, v3}`; incorrectly using it as the diff base would
+/// emit only `v4` for ISTREAM and `v2` for DSTREAM, which these assertions
+/// reject.
+#[test]
+fn continuous_query_count_window_slide_diffs_consecutive_reports() {
+    let run = |r2s| {
+        let mut q = ContinuousQuery::register(
+            "SELECT ?v WHERE { ?s <http://ex/value> ?v } ORDER BY ?v",
+            WindowSpec::count(2).with_slide(2),
+        )
+        .unwrap()
+        .with_r2s(r2s);
+        let mut reports = Vec::new();
+        let mut sink = |r: sparq_rsp::WindowResult| reports.push(r.rows);
+
+        for i in 1..=4 {
+            q.push(t(&format!("s{i}"), "value", &format!("v{i}")), i, &mut sink)
+                .unwrap();
+        }
+        reports
+    };
+    let rows = |values: &[&str]| {
+        values
+            .iter()
+            .map(|value| vec![Some(iri(value))])
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        run(R2S::IStream),
+        vec![rows(&["v1", "v2"]), rows(&["v3", "v4"])]
+    );
+    assert_eq!(run(R2S::DStream), vec![rows(&[]), rows(&["v1", "v2"])]);
+}
+
 /// Lateness propagates through ContinuousQuery: late triples never reach a
 /// result; the counter is observable.
 #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Bead: `sq-f0v71`

## Summary

- cover `ContinuousQuery` ISTREAM and DSTREAM over `WindowSpec::count(2).with_slide(2)`
- assert exact multiset diffs between the two reported windows, including the empty first DSTREAM report
- make the unreported third-arrival window observable as an invalid diff base

## Mutation witness

Forcing the count-window reporting predicate to emit on every arrival made the new test fail (`mutation_test_exit=101`); restoring the slide predicate made it pass. The exact expected diffs also reject using transient `{v2, v3}` as the second report diff base.

## Gates

- `cargo clippy -p sparq-rsp --all-targets -- -D warnings`
- `cargo clippy -p sparq-rsp --all-targets --all-features -- -D warnings`
- `cargo test -p sparq-rsp`
- `cargo test -p sparq-rsp --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-rsp --no-deps --all-features`
- `git diff --check origin/main...HEAD`

All green. `sparq-rsp` has no named Cargo features, so `--all-features` is the feature-on matrix state. No README or public API changed.