### PR TITLE
sparq-prov: used_inputs() accessor on Derivation + UpdateDerivation (p
sq-cg237 [GPT-5.6]

### DIFF
--- a/crates/sparq-prov/src/lib.rs
+++ b/crates/sparq-prov/src/lib.rs
@@ -186,6 +186,12 @@ impl Derivation {
         &self.entity
     }
 
+    /// The configured input-source IRIs, in their original order.
+    // [GPT-5.6] sq-cg237
+    pub fn used_inputs(&self) -> &[NamedNode] {
+        &self.used
+    }
+
     /// The PROV-O lineage of this derivation as an RDF graph (a `Vec<Triple>`).
     ///
     /// Emits, for the result entity `E`, activity `A`, and each input `Iᵢ`:

--- a/crates/sparq-prov/src/tests.rs
+++ b/crates/sparq-prov/src/tests.rs
@@ -76,6 +76,35 @@ fn construct_derivation_emits_core_prov_shape() {
     assert!(lines.iter().any(|l| l.contains("#endedAtTime>")));
 }
 
+/// [GPT-5.6] sq-cg237: the direct accessor preserves configured order and agrees with
+/// every `prov:used` edge materialised for the derivation activity.
+#[test]
+fn construct_used_inputs_are_exposed_in_order_and_materialised() {
+    let source1 = NamedNode::new_unchecked("http://ex/source-1");
+    let source2 = NamedNode::new_unchecked("http://ex/source-2");
+    let inputs = [source1, source2];
+    let config = ProvConfig {
+        used: inputs.to_vec(),
+        clock: fixed_clock,
+        ..ProvConfig::default()
+    };
+    let derivation =
+        derive_construct(&g(), "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }", config).unwrap();
+
+    assert_eq!(derivation.used_inputs(), inputs.as_slice());
+    assert_eq!(derivation.used_inputs().len(), 2);
+
+    let activity = NamedOrBlankNode::NamedNode(derivation.activity().clone());
+    let provenance = derivation.prov_graph();
+    for input in &inputs {
+        assert!(provenance.iter().any(|triple| {
+            triple.subject == activity
+                && triple.predicate.as_str() == "http://www.w3.org/ns/prov#used"
+                && triple.object == Term::NamedNode(input.clone())
+        }));
+    }
+}
+
 #[test]
 fn prov_graph_is_valid_rdf_and_round_trips() {
     let d = derive_construct(

--- a/crates/sparq-prov/src/update.rs
+++ b/crates/sparq-prov/src/update.rs
@@ -94,6 +94,12 @@ impl UpdateDerivation {
         &self.entity
     }
 
+    /// The configured input-source IRIs, in their original order.
+    // [GPT-5.6] sq-cg237
+    pub fn used_inputs(&self) -> &[NamedNode] {
+        &self.used
+    }
+
     /// Start/end wall-clock instants of the update activity.
     pub fn timing(&self) -> (SystemTime, SystemTime) {
         (self.started, self.ended)
@@ -493,6 +499,30 @@ mod tests {
         // The derived data: one renamed triple per matched subject; nothing retracted.
         assert_eq!(d.inserted().len(), 2);
         assert!(d.deleted().is_empty());
+    }
+
+    /// [GPT-5.6] sq-cg237: the direct accessor exposes the configured input and agrees
+    /// with the update activity's materialised `prov:used` edge.
+    #[test]
+    fn update_used_inputs_are_exposed_and_materialised() {
+        let source = NamedNode::new_unchecked("http://ex/update-source");
+        let mut graph = g();
+        let derivation = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            ProvConfig::with_inputs([source.clone()]),
+        )
+        .unwrap();
+
+        assert_eq!(derivation.used_inputs(), std::slice::from_ref(&source));
+        assert_eq!(derivation.used_inputs().len(), 1);
+
+        let activity = NamedOrBlankNode::NamedNode(derivation.activity().clone());
+        assert!(derivation.prov_graph().iter().any(|triple| {
+            triple.subject == activity
+                && triple.predicate.as_str() == "http://www.w3.org/ns/prov#used"
+                && triple.object == Term::NamedNode(source.clone())
+        }));
     }
 
     #[test]

--- a/skills/prov-lineage/SKILL.md
+++ b/skills/prov-lineage/SKILL.md
@@ -45,6 +45,7 @@ let d = derive_construct(
 ).unwrap();
 
 let derived = d.triples();       // the derived data (Vec<Triple>)
+let inputs  = d.used_inputs();   // configured input IRIs, in order (&[NamedNode])
 let lineage = d.prov_graph();    // its PROV-O record (Vec<Triple>)
 let turtle  = d.prov_ntriples(); // …serialised (N-Triples ⊂ Turtle)
 ```
@@ -93,6 +94,7 @@ let d = derive_update(
 
 let inserted = d.inserted();    // the generated (derived) triples
 let deleted  = d.deleted();     // the retracted (invalidated) triples
+let inputs   = d.used_inputs(); // configured input IRIs, in order
 let lineage  = d.prov_graph();  // its PROV-O record (Vec<Triple>)
 ```
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-cg237** — sparq-prov: used_inputs() accessor on Derivation + UpdateDerivation (parity with activity/entity/timing)
sq-cg237.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-cg237","crate":"sparq-prov","committed":true,"gates_green":true,"branch":"feat/sq-cg237-codex-gpt56","non_vacuity_verified":true,"notes":"commit 5714a719; clippy_preexisting_drift:sparq-core"}
```

Not armed — the orchestrator arms after review.