### PR TITLE
sparq-hdt: stats_reader_filtered() triple-pattern-filtered archive sta
sq-obhf1 [GPT-5.6]

### DIFF
--- a/crates/sparq-hdt/README.md
+++ b/crates/sparq-hdt/README.md
@@ -65,11 +65,11 @@ export direction over `save` (sq-8ju74).
 - **Header access**: `header()` / `header_reader()` decode just the dataset
   metadata triples (the "H" in HDT) into a queryable `Graph` without touching
   the dictionary/triples sections.
-- **Filtered loading** (opt-in `load-filter` feature, [GPT-5.6] sq-lsp7k.24):
-  `load_reader_filtered(reader, &(subject, predicate, object))` accepts an
-  `Option` in each position, with `None` as a wildcard. It filters during the
-  one-shot SPO walk and interns only accepted triples into the returned graph;
-  an all-wildcard pattern is identical to `load_reader`.
+- **Filtered loading and stats** (opt-in `load-filter` feature, [GPT-5.6]
+  sq-lsp7k.24 / sq-obhf1): `load_reader_filtered(reader, &pattern)` loads matches;
+  `stats_reader_filtered(reader, &pattern)` counts them without constructing a
+  result graph. Both filter during the one-shot SPO walk; an all-wildcard pattern
+  is identical to the corresponding unfiltered operation.
 - **Writing** (opt-in `write` feature): `save(&graph, path)` serialises a `Graph` to a
   standard-layout `.hdt` (or `.hdt.gz`/`.hdt.zst`/`.hdt.bz2`, chosen by the output
   extension), encoding the HDT sections **directly** from sparq's in-memory dictionary +

--- a/crates/sparq-hdt/src/decode.rs
+++ b/crates/sparq-hdt/src/decode.rs
@@ -657,7 +657,7 @@ pub struct StageTimings {
 /// [`decode_dict`] when (and only when) the caller asks for finer timings. Each section
 /// wall is the elapsed of that section's lone [`decode_section`] call (timed inside the
 /// rayon worker in the parallel path, so the four overlap there); `merge` is the four
-/// [`merge_section`] calls. Folded into [`StageTimings`] by [`graph_from_reader_impl`].
+/// [`merge_section`] calls. Folded into [`StageTimings`] by [`decode_reader_with`].
 #[derive(Debug, Clone, Copy, Default)]
 struct DictSectionTimings {
     shared: std::time::Duration,
@@ -671,35 +671,34 @@ struct DictSectionTimings {
 /// collector is monomorphised, keeping the existing unfiltered hot loop free of
 /// dynamic dispatch and feature-specific branches.
 trait TripleCollector {
+    type Output;
+
     fn push(&mut self, source: &Dict, triple: [Id; 3]);
-    fn into_graph(self, source: Dict) -> Graph;
+    fn finish(self, source: Dict, archive_stats: HdtStats) -> Self::Output;
 }
 
 struct AllTriples(Vec<[Id; 3]>);
 
 impl TripleCollector for AllTriples {
+    type Output = Graph;
+
     #[inline]
     fn push(&mut self, _source: &Dict, triple: [Id; 3]) {
         self.0.push(triple);
     }
 
-    fn into_graph(self, source: Dict) -> Graph {
+    fn finish(self, source: Dict, _archive_stats: HdtStats) -> Self::Output {
         Graph::from_parts(source, self.0)
     }
 }
 
-/// [GPT-5.6] sq-lsp7k.24: collector for the opt-in filtered loader. Pattern
-/// terms are resolved once to source-dictionary ids; only accepted triples are
-/// re-interned into the result dictionary.
+/// [GPT-5.6] sq-obhf1: one pattern-resolution and match predicate shared by
+/// filtered graph loading and filtered statistics.
 #[cfg(feature = "load-filter")]
-struct FilteredTriples {
-    bound: [Option<Id>; 3],
-    dict: Dict,
-    triples: Vec<[Id; 3]>,
-}
+struct ResolvedPattern([Option<Id>; 3]);
 
 #[cfg(feature = "load-filter")]
-impl FilteredTriples {
+impl ResolvedPattern {
     fn new(source: &Dict, pattern: &TriplePattern) -> Self {
         let subject = pattern.0.as_ref().map(|subject| {
             let term: oxrdf::Term = subject.clone().into();
@@ -710,8 +709,33 @@ impl FilteredTriples {
             source.lookup(&term)
         });
         let object = pattern.2.as_ref().map(|object| source.lookup(object));
+        Self([subject, predicate, object])
+    }
+
+    #[inline]
+    fn matches(&self, triple: [Id; 3]) -> bool {
+        self.0
+            .iter()
+            .zip(triple)
+            .all(|(bound, id)| bound.is_none_or(|expected| expected == id))
+    }
+}
+
+/// [GPT-5.6] sq-lsp7k.24: collector for the opt-in filtered loader. Pattern
+/// terms are resolved once to source-dictionary ids; only accepted triples are
+/// re-interned into the result dictionary.
+#[cfg(feature = "load-filter")]
+struct FilteredTriples {
+    pattern: ResolvedPattern,
+    dict: Dict,
+    triples: Vec<[Id; 3]>,
+}
+
+#[cfg(feature = "load-filter")]
+impl FilteredTriples {
+    fn new(source: &Dict, pattern: &TriplePattern) -> Self {
         Self {
-            bound: [subject, predicate, object],
+            pattern: ResolvedPattern::new(source, pattern),
             dict: Dict::new(),
             // Do not reserve the archive's full triple count: a selective pattern
             // must retain memory in proportion to its matches, not its input.
@@ -722,14 +746,11 @@ impl FilteredTriples {
 
 #[cfg(feature = "load-filter")]
 impl TripleCollector for FilteredTriples {
+    type Output = Graph;
+
     #[inline]
     fn push(&mut self, source: &Dict, triple: [Id; 3]) {
-        if !self
-            .bound
-            .iter()
-            .zip(triple)
-            .all(|(bound, id)| bound.is_none_or(|expected| expected == id))
-        {
+        if !self.pattern.matches(triple) {
             return;
         }
 
@@ -737,8 +758,43 @@ impl TripleCollector for FilteredTriples {
         self.triples.push(translated);
     }
 
-    fn into_graph(self, _source: Dict) -> Graph {
+    fn finish(self, _source: Dict, _archive_stats: HdtStats) -> Self::Output {
         Graph::from_parts(self.dict, self.triples)
+    }
+}
+
+/// [GPT-5.6] sq-obhf1: counts accepted triples in the same monomorphised SPO
+/// walk as [`FilteredTriples`], without constructing a result dictionary or graph.
+#[cfg(feature = "load-filter")]
+struct FilteredStats {
+    pattern: ResolvedPattern,
+    triples: usize,
+}
+
+#[cfg(feature = "load-filter")]
+impl FilteredStats {
+    fn new(source: &Dict, pattern: &TriplePattern) -> Self {
+        Self {
+            pattern: ResolvedPattern::new(source, pattern),
+            triples: 0,
+        }
+    }
+}
+
+#[cfg(feature = "load-filter")]
+impl TripleCollector for FilteredStats {
+    type Output = HdtStats;
+
+    #[inline]
+    fn push(&mut self, _source: &Dict, triple: [Id; 3]) {
+        if self.pattern.matches(triple) {
+            self.triples += 1;
+        }
+    }
+
+    fn finish(self, _source: Dict, mut archive_stats: HdtStats) -> Self::Output {
+        archive_stats.triples = self.triples;
+        archive_stats
     }
 }
 
@@ -747,7 +803,7 @@ impl TripleCollector for FilteredTriples {
 /// decodes the triples section's bitmaps/sequences directly and emits SPO
 /// id-triples — never constructing the upstream wavelet matrix / OP-index.
 pub fn graph_from_reader<R: BufRead>(reader: R) -> Result<Graph, Error> {
-    graph_from_reader_impl(reader, None, |_dict, capacity| {
+    decode_reader_with(reader, None, |_dict, capacity| {
         AllTriples(Vec::with_capacity(capacity))
     })
 }
@@ -758,8 +814,19 @@ pub(crate) fn graph_from_reader_filtered<R: BufRead>(
     reader: R,
     pattern: &TriplePattern,
 ) -> Result<Graph, Error> {
-    graph_from_reader_impl(reader, None, |dict, _capacity| {
+    decode_reader_with(reader, None, |dict, _capacity| {
         FilteredTriples::new(dict, pattern)
+    })
+}
+
+/// Opt-in filtered statistics over the same walk as [`graph_from_reader_filtered`].
+#[cfg(feature = "load-filter")]
+pub(crate) fn stats_from_reader_filtered<R: BufRead>(
+    reader: R,
+    pattern: &TriplePattern,
+) -> Result<HdtStats, Error> {
+    decode_reader_with(reader, None, |dict, _capacity| {
+        FilteredStats::new(dict, pattern)
     })
 }
 
@@ -771,16 +838,16 @@ pub fn graph_from_reader_timed<R: BufRead>(
     reader: R,
     timings: &mut StageTimings,
 ) -> Result<Graph, Error> {
-    graph_from_reader_impl(reader, Some(timings), |_dict, capacity| {
+    decode_reader_with(reader, Some(timings), |_dict, capacity| {
         AllTriples(Vec::with_capacity(capacity))
     })
 }
 
-fn graph_from_reader_impl<R, C, F>(
+fn decode_reader_with<R, C, F>(
     mut reader: R,
     mut timings: Option<&mut StageTimings>,
     make_collector: F,
-) -> Result<Graph, Error>
+) -> Result<C::Output, Error>
 where
     R: BufRead,
     C: TripleCollector,
@@ -861,6 +928,13 @@ where
     // `stats.reserve(n.min(max_records))` in sparq-core's `load_pred_stats`.
     let cap_triples = num_triples.min(sequence_z.data.len().saturating_mul(64));
     let mut collector = make_collector(&dict, cap_triples);
+    let archive_stats = HdtStats {
+        triples: num_triples,
+        shared: dict_hdt.shared.num_strings,
+        subjects_only: dict_hdt.subjects.num_strings,
+        objects_only: dict_hdt.objects.num_strings,
+        predicates: dict_hdt.predicates.num_strings,
+    };
 
     // Sequential SPO walk, mirroring `SubjectIter::next` but with predicates from
     // `sequence_y` (H2) and end-of-run bits from raw bitmap reads (no wavelet, no
@@ -899,11 +973,11 @@ where
         t.scan_walk = t_build.duration_since(t_walk);
     }
 
-    let graph = collector.into_graph(dict);
+    let output = collector.finish(dict, archive_stats);
     if let Some(t) = timings.as_mut() {
         t.build = t_build.elapsed();
     }
-    Ok(graph)
+    Ok(output)
 }
 
 #[cfg(test)]

--- a/crates/sparq-hdt/src/lib.rs
+++ b/crates/sparq-hdt/src/lib.rs
@@ -332,6 +332,25 @@ pub fn stats_reader<R: BufRead>(reader: R) -> Result<HdtStats, Error> {
     with_hdt_stream(reader, |r| decode::stats_from_reader(r))
 }
 
+// [GPT-5.6] sq-obhf1: filtered count parity with `load_reader_filtered`.
+/// Counts triples matching `pattern` without constructing a result [`Graph`].
+///
+/// Matching uses the same one-shot SPO walk and resolved [`TriplePattern`] as
+/// [`load_reader_filtered`]. The returned [`HdtStats::triples`] is the number of
+/// matches; its dictionary cardinalities still describe the complete archive.
+/// An all-wildcard pattern is exactly equivalent to [`stats_reader`]. Compressed
+/// containers are detected and streamed as in [`load_reader`].
+#[cfg(feature = "load-filter")]
+pub fn stats_reader_filtered<R: BufRead>(
+    reader: R,
+    pattern: &TriplePattern,
+) -> Result<HdtStats, Error> {
+    if pattern.0.is_none() && pattern.1.is_none() && pattern.2.is_none() {
+        return stats_reader(reader);
+    }
+    with_hdt_stream(reader, |r| decode::stats_from_reader_filtered(r, pattern))
+}
+
 /// Converts an already-decoded [`hdt::Hdt`] into a sparq [`Graph`] — the seam for
 /// callers that hold an `Hdt` (e.g. to also query its header metadata).
 pub fn graph_from_hdt(hdt: &Hdt) -> Result<Graph, Error> {

--- a/crates/sparq-hdt/tests/load_filtered.rs
+++ b/crates/sparq-hdt/tests/load_filtered.rs
@@ -58,6 +58,46 @@ fn predicate_filter_matches_full_load_oracle() {
     assert_eq!(triple_set(&actual), expected);
 }
 
+// [GPT-5.6] sq-obhf1: value-pinned parity and mutation witness for filtered stats.
+#[test]
+fn filtered_stats_match_filtered_load_and_wildcard_stats() {
+    let bytes = load_bytes();
+    let predicate = NamedNode::new("http://www.w3.org/2000/01/rdf-schema#label").unwrap();
+    let pattern = (None, Some(predicate), None);
+
+    let filtered_stats =
+        sparq_hdt::stats_reader_filtered(std::io::Cursor::new(bytes.clone()), &pattern)
+            .expect("counting predicate matches");
+    let filtered_graph =
+        sparq_hdt::load_reader_filtered(std::io::Cursor::new(bytes.clone()), &pattern)
+            .expect("loading predicate matches");
+    let archive_stats = sparq_hdt::stats_reader(std::io::Cursor::new(bytes.clone()))
+        .expect("counting the complete archive");
+    let wildcard_stats =
+        sparq_hdt::stats_reader_filtered(std::io::Cursor::new(bytes), &(None, None, None))
+            .expect("counting an all-wildcard pattern");
+
+    assert_eq!(archive_stats.triples, 328, "fixture triple count changed");
+    assert_eq!(
+        filtered_stats.triples, 74,
+        "fixture predicate count changed"
+    );
+    assert_eq!(filtered_stats.triples, filtered_graph.len());
+    assert_eq!(wildcard_stats, archive_stats);
+    assert_eq!(
+        filtered_stats,
+        sparq_hdt::HdtStats {
+            triples: 74,
+            ..archive_stats
+        },
+        "dictionary cardinalities remain archive-wide"
+    );
+    assert_ne!(
+        filtered_stats.triples, archive_stats.triples,
+        "a real predicate filter must not return the unfiltered count"
+    );
+}
+
 #[test]
 fn all_wildcards_are_identical_to_load_reader() {
     let bytes = load_bytes();

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -194,6 +194,8 @@ pub type TriplePattern = (
 );
 #[cfg(feature = "load-filter")]
 pub fn load_reader_filtered<R: BufRead>(reader: R, pattern: &TriplePattern) -> Result<Graph, Error>
+#[cfg(feature = "load-filter")]
+pub fn stats_reader_filtered<R: BufRead>(reader: R, pattern: &TriplePattern) -> Result<HdtStats, Error>
 
 pub fn header(path: impl AsRef<Path>) -> Result<Graph, Error>       // HDT header metadata as a Graph
 pub fn header_reader<R: BufRead>(reader: R) -> Result<Graph, Error>
@@ -268,7 +270,10 @@ let pattern: sparq_hdt::TriplePattern = (
     Some(oxrdf::NamedNode::new("http://www.w3.org/2000/01/rdf-schema#label")?),
     None,
 );
+// [GPT-5.6] sq-obhf1: count matches without constructing a result Graph/Dict.
+let label_stats = sparq_hdt::stats_reader_filtered(std::io::Cursor::new(bytes.clone()), &pattern)?;
 let labels = sparq_hdt::load_reader_filtered(std::io::Cursor::new(bytes), &pattern)?;
+assert_eq!(label_stats.triples, labels.len());
 // WRITE back (opt-in `write` feature): sparq_hdt::save(&g, "out.hdt.gz")?;
 //   (currently a temp-N-Triples round-trip through the wrapped builder — see
 //    sparq-hdt/UPSTREAM.md for the queued in-memory-builder contribution)
@@ -626,10 +631,11 @@ cargo build -p sparq-cli --features serialize-rdf
   file extension**, so a mislabeled `.hdt` still loads; all three (`gz`/`zst`/`bz2`) decode
   in a streaming fashion.
 - **HDT triple-pattern loading is separately opt-in.** Enable `sparq-hdt`'s
-  `load-filter` feature for `TriplePattern` and `load_reader_filtered`. The
-  decoder still validates and decodes the archive dictionary, but rejected
-  triples are not accumulated, interned into the result, or indexed; result
-  memory therefore follows the matches rather than the full triple set.
+  `load-filter` feature for `TriplePattern`, `load_reader_filtered`, and
+  `stats_reader_filtered`. Both filtered operations share one resolved-pattern
+  SPO walk. The stats call counts matches without building a result graph; its
+  dictionary cardinalities remain archive-wide. The loader does not accumulate,
+  intern, or index rejected triples, so result memory follows the matches.
 - **HDT format coverage:** standard v1.0 layout only (FourSectionDictionary / Plain Front
   Coding + BitmapTriples, SPO order) as emitted by hdt-cpp / hdt-java. Exotic submission
   layouts are rejected with an error.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-obhf1** — sparq-hdt: stats_reader_filtered() triple-pattern-filtered archive stats (parity with load_reader_filtered/stats_reader)
sq-obhf1.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-obhf1","crate":"sparq-hdt","committed":true,"gates_green":true,"branch":"feat/sq-obhf1-codex-gpt56","non_vacuity_verified":true,"notes":"commit 74a921ca; all required gates green; no clippy drift"}
```

Not armed — the orchestrator arms after review.