### PR TITLE
sparq-arrow: schema-only variable readers ipc_variables_from_bytes + p
sq-ksxa2 [GPT-5.6]

### DIFF
--- a/crates/sparq-arrow/README.md
+++ b/crates/sparq-arrow/README.md
@@ -8,6 +8,7 @@
 > [GPT-5.6] Bead `sq-lsp7k.16` adds the checked inverse, `from_record_batch`.
 > [GPT-5.6] Bead `sq-lsp7k.21` adds Parquet byte serialization over that same schema.
 > [GPT-5.6] Bead `sq-r3cab` adds Arrow IPC stream byte serialization.
+> [GPT-5.6] Bead `sq-ksxa2` adds schema-only variable readers for both containers.
 
 **Opt-in / lean-core by construction.** This is a separate leaf crate, and Arrow
 import/export sits behind the `arrow` feature (OFF by default). The `arrow-*` dependency
@@ -44,9 +45,10 @@ To serialize the same term-struct batch as an in-memory Parquet file, enable the
 default-OFF `parquet` feature:
 
 ```rust,ignore
-use sparq_arrow::{from_parquet_bytes, to_parquet_bytes};
+use sparq_arrow::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
 
 let bytes = to_parquet_bytes(&result)?;
+assert_eq!(parquet_variables_from_bytes(&bytes)?, result.vars);
 let restored = from_parquet_bytes(&bytes)?;
 assert_eq!(restored.vars, result.vars);
 assert_eq!(restored.rows, result.rows);
@@ -57,8 +59,10 @@ Use `cargo add sparq-arrow --features parquet` (or
 `cargo build -p sparq-arrow --features parquet`); `parquet` implies `arrow`.
 
 For an Arrow IPC stream instead, enable the default-OFF `ipc` feature and call
-`to_ipc_bytes(&result)` / `from_ipc_bytes(&bytes)`. The stream uses the same term-struct
-schema and preserves empty-result variables. Use `cargo add sparq-arrow --features ipc`.
+`to_ipc_bytes(&result)` / `from_ipc_bytes(&bytes)`. Call
+`ipc_variables_from_bytes(&bytes)` to read only its schema. The stream uses the same
+term-struct schema and preserves empty-result variables. Use
+`cargo add sparq-arrow --features ipc`.
 
 ## ✨ The RDF-term → Arrow mapping
 
@@ -85,6 +89,8 @@ metadata return `ArrowError`; they never panic or silently select a fallback ter
 `from_parquet_bytes` validates the recovered schema before decoding any row. Empty
 results retain their variable projection, and multiple row groups keep file order.
 `to_ipc_bytes` and `from_ipc_bytes` provide the equivalent checked Arrow IPC stream.
+The `parquet_variables_from_bytes` and `ipc_variables_from_bytes` schema readers recover
+only the variables without decoding rows.
 
 ## 📚 Honest boundary / caveats
 

--- a/crates/sparq-arrow/src/import.rs
+++ b/crates/sparq-arrow/src/import.rs
@@ -1,6 +1,7 @@
 //! The `arrow`-feature-gated import: Arrow `RecordBatch` → `QueryResult`.
 
 use arrow_array::{Array, RecordBatch, StringArray, StructArray};
+use arrow_schema::Schema;
 use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Variable};
 use sparq_engine::QueryResult;
 
@@ -31,6 +32,35 @@ impl std::fmt::Display for ArrowError {
 }
 
 impl std::error::Error for ArrowError {}
+
+// [GPT-5.6] One schema-validation path serves RecordBatch, IPC, and Parquet imports so
+// schema-only readers cannot drift from the full row decoders.
+pub(crate) fn variables_from_schema(schema: &Schema) -> Result<Vec<Variable>, ArrowError> {
+    let mut vars = Vec::with_capacity(schema.fields().len());
+    for field in schema.fields() {
+        let variable = Variable::new(field.name().to_string()).map_err(|error| {
+            ArrowError::invalid(format!(
+                "invalid SELECT variable in Arrow field '{}': {}",
+                field.name(),
+                error
+            ))
+        })?;
+        if vars.iter().any(|existing: &Variable| existing == &variable) {
+            return Err(ArrowError::invalid(format!(
+                "duplicate SELECT variable '{}' in Arrow schema",
+                field.name()
+            )));
+        }
+        if !field.is_nullable() || field.data_type() != &term_struct_type() {
+            return Err(ArrowError::invalid(format!(
+                "Arrow field '{}' does not use the nullable RDF-term struct schema",
+                field.name()
+            )));
+        }
+        vars.push(variable);
+    }
+    Ok(vars)
+}
 
 /// Convert an Arrow [`RecordBatch`] using this crate's RDF-term struct projection back
 /// into a SPARQL [`QueryResult`].
@@ -65,30 +95,10 @@ pub fn from_record_batch(batch: &RecordBatch) -> Result<QueryResult, ArrowError>
     // [GPT-5.6] Validate before reading: Arrow permits arbitrary struct schemas, while
     // this inverse is sound only for the exact lossless projection emitted by this crate.
     let schema = batch.schema();
-    let mut vars = Vec::with_capacity(schema.fields().len());
+    let vars = variables_from_schema(schema.as_ref())?;
     let mut columns = Vec::with_capacity(schema.fields().len());
 
     for (index, field) in schema.fields().iter().enumerate() {
-        let variable = Variable::new(field.name().to_string()).map_err(|error| {
-            ArrowError::invalid(format!(
-                "invalid SELECT variable in Arrow field '{}': {}",
-                field.name(),
-                error
-            ))
-        })?;
-        if vars.iter().any(|existing: &Variable| existing == &variable) {
-            return Err(ArrowError::invalid(format!(
-                "duplicate SELECT variable '{}' in Arrow schema",
-                field.name()
-            )));
-        }
-        if !field.is_nullable() || field.data_type() != &term_struct_type() {
-            return Err(ArrowError::invalid(format!(
-                "Arrow field '{}' does not use the nullable RDF-term struct schema",
-                field.name()
-            )));
-        }
-
         let column = batch
             .column(index)
             .as_any()
@@ -99,7 +109,6 @@ pub fn from_record_batch(batch: &RecordBatch) -> Result<QueryResult, ArrowError>
                     field.name()
                 ))
             })?;
-        vars.push(variable);
         columns.push(column);
     }
 

--- a/crates/sparq-arrow/src/ipc.rs
+++ b/crates/sparq-arrow/src/ipc.rs
@@ -1,11 +1,12 @@
 //! The `ipc`-feature-gated Arrow IPC stream serialization of the RDF-term projection.
 
-use arrow_array::RecordBatch;
 use arrow_ipc::reader::StreamReader;
 use arrow_ipc::writer::StreamWriter;
 use arrow_schema::ArrowError as ArrowLibraryError;
+use oxrdf::Variable;
 use sparq_engine::QueryResult;
 
+use crate::import::variables_from_schema;
 use crate::{from_record_batch, to_record_batch, ArrowError, ArrowExportError};
 
 fn import_error(error: ArrowLibraryError) -> ArrowError {
@@ -33,6 +34,20 @@ pub fn to_ipc_bytes(result: &QueryResult) -> Result<Vec<u8>, ArrowExportError> {
     writer.into_inner().map_err(ArrowExportError::from)
 }
 
+/// Read the SPARQL `SELECT` variables from an Arrow IPC stream schema.
+///
+/// This validates the same variable names and nullable five-field RDF-term struct
+/// schema as [`from_ipc_bytes`], but does not decode any record batches.
+///
+/// # Errors
+///
+/// Returns [`ArrowError`] if `bytes` do not contain a readable Arrow IPC stream header
+/// or its schema violates this crate's RDF-term projection contract.
+pub fn ipc_variables_from_bytes(bytes: &[u8]) -> Result<Vec<Variable>, ArrowError> {
+    let reader = StreamReader::try_new(bytes, None).map_err(import_error)?;
+    variables_from_schema(reader.schema().as_ref())
+}
+
 /// Deserialize an Arrow IPC stream containing this crate's RDF-term projection.
 ///
 /// Every decoded batch is validated through [`from_record_batch`]. The stream schema is
@@ -48,9 +63,11 @@ pub fn from_ipc_bytes(bytes: &[u8]) -> Result<QueryResult, ArrowError> {
     let reader = StreamReader::try_new(bytes, None).map_err(import_error)?;
 
     // Validate the stream header independently of its batches so a zero-row stream
-    // cannot bypass the schema contract. `new_empty` retains the SELECT variable names.
-    let empty = RecordBatch::new_empty(reader.schema());
-    let mut result = from_record_batch(&empty)?;
+    // cannot bypass the schema contract.
+    let mut result = QueryResult {
+        vars: variables_from_schema(reader.schema().as_ref())?,
+        rows: Vec::new(),
+    };
 
     for batch in reader {
         let decoded = from_record_batch(&batch.map_err(decode_error)?)?;

--- a/crates/sparq-arrow/src/lib.rs
+++ b/crates/sparq-arrow/src/lib.rs
@@ -49,10 +49,12 @@
 //!   `from_record_batch` reconstructs terms from the five fields, but the Arrow batch is not
 //!   itself an RDF document.
 //! * With the opt-in `parquet` feature, `to_parquet_bytes` / `from_parquet_bytes`
-//!   serialize and restore this exact RecordBatch projection. Parquet adds a container;
-//!   it does not define a second RDF-term encoding.
+//!   serialize and restore this exact RecordBatch projection;
+//!   `parquet_variables_from_bytes` reads only its variables from the stored schema.
+//!   Parquet adds a container; it does not define a second RDF-term encoding.
 //! * With the opt-in `ipc` feature, `to_ipc_bytes` / `from_ipc_bytes` do the same through
-//!   the Arrow IPC streaming format, including preservation of an empty result's schema.
+//!   the Arrow IPC streaming format, including preservation of an empty result's schema;
+//!   `ipc_variables_from_bytes` reads that schema without decoding record batches.
 
 /// Struct field name: the term kind — `"uri"`, `"bnode"`, `"literal"`, or `"triple"`.
 pub const FIELD_KIND: &str = "kind";
@@ -101,8 +103,8 @@ pub use import::{from_record_batch, ArrowError};
 
 #[cfg(feature = "parquet")]
 #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
-pub use parquet::{from_parquet_bytes, to_parquet_bytes};
+pub use parquet::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
 
 #[cfg(feature = "ipc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]
-pub use ipc::{from_ipc_bytes, to_ipc_bytes};
+pub use ipc::{from_ipc_bytes, ipc_variables_from_bytes, to_ipc_bytes};

--- a/crates/sparq-arrow/src/parquet.rs
+++ b/crates/sparq-arrow/src/parquet.rs
@@ -1,13 +1,14 @@
 //! The `parquet`-feature-gated serialization of the Arrow RDF-term projection.
 
-use arrow_array::RecordBatch;
 use arrow_schema::ArrowError as ArrowLibraryError;
 use bytes::Bytes;
+use oxrdf::Variable;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use parquet::errors::ParquetError;
 use sparq_engine::QueryResult;
 
+use crate::import::variables_from_schema;
 use crate::{from_record_batch, to_record_batch, ArrowError, ArrowExportError};
 
 // [GPT-5.6] Keep Parquet failures inside the existing export error surface instead of
@@ -42,6 +43,22 @@ pub fn to_parquet_bytes(result: &QueryResult) -> Result<Vec<u8>, ArrowExportErro
     writer.into_inner().map_err(export_error)
 }
 
+/// Read the SPARQL `SELECT` variables from a Parquet file's Arrow schema.
+///
+/// This validates the same variable names and nullable five-field RDF-term struct
+/// schema as [`from_parquet_bytes`], but does not build a record-batch reader or decode
+/// any row groups.
+///
+/// # Errors
+///
+/// Returns [`ArrowError`] if `bytes` do not contain readable Parquet metadata or their
+/// Arrow schema violates this crate's RDF-term projection contract.
+pub fn parquet_variables_from_bytes(bytes: &[u8]) -> Result<Vec<Variable>, ArrowError> {
+    let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::copy_from_slice(bytes))
+        .map_err(import_error)?;
+    variables_from_schema(builder.schema().as_ref())
+}
+
 /// Deserialize Parquet bytes containing this crate's RDF-term Arrow projection.
 ///
 /// Every decoded batch is validated through [`from_record_batch`]. This includes files
@@ -59,9 +76,11 @@ pub fn from_parquet_bytes(bytes: &[u8]) -> Result<QueryResult, ArrowError> {
         .map_err(import_error)?;
 
     // Validate independently of decoded batches so a zero-row file cannot bypass the
-    // schema contract. `new_empty` retains all variable names and struct field metadata.
-    let empty = RecordBatch::new_empty(builder.schema().clone());
-    let mut result = from_record_batch(&empty)?;
+    // schema contract.
+    let mut result = QueryResult {
+        vars: variables_from_schema(builder.schema().as_ref())?,
+        rows: Vec::new(),
+    };
 
     let reader = builder.build().map_err(import_error)?;
     for batch in reader {

--- a/crates/sparq-arrow/tests/ipc.rs
+++ b/crates/sparq-arrow/tests/ipc.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "ipc")]
 
 use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Triple, Variable};
-use sparq_arrow::{from_ipc_bytes, to_ipc_bytes};
+use sparq_arrow::{from_ipc_bytes, ipc_variables_from_bytes, to_ipc_bytes};
 use sparq_engine::QueryResult;
 
 fn assert_ipc_identity(result: &QueryResult) {
@@ -48,6 +48,29 @@ fn every_term_kind_empty_literal_and_unbound_round_trip_row_for_row() {
     assert_ipc_identity(&result);
 }
 
+/// [GPT-5.6] Value-pinned mutation witness: changing either expected name fails while
+/// the encoded rows remain untouched.
+#[test]
+fn schema_only_reader_recovers_nonempty_result_variables() {
+    let result = QueryResult {
+        vars: vec![Variable::new("s").unwrap(), Variable::new("label").unwrap()],
+        rows: vec![vec![
+            Some(Term::NamedNode(
+                NamedNode::new("https://example.test/s").unwrap(),
+            )),
+            Some(Term::Literal(Literal::new_simple_literal("label"))),
+        ]],
+    };
+    let bytes = to_ipc_bytes(&result).unwrap();
+
+    let variables = ipc_variables_from_bytes(&bytes).unwrap();
+    assert_eq!(variables, result.vars);
+    assert_eq!(
+        variables.iter().map(Variable::as_str).collect::<Vec<_>>(),
+        ["s", "label"]
+    );
+}
+
 #[test]
 fn empty_result_preserves_two_variable_schema_and_zero_rows() {
     let result = QueryResult {
@@ -58,6 +81,8 @@ fn empty_result_preserves_two_variable_schema_and_zero_rows() {
         rows: Vec::new(),
     };
 
+    let bytes = to_ipc_bytes(&result).unwrap();
+    assert_eq!(ipc_variables_from_bytes(&bytes).unwrap(), result.vars);
     assert_ipc_identity(&result);
 }
 

--- a/crates/sparq-arrow/tests/parquet.rs
+++ b/crates/sparq-arrow/tests/parquet.rs
@@ -7,7 +7,7 @@ use arrow_array::{ArrayRef, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Triple, Variable};
 use parquet::arrow::ArrowWriter;
-use sparq_arrow::{from_parquet_bytes, to_parquet_bytes};
+use sparq_arrow::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
 use sparq_engine::QueryResult;
 
 fn assert_identity(result: &QueryResult) {
@@ -53,6 +53,29 @@ fn every_term_kind_empty_literal_and_unbound_round_trip_row_for_row() {
     assert_identity(&result);
 }
 
+/// [GPT-5.6] Value-pinned mutation witness: changing either expected name fails while
+/// the encoded rows remain untouched.
+#[test]
+fn schema_only_reader_recovers_nonempty_result_variables() {
+    let result = QueryResult {
+        vars: vec![Variable::new("s").unwrap(), Variable::new("o").unwrap()],
+        rows: vec![vec![
+            Some(Term::NamedNode(
+                NamedNode::new("https://example.test/s").unwrap(),
+            )),
+            Some(Term::Literal(Literal::new_simple_literal("object"))),
+        ]],
+    };
+    let bytes = to_parquet_bytes(&result).unwrap();
+
+    let variables = parquet_variables_from_bytes(&bytes).unwrap();
+    assert_eq!(variables, result.vars);
+    assert_eq!(
+        variables.iter().map(Variable::as_str).collect::<Vec<_>>(),
+        ["s", "o"]
+    );
+}
+
 #[test]
 fn empty_result_preserves_variable_schema_and_zero_rows() {
     let result = QueryResult {
@@ -63,6 +86,8 @@ fn empty_result_preserves_variable_schema_and_zero_rows() {
         rows: Vec::new(),
     };
 
+    let bytes = to_parquet_bytes(&result).unwrap();
+    assert_eq!(parquet_variables_from_bytes(&bytes).unwrap(), result.vars);
     assert_identity(&result);
 }
 
@@ -76,6 +101,14 @@ fn parquet_with_deviating_arrow_schema_is_rejected() {
     let mut writer = ArrowWriter::try_new(Vec::new(), schema, None).unwrap();
     writer.write(&batch).unwrap();
     let bytes = writer.into_inner().unwrap();
+
+    let schema_error = parquet_variables_from_bytes(&bytes).unwrap_err();
+    assert!(
+        schema_error
+            .to_string()
+            .contains("does not use the nullable RDF-term struct schema"),
+        "{schema_error}"
+    );
 
     let error = from_parquet_bytes(&bytes).unwrap_err();
     assert!(

--- a/crates/sparq-arrow/tests/record_batch.rs
+++ b/crates/sparq-arrow/tests/record_batch.rs
@@ -13,11 +13,11 @@ use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
 use arrow_array::{Array, ArrayRef, RecordBatch, StringArray, StructArray};
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Schema};
 use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Triple, Variable};
 use sparq_arrow::{
-    from_record_batch, term_schema, to_record_batch, FIELD_DATATYPE, FIELD_DIRECTION, FIELD_KIND,
-    FIELD_LANGUAGE, FIELD_VALUE,
+    from_record_batch, term_schema, term_struct_type, to_record_batch, FIELD_DATATYPE,
+    FIELD_DIRECTION, FIELD_KIND, FIELD_LANGUAGE, FIELD_VALUE,
 };
 use sparq_core::Graph;
 use sparq_engine::{query, QueryResult};
@@ -293,6 +293,22 @@ fn invalid_term_schema_is_rejected() {
         error
             .to_string()
             .contains("does not use the nullable RDF-term struct schema"),
+        "{error}"
+    );
+}
+
+/// Duplicate field names are rejected by the shared schema-to-variable validator.
+#[test]
+fn duplicate_import_variable_is_rejected() {
+    let field = Field::new("term", term_struct_type(), true);
+    let schema = Arc::new(Schema::new(vec![field.clone(), field]));
+    let batch = RecordBatch::new_empty(schema);
+
+    let error = from_record_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate SELECT variable 'term' in Arrow schema"),
         "{error}"
     );
 }

--- a/skills/arrow-columnar/SKILL.md
+++ b/skills/arrow-columnar/SKILL.md
@@ -14,8 +14,10 @@ Use `sparq-arrow` when a Rust application needs a faithful columnar representati
 
 - Enable `arrow` for `to_record_batch`, `from_record_batch`, `term_schema`, and
   `term_struct_type`.
-- Enable `parquet` for `to_parquet_bytes` and `from_parquet_bytes`; it implies `arrow`.
-- Enable `ipc` for `to_ipc_bytes` and `from_ipc_bytes`; it implies `arrow`.
+- Enable `parquet` for `to_parquet_bytes`, `from_parquet_bytes`, and
+  `parquet_variables_from_bytes`; it implies `arrow`.
+- Enable `ipc` for `to_ipc_bytes`, `from_ipc_bytes`, and
+  `ipc_variables_from_bytes`; it implies `arrow`.
 - Leave all features disabled to retain only the dependency-free field-name constants.
 
 All features are default-OFF. The crate is a leaf capability crate, so no Arrow
@@ -38,10 +40,12 @@ Add the feature with `cargo add sparq-arrow --features arrow`.
 ## Use Parquet bytes
 
 ```rust,ignore
-use sparq_arrow::{from_parquet_bytes, to_parquet_bytes};
+use sparq_arrow::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
 
 let bytes: Vec<u8> = to_parquet_bytes(&result)?;
+let variables = parquet_variables_from_bytes(&bytes)?;
 let restored = from_parquet_bytes(&bytes)?;
+assert_eq!(variables, result.vars);
 assert_eq!(restored.vars, result.vars);
 assert_eq!(restored.rows, result.rows);
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -49,16 +53,19 @@ assert_eq!(restored.rows, result.rows);
 
 Add the feature with `cargo add sparq-arrow --features parquet`. Parquet is only a
 serialization of the same RecordBatch projection; it does not use a second term
-encoding. `from_parquet_bytes` rejects unreadable files, a schema that deviates from the
-five-field term struct, and invalid RDF lexical components.
+encoding. `parquet_variables_from_bytes` validates and reads only the stored schema,
+without decoding row groups. `from_parquet_bytes` additionally rejects invalid RDF
+lexical components while decoding rows.
 
 ## Use Arrow IPC stream bytes
 
 ```rust,ignore
-use sparq_arrow::{from_ipc_bytes, to_ipc_bytes};
+use sparq_arrow::{from_ipc_bytes, ipc_variables_from_bytes, to_ipc_bytes};
 
 let bytes: Vec<u8> = to_ipc_bytes(&result)?;
+let variables = ipc_variables_from_bytes(&bytes)?;
 let restored = from_ipc_bytes(&bytes)?;
+assert_eq!(variables, result.vars);
 assert_eq!(restored.vars, result.vars);
 assert_eq!(restored.rows, result.rows);
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -66,6 +73,7 @@ assert_eq!(restored.rows, result.rows);
 
 Add the feature with `cargo add sparq-arrow --features ipc`. The IPC stream carries the
 same schema as the RecordBatch and preserves variable names for an empty result.
+`ipc_variables_from_bytes` validates and reads that schema without decoding batches.
 
 ## Preserve the mapping
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-ksxa2** — sparq-arrow: schema-only variable readers ipc_variables_from_bytes + parquet_variables_from_bytes (parity with from_ipc_bytes/from_parquet_bytes)
sq-ksxa2.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-ksxa2","crate":"sparq-arrow","committed":true,"gates_green":true,"branch":"feat/sq-ksxa2-codex-gpt56","non_vacuity_verified":true,"notes":"clippy_preexisting_drift:sparq-core,sparq-arrow/export.rs; all owned checks green"}
```

Not armed — the orchestrator arms after review.