### PR TITLE
sparq-rsp: Agg::Avg mean fold in window_aggregate (parity with Sum/Min
sq-xf3b8 [GPT-5.6]

### DIFF
--- a/crates/sparq-rsp/README.md
+++ b/crates/sparq-rsp/README.md
@@ -56,7 +56,7 @@ q.flush(|result| { /* end-of-stream: close everything up to max ts */ })?;
   (CONSTRUCT, stream-to-stream), and `ContinuousAsk` (ASK), each parsed **once** at
   `register` into a `sparq_engine::PreparedQuery` and re-run per closed window.
 - **Closed-window aggregates** — the default-off `window-aggregate` feature adds
-  `window_aggregate(&WindowResult, var, Agg)` for deterministic COUNT/SUM/MIN/MAX
+  `window_aggregate(&WindowResult, var, Agg)` for deterministic COUNT/SUM/AVG/MIN/MAX
   scalar folds over emitted rows, without a clock read or another query.
 - **Relation-to-stream (R2S)** — `R2S::{RStream, IStream, DStream}`: full / added /
   removed rows per window, computed as multiset diffs over 64-bit row hashes.

--- a/crates/sparq-rsp/src/aggregate.rs
+++ b/crates/sparq-rsp/src/aggregate.rs
@@ -11,6 +11,9 @@ pub enum Agg {
     Count,
     /// Sum of the selected variable's numeric literal bindings.
     Sum,
+    /// Arithmetic mean of the selected variable's numeric literal bindings.
+    // [GPT-5.6] sq-xf3b8: keep AVG on the same deterministic numeric fold as SUM.
+    Avg,
     /// Minimum of the selected variable's numeric literal bindings.
     Min,
     /// Maximum of the selected variable's numeric literal bindings.
@@ -23,7 +26,7 @@ pub enum Agg {
 /// `window.vars`, this returns `None`. [`Agg::Count`] counts every emitted row,
 /// including unbound and non-numeric bindings. The other aggregates skip
 /// unbound, non-literal, non-numeric, and ill-formed numeric bindings. An empty
-/// numeric input has sum `0.0` and no minimum or maximum.
+/// numeric input has sum `0.0` and no average, minimum, or maximum.
 ///
 /// This helper only folds `window.rows`: it does not read the clock, re-query
 /// the graph, or mutate the continuous query.
@@ -56,6 +59,10 @@ pub fn window_aggregate(window: &WindowResult, var: &str, aggregate: Agg) -> Opt
 
     match aggregate {
         Agg::Sum => Some(numbers.into_iter().sum()),
+        Agg::Avg => {
+            let count = numbers.len();
+            (count != 0).then(|| numbers.into_iter().sum::<f64>() / count as f64)
+        }
         Agg::Min => numbers.first().copied(),
         Agg::Max => numbers.last().copied(),
         Agg::Count => unreachable!("count returns before the numeric fold"),

--- a/crates/sparq-rsp/tests/window_aggregate_oracle.rs
+++ b/crates/sparq-rsp/tests/window_aggregate_oracle.rs
@@ -30,6 +30,7 @@ fn exact_count_sum_min_and_max_oracle() {
 
     assert_eq!(window_aggregate(&window, "x", Agg::Count), Some(3.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Sum), Some(6.0));
+    assert_eq!(window_aggregate(&window, "x", Agg::Avg), Some(2.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Min), Some(1.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Max), Some(3.0));
 }
@@ -52,6 +53,7 @@ fn numeric_fold_skips_unbound_and_non_numeric_while_count_keeps_rows() {
 
     assert_eq!(window_aggregate(&window, "x", Agg::Count), Some(6.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Sum), Some(2.0));
+    assert_eq!(window_aggregate(&window, "x", Agg::Avg), Some(1.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Min), Some(-2.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Max), Some(4.0));
 }
@@ -60,7 +62,7 @@ fn numeric_fold_skips_unbound_and_non_numeric_while_count_keeps_rows() {
 fn absent_variable_returns_none_for_every_aggregate() {
     let window = result(&["x"], vec![vec![number(1)]]);
 
-    for aggregate in [Agg::Count, Agg::Sum, Agg::Min, Agg::Max] {
+    for aggregate in [Agg::Count, Agg::Sum, Agg::Avg, Agg::Min, Agg::Max] {
         assert_eq!(window_aggregate(&window, "notavar", aggregate), None);
     }
 }
@@ -71,6 +73,7 @@ fn empty_window_has_zero_count_and_sum_but_no_extrema() {
 
     assert_eq!(window_aggregate(&window, "x", Agg::Count), Some(0.0));
     assert_eq!(window_aggregate(&window, "x", Agg::Sum), Some(0.0));
+    assert_eq!(window_aggregate(&window, "x", Agg::Avg), None);
     assert_eq!(window_aggregate(&window, "x", Agg::Min), None);
     assert_eq!(window_aggregate(&window, "x", Agg::Max), None);
 }
@@ -94,10 +97,23 @@ fn column_selection_and_row_order_do_not_change_the_oracle() {
         ],
     );
 
-    for aggregate in [Agg::Count, Agg::Sum, Agg::Min, Agg::Max] {
+    for aggregate in [Agg::Count, Agg::Sum, Agg::Avg, Agg::Min, Agg::Max] {
         assert_eq!(
             window_aggregate(&first, "x", aggregate),
             window_aggregate(&reversed, "x", aggregate)
         );
     }
+}
+
+#[test]
+fn average_uses_only_numeric_bindings() {
+    // [GPT-5.6] sq-xf3b8: value-pinned oracle witnesses the divisor and unbound skip.
+    let numeric = result(
+        &["x"],
+        vec![vec![number(2)], vec![number(4)], vec![number(6)]],
+    );
+    let with_unbound = result(&["x"], vec![vec![number(10)], vec![None], vec![number(20)]]);
+
+    assert_eq!(window_aggregate(&numeric, "x", Agg::Avg), Some(4.0));
+    assert_eq!(window_aggregate(&with_unbound, "x", Agg::Avg), Some(15.0));
 }

--- a/skills/streaming-rsp/SKILL.md
+++ b/skills/streaming-rsp/SKILL.md
@@ -90,7 +90,7 @@ ContinuousQuery::register(sparql: &str, spec: WindowSpec) -> Result<ContinuousQu
   .late_dropped() -> u64            // arrivals dropped because every covering window had closed
 
 // --- Optional closed-window scalar fold (feature = "window-aggregate") ---
-enum Agg { Count, Sum, Min, Max }
+enum Agg { Count, Sum, Avg, Min, Max }
 window_aggregate(window: &WindowResult, var: &str, aggregate: Agg) -> Option<f64>
 
 // --- Continuous CONSTRUCT: GraphResult { start, end, triples: Vec<Triple> } (stream->stream) ---
@@ -150,9 +150,10 @@ clock, and reported bounds are inclusive `[first_event_ts, last_event_ts]`.
 
 **Fold an emitted SELECT window to a scalar:** enable `window-aggregate`, then call
 `window_aggregate(&result, "v", Agg::Sum)`. `Count` includes every emitted row,
-even when `v` is unbound or non-numeric. `Sum`/`Min`/`Max` use well-formed XSD
-numeric literal bindings only. An unknown projected variable returns `None`; an
-empty numeric input returns `Some(0.0)` for `Sum` and `None` for `Min`/`Max`.
+even when `v` is unbound or non-numeric. `Sum`/`Avg`/`Min`/`Max` use well-formed
+XSD numeric literal bindings only. An unknown projected variable returns `None`;
+an empty numeric input returns `Some(0.0)` for `Sum` and `None` for
+`Avg`/`Min`/`Max`.
 
 **CONSTRUCT to transform a stream into another stream (each window -> a graph):**
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-xf3b8** — sparq-rsp: Agg::Avg mean fold in window_aggregate (parity with Sum/Min/Max)
sq-xf3b8.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-xf3b8","crate":"sparq-rsp","committed":true,"gates_green":true,"branch":"feat/sq-xf3b8-codex-gpt56","non_vacuity_verified":true,"notes":"All scoped gates and workspace API checks passed; mutation witness failed as expected; commit b674848b."}
```

Not armed — the orchestrator arms after review.