### PR TITLE
feat(arrow): import RecordBatch into QueryResult [GPT-5.6]

### DIFF
--- a/crates/sparq-arrow/Cargo.toml
+++ b/crates/sparq-arrow/Cargo.toml
@@ -1,11 +1,11 @@
-# sparq-arrow (gh-910, bead sq-v78l4): opt-in Apache Arrow columnar export for SPARQL
-# SELECT results. Converts a sparq-engine `QueryResult` (variable columns + RDF-term
-# rows) into an Arrow `RecordBatch` so results flow zero-copy-ish into the dataframe /
-# analytics ecosystem (Polars / DuckDB / pandas via the Python follow-up). [OPUS-4.8]
+# sparq-arrow (gh-910, beads sq-v78l4 + sq-lsp7k.16): opt-in Apache Arrow columnar
+# import/export for SPARQL SELECT results. Converts between a sparq-engine `QueryResult`
+# and an Arrow `RecordBatch` for dataframe / analytics interoperability.
+# [OPUS-4.8] [GPT-5.6]
 #
 # OPT-IN / LEAN-CORE by construction: this is a SEPARATE leaf crate, so the `arrow-*`
 # dependency closure NEVER enters sparq-core / sparq-engine / the wasm bundle. Nothing
-# in the workspace default build depends on it. The Arrow export is itself feature-gated
+# in the workspace default build depends on it. Arrow interop is feature-gated
 # (`arrow`, OFF by default) so even building THIS crate without the feature pulls no
 # Arrow code — the crate then exposes only the dependency-free schema documentation.
 
@@ -15,7 +15,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Opt-in Apache Arrow columnar export for sparq: convert a SPARQL SELECT QueryResult into an Arrow RecordBatch (one struct column per variable: kind / value / datatype / language / direction), a faithful round-trippable projection of the SPARQL-Results term model for zero-copy transfer into Polars / DuckDB / pandas"
+description = "Opt-in Apache Arrow columnar import/export for sparq: convert SPARQL SELECT QueryResult values to and from a faithful RecordBatch term-struct projection for Polars, DuckDB, and pandas interoperability"
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
@@ -23,7 +23,7 @@ categories.workspace = true
 readme = "README.md"
 
 # [OPUS-4.8] docs.rs: build with all features + the `docsrs` cfg so the `arrow`-gated
-# `to_record_batch` / `term_schema` items render on the docs.rs front page.
+# `to_record_batch` / `from_record_batch` / `term_schema` items render on docs.rs.
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
@@ -32,7 +32,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 # OFF by default: the default build of this crate carries ZERO Arrow code and no
 # Arrow dependency — only the schema documentation + the public field-name constants
 # compile. Turning `arrow` ON pulls `arrow-array` + `arrow-schema` and enables
-# `to_record_batch` / `term_schema`. The crate is itself opt-in (a separate leaf crate
+# `to_record_batch` / `from_record_batch` / `term_schema`. The crate is itself opt-in
+# (a separate leaf crate
 # off the default workspace build), and the Arrow dependency is opt-in on top of that.
 default = []
 arrow = ["dep:arrow-array", "dep:arrow-schema", "dep:arrow-buffer"]

--- a/crates/sparq-arrow/README.md
+++ b/crates/sparq-arrow/README.md
@@ -4,9 +4,11 @@
 > Projects a SPARQL `SELECT` result (`sparq_engine::QueryResult`) into an Arrow
 > `RecordBatch` so query results flow into the dataframe / analytics / ML ecosystem
 > (Polars, DuckDB, pandas) without a CSV round-trip. Issue #910, bead `sq-v78l4`.
+>
+> [GPT-5.6] Bead `sq-lsp7k.16` adds the checked inverse, `from_record_batch`.
 
-**Opt-in / lean-core by construction.** This is a separate leaf crate, and the export
-itself sits behind the `arrow` feature (OFF by default). The `arrow-*` dependency
+**Opt-in / lean-core by construction.** This is a separate leaf crate, and Arrow
+import/export sits behind the `arrow` feature (OFF by default). The `arrow-*` dependency
 closure NEVER enters `sparq-core` / `sparq-engine` / the wasm bundle; nothing in the
 workspace default build depends on it. The default build of *this* crate pulls no Arrow
 code at all — only the dependency-free field-name constants and the schema docs.
@@ -14,7 +16,7 @@ code at all — only the dependency-free field-name constants and the schema doc
 ## 🚀 Quickstart
 
 ```rust,ignore
-use sparq_arrow::to_record_batch;
+use sparq_arrow::{from_record_batch, to_record_batch};
 use sparq_engine::{query, QueryResult};
 use sparq_core::Graph;
 
@@ -25,6 +27,9 @@ let result: QueryResult = query(&graph, "SELECT ?s ?o WHERE { ?s ?p ?o }")?;
 let batch = to_record_batch(&result)?;       // needs --features arrow
 assert_eq!(batch.num_columns(), 2);          // ?s, ?o
 assert_eq!(batch.schema().field(0).name(), "s");
+let restored = from_record_batch(&batch)?;
+assert_eq!(restored.vars, result.vars);
+assert_eq!(restored.rows, result.rows);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
@@ -48,6 +53,10 @@ one column of `Struct<kind, value, datatype, language, direction>` (all nullable
 
 An **unbound** binding is a `null` struct slot — distinct from a bound empty-string
 literal. `term_schema(&vars)` builds the schema without materialising rows.
+`from_record_batch(&batch)` validates that exact schema and reconstructs the variables,
+row order, unbound cells, and RDF terms. Invalid variable names, schemas, kinds, IRIs,
+blank-node labels, language tags, directions, triple terms, or incompatible literal
+metadata return `ArrowError`; they never panic or silently select a fallback term kind.
 
 ## 📚 Honest boundary / caveats
 
@@ -61,7 +70,7 @@ literal. `term_schema(&vars)` builds the schema without materialising rows.
 - **Triple terms are stringified** to N-Triples in `value` (`kind = "triple"`), not
   exploded into nested struct fields.
 - This is a **projection for transport**, not a canonical RDF serialisation: the Arrow
-  batch is not itself an RDF document (round-tripping from the five fields is trivial).
+  batch is not itself an RDF document. `from_record_batch` is its checked inverse.
 - **Python binding.** Issue #910 frames a `sparq-py` `Graph.query_arrow() ->
   pyarrow.Table` over this export; that PyO3 binding lives in the opt-in `arrow` feature
   of `sparq-py` (bead `sq-lt1ml`) — it reuses `to_record_batch` here and bridges the

--- a/crates/sparq-arrow/src/import.rs
+++ b/crates/sparq-arrow/src/import.rs
@@ -1,0 +1,307 @@
+//! The `arrow`-feature-gated import: Arrow `RecordBatch` → `QueryResult`.
+
+use arrow_array::{Array, RecordBatch, StringArray, StructArray};
+use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Variable};
+use sparq_engine::QueryResult;
+
+use crate::{term_struct_type, RDF_TERM_FIELDS};
+
+/// Failure converting an Arrow [`RecordBatch`] into a [`QueryResult`].
+///
+/// The importer rejects any schema or cell that does not follow this crate's RDF-term
+/// struct contract. The error is intentionally opaque apart from its message so future
+/// validation can become stricter without adding semver-visible enum variants.
+#[derive(Debug)]
+pub struct ArrowError {
+    message: String,
+}
+
+impl ArrowError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ArrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ArrowError {}
+
+/// Convert an Arrow [`RecordBatch`] using this crate's RDF-term struct projection back
+/// into a SPARQL [`QueryResult`].
+///
+/// Variables are reconstructed from the top-level field names. Rows and variables keep
+/// their batch order, and a null struct slot becomes an unbound result cell. All other
+/// cells must contain exactly the five nullable UTF-8 children documented at the crate
+/// root.
+///
+/// # Errors
+///
+/// Returns [`ArrowError`] if a variable name, schema, term kind, RDF lexical component,
+/// or combination of literal metadata violates the projection contract.
+///
+/// # Example
+///
+/// ```
+/// # use oxrdf::{NamedNode, Term, Variable};
+/// # use sparq_engine::QueryResult;
+/// let result = QueryResult {
+///     vars: vec![Variable::new("s").unwrap()],
+///     rows: vec![vec![Some(Term::NamedNode(
+///         NamedNode::new("http://example.com/s").unwrap(),
+///     ))]],
+/// };
+/// let batch = sparq_arrow::to_record_batch(&result).unwrap();
+/// let restored = sparq_arrow::from_record_batch(&batch).unwrap();
+/// assert_eq!(restored.vars, result.vars);
+/// assert_eq!(restored.rows, result.rows);
+/// ```
+pub fn from_record_batch(batch: &RecordBatch) -> Result<QueryResult, ArrowError> {
+    // [GPT-5.6] Validate before reading: Arrow permits arbitrary struct schemas, while
+    // this inverse is sound only for the exact lossless projection emitted by this crate.
+    let schema = batch.schema();
+    let mut vars = Vec::with_capacity(schema.fields().len());
+    let mut columns = Vec::with_capacity(schema.fields().len());
+
+    for (index, field) in schema.fields().iter().enumerate() {
+        let variable = Variable::new(field.name().to_string()).map_err(|error| {
+            ArrowError::invalid(format!(
+                "invalid SELECT variable in Arrow field '{}': {}",
+                field.name(),
+                error
+            ))
+        })?;
+        if vars.iter().any(|existing: &Variable| existing == &variable) {
+            return Err(ArrowError::invalid(format!(
+                "duplicate SELECT variable '{}' in Arrow schema",
+                field.name()
+            )));
+        }
+        if !field.is_nullable() || field.data_type() != &term_struct_type() {
+            return Err(ArrowError::invalid(format!(
+                "Arrow field '{}' does not use the nullable RDF-term struct schema",
+                field.name()
+            )));
+        }
+
+        let column = batch
+            .column(index)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .ok_or_else(|| {
+                ArrowError::invalid(format!(
+                    "Arrow field '{}' is not backed by a StructArray",
+                    field.name()
+                ))
+            })?;
+        vars.push(variable);
+        columns.push(column);
+    }
+
+    let mut rows = Vec::with_capacity(batch.num_rows());
+    for row_index in 0..batch.num_rows() {
+        let mut row = Vec::with_capacity(columns.len());
+        for (column_index, column) in columns.iter().enumerate() {
+            row.push(read_cell(
+                column,
+                row_index,
+                schema.field(column_index).name(),
+            )?);
+        }
+        rows.push(row);
+    }
+
+    Ok(QueryResult { vars, rows })
+}
+
+fn read_cell(
+    column: &StructArray,
+    row: usize,
+    column_name: &str,
+) -> Result<Option<Term>, ArrowError> {
+    let children = string_children(column, column_name)?;
+    if column.is_null(row) {
+        if children.iter().any(|child| child.is_valid(row)) {
+            return Err(cell_error(
+                column_name,
+                row,
+                "an unbound struct slot must have five null children",
+            ));
+        }
+        return Ok(None);
+    }
+
+    let kind = required(children[0], row, column_name, "kind")?;
+    let value = required(children[1], row, column_name, "value")?;
+    let datatype = optional(children[2], row);
+    let language = optional(children[3], row);
+    let direction = optional(children[4], row);
+
+    let term =
+        match kind {
+            "uri" => {
+                require_no_metadata(column_name, row, datatype, language, direction)?;
+                Term::NamedNode(NamedNode::new(value).map_err(|error| {
+                    cell_error(column_name, row, format!("invalid IRI: {error}"))
+                })?)
+            }
+            "bnode" => {
+                require_no_metadata(column_name, row, datatype, language, direction)?;
+                Term::BlankNode(BlankNode::new(value).map_err(|error| {
+                    cell_error(
+                        column_name,
+                        row,
+                        format!("invalid blank-node label: {error}"),
+                    )
+                })?)
+            }
+            "literal" => Term::Literal(read_literal(
+                value,
+                datatype,
+                language,
+                direction,
+                column_name,
+                row,
+            )?),
+            "triple" => {
+                require_no_metadata(column_name, row, datatype, language, direction)?;
+                match value.parse::<Term>().map_err(|error| {
+                    cell_error(
+                        column_name,
+                        row,
+                        format!("invalid N-Triples triple term: {error}"),
+                    )
+                })? {
+                    term @ Term::Triple(_) => term,
+                    _ => {
+                        return Err(cell_error(
+                            column_name,
+                            row,
+                            "kind 'triple' requires an N-Triples triple term",
+                        ));
+                    }
+                }
+            }
+            other => {
+                return Err(cell_error(
+                    column_name,
+                    row,
+                    format!("unknown RDF term kind '{other}'"),
+                ));
+            }
+        };
+
+    Ok(Some(term))
+}
+
+fn string_children<'a>(
+    column: &'a StructArray,
+    column_name: &str,
+) -> Result<[&'a StringArray; 5], ArrowError> {
+    let mut children = Vec::with_capacity(RDF_TERM_FIELDS.len());
+    for (index, field_name) in RDF_TERM_FIELDS.iter().enumerate() {
+        let child = column
+            .column(index)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| {
+                ArrowError::invalid(format!(
+                    "Arrow field '{column_name}.{field_name}' is not backed by a UTF-8 array"
+                ))
+            })?;
+        children.push(child);
+    }
+    children.try_into().map_err(|_| {
+        ArrowError::invalid(format!(
+            "Arrow field '{column_name}' does not have five RDF-term children"
+        ))
+    })
+}
+
+fn required<'a>(
+    child: &'a StringArray,
+    row: usize,
+    column: &str,
+    field: &str,
+) -> Result<&'a str, ArrowError> {
+    if child.is_null(row) {
+        return Err(cell_error(
+            column,
+            row,
+            format!("bound term has null '{field}'"),
+        ));
+    }
+    Ok(child.value(row))
+}
+
+fn optional(child: &StringArray, row: usize) -> Option<&str> {
+    child.is_valid(row).then(|| child.value(row))
+}
+
+fn require_no_metadata(
+    column: &str,
+    row: usize,
+    datatype: Option<&str>,
+    language: Option<&str>,
+    direction: Option<&str>,
+) -> Result<(), ArrowError> {
+    if datatype.is_some() || language.is_some() || direction.is_some() {
+        return Err(cell_error(
+            column,
+            row,
+            "non-literal term must not have datatype, language, or direction metadata",
+        ));
+    }
+    Ok(())
+}
+
+fn read_literal(
+    value: &str,
+    datatype: Option<&str>,
+    language: Option<&str>,
+    direction: Option<&str>,
+    column: &str,
+    row: usize,
+) -> Result<Literal, ArrowError> {
+    match (datatype, language, direction) {
+        (Some(datatype), None, None) => {
+            let datatype = NamedNode::new(datatype).map_err(|error| {
+                cell_error(column, row, format!("invalid datatype IRI: {error}"))
+            })?;
+            Ok(Literal::new_typed_literal(value, datatype))
+        }
+        (None, Some(language), None) => Literal::new_language_tagged_literal(value, language)
+            .map_err(|error| cell_error(column, row, format!("invalid language tag: {error}"))),
+        (None, Some(language), Some(direction)) => {
+            let direction = match direction {
+                "ltr" => BaseDirection::Ltr,
+                "rtl" => BaseDirection::Rtl,
+                other => {
+                    return Err(cell_error(
+                        column,
+                        row,
+                        format!("invalid base direction '{other}'"),
+                    ));
+                }
+            };
+            Literal::new_directional_language_tagged_literal(value, language, direction)
+                .map_err(|error| cell_error(column, row, format!("invalid language tag: {error}")))
+        }
+        _ => Err(cell_error(
+            column,
+            row,
+            "literal requires either a datatype or a language tag; direction requires language",
+        )),
+    }
+}
+
+fn cell_error(column: &str, row: usize, message: impl std::fmt::Display) -> ArrowError {
+    ArrowError::invalid(format!(
+        "invalid RDF term at column '{column}', row {row}: {message}"
+    ))
+}

--- a/crates/sparq-arrow/src/lib.rs
+++ b/crates/sparq-arrow/src/lib.rs
@@ -17,7 +17,7 @@
 //! Each SELECT variable becomes one Arrow column of the struct type produced by
 //! `term_struct_type` (a `Struct` of five nullable `Utf8` fields — the names are the
 //! [`FIELD_*`](FIELD_KIND) constants; the `arrow`-gated `term_struct_type` /
-//! `to_record_batch` / `term_schema` items carry the full rustdoc):
+//! `to_record_batch` / `from_record_batch` / `term_schema` items carry the full rustdoc):
 //!
 //! | field        | meaning                                                                                   |
 //! |--------------|-------------------------------------------------------------------------------------------|
@@ -45,9 +45,9 @@
 //!   N-Triples form in `value` (`kind = "triple"`); its components are not exploded into
 //!   nested struct fields. RDF-1.2 triple terms in result *bindings* are rare; a nested
 //!   encoding is left to the same typed-view follow-up.
-//! * This is a **projection for transport**, not a canonical RDF serialisation: round-tripping
-//!   back to terms is straightforward from the five fields, but the Arrow batch is not itself
-//!   an RDF document.
+//! * This is a **projection for transport**, not a canonical RDF serialisation:
+//!   `from_record_batch` reconstructs terms from the five fields, but the Arrow batch is not
+//!   itself an RDF document.
 
 /// Struct field name: the term kind — `"uri"`, `"bnode"`, `"literal"`, or `"triple"`.
 pub const FIELD_KIND: &str = "kind";
@@ -78,5 +78,12 @@ pub const RDF_TERM_FIELDS: [&str; 5] = [
 mod export;
 
 #[cfg(feature = "arrow")]
+mod import;
+
+#[cfg(feature = "arrow")]
 #[cfg_attr(docsrs, doc(cfg(feature = "arrow")))]
 pub use export::{term_schema, term_struct_type, to_record_batch, ArrowExportError};
+
+#[cfg(feature = "arrow")]
+#[cfg_attr(docsrs, doc(cfg(feature = "arrow")))]
+pub use import::{from_record_batch, ArrowError};

--- a/crates/sparq-arrow/tests/record_batch.rs
+++ b/crates/sparq-arrow/tests/record_batch.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the Arrow export (the `arrow` feature). The whole file is
+//! Integration tests for Arrow import/export (the `arrow` feature). The whole file is
 //! `#![cfg(feature = "arrow")]`, so it ONLY runs with `--features arrow`; the default
 //! (no-feature) build is exercised by the workspace default lane (the field-name
 //! constants + the schema docs are all that compiles there).
@@ -9,13 +9,15 @@
 //! language / direction land in the right fields).
 #![cfg(feature = "arrow")]
 
+use std::sync::Arc;
+
 use arrow_array::cast::AsArray;
-use arrow_array::{Array, StringArray, StructArray};
-use arrow_schema::DataType;
-use oxrdf::{NamedNode, Term, Variable};
+use arrow_array::{Array, ArrayRef, RecordBatch, StringArray, StructArray};
+use arrow_schema::{DataType, Field};
+use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Triple, Variable};
 use sparq_arrow::{
-    term_schema, to_record_batch, FIELD_DATATYPE, FIELD_DIRECTION, FIELD_KIND, FIELD_LANGUAGE,
-    FIELD_VALUE,
+    from_record_batch, term_schema, to_record_batch, FIELD_DATATYPE, FIELD_DIRECTION, FIELD_KIND,
+    FIELD_LANGUAGE, FIELD_VALUE,
 };
 use sparq_core::Graph;
 use sparq_engine::{query, QueryResult};
@@ -197,5 +199,100 @@ fn duplicate_variable_is_an_error() {
         format!("{}", err).contains("duplicate SELECT variable 'x'"),
         "{}",
         err
+    );
+}
+
+/// [GPT-5.6] Mutation witness for the inverse mapping: removing any term-kind arm or
+/// metadata reconstruction makes this exact row-for-row identity assertion fail.
+#[test]
+fn all_term_kinds_round_trip_to_identical_query_result() {
+    let vars = vec![Variable::new("term").unwrap()];
+    let result = QueryResult {
+        vars: vars.clone(),
+        rows: vec![
+            vec![Some(Term::NamedNode(
+                NamedNode::new("http://example.com/resource").unwrap(),
+            ))],
+            vec![Some(Term::BlankNode(BlankNode::new("blank-1").unwrap()))],
+            vec![Some(Term::Literal(Literal::new_simple_literal("plain")))],
+            vec![Some(Term::Literal(Literal::new_typed_literal(
+                "42",
+                NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap(),
+            )))],
+            vec![Some(Term::Literal(
+                Literal::new_language_tagged_literal("hello", "en").unwrap(),
+            ))],
+            vec![Some(Term::Literal(
+                Literal::new_directional_language_tagged_literal("مرحبا", "ar", BaseDirection::Rtl)
+                    .unwrap(),
+            ))],
+            vec![Some(Term::Triple(Box::new(Triple::new(
+                NamedNode::new("http://example.com/s").unwrap(),
+                NamedNode::new("http://example.com/p").unwrap(),
+                Literal::new_simple_literal("object"),
+            ))))],
+            vec![None],
+        ],
+    };
+
+    let batch = to_record_batch(&result).unwrap();
+    let restored = from_record_batch(&batch).unwrap();
+
+    assert_eq!(restored.vars, result.vars);
+    assert_eq!(restored.rows, result.rows);
+    assert_eq!(restored.vars, vars);
+}
+
+/// A kind outside the four-value contract is rejected, never guessed as a term.
+#[test]
+fn unknown_kind_is_rejected() {
+    let vars = vec![Variable::new("term").unwrap()];
+    let children: Vec<(Arc<Field>, ArrayRef)> = vec![
+        (
+            Arc::new(Field::new(FIELD_KIND, DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![Some("mystery")])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new(FIELD_VALUE, DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![Some("value")])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new(FIELD_DATATYPE, DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new(FIELD_LANGUAGE, DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,
+        ),
+        (
+            Arc::new(Field::new(FIELD_DIRECTION, DataType::Utf8, true)),
+            Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,
+        ),
+    ];
+    let column = Arc::new(StructArray::from(children)) as ArrayRef;
+    let batch = RecordBatch::try_new(Arc::new(term_schema(&vars).unwrap()), vec![column]).unwrap();
+
+    let error = from_record_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("unknown RDF term kind 'mystery'"),
+        "{error}"
+    );
+}
+
+/// A top-level column outside the term-struct schema is rejected before any cell read.
+#[test]
+fn invalid_term_schema_is_rejected() {
+    let schema = arrow_schema::Schema::new(vec![Field::new("term", DataType::Utf8, true)]);
+    let column = Arc::new(StringArray::from(vec![Some("http://example.com/resource")])) as ArrayRef;
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![column]).unwrap();
+
+    let error = from_record_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("does not use the nullable RDF-term struct schema"),
+        "{error}"
     );
 }

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -1011,24 +1011,28 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   prefer `PreparedQuery` when running one query against many graphs (e.g. continuous/RSP queries).
 - **CLI/HTTP alternative**: `sparq-cli` and `sparq-server` (W3C SPARQL Protocol, `?explain=`,
   result formats JSON/XML/CSV/TSV, `/metrics`) wrap this same surface if you don't want to embed.
-- **Apache Arrow columnar export** is the opt-in `sparq-arrow` crate (separate leaf crate +
+- **Apache Arrow columnar import/export** is the opt-in `sparq-arrow` crate (separate leaf crate +
   its own `arrow` feature, both OFF the default build — the `arrow-*` deps NEVER reach
   `sparq-core`/`sparq-engine`/wasm). `sparq_arrow::to_record_batch(&QueryResult) -> RecordBatch`
-  projects a SELECT result into one Arrow **struct column per variable** —
+  projects a SELECT result into one Arrow **struct column per variable**, and
+  `sparq_arrow::from_record_batch(&RecordBatch) -> Result<QueryResult, ArrowError>` is its
+  checked inverse —
   `Struct<kind, value, datatype, language, direction>` (all nullable `Utf8`; the field names are
   `sparq_arrow::RDF_TERM_FIELDS`). Faithful & round-trippable: an **unbound** binding is a `null`
   struct slot (distinct from a bound empty string); `xsd:string` is written **explicitly** (not
   elided). Honest v1 boundaries — **no numeric narrowing** (`42^^xsd:integer` is the string `"42"`
   + a datatype field, not an `Int64`; a typed-column view is a follow-up) and **triple terms are
-  stringified** to N-Triples in `value`. The intended on-ramp into Polars/DuckDB/pandas; a
+  stringified** to N-Triples in `value`. Import rejects malformed schemas, term kinds, and
+  incompatible field combinations instead of guessing. The intended on-ramp into
+  Polars/DuckDB/pandas; a
   `sparq-py` `Graph.query_arrow() -> pyarrow.Table` PyO3 binding is a follow-up (bead `sq-lt1ml`).
 
 ## See also
 
 - `rust-parallel-parsing` / `fused-decompress-parse` — fast/compressed RDF ingest into a `Graph`.
 - `hdt-format` — loading `.hdt` archives into a `Graph` (`sparq-hdt`).
-- `sparq-arrow` — opt-in Apache Arrow columnar export of a SELECT `QueryResult` into a
-  `RecordBatch` (one struct column per variable) for transfer into the dataframe ecosystem.
+- `sparq-arrow` — opt-in Apache Arrow columnar import/export between a SELECT `QueryResult`
+  and a `RecordBatch` (one struct column per variable) for dataframe interoperability.
 - `sparql-formal-semantics` — the algebra/semantics reference for the SPARQL fragment.
 - `noir-circuit-patterns` / `verifiable-credentials-zk` / `mpc-protocols` — the ZK/MPC estate built
   on the `zk` trace seam (non-default `zk` feature; consumed by `sparq-zk`).


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements `sq-lsp7k.16`.

Summary:
- add feature-gated `from_record_batch(&RecordBatch) -> Result<QueryResult, ArrowError>`
- validate the exact RDF-term struct schema and fail closed on invalid variables, cells, metadata, RDF components, and term kinds
- preserve variable order, row order, unbound cells, all RDF term kinds, language, datatype, direction, and triple terms
- update the crate README and `sparql-query` skill for the new public API

Verification:
- `cargo clippy -p sparq-arrow --all-targets -- -D warnings`
- `cargo clippy -p sparq-arrow --all-targets --features arrow -- -D warnings`
- `cargo test -p sparq-arrow`
- `cargo test -p sparq-arrow --features arrow`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-arrow --no-deps --all-features`
- `cargo check --workspace` with `sparq-arrow/arrow` off and on
- README template, markdownlint, terminology, no-performance-numbers, formatting, and diff hygiene checks
- mutation witness: disabling the blank-node inverse arm makes the exact round-trip acceptance test fail; restoring it passes

No auto-merge is armed.