### PR TITLE
feat(prov): render proof-tree lineage as N-Triples (sq-8jn86) [GPT-5.6]

### DIFF
--- a/crates/sparq-prov/src/lib.rs
+++ b/crates/sparq-prov/src/lib.rs
@@ -39,8 +39,9 @@
 //! inferred fact, one `prov:Activity` per rule firing, with
 //! `wasGeneratedBy`/`used`/`wasDerivedFrom` edges. Inference *is* derivation, and
 //! the proof tree is a finer-grained provenance (it names the rule and exact
-//! premises for each fact) than a single CONSTRUCT-style activity. See the
-//! `reason` module.
+//! premises for each fact) than a single CONSTRUCT-style activity.
+//! `prov_ntriples` renders that lineage as N-Triples in one call. See the
+//! `reason` module. <!-- [GPT-5.6] sq-8jn86 -->
 //!
 //! **Missing-answer explanation** is available under the non-default `why-not`
 //! feature. The `why_not` function accepts one basic graph pattern and a fully
@@ -79,7 +80,7 @@ pub use update::{derive_update, derive_update_with_budget, UpdateDerivation};
 #[cfg(feature = "reason")]
 pub mod reason;
 #[cfg(feature = "reason")]
-pub use reason::{prov_from_proof, ProvProofConfig};
+pub use reason::{prov_from_proof, prov_ntriples, ProvProofConfig};
 // [GPT-5.6] sq-lsp7k.17: exact missing-conjunct explanation, opt-in so the
 // default public API remains unchanged.
 #[cfg(feature = "why-not")]

--- a/crates/sparq-prov/src/reason.rs
+++ b/crates/sparq-prov/src/reason.rs
@@ -214,6 +214,16 @@ pub fn prov_from_proof(proof: &ProofTree, config: &ProvProofConfig) -> Vec<Tripl
     out
 }
 
+/// Render one reasoner proof tree's W3C PROV-O lineage as N-Triples.
+///
+/// This is the string-serialization counterpart to `prov_from_proof`; it preserves
+/// that function's deterministic triple order and content-addressed IRIs.
+///
+/// [GPT-5.6] sq-8jn86
+pub fn prov_ntriples(proof: &ProofTree, config: &ProvProofConfig) -> String {
+    sparq_engine::triples_to_ntriples(&prov_from_proof(proof, config))
+}
+
 /// Mint a stable `…fact:<hash>` entity IRI from a fact's term strings. The
 /// conclusion strings are canonical (one rendering per term), so the same fact
 /// always names the same entity — letting lineage from different proofs stitch.

--- a/crates/sparq-prov/tests/reason_prov.rs
+++ b/crates/sparq-prov/tests/reason_prov.rs
@@ -154,6 +154,31 @@ fn lineage_is_valid_rdf_and_round_trips() {
 }
 
 #[test]
+fn prov_ntriples_matches_the_lineage_graph_and_parses() {
+    // [GPT-5.6] sq-8jn86: the exact string oracle witnesses the serializer call;
+    // replacing the wrapper body with an empty or differently rendered value fails.
+    let (g, dict, fact) = dog_setup();
+    let proof = g.why(&dict, fact).unwrap();
+    let cfg = ProvProofConfig::default();
+    let triples = prov_from_proof(&proof, &cfg);
+    let expected = triples
+        .iter()
+        .map(|t| format!("{} {} {} .\n", t.subject, t.predicate, t.object))
+        .collect::<String>();
+    assert!(!expected.is_empty(), "dog proof must emit lineage triples");
+
+    let nt = sparq_prov::prov_ntriples(&proof, &cfg);
+    assert_eq!(nt, expected);
+
+    use oxttl::NTriplesParser;
+    let parsed: Vec<_> = NTriplesParser::new()
+        .for_reader(nt.as_bytes())
+        .collect::<Result<_, _>>()
+        .expect("rendered lineage must be well-formed N-Triples");
+    assert_eq!(parsed.len(), triples.len());
+}
+
+#[test]
 fn deterministic_and_content_addressed() {
     let (g, dict, fact) = dog_setup();
     let proof = g.why(&dict, fact).unwrap();

--- a/skills/prov-lineage/SKILL.md
+++ b/skills/prov-lineage/SKILL.md
@@ -152,12 +152,17 @@ sparq-reason = { path = "crates/sparq-reason", features = ["explain"] }
 ```
 
 ```rust
-use sparq_prov::{prov_from_proof, ProvProofConfig};
+use sparq_prov::{prov_from_proof, prov_ntriples, ProvProofConfig};
 
 // g: a sparq_reason::MaterializedGraph / MaterializedOwlGraph / MaterializedN3Graph.
 let proof   = g.why(&dict, inferred_fact).expect("fact is in the closure");
 let lineage = prov_from_proof(&proof, &ProvProofConfig::default());  // Vec<Triple>
+let ntriples = prov_ntriples(&proof, &ProvProofConfig::default());   // String
 ```
+
+`prov_ntriples` is the one-call serializer for the same ordered lineage triples.
+With the default clock-free configuration, both the triples and their
+content-addressed IRIs are deterministic. <!-- [GPT-5.6] sq-8jn86 -->
 
 Emitted shape — for each proof node (fact) `F` and the rule firing `R` that
 generated a non-leaf `F` from premises `Pᵢ`:
@@ -184,7 +189,7 @@ DAG (the same shared fact names the same entity).
 | Derivation path | Status |
 |---|---|
 | `CONSTRUCT` / `DESCRIBE` | ✅ covered (`derive_construct`) |
-| Reasoner materialization (RDFS / OWL-RL / N3) | ✅ covered (`reason` feature → `prov_from_proof`) |
+| Reasoner materialization (RDFS / OWL-RL / N3) | ✅ covered (`reason` feature → `prov_from_proof` / `prov_ntriples`) |
 | SPARQL UPDATE data ops (`INSERT … WHERE`, `INSERT DATA`, `DELETE …`, `LOAD`) | ✅ covered (`derive_update`) — inserts ⇒ generated/derived, deletes ⇒ `wasInvalidatedBy` |
 | SPARQL UPDATE structural ops (`CLEAR` / `DROP` / `CREATE`) | ⛔ no per-triple entity (deliberate boundary — recorded only as the activity kind) |
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6**

Implements bead `sq-8jn86`.

## Summary

- Add feature-gated `sparq_prov::prov_ntriples` for one-call proof-tree PROV-O N-Triples rendering.
- Re-export the helper beside `prov_from_proof` and document it in the `prov-lineage` skill.
- Add an exact ordered-string oracle plus N-Triples parser validation. The test was mutation-witnessed by replacing the helper body with an empty string and observing the targeted test fail.

No new Cargo feature was added. The existing default-off `reason` feature remains the opt-in boundary, and the existing all-features coverage executor reaches `reason_prov`; the C1 structural guard and feature-matrix golden suite pass without matrix churn.

## Gates

- `cargo clippy -p sparq-prov --all-targets -- -D warnings`
- `cargo clippy -p sparq-prov --all-targets --features reason -- -D warnings`
- `cargo test -p sparq-prov`
- `cargo test -p sparq-prov --features reason`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-prov --no-deps --no-default-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-prov --no-deps --all-features`
- `cargo check --workspace`
- `cargo check --workspace --features sparq-prov/reason`
- `python3 scripts/tests/test_feature_matrix_assemble.py`
- `python3 scripts/check-feature-test-execution.py --check`
- `typos` over changed Rust/docs paths
- `python3 scripts/check-terminology.py`
- `markdownlint-cli2@0.18.1`

The local roborev hook enqueued final commit `e03cc5e`, but the daemon skipped both jobs immediately because its Codex quota cooldown is active; it produced no review findings.

Bead: `sq-8jn86`