### PR TITLE
Add canonicalize/canonicalize_renamed idempotence tests [HAIKU-4.5]

### DIFF
--- a/crates/sparq-serve/src/canon.rs
+++ b/crates/sparq-serve/src/canon.rs
@@ -304,4 +304,70 @@ mod tests {
         let r = canonicalize(q);
         assert!(r.contains(r#""a \" b""#));
     }
+
+    #[test]
+    fn canonicalize_idempotent() {
+        // Verify that applying canonicalize twice is idempotent.
+        // After one pass whitespace is already collapsed/trimmed and comments removed,
+        // so a second pass finds nothing to normalize.
+        let test_cases = vec![
+            // Whitespace runs
+            "SELECT  ?x\n WHERE {\t?x ?y ?z }",
+            // Leading/trailing space
+            "   SELECT ?x WHERE { ?x }  ",
+            // Comments with variables
+            "SELECT ?x # comment with ?y\n WHERE { ?x ?p ?o }",
+            // String literal containing ?x-like data
+            r#"SELECT ?x { ?x ?p "contains ?y inside" }"#,
+            // Mixed ? and $ sigils
+            "SELECT ?x { $x ?y ?z }",
+            // Empty input
+            "",
+            // Complex: whitespace + comments + literals + mixed sigils
+            "  SELECT  ?a   # this comment has ?unused\n { $a  ?b  \"string with ?data\"  }  ",
+        ];
+
+        for q in test_cases {
+            let once = canonicalize(q);
+            let twice = canonicalize(&once);
+            assert_eq!(
+                once, twice,
+                "canonicalize is not idempotent for query: {:?}",
+                q
+            );
+        }
+    }
+
+    #[test]
+    fn canonicalize_renamed_idempotent() {
+        // Verify that applying canonicalize_renamed twice is idempotent.
+        // After one pass, variables are already renamed to ?v0,?v1,... in
+        // first-occurrence order, so a re-rename is the identity map.
+        let test_cases = vec![
+            // Simple query with multiple variables
+            "SELECT ?x WHERE { ?x ?y ?z }",
+            // Variables renamed already but with whitespace
+            "SELECT  ?v0\n WHERE {\t?v0 ?v1 ?v2 }",
+            // Mixed ? and $ sigils (collapse to same variable)
+            "SELECT ?x { $x ?y ?x }",
+            // String literal with variable-like data
+            r#"SELECT ?myvar { ?myvar ?p "contains ?unused inside" }"#,
+            // Comment containing variable-like text
+            "SELECT ?x # comment ?y\n WHERE { ?x ?p ?o }",
+            // Empty input
+            "",
+            // Complex: multiple distinct vars + literals + comments + whitespace
+            "  SELECT  ?author  ?title   # find ?unused\n { ?author  <dc:title>  ?title  ;  \"string ?data\" }  ",
+        ];
+
+        for q in test_cases {
+            let once = canonicalize_renamed(q);
+            let twice = canonicalize_renamed(&once);
+            assert_eq!(
+                once, twice,
+                "canonicalize_renamed is not idempotent for query: {:?}",
+                q
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implement sq-bvdyd: additive test-only bead for sparq-serve.

Two property-based #[test]s verify that both query canonicalization functions
are **idempotent** — applying them twice produces identical output to applying 
once. This is **load-bearing** for cache-key stability in result-cache 
(sq-jluc, research/concurrent-serving.md §6.3).

## Implementation

Added to `crates/sparq-serve/src/canon.rs#[cfg(test)] mod tests`:

1. **`canonicalize_idempotent`**: verifies `canonicalize(canonicalize(q)) == canonicalize(q)` 
   - After one pass, whitespace is collapsed to single spaces, trailing trimmed, and comments removed
   - Second pass finds nothing to normalize → returns identical output
   - Covers: whitespace runs, leading/trailing space, comments with variables, string literals with ?x-like data, mixed ?/$ sigils, empty input

2. **`canonicalize_renamed_idempotent`**: verifies `canonicalize_renamed(canonicalize_renamed(q)) == canonicalize_renamed(q)`
   - After first pass, variables are positionally renamed to ?v0, ?v1, ... in first-occurrence order
   - Second pass sees ?v0 → maps to ?v0, ?v1 → ?v1, etc. (re-renaming is identity)
   - Same coverage as above, plus tests with already-renamed variables

## Test status

- ✅ Non-vacuous: invariants are mathematically sound; can be verified by code inspection (see logic above)
- ✅ Gates: `cargo clippy -p sparq-serve --all-targets -D warnings` (clean), `cargo test -p sparq-serve` (all pass)
- ✅ No feature-state regressions: tests are unconditional, no feature-gating needed
- ✅ Coverage floor not regressed

🤖 **SPARQ agent — Claude Haiku 4.5**
Cited bead: sq-bvdyd