### PR TITLE
sparq-gpu: add hash32 determinism test [HAIKU-4.5]

### DIFF
--- a/crates/sparq-gpu/src/lib.rs
+++ b/crates/sparq-gpu/src/lib.rs
@@ -639,3 +639,42 @@ impl Gpu {
 // The WGSL result-buffer bindings above are written through the kernels' result
 // arrays; bind-group layout note: `inputs` occupy bindings 0..k, the result
 // buffer binding k, the uniform params binding k+1 — matching each shader.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash32_determinism() {
+        // Test fixed edge inputs for bit-identical purity
+        let edge_inputs = [
+            0,
+            1,
+            u32::MAX,
+            u32::MAX - 1,
+            u32::MAX / 2,
+            EMPTY_KEY - 1, // sentinel-adjacent
+        ];
+
+        for &x in &edge_inputs {
+            let hash1 = hash32(x);
+            let hash2 = hash32(x);
+            assert_eq!(
+                hash1, hash2,
+                "hash32 must be pure: hash32({:x}) != hash32({:x})",
+                x, x
+            );
+        }
+
+        // Test bounded range for totality (no panic) and determinism
+        for x in 0..10_000 {
+            let hash1 = hash32(x);
+            let hash2 = hash32(x);
+            assert_eq!(
+                hash1, hash2,
+                "hash32 must be pure: hash32({:x}) != hash32({:x})",
+                x, x
+            );
+        }
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — **Claude Haiku 4.5**

## Summary

Implement the hash32 determinism test for bead sq-pz5rf: verify that hash32 is a pure total function by asserting bit-identical results across identical calls on edge inputs (0, 1, u32::MAX, u32::MAX-1, u32::MAX/2, EMPTY_KEY-1) and a bounded range (0..10_000).

- Verifies no panic/overflow on wrapping_mul and bitwise operations (totality)
- Confirms bit-for-bit determinism (critical for CPU/WGSL probe-sequence alignment)
- Mutation-witnessed: test fails when hash32 alternates XOR with 0xDEADBEEF

## Test plan

- ✅ All gates green: clippy -D warnings (0 findings), cargo test (11/11 pass including new test)
- ✅ Non-vacuous: mutation (alternating XOR bit) makes test FAIL with assertion error
- ✅ Single-crate, additive test only: no production code changes, no dependencies added

Refs: sq-pz5rf