### PR TITLE
sparq-shacl: ValidationReport::to_ntriples() serializer (parity with t
sq-qcuhh [GPT-5.6]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -11,7 +11,7 @@ Opt-in **SHACL Core + SHACL-SPARQL (`sh:sparql`)** validation over
 [`sparq_core::Graph`]s. Core constraints run at the dictionary-id level via direct,
 index-backed permutation scans (no SPARQL round-trip; terms materialise only at the
 report boundary); `sh:sparql` routes its `sh:select` through `sparq-engine`. Reports:
-`conforms` + per-result detail, `to_turtle()` (W3C vocabulary), `to_text()`.
+`conforms` + per-result detail; `to_turtle()` / `to_ntriples()` (W3C report graph), `to_json()`, and `to_text()`.
 
 Like `sparq-reason`, this crate is **isolated**: no other sparq crate depends on it, so
 the core engine and the default wasm bundle carry zero SHACL code. The browser/JS

--- a/crates/sparq-shacl/src/report.rs
+++ b/crates/sparq-shacl/src/report.rs
@@ -1,6 +1,6 @@
-//! Validation reports: the result structs, the report RDF graph (as Turtle, per
-//! the SHACL results vocabulary), deterministic JSON and a human-readable text
-//! rendering.
+//! Validation reports: the result structs, the report RDF graph (as Turtle or
+//! N-Triples, per the SHACL results vocabulary), deterministic JSON and a
+//! human-readable text rendering.
 
 use crate::model::SH;
 use crate::path::Path;
@@ -183,6 +183,28 @@ impl ValidationReport {
         }
         let _ = writeln!(out, " .");
         out
+    }
+
+    /// The report RDF graph serialised as one N-Triples statement per line.
+    ///
+    /// This emits the same validation-report graph as [`to_turtle`](Self::to_turtle),
+    /// including nested `sh:detail` results.
+    pub fn to_ntriples(&self) -> String {
+        // [GPT-5.6] (sq-qcuhh) Keep the Turtle renderer as the single report-graph
+        // construction path, then use oxttl for complete N-Triples term escaping.
+        let turtle = self.to_turtle();
+        let triples = oxttl::TurtleParser::new().for_slice(turtle.as_bytes());
+        let mut serializer = oxttl::NTriplesSerializer::new().low_level();
+        let mut out = Vec::new();
+
+        for triple in triples {
+            let triple = triple.expect("ValidationReport::to_turtle must emit valid Turtle");
+            serializer
+                .serialize_triple(triple.as_ref(), &mut out)
+                .expect("serialising N-Triples into memory must succeed");
+        }
+
+        String::from_utf8(out).expect("N-Triples output must be valid UTF-8")
     }
 
     /// A human-readable rendering of the report.
@@ -719,6 +741,81 @@ mod tests {
             .filter(|t| t.predicate.as_str().ends_with("#result"))
             .count();
         assert_eq!(n_results, 2, "{ttl}");
+    }
+
+    // [GPT-5.6] (sq-qcuhh) Value-pinned direct coverage for the public N-Triples
+    // serializer: two violations must remain two report links and conformity must
+    // be the boolean false in the emitted report graph.
+    #[test]
+    fn ntriples_emits_two_result_nonconforming_report_graph() {
+        let report = ValidationReport::new(vec![
+            result(
+                iri(&format!("{EX}alice")),
+                None,
+                None,
+                "MinCountConstraintComponent",
+                "Violation",
+                vec![],
+            ),
+            result(
+                iri(&format!("{EX}bob")),
+                Some(Path::Predicate(format!("{EX}age"))),
+                Some(lit("thirty")),
+                "DatatypeConstraintComponent",
+                "Violation",
+                vec![],
+            ),
+        ]);
+
+        assert!(!report.conforms);
+        assert_eq!(report.results.len(), 2);
+        let nt = report.to_ntriples();
+        assert!(
+            nt.lines()
+                .filter(|line| !line.trim().is_empty())
+                .all(|line| line.trim_end().ends_with(" .")),
+            "{nt}"
+        );
+
+        let triples = oxttl::NTriplesParser::new()
+            .for_slice(nt.as_bytes())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_or_else(|error| panic!("report N-Triples does not parse: {error}\n{nt}"));
+        let report_type = format!("{SH}ValidationReport");
+        let report_nodes: Vec<_> = triples
+            .iter()
+            .filter(|triple| {
+                triple.predicate.as_str() == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+                    && matches!(&triple.object, Term::NamedNode(node) if node.as_str() == report_type)
+            })
+            .map(|triple| triple.subject.clone())
+            .collect();
+        assert_eq!(report_nodes.len(), 1, "{nt}");
+        let report_node = &report_nodes[0];
+
+        let conforms: Vec<_> = triples
+            .iter()
+            .filter(|triple| {
+                &triple.subject == report_node
+                    && triple.predicate.as_str() == format!("{SH}conforms")
+            })
+            .collect();
+        assert_eq!(conforms.len(), 1, "{nt}");
+        assert!(
+            matches!(&conforms[0].object, Term::Literal(literal) if literal.value() == "false"),
+            "{nt}"
+        );
+        assert_eq!(
+            triples
+                .iter()
+                .filter(|triple| {
+                    &triple.subject == report_node
+                        && triple.predicate.as_str() == format!("{SH}result")
+                })
+                .count(),
+            2,
+            "{nt}"
+        );
     }
 
     #[test]

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: shacl-validation
-description: "Validate RDF data against SHACL shapes with the sparq engine: SHACL Core constraints (class, datatype incl. the SHACL-1.2 disjunctive list form, cardinality, ranges, paths, logical, node/property, qualified, closed incl. sh:ByTypes, in/hasValue, the SHACL-1.2 list constraints sh:memberShape / sh:uniqueMembers / sh:min+maxListLength / sh:uniqueValuesFor, and the SHACL-1.2 value constraints sh:subsetOf / sh:someValue / sh:singleLine / sh:rootClass with path-valued sh:equals/disjoint/lessThan comparands and severity-threshold sh:conforms), SHACL-SPARQL sh:sparql constraints (§5.2), and custom SPARQL-based constraint components (sh:ConstraintComponent, §6) — then read the conformance/violations validation report as deterministic JSON, W3C report-vocabulary Turtle, or human text. Also runs opt-in SHACL Advanced Features (SHACL-AF) rules — sh:rule (sh:TripleRule + sh:SPARQLRule) — to INFER triples (feature `shacl-af`). Use when an agent needs to check whether a sparq_core::Graph conforms to shapes, run shape validation, produce a SHACL validation report, or apply SHACL rules to infer/expand a graph in Rust."
+description: "Validate RDF data against SHACL shapes with the sparq engine: SHACL Core constraints (class, datatype incl. the SHACL-1.2 disjunctive list form, cardinality, ranges, paths, logical, node/property, qualified, closed incl. sh:ByTypes, in/hasValue, the SHACL-1.2 list constraints sh:memberShape / sh:uniqueMembers / sh:min+maxListLength / sh:uniqueValuesFor, and the SHACL-1.2 value constraints sh:subsetOf / sh:someValue / sh:singleLine / sh:rootClass with path-valued sh:equals/disjoint/lessThan comparands and severity-threshold sh:conforms), SHACL-SPARQL sh:sparql constraints (§5.2), and custom SPARQL-based constraint components (sh:ConstraintComponent, §6) — then read the conformance/violations validation report as N-Triples, deterministic JSON, W3C report-vocabulary Turtle, or human text. Also runs opt-in SHACL Advanced Features (SHACL-AF) rules — sh:rule (sh:TripleRule + sh:SPARQLRule) — to INFER triples (feature `shacl-af`). Use when an agent needs to check whether a sparq_core::Graph conforms to shapes, run shape validation, produce a SHACL validation report, or apply SHACL rules to infer/expand a graph in Rust."
 ---
 
 # sparq-shacl-validation
 
 Validate a data `Graph` against a shapes `Graph` and get back a `ValidationReport`
-(conformance flag + per-violation results, renderable as deterministic JSON,
-W3C-vocabulary Turtle, or plain text). Covers the full SHACL Core component set,
+(conformance flag + per-violation results, renderable as N-Triples, deterministic
+JSON, W3C-vocabulary Turtle, or plain text). Covers the full SHACL Core component set,
 SHACL-SPARQL (`sh:sparql`, §5.2), and custom SPARQL-based constraint components
 (`sh:ConstraintComponent`, §6).
 
@@ -61,6 +61,7 @@ assert!(!report.conforms);                 // sh:conforms = false
 assert_eq!(report.results.len(), 1);       // one DatatypeConstraintComponent violation
 eprintln!("{}", report.to_text());         // human-readable
 println!("{}", report.to_turtle());        // W3C sh:ValidationReport graph
+println!("{}", report.to_ntriples());      // same graph, one N-Triples statement per line
 println!("{}", report.to_json());          // deterministic machine-readable object
 ```
 
@@ -191,6 +192,7 @@ pub fn conforms_with_disallowed(&self, disallowed: &[&str]) -> bool;  // custom 
 pub fn results_with_severity<'a>(&'a self, severity: &'a str)         // full IRI, e.g. ".../shacl#Warning"
     -> impl Iterator<Item = &'a ValidationResult>;
 pub fn to_turtle(&self) -> String;          // W3C report vocabulary (valid, round-trippable Turtle)
+pub fn to_ntriples(&self) -> String;        // same report graph, one N-Triples statement per line
 pub fn to_text(&self) -> String;            // human-readable summary
 pub fn to_json(&self) -> String;            // deterministic JSON; fixed keys and result order
 ```


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-qcuhh** — sparq-shacl: ValidationReport::to_ntriples() serializer (parity with to_turtle/to_json/to_text)
sq-qcuhh.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-qcuhh","crate":"sparq-shacl","committed":true,"gates_green":true,"branch":"feat/sq-qcuhh-codex-gpt56","non_vacuity_verified":true,"notes":"commit 0fafb9a5; coverage 95.15% >= 93%; workspace checks green"}
```

Not armed — the orchestrator arms after review.