### PR TITLE
sparq-rsp: add opt-in session windows [GPT-5.6]

### DIFF
--- a/crates/sparq-rsp/Cargo.toml
+++ b/crates/sparq-rsp/Cargo.toml
@@ -27,6 +27,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 # behaviour is deterministic and unit-testable; wrapping pushes in tokio/threads
 # is the embedder's choice.
 
+[features]
+default = []
+# [GPT-5.6] sq-zckkq: gap-triggered event-time session windows are an explicit
+# opt-in so the established time/count paths remain byte-neutral by default.
+session_windows = []
+
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
 # (required to publish — crates.io strips `path`).

--- a/crates/sparq-rsp/README.md
+++ b/crates/sparq-rsp/README.md
@@ -49,7 +49,9 @@ q.flush(|result| { /* end-of-stream: close everything up to max ts */ })?;
 - **Windows (S2R)** — `WindowSpec::time` half-open `[t0 + k·step, t0 + k·step + range)`
   time windows (tumbling, or overlapping when `step < range`) and `WindowSpec::count`
   CQL-style row windows; closure is driven by the `max_ts − max_delay` watermark, with
-  out-of-order tolerance and empty-window reporting.
+  out-of-order tolerance and empty-window reporting. The default-off `session_windows`
+  feature adds `WindowSpec::session(gap)`: maximal event-time runs split by an inactivity
+  gap greater than or equal to `gap`, with inclusive `[first.ts, last.ts]` bounds.
 - **Continuous queries (R2R)** — `ContinuousQuery` (SELECT), `ContinuousConstruct`
   (CONSTRUCT, stream-to-stream), and `ContinuousAsk` (ASK), each parsed **once** at
   `register` into a `sparq_engine::PreparedQuery` and re-run per closed window.

--- a/crates/sparq-rsp/src/query.rs
+++ b/crates/sparq-rsp/src/query.rs
@@ -66,7 +66,7 @@ pub enum R2S {
 #[derive(Debug, Clone)]
 pub struct WindowResult {
     /// Window bounds, as reported by the window operator: time windows are
-    /// half-open `[start, end)`; count windows carry the inclusive
+    /// half-open `[start, end)`; count and session windows carry the inclusive
     /// `[first.ts, last.ts]` of their content (see `crate::window`).
     pub start: u64,
     /// See `start`.

--- a/crates/sparq-rsp/src/window.rs
+++ b/crates/sparq-rsp/src/window.rs
@@ -1,5 +1,6 @@
 //! Window operators (the RSP-QL S2R step): time-based sliding windows
-//! (`RANGE w STEP s`) and count-based windows (`ROWS n`).
+//! (`RANGE w STEP s`), count-based windows (`ROWS n`), and opt-in
+//! gap-triggered session windows.
 //!
 //! # Time-window semantics (read this; the tests pin it down)
 //!
@@ -46,6 +47,15 @@
 //! `[first.ts, last.ts]` of the content (empty never occurs: a count window is
 //! only reported after an arrival). [`flush`](WindowedStream::flush) is a
 //! no-op for count windows — there is no watermark to advance.
+//!
+//! # Session-window semantics (`session_windows` feature)
+//!
+//! `WindowSpec::session(gap)` groups timestamp-ordered events into maximal
+//! runs whose consecutive timestamp gaps are strictly less than `gap`. A gap
+//! equal to `gap` starts a new session. Closure is event-time-only: a session
+//! closes when the watermark reaches `last_event_ts + gap`; `flush` closes the
+//! final open session. Reported bounds are the inclusive
+//! `[first_event_ts, last_event_ts]` of the session content.
 
 use std::collections::{BTreeMap, VecDeque};
 
@@ -66,6 +76,11 @@ pub enum WindowSpec {
     /// `ROWS rows` — count window over the last `rows` arrivals, reported
     /// every `slide` arrivals (CQL default: every arrival, `slide = 1`).
     Count { rows: usize, slide: usize },
+    /// A gap-triggered event-time session window. Consecutive events whose
+    /// timestamp difference is less than `gap` share a session; a difference
+    /// greater than or equal to `gap` starts a new session.
+    #[cfg(feature = "session_windows")]
+    Session { gap: u64 },
 }
 
 impl WindowSpec {
@@ -89,6 +104,20 @@ impl WindowSpec {
         WindowSpec::Count { rows, slide: 1 }
     }
 
+    /// Creates a gap-triggered event-time session window.
+    ///
+    /// `gap` uses the same application-supplied `u64` logical timestamp unit
+    /// as stream elements. A timestamp difference equal to `gap` starts a new
+    /// session. Session bounds are inclusive.
+    ///
+    /// # Panics
+    /// If `gap == 0`.
+    #[cfg(feature = "session_windows")]
+    pub fn session(gap: u64) -> Self {
+        assert!(gap > 0, "session window GAP must be > 0");
+        WindowSpec::Session { gap }
+    }
+
     /// Sets the out-of-order tolerance of a time window.
     ///
     /// # Panics
@@ -100,6 +129,8 @@ impl WindowSpec {
                 WindowSpec::Time { range, step, max_delay, t0 }
             }
             WindowSpec::Count { .. } => panic!("max_delay applies to time windows only"),
+            #[cfg(feature = "session_windows")]
+            WindowSpec::Session { .. } => panic!("max_delay applies to time windows only"),
         }
     }
 
@@ -116,6 +147,8 @@ impl WindowSpec {
                 WindowSpec::Time { range, step, max_delay, t0 }
             }
             WindowSpec::Count { .. } => panic!("t0 applies to time windows only"),
+            #[cfg(feature = "session_windows")]
+            WindowSpec::Session { .. } => panic!("t0 applies to time windows only"),
         }
     }
 
@@ -129,23 +162,25 @@ impl WindowSpec {
         match self {
             WindowSpec::Count { rows, .. } => WindowSpec::Count { rows, slide },
             WindowSpec::Time { .. } => panic!("slide applies to count windows only (use STEP)"),
+            #[cfg(feature = "session_windows")]
+            WindowSpec::Session { .. } => panic!("slide applies to count windows only"),
         }
     }
 }
 
-/// One CLOSED (time) or REPORTED (count) window: bounds + frozen content.
+/// One CLOSED (time/session) or REPORTED (count) window: bounds + frozen content.
 /// Generic over the stream payload (the public API works with `[Term; 3]`;
 /// the persistent-dictionary evaluation mode windows `[Id; 3]`s).
 #[derive(Debug, Clone)]
 pub struct Window<T = [Term; 3]> {
-    /// Time window: inclusive start `t0 + k·step`. Count window: `ts` of the
-    /// oldest content triple.
+    /// Time window: inclusive start `t0 + k·step`. Count/session window:
+    /// inclusive `ts` of the oldest content triple.
     pub start: u64,
-    /// Time window: EXCLUSIVE end `start + range`. Count window: INCLUSIVE
-    /// `ts` of the newest content triple.
+    /// Time window: EXCLUSIVE end `start + range`. Count/session window:
+    /// INCLUSIVE `ts` of the newest content triple.
     pub end: u64,
-    /// Content. Time windows: timestamp order (arrival order within equal
-    /// timestamps). Count windows: arrival order.
+    /// Content. Time/session windows: timestamp order (arrival order within
+    /// equal timestamps). Count windows: arrival order.
     pub triples: Vec<Timestamped<T>>,
 }
 
@@ -177,6 +212,14 @@ pub struct WindowedStream<T = [Term; 3]> {
     ring: VecDeque<Timestamped<T>>,
     /// Count-window arrival counter (drives `slide`).
     arrivals: u64,
+    /// End-of-stream horizon for session windows. A flush freezes the final
+    /// session, so later arrivals at or below this timestamp are late.
+    #[cfg(feature = "session_windows")]
+    session_flushed_horizon: Option<u64>,
+    /// Whether a session event has been accepted. Distinguishes an empty
+    /// stream from a first event at timestamp zero when recording a flush.
+    #[cfg(feature = "session_windows")]
+    session_seen_event: bool,
     /// Windows closed/reported but not yet taken.
     closed: Vec<Window<T>>,
 }
@@ -206,6 +249,10 @@ impl<T: Clone> WindowedStream<T> {
             late_dropped: 0,
             ring: VecDeque::new(),
             arrivals: 0,
+            #[cfg(feature = "session_windows")]
+            session_flushed_horizon: None,
+            #[cfg(feature = "session_windows")]
+            session_seen_event: false,
             closed: Vec::new(),
         }
     }
@@ -223,6 +270,75 @@ impl<T: Clone> WindowedStream<T> {
                 self.push_time(triple, ts, range, step, max_delay, t0)
             }
             WindowSpec::Count { rows, slide } => self.push_count(triple, ts, rows, slide),
+            #[cfg(feature = "session_windows")]
+            WindowSpec::Session { gap } => self.push_session(triple, ts, gap),
+        }
+    }
+
+    /// [GPT-5.6] sq-zckkq: Inserts into the still-open event-time session, or
+    /// starts a new one. With the v1 session watermark delay fixed at zero, an
+    /// out-of-order event is accepted only when it joins an open session; an
+    /// isolated session whose inactivity deadline is already behind the
+    /// watermark is late and cannot retroactively surface.
+    #[cfg(feature = "session_windows")]
+    fn push_session(&mut self, triple: T, ts: u64, gap: u64) {
+        if self.session_flushed_horizon.is_some_and(|horizon| ts <= horizon) {
+            self.late_dropped += 1;
+            return;
+        }
+
+        let watermark = self.max_ts.max(ts);
+        let joins_open_session = self
+            .buffer
+            .range(..=ts)
+            .next_back()
+            .is_some_and(|(&previous, _)| ts - previous < gap)
+            || self
+                .buffer
+                .range(ts..)
+                .next()
+                .is_some_and(|(&next, _)| next - ts < gap);
+
+        if !joins_open_session && ts.saturating_add(gap) <= watermark {
+            self.late_dropped += 1;
+            return;
+        }
+
+        self.buffer.entry(ts).or_default().push(triple);
+        self.session_seen_event = true;
+        self.max_ts = watermark;
+        self.close_ready_sessions(gap, watermark, false);
+    }
+
+    /// Closes timestamp-ordered session components from oldest to newest.
+    /// `force` is the end-of-stream path and ignores inactivity deadlines.
+    #[cfg(feature = "session_windows")]
+    fn close_ready_sessions(&mut self, gap: u64, watermark: u64, force: bool) {
+        while let Some(start) = self.buffer.first_key_value().map(|(&ts, _)| ts) {
+            let mut last = start;
+            for ts in self.buffer.range(start..).map(|(&ts, _)| ts) {
+                if ts - last >= gap {
+                    break;
+                }
+                last = ts;
+            }
+
+            if !force && watermark < last.saturating_add(gap) {
+                break;
+            }
+
+            let triples = self
+                .buffer
+                .range(start..=last)
+                .flat_map(|(&ts, ts_triples)| {
+                    ts_triples.iter().map(move |t| Timestamped { triple: t.clone(), ts })
+                })
+                .collect();
+            self.closed.push(Window { start, end: last, triples });
+
+            let mut after = self.buffer.split_off(&last);
+            after.remove(&last);
+            self.buffer = after;
         }
     }
 
@@ -279,10 +395,11 @@ impl<T: Clone> WindowedStream<T> {
     }
 
     /// [OPUS-4.8] Advances event time to `ts` WITHOUT inserting a triple — a
-    /// watermark heartbeat. Closes (and empty-reports) every window the new
-    /// watermark has reached, exactly as a gap arrival at `ts` would, but buffers
-    /// nothing. A no-op for count windows (no watermark) and when `ts` does not
-    /// advance `max_ts`.
+    /// watermark heartbeat. Closes every time/session window the new watermark
+    /// has reached, exactly as a gap arrival at `ts` would, but buffers nothing.
+    /// Time windows empty-report skipped intervals; session windows have no
+    /// empty intervals to report. A no-op for count windows (no watermark) and
+    /// when `ts` does not advance `max_ts`.
     ///
     /// Used by [`ContinuousMultiQuery`](crate::ContinuousMultiQuery) to drive
     /// every window off a SHARED event-time clock: a triple on one stream
@@ -293,6 +410,15 @@ impl<T: Clone> WindowedStream<T> {
     /// tracked and eventually emitted, possibly empty), matching the documented
     /// gap-first-arrival rule.
     pub fn advance(&mut self, ts: u64) {
+        #[cfg(feature = "session_windows")]
+        if let WindowSpec::Session { gap } = self.spec {
+            if ts > self.max_ts {
+                self.max_ts = ts;
+            }
+            self.close_ready_sessions(gap, self.max_ts, false);
+            return;
+        }
+
         let WindowSpec::Time { range, step, max_delay, t0 } = self.spec else {
             return; // count windows have no time axis / watermark
         };
@@ -349,11 +475,20 @@ impl<T: Clone> WindowedStream<T> {
     }
 
     /// End-of-stream: closes every time window up to and including the last
-    /// one covering `max_ts` — regardless of `max_delay` — and returns ALL
-    /// pending windows (the flushed ones plus any not yet taken). No-op for
-    /// count windows beyond draining. After a flush, further pushes at or
-    /// below the flushed horizon count as late.
+    /// one covering `max_ts` regardless of `max_delay`, or the final open
+    /// session, and returns ALL pending windows (the flushed ones plus any not
+    /// yet taken). No-op for count windows beyond draining. After a flush,
+    /// further pushes at or below the flushed horizon count as late.
     pub fn flush(&mut self) -> Vec<Window<T>> {
+        #[cfg(feature = "session_windows")]
+        if let WindowSpec::Session { gap } = self.spec {
+            if self.session_seen_event {
+                self.session_flushed_horizon = Some(self.max_ts);
+            }
+            self.close_ready_sessions(gap, self.max_ts, true);
+            return self.take_closed();
+        }
+
         if let WindowSpec::Time { range, step, t0, .. } = self.spec {
             while let Some(k) = self.next_close {
                 if t0 + k * step > self.max_ts {
@@ -370,7 +505,7 @@ impl<T: Clone> WindowedStream<T> {
         std::mem::take(&mut self.closed)
     }
 
-    /// How many arrivals were dropped as too late (time windows only).
+    /// How many arrivals were dropped as too late (time/session windows only).
     pub fn late_dropped(&self) -> u64 {
         self.late_dropped
     }

--- a/crates/sparq-rsp/tests/session_oracle.rs
+++ b/crates/sparq-rsp/tests/session_oracle.rs
@@ -1,0 +1,208 @@
+#![cfg(feature = "session_windows")]
+
+// [GPT-5.6] sq-zckkq: deterministic, hand-derived session-window oracle.
+
+use oxrdf::{NamedNode, Term};
+use sparq_rsp::{ContinuousQuery, Window, WindowResult, WindowSpec, WindowedStream, R2S};
+
+const GAP: u64 = 10;
+const QUERY: &str = "SELECT ?s WHERE { ?s <http://example/p> <http://example/o> } ORDER BY ?s";
+
+fn subject(name: &str) -> Term {
+    NamedNode::new_unchecked(format!("http://example/{name}")).into()
+}
+
+fn triple(name: &str) -> [Term; 3] {
+    [
+        subject(name),
+        NamedNode::new_unchecked("http://example/p").into(),
+        NamedNode::new_unchecked("http://example/o").into(),
+    ]
+}
+
+fn two_burst_script() -> Vec<([Term; 3], u64)> {
+    vec![
+        (triple("a"), 1),
+        (triple("b"), 2),
+        (triple("c"), 3),
+        (triple("b"), 100),
+        (triple("d"), 101),
+    ]
+}
+
+fn collect_low_level(script: Vec<([Term; 3], u64)>) -> Vec<Window> {
+    let mut stream = WindowedStream::empty(WindowSpec::session(GAP));
+    let mut closed = Vec::new();
+    for (triple, ts) in script {
+        stream.push(triple, ts);
+        closed.extend(stream.take_closed());
+    }
+    closed.extend(stream.flush());
+    closed
+}
+
+fn collect_query(r2s: R2S) -> Vec<WindowResult> {
+    let mut query = ContinuousQuery::register(QUERY, WindowSpec::session(GAP))
+        .unwrap()
+        .with_r2s(r2s);
+    let mut results = Vec::new();
+    for (triple, ts) in two_burst_script() {
+        query
+            .push(triple, ts, |result| results.push(result))
+            .unwrap();
+    }
+    query.flush(|result| results.push(result)).unwrap();
+    results
+}
+
+fn rows(names: &[&str]) -> Vec<Vec<Option<Term>>> {
+    names.iter().map(|name| vec![Some(subject(name))]).collect()
+}
+
+#[test]
+fn two_bursts_close_as_two_exact_inclusive_sessions() {
+    let sessions = collect_low_level(two_burst_script());
+    assert_eq!(sessions.len(), 2);
+
+    assert_eq!((sessions[0].start, sessions[0].end), (1, 3));
+    assert_eq!(
+        sessions[0]
+            .triples
+            .iter()
+            .map(|item| item.ts)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        sessions[0]
+            .triples
+            .iter()
+            .map(|item| item.triple[0].clone())
+            .collect::<Vec<_>>(),
+        vec![subject("a"), subject("b"), subject("c")]
+    );
+
+    assert_eq!((sessions[1].start, sessions[1].end), (100, 101));
+    assert_eq!(
+        sessions[1]
+            .triples
+            .iter()
+            .map(|item| item.ts)
+            .collect::<Vec<_>>(),
+        vec![100, 101]
+    );
+    assert_eq!(
+        sessions[1]
+            .triples
+            .iter()
+            .map(|item| item.triple[0].clone())
+            .collect::<Vec<_>>(),
+        vec![subject("b"), subject("d")]
+    );
+}
+
+fn scalar_sessions(timestamps: &[u64]) -> Vec<Window<u64>> {
+    let mut stream = WindowedStream::empty(WindowSpec::session(GAP));
+    let mut closed = Vec::new();
+    for &ts in timestamps {
+        stream.push(ts, ts);
+        closed.extend(stream.take_closed());
+    }
+    closed.extend(stream.flush());
+    closed
+}
+
+#[test]
+fn exact_gap_splits_but_gap_minus_one_extends() {
+    let split = scalar_sessions(&[5, 15]);
+    assert_eq!(split.len(), 2);
+    assert_eq!((split[0].start, split[0].end), (5, 5));
+    assert_eq!((split[1].start, split[1].end), (15, 15));
+    assert_eq!(split[0].triples[0].triple, 5);
+    assert_eq!(split[1].triples[0].triple, 15);
+
+    let joined = scalar_sessions(&[5, 14]);
+    assert_eq!(joined.len(), 1);
+    assert_eq!((joined[0].start, joined[0].end), (5, 14));
+    assert_eq!(
+        joined[0]
+            .triples
+            .iter()
+            .map(|item| item.triple)
+            .collect::<Vec<_>>(),
+        vec![5, 14]
+    );
+}
+
+#[test]
+fn heartbeat_closes_at_the_exact_inactivity_deadline() {
+    let mut stream = WindowedStream::empty(WindowSpec::session(GAP));
+    stream.push(5_u64, 5);
+    stream.advance(14);
+    assert!(stream.take_closed().is_empty());
+
+    stream.advance(15);
+    let closed = stream.take_closed();
+    assert_eq!(closed.len(), 1);
+    assert_eq!((closed[0].start, closed[0].end), (5, 5));
+    assert!(stream.flush().is_empty());
+}
+
+#[test]
+fn r2s_operators_emit_exact_hand_derived_multiset_diffs() {
+    let rstream = collect_query(R2S::RStream);
+    assert_eq!(rstream.len(), 2);
+    assert_eq!((rstream[0].start, rstream[0].end), (1, 3));
+    assert_eq!(rstream[0].rows, rows(&["a", "b", "c"]));
+    assert_eq!((rstream[1].start, rstream[1].end), (100, 101));
+    assert_eq!(rstream[1].rows, rows(&["b", "d"]));
+
+    let istream = collect_query(R2S::IStream);
+    assert_eq!(istream.len(), 2);
+    assert_eq!(istream[0].rows, rows(&["a", "b", "c"]));
+    assert_eq!(istream[1].rows, rows(&["d"]));
+
+    let dstream = collect_query(R2S::DStream);
+    assert_eq!(dstream.len(), 2);
+    assert!(dstream[0].rows.is_empty());
+    assert_eq!(dstream[1].rows, rows(&["a", "c"]));
+}
+
+#[test]
+fn out_of_order_events_join_only_a_still_open_session() {
+    let mut stream = WindowedStream::empty(WindowSpec::session(GAP));
+    stream.push(100_u64, 100);
+    stream.push(95, 95);
+    stream.push(50, 50);
+    assert_eq!(stream.late_dropped(), 1);
+
+    let sessions = stream.flush();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!((sessions[0].start, sessions[0].end), (95, 100));
+    assert_eq!(
+        sessions[0]
+            .triples
+            .iter()
+            .map(|item| item.triple)
+            .collect::<Vec<_>>(),
+        vec![95, 100]
+    );
+}
+
+#[test]
+fn flushing_an_empty_stream_does_not_make_timestamp_zero_late() {
+    let mut stream = WindowedStream::empty(WindowSpec::session(GAP));
+    assert!(stream.flush().is_empty());
+
+    stream.push(0_u64, 0);
+    assert_eq!(stream.late_dropped(), 0);
+    let sessions = stream.flush();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!((sessions[0].start, sessions[0].end), (0, 0));
+}
+
+#[test]
+#[should_panic(expected = "session window GAP must be > 0")]
+fn zero_gap_is_rejected() {
+    let _ = WindowSpec::session(0);
+}

--- a/skills/streaming-rsp/SKILL.md
+++ b/skills/streaming-rsp/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: streaming-rsp
-description: Use when running continuous/standing SPARQL over a live RDF triple stream with the sparq engine — sliding/tumbling time windows (RANGE/STEP), count (ROWS) windows, RSTREAM/ISTREAM/DSTREAM output, RSP-QL surface syntax (REGISTER STREAM, FROM NAMED WINDOW ... ON ... RANGE/STEP), and multi-window joins (WINDOW <w1>{} JOIN WINDOW <w2>{}). Covers the sparq-rsp crate's ContinuousQuery / ContinuousConstruct / ContinuousAsk / ContinuousMultiQuery / RspqlQuery / WindowSpec.
+description: Use when running continuous/standing SPARQL over a live RDF triple stream with the sparq engine — sliding/tumbling time windows (RANGE/STEP), count (ROWS) windows, opt-in gap-triggered session windows, RSTREAM/ISTREAM/DSTREAM output, RSP-QL surface syntax (REGISTER STREAM, FROM NAMED WINDOW ... ON ... RANGE/STEP), and multi-window joins (WINDOW <w1>{} JOIN WINDOW <w2>{}). Covers the sparq-rsp crate's ContinuousQuery / ContinuousConstruct / ContinuousAsk / ContinuousMultiQuery / RspqlQuery / WindowSpec.
 ---
 
 # sparq-streaming-rsp
 
-`sparq-rsp` runs **windowed continuous SPARQL** (RSP-QL-style RDF Stream Processing) over a stream of `(triple, timestamp)` elements, as a deterministic **synchronous library** — no async runtime, no wall clock, no service. You push timestamped triples; it closes windows on a watermark and fires your callback once per closed window with the SELECT / CONSTRUCT / ASK result. It is a fully isolated, opt-in crate: nothing else in the workspace depends on it, the core engine and the **lean** `sparq-wasm` bundle carry zero streaming code (streaming ships as a *separate*, lazy-loaded `sparq-rsp-wasm` bundle — see below), and there are **no cargo features** — you engage it simply by depending on the crate.
+`sparq-rsp` runs **windowed continuous SPARQL** (RSP-QL-style RDF Stream Processing) over a stream of `(triple, timestamp)` elements, as a deterministic **synchronous library** — no async runtime, no wall clock, no service. You push timestamped triples; it closes windows on a watermark and fires your callback once per closed window with the SELECT / CONSTRUCT / ASK result. It is a fully isolated, opt-in crate: nothing else in the workspace depends on it, and the core engine and the **lean** `sparq-wasm` bundle carry zero streaming code (streaming ships as a *separate*, lazy-loaded `sparq-rsp-wasm` bundle — see below). Time/count windows are the default surface; gap-triggered session windows require the default-off `session_windows` cargo feature.
 
 ## Quickstart
 
@@ -13,7 +13,7 @@ description: Use when running continuous/standing SPARQL over a live RDF triple 
 
 ```toml
 [dependencies]
-sparq-rsp = { path = "../sparq/crates/sparq-rsp" } # or version = "0.1.0" once published
+sparq-rsp = { path = "../sparq/crates/sparq-rsp" } # add features = ["session_windows"] for sessions
 oxrdf = { version = "0.3", features = ["rdf-12"] } # the term model (Term/NamedNode/Literal)
 ```
 
@@ -70,6 +70,7 @@ All public items are re-exported at the crate root (`sparq_rsp::…`).
 // --- S2R: the window spec (Copy enum + builders) ---
 WindowSpec::time(range: u64, step: u64) -> WindowSpec   // panics if range==0 or step==0
 WindowSpec::count(rows: usize) -> WindowSpec            // CQL count window; panics if rows==0
+WindowSpec::session(gap: u64) -> WindowSpec             // feature=session_windows; panics if gap==0
   .with_max_delay(d: u64) -> WindowSpec   // out-of-order tolerance (time windows only)
   .with_t0(t0: u64)       -> WindowSpec   // RSP-QL window origin (time windows only; default 0)
   .with_slide(s: usize)   -> WindowSpec   // report cadence (count windows only; default 1)
@@ -137,6 +138,12 @@ let mut q = ContinuousQuery::register("SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o 
 # Ok::<(), String>(())
 ```
 
+**Session window — split after an inactivity gap:** enable the `session_windows`
+cargo feature, then use `WindowSpec::session(10)`. Events at `t` and `t + 9`
+share a session; events at `t` and `t + 10` start separate sessions. The gap is
+measured in the stream's application-supplied `u64` timestamp ticks, never wall
+clock, and reported bounds are inclusive `[first_event_ts, last_event_ts]`.
+
 **CONSTRUCT to transform a stream into another stream (each window -> a graph):**
 
 ```rust
@@ -181,14 +188,14 @@ q.flush(|_| {})?;
 
 ## Gotchas / feature flags / prerequisites
 
-- **No cargo features, no async, no clock.** The crate has zero feature flags — depend on it and it's on. Timestamps are **application-supplied `u64`s** (logical ticks, epoch millis, sequence numbers — your scale); the engine never reads the wall clock. Time advances only through pushed timestamps. A quiet stream closes nothing until the next push or `flush()`.
-- **Window semantics are half-open `[start, end)`** — start inclusive, end exclusive. `RANGE 10 STEP 10` gives `[0,10) [10,20) …` (a triple at `ts=10` is in `[10,20)` only). `step < range` ⇒ overlapping (sliding) windows; `step > range` leaves uncovered gaps (a gap triple enters no window but still advances the watermark). Origin defaults to `t0=0`; pre-`t0` arrivals belong to no window but advance the watermark.
+- **No async and no clock.** Timestamps are **application-supplied `u64`s** (logical ticks, epoch millis, sequence numbers — your scale); the engine never reads the wall clock. Time advances only through pushed timestamps. A quiet stream closes nothing until the next push or `flush()`. The only cargo feature is default-off `session_windows`; time/count behaviour is unchanged without it.
+- **Window bounds depend on the window type.** Time windows are half-open `[start, end)`: `RANGE 10 STEP 10` gives `[0,10) [10,20) …` (a triple at `ts=10` is in `[10,20)` only). `step < range` ⇒ overlapping (sliding) windows; `step > range` leaves uncovered gaps. Count and session windows report inclusive `[first.ts, last.ts]` content bounds. For sessions, a consecutive gap `< gap` extends the run and a gap `>= gap` splits it.
 - **Watermark + lateness.** A window closes when `max_ts_seen − max_delay` reaches its `end`. `with_max_delay(d)` is the out-of-order tolerance (default 0 = close at first sight of a newer-window triple). An arrival whose *every* covering window has already closed is dropped and counted in `late_dropped()`. `flush()` ignores `max_delay` and closes everything up to the last timestamp seen.
 - **Empty windows are reported** (evaluated + delivered) when the watermark jumps a gap — DSTREAM needs to observe results disappear. Windows wholly closed before the first arrival's watermark are skipped (a stream starting at `ts=10⁹` won't replay a billion empties).
 - **Materialisation is set-semantic:** a window is an RDF *graph*, so the same triple at several timestamps within one window counts once. CONSTRUCT results are triple sets (exact set-diff for I/DSTREAM); SELECT results are multisets diffed by 64-bit `FxHasher` row hashes (a hash collision could theoretically suppress a diff — accepted as vanishingly unlikely).
 - **`register` rejects the wrong query form:** `ContinuousQuery` requires SELECT, `ContinuousConstruct` requires CONSTRUCT, `ContinuousAsk` requires ASK. Errors come back as `Err(String)` at registration. `push`/`flush` errors are engine evaluation errors.
 - **`with_mode` must precede the first push** (switching mode resets stream state). Default `EvalMode::PersistentDict` wins every measured scenario and bounds dictionary memory to the *live* window vocabulary via refcount-exact compaction. `Rebuild` bounds memory to one window. `Delta` keeps one live graph evolved by per-slide deltas (kept for huge-window / cheap-eval cases; never the benchmark winner); the consecutive-window diff itself runs on the shared eval substrate (`sparq-substrate` `join::delta::DeltaTable`, id-level, monomorphic — the previous window's build table persists across slides so it is never re-hashed). [FABLE-5] sq-2n1q3.4 `Snapshot` is `Delta` plus a cheap `O(overlay)` **immutable point-in-time** `Graph::snapshot` per closed window — a logically-independent, `Send + Sync` view the engine (or your callback) can retain or publish across windows, where `Delta`'s live `&Graph` borrow cannot. Results are identical across all four modes.
-- **RSP-QL parser scope (`RspqlQuery::parse` / `ContinuousMultiQuery`):** parses `REGISTER [STREAM|RSTREAM|ISTREAM|DSTREAM] <out> AS`, `FROM NAMED WINDOW <w> ON <s> [RANGE <dur> [STEP <dur>]]` (tumbling when STEP omitted), and `WINDOW <w> { … }` (rewritten to `GRAPH <w> { … }`). Durations are ISO-8601 (`PT10S`, `PT1M30S`, `PT2H`, `P1D`; **seconds resolution**, years/months/weeks rejected) or bare integers (logical ticks). IRIs may be `<…>` or prefixed names resolved against the body's `PREFIX`/`BASE`. **Scoped out** (use the programmatic `WindowSpec` instead): window *variables* (`WINDOW ?w`), `ROWS` count windows, the `t0`/`max_delay` parameters, and relative `NOW-PT…TO…` bounds. `ContinuousMultiQuery` requires ≥2 windows (use `ContinuousQuery` for one); 3 or more windows work — each gets its own S2R state on the shared synchronized clock. RSTREAM/ISTREAM/DSTREAM are all supported: `REGISTER ISTREAM <out> AS` emits per-tick added rows; `REGISTER DSTREAM <out> AS` emits per-tick removed rows (multiset diff against the previous tick's full join result). [SONNET-4.6] sq-2n1q3.3
+- **RSP-QL parser scope (`RspqlQuery::parse` / `ContinuousMultiQuery`):** parses `REGISTER [STREAM|RSTREAM|ISTREAM|DSTREAM] <out> AS`, `FROM NAMED WINDOW <w> ON <s> [RANGE <dur> [STEP <dur>]]` (tumbling when STEP omitted), and `WINDOW <w> { … }` (rewritten to `GRAPH <w> { … }`). Durations are ISO-8601 (`PT10S`, `PT1M30S`, `PT2H`, `P1D`; **seconds resolution**, years/months/weeks rejected) or bare integers (logical ticks). IRIs may be `<…>` or prefixed names resolved against the body's `PREFIX`/`BASE`. **Scoped out** (use the programmatic `WindowSpec` instead): window *variables* (`WINDOW ?w`), `ROWS` count windows, session windows, the `t0`/`max_delay` parameters, and relative `NOW-PT…TO…` bounds. `ContinuousMultiQuery` requires ≥2 windows (use `ContinuousQuery` for one); 3 or more windows work — each gets its own S2R state on the shared synchronized clock. RSTREAM/ISTREAM/DSTREAM are all supported: `REGISTER ISTREAM <out> AS` emits per-tick added rows; `REGISTER DSTREAM <out> AS` emits per-tick removed rows (multiset diff against the previous tick's full join result). [SONNET-4.6] sq-2n1q3.3
 - **Term model is `oxrdf`** (`oxrdf::Term`/`NamedNode`/`Literal`); stream elements are `[Term; 3]`. Add `oxrdf` with `features = ["rdf-12"]` to match the workspace.
 
 ## Conformance / correctness ratchet (honest scope)


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements bead `sq-zckkq`.

Adds the default-off `session_windows` feature with `WindowSpec::Session { gap: u64 }` and `WindowSpec::session(gap)`. Session membership and closure use application-supplied event-time ticks only: gaps `< gap` extend, gaps `>= gap` split, bounds are inclusive, watermarks and `advance` close inactive sessions, and `flush` freezes the final session. Existing RSTREAM/ISTREAM/DSTREAM emission is reused unchanged.

The new deterministic oracle pins two bursts, exact-gap and gap-minus-one boundaries, heartbeat closure, hand-derived R2S multisets, out-of-order handling, empty-stream flush, and the zero-gap guard. The exact-gap test was mutation-witnessed by changing `>=` to `>` and observing it fail before restoration.

Public API documentation is updated in the crate README and `skills/streaming-rsp/SKILL.md`. The SRBench floor is unchanged, and the lean `sparq-wasm` dependency graph still contains no `sparq-rsp` edge.

Gates green:
- `cargo clippy -p sparq-rsp --all-targets -- -D warnings`
- `cargo clippy -p sparq-rsp --all-targets --features session_windows -- -D warnings`
- `cargo test -p sparq-rsp`
- `cargo test -p sparq-rsp --features session_windows`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-rsp --no-deps --all-features` plus default-feature rustdoc
- `cargo check --workspace` in default and `sparq-rsp/session_windows` states
- README template, markdownlint, and no-perf-number documentation gates