### PR TITLE
feat(text): add bounded fuzzy search [GPT-5.6]

### DIFF
--- a/crates/sparq-text/Cargo.toml
+++ b/crates/sparq-text/Cargo.toml
@@ -47,6 +47,9 @@ default = ["engine", "parallel", "engine-builtins"]
 engine = ["dep:sparq-engine", "dep:spargebra"]
 engine-builtins = ["engine", "sparq-engine/regex", "sparq-engine/digest"]
 parallel = ["dep:rayon", "sparq-core/parallel", "sparq-engine?/parallel"]
+# [GPT-5.6] sq-lsp7k.14: bounded typo-tolerant lookup. OFF by default so the
+# ordinary index, native dependency graph, and lean wasm bundle pay nothing.
+fuzzy = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-text/README.md
+++ b/crates/sparq-text/README.md
@@ -72,10 +72,10 @@ let r = query_text(&graph, r#"
 
 ## ✨ Features
 
-- **`text:` magic predicates** — `text:matches` (AND), `text:matchesAny` (OR),
-  `text:phrase` (adjacency), `text:near` (proximity/slop, relevance-ranked) with the
+- **`text:` magic predicates** — `text:matches` (AND), `text:matchesAny` (OR), `text:phrase` (adjacency), `text:near` (proximity/slop, relevance-ranked) with the
   `text:slop N` and `text:score ?s` companions. The query string must be a **constant**
   literal, the match subject a variable, and an unknown `text:` IRI is a hard error.
+- **Opt-in fuzzy search** — the default-OFF `fuzzy` feature adds `TextIndex::fuzzy(term, max_distance)` and `text:fuzzy`, backed by bounded deletion-neighbour candidates and exact Levenshtein verification (default one, hard cap two). [GPT-5.6] sq-lsp7k.14
 - **BM25 ranking, exact-token semantics** — UAX #29 word segmentation + Unicode
   lowercasing; **no stemming, no stopword list, no diacritic folding** (`café` ≠ `cafe`)
   — language-neutral by design. Only plain / `xsd:string` / language-tagged literals are

--- a/crates/sparq-text/src/fuzzy.rs
+++ b/crates/sparq-text/src/fuzzy.rs
@@ -1,0 +1,179 @@
+//! Bounded typo-tolerant lookup over a [`TextIndex`](crate::TextIndex).
+//!
+//! The `fuzzy` feature is default-OFF. When enabled, the ordinary token index
+//! additionally records deletion signatures through distance two. A query
+//! probes only its own bounded deletion neighbourhood, then verifies candidates
+//! with exact Levenshtein distance; it never walks the full token dictionary.
+//! [GPT-5.6] sq-lsp7k.14
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use sparq_core::dict::Id;
+
+/// Default edit-distance budget for fuzzy lookup.
+pub const DEFAULT_MAX_DISTANCE: u8 = 1;
+/// Largest accepted edit-distance budget.
+pub const MAX_DISTANCE: u8 = 2;
+
+/// One typo-tolerant text hit, ordered by distance ascending, BM25 descending,
+/// matched token ascending, then dictionary id ascending.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FuzzyHit {
+    /// Matching literal dictionary id.
+    pub id: Id,
+    /// Levenshtein distance between the analyzed query and `term`.
+    pub distance: u8,
+    /// BM25 score for `term` in this literal.
+    pub score: f32,
+    /// The indexed token that matched the query.
+    pub term: Box<str>,
+}
+
+/// Invalid fuzzy-query configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FuzzyError {
+    /// Fuzzy lookup accepts exactly one analyzed token.
+    ExpectedSingleToken { found: usize },
+    /// Prefix syntax belongs to exact `search`, not fuzzy lookup.
+    PrefixNotSupported,
+    /// The requested edit-distance budget exceeds [`MAX_DISTANCE`].
+    DistanceTooLarge { requested: u8 },
+}
+
+impl fmt::Display for FuzzyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExpectedSingleToken { found } => {
+                write!(
+                    f,
+                    "fuzzy query must contain exactly one token, found {found}"
+                )
+            }
+            Self::PrefixNotSupported => {
+                f.write_str("fuzzy query does not accept the `*` prefix marker")
+            }
+            Self::DistanceTooLarge { requested } => write!(
+                f,
+                "fuzzy max_distance must be at most {MAX_DISTANCE}, got {requested}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FuzzyError {}
+
+/// Deletion signature -> sorted distinct indexed tokens. Signatures through
+/// the global cap are built once when a token first enters the inverted index.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub(crate) struct FuzzyTerms {
+    signatures: BTreeMap<Box<str>, Vec<Box<str>>>,
+}
+
+impl FuzzyTerms {
+    pub(crate) fn insert(&mut self, term: &str) {
+        for signature in deletion_signatures(term, MAX_DISTANCE) {
+            let terms = self
+                .signatures
+                .entry(signature.into_boxed_str())
+                .or_default();
+            match terms.binary_search_by(|known| known.as_ref().cmp(term)) {
+                Ok(_) => {}
+                Err(at) => terms.insert(at, term.into()),
+            }
+        }
+    }
+
+    pub(crate) fn candidates<'a>(&'a self, query: &str, max_distance: u8) -> Vec<(&'a str, u8)> {
+        let mut candidates: BTreeSet<&str> = BTreeSet::new();
+        for signature in deletion_signatures(query, max_distance) {
+            if let Some(terms) = self.signatures.get(signature.as_str()) {
+                candidates.extend(terms.iter().map(Box::as_ref));
+            }
+        }
+        candidates
+            .into_iter()
+            .filter_map(|term| {
+                bounded_levenshtein(query, term, max_distance).map(|distance| (term, distance))
+            })
+            .collect()
+    }
+
+    pub(crate) fn heap_bytes(&self) -> usize {
+        self.signatures
+            .iter()
+            .map(|(signature, terms)| {
+                signature.len()
+                    + terms.iter().map(|term| term.len()).sum::<usize>()
+                    + terms.capacity() * std::mem::size_of::<Box<str>>()
+            })
+            .sum()
+    }
+}
+
+fn deletion_signatures(term: &str, distance: u8) -> BTreeSet<String> {
+    let mut all = BTreeSet::from([term.to_owned()]);
+    let mut frontier = vec![term.to_owned()];
+    for _ in 0..distance {
+        let mut next = Vec::new();
+        for value in frontier {
+            let chars: Vec<char> = value.chars().collect();
+            for removed in 0..chars.len() {
+                let deletion: String = chars[..removed]
+                    .iter()
+                    .chain(&chars[removed + 1..])
+                    .collect();
+                if all.insert(deletion.clone()) {
+                    next.push(deletion);
+                }
+            }
+        }
+        frontier = next;
+    }
+    all
+}
+
+/// Exact Unicode-scalar Levenshtein distance with a small upper bound.
+fn bounded_levenshtein(a: &str, b: &str, cap: u8) -> Option<u8> {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.len().abs_diff(b.len()) > usize::from(cap) {
+        return None;
+    }
+    let mut previous: Vec<usize> = (0..=b.len()).collect();
+    let mut current = vec![0; b.len() + 1];
+    for (i, left) in a.iter().enumerate() {
+        current[0] = i + 1;
+        let mut row_min = current[0];
+        for (j, right) in b.iter().enumerate() {
+            current[j + 1] = (previous[j + 1] + 1)
+                .min(current[j] + 1)
+                .min(previous[j] + usize::from(left != right));
+            row_min = row_min.min(current[j + 1]);
+        }
+        if row_min > usize::from(cap) {
+            return None;
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    (previous[b.len()] <= usize::from(cap)).then_some(previous[b.len()] as u8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deletion_index_has_no_false_negatives_for_reference_pairs() {
+        let mut terms = FuzzyTerms::default();
+        for term in ["quickly", "quote", "quick", "quaxly", "café"] {
+            terms.insert(term);
+        }
+        assert_eq!(terms.candidates("quikly", 1), vec![("quickly", 1)]);
+        assert_eq!(
+            terms.candidates("quikly", 2),
+            vec![("quaxly", 2), ("quickly", 1)]
+        );
+        assert!(terms.candidates("quikly", 0).is_empty());
+    }
+}

--- a/crates/sparq-text/src/index.rs
+++ b/crates/sparq-text/src/index.rs
@@ -184,15 +184,21 @@ pub struct TextIndex {
     /// of the index state, so two indexes built with different analyzers are not
     /// equal. [OPUS-4.8] sq-m3ln
     analyzer: Analyzer,
+    /// Bounded deletion-neighbour index, absent from feature-OFF builds.
+    /// [GPT-5.6] sq-lsp7k.14
+    #[cfg(feature = "fuzzy")]
+    fuzzy: crate::fuzzy::FuzzyTerms,
 }
 
 /// The lexical value of a string literal (plain `xsd:string` or
 /// language-tagged), `None` for every other term kind.
 fn text_value<'a>(parts: &TermParts<'a>) -> Option<&'a str> {
     match parts {
-        TermParts::Lit { value, datatype, lang } => {
-            (lang.is_some() || *datatype == XSD_STRING).then_some(*value)
-        }
+        TermParts::Lit {
+            value,
+            datatype,
+            lang,
+        } => (lang.is_some() || *datatype == XSD_STRING).then_some(*value),
         _ => None,
     }
 }
@@ -237,14 +243,21 @@ impl TextIndex {
     /// incremental/delta-fed case (the [`with_positions`](Self::with_positions)
     /// counterpart with an explicit analyzer). [OPUS-4.8] sq-m3ln
     pub fn with_positions_analyzer(analyzer: Analyzer) -> TextIndex {
-        TextIndex { positions: Some(BTreeMap::new()), analyzer, ..Default::default() }
+        TextIndex {
+            positions: Some(BTreeMap::new()),
+            analyzer,
+            ..Default::default()
+        }
     }
 
     /// An empty index that uses `analyzer` (the `TextIndex::default()`
     /// counterpart with an explicit analyzer), for the delta-fed case without
     /// positions. [OPUS-4.8] sq-m3ln
     pub fn with_analyzer(analyzer: Analyzer) -> TextIndex {
-        TextIndex { analyzer, ..Default::default() }
+        TextIndex {
+            analyzer,
+            ..Default::default()
+        }
     }
 
     /// The [`Analyzer`] this index was built/seeded with. [OPUS-4.8] sq-m3ln
@@ -266,7 +279,10 @@ impl TextIndex {
     /// counterpart of `TextIndex::default()`, for the incremental/delta-fed
     /// case. [OPUS-4.8]
     pub fn with_positions() -> TextIndex {
-        TextIndex { positions: Some(BTreeMap::new()), ..Default::default() }
+        TextIndex {
+            positions: Some(BTreeMap::new()),
+            ..Default::default()
+        }
     }
 
     // Note: `Analyzer::default()` is `Unicode`, so `TextIndex::default()` and
@@ -364,11 +380,21 @@ impl TextIndex {
             .iter()
             .flat_map(|m| m.iter())
             .map(|(k, docs)| {
-                k.len() + std::mem::size_of::<Box<str>>() + 24
+                k.len()
+                    + std::mem::size_of::<Box<str>>()
+                    + 24
                     + docs.values().map(|p| 16 + p.capacity() * 4).sum::<usize>()
             })
             .sum();
-        postings + positions + self.docs.len() * 16
+        let base = postings + positions + self.docs.len() * 16;
+        #[cfg(feature = "fuzzy")]
+        {
+            base + self.fuzzy.heap_bytes()
+        }
+        #[cfg(not(feature = "fuzzy"))]
+        {
+            base
+        }
     }
 
     /// Tokenizes `text` and adds it as document `id`. Caller guarantees `id`
@@ -394,6 +420,10 @@ impl TextIndex {
             *tf.entry(t).or_insert(0) += 1;
         }
         for (token, n) in tf {
+            #[cfg(feature = "fuzzy")]
+            if !self.postings.contains_key(token.as_str()) {
+                self.fuzzy.insert(&token);
+            }
             let rows = self.postings.entry(token.into_boxed_str()).or_default();
             match rows.last() {
                 // Build and delta both feed increasing ids: append is the fast path.
@@ -414,6 +444,10 @@ impl TextIndex {
     #[cfg(feature = "parallel")]
     fn append_shard(&mut self, shard: TextIndex) {
         for (token, rows) in shard.postings {
+            #[cfg(feature = "fuzzy")]
+            if !self.postings.contains_key(token.as_ref()) {
+                self.fuzzy.insert(&token);
+            }
             self.postings.entry(token).or_default().extend(rows);
         }
         // Merge per-token position maps the same way: shard doc ids are
@@ -558,7 +592,11 @@ impl TextIndex {
     /// (tf summed, df = union size) — one pseudo-term for scoring.
     fn resolve(&self, t: &QueryToken) -> Vec<(Id, u32)> {
         if !t.prefix {
-            return self.postings.get(t.token.as_str()).cloned().unwrap_or_default();
+            return self
+                .postings
+                .get(t.token.as_str())
+                .cloned()
+                .unwrap_or_default();
         }
         let mut merged: FxHashMap<Id, u32> = FxHashMap::default();
         for (token, rows) in self.postings.range(t.token.clone().into_boxed_str()..) {
@@ -587,6 +625,84 @@ impl TextIndex {
         self.run(query, false)
     }
 
+    /// Typo-tolerant single-token search behind the default-OFF `fuzzy`
+    /// feature. Candidate terms come from a bounded deletion-neighbourhood
+    /// index and are verified with exact Levenshtein distance; the token
+    /// dictionary is never scanned at query time. Results are stably ordered
+    /// by edit distance ascending, BM25 descending, matched term ascending,
+    /// then dictionary id ascending. [GPT-5.6] sq-lsp7k.14
+    ///
+    /// At `max_distance == 0`, this returns exactly the same hit set and BM25
+    /// scores as [`search`](Self::search) for the same single-token query.
+    #[cfg(feature = "fuzzy")]
+    pub fn fuzzy(
+        &self,
+        query: &str,
+        max_distance: u8,
+    ) -> Result<Vec<crate::fuzzy::FuzzyHit>, crate::fuzzy::FuzzyError> {
+        use crate::fuzzy::{FuzzyError, FuzzyHit, MAX_DISTANCE};
+
+        if max_distance > MAX_DISTANCE {
+            return Err(FuzzyError::DistanceTooLarge {
+                requested: max_distance,
+            });
+        }
+        let tokens = tokenize_query_with(query, self.analyzer);
+        if tokens.len() != 1 {
+            return Err(FuzzyError::ExpectedSingleToken {
+                found: tokens.len(),
+            });
+        }
+        if tokens[0].prefix {
+            return Err(FuzzyError::PrefixNotSupported);
+        }
+        if self.docs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let query = &tokens[0].token;
+        let n = self.docs.len() as f32;
+        let avgdl = (self.total_tokens as f32 / n).max(f32::MIN_POSITIVE);
+        let mut best: FxHashMap<Id, FuzzyHit> = FxHashMap::default();
+        for (term, distance) in self.fuzzy.candidates(query, max_distance) {
+            let rows = self
+                .postings
+                .get(term)
+                .expect("fuzzy signatures are derived from posting keys");
+            let df = rows.len() as f32;
+            let idf = ((n - df + 0.5) / (df + 0.5) + 1.0).ln();
+            for &(id, tf) in rows {
+                let dl = self.docs[&id] as f32;
+                let tf = tf as f32;
+                let score = idf * tf * (K1 + 1.0) / (tf + K1 * (1.0 - B + B * dl / avgdl));
+                let candidate = FuzzyHit {
+                    id,
+                    distance,
+                    score,
+                    term: term.into(),
+                };
+                let replace = best.get(&id).is_none_or(|known| {
+                    candidate.distance < known.distance
+                        || (candidate.distance == known.distance
+                            && (candidate.score > known.score
+                                || (candidate.score == known.score && candidate.term < known.term)))
+                });
+                if replace {
+                    best.insert(id, candidate);
+                }
+            }
+        }
+        let mut hits: Vec<FuzzyHit> = best.into_values().collect();
+        hits.sort_unstable_by(|a, b| {
+            a.distance
+                .cmp(&b.distance)
+                .then_with(|| b.score.total_cmp(&a.score))
+                .then_with(|| a.term.cmp(&b.term))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        Ok(hits)
+    }
+
     /// Phrase query: literals where the query's tokens appear ADJACENT
     /// (consecutive positions) and IN ORDER. `phrase("foo bar")` matches a
     /// document only where `foo` is immediately followed by `bar`; the same
@@ -607,10 +723,9 @@ impl TextIndex {
     /// [`with_positions`](Self::with_positions)). Guard with
     /// [`has_positions`](Self::has_positions) if unsure.
     pub fn phrase(&self, query: &str) -> Vec<Id> {
-        let positions = self
-            .positions
-            .as_ref()
-            .expect("phrase() requires a positional index: build with TextIndex::build_with_positions");
+        let positions = self.positions.as_ref().expect(
+            "phrase() requires a positional index: build with TextIndex::build_with_positions",
+        );
         let tokens = tokenize_with(query, self.analyzer);
         if tokens.is_empty() {
             return Vec::new();
@@ -729,7 +844,10 @@ impl TextIndex {
             .filter_map(|id| {
                 Self::min_phrase_gap(&lists, driver_i, id)
                     .filter(|&g| g <= slop)
-                    .map(|g| Hit { id, score: 1.0 / (1.0 + g as f32) })
+                    .map(|g| Hit {
+                        id,
+                        score: 1.0 / (1.0 + g as f32),
+                    })
             })
             .collect();
         // Best-first (tighter proximity = higher score), ties by ascending id —
@@ -761,15 +879,18 @@ impl TextIndex {
         // over all starts is the document's minimum. Positions are ascending, so
         // `partition_point` is a binary search for "strictly greater than prev".
         let first = &lists[0][&id];
-        first.iter().filter_map(|&start| {
-            let mut prev = start;
-            for docs in &lists[1..] {
-                let ps = &docs[&id];
-                let i = ps.partition_point(|&p| p <= prev);
-                prev = *ps.get(i)?; // no in-order position for this token after prev
-            }
-            Some((prev - start) - (n - 1))
-        }).min()
+        first
+            .iter()
+            .filter_map(|&start| {
+                let mut prev = start;
+                for docs in &lists[1..] {
+                    let ps = &docs[&id];
+                    let i = ps.partition_point(|&p| p <= prev);
+                    prev = *ps.get(i)?; // no in-order position for this token after prev
+                }
+                Some((prev - start) - (n - 1))
+            })
+            .min()
     }
 
     fn run(&self, query: &str, all: bool) -> Vec<Hit> {

--- a/crates/sparq-text/src/lib.rs
+++ b/crates/sparq-text/src/lib.rs
@@ -5,16 +5,20 @@
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 pub mod complete;
+#[cfg(feature = "fuzzy")]
+pub mod fuzzy;
 pub mod index;
 #[cfg(feature = "engine")]
 pub mod rewrite;
 pub mod tokenize;
 
 pub use complete::{Candidate, CandidateKind, CompletionIndex};
+#[cfg(feature = "fuzzy")]
+pub use fuzzy::{FuzzyError, FuzzyHit, DEFAULT_MAX_DISTANCE, MAX_DISTANCE};
 pub use index::{Hit, TextIndex};
-pub use tokenize::Analyzer;
 #[cfg(feature = "engine")]
 pub use rewrite::{prepare_text, query_text, query_text_with_budget, rewrite_query};
+pub use tokenize::Analyzer;
 
 /// The `text:` vocabulary — magic predicates recognised by [`rewrite`]
 /// (`http://sparq.dev/text#`, the sparq extension namespace).
@@ -26,6 +30,16 @@ pub mod vocab {
     pub const MATCHES: &str = "http://sparq.dev/text#matches";
     /// `?lit text:matchesAny "query"` — literals containing AT LEAST ONE token.
     pub const MATCHES_ANY: &str = "http://sparq.dev/text#matchesAny";
+    /// `?lit text:fuzzy "term"` — typo-tolerant single-token lookup, available
+    /// only with the `fuzzy` feature. The edit-distance budget defaults to one
+    /// and is set by a `?lit text:maxDistance N` companion (hard-capped at two).
+    /// Results are ranked by distance, then BM25, then matched token. [GPT-5.6]
+    #[cfg(feature = "fuzzy")]
+    pub const FUZZY: &str = "http://sparq.dev/text#fuzzy";
+    /// `?lit text:maxDistance N` — sets the bounded Levenshtein distance for a
+    /// `text:fuzzy` request on the same variable (`0..=2`). [GPT-5.6]
+    #[cfg(feature = "fuzzy")]
+    pub const MAX_DISTANCE: &str = "http://sparq.dev/text#maxDistance";
     /// `?lit text:phrase "foo bar"` — literals where the query's tokens appear
     /// ADJACENT and IN ORDER (a positional phrase match, not a BM25 ranking).
     /// Requires a positions-enabled index (`TextIndex::build_with_positions`);

--- a/crates/sparq-text/src/rewrite.rs
+++ b/crates/sparq-text/src/rewrite.rs
@@ -24,6 +24,9 @@
 //!
 //! - `?lit text:matches "query"` — AND of tokens, `*`-suffix = prefix token;
 //! - `?lit text:matchesAny "query"` — OR of tokens;
+//! - `?lit text:fuzzy "term"` — with the `fuzzy` feature, a typo-tolerant
+//!   single-token match at edit distance one by default; a same-subject
+//!   `text:maxDistance N` companion selects `0..=2`. [GPT-5.6]
 //! - `?lit text:phrase "foo bar"` — tokens ADJACENT and IN ORDER (a positional
 //!   phrase match; needs a positions-enabled index — see below). [OPUS-4.8]
 //! - `?lit text:near "foo bar"` — tokens IN ORDER within a bounded gap (the
@@ -88,8 +91,14 @@ pub fn query_text_with_budget(
 /// engine's `*_prepared` entry points (`ask_prepared`, `construct_prepared`,
 /// …). Note the hits are frozen at rewrite time: re-prepare after the graph
 /// (and index) change.
-pub fn prepare_text(graph: &Graph, sparql: &str, index: &TextIndex) -> Result<PreparedQuery, String> {
-    let query = spargebra::SparqlParser::new().parse_query(sparql).map_err(|e| e.to_string())?;
+pub fn prepare_text(
+    graph: &Graph,
+    sparql: &str,
+    index: &TextIndex,
+) -> Result<PreparedQuery, String> {
+    let query = spargebra::SparqlParser::new()
+        .parse_query(sparql)
+        .map_err(|e| e.to_string())?;
     Ok(PreparedQuery::from(rewrite_query(query, graph, index)?))
 }
 
@@ -144,12 +153,31 @@ fn rewrite_pattern(p: &mut GraphPattern, graph: &Graph, index: &TextIndex) -> Re
 /// it; an explicit budget is the common case. [OPUS-4.8]
 pub const DEFAULT_SLOP: u32 = 0;
 
+#[cfg(feature = "fuzzy")]
+fn is_match_predicate(iri: &str) -> bool {
+    matches!(
+        iri,
+        vocab::MATCHES | vocab::MATCHES_ANY | vocab::PHRASE | vocab::NEAR | vocab::FUZZY
+    )
+}
+
+#[cfg(not(feature = "fuzzy"))]
+fn is_match_predicate(iri: &str) -> bool {
+    matches!(
+        iri,
+        vocab::MATCHES | vocab::MATCHES_ANY | vocab::PHRASE | vocab::NEAR
+    )
+}
+
 /// Which index query a `text:` match request runs.
 enum ReqKind {
     /// `text:matches` — AND of tokens (BM25-scored).
     All,
     /// `text:matchesAny` — OR of tokens (BM25-scored).
     Any,
+    /// `text:fuzzy` — bounded single-token Levenshtein lookup. [GPT-5.6]
+    #[cfg(feature = "fuzzy")]
+    Fuzzy { max_distance: Option<u8> },
     /// `text:phrase` — adjacent, in-order tokens (positional, unscored). [OPUS-4.8]
     Phrase,
     /// `text:near` — in-order tokens within a bounded total gap, proximity-scored
@@ -181,6 +209,8 @@ fn rewrite_bgp(
     // (subject var, parsed slop) collected from `text:slop` patterns, attached
     // to the matching `text:near` after the scan (order-independent). [OPUS-4.8]
     let mut slops: Vec<(Variable, u32)> = Vec::new();
+    #[cfg(feature = "fuzzy")]
+    let mut max_distances: Vec<(Variable, u8)> = Vec::new();
 
     for tp in patterns {
         let NamedNodePattern::NamedNode(pred) = &tp.predicate else {
@@ -195,11 +225,13 @@ fn rewrite_bgp(
         let subject_var = |s: &TermPattern| -> Result<Variable, String> {
             match s {
                 TermPattern::Variable(v) => Ok(v.clone()),
-                other => Err(format!("text: the subject of <{iri}> must be a variable, got {other}")),
+                other => Err(format!(
+                    "text: the subject of <{iri}> must be a variable, got {other}"
+                )),
             }
         };
         match iri {
-            vocab::MATCHES | vocab::MATCHES_ANY | vocab::PHRASE | vocab::NEAR => {
+            iri if is_match_predicate(iri) => {
                 let var = subject_var(&tp.subject)?;
                 let TermPattern::Literal(q) = &tp.object else {
                     return Err(format!(
@@ -211,9 +243,16 @@ fn rewrite_bgp(
                     vocab::MATCHES_ANY => ReqKind::Any,
                     vocab::PHRASE => ReqKind::Phrase,
                     vocab::NEAR => ReqKind::Near { slop: None },
+                    #[cfg(feature = "fuzzy")]
+                    vocab::FUZZY => ReqKind::Fuzzy { max_distance: None },
                     _ => ReqKind::All,
                 };
-                reqs.push(MatchReq { var, query: q.value().to_string(), kind, score: None });
+                reqs.push(MatchReq {
+                    var,
+                    query: q.value().to_string(),
+                    kind,
+                    score: None,
+                });
             }
             vocab::SLOP => {
                 let var = subject_var(&tp.subject)?;
@@ -234,6 +273,32 @@ fn rewrite_bgp(
                 })?;
                 slops.push((var, slop));
             }
+            #[cfg(feature = "fuzzy")]
+            vocab::MAX_DISTANCE => {
+                let var = subject_var(&tp.subject)?;
+                let TermPattern::Literal(n) = &tp.object else {
+                    return Err(format!(
+                        "text: the object of text:maxDistance must be a constant integer in \
+                         0..={}, got {}",
+                        crate::fuzzy::MAX_DISTANCE,
+                        tp.object
+                    ));
+                };
+                let distance: u8 = n.value().parse().map_err(|_| {
+                    format!(
+                        "text: text:maxDistance must be an integer in 0..={}, got \"{}\"",
+                        crate::fuzzy::MAX_DISTANCE,
+                        n.value()
+                    )
+                })?;
+                if distance > crate::fuzzy::MAX_DISTANCE {
+                    return Err(format!(
+                        "text: text:maxDistance must be at most {}, got {distance}",
+                        crate::fuzzy::MAX_DISTANCE
+                    ));
+                }
+                max_distances.push((var, distance));
+            }
             vocab::SCORE => {
                 let var = subject_var(&tp.subject)?;
                 let TermPattern::Variable(score_var) = &tp.object else {
@@ -247,7 +312,41 @@ fn rewrite_bgp(
             _ => {
                 return Err(format!(
                     "text: unknown magic predicate <{iri}> (supported: text:matches, \
-                     text:matchesAny, text:phrase, text:near, text:slop, text:score)"
+                     text:matchesAny, text:phrase, text:near, text:slop, text:score{})",
+                    if cfg!(feature = "fuzzy") {
+                        ", text:fuzzy, text:maxDistance"
+                    } else {
+                        ""
+                    }
+                ))
+            }
+        }
+    }
+
+    #[cfg(feature = "fuzzy")]
+    for (var, value) in max_distances {
+        let mut owners = reqs.iter_mut().filter(|r| r.var == var);
+        match (owners.next(), owners.next()) {
+            (Some(req), None) => match &mut req.kind {
+                ReqKind::Fuzzy { max_distance } => {
+                    if max_distance.replace(value).is_some() {
+                        return Err(format!("text: duplicate text:maxDistance for {var}"));
+                    }
+                }
+                _ => {
+                    return Err(format!(
+                        "text: text:maxDistance on {var} is only valid alongside text:fuzzy"
+                    ))
+                }
+            },
+            (None, _) => {
+                return Err(format!(
+                    "text: text:maxDistance on {var} has no text:fuzzy in the same basic graph pattern"
+                ))
+            }
+            (Some(_), Some(_)) => {
+                return Err(format!(
+                    "text: text:maxDistance on {var} is ambiguous ({var} has more than one text: match pattern in this basic graph pattern)"
                 ))
             }
         }
@@ -325,10 +424,26 @@ fn rewrite_bgp(
         // proximity `text:near`) also carry a score, the positional phrase mode
         // is unscored (id only). [OPUS-4.8]
         let hits: Vec<(Id, Option<f32>)> = match req.kind {
-            ReqKind::All => index.search(&req.query).into_iter().map(|h| (h.id, Some(h.score))).collect(),
-            ReqKind::Any => {
-                index.search_any(&req.query).into_iter().map(|h| (h.id, Some(h.score))).collect()
-            }
+            ReqKind::All => index
+                .search(&req.query)
+                .into_iter()
+                .map(|h| (h.id, Some(h.score)))
+                .collect(),
+            ReqKind::Any => index
+                .search_any(&req.query)
+                .into_iter()
+                .map(|h| (h.id, Some(h.score)))
+                .collect(),
+            #[cfg(feature = "fuzzy")]
+            ReqKind::Fuzzy { max_distance } => index
+                .fuzzy(
+                    &req.query,
+                    max_distance.unwrap_or(crate::fuzzy::DEFAULT_MAX_DISTANCE),
+                )
+                .map_err(|error| format!("text: {error}"))?
+                .into_iter()
+                .map(|hit| (hit.id, Some(hit.score)))
+                .collect(),
             ReqKind::Phrase => {
                 if !index.has_positions() {
                     return Err(
@@ -337,7 +452,11 @@ fn rewrite_bgp(
                             .to_string(),
                     );
                 }
-                index.phrase(&req.query).into_iter().map(|id| (id, None)).collect()
+                index
+                    .phrase(&req.query)
+                    .into_iter()
+                    .map(|id| (id, None))
+                    .collect()
             }
             ReqKind::Near { slop } => {
                 if !index.has_positions() {
@@ -348,7 +467,11 @@ fn rewrite_bgp(
                     );
                 }
                 let slop = slop.unwrap_or(DEFAULT_SLOP);
-                index.phrase_near(&req.query, slop).into_iter().map(|h| (h.id, Some(h.score))).collect()
+                index
+                    .phrase_near(&req.query, slop)
+                    .into_iter()
+                    .map(|h| (h.id, Some(h.score)))
+                    .collect()
             }
         };
         let mut variables = vec![req.var];
@@ -369,11 +492,17 @@ fn rewrite_bgp(
                 row
             })
             .collect();
-        let values = GraphPattern::Values { variables, bindings };
+        let values = GraphPattern::Values {
+            variables,
+            bindings,
+        };
         out = match out {
             // An all-magic BGP leaves an empty Bgp behind: drop the unit table.
             GraphPattern::Bgp { ref patterns } if patterns.is_empty() => values,
-            other => GraphPattern::Join { left: Box::new(values), right: Box::new(other) },
+            other => GraphPattern::Join {
+                left: Box::new(values),
+                right: Box::new(other),
+            },
         };
     }
     Ok(out)

--- a/crates/sparq-text/tests/e2e.rs
+++ b/crates/sparq-text/tests/e2e.rs
@@ -329,9 +329,10 @@ fn rewrite_errors() {
             "SELECT ?t WHERE { ?t <http://sparq.dev/text#matches> ?q }",
             "constant query-string literal",
         ),
-        // Unknown text: predicate is a typo guard.
+        // Unknown text: predicate is a typo guard (`fuzzy` is now feature-gated).
+        // [GPT-5.6] sq-lsp7k.14
         (
-            r#"SELECT ?t WHERE { ?t <http://sparq.dev/text#fuzzy> "fox" }"#,
+            r#"SELECT ?t WHERE { ?t <http://sparq.dev/text#fuzzzy> "fox" }"#,
             "unknown magic predicate",
         ),
         // text:score needs a match pattern on the same variable.

--- a/crates/sparq-text/tests/fuzzy.rs
+++ b/crates/sparq-text/tests/fuzzy.rs
@@ -1,0 +1,114 @@
+//! Mutation-witnessed fuzzy lookup acceptance tests. Removing the deletion
+//! signatures, exact-distance verifier, distance ordering, or rewrite arm makes
+//! at least one concrete assertion fail. [GPT-5.6] sq-lsp7k.14
+#![cfg(feature = "fuzzy")]
+
+use sparq_core::Graph;
+use sparq_text::{FuzzyError, TextIndex};
+
+const DATA: &str = r#"
+    <http://ex/a> <http://ex/title> "quickly" .
+    <http://ex/b> <http://ex/title> "quote" .
+    <http://ex/c> <http://ex/title> "quick" .
+    <http://ex/d> <http://ex/title> "quaxly" .
+"#;
+
+#[test]
+fn bounded_candidates_and_zero_distance_exact_invariant() {
+    let graph = Graph::load_str(DATA, "ntriples").unwrap();
+    let index = TextIndex::build(&graph);
+
+    let one = index.fuzzy("quikly", 1).unwrap();
+    assert_eq!(one.len(), 1);
+    assert_eq!((&*one[0].term, one[0].distance), ("quickly", 1));
+
+    let two = index.fuzzy("quikly", 2).unwrap();
+    assert_eq!(
+        two.iter()
+            .map(|hit| (&*hit.term, hit.distance))
+            .collect::<Vec<_>>(),
+        [("quickly", 1), ("quaxly", 2)]
+    );
+    assert!(two
+        .iter()
+        .all(|hit| &*hit.term != "quote" && &*hit.term != "quick"));
+
+    let fuzzy_exact = index.fuzzy("quick", 0).unwrap();
+    let exact = index.search("quick");
+    assert_eq!(
+        fuzzy_exact
+            .iter()
+            .map(|hit| (hit.id, hit.score.to_bits()))
+            .collect::<Vec<_>>(),
+        exact
+            .iter()
+            .map(|hit| (hit.id, hit.score.to_bits()))
+            .collect::<Vec<_>>()
+    );
+    assert!(index.fuzzy("quikly", 0).unwrap().is_empty());
+}
+
+#[test]
+fn validates_bound_and_single_term_contract() {
+    let graph = Graph::load_str(DATA, "ntriples").unwrap();
+    let index = TextIndex::build(&graph);
+    assert_eq!(
+        index.fuzzy("quick", 3),
+        Err(FuzzyError::DistanceTooLarge { requested: 3 })
+    );
+    assert_eq!(
+        index.fuzzy("quick fox", 1),
+        Err(FuzzyError::ExpectedSingleToken { found: 2 })
+    );
+    assert_eq!(index.fuzzy("quick*", 1), Err(FuzzyError::PrefixNotSupported));
+}
+
+#[cfg(feature = "engine")]
+#[test]
+fn fuzzy_magic_predicate_uses_default_and_explicit_distance() {
+    use oxrdf::Term;
+    use sparq_text::query_text;
+
+    let graph = Graph::load_str(DATA, "ntriples").unwrap();
+    let index = TextIndex::build(&graph);
+    let query = |distance: Option<u8>| {
+        let companion = distance
+            .map(|n| format!("?title text:maxDistance {n} ."))
+            .unwrap_or_default();
+        query_text(
+            &graph,
+            &format!(
+                "PREFIX text: <http://sparq.dev/text#>\n\
+                 SELECT ?post WHERE {{\n\
+                   ?post <http://ex/title> ?title .\n\
+                   ?title text:fuzzy \"quikly\" .\n\
+                   {companion}\n\
+                 }}"
+            ),
+            &index,
+        )
+        .unwrap()
+    };
+
+    let default = query(None);
+    assert_eq!(default.rows.len(), 1);
+    assert!(matches!(
+        &default.rows[0][0],
+        Some(Term::NamedNode(node)) if node.as_str() == "http://ex/a"
+    ));
+
+    let widened = query(Some(2));
+    let mut iris: Vec<&str> = widened
+        .rows
+        .iter()
+        .map(|row| match &row[0] {
+            Some(Term::NamedNode(node)) => node.as_str(),
+            other => panic!("expected IRI, got {other:?}"),
+        })
+        .collect();
+    iris.sort_unstable();
+    assert_eq!(iris, ["http://ex/a", "http://ex/d"]);
+
+    let exact = query(Some(0));
+    assert!(exact.rows.is_empty());
+}

--- a/skills/full-text-search/SKILL.md
+++ b/skills/full-text-search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: full-text-search
-description: "Full-text search and IRI/label prefix completion via sparq-text: build TextIndex or CompletionIndex and run text: magic predicates inside SPARQL. Use for keyword/prefix/phrase/proximity search, relevance ranking, or entity autocomplete in a sparq Graph."
+description: "Full-text search and IRI/label prefix completion via sparq-text: build TextIndex or CompletionIndex and run text: magic predicates inside SPARQL. Use for keyword/prefix/phrase/proximity or opt-in typo-tolerant search, relevance ranking, or entity autocomplete in a sparq Graph."
 ---
 
 # sparq full-text search (sparq-text)
@@ -54,6 +54,7 @@ Index (always available, `index` module — re-exported at crate root as `TextIn
 - **CJK n-gram analyzer (opt-in).** [OPUS-4.8] sq-m3ln The default analyzer splits an unspaced Han run per ideograph, so a multi-char CJK term searches as the (low-precision) AND of its characters. `TextIndex::build_with_analyzer(graph, Analyzer::CjkNgram)` (and `build_with_positions_analyzer` / `with_analyzer` / `with_positions_analyzer` for the positional and delta-fed cases) instead indexes each maximal Han run as its **overlapping character bigrams** (`東京都` → `東京`,`京都`), so `text:matches "東京"` (or `search("東京")`) matches only docs where that pair co-occurs. The index **records its analyzer** (`index.analyzer() -> Analyzer`), so `search`/`phrase`/`apply_delta`/`reconcile`/the `text:` rewrite all tokenize the query the same way. Non-CJK text is byte-for-byte the default analyzer (so a Latin corpus is unchanged); kana/Hangul are not bigrammed (UAX #29 already groups them). Trade-off: a single-ideograph query only matches docs where that char is an *isolated* run — hence opt-in. No new dependencies.
 - `TextIndex::search(&self, query: &str) -> Vec<Hit>` — AND of tokens (`*`-suffix = prefix token), BM25-ranked best-first.
 - `TextIndex::search_any(&self, query: &str) -> Vec<Hit>` — OR of tokens; scores sum over tokens present.
+- With `features = ["fuzzy"]`: `TextIndex::fuzzy(&self, term: &str, max_distance: u8) -> Result<Vec<FuzzyHit>, FuzzyError>` — exactly one analyzed query token; distance must be `0..=2`. A bounded deletion-neighbour index supplies candidates (no full token-dictionary scan), exact Unicode-scalar Levenshtein verifies them, and results order by `(distance asc, BM25 desc, matched term asc, id asc)`. `max_distance = 0` has exactly the `search(term)` hit set and scores. `FuzzyHit { id, distance, score, term }`; defaults/constants are `DEFAULT_MAX_DISTANCE = 1` and `MAX_DISTANCE = 2`. [GPT-5.6] sq-lsp7k.14
 - `TextIndex::phrase(&self, query: &str) -> Vec<Id>` — adjacent-and-in-order tokens, ascending ids (unranked). **Panics** if the index has no positions.
 - `TextIndex::phrase_near(&self, query: &str, slop: u32) -> Vec<Hit>` — proximity/slop: in-order tokens within a bounded total gap, **relevance-ranked** best-first (`score = 1/(1+gap)`, so adjacency = 1.0). `phrase_near(q, 0)` == `phrase(q)` (each at score 1.0); the hit set grows monotonically with `slop`; order stays significant. Same positions requirement / panic as `phrase`. [OPUS-4.8]
 - `TextIndex::apply_delta(&mut self, graph: &Graph, inserts: &[[Term;3]], deletes: &[[Term;3]])` — mirror a `Graph::apply_delta` batch (inserts of new string literals are indexed; deletes are a documented no-op).
@@ -81,6 +82,7 @@ SPARQL rewrite (`engine` feature, default on — `rewrite` module):
 Magic predicates (`sparq_text::vocab`, namespace `http://sparq.dev/text#`):
 - `?lit text:matches "q"` — `?lit` ranges over literals containing **every** token of `q` (token ending in `*` = prefix).
 - `?lit text:matchesAny "q"` — literals containing **at least one** token.
+- With `fuzzy`: `?lit text:fuzzy "term"` — typo-tolerant single-token match, default edit distance one; add `?lit text:maxDistance N` on the same subject for `N` in `0..=2`. It is BM25-scored and accepts `text:score ?s`. [GPT-5.6]
 - `?lit text:phrase "foo bar"` — literals where the tokens are **adjacent and in order** (needs a positions-enabled index).
 - `?lit text:near "foo bar"` — proximity/slop generalisation of `text:phrase`: tokens **in order within a bounded gap**, **relevance-ranked**. Needs positions. Gap budget defaults to 0 (== `text:phrase`); set it with a `text:slop N` companion. Takes an optional `text:score ?s` (the proximity score). [OPUS-4.8]
 - `?lit text:slop N` — sets the proximity gap budget for the `text:near` on the same subject variable in the same BGP (a non-negative integer; at most one; valid only beside a `text:near`). [OPUS-4.8]
@@ -92,6 +94,19 @@ Magic predicates (`sparq_text::vocab`, namespace `http://sparq.dev/text#`):
 ```rust
 let hits = index.search("auto*");                       // matches "autonomous", "automatic", ...
 // In SPARQL: ?title text:matchesAny "fox auto*"
+```
+
+**Typo-tolerant search (default-OFF `fuzzy` feature).** Enable the feature explicitly; ordinary builds contain no fuzzy index or query code:
+```toml
+sparq-text = { path = "../sparq-text", features = ["fuzzy"] }
+```
+
+```rust
+let hits = index.fuzzy("quikly", 1)?; // matches the indexed token "quickly"
+// In SPARQL:
+//   ?title text:fuzzy "quikly" .
+//   ?title text:maxDistance 1 .
+//   ?title text:score ?s .
 ```
 
 **Relevance-ranked SPARQL results.** `VALUES` rows carry no order through joins — always sort on a `text:score` variable:
@@ -146,7 +161,8 @@ sparq-text = { path = "../sparq-text", default-features = false }   # or default
 
 ## Gotchas / feature flags / prerequisites
 
-- **Feature flags.** `engine` (default on) brings in the `rewrite` module + `sparq-engine`/`spargebra` (with NO engine default features) — needed for `query_text`/`prepare_text`/`rewrite_query` and all `text:` magic predicates. `engine-builtins` (default on) turns the engine's `regex` (SPARQL REGEX/REPLACE) + `digest` (hash builtins) back on, so a `text:` rewrite over a query that ALSO uses those builtins works. `parallel` (default on) rayon-shards `TextIndex::build` and forwards the engine's parallel execution. Disable defaults for the bare index (tokenizer + `TextIndex` + BM25) with no engine in the graph; take `features = ["engine"]` ONLY for the lean wasm shape (engine present, but no rayon/regex/digest — what the `sparq-text-wasm` bundle does). [OPUS-4.8] sq-jbe6
+- **Feature flags.** `engine` (default on) brings in the `rewrite` module + `sparq-engine`/`spargebra` (with NO engine default features) — needed for `query_text`/`prepare_text`/`rewrite_query` and all `text:` magic predicates. `engine-builtins` (default on) turns the engine's `regex` (SPARQL REGEX/REPLACE) + `digest` (hash builtins) back on, so a `text:` rewrite over a query that ALSO uses those builtins works. `parallel` (default on) rayon-shards `TextIndex::build` and forwards the engine's parallel execution. `fuzzy` is default-OFF and adds only the bounded deletion-neighbour index/API plus the `text:fuzzy`/`text:maxDistance` rewrite arms. Disable defaults for the bare index (tokenizer + `TextIndex` + BM25) with no engine in the graph; take `features = ["engine"]` ONLY for the lean wasm shape (engine present, but no rayon/regex/digest/fuzzy — what the `sparq-text-wasm` bundle does). [GPT-5.6] sq-lsp7k.14
+- **Fuzzy constraints.** `TextIndex::fuzzy` and `text:fuzzy` accept exactly one analyzed token (not a phrase or prefix expression); `max_distance`/`text:maxDistance` must be `0..=2`. Each result is admitted iff exact Levenshtein distance is within the bound. When one literal contains several admitted tokens, its best `(distance, -BM25, term)` candidate wins, so each literal appears once. [GPT-5.6]
 - **In-browser ("W-text") bundle.** `crates/sparq-text-wasm` ([OPUS-4.8] sq-jbe6) compiles the `engine`-on `sparq-text` (BM25 index + `text:` rewrite + `sparq-engine`) to `wasm32-unknown-unknown` as a SEPARATE, lazy-loaded bundle (NOT in the lean `sparq-wasm` bundle), for the showcase site's `/surface/full-text` page. It exposes a stateless one-shot `TextSearch`: `query(data, format, sparql)` (parse → build a **positions-enabled** index → rewrite + run the `text:` query → SPARQL-1.1-JSON) and `indexStats(data, format)` (a `{docs,tokens,heapBytes,hasPositions}` footprint — the index-build memory is the bundle's risk, so keep the corpus small). `parallel` is off (no wasm threads); the tokenizer's `unicode-segmentation` is pure-Rust and wasm-portable. Build with `wasm-pack build crates/sparq-text-wasm --target web --release`.
 - **What gets indexed.** Only plain/`xsd:string` and language-tagged literals from the graph's dictionary. Typed literals (numbers, dates, `geo:wktLiteral`, ...) are skipped.
 - **Per-graph indexes.** Dictionary ids are local to each graph. Named graphs have their own dictionaries — build one `TextIndex` per graph you want searchable, and pass the matching index to `query_text`. Hits come from the index you pass (typically the default graph's).


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Closes sq-lsp7k.14.

## Summary

- adds the default-OFF `fuzzy` feature to `sparq-text`
- builds deletion-neighbour signatures through the hard distance cap, then exact-verifies candidates without a full token-dictionary scan
- exposes stable `(distance, BM25, term, id)` ranked `TextIndex::fuzzy` hits
- adds `text:fuzzy` with same-BGP `text:maxDistance` (default 1, cap 2) and `text:score`
- updates the crate README and `full-text-search` skill in the same public-API change

## Design choice

`text:maxDistance` follows the existing `text:slop` companion-predicate convention. Distance zero is pinned to the exact `text:matches` single-term result set and BM25 scores.

## Gates

- `cargo test -p sparq-text`
- `cargo test -p sparq-text --all-features`
- `cargo clippy -p sparq-text --all-targets -- -D warnings`
- `cargo clippy -p sparq-text --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-text --no-deps --all-features`
- `cargo check --workspace`
- `cargo check --workspace --features sparq-text/fuzzy`
- README template, markdownlint, and diff hygiene checks