### PR TITLE
feat(vectors): add per-vector metadata sidecar [GPT-5.6]

### DIFF
--- a/.github/feature-matrix.d/sparq-vectors.yml
+++ b/.github/feature-matrix.d/sparq-vectors.yml
@@ -105,3 +105,12 @@
   crate: "sparq-vectors"
   features: "spqv-provenance"
   test: true
+
+# [GPT-5.6] sq-lsp7k.25: per-vector opaque metadata persisted in `.spqv` v4 and attached to exact
+# search hits without affecting ranking. The integration suite is feature-gated and otherwise
+# compiles empty, so this dedicated leg is its CI executor. Compose with `spqv-provenance` to cover
+# the v4 header's optional provenance block as well as tagged/untagged round-trip behavior.
+- name: "sparq-vectors (metadata-sidecar — per-vector tags on exact search)"
+  crate: "sparq-vectors"
+  features: "metadata-sidecar,spqv-provenance"
+  test: true

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -109,6 +109,11 @@ filtered-ann = []
 # pending the cross-implementation profile #1746 — the KERN boundary), so this ships the core v3
 # record without privileging any encoder.
 spqv-provenance = []
+# [GPT-5.6] sq-lsp7k.25: opaque per-vector UTF-8 metadata persisted inside `.spqv` and returned
+# beside exact-search hits. OPT-IN and OFF by default; a LEAN feature with no new dependency.
+# Ordinary `put` stores keep writing the existing v2/v3 formats byte-for-byte; the v4 metadata
+# block is selected only after `put_with_meta` records at least one tag.
+metadata-sidecar = []
 # [OPUS-4.8] sq-pi44: incremental add / remove / update of vectors against an already-finalized
 # store via an in-RAM DELTA SIDECAR (+ `compact` to fold it back into a fresh base), so a single
 # graph change no longer forces a full re-embed + file rebuild. OPT-IN and OFF by default; a LEAN

--- a/crates/sparq-vectors/src/ann.rs
+++ b/crates/sparq-vectors/src/ann.rs
@@ -88,6 +88,24 @@ pub fn nearest_exact(store: &VectorStore, query: &[f32], k: usize) -> Vec<(Id, f
     scored
 }
 
+/// Exact cosine top-`k` with each hit's opaque metadata tag attached.
+///
+/// Ranking is delegated to [`nearest_exact`] and is therefore identical, including its ascending-id
+/// tie-break. Metadata only decorates the completed ranking and never filters or reorders it. IDs
+/// written with [`VectorStore::put`] return `None`; IDs written with
+/// [`VectorStore::put_with_meta`] return the tag byte-for-byte as a `String`.
+#[cfg(feature = "metadata-sidecar")]
+pub fn nearest_exact_with_meta(
+    store: &VectorStore,
+    query: &[f32],
+    k: usize,
+) -> Vec<(Id, f32, Option<String>)> {
+    nearest_exact(store, query, k)
+        .into_iter()
+        .map(|(id, score)| (id, score, store.meta(id).map(str::to_owned)))
+        .collect()
+}
+
 /// Like [`nearest_exact`] but query-by-term: resolves `term` through the graph's
 /// dictionary, looks its vector up in the store, excludes the term itself from the
 /// results and maps neighbor ids back to [`Term`]s. Empty if the term is absent from

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -75,6 +75,11 @@ pub mod compose;
 pub mod fuse;
 pub mod import;
 pub mod labels;
+// [GPT-5.6] sq-lsp7k.25: deterministic `.spqv` v4 metadata-block codec. Private implementation;
+// the public surface is `VectorStore::{put_with_meta,meta}` + `nearest_exact_with_meta`, all behind
+// the default-OFF `metadata-sidecar` feature.
+#[cfg(feature = "metadata-sidecar")]
+mod metadata;
 pub mod quant;
 // [FABLE-5] sq-lhcot.1 (GenAI review gap 1; spec estate sq-rvgr2.4): the `.spqv` v3 EMBEDDING
 // PROVENANCE record (model id / model+content version / metric / normalization / verbalization
@@ -173,6 +178,8 @@ pub mod prov_vocab {
     pub const VERBALIZATION: &str = "http://sparq.dev/spqv-prov#verbalization";
 }
 
+#[cfg(feature = "metadata-sidecar")]
+pub use ann::nearest_exact_with_meta;
 pub use ann::{cosine, nearest_exact, nearest_term_exact, nearest_term_exact_checked};
 // [OPUS-4.8] (sq-ip3a) The in-RAM HNSW index is the approximate backend — `approx-ann` only
 // (the only feature pulling `instant-distance`). The default build re-exports just the exact

--- a/crates/sparq-vectors/src/metadata.rs
+++ b/crates/sparq-vectors/src/metadata.rs
@@ -1,0 +1,99 @@
+//! Deterministic codec for the opt-in per-vector metadata block in `.spqv` v4.
+//!
+//! Metadata is an opaque UTF-8 string keyed by vector id. Entries are encoded in ascending id
+//! order, so hash-map insertion order cannot affect the store bytes.
+
+use rustc_hash::FxHashMap;
+use sparq_core::dict::Id;
+
+pub(crate) const MAGIC: [u8; 4] = *b"SPQM";
+const VERSION: u32 = 1;
+const HEADER_LEN: usize = 16;
+
+pub(crate) fn encode(metadata: &FxHashMap<Id, String>) -> Vec<u8> {
+    let mut entries: Vec<_> = metadata.iter().collect();
+    entries.sort_unstable_by_key(|&(id, _)| *id);
+
+    let body_len = entries
+        .iter()
+        .map(|(_, value)| 8 + value.len())
+        .sum::<usize>();
+    let mut bytes = Vec::with_capacity(HEADER_LEN + body_len);
+    bytes.extend_from_slice(&MAGIC);
+    bytes.extend_from_slice(&VERSION.to_le_bytes());
+    bytes.extend_from_slice(&(entries.len() as u64).to_le_bytes());
+    for (id, value) in entries {
+        bytes.extend_from_slice(&id.to_le_bytes());
+        bytes.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(value.as_bytes());
+    }
+    bytes
+}
+
+pub(crate) fn decode(
+    bytes: &[u8],
+    vector_count: usize,
+    origin: &str,
+) -> Result<FxHashMap<Id, String>, String> {
+    if bytes.len() < HEADER_LEN {
+        return Err(format!("{origin}: truncated metadata block"));
+    }
+    if bytes[0..4] != MAGIC {
+        return Err(format!("{origin}: invalid metadata block magic"));
+    }
+    let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+    if version != VERSION {
+        return Err(format!(
+            "{origin}: unsupported metadata block version {version}"
+        ));
+    }
+    let entry_count64 = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+    let entry_count: usize = entry_count64
+        .try_into()
+        .map_err(|_| format!("{origin}: metadata entry count exceeds the address space"))?;
+    if entry_count > vector_count {
+        return Err(format!(
+            "{origin}: metadata has {entry_count} entries for only {vector_count} vectors"
+        ));
+    }
+
+    let mut metadata = FxHashMap::default();
+    metadata.reserve(entry_count);
+    let mut offset = HEADER_LEN;
+    let mut previous_id = None;
+    for entry in 0..entry_count {
+        let header_end = offset
+            .checked_add(8)
+            .ok_or_else(|| format!("{origin}: metadata entry {entry} header offset overflows"))?;
+        if header_end > bytes.len() {
+            return Err(format!("{origin}: truncated metadata entry {entry} header"));
+        }
+        let id = u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap());
+        let value_len =
+            u32::from_le_bytes(bytes[offset + 4..header_end].try_into().unwrap()) as usize;
+        if previous_id.is_some_and(|previous| previous >= id) {
+            return Err(format!(
+                "{origin}: metadata entry {entry} (id {id}) is not strictly ascending"
+            ));
+        }
+        previous_id = Some(id);
+        offset = header_end;
+        let value_end = offset
+            .checked_add(value_len)
+            .ok_or_else(|| format!("{origin}: metadata value length {value_len} overflows"))?;
+        if value_end > bytes.len() {
+            return Err(format!("{origin}: truncated metadata value for id {id}"));
+        }
+        let value = std::str::from_utf8(&bytes[offset..value_end])
+            .map_err(|e| format!("{origin}: metadata for id {id} is not UTF-8: {e}"))?;
+        metadata.insert(id, value.to_owned());
+        offset = value_end;
+    }
+    if offset != bytes.len() {
+        return Err(format!(
+            "{origin}: metadata block has {} trailing bytes",
+            bytes.len() - offset
+        ));
+    }
+    Ok(metadata)
+}

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -45,6 +45,15 @@
 //! provenance, so `check_provenance` fails closed against it unless the caller opts into
 //! [`LegacyMode::Allow`].
 //!
+//! # Version 4 — opt-in per-vector metadata
+//!
+//! With the default-OFF `metadata-sidecar` feature, calling `put_with_meta` selects v4. It adds a
+//! deterministic, length-delimited metadata block between the optional provenance block and the
+//! aligned vector data. Each entry is `(id, opaque UTF-8 bytes)`, sorted by id. Ordinary `put` calls
+//! write v2 (or v3 when provenance is bound) exactly as before, even when the feature is enabled.
+//! Metadata is accessed with `meta` and decorates `nearest_exact_with_meta`; it never participates
+//! in scoring or ordering.
+//!
 //! [OPUS-4.8] (sq-32i5) The **fingerprint** binds the store to the graph it was built against
 //! (see [`crate::fingerprint`]): a store keyed by dictionary id is meaningless against a graph
 //! whose ids have shifted, so [`VectorStore::check_graph`] errors on a mismatch instead of letting
@@ -104,6 +113,10 @@ pub const SPQV_VERSION: u32 = 2;
 /// `spqv-provenance` feature is on and a provenance was bound (`VectorStore::with_provenance`); READ
 /// always (a v3 file opens regardless of features).
 pub const SPQV_VERSION_V3: u32 = 3;
+/// Metadata-bearing `.spqv` format, written only by the opt-in `metadata-sidecar` feature when at
+/// least one vector carries a tag.
+#[cfg(feature = "metadata-sidecar")]
+pub const SPQV_VERSION_V4: u32 = 4;
 /// Header length of a version-1 file (no fingerprint block).
 const HEADER_LEN_V1: usize = 32;
 /// Header length of the version-2 format: the v1 header + the fingerprint block. Also the length of
@@ -258,6 +271,10 @@ pub struct VectorStore {
     /// feature, so the default build carries no delta state. See [`crate::delta`].
     #[cfg(feature = "delta")]
     delta: Option<crate::delta::VectorDelta>,
+    /// Opaque per-vector tags. Present only in `metadata-sidecar` builds, so the default store
+    /// carries neither the map nor the v4 codec.
+    #[cfg(feature = "metadata-sidecar")]
+    metadata: FxHashMap<Id, String>,
 }
 
 impl VectorStore {
@@ -280,6 +297,8 @@ impl VectorStore {
             inverse: std::sync::OnceLock::new(),
             #[cfg(feature = "delta")]
             delta: None,
+            #[cfg(feature = "metadata-sidecar")]
+            metadata: FxHashMap::default(),
         })
     }
 
@@ -359,6 +378,16 @@ impl VectorStore {
             return Err(format!("{origin}: not a .spqv file (bad magic)"));
         }
         let version = u32::from_le_bytes(map[4..8].try_into().unwrap());
+        let dim = u32::from_le_bytes(map[8..12].try_into().unwrap()) as usize;
+        let count64 = u64::from_le_bytes(map[12..20].try_into().unwrap());
+        if dim == 0 {
+            return Err(format!("{origin}: zero dimension"));
+        }
+        let count: usize = count64
+            .try_into()
+            .map_err(|_| format!("{origin}: count {count64} exceeds the address space"))?;
+        #[cfg(feature = "metadata-sidecar")]
+        let mut metadata = FxHashMap::default();
         // [OPUS-4.8] (sq-32i5) v1 (no fingerprint, 32-byte header), v2 (fingerprint, 56-byte header),
         // and [FABLE-5] (sq-lhcot.1) v3 (v2 header + a length-prefixed embedding-provenance block)
         // all open; the header length and the offset where the vector data begins depend on the
@@ -420,16 +449,70 @@ impl VectorStore {
                     }
                     (padded, fp, Some(prov))
                 }
+                #[cfg(feature = "metadata-sidecar")]
+                4 => {
+                    if map.len() < HEADER_LEN + 4 {
+                        return Err(format!(
+                            "{origin}: truncated version-4 header (provenance length prefix)"
+                        ));
+                    }
+                    let fp = Fingerprint::from_bytes_opt(&map[HEADER_LEN_V1..HEADER_LEN]);
+                    let prov_len =
+                        u32::from_le_bytes(map[HEADER_LEN..HEADER_LEN + 4].try_into().unwrap())
+                            as usize;
+                    if prov_len > crate::spqv_provenance::MAX_PROVENANCE_BLOCK_LEN {
+                        return Err(format!(
+                            "{origin}: version-4 provenance block length {prov_len} exceeds the cap"
+                        ));
+                    }
+                    let prov_start = HEADER_LEN + 4;
+                    let prov_end = prov_start.checked_add(prov_len).ok_or_else(|| {
+                        format!("{origin}: version-4 provenance length {prov_len} overflows")
+                    })?;
+                    let meta_len_end = prov_end.checked_add(8).ok_or_else(|| {
+                        format!("{origin}: version-4 metadata length offset overflows")
+                    })?;
+                    if map.len() < meta_len_end {
+                        return Err(format!(
+                            "{origin}: truncated version-4 header (metadata length prefix)"
+                        ));
+                    }
+                    let provenance = if prov_len == 0 {
+                        None
+                    } else {
+                        Some(
+                            EmbeddingProvenance::from_bytes(&map[prov_start..prov_end])
+                                .map_err(|e| format!("{origin}: {e}"))?,
+                        )
+                    };
+                    let meta_len64 =
+                        u64::from_le_bytes(map[prov_end..meta_len_end].try_into().unwrap());
+                    let meta_len: usize = meta_len64.try_into().map_err(|_| {
+                        format!("{origin}: metadata block length exceeds the address space")
+                    })?;
+                    let meta_end = meta_len_end.checked_add(meta_len).ok_or_else(|| {
+                        format!("{origin}: version-4 metadata length {meta_len} overflows")
+                    })?;
+                    if map.len() < meta_end {
+                        return Err(format!(
+                            "{origin}: truncated version-4 metadata block (need {meta_len} bytes)"
+                        ));
+                    }
+                    metadata = crate::metadata::decode(
+                        &map[meta_len_end..meta_end],
+                        count,
+                        origin,
+                    )?;
+                    let padded = meta_end.div_ceil(4) * 4;
+                    if map.len() < padded {
+                        return Err(format!(
+                            "{origin}: truncated version-4 header (metadata padding)"
+                        ));
+                    }
+                    (padded, fp, provenance)
+                }
                 v => return Err(format!("{origin}: unsupported .spqv version {v}")),
             };
-        let dim = u32::from_le_bytes(map[8..12].try_into().unwrap()) as usize;
-        let count64 = u64::from_le_bytes(map[12..20].try_into().unwrap());
-        if dim == 0 {
-            return Err(format!("{origin}: zero dimension"));
-        }
-        let count: usize = count64
-            .try_into()
-            .map_err(|_| format!("{origin}: count {count64} exceeds the address space"))?;
         // Checked size arithmetic: a malformed header must be rejected here, not wrap
         // around and pass the size check (or panic later in `get`/`iter`).
         let expect = count
@@ -451,9 +534,12 @@ impl VectorStore {
         // `iter`'s inverse map assumes). After this, no read path can panic on a
         // corrupt index.
         {
-            let index = &map[data_offset + count * dim * 4..];
+            let index_start = data_offset + count * dim * 4;
+            let index = &map[index_start..index_start + count * 8];
             let mut slot_seen = vec![false; count];
             let mut prev_id: Option<Id> = None;
+            #[cfg(feature = "metadata-sidecar")]
+            let mut metadata_matches = 0usize;
             for i in 0..count {
                 let id = u32::from_le_bytes(index[i * 8..i * 8 + 4].try_into().unwrap());
                 let slot =
@@ -470,6 +556,16 @@ impl VectorStore {
                     ));
                 }
                 slot_seen[slot] = true;
+                #[cfg(feature = "metadata-sidecar")]
+                if metadata.contains_key(&id) {
+                    metadata_matches += 1;
+                }
+            }
+            #[cfg(feature = "metadata-sidecar")]
+            if metadata_matches != metadata.len() {
+                return Err(format!(
+                    "{origin}: metadata references an id that has no vector"
+                ));
             }
         }
         Ok(VectorStore {
@@ -482,6 +578,8 @@ impl VectorStore {
             inverse: std::sync::OnceLock::new(),
             #[cfg(feature = "delta")]
             delta: None,
+            #[cfg(feature = "metadata-sidecar")]
+            metadata,
         })
     }
 
@@ -504,6 +602,22 @@ impl VectorStore {
         Ok(())
     }
 
+    /// Appends `vector` for `id` and associates an opaque UTF-8 metadata tag with it.
+    ///
+    /// Validation and build-phase restrictions are identical to [`put`](Self::put). The tag is
+    /// persisted byte-for-byte by [`finalize`](Self::finalize), including an empty string. Writing
+    /// the first tag selects the opt-in v4 format; stores built exclusively with `put` retain the
+    /// existing v2/v3 format exactly.
+    #[cfg(feature = "metadata-sidecar")]
+    pub fn put_with_meta(&mut self, id: Id, vector: &[f32], meta: &str) -> Result<(), String> {
+        if meta.len() > u32::MAX as usize {
+            return Err(format!("metadata for id {id} exceeds the .spqv length limit"));
+        }
+        self.put(id, vector)?;
+        self.metadata.insert(id, meta.to_owned());
+        Ok(())
+    }
+
     /// Writes the `.spqv` file and re-opens it memory-mapped; the handle then serves
     /// reads from the map and rejects further [`put`](Self::put)s. Idempotent on an
     /// already-finalized/opened store.
@@ -515,7 +629,14 @@ impl VectorStore {
         // [FABLE-5] (sq-lhcot.1) Build the header: v3 (with the embedding-provenance block) if a
         // provenance is bound, else v2 exactly as before. `build_header` is the single seam that both
         // this in-RAM writer and the `StreamingWriter` share, so the two writers stay byte-identical.
-        let header = build_header(self.dim, count, self.fingerprint, self.provenance.as_ref());
+        let header = build_header(
+            self.dim,
+            count,
+            self.fingerprint,
+            self.provenance.as_ref(),
+            #[cfg(feature = "metadata-sidecar")]
+            (!self.metadata.is_empty()).then_some(&self.metadata),
+        );
 
         let mut index: Vec<(Id, u32)> = slots.iter().map(|(&id, &slot)| (id, slot)).collect();
         index.sort_unstable();
@@ -551,6 +672,10 @@ impl VectorStore {
         self.provenance = reopened.provenance;
         self.data_offset = reopened.data_offset;
         self.inverse = std::sync::OnceLock::new();
+        #[cfg(feature = "metadata-sidecar")]
+        {
+            self.metadata = reopened.metadata;
+        }
         Ok(())
     }
 
@@ -571,6 +696,14 @@ impl VectorStore {
             }
         }
         self.base_get(id)
+    }
+
+    /// Returns `id`'s opaque metadata tag, or `None` when the id has no effective vector or was
+    /// written with [`put`](Self::put) rather than [`put_with_meta`](Self::put_with_meta).
+    #[cfg(feature = "metadata-sidecar")]
+    pub fn meta(&self, id: Id) -> Option<&str> {
+        self.get(id)?;
+        self.metadata.get(&id).map(String::as_str)
     }
 
     /// The vector for `id` from the immutable base only (no delta) — the original `get` body. The
@@ -861,6 +994,8 @@ impl VectorStore {
                     *s -= 1;
                 }
             }
+            #[cfg(feature = "metadata-sidecar")]
+            self.metadata.remove(&id);
             return true;
         }
         let had = self.get(id).is_some();
@@ -868,6 +1003,8 @@ impl VectorStore {
             let delta = self.delta_mut();
             delta.appended.remove(&id);
             delta.tombstones.insert(id);
+            #[cfg(feature = "metadata-sidecar")]
+            self.metadata.remove(&id);
         }
         had
     }
@@ -965,6 +1102,11 @@ impl VectorStore {
         let pairs: Vec<(Id, Vec<f32>)> =
             self.iter().map(|(id, v)| (id, v.to_vec())).collect();
         for (id, v) in &pairs {
+            #[cfg(feature = "metadata-sidecar")]
+            if let Some(meta) = self.meta(*id) {
+                fresh.put_with_meta(*id, v, meta)?;
+                continue;
+            }
             fresh.put(*id, v)?;
         }
         fresh.finalize()?;
@@ -1112,15 +1254,16 @@ fn describe_generation(fp: Option<Fingerprint>) -> String {
 }
 
 /// [FABLE-5] (sq-lhcot.1) Builds the `.spqv` header bytes for a store with `count` vectors of the
-/// given `dim`, optional graph `fingerprint`, and optional embedding `provenance`. Emits the **v3**
-/// format (v2 header + a `u32`-length-prefixed provenance block) when `provenance` is `Some`, else
-/// the **v2** format (byte-identical to the pre-v3 writer). The single header seam both the in-RAM
-/// [`VectorStore::finalize`] and the [`StreamingWriter`] share, so the two writers agree byte-for-byte.
+/// given `dim`, optional graph `fingerprint`, optional embedding `provenance`, and (when enabled)
+/// optional metadata. Emits v4 when metadata is present, v3 when only provenance is present, and v2
+/// otherwise. The single header seam both the in-RAM [`VectorStore::finalize`] and the
+/// [`StreamingWriter`] share, so untagged stores agree byte-for-byte.
 fn build_header(
     dim: usize,
     count: usize,
     fingerprint: Option<Fingerprint>,
     provenance: Option<&EmbeddingProvenance>,
+    #[cfg(feature = "metadata-sidecar")] metadata: Option<&FxHashMap<Id, String>>,
 ) -> Vec<u8> {
     // The provenance-block bytes (empty ⇒ v2). The `EmbeddingProvenance` codec is always compiled
     // (v3 read path), so this seam works in both feature states — v3 is written only when a
@@ -1128,7 +1271,18 @@ fn build_header(
     let prov_bytes = provenance.map(|p| p.to_bytes());
     let mut header = vec![0u8; HEADER_LEN];
     header[0..4].copy_from_slice(&SPQV_MAGIC);
-    // Version tag: v3 iff a provenance is present, else v2.
+    #[cfg(feature = "metadata-sidecar")]
+    let metadata_bytes = metadata.map(crate::metadata::encode);
+    // Version tag: v4 iff metadata is present, otherwise v3 iff provenance is present, else v2.
+    #[cfg(feature = "metadata-sidecar")]
+    let version = if metadata_bytes.is_some() {
+        SPQV_VERSION_V4
+    } else if prov_bytes.is_some() {
+        SPQV_VERSION_V3
+    } else {
+        SPQV_VERSION
+    };
+    #[cfg(not(feature = "metadata-sidecar"))]
     let version = if prov_bytes.is_some() { SPQV_VERSION_V3 } else { SPQV_VERSION };
     header[4..8].copy_from_slice(&version.to_le_bytes());
     header[8..12].copy_from_slice(&(dim as u32).to_le_bytes());
@@ -1142,6 +1296,18 @@ fn build_header(
     // ZERO-PAD to the next 4-byte boundary so the dense f32 data section that follows stays
     // 4-byte-aligned (the `slot_vector` f32 cast requires it — a misaligned cast is UB). The stored
     // `prov_len` is the REAL block length; the reader recomputes the same padded data offset.
+    #[cfg(feature = "metadata-sidecar")]
+    if let Some(metadata_bytes) = metadata_bytes {
+        let provenance_bytes = prov_bytes.as_deref().unwrap_or_default();
+        header.extend_from_slice(&(provenance_bytes.len() as u32).to_le_bytes());
+        header.extend_from_slice(provenance_bytes);
+        header.extend_from_slice(&(metadata_bytes.len() as u64).to_le_bytes());
+        header.extend_from_slice(&metadata_bytes);
+        let pad = (4 - header.len() % 4) % 4;
+        header.extend(std::iter::repeat_n(0u8, pad));
+        debug_assert_eq!(header.len() % 4, 0, "v4 data section must start 4-byte aligned");
+        return header;
+    }
     if let Some(bytes) = prov_bytes {
         header.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
         header.extend_from_slice(&bytes);
@@ -1255,7 +1421,14 @@ impl StreamingWriter {
         // (offset 32..56) and — for v3 — the length-prefixed provenance block are known up front, so
         // they are written here (via the shared `build_header` seam), not patched. `build_header`
         // emits v3 iff a provenance is present, else v2 (byte-identical to the pre-v3 streaming header).
-        let header = build_header(dim, 0, fingerprint, provenance.as_ref());
+        let header = build_header(
+            dim,
+            0,
+            fingerprint,
+            provenance.as_ref(),
+            #[cfg(feature = "metadata-sidecar")]
+            None,
+        );
         file.write_all(&header).map_err(|e| format!("write {}: {e}", path.display()))?;
         let ids_path = {
             let mut p = path.clone().into_os_string();
@@ -1768,7 +1941,14 @@ mod provenance_read_tests {
     /// always-compiled `build_header` seam (no `with_provenance`, so this works with the feature off).
     fn write_v3(path: &std::path::Path, dim: usize, rows: &[(Id, Vec<f32>)], p: &EmbeddingProvenance) {
         let count = rows.len();
-        let header = build_header(dim, count, None, Some(p));
+        let header = build_header(
+            dim,
+            count,
+            None,
+            Some(p),
+            #[cfg(feature = "metadata-sidecar")]
+            None,
+        );
         let mut bytes = header;
         // Dense data in insertion-slot order.
         for (_, v) in rows {

--- a/crates/sparq-vectors/tests/metadata_sidecar.rs
+++ b/crates/sparq-vectors/tests/metadata_sidecar.rs
@@ -1,0 +1,96 @@
+#![cfg(feature = "metadata-sidecar")]
+
+use sparq_vectors::{nearest_exact, nearest_exact_with_meta, VectorStore, SPQV_VERSION};
+
+fn tmp_path(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "sparq-vectors-metadata-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join(name)
+}
+
+#[test]
+fn exact_ranking_and_metadata_survive_finalize_and_open_from_bytes() {
+    let path = tmp_path("roundtrip.spqv");
+    let mut store = VectorStore::create(&path, 2).unwrap();
+    store
+        .put_with_meta(30, &[0.0, 1.0], "tag:\0beta-β")
+        .unwrap();
+    store.put(10, &[1.0, 0.0]).unwrap();
+    store.put_with_meta(20, &[-1.0, 0.0], "").unwrap();
+
+    assert_eq!(store.meta(30), Some("tag:\0beta-β"));
+    assert_eq!(store.meta(10), None);
+    assert_eq!(store.meta(20), Some(""));
+
+    store.finalize().unwrap();
+    let bytes = std::fs::read(&path).unwrap();
+    assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 4);
+
+    let plain = nearest_exact(&store, &[1.0, 0.0], 3);
+    let decorated = nearest_exact_with_meta(&store, &[1.0, 0.0], 3);
+    let decorated_ranking: Vec<_> = decorated
+        .iter()
+        .map(|&(id, score, _)| (id, score))
+        .collect();
+    assert_eq!(
+        decorated_ranking, plain,
+        "metadata must not change ranking or scores"
+    );
+    assert_eq!(
+        decorated,
+        vec![
+            (10, 1.0, None),
+            (30, 0.0, Some("tag:\0beta-β".to_owned())),
+            (20, -1.0, Some(String::new())),
+        ]
+    );
+
+    let reopened = VectorStore::open_from_bytes(bytes).unwrap();
+    assert_eq!(reopened.meta(30), Some("tag:\0beta-β"));
+    assert_eq!(reopened.meta(10), None);
+    assert_eq!(reopened.meta(20), Some(""));
+    assert_eq!(
+        nearest_exact_with_meta(&reopened, &[1.0, 0.0], 3),
+        decorated,
+        "finalize + open_from_bytes must preserve tags and exact ranking"
+    );
+}
+
+#[test]
+fn enabling_the_feature_without_writing_metadata_keeps_the_default_format() {
+    let path = tmp_path("untagged.spqv");
+    let mut store = VectorStore::create(&path, 2).unwrap();
+    store.put(7, &[1.0, 0.0]).unwrap();
+    store.finalize().unwrap();
+
+    let bytes = std::fs::read(path).unwrap();
+    assert_eq!(
+        u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+        SPQV_VERSION,
+        "an untagged store must keep the default v2 format"
+    );
+    assert_eq!(store.meta(7), None);
+}
+
+#[cfg(feature = "spqv-provenance")]
+#[test]
+fn metadata_composes_with_embedding_provenance() {
+    use sparq_vectors::{EmbeddingMetric, EmbeddingProvenance, Normalization};
+
+    let path = tmp_path("provenance.spqv");
+    let provenance =
+        EmbeddingProvenance::new("model-a", EmbeddingMetric::Cosine, Normalization::L2);
+    let mut store = VectorStore::create(&path, 2)
+        .unwrap()
+        .with_provenance(provenance.clone());
+    store.put_with_meta(5, &[1.0, 0.0], "source-a").unwrap();
+    store.finalize().unwrap();
+
+    let reopened = VectorStore::open(&path).unwrap();
+    assert_eq!(reopened.provenance(), Some(&provenance));
+    assert_eq!(reopened.meta(5), Some("source-a"));
+}

--- a/scripts/tests/feature-matrix-legnames.golden.txt
+++ b/scripts/tests/feature-matrix-legnames.golden.txt
@@ -116,6 +116,7 @@ opt-in sparq-trust (store,cert-graph — TrustStore x certification-graph compos
 opt-in sparq-vc (did-web — did:web resolver over a pluggable fetcher)
 opt-in sparq-vectors (compose — read-path URI-hiding NL→NL A/B)
 opt-in sparq-vectors (kge — structure-aware + Phase-4 provenance-weighting)
+opt-in sparq-vectors (metadata-sidecar — per-vector tags on exact search)
 opt-in sparq-vectors (neuro-symbolic — propose-then-verify grounding)
 opt-in sparq-vectors (spqv-provenance — v3 embedding-provenance write + fail-closed rejection)
 opt-in sparq-vectors (vec-predicate, filtered-ann)

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -68,6 +68,9 @@ impl VectorStore {
     fn get(&self, id: Id) -> Option<&[f32]>;  fn iter(&self) -> impl Iterator<Item=(Id, &[f32])>
     fn dim(&self) -> usize;  fn len(&self) -> usize;  fn is_empty(&self) -> bool
 }
+# feature = "metadata-sidecar": opaque per-vector tags persisted in `.spqv` v4; no new dependency
+store.put_with_meta(id, vector, meta: &str) -> Result<(), String>               // build phase; exact UTF-8 bytes retained
+store.meta(id) -> Option<&str>                                                  // None for untagged or absent ids
 StreamingWriter::create(path, dim);  fn put(&mut self, id, &[f32]); fn finalize(self) -> Result<VectorStore, String>  // O(1) build RAM, byte-identical output
 
 // --- bulk import of externally-computed embeddings (src/import.rs) --- bring-your-own vectors; reuses the store writer
@@ -147,6 +150,8 @@ VectorStore::sibling_delta_path(&Path) -> PathBuf;  VectorStore::has_persisted_d
 
 // --- search (src/ann.rs) --- all return cosine in [-1,1], best first; zero query -> empty
 nearest_exact(&VectorStore, query: &[f32], k) -> Vec<(Id, f32)>                 // ground-truth full scan
+# feature = "metadata-sidecar": same ranking/scores, decorated after ranking
+nearest_exact_with_meta(&VectorStore, query: &[f32], k) -> Vec<(Id, f32, Option<String>)>
 nearest_term_exact(&VectorStore, &Graph, &Term, k) -> Vec<(Term, f32)>          // UNCHECKED: stale store -> silently wrong
 nearest_term_exact_checked(&VectorStore, &Graph, &Term, k) -> Result<Vec<(Term, f32)>, String>  // errs on stale store
 cosine(a: &[f32], b: &[f32]) -> f32
@@ -1319,6 +1324,40 @@ container was knowingly **non-conforming** on that reproducibility obligation (i
 dimension + graph fingerprint). The v3 format + the mandatory `check_provenance` **close that gap** for
 the DEFINED axes. The extensible-provenance profile itself (the `#1746` reserved-area semantics) is
 NOT frozen, so the reserved area stays opaque here — it is the remaining, deliberately-deferred, part.
+
+### 21. Carry opaque metadata beside exact-search hits (opt-in, feature = `metadata-sidecar`)
+
+Use the metadata sidecar when each vector needs a caller-owned label, partition token, or
+post-filtering tag without a second id-to-tag lookup table. Tags do not affect similarity or rank.
+
+```toml
+sparq-vectors = { path = "../sparq-vectors", features = ["metadata-sidecar"] }
+```
+
+```rust,ignore
+use sparq_vectors::{nearest_exact_with_meta, VectorStore};
+
+let mut store = VectorStore::create("graph.spqv", 2)?;
+store.put_with_meta(10, &[1.0, 0.0], "tenant-a")?;
+store.put(20, &[0.0, 1.0])?; // untagged is valid
+store.finalize()?;
+
+let hits = nearest_exact_with_meta(&store, &[1.0, 0.0], 2);
+assert_eq!(hits[0].2.as_deref(), Some("tenant-a"));
+assert_eq!(store.meta(20), None);
+
+let reopened = VectorStore::open_from_bytes(std::fs::read("graph.spqv")?)?;
+assert_eq!(reopened.meta(10), Some("tenant-a"));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The first `put_with_meta` selects `.spqv` v4. A build that only calls `put` still emits the existing
+v2 format, or v3 when embedding provenance is bound, even when `metadata-sidecar` is enabled. Tagged
+and untagged vectors can be mixed; an empty string is a present tag (`Some("")`), distinct from
+`None`. The metadata is returned only after `nearest_exact` has fixed the top-`k`, so the `(id,
+score)` sequence and deterministic tie-break are identical to the undecorated search. The v4 reader
+and writer are both feature-gated; enable `metadata-sidecar` in every process that opens a tagged
+store. A feature-off build continues to support the pre-existing v1/v2/v3 formats only.
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Bead: `sq-lsp7k.25`

## Summary

- add the default-off, dependency-free `metadata-sidecar` feature to `sparq-vectors`
- persist deterministic opaque UTF-8 tags in `.spqv` v4 only when metadata is written; ordinary stores retain the existing v2/v3 format
- expose `VectorStore::put_with_meta`, `VectorStore::meta`, and `nearest_exact_with_meta` while preserving exact ranking and tie-breaking
- validate metadata block structure, UTF-8, ordering, and vector-id membership during open
- document the public API in `skills/vector-search/SKILL.md` and add the required feature-matrix leg/golden

## Verification

- `cargo clippy -p sparq-vectors --all-targets -- -D warnings`
- `cargo clippy -p sparq-vectors --all-targets --features metadata-sidecar -- -D warnings`
- `cargo test -p sparq-vectors`
- `cargo test -p sparq-vectors --features metadata-sidecar`
- `cargo test -p sparq-vectors --features metadata-sidecar,spqv-provenance --test metadata_sidecar`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-vectors --no-deps --all-features`
- default-feature rustdoc with warnings denied
- `cargo check --workspace` in default and `sparq-vectors/metadata-sidecar` feature states
- feature-matrix assembly test, regenerated leg-name golden, C1 feature-test executor guard, `typos`, markdownlint, G2 API-skill gate, and no-performance-numbers gate

The round-trip test is mutation-witnessed: temporarily disabling v4 selection makes it fail on the persisted format before metadata can reopen.