### PR TITLE
docs(research): HTTP/3 (sq-oprna) + wasm Solid server on npm (sq-6xasp) design records [OPUS-4.8]

### DIFF
--- a/research/http3-quic-servers-design.md
+++ b/research/http3-quic-servers-design.md
@@ -1,0 +1,299 @@
+# HTTP/3 (QUIC) across all sparq HTTP servers — opt-in design (2026-07) [OPUS-4.8]
+
+Status: **design-for-review, maintainer-requested** (epic `sq-oprna`, P1). This
+record designs an **opt-in, feature-gated** HTTP/3 path for the two sparq HTTP
+servers — `sparq-server` (the query API) and `sparq-lws-core` (the Solid/LDP
+server) — decomposes it into disjoint child beads, and is honest about the
+maturity of the Rust HTTP/3 stack. The author is a SPARQ research agent; nothing
+here is implemented — it is a plan for the maintainer to review before any code
+lands.
+
+## 0. Honesty boundary (read first)
+
+- **No QUIC/HTTP/3 exists anywhere in the workspace today.** Verified:
+  `grep -rn 'quinn\|h3\|quic' crates/ --include=Cargo.toml` returns zero QUIC
+  hits (only `quick-xml`); every `h3` in source is a cryptographic 3-input hash
+  (`h3(...)` in `crates/sparq-zk/`) or a hypothesis label. This is greenfield.
+- **The brief's transport premise is CORRECT with one refinement.**
+  `sparq-server` is HTTP/1.1-**only** and terminates **plain HTTP** (no TLS at
+  all) — confirmed. But `sparq-lws-core` is **not** HTTP/1.1-only: on its
+  **TLS/mTLS path** it already negotiates **HTTP/2** (ALPN `["h2","http/1.1"]`,
+  the hyper-util `auto::Builder` with the h2 knobs applied). Its **plain-TCP**
+  path uses `axum::serve` (auto-builder default). So "no HTTP/2 even" holds for
+  `sparq-server` but is **false for `sparq-lws-core`'s TLS path**. This changes
+  the "cheap HTTP/2 prerequisite" recommendation per-server (§4).
+- **The Rust HTTP/3 stack is pre-1.0.** The mainstream path is the `h3` crate
+  (hyperium/h3, published `0.0.x`) over `h3-quinn` (`0.0.x`) over `quinn`
+  (`0.11.x`, a mature 1.0-adjacent QUIC transport) over `rustls 0.23`. `h3`
+  itself is explicitly a work-in-progress API and **not** a stable dependency;
+  this is a real adoption risk and the single strongest argument for keeping the
+  whole thing behind a default-off feature. External helper crates exist
+  (`h3-axum`, `libhttp3`, `h3x`) but are early/thin — the design does **not**
+  depend on them; it drives `h3` directly and dispatches into the shared
+  `axum::Router` via `tower::Service`. Version pins here are the versions
+  observed as current in July 2026 and are **starting points to resolve at
+  implementation time**, not asserted-exact.
+- **This is a work box (EC2).** No timings are canonical; none are quoted.
+
+## 1. Problem framing
+
+HTTP/3 runs HTTP semantics over **QUIC** (a UDP-based, TLS-1.3-integrated,
+multiplexed transport) instead of TCP. Its wins over HTTP/1.1/2 are: no
+head-of-line blocking across streams, faster (0/1-RTT) connection setup,
+connection migration, and mandatory encryption. For sparq the realistic value is
+(a) modern-client parity (browsers prefer h3 when advertised) and (b) better
+behaviour for many concurrent small SPARQL requests over lossy links. It is a
+**capability/parity** feature, not a throughput claim — we make **no** perf
+claim here.
+
+The core constraint: **axum/hyper do not serve HTTP/3.** hyper is TCP-only; QUIC
+lives in a separate transport (`quinn`) and HTTP/3 framing in a separate crate
+(`h3`). So HTTP/3 cannot be a config flag on the existing server — it is a
+**second listener** (a UDP `quinn::Endpoint`) running **alongside** the existing
+TCP/axum server, both dispatching into the **same** application `Router`.
+
+### 1.1 What the code actually looks like (verified)
+
+`sparq-server` (query API):
+
+- Served by the crate's **own** `sparq_server::serve` (`src/http.rs:4157`), not
+  `axum::serve` — it drives `hyper::server::conn::http1::Builder` directly
+  (`http.rs:4227`) to get the slow-loris `header_read_timeout` timer hook. axum
+  is compiled `http1`-only (`Cargo.toml`: `axum` features `["http1",...]`,
+  `hyper` `["http1","server"]`) — **no `http2` feature anywhere**.
+- **No TLS.** No `rustls`/`axum-server`/`tokio-rustls` dep; the crate documents
+  that it "terminates PLAIN HTTP" behind a TLS-terminating proxy
+  (`http.rs:3173`, `7244`).
+- The app is an `axum::Router`; builder `pub fn router(state: AppState) -> Router`
+  (`http.rs:2988`), hardened by `harden(routes, config) -> Router` (`http.rs:4037`).
+- Uses HTTP/1 `Upgrade` for `/subscriptions` (WebSocket, `.with_upgrades()`).
+
+`sparq-lws-core` (Solid server) — a lib **and** a binary (`src/lib.rs` +
+`src/main.rs`):
+
+- **Plain path** (`main.rs:938`): `axum::serve(listener,
+  app.into_make_service_with_connect_info::<SocketAddr>())`.
+- **TLS path** (`main.rs:839`): `axum_server::from_tcp_rustls(std_listener,
+  config)` then `transport_config.apply_to_builder(server.http_builder())`
+  (the hyper-util `auto::Builder`) — **h1 + h2**, ALPN `["h2","http/1.1"]`
+  (`tls.rs:230`).
+- **mTLS path** (`main.rs:911`): the **same** TLS listener wrapped with a
+  `ConnPopAcceptor` to read the peer client cert — not a separate bind.
+- TLS = `rustls 0.23` + `aws-lc-rs`; the crypto provider is installed **once,
+  process-wide** at `main.rs:253`
+  (`rustls::crypto::aws_lc_rs::default_provider().install_default()`);
+  `axum-server` uses `tls-rustls-no-provider` to reuse it.
+- The app is an `axum::Router`; builders
+  `pub fn build_router<J,R,S>(state) -> Router` (`app.rs:149`) and
+  `build_router_with_overload<J,R,S>(state, overload) -> Router` (`app.rs:172`,
+  the binary's path), generic over three seams `<J,R,S>`.
+- The pre-crypto rate limiter **requires `ConnectInfo<SocketAddr>`** in request
+  extensions and **fails open to auth** if it is missing — so any alternative
+  listener must inject the peer address as `ConnectInfo<SocketAddr>`.
+
+Workspace MSRV is `rust-version = "1.88"` (well above quinn/h3 floors).
+
+## 2. The building blocks (external, honest maturity)
+
+The verified-canonical h3-over-quinn server shape (from hyperium/h3 and quinn
+examples):
+
+1. Build a `rustls::ServerConfig` (0.23, aws-lc-rs provider) with
+   `alpn_protocols = vec![b"h3".to_vec()]`.
+2. `let qsc = quinn::crypto::rustls::QuicServerConfig::try_from(rustls_config)?;`
+   then `quinn::ServerConfig::with_crypto(Arc::new(qsc))`.
+3. `let endpoint = quinn::Endpoint::server(server_config, udp_addr)?;` — a UDP
+   socket, typically the **same port** as the TCP :443 (UDP/443 vs TCP/443).
+4. Accept loop: `while let Some(conn) = endpoint.accept().await { … }`; per
+   connection, `h3::server::Connection::new(h3_quinn::Connection::new(conn.await?))`.
+5. Per request: `conn.accept().await` yields `(http::Request<()>, stream)`; read
+   the body from the stream, **build an `http::Request<Body>`**, call the shared
+   `tower::Service` (the `Router`) with `ServiceExt::oneshot`, then write the
+   `http::Response` status/headers/body back onto the h3 stream.
+
+**Load-bearing design point:** the `h3` request handler is **not** a
+`tower::Service` and axum's `into_make_service*` is TCP-connection-shaped, so we
+do **not** reuse the make-service; we clone the `Router` and call
+`(&router).oneshot(req)` per h3 request. The `Router` is `Service<Request<Body>>`
+and `Clone`, so this is sound. The peer `SocketAddr` from the quinn connection is
+injected into `req.extensions_mut()` as `ConnectInfo<SocketAddr>` — mandatory for
+`sparq-lws-core`, harmless for `sparq-server`.
+
+Maturity caveats to carry into every PR body and any doc: `h3`/`h3-quinn` are
+`0.0.x` (API churn expected); WebSocket-over-HTTP/3 (RFC 9220 Extended CONNECT)
+is a **separate** effort and does **not** come for free — so `sparq-server`'s
+`/subscriptions` WS upgrade and `sparq-lws-core`'s `ws` endpoint remain
+**HTTP/1.1/2-only** and clients must fall back (documented, not a regression).
+
+## 3. Design
+
+### 3.1 Shared plumbing — a small internal helper module
+
+The two routers differ (monomorphic vs generic `<J,R,S>`), but **both final
+apps are `axum::Router`**. So the shared helper takes an **already-built
+`Router`** (sidestepping the generics) plus a QUIC config and runs the accept
+loop. Proposed shape (illustrative, not final):
+
+```rust
+// serve one h3 connection's requests by dispatching into a cloned axum Router
+pub async fn serve_h3(
+    endpoint: quinn::Endpoint,
+    router: axum::Router,          // already built + hardened
+    shutdown: impl Future<Output = ()>,
+) -> std::io::Result<()>;
+
+pub fn quic_server_config(
+    rustls_server_config: rustls::ServerConfig, // ALPN must include b"h3"
+) -> Result<quinn::ServerConfig, Http3Error>;
+```
+
+**Where the helper lives** — decision (proceed-and-document): a **new tiny
+opt-in crate `sparq-http3`** (crate-type `rlib`, all behind its own build, no
+default in the workspace) rather than duplicating the loop in both servers or
+bloating either. Rationale: the accept/dispatch loop and the
+`rustls→QuicServerConfig` bridge are genuinely common; a shared crate is the
+"opt-in feature crate" pattern the repo already prefers (core stays lean; the
+QUIC deps `quinn`/`h3`/`h3-quinn` live in ONE place). Each server depends on it
+**only** under its own `http3` feature. The crate is **not** published initially
+(`publish = false`) — it's an internal seam until the h3 stack stabilises.
+
+### 3.2 Per-server wiring, all behind a default-off `http3` feature
+
+`sparq-server`:
+
+- New `http3` feature ⇒ pulls `sparq-http3` + rustls (this crate has **no TLS
+  today**, so `http3` also introduces the rustls/aws-lc-rs dependency and a
+  cert/key source — QUIC is **mandatorily encrypted**, there is no plaintext
+  HTTP/3). New flags `--http3`, `--http3-addr`, `--tls-cert`, `--tls-key` (only
+  compiled under the feature). When `--http3` is set: build `router(state)` once,
+  keep serving the existing plain-HTTP TCP path unchanged, **and** spawn the
+  `serve_h3` UDP listener with a clone of the same `Router`.
+- This is the larger delta (introduces TLS into a plain-HTTP crate). Keep the
+  plain-HTTP default byte-identical when the feature is off.
+
+`sparq-lws-core`:
+
+- New `http3` feature ⇒ pulls `sparq-http3`. It **already** has rustls +
+  aws-lc-rs + a cert/key path (the TLS serve path) and installs the crypto
+  provider process-wide, so the QUIC config **reuses** that provider and cert.
+  Add `h3` to the existing ALPN list only for the QUIC endpoint (the TCP ALPN
+  stays `["h2","http/1.1"]`).
+- When TLS is configured **and** `http3` is on: build `build_router_with_overload`
+  once, serve the existing TLS TCP path unchanged, **and** spawn `serve_h3` with
+  a clone, injecting the quinn peer `SocketAddr` as `ConnectInfo<SocketAddr>`
+  (mandatory — the rate limiter fails open without it).
+- Smaller delta than `sparq-server` (TLS already present).
+
+### 3.3 Alt-Svc advertising (cheap, both servers)
+
+On the HTTP/1.1+2 responses, add `Alt-Svc: h3=":<port>"; ma=86400` so compliant
+clients discover and upgrade to HTTP/3 on the next request. Implement as a tiny
+tower/axum response-header layer applied in each server's router **only when
+`http3` is enabled and configured** (advertising h3 when it isn't listening is a
+client-visible bug). This is header-only, no crypto — the cheap `gpt`-tier slice.
+
+### 3.4 HTTP/2 — the "cheaper prerequisite win" question, per-server
+
+- `sparq-lws-core` **already** has HTTP/2 on its TLS path — nothing to do there.
+- `sparq-server` has **no** HTTP/2 and no TLS. Adding HTTP/2 is a *separate,
+  cheaper, independently-valuable* win: it means switching its bespoke
+  `http1::Builder` serve to the hyper-util `auto::Builder` (h1+h2) and adding the
+  `http2` feature to axum/hyper — but **h2 cleartext (h2c) is rarely used by
+  browsers**, so real HTTP/2 value on `sparq-server` also needs TLS + ALPN, which
+  is exactly what `http3` introduces. **Recommendation:** treat HTTP/2 on
+  `sparq-server` as an **optional, separate `http2` feature bead** (not a hard
+  prerequisite for h3 — the h3 listener is independent of the TCP builder). It is
+  a genuine parity gap worth its own bead but should not block the h3 epic.
+
+## 4. Recommendation
+
+1. **Ship HTTP/3 as a default-off `http3` feature per server, dispatching into
+   the existing shared `axum::Router` via a new `sparq-http3` helper crate.**
+   Never touch the default (plain-HTTP for `sparq-server`, h1/h2 for
+   `sparq-lws-core`) build.
+2. **Do `sparq-lws-core` first** — it already has the TLS/rustls/aws-lc-rs stack,
+   ALPN ownership, and provider install, so the h3 delta is smallest and lowest
+   risk. `sparq-server` second (it must also acquire TLS).
+3. **Keep the `sparq-http3` helper crate the single home** for `quinn`/`h3`/
+   `h3-quinn` so the pre-1.0 churn is contained to one crate.
+4. **HTTP/2 on `sparq-server` is a separate, non-blocking bead**, not a
+   prerequisite.
+5. **Carry the maturity caveat** (`h3` is `0.0.x`) in every PR body and any doc;
+   no perf claims; WS-over-h3 explicitly out of scope (clients fall back).
+
+## 5. Phased plan (each phase → a future child bead of `sq-oprna`)
+
+Ordered; feasibility/shared plumbing first. Each bead states {crate, model_tier,
+INVARIANT, ACCEPTANCE TEST, depends_on}. Security-adjacent QUIC/rustls wiring →
+`fable`; header/tests → `gpt`. Bead IDs are assigned at mint time; the sequence
+is the build order.
+
+1. **`sparq-http3` helper crate + `rustls→QuicServerConfig` bridge + generic
+   `serve_h3(endpoint, router, shutdown)` loop.** (crate: new `sparq-http3`;
+   tier: `fable`.) INVARIANT: no default-workspace build pulls quinn/h3 (crate
+   is only referenced under downstream `http3` features); the loop injects
+   `ConnectInfo<SocketAddr>` and dispatches via `Router::oneshot`. ACCEPTANCE:
+   a unit/integration test in the crate boots an endpoint on an ephemeral UDP
+   port, an `h3-quinn` client issues a GET into a trivial 2-route `Router`, and
+   the response body/status match; `cargo build -p sparq-http3` green; workspace
+   default build unaffected. depends_on: none.
+2. **`sparq-lws-core` `http3` feature + h3 listener wired to
+   `build_router_with_overload`, reusing the process-wide aws-lc-rs provider +
+   existing cert; ALPN `h3` added to the QUIC endpoint only.** (crate:
+   `sparq-lws-core`; tier: `fable`.) INVARIANT: feature OFF ⇒ serve paths
+   byte-identical (plain + TLS + mTLS unchanged); feature ON + TLS configured ⇒
+   TCP path unchanged AND a UDP/h3 listener serves the same Router with the peer
+   addr injected as `ConnectInfo`. ACCEPTANCE: feature-off `cargo build`/`clippy`
+   identical to main; feature-on integration test — start with a self-signed
+   cert, an h3 client GETs an LDP resource and gets the **same** status+body as
+   the h1/h2 client for the same request; rate-limiter `ConnectInfo` present
+   (not fail-open). depends_on: 1.
+3. **`sparq-server` `http3` feature: introduce rustls/aws-lc-rs + cert/key flags
+   + h3 listener wired to `router(state)`, keeping the plain-HTTP TCP path.**
+   (crate: `sparq-server`; tier: `fable`.) INVARIANT: feature OFF ⇒ no rustls in
+   the tree, plain-HTTP serve byte-identical; feature ON ⇒ plain-HTTP TCP path
+   unchanged AND an encrypted UDP/h3 listener serves the same `router(state)`.
+   ACCEPTANCE: feature-off build/clippy identical to main; feature-on test — an
+   h3 client issues a SPARQL query and gets the **same** result serialization as
+   the HTTP/1.1 client; `--http3` requires cert/key or errors clearly.
+   depends_on: 1.
+4. **Alt-Svc advertising layer (both servers), gated on `http3` being enabled +
+   configured.** (crate: `sparq-http3` for the shared layer + `sparq-server` and
+   `sparq-lws-core` wiring; tier: `gpt`.) INVARIANT: `Alt-Svc: h3=":<port>"`
+   header appears on h1/h2 responses **only** when an h3 listener is actually
+   bound; never advertised otherwise. ACCEPTANCE: with `http3` on, an h1 GET
+   response carries a well-formed `Alt-Svc` naming the live h3 port; with `http3`
+   off, the header is absent. depends_on: 2, 3.
+5. **Cross-protocol conformance/integration test: h3 request == h1 response for a
+   representative endpoint on each server, plus a WS-fallback assertion.** (crate:
+   `sparq-server` + `sparq-lws-core` tests; tier: `gpt`.) INVARIANT: for a matrix
+   of representative requests, the h3 response is byte-equivalent (status, media
+   type, body) to the h1 response; a WS/`/subscriptions` request over h3 is
+   cleanly refused/falls back (documented) and still works over h1/h2. ACCEPTANCE:
+   the test passes in the `http3`-feature CI leg; feature-off CI unaffected.
+   depends_on: 2, 3, 4.
+6. **(Non-blocking, separable) `sparq-server` optional `http2` feature: switch the
+   TCP serve to the hyper-util `auto::Builder` (h1+h2), gated + default-off,
+   preserving the slow-loris `header_read_timeout` hook.** (crate: `sparq-server`;
+   tier: `fable`.) INVARIANT: feature OFF ⇒ HTTP/1.1-only serve byte-identical
+   incl. the header-read-timeout timer; feature ON ⇒ h1+h2 with the same timeout
+   behaviour. ACCEPTANCE: feature-off build identical; feature-on test negotiates
+   h2 (over TLS from bead 3) and h1 still works; slow-loris timeout test still
+   passes. depends_on: 3 (for TLS/ALPN). **Not required by 1–5** — independently
+   valuable parity work.
+
+## 6. Open questions for the maintainer
+
+- **New crate vs per-server module:** this design mints `sparq-http3`. If you'd
+  rather **not** add a crate, the fallback is a private `http3` module duplicated
+  (or a shared `sparq-serve`-hosted module) — say which you prefer; I've proceeded
+  with the crate per the opt-in-feature-crate house pattern.
+- **Cert source for `sparq-server` h3:** `sparq-server` has no cert story today
+  (plain HTTP behind a proxy). h3 forces in-process TLS. Are file-path
+  `--tls-cert/--tls-key` flags acceptable, or should h3 on `sparq-server` be
+  deferred until there's a broader TLS story for that crate? (`sparq-lws-core`
+  already has this, which is why it's sequenced first.)
+- **h3 maturity gate:** are you comfortable shipping against `h3` `0.0.x`
+  (default-off), or should this wait for an `h3` `0.x`-stable / a `quinn`-native
+  HTTP/3 API? The design contains the churn to one crate either way.
+- **WS-over-HTTP/3 (RFC 9220):** confirmed out of scope for this epic — OK?

--- a/research/wasm-solid-server-npm-design.md
+++ b/research/wasm-solid-server-npm-design.md
@@ -1,0 +1,258 @@
+# WebAssembly build of the sparq Solid server on npm — feasibility + design (2026-07) [OPUS-4.8]
+
+Status: **design-for-review, maintainer-requested** (epic `sq-6xasp`, P1). This
+record gives an honest feasibility verdict for compiling the sparq Solid server
+(`sparq-lws-core`) — or its request-handling core — to `wasm32`, publishing it as
+an npm package for `npx`/`npm` spin-up, and decomposes the realistic (reduced-
+scope) path into disjoint child beads. The author is a SPARQ research agent;
+nothing here is implemented. It is verified against the checked-out code.
+
+## 0. Feasibility verdict (read first)
+
+**A wasm build of the FULL `sparq-lws-core` crate as-written is NOT feasible —
+there are hard, unavoidable blockers. But the request-handling CORE (LDP verbs +
+WAC access control over an in-memory store) has a clean, ALREADY-EXISTING seam,
+so a REDUCED-SCOPE in-memory wasm demo published to npm is realistic and
+MEDIUM-effort.** The decisive facts:
+
+- The heavy architectural work is **already done**: the app is a pure
+  `axum::Router` returned by `build_router(state) -> Router` (`app.rs:149`),
+  decoupled from the listener; the LDP handlers are generic over `S: Store`
+  (`ldp/handler.rs`) and call only `self.store.<method>().await` (grep of
+  `handler.rs` for `tokio::spawn`/`spawn_blocking`/`tokio::net`/`tokio::time`
+  returns **zero**); the `Store` trait has **in-memory doubles that are the
+  default boot path** (`InMemorySparqClient` `store/sparq.rs:225`,
+  `InMemoryBlobStore` `store/blob.rs:195`; `main.rs:174` default backend is
+  `memory`). The engine core is **already wasm-proven** (`sparq-wasm` depends on
+  `sparq-core`+`sparq-engine` and ships to wasm today).
+- The blockers are concentrated in **transport + crypto + network-auth**, all in
+  identifiable modules that a wasm profile excludes — not smeared through the
+  handler logic.
+
+**The one genuine hard blocker that constrains scope: `aws-lc-rs`** (the rustls
+crypto backend, a C/asm library) **does not build for
+`wasm32-unknown-unknown`.** It is reachable not only from TLS (`main.rs`,
+`tls.rs`) but also from the **notifications** provider install (`notifications/mod.rs:248`)
+and the **PoP session-key derivation** (`pop/sk/derive.rs:30`, HKDF/HMAC). So the
+first wasm demo must **exclude** TLS + notifications + PoP-SK (all native-transport
+concerns anyway) — which is fine, because in a Node host the HTTP listener and TLS
+live in **JS**, not in the wasm module.
+
+**Minimal working demo = in-memory store, no OIDC network, no TLS, no
+notifications, no PoP.** That is a real, useful Solid pod (LDP CRUD + WAC) that a
+developer can `npx` up in seconds.
+
+## 1. The two brief premises — verified
+
+- **"wasm32 can't run tokio's full runtime / native TLS / native fs"** —
+  CORRECT. `sparq-lws-core`'s tokio features are
+  `["fs","rt-multi-thread","macros","net","signal","sync","time"]`
+  (`Cargo.toml:25`); `rt-multi-thread`, `net`, `signal`, `fs` are native-only on
+  `wasm32-unknown-unknown`. Native TLS = `aws-lc-rs` (does not build for wasm).
+  Native fs = only in `tls.rs` (PEM read, all in tests) — the in-memory store
+  path touches neither `std::fs` nor `tokio::fs`.
+- **"compile the REQUEST-HANDLING LOGIC over the embedded in-memory backend, JS
+  host provides the listener + storage"** — CORRECT and the right shape. Refined:
+  the JS host provides the **listener** (and optional persistence); the
+  **storage** can stay **inside wasm** (the `InMemoryBlobStore`/`InMemorySparqClient`
+  `HashMap`s live in linear memory) for the first demo, which is simpler than a
+  JS-fs round-trip. A JS-fs / IndexedDB-backed `Store` is a clean follow-up
+  because `Store` is already a swappable async trait.
+
+## 2. The existing wasm pattern in the repo (reuse it)
+
+Five wasm crates share one pattern — `sparq-wasm`, `sparq-reason-wasm`,
+`sparq-text-wasm`, `sparq-rsp-wasm`, `sparq-shacl-wasm`:
+
+- crate-type `["cdylib","rlib"]`, `publish = false`, `wasm-bindgen = "0.2"`,
+  `wasm-bindgen-test = "0.3"` (dev). All deps `default-features = false` (no
+  rayon — no wasm threads).
+- Entry shape: a `#[wasm_bindgen]` struct with `#[wasm_bindgen(constructor)]` +
+  camelCase methods (`js_name = queryQuads`, …), plus free functions. Synchronous,
+  in-memory, single-threaded (`sparq-wasm/src/lib.rs:113`).
+- `getrandom`: the workspace `.cargo/config.toml` sets
+  `--cfg getrandom_backend="wasm_js"` + `+simd128` for all wasm32 builds; each
+  crate adds `getrandom` under `[target.'cfg(target_arch="wasm32")'.dependencies]`.
+  **Caveat:** `sparq-lws-core` uses **getrandom 0.2** (needs the `js` feature),
+  not 0.3 (`wasm_js` cfg) — the `sparq-wasm` `getrandom02` shim
+  (`sparq-wasm/Cargo.toml:70`) is the template.
+- Build/publish: `js/package.json` scripts run
+  `wasm-pack build ../crates/<crate> --target web --profile release-wasm`; npm
+  scope is **`@jeswr/sparq`** (`js/package.json:2`) (a second `@sparq-org` scope
+  also exists). CI: `.github/workflows/js.yml` (gating wasm-pack build+test) and
+  `.github/workflows/publish.yml` (OIDC trusted-publishing to npm + SLSA
+  provenance, `--access public`). A new bundle adds a `build:lws-wasm` script +
+  a `package.json`, mirroring `sparq-reason-wasm`.
+
+## 3. Wasm-incompatibility audit of `sparq-lws-core` (verified)
+
+| Dependency / concern | Verdict | Notes |
+| --- | --- | --- |
+| **tokio** `fs,rt-multi-thread,net,signal,time` | HARD (replace/exclude) | native-only. The listener/serve is in `main.rs` (excluded). `spawn_blocking` in `store/embedded.rs:166` and `spawn` in `store/reconcile.rs:563` must be cfg'd out. **Handlers themselves have no tokio primitives** — only `Store` `.await`, trivial on in-memory doubles. Needs `wasm-bindgen-futures` (or a sync entry) to drive the async trait. |
+| **aws-lc-rs** (via rustls) | **HARD BLOCKER** | C/asm; does not build for wasm32. Reachable from `main.rs:253` (provider install), `notifications/mod.rs:248`, `pop/sk/derive.rs:30`. Exclude TLS + notifications + PoP-SK. |
+| **axum-server** (`tls-rustls`) | HARD (out of core seam) | native listener; confined to `main.rs`/`tls.rs`, not in `build_router`. |
+| **axum 0.8** (`ws`) | partial / cfg-gate | `Router`/extractors/handlers largely portable; `axum::serve`, `ws` upgrade, hyper server are native → excluded. The wasm entry calls handlers via the `Router` directly. |
+| **solid-oidc-verifier** (`network`) | HARD (network feature) | `network` pulls hickory-resolver/hickory-proto + reqwest — native. The verifier **core** (`Verifier::verify`) is seam-based over in-memory doubles (`StaticJwksProvider`, `InMemoryReplayStore`, `auth.rs:39`). Reduced demo depends on the verifier **without `network`** (inject static JWKS) OR stubs auth. **Unverified risk:** whether the verifier's no-network core compiles to wasm32 (pulls sha2/base64/p256-ish crypto — likely OK, needs a spike). |
+| **object_store 0.13** | drop (unused) | grep of `src/` for `object_store::` = **zero** real uses (doc-comments only). Real bytes → `InMemoryBlobStore`. |
+| **embedded-sparq** (`sparq-core`+`sparq-engine`) | core wasm-OK, wiring not | engine builds for wasm (proven). BUT lws-core enables `sparq-core` with **`mmap`** (`store/embedded.rs:100` `Graph::open`) and runs engine calls through `spawn_blocking` — both native. For wasm: in-memory `Graph` (no mmap), synchronous engine call (as `sparq-wasm` does), or just use `InMemorySparqClient`. |
+| **mimalloc** | exclude | vendored C global allocator, installed in `main.rs` only. |
+| **redis / r2d2** (`redis-replay`) | exclude | opt-in, off by default. |
+| **hyper / hyper-util** | exclude | HTTP client + transport hardening; embedded path doesn't need them. |
+| **getrandom 0.2** | needs `js` feature | used in `overload.rs:167`, `rate_limit.rs:629`, `pop/sk/derive.rs:91`, blob-key mint. |
+| **sha2, subtle, base64, url, itoa, bytes, http, thiserror, serde/serde_json, async-trait, pin-project-lite** | wasm-OK | pure-Rust auth_cache + response-build primitives. |
+
+## 4. The clean seam (why this is medium, not a rewrite)
+
+- **`build_router(state) -> axum::Router`** (`app.rs:149`) and
+  `build_router_with_overload` (`app.rs:172`) return a pure `Router`; all
+  listener/serve/TLS/signal handling lives in `main.rs`.
+- **Handlers generic over `S: Store`** (`get_handler<S: Store>`, etc.,
+  `ldp/handler.rs:660,973,1112,1277,1403`), calling only `self.store.<method>().await`
+  and pure functions — runtime-agnostic.
+- **WAC** (`authz/` — acl/wac/mode/wac_allow) is pure logic reading `.acl`
+  through the same `Store`; works unchanged in wasm.
+- **`Store` is a swappable `async_trait`** (`store/mod.rs:125`) with in-memory
+  doubles that are **already the default boot path** — no new storage abstraction
+  is needed for the demo.
+- Module map of `src/` (~38k lines): `app.rs` (router), `ldp/` (verb surface,
+  portable), `authz/` (WAC, portable), `auth.rs`/`auth_cache.rs` (verifier seam),
+  `store/` (seam + in-memory doubles + embedded/http/blob backends),
+  **native-only (exclude for the demo):** `notifications/` (tokio broadcast +
+  aws-lc-rs), `pop/` (mTLS/DPoP-SK + aws-lc-rs), `overload.rs`, `rate_limit.rs`,
+  `body_limit.rs`, `transport.rs`, `tls.rs`, `main.rs`, `nodelay.rs`,
+  `redis_replay.rs`.
+
+## 5. Design — the realistic path
+
+### 5.1 Architecture
+
+A **new crate `sparq-lws-wasm`** (crate-type `["cdylib","rlib"]`, `publish =
+false`) that depends on `sparq-lws-core` via a **new `wasm` feature** on
+`sparq-lws-core` that cfg-gates OUT the native runtime/transport/crypto/network
+surface (tokio net/rt/signal/fs coupling, `axum-server`, `tls`, `pop`,
+`notifications`, `mimalloc`, `object_store`, `redis`, and the verifier `network`
+feature). The wasm crate exposes a `#[wasm_bindgen]` entry over a
+`CompositeStore<InMemorySparqClient, InMemoryBlobStore>`.
+
+Two viable entry shapes; the design **recommends (a)** to preserve the exact
+routing/middleware semantics:
+
+- **(a) Drive the existing `Router`** through a hand-built `http::Request` via
+  `tower::Service::call` under `wasm-bindgen-futures` (async wasm methods). Keeps
+  axum routing, content negotiation, conditional requests, WAC middleware — the
+  server behaves identically to native, minus the excluded transport.
+- **(b) A thinner `handle_request(method, path, headers, body) -> Response`** that
+  calls the `*_handler` functions directly. Less faithful (bypasses the router's
+  layer stack), only if (a) hits a wasm-bindgen-futures/async-trait snag.
+
+The npm package is a **Node wrapper** exposing `startSolidServer(opts)` (and an
+`npx @jeswr/solid-server` bin) that boots a Node `http` listener and routes each
+request into the wasm handler; storage is in-wasm-memory for v1. TLS, if wanted,
+is terminated in Node/a proxy — never in wasm.
+
+### 5.2 Auth for the demo
+
+For the **first** demo, **disable/stub OIDC** (or inject a `StaticJwksProvider` +
+`InMemoryReplayStore` with a pre-baked token) — **no network**. This is honest:
+the demo is an **unauthenticated or static-token** Solid pod for local dev, not a
+production IdP-verifying server. Real OIDC in wasm (JWKS fetch via JS `fetch`,
+WebID resolution) is a **follow-up bead** contingent on the verifier's no-network
+core compiling to wasm.
+
+### 5.3 The hard blocker + the minimal working demo
+
+**Hard blocker:** `aws-lc-rs` (and thus in-wasm TLS, notifications-provider,
+PoP-SK) cannot compile to wasm32. **Minimal working demo that dodges it entirely:**
+in-memory store, no TLS (Node/proxy terminates it), no notifications, no PoP, no
+OIDC network → a Solid pod that round-trips LDP CRUD + WAC. This is a genuinely
+useful artifact and the correct v1 scope.
+
+## 6. Recommendation
+
+1. **Feasible only in reduced scope; ship that.** New `sparq-lws-wasm` crate +
+   a `wasm` feature on `sparq-lws-core` gating out native transport/crypto/network;
+   in-memory store; drive the real `Router` via `wasm-bindgen-futures`.
+2. **De-risk with a spike FIRST** (bead 1): confirm (i) `solid-oidc-verifier`
+   without `network` compiles to wasm32 (or decide to stub auth), and (ii) the
+   async-trait `Store` path drives cleanly under `wasm-bindgen-futures` with no
+   tokio reactor. This is the highest-uncertainty item; do it before committing
+   the crate structure.
+3. **Sequence:** spike → `wasm` feature/cfg-gating on `sparq-lws-core` → wasm
+   entry crate → Node host + npm package → smoke test. Auth (real OIDC) and
+   persistent storage (JS-fs/IndexedDB `Store`) are explicit follow-ups.
+4. **Be honest in the README/package:** v1 is a local-dev, in-memory,
+   (un)authenticated Solid pod — **not** a production server. No perf claims.
+
+## 7. Phased plan (each phase → a future child bead of `sq-6xasp`)
+
+Ordered; feasibility spike first. Each bead states {crate, model_tier, INVARIANT,
+ACCEPTANCE TEST, depends_on}. cfg-gating soundness → `fable`; JS host + packaging
+→ `gpt`. Bead IDs assigned at mint; sequence = build order.
+
+1. **Feasibility spike: prove the wasm-critical unknowns compile/run.** (crate:
+   throwaway/experimental; tier: `fable`.) INVARIANT: no change to shipped crates;
+   findings captured as a bead note. ACCEPTANCE: a documented result answering —
+   does `solid-oidc-verifier` (no `network`) build for `wasm32-unknown-unknown`?
+   does the async-trait `Store` + a minimal handler drive under
+   `wasm-bindgen-futures` without a tokio reactor? does `sparq-engine`'s
+   in-memory `Graph` query path work in wasm (expected yes)? Pass = a written
+   go/no-go with the exact deps that must be stubbed. depends_on: none.
+2. **`wasm` feature on `sparq-lws-core` cfg-gating out native
+   transport/crypto/network.** (crate: `sparq-lws-core`; tier: `fable`.)
+   INVARIANT: default (native) build byte-identical — every gate is
+   `#[cfg(not(target_arch = "wasm32"))]` / `#[cfg(feature = "wasm")]` around
+   `main`/`tls`/`pop`/`notifications`/`transport`/`redis`/mimalloc/object_store +
+   the `spawn_blocking`/`spawn` sites; the verifier `network` feature and
+   `sparq-core/mmap` are off under `wasm`; getrandom `js`. ACCEPTANCE: native
+   `cargo build`/`clippy -D warnings` unchanged (feature-off byte-identical);
+   `cargo build -p sparq-lws-core --features wasm --target wasm32-unknown-unknown`
+   compiles the router + LDP handlers + WAC + in-memory store (no aws-lc-rs, no
+   tokio-net in the wasm object). depends_on: 1.
+3. **`sparq-lws-wasm` crate: `#[wasm_bindgen]` entry over
+   `CompositeStore<InMemorySparqClient, InMemoryBlobStore>`, driving the real
+   `Router` via `wasm-bindgen-futures`.** (crate: new `sparq-lws-wasm`; tier:
+   `fable` for the async/store wiring soundness.) INVARIANT: single-threaded,
+   in-memory, no network; auth stubbed/static for v1 (documented). ACCEPTANCE:
+   `wasm-pack build crates/sparq-lws-wasm --target web` succeeds; a
+   `wasm-bindgen-test` issues a PUT then GET of an LDP resource against the wasm
+   handler and the bytes round-trip; a WAC-denied request returns 401/403.
+   depends_on: 2.
+4. **Node host + npm package: `startSolidServer(opts)` + `npx @jeswr/solid-server`
+   bin routing a Node HTTP listener into the wasm handler; in-memory storage;
+   `package.json` + `build:lws-wasm` script; wire into `js.yml`/`publish.yml`.**
+   (crate: `js/` package + `sparq-lws-wasm` glue; tier: `gpt`.) INVARIANT: no TLS
+   in wasm (Node/proxy terminates); package README states the honest v1 scope
+   (local-dev, in-memory, (un)authenticated). ACCEPTANCE: `npm install` +
+   `npx @jeswr/solid-server` boots a listener; a `curl`/`fetch` PUT then GET of a
+   Turtle resource round-trips; the CI `js` leg builds the bundle. depends_on: 3.
+5. **Smoke test: install → spin up → a Solid LDP request round-trips (CI leg).**
+   (crate: `js/` tests; tier: `gpt`.) INVARIANT: the smoke test runs in the
+   existing `js.yml` matrix and does not gate the native workspace. ACCEPTANCE: a
+   scripted `npx`-boot + LDP CREATE/READ/UPDATE/DELETE + a WAC check passes in CI;
+   failure is visible on the PR. depends_on: 4.
+6. **(Follow-up, non-blocking) Real OIDC in wasm via JS `fetch` JWKS/WebID
+   adapters (contingent on bead-1 verifier-wasm result).** (crate: `sparq-lws-wasm`
+   + `js/`; tier: `fable` for the auth-path soundness.) INVARIANT: default demo
+   stays stub-auth; real-auth is opt-in and clearly scoped. ACCEPTANCE: a wasm
+   build with a JS-`fetch`-backed `JwksProvider` verifies a real DPoP-bound token
+   against a live IdP in a test. depends_on: 5 + a positive bead-1 verdict.
+7. **(Follow-up, non-blocking) Persistent `Store` for wasm: a JS-fs / IndexedDB
+   backend behind the existing `Store` trait.** (crate: `sparq-lws-wasm` + `js/`;
+   tier: `gpt`.) INVARIANT: the in-memory store stays the default; persistence is
+   opt-in. ACCEPTANCE: data survives a listener restart via the JS-backed store in
+   a test. depends_on: 5.
+
+## 8. Open questions for the maintainer
+
+- **v1 auth stance:** OK to ship the first npm demo as **unauthenticated /
+  static-token** (no OIDC network), with real OIDC as bead 6? This is the honest
+  minimal-scope path around the aws-lc-rs blocker.
+- **npm scope + name:** `@jeswr/sparq` is the existing scope. Publish as
+  `@jeswr/solid-server` (proposed `npx` target) or under `@sparq-org`? I've
+  written the plan against `@jeswr/solid-server`.
+- **Storage location for v1:** in-wasm-memory (simplest, proposed) vs a JS-fs
+  `Store` from the start? I've proposed in-memory for v1, JS-fs as bead 7.
+- **Verifier-wasm dependency:** bead 6 (real OIDC) is contingent on
+  `solid-oidc-verifier` compiling to wasm without `network` — if it doesn't, real
+  wasm OIDC needs upstream work on that crate (a separate track). The bead-1 spike
+  settles this.


### PR DESCRIPTION
> 🤖 **SPARQ agent (research/architecture).** Design-for-review only — no implementation. Two maintainer-requested design records + disjoint child beads minted under each epic (the orchestrator re-exports the beads; none are staged in this PR).

## What this is

Two `research/` design records, decomposed into future child beads:

### Epic 1 — `sq-oprna`: HTTP/3 (QUIC) across all sparq HTTP servers
`research/http3-quic-servers-design.md`. Opt-in **default-off `http3`** feature per server; a new **`sparq-http3` helper crate** houses `quinn`/`h3`/`h3-quinn` (the **pre-1.0 `h3` churn is contained to one crate**) and dispatches each h3 request into the shared `axum::Router` via `tower::Service::oneshot`, injecting the quinn peer addr as `ConnectInfo<SocketAddr>`.

**Correction to the brief's premise:** `sparq-lws-core` **already has HTTP/2** on its TLS path (ALPN `[h2,http/1.1]`); only `sparq-server` is HTTP/1.1-only + plain-HTTP. So lws-core is sequenced **first** (TLS/rustls/aws-lc-rs already present → smallest delta); `sparq-server` must also acquire TLS. HTTP/2 on `sparq-server` is a separate, non-blocking bead. No perf claims; WS-over-HTTP/3 (RFC 9220) is out of scope. Maturity caveat carried throughout: `h3`/`h3-quinn` are `0.0.x`.

Beads: `sq-oprna.1..6` (build order 1→2/3→4→5; 6 non-blocking).

### Epic 2 — `sq-6xasp`: WebAssembly build of the Solid server on npm
`research/wasm-solid-server-npm-design.md`. **Feasibility verdict:** the **full crate is NOT wasm-able** — hard blocker is **`aws-lc-rs`** (rustls backend, C/asm; reachable from TLS + notifications + PoP-SK), plus tokio net/rt/fs, `axum-server`, and the verifier `network` feature. **But** the request-handling core has an **already-clean seam** (`build_router(state) -> Router` decoupled from the listener; handlers generic over `S: Store` with zero tokio primitives; in-memory `Store` doubles that are the default boot path; engine core already wasm-proven via `sparq-wasm`). So a **reduced-scope in-memory demo** (no TLS/OIDC-network/notifications/PoP) on npm is **realistic + MEDIUM effort**. Spike-first sequencing to settle the two real unknowns (verifier-no-network-on-wasm; async-trait `Store` under `wasm-bindgen-futures`).

Beads: `sq-6xasp.1..7` (build order 1→2→3→4→5; 6/7 non-blocking follow-ups).

## Honesty notes
- Both records verified against the checked-out code (file:line cited), not the brief on faith.
- No QUIC/h3 exists in the workspace today (greenfield). No perf numbers (work box; non-canonical).
- Any privacy/auth-soundness wording stays caveated (privacy-claims gate is live); the wasm auth path is stub/static for v1.

`markdownlint-cli2` clean (0 errors). **Do NOT arm** — for maintainer review.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>