### PR TITLE
sparq-algos: is_acyclic() boolean over directed graph (parity with top
sq-ulsqh [GPT-5.6]

### DIFF
--- a/crates/sparq-algos/README.md
+++ b/crates/sparq-algos/README.md
@@ -4,9 +4,9 @@
 epic sq-3183) that runs classic graph algorithms directly over a `sparq_core::Graph`.
 PageRank, degree/in/out centrality, weakly-connected-component and label-propagation
 community detection — plus feature-gated exact betweenness, harmonic closeness, strongly
-connected components, and topological sorting — computed from sparq-core's permutation
-indexes with no model and no network. Nothing in the workspace depends on it; the default
-engine build does not even compile it.
+connected components, boolean acyclicity checks, and topological sorting — computed from
+sparq-core's permutation indexes with no model and no network. Nothing in the workspace
+depends on it; the default engine build does not even compile it.
 
 ## 🚀 Quickstart
 
@@ -17,7 +17,7 @@ use sparq_algos::{
     degree_centrality, Direction, top_k,
     betweenness_centrality, closeness_centrality,
     weakly_connected_components, label_propagation, LabelPropConfig, num_communities,
-    strongly_connected_components, topological_sort,
+    is_acyclic, strongly_connected_components, topological_sort,
 };
 
 // Project the RDF graph onto a directed node graph (subjects + entity objects = nodes,
@@ -44,6 +44,7 @@ let k    = num_communities(&comm);
 
 // Directed topology; requires feature `topology`.
 let scc = strongly_connected_components(&g);              // dense component id per node
+let dag = is_acyclic(&g);                                  // false for any directed cycle
 let order = topological_sort(&g)?;                         // Err(CycleError) on a cycle
 ```
 
@@ -69,7 +70,7 @@ let order = topological_sort(&g)?;                         // Err(CycleError) on
 - **Directed topology** — with the default-OFF `topology` feature, iterative Tarjan
   strongly connected components and a canonical topological sort. SCC ids are densified by
   ascending node index; topological-sort ties choose the smallest ready node and cycles,
-  including self-loops, return `CycleError`.
+  including self-loops, return `CycleError`; `is_acyclic` exposes the same check as a boolean.
 - **Opt-in & lean** — consumes only sparq-core's public read API; the only dependencies
   are `sparq-core`, `oxrdf`, and `rustc-hash`. The heavier all-pairs algorithms are behind
   `centrality-extended`, and directed topology is behind `topology`; both features are OFF

--- a/crates/sparq-algos/src/lib.rs
+++ b/crates/sparq-algos/src/lib.rs
@@ -19,7 +19,7 @@ pub use community::{
 pub use graph::{NodeFilter, NodeGraph};
 pub use pagerank::{pagerank, PageRankConfig};
 #[cfg(feature = "topology")]
-pub use topology::{strongly_connected_components, topological_sort, CycleError};
+pub use topology::{is_acyclic, strongly_connected_components, topological_sort, CycleError};
 
 #[cfg(test)]
 mod tests {

--- a/crates/sparq-algos/src/topology.rs
+++ b/crates/sparq-algos/src/topology.rs
@@ -1,7 +1,7 @@
 //! Directed topology algorithms over a [`NodeGraph`].
 //!
 //! [GPT-5.6] sq-lsp7k.20: unlike the crate's weak community and extended-centrality
-//! passes, both algorithms in this module preserve edge direction. Strongly connected
+//! passes, the algorithms in this module preserve edge direction. Strongly connected
 //! components use an iterative Tarjan traversal, and topological sorting uses Kahn's
 //! algorithm with an ascending-node ready queue. Neither algorithm uses recursion or RNG.
 
@@ -178,4 +178,13 @@ pub fn topological_sort(g: &NodeGraph) -> Result<Vec<usize>, CycleError> {
     } else {
         Err(CycleError)
     }
+}
+
+/// Returns whether the directed graph is acyclic.
+///
+/// A self-loop counts as a cycle. This is a convenience wrapper around
+/// [`topological_sort`] and has the same `O((V + E) log V)` running time.
+/// [GPT-5.6] sq-ulsqh.
+pub fn is_acyclic(g: &NodeGraph) -> bool {
+    topological_sort(g).is_ok()
 }

--- a/crates/sparq-algos/tests/topology.rs
+++ b/crates/sparq-algos/tests/topology.rs
@@ -3,7 +3,9 @@
 #![cfg(feature = "topology")]
 
 use proptest::prelude::*;
-use sparq_algos::{strongly_connected_components, topological_sort, CycleError, NodeGraph};
+use sparq_algos::{
+    is_acyclic, strongly_connected_components, topological_sort, CycleError, NodeGraph,
+};
 use sparq_core::Graph;
 
 fn build(nt: &str) -> NodeGraph {
@@ -57,6 +59,30 @@ fn self_loop_is_a_singleton_component_but_a_cycle() {
     let graph = build("<http://e/0> <http://p/edge> <http://e/0> .\n");
     assert_eq!(strongly_connected_components(&graph), vec![0]);
     assert_eq!(topological_sort(&graph), Err(CycleError));
+}
+
+/// [GPT-5.6] sq-ulsqh: pins both boolean outcomes and the self-loop boundary so negating
+/// the thin `topological_sort(...).is_ok()` wrapper fails on the DAG and directed cycle.
+#[test]
+fn acyclicity_predicate_distinguishes_dag_cycle_and_self_loop() {
+    let dag = build(
+        r#"
+<http://e/a> <http://p/edge> <http://e/b> .
+<http://e/b> <http://p/edge> <http://e/c> .
+"#,
+    );
+    let cycle = build(
+        r#"
+<http://e/a> <http://p/edge> <http://e/b> .
+<http://e/b> <http://p/edge> <http://e/c> .
+<http://e/c> <http://p/edge> <http://e/a> .
+"#,
+    );
+    let self_loop = build("<http://e/a> <http://p/edge> <http://e/a> .\n");
+
+    assert!(is_acyclic(&dag));
+    assert!(!is_acyclic(&cycle));
+    assert!(!is_acyclic(&self_loop));
 }
 
 #[test]

--- a/skills/graph-analytics/SKILL.md
+++ b/skills/graph-analytics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: graph-analytics
-description: "Graph analytics over a sparq RDF graph with the opt-in sparq-algos crate: project the graph onto a directed NodeGraph and run PageRank, centrality, k-core decomposition, community detection, and feature-gated directed strongly connected components or topological sorting — all read directly from sparq-core's permutation indexes, deterministic, no model, no network. Use when ranking entities, measuring node cohesion, finding communities, classifying directed cycles, or ordering a DAG; topology-only (edges are predicate-erased and unweighted — filter the source graph for a per-predicate sub-graph)."
+description: "Graph analytics over a sparq RDF graph with the opt-in sparq-algos crate: project the graph onto a directed NodeGraph and run PageRank, centrality, k-core decomposition, community detection, and feature-gated directed strongly connected components, acyclicity checks, or topological sorting — all read directly from sparq-core's permutation indexes, deterministic, no model, no network. Use when ranking entities, measuring node cohesion, finding communities, classifying directed cycles, or ordering a DAG; topology-only (edges are predicate-erased and unweighted — filter the source graph for a per-predicate sub-graph)."
 license: MIT
 metadata:
   version: "0.1.0"
@@ -15,9 +15,10 @@ total), feature-gated exact **Brandes betweenness**, **harmonic closeness**, and
 decomposition**,
 **weakly-connected components**, and a deterministic **label-propagation** community
 heuristic, plus feature-gated directed **strongly connected components** and
-**topological sorting**. It consumes only sparq-core's public read API (the borrowing
-triple-id iterator + dict lookups), holds no graph state of its own, and nothing in the
-workspace depends on it — the default engine build does not even compile it.
+boolean **acyclicity checks** and **topological sorting**. It consumes only sparq-core's
+public read API (the borrowing triple-id iterator + dict lookups), holds no graph state of
+its own, and nothing in the workspace depends on it — the default engine build does not
+even compile it.
 
 These are **topology** algorithms: every triple `(s, p, o)` becomes one directed edge
 `s → o`, the predicate is **erased**, parallel edges are collapsed, and edges are
@@ -44,7 +45,7 @@ use sparq_algos::{
     degree_centrality, degree_centrality_normalized, Direction, top_k,
     betweenness_centrality, closeness_centrality, core_number,
     weakly_connected_components, label_propagation, LabelPropConfig, num_communities,
-    strongly_connected_components, topological_sort,
+    is_acyclic, strongly_connected_components, topological_sort,
 };
 
 // Project the RDF graph onto a directed node graph.
@@ -74,6 +75,7 @@ let k    = num_communities(&comm);                         // distinct community
 
 // --- Directed topology ---
 let scc   = strongly_connected_components(&g);             // dense component id per node
+let dag   = is_acyclic(&g);                                 // false for any directed cycle
 let order = topological_sort(&g)?;                         // canonical DAG order; Err on cycle
 ```
 
@@ -97,6 +99,7 @@ let order = topological_sort(&g)?;                         // canonical DAG orde
 | `label_propagation(&g, LabelPropConfig)` | heuristic community labels (`Vec<usize>`) |
 | `num_communities(&labels)` | distinct community count |
 | `strongly_connected_components(&g)` | directed SCC id per node; requires `topology` |
+| `is_acyclic(&g)` | whether the directed graph has no cycle; requires `topology` |
 | `topological_sort(&g)` | canonical `Result<Vec<usize>, CycleError>`; requires `topology` |
 
 ## Honest scope / caveats
@@ -124,10 +127,10 @@ let order = topological_sort(&g)?;                         // canonical DAG orde
   closeness take `O(V * (V + E))` time, while k-core decomposition takes `O(V + E)`.
   Enable the default-OFF `centrality-extended` feature to compile them.
 - **Directed topology preserves direction.** SCC follows out-edges and identifies mutual
-  directed reachability. Topological sorting succeeds only for a DAG; self-loops and larger
-  cycles return `CycleError`. Both are deterministic, with ascending node indices fixing
-  component ids and ready-node ties. Enable the default-OFF `topology` feature to compile
-  them.
+  directed reachability. `is_acyclic` reports the same cycle classification as topological
+  sorting, which succeeds only for a DAG; self-loops and larger cycles return `CycleError`.
+  Both are deterministic, with ascending node indices fixing component ids and ready-node
+  ties. Enable the default-OFF `topology` feature to compile them.
 - **PageRank** handles dangling (out-degree-0) nodes by redistributing their mass
   uniformly each iteration, so the result is a proper probability distribution.
 - **In-memory.** The `NodeGraph` is built from one pass over `Graph::iter_ids` and held in


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-ulsqh** — sparq-algos: is_acyclic() boolean over directed graph (parity with topological_sort)
sq-ulsqh.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-ulsqh","crate":"sparq-algos","committed":true,"gates_green":true,"branch":"feat/sq-ulsqh-codex-gpt56","non_vacuity_verified":true,"notes":"clippy_preexisting_drift:sparq-core,sparq-algos/tests/topology_oracles.rs"}
```

Not armed — the orchestrator arms after review.