### PR TITLE
Test dateTime comparison reversal symmetry [GPT-5.6]

### DIFF
--- a/crates/sparq-difftest/src/temporal.rs
+++ b/crates/sparq-difftest/src/temporal.rs
@@ -481,6 +481,51 @@ mod tests {
     }
 
     #[test]
+    fn dt_compare_is_symmetric_under_argument_reversal() {
+        // [GPT-5.6] sq-dfoik: exercise every timezone pairing and both mixed-pair outcomes.
+        let cases = [
+            (
+                "both timezoned",
+                dt("2020-01-01T00:00:00Z"),
+                dt("2020-01-02T00:00:00Z"),
+                TemporalOrder::Less,
+            ),
+            (
+                "both timezone-less",
+                dt("2020-01-01T00:00:00"),
+                dt("2020-01-02T00:00:00"),
+                TemporalOrder::Less,
+            ),
+            (
+                "mixed outside the 14-hour window",
+                dt("2020-01-01T00:00:00Z"),
+                dt("2020-01-03T00:00:00"),
+                TemporalOrder::Less,
+            ),
+            (
+                "mixed within the 14-hour window",
+                dt("2020-01-01T00:00:00Z"),
+                dt("2020-01-01T06:00:00"),
+                TemporalOrder::Indeterminate,
+            ),
+        ];
+
+        for (case, a, b, expected) in cases {
+            let forward = dt_compare(&a, &b);
+            assert_eq!(forward, expected, "unexpected forward order for {case}");
+            assert_eq!(
+                flip(forward),
+                dt_compare(&b, &a),
+                "argument reversal did not flip the order for {case}"
+            );
+        }
+
+        for value in [dt("2020-01-01T00:00:00Z"), dt("2020-01-01T00:00:00")] {
+            assert_eq!(dt_compare(&value, &value), TemporalOrder::Equal);
+        }
+    }
+
+    #[test]
     fn parse_datetime_rejects_invalid_calendar_fields() {
         // Out-of-range month/day must NOT value-canonicalise — they fall back to exact-lexical keying.
         assert!(parse_datetime("2020-00-01T00:00:00Z", DT).is_none(), "month 0");


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

## Summary

- Add a focused `dt_compare` argument-reversal symmetry test for both timezone modes.
- Cover definite and indeterminate mixed-timezone comparisons plus reflexivity.
- Assert forward outcomes so the invariant check is non-vacuous.

## Verification

- `cargo test -p sparq-difftest`
- `cargo clippy -p sparq-difftest --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-difftest --no-deps --all-features`
- Mutation witness: removing the mixed-pair `flip` makes the new test fail on the outside-window case.

Bead: `sq-dfoik`