### PR TITLE
test(gpu): cover hash32 determinism and totality [GPT-5.6]

### DIFF
--- a/crates/sparq-gpu/src/lib.rs
+++ b/crates/sparq-gpu/src/lib.rs
@@ -56,6 +56,30 @@ pub fn hash32(mut x: u32) -> u32 {
     x
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{hash32, EMPTY_KEY};
+
+    // [GPT-5.6] sq-pz5rf: Exercise the mixer directly, including values around
+    // the hash-table sentinel and a bounded sample of the full u32 domain.
+    #[test]
+    fn hash32_is_deterministic_and_total_for_sampled_inputs() {
+        let edge_inputs = [
+            0,
+            1,
+            u32::MAX,
+            u32::MAX - 1,
+            u32::MAX / 2,
+            EMPTY_KEY - 2,
+            EMPTY_KEY - 1,
+        ];
+
+        for input in edge_inputs.into_iter().chain(0..10_000) {
+            assert_eq!(hash32(input), hash32(input), "input {input}");
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // WGSL kernels
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

## Summary

- Add a direct unit test for `hash32` repeatability over edge cases, sentinel-adjacent values, and a bounded input range.
- Exercise overflow-sensitive inputs to witness that wrapping arithmetic keeps the mixer total.
- Avoid statistical distribution or collision assertions.

Closes bead `sq-pz5rf`.

## Gates

- [x] `cargo fmt -p sparq-gpu`
- [x] `cargo clippy -p sparq-gpu --all-targets -- -D warnings`
- [x] `cargo clippy -p sparq-gpu --all-targets --all-features -- -D warnings`
- [x] `cargo test -p sparq-gpu`
- [x] `cargo test -p sparq-gpu --all-features`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-gpu --no-deps --all-features`
- [x] Mutation witness: replacing the first wrapping multiplication with ordinary multiplication makes the new test fail on overflow.

## Scope

Single-crate additive test only; no public API, documentation, dependency, or security-sensitive surface changed. The PR is intentionally not armed for auto-merge.