### PR TITLE
test(engine-service): cover predefined XML entities (sq-5kh4d) [GPT-5.6]

### DIFF
--- a/crates/sparq-engine-service/src/service.rs
+++ b/crates/sparq-engine-service/src/service.rs
@@ -3792,7 +3792,23 @@ mod tests {
         );
     }
 
-    // --- resolve_xml_entity: numeric character references --------------------
+    // --- resolve_xml_entity: named and numeric character references ----------
+
+    /// The five predefined XML entities resolve to their exact characters.
+    #[test]
+    fn resolve_xml_entity_predefined_named_entities() {
+        // [GPT-5.6] (sq-5kh4d) Directly cover the named-entity branch rather than
+        // relying only on the SRX parser integration test.
+        for (name, expected) in [
+            ("amp", "&"),
+            ("lt", "<"),
+            ("gt", ">"),
+            ("quot", "\""),
+            ("apos", "'"),
+        ] {
+            assert_eq!(super::resolve_xml_entity(name).unwrap(), expected);
+        }
+    }
 
     /// Decimal numeric character reference `#38` resolves to `&` (U+0026).
     #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements bead **sq-5kh4d**.

Adds a direct table-driven unit test for the five XML predefined named entities handled by `resolve_xml_entity`: `amp`, `lt`, `gt`, `quot`, and `apos`. Each assertion checks the exact replacement character. This closes the direct-coverage gap while leaving production code and public APIs unchanged.

Mutation witness: temporarily corrupting the `amp` production mapping made the new test fail with exit 101; the implementation was then restored.

Scoped gates:

- `cargo clippy -p sparq-engine-service --all-targets -- -D warnings`
- `cargo clippy -p sparq-engine-service --all-targets --features service -- -D warnings`
- `cargo test -p sparq-engine-service`
- `cargo test -p sparq-engine-service --features service`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-engine-service --no-deps --all-features`
- scoped rustfmt and `git diff --check`

All green. The branch was refreshed against `origin/main` before push. This PR is intentionally unarmed for merge-coordinator review.