### PR TITLE
sparq-http3 serve_h3 accept loop has no endpoint-level connection cap 
sq-h1f9g [GPT-5.6]

### DIFF
--- a/crates/sparq-http3/Cargo.toml
+++ b/crates/sparq-http3/Cargo.toml
@@ -44,7 +44,7 @@ http-body-util = { version = "0.1", optional = true }
 quinn = { version = "0.11.11", default-features = false, features = ["runtime-tokio", "rustls-aws-lc-rs"], optional = true }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"], optional = true }
 thiserror = { version = "2", optional = true }
-tokio = { version = "1", default-features = false, features = ["macros", "rt"], optional = true }
+tokio = { version = "1", default-features = false, features = ["macros", "rt", "sync"], optional = true }
 tower = { version = "0.5", default-features = false, features = ["util"], optional = true }
 
 [dev-dependencies]

--- a/crates/sparq-http3/README.md
+++ b/crates/sparq-http3/README.md
@@ -7,7 +7,11 @@ so a default workspace build does not pull those dependencies.
 
 Enable `server` to convert an aws-lc-rs-backed rustls server configuration and dispatch
 HTTP/3 requests into a cloned `axum::Router`. The bridge injects the QUIC peer address as
-`ConnectInfo<SocketAddr>` and streams request and response bodies.
+`ConnectInfo<SocketAddr>` and streams request and response bodies. Its compatibility entry point is
+safe by default: `serve_h3` applies global and per-IP concurrent-connection caps, while
+`serve_h3_with_limits` accepts custom `H3ConnectionLimits`. Internal IPs are exempt from the per-IP
+default but remain covered by the global cap. The generated Quinn configuration also uses a bounded
+connection receive window.
 
 WebSocket-over-HTTP/3 is outside this helper's scope; clients use the existing HTTP/1.1 or
 HTTP/2 listener for WebSocket upgrades.

--- a/crates/sparq-http3/src/lib.rs
+++ b/crates/sparq-http3/src/lib.rs
@@ -9,4 +9,6 @@
 mod server;
 
 #[cfg(feature = "server")]
-pub use server::{quic_server_config, serve_h3, Http3ConfigError};
+pub use server::{
+    quic_server_config, serve_h3, serve_h3_with_limits, H3ConnectionLimits, Http3ConfigError,
+};

--- a/crates/sparq-http3/src/server.rs
+++ b/crates/sparq-http3/src/server.rs
@@ -1,4 +1,10 @@
-use std::{future::Future, io, net::SocketAddr, sync::Arc};
+use std::{
+    collections::HashMap,
+    future::Future,
+    io,
+    net::{IpAddr, SocketAddr},
+    sync::{Arc, Mutex},
+};
 
 use axum::{
     body::Body,
@@ -11,7 +17,49 @@ use futures_util::stream;
 use h3::server::RequestStream;
 use http_body_util::BodyExt as _;
 use quinn::crypto::rustls::{NoInitialCipherSuite, QuicServerConfig};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tower::ServiceExt as _;
+
+/// Default ceiling for concurrently served HTTP/3 connections.
+const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
+
+/// Default ceiling for concurrent HTTP/3 connections from one non-internal IP address.
+const DEFAULT_MAX_CONNECTIONS_PER_IP: usize = 512;
+
+/// Connection-level QUIC receive window used by [`quic_server_config`].
+const RECEIVE_WINDOW_BYTES: u32 = 16 * 1024 * 1024;
+
+type PerIpCounts = Arc<Mutex<HashMap<IpAddr, usize>>>;
+
+/// Concurrent-connection limits enforced by [`serve_h3_with_limits`].
+///
+/// Zero values are clamped to one so a direct configuration cannot accidentally disable the
+/// listener. Set [`max_connections_per_ip`](Self::max_connections_per_ip) to `None` to disable only
+/// the per-IP limit; the global limit is always enforced.
+// [GPT-5.6] sq-h1f9g: keep the compatibility entry point safe by default while allowing tuning.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct H3ConnectionLimits {
+    /// Maximum number of concurrently served HTTP/3 connections.
+    pub max_connections: usize,
+    /// Maximum concurrent connections from one IP address, or `None` to disable this limit.
+    pub max_connections_per_ip: Option<usize>,
+    /// Exempt loopback, private, link-local, and IPv6 unique-local addresses from the per-IP limit.
+    ///
+    /// The global connection limit still applies to exempt addresses. This defaults to `true` so a
+    /// reverse proxy, container bridge, or conformance runner is not treated as a single public
+    /// client.
+    pub exempt_internal_ips: bool,
+}
+
+impl Default for H3ConnectionLimits {
+    fn default() -> Self {
+        Self {
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            max_connections_per_ip: Some(DEFAULT_MAX_CONNECTIONS_PER_IP),
+            exempt_internal_ips: true,
+        }
+    }
+}
 
 /// A rustls server configuration cannot be used for HTTP/3.
 #[derive(Debug, thiserror::Error)]
@@ -28,7 +76,9 @@ pub enum Http3ConfigError {
 /// Converts an aws-lc-rs-backed rustls server configuration into Quinn's server config.
 ///
 /// The input must advertise the exact `h3` ALPN token. Certificate loading, client-auth
-/// policy, and transport tuning remain the caller's responsibility.
+/// policy, and additional transport tuning remain the caller's responsibility. The returned config
+/// owns an explicit bounded connection-level receive window instead of Quinn's effectively unbounded
+/// default.
 pub fn quic_server_config(
     rustls_config: rustls::ServerConfig,
 ) -> Result<quinn::ServerConfig, Http3ConfigError> {
@@ -41,7 +91,11 @@ pub fn quic_server_config(
     }
 
     let crypto = QuicServerConfig::try_from(rustls_config)?;
-    Ok(quinn::ServerConfig::with_crypto(Arc::new(crypto)))
+    let mut transport = quinn::TransportConfig::default();
+    transport.receive_window(quinn::VarInt::from_u32(RECEIVE_WINDOW_BYTES));
+    let mut config = quinn::ServerConfig::with_crypto(Arc::new(crypto));
+    config.transport_config(Arc::new(transport));
+    Ok(config)
 }
 
 /// Serves HTTP/3 connections from `endpoint` until `shutdown` resolves.
@@ -49,15 +103,43 @@ pub fn quic_server_config(
 /// Every request is dispatched through a clone of `router`, and the QUIC peer address is
 /// inserted as `ConnectInfo<SocketAddr>`. Connection- and request-local protocol failures
 /// close only the affected connection or stream; the endpoint keeps accepting other peers.
-/// On shutdown, all endpoint connections are closed and the function waits for them to drain.
+/// The default global and per-IP connection limits bound accepted connection work; internal IPs are
+/// exempt from the per-IP limit but remain subject to the global limit. On shutdown, all endpoint
+/// connections are closed and the function waits for them to drain.
 pub async fn serve_h3(
     endpoint: quinn::Endpoint,
     router: Router,
     shutdown: impl Future<Output = ()>,
 ) -> io::Result<()> {
+    serve_h3_with_limits(endpoint, router, H3ConnectionLimits::default(), shutdown).await
+}
+
+/// Serves HTTP/3 connections with caller-selected concurrent-connection limits.
+///
+/// A global semaphore permit is reserved before polling `endpoint.accept()`, so connections beyond
+/// the global cap remain in Quinn's bounded incoming queue rather than creating tasks. After accept,
+/// a non-exempt peer at its per-IP cap is refused before a task is spawned. Both slots are held for
+/// the full handshake and connection lifetime and released on every exit path.
+pub async fn serve_h3_with_limits(
+    endpoint: quinn::Endpoint,
+    router: Router,
+    limits: H3ConnectionLimits,
+    shutdown: impl Future<Output = ()>,
+) -> io::Result<()> {
     tokio::pin!(shutdown);
+    let limiter = ConnectionLimiter::new(limits);
 
     loop {
+        let permit = tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                endpoint.close(quinn::VarInt::from_u32(0), b"server shutdown");
+                endpoint.wait_idle().await;
+                return Ok(());
+            }
+            permit = limiter.acquire() => permit,
+        };
+
         tokio::select! {
             biased;
             () = &mut shutdown => {
@@ -69,8 +151,14 @@ pub async fn serve_h3(
                 let Some(incoming) = incoming else {
                     return Ok(());
                 };
+                let Some(ip_guard) = limiter.try_acquire_ip(incoming.remote_address().ip()) else {
+                    incoming.refuse();
+                    continue;
+                };
                 let router = router.clone();
                 tokio::spawn(async move {
+                    let _permit = permit;
+                    let _ip_guard = ip_guard;
                     let Ok(connection) = incoming.await else {
                         return;
                     };
@@ -78,6 +166,104 @@ pub async fn serve_h3(
                     let _ = serve_connection(connection, router, peer_addr).await;
                 });
             }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ConnectionLimiter {
+    semaphore: Arc<Semaphore>,
+    max_per_ip: Option<usize>,
+    exempt_internal_ips: bool,
+    per_ip: PerIpCounts,
+}
+
+impl ConnectionLimiter {
+    fn new(limits: H3ConnectionLimits) -> Self {
+        let max_connections = limits.max_connections.clamp(1, Semaphore::MAX_PERMITS);
+        Self {
+            semaphore: Arc::new(Semaphore::new(max_connections)),
+            max_per_ip: limits.max_connections_per_ip.map(|limit| limit.max(1)),
+            exempt_internal_ips: limits.exempt_internal_ips,
+            per_ip: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    async fn acquire(&self) -> OwnedSemaphorePermit {
+        self.semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("the private HTTP/3 connection semaphore is never closed")
+    }
+
+    fn try_acquire_ip(&self, ip: IpAddr) -> Option<IpConnectionGuard> {
+        let Some(max_per_ip) = self.max_per_ip else {
+            return Some(IpConnectionGuard::disabled());
+        };
+        if self.exempt_internal_ips && is_internal_ip(ip) {
+            return Some(IpConnectionGuard::disabled());
+        }
+
+        let mut counts = match self.per_ip.lock() {
+            Ok(counts) => counts,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let count = counts.get(&ip).copied().unwrap_or(0);
+        if count >= max_per_ip {
+            return None;
+        }
+        counts.insert(ip, count + 1);
+        Some(IpConnectionGuard::tracked(self.per_ip.clone(), ip))
+    }
+}
+
+struct IpConnectionGuard {
+    tracked: Option<(PerIpCounts, IpAddr)>,
+}
+
+impl IpConnectionGuard {
+    fn disabled() -> Self {
+        Self { tracked: None }
+    }
+
+    fn tracked(counts: PerIpCounts, ip: IpAddr) -> Self {
+        Self {
+            tracked: Some((counts, ip)),
+        }
+    }
+}
+
+impl Drop for IpConnectionGuard {
+    fn drop(&mut self) {
+        let Some((counts, ip)) = &self.tracked else {
+            return;
+        };
+        let mut counts = match counts.lock() {
+            Ok(counts) => counts,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(count) = counts.get_mut(ip) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                counts.remove(ip);
+            }
+        }
+    }
+}
+
+fn is_internal_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_loopback() || ip.is_private() || ip.is_link_local(),
+        IpAddr::V6(ip) => {
+            if ip.is_loopback() {
+                return true;
+            }
+            if let Some(ipv4) = ip.to_ipv4() {
+                return ipv4.is_loopback() || ipv4.is_private() || ipv4.is_link_local();
+            }
+            let prefix = ip.segments()[0];
+            (prefix & 0xfe00) == 0xfc00 || (prefix & 0xffc0) == 0xfe80
         }
     }
 }

--- a/crates/sparq-http3/tests/h3_round_trip.rs
+++ b/crates/sparq-http3/tests/h3_round_trip.rs
@@ -14,7 +14,9 @@ use h3::quic::OpenStreams;
 use quinn::crypto::rustls::QuicClientConfig;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
-use sparq_http3::{quic_server_config, serve_h3, Http3ConfigError};
+use sparq_http3::{
+    quic_server_config, serve_h3, serve_h3_with_limits, H3ConnectionLimits, Http3ConfigError,
+};
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
 
@@ -89,6 +91,28 @@ fn config_rejects_a_server_without_h3_alpn() -> TestResult {
     Ok(())
 }
 
+#[test]
+fn config_replaces_quinns_unbounded_connection_receive_window() -> TestResult {
+    let (cert, key) = certificate()?;
+    let mut tls = rustls_server_config(cert, key)?;
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+
+    let config = quic_server_config(tls)?;
+    let transport = format!("{:?}", config.transport);
+    assert!(
+        transport.contains("receive_window:"),
+        "Quinn's transport debug output must expose the checked receive window: {transport}"
+    );
+    assert!(
+        !transport.contains(&format!(
+            "receive_window: {}",
+            quinn::VarInt::MAX.into_inner()
+        )),
+        "the connection receive window must not retain Quinn's VarInt::MAX default: {transport}"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn h3_dispatches_body_status_and_peer_connect_info() -> TestResult {
     async fn echo(body: Bytes) -> (StatusCode, Bytes) {
@@ -149,4 +173,108 @@ async fn h3_dispatches_body_status_and_peer_connect_info() -> TestResult {
         .map_err(|()| "server stopped before shutdown")?;
     tokio::time::timeout(Duration::from_secs(5), server).await???;
     Ok(())
+}
+
+async fn limited_server(
+    limits: H3ConnectionLimits,
+) -> TestResult<(
+    SocketAddr,
+    CertificateDer<'static>,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<std::io::Result<()>>,
+)> {
+    let (cert, key) = certificate()?;
+    let mut tls = rustls_server_config(cert.clone(), key)?;
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+    let endpoint = quinn::Endpoint::server(quic_server_config(tls)?, "127.0.0.1:0".parse()?)?;
+    let server_addr = endpoint.local_addr()?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve_h3_with_limits(
+        endpoint,
+        Router::new(),
+        limits,
+        async move {
+            let _ = shutdown_rx.await;
+        },
+    ));
+    Ok((server_addr, cert, shutdown_tx, server))
+}
+
+async fn stop_limited_server(
+    endpoint: quinn::Endpoint,
+    shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    server: tokio::task::JoinHandle<std::io::Result<()>>,
+) -> TestResult {
+    endpoint.close(quinn::VarInt::from_u32(0), b"test complete");
+    shutdown_tx
+        .send(())
+        .map_err(|()| "server stopped before shutdown")?;
+    tokio::time::timeout(Duration::from_secs(5), server).await???;
+    Ok(())
+}
+
+#[tokio::test]
+async fn global_connection_cap_queues_excess_connections_until_release() -> TestResult {
+    let limits = H3ConnectionLimits {
+        max_connections: 1,
+        max_connections_per_ip: None,
+        exempt_internal_ips: true,
+    };
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits).await?;
+    let endpoint = client_endpoint(cert)?;
+
+    let first = endpoint.connect(server_addr, "localhost")?.await?;
+    let second = endpoint.connect(server_addr, "localhost")?;
+    tokio::pin!(second);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), &mut second)
+            .await
+            .is_err(),
+        "a second QUIC connection must remain queued while the sole global slot is held"
+    );
+
+    first.close(quinn::VarInt::from_u32(0), b"release global slot");
+    let second = tokio::time::timeout(Duration::from_secs(5), second).await??;
+    second.close(quinn::VarInt::from_u32(0), b"test complete");
+    stop_limited_server(endpoint, shutdown_tx, server).await
+}
+
+#[tokio::test]
+async fn per_ip_connection_cap_refuses_excess_connections() -> TestResult {
+    let limits = H3ConnectionLimits {
+        max_connections: 4,
+        max_connections_per_ip: Some(1),
+        exempt_internal_ips: false,
+    };
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits).await?;
+    let endpoint = client_endpoint(cert)?;
+
+    let first = endpoint.connect(server_addr, "localhost")?.await?;
+    let second = endpoint.connect(server_addr, "localhost")?;
+    let refusal = tokio::time::timeout(Duration::from_secs(5), second).await?;
+    assert!(
+        refusal.is_err(),
+        "a second connection from the same IP must be refused at the per-IP cap"
+    );
+
+    first.close(quinn::VarInt::from_u32(0), b"test complete");
+    stop_limited_server(endpoint, shutdown_tx, server).await
+}
+
+#[tokio::test]
+async fn internal_ip_exemption_leaves_only_the_global_cap() -> TestResult {
+    let limits = H3ConnectionLimits {
+        max_connections: 2,
+        max_connections_per_ip: Some(1),
+        exempt_internal_ips: true,
+    };
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits).await?;
+    let endpoint = client_endpoint(cert)?;
+
+    let first = endpoint.connect(server_addr, "localhost")?.await?;
+    let second = endpoint.connect(server_addr, "localhost")?.await?;
+
+    first.close(quinn::VarInt::from_u32(0), b"test complete");
+    second.close(quinn::VarInt::from_u32(0), b"test complete");
+    stop_limited_server(endpoint, shutdown_tx, server).await
 }

--- a/skills/http3-server/SKILL.md
+++ b/skills/http3-server/SKILL.md
@@ -44,7 +44,9 @@ let endpoint = quinn::Endpoint::server(quic, udp_addr)?;
 ```
 
 `quic_server_config` fails closed when `h3` is missing from ALPN or the provider lacks
-QUIC's required initial cipher suite.
+QUIC's required initial cipher suite. It also replaces Quinn's effectively unbounded default
+connection receive window with an owned finite bound; a caller may still replace the returned
+config's transport settings before binding the endpoint.
 
 ## Serve the shared router
 
@@ -56,16 +58,34 @@ sparq_http3::serve_h3(endpoint, router.clone(), async move {
 # Ok::<(), std::io::Error>(())
 ```
 
-The bridge clones the router per connection and request, streams request and response
-bodies, and inserts the Quinn peer address as `axum::extract::ConnectInfo<SocketAddr>`.
+The compatibility entry point is safe by default: it limits total concurrent connections and
+connections from one public IP. Internal addresses are exempt from the per-IP cap to avoid treating
+a proxy, container bridge, or conformance runner as one client, but the global cap still applies.
+Existing callers need no changes. To tune the caps, use the additive variant:
+
+```rust
+let limits = sparq_http3::H3ConnectionLimits {
+    max_connections: 2_000,
+    max_connections_per_ip: Some(128),
+    exempt_internal_ips: true,
+};
+sparq_http3::serve_h3_with_limits(endpoint, router.clone(), limits, shutdown_signal).await?;
+# Ok::<(), std::io::Error>(())
+```
+
+Set `max_connections_per_ip` to `None` only when the global cap is sufficient for the deployment.
+Zero numeric caps are clamped to one rather than disabling the listener. The bridge clones the
+router per connection and request, streams request and response bodies, and inserts the Quinn peer
+address as `axum::extract::ConnectInfo<SocketAddr>`.
 That extension is load-bearing for request policies keyed by the remote socket address.
 Protocol failures are isolated to their connection or stream; resolving the shutdown
 future closes the endpoint and waits for its QUIC connections to drain.
 
 ## Boundaries
 
-- The caller owns rustls policy, certificates, client authentication, Quinn transport
-  tuning, listener binding, and process-wide provider installation.
+- The caller owns rustls policy, certificates, client authentication, any Quinn transport
+  tuning beyond the helper's bounded receive window, listener binding, and process-wide provider
+  installation.
 - HTTP/3 is a separate UDP listener. Keep the existing TCP listener running for HTTP/1.1
   and HTTP/2 clients.
 - `h3` and `h3-quinn` are pre-1.0 dependencies; keep all direct use inside this helper.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-h1f9g** — sparq-http3 serve_h3 accept loop has no endpoint-level connection cap or per-IP connection cap (h3/QUIC DoS parity gap vs the TCP transport hardening)
sq-h1f9g.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-h1f9g","crate":"sparq-http3","committed":true,"gates_green":true,"branch":"feat/sq-h1f9g-codex-gpt56","non_vacuity_verified":true,"notes":"Added default and custom HTTP/3 connection caps plus bounded receive window; commit e7f3c862"}
```

Not armed — the orchestrator arms after review.