### PR TITLE
test(serve): cover canonicalization idempotence [GPT-5.6]

### DIFF
--- a/crates/sparq-serve/src/canon.rs
+++ b/crates/sparq-serve/src/canon.rs
@@ -232,6 +232,15 @@ impl Renamer {
 mod tests {
     use super::*;
 
+    // [GPT-5.6] sq-bvdyd: exercise every lexical context that can affect whether
+    // a second canonicalization pass changes the cache key.
+    const IDEMPOTENCE_QUERIES: [&str; 4] = [
+        "  SELECT   ?x\n WHERE {\t?x ?p ?o } # trailing comment\n",
+        "SELECT ?x # ignored ?comment\nWHERE { ?x ?p \"literal  ?data and $data\" }",
+        "ASK { $x ?p 'literal ?x and $x' ; ?q $x .\n}",
+        "",
+    ];
+
     #[test]
     fn whitespace_collapses() {
         let a = canonicalize("SELECT  ?x\n WHERE {\t?x ?y ?z }");
@@ -303,5 +312,21 @@ mod tests {
         let q = r#"ASK { ?s ?p "a \" b" }"#;
         let r = canonicalize(q);
         assert!(r.contains(r#""a \" b""#));
+    }
+
+    #[test]
+    fn canonicalize_is_idempotent() {
+        for query in IDEMPOTENCE_QUERIES {
+            let once = canonicalize(query);
+            assert_eq!(canonicalize(&once), once, "query: {query:?}");
+        }
+    }
+
+    #[test]
+    fn canonicalize_renamed_is_idempotent() {
+        for query in IDEMPOTENCE_QUERIES {
+            let once = canonicalize_renamed(query);
+            assert_eq!(canonicalize_renamed(&once), once, "query: {query:?}");
+        }
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements `sq-bvdyd`.

## Summary

- Add a shared query corpus covering whitespace runs, comments, quoted variable-like data, both variable sigils, and empty input.
- Assert idempotence separately for label-safe canonicalization and alpha-renaming canonicalization.
- Keep the change additive and confined to the opt-in result-cache test module.

## Verification

- `cargo clippy -p sparq-serve --all-targets -- -D warnings`
- `cargo clippy -p sparq-serve --all-targets --features result-cache -- -D warnings`
- `cargo test -p sparq-serve`
- `cargo test -p sparq-serve --features result-cache`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-serve --no-deps --all-features`
- Mutation witness: temporarily made each rewrite pass prepend a marker; both new tests failed, then passed after restoring production code.