### PR TITLE
test(sparq-py): exercise Term N3 rendering (sq-ct7gh) [GPT-5.6]

### DIFF
--- a/crates/sparq-py/src/lib.rs
+++ b/crates/sparq-py/src/lib.rs
@@ -56,8 +56,7 @@ use spargebra::{Query, SparqlParser};
 
 #[cfg(feature = "arrow")]
 mod arrow_export;
-
-const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+mod term_render;
 
 /// Map an engine `Err(String)` (parse/eval failure) to a Python `ValueError`.
 fn engine_err(e: String) -> PyErr {
@@ -141,28 +140,13 @@ impl Term {
 
     /// N-Triples-style rendering (shared by `__repr__`).
     fn n3(&self) -> String {
-        match self.kind.as_str() {
-            "uri" => format!("<{}>", self.value),
-            "bnode" => format!("_:{}", self.value),
-            "triple" => self.value.clone(), // already rendered as << s p o >>
-
-            _ => {
-                let v = self.value.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n");
-                if let Some(lang) = &self.language {
-                    // [OPUS-4.8] sq-bj7o: a directional language string renders as
-                    // `"v"@lang--dir` (the RDF 1.2 / Turtle surface form).
-                    match &self.direction {
-                        Some(dir) => format!("\"{v}\"@{lang}--{dir}"),
-                        None => format!("\"{v}\"@{lang}"),
-                    }
-                } else {
-                    match self.datatype.as_deref() {
-                        None | Some(XSD_STRING) => format!("\"{v}\""),
-                        Some(dt) => format!("\"{v}\"^^<{dt}>"),
-                    }
-                }
-            }
-        }
+        term_render::render_n3(
+            &self.kind,
+            &self.value,
+            self.language.as_deref(),
+            self.datatype.as_deref(),
+            self.direction.as_deref(),
+        )
     }
 }
 

--- a/crates/sparq-py/src/term_render.rs
+++ b/crates/sparq-py/src/term_render.rs
@@ -1,0 +1,37 @@
+//! Pure RDF term rendering used by the Python `Term` wrapper.
+
+pub(crate) const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
+
+/// Renders the fields of a Python-facing term in the notation used by `Term.__repr__`.
+// [GPT-5.6] sq-ct7gh: keep this function free of PyO3 so the disabled cdylib test
+// harness does not prevent direct Rust coverage of rendering and literal escaping.
+pub(crate) fn render_n3(
+    kind: &str,
+    value: &str,
+    language: Option<&str>,
+    datatype: Option<&str>,
+    direction: Option<&str>,
+) -> String {
+    match kind {
+        "uri" => format!("<{value}>"),
+        "bnode" => format!("_:{value}"),
+        "triple" => value.to_owned(),
+        _ => {
+            let escaped = value
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', "\\n");
+            if let Some(language) = language {
+                match direction {
+                    Some(direction) => format!("\"{escaped}\"@{language}--{direction}"),
+                    None => format!("\"{escaped}\"@{language}"),
+                }
+            } else {
+                match datatype {
+                    None | Some(XSD_STRING) => format!("\"{escaped}\""),
+                    Some(datatype) => format!("\"{escaped}\"^^<{datatype}>"),
+                }
+            }
+        }
+    }
+}

--- a/crates/sparq-py/tests/term_n3.rs
+++ b/crates/sparq-py/tests/term_n3.rs
@@ -1,0 +1,64 @@
+// The sparq-py cdylib disables its lib test harness because linking a PyO3
+// extension-module harness fails on macOS. Compile the pure renderer directly so
+// these tests remain ordinary Rust integration tests with no Python dependency.
+#[path = "../src/term_render.rs"]
+mod term_render;
+
+use term_render::{render_n3, XSD_STRING};
+
+#[test]
+fn renders_resource_term_kinds() {
+    assert_eq!(
+        render_n3("uri", "https://example.com/resource", None, None, None),
+        "<https://example.com/resource>"
+    );
+    assert_eq!(render_n3("bnode", "node-1", None, None, None), "_:node-1");
+
+    let triple = "<< <https://example.com/s> <https://example.com/p> \"object\" >>";
+    assert_eq!(render_n3("triple", triple, None, None, None), triple);
+}
+
+#[test]
+fn escapes_literal_backslashes_quotes_and_newlines_in_order() {
+    assert_eq!(
+        render_n3(
+            "literal",
+            "first\\\"line\nsecond",
+            None,
+            Some(XSD_STRING),
+            None,
+        ),
+        "\"first\\\\\\\"line\\nsecond\""
+    );
+}
+
+#[test]
+fn renders_plain_and_typed_literals() {
+    assert_eq!(render_n3("literal", "plain", None, None, None), "\"plain\"");
+    assert_eq!(
+        render_n3("literal", "plain", None, Some(XSD_STRING), None),
+        "\"plain\""
+    );
+    assert_eq!(
+        render_n3(
+            "literal",
+            "42",
+            None,
+            Some("http://www.w3.org/2001/XMLSchema#integer"),
+            None,
+        ),
+        "\"42\"^^<http://www.w3.org/2001/XMLSchema#integer>"
+    );
+}
+
+#[test]
+fn renders_language_and_directional_literals() {
+    assert_eq!(
+        render_n3("literal", "bonjour", Some("fr"), None, None),
+        "\"bonjour\"@fr"
+    );
+    assert_eq!(
+        render_n3("literal", "hello", Some("en"), None, Some("ltr"),),
+        "\"hello\"@en--ltr"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Bead: `sq-ct7gh`

## Summary

- extract the Python `Term` N3 renderer into a private, PyO3-free module
- exercise URI, blank node, triple term, plain/typed literal, language/direction, and escaping branches from a Rust integration target
- preserve the disabled cdylib test harness and the existing Python API

## Verification

- `cargo test -p sparq-py`
- `cargo test -p sparq-py --all-features`
- `cargo clippy -p sparq-py --all-targets -- -D warnings`
- `cargo clippy -p sparq-py --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-py --no-deps --all-features`
- `python3 scripts/tests/test_feature_matrix_assemble.py` plus generated-name golden comparison
- `typos` over the added source comments and tests
- mutation witness: removing newline escaping makes the targeted integration test fail

No Cargo feature, public API, README, or markdown surface changed.

Roborev hook note: commit `c19c278a6` was enqueued, but the local reviewer daemon failed before producing a review record; recent queued commits show the same infrastructure failure.
