### PR TITLE
test(acbench): cover AllExcept oracle behavior [GPT-5.6]

### DIFF
--- a/crates/sparq-acbench/tests/oracle_behavioral.rs
+++ b/crates/sparq-acbench/tests/oracle_behavioral.rs
@@ -261,6 +261,55 @@ fn odrl_permission_overrides_matching_prohibition() {
     );
 }
 
+/// `AllExcept` matches agents outside its exclusion list, for both effects and both
+/// policy models that support deny. The excluded-agent deny cases deliberately remain
+/// fail-closed: exclusion means that row does not match, not that access is granted.
+///
+/// The `Allow` assertions are the mutation witness: inverting the exclusion membership
+/// check swaps the two decisions and makes this test fail for both ACP and ODRL.
+#[test]
+fn all_except_membership_controls_acp_and_odrl_effects() {
+    // [GPT-5.6] sq-n489k — behavioral oracle coverage for AllExcept membership polarity.
+    const EXCLUDED_AGENT: &str = "excluded-agent";
+
+    let non_excluded_request = read_request(ALICE, RES);
+    let excluded_request = read_request(EXCLUDED_AGENT, RES);
+
+    for (effect, expected_non_excluded) in [
+        (Effect::Deny, Decision::Deny),
+        (Effect::Allow, Decision::Allow),
+    ] {
+        let row = IntentRow {
+            audience: Audience::AllExcept(vec![EXCLUDED_AGENT.to_string()]),
+            effect: effect.clone(),
+            ..allow_read(ALICE, RES)
+        };
+
+        for (model, non_excluded_decision, excluded_decision) in [
+            (
+                AcModel::Acp,
+                oracle_acp(&non_excluded_request, std::slice::from_ref(&row)),
+                oracle_acp(&excluded_request, std::slice::from_ref(&row)),
+            ),
+            (
+                AcModel::Odrl,
+                oracle_odrl(&non_excluded_request, std::slice::from_ref(&row)),
+                oracle_odrl(&excluded_request, std::slice::from_ref(&row)),
+            ),
+        ] {
+            assert_eq!(
+                non_excluded_decision, expected_non_excluded,
+                "{model:?} oracle: a non-excluded agent must match an AllExcept {effect:?} row"
+            );
+            assert_eq!(
+                excluded_decision,
+                Decision::Deny,
+                "{model:?} oracle: an excluded agent must not match an AllExcept {effect:?} row"
+            );
+        }
+    }
+}
+
 // ── 3. condition gating flips the decision ────────────────────────────────────────────
 
 /// Condition gating is load-bearing, not ignored: the SAME `Allow` intent flips


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements bead `sq-n489k`.

Adds a behavioral-oracle regression test for `Audience::AllExcept` across ACP and ODRL, covering both Allow and Deny effects for excluded and non-excluded requesters. This is benchmark-oracle coverage, not a production access-control soundness claim.

Mutation witness:
- Inverting ACP AllExcept membership made the focused test fail.
- Independently inverting ODRL AllExcept membership made the focused test fail.

Scoped gates:
- `cargo clippy -p sparq-acbench --all-targets -- -D warnings`
- `cargo clippy -p sparq-acbench --all-targets --all-features -- -D warnings`
- `cargo test -p sparq-acbench`
- `cargo test -p sparq-acbench --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-acbench --no-deps --all-features`
- crate-local rustfmt check
- `git diff --check`

All passed. The branch was merged with current `origin/main` before the final gate run.

The PR is intentionally not armed or merged.