### PR TITLE
sparq-server TCP serve path should inject ConnectInfo(peer_addr) for p
sq-rejk9 [GPT-5.6]

### DIFF
--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -4150,10 +4150,12 @@ pub fn harden(routes: Router, config: &ServerConfig) -> Router {
 /// This loop is a faithful port of `axum::serve`'s own accept + graceful-shutdown loop
 /// (per-connection task, watch-channel drain, `serve_connection(...).with_upgrades()` so the
 /// `/subscriptions` WebSocket upgrade still works) with two behavioural additions: the connection
-/// builder installs a `TokioTimer` and sets `header_read_timeout`, and the per-connection service
-/// optionally wraps the body in the `body_read_timeout` layer. `None` on either opts back out to
-/// the unbounded behaviour. axum is configured HTTP/1-only (no `http2` feature), so this uses
-/// hyper's `http1::Builder` directly — the smallest builder that carries the header knob.
+/// builder installs a `TokioTimer` and sets `header_read_timeout`, the per-connection service
+/// optionally wraps the body in the `body_read_timeout` layer, and each request receives the
+/// accepted peer as `ConnectInfo<SocketAddr>` (matching the HTTP/3 listener). `None` on either
+/// deadline opts back out to the unbounded behaviour. axum is configured HTTP/1-only (no `http2`
+/// feature), so this uses hyper's `http1::Builder` directly — the smallest builder that carries
+/// the header knob.
 #[cfg(feature = "server")]
 pub async fn serve<F>(
     listener: tokio::net::TcpListener,
@@ -4165,6 +4167,7 @@ pub async fn serve<F>(
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
+    use axum::{extract::ConnectInfo, Extension};
     use futures_util::FutureExt;
     use hyper_util::rt::{TokioIo, TokioTimer};
     use hyper_util::service::TowerToHyperService;
@@ -4195,7 +4198,7 @@ where
     drop(_close_rx); // the loop itself does not hold a connection slot
 
     loop {
-        let (stream, _remote) = tokio::select! {
+        let (stream, remote) = tokio::select! {
             conn = listener.accept() => match conn {
                 Ok(c) => c,
                 // A transient accept error (e.g. EMFILE / a peer that vanished mid-handshake)
@@ -4216,7 +4219,9 @@ where
         let io = TokioIo::new(stream);
         // [OPUS-4.8] sq-lodb: apply the (optional) slow-body read/idle deadline around this
         // connection's clone of the router, then hand the composed tower service to hyper.
+        // [GPT-5.6] sq-rejk9: expose the accepted TCP peer to every request, matching serve_h3.
         let service = ServiceBuilder::new()
+            .layer(Extension(ConnectInfo(remote)))
             .layer(body_timeout_layer.clone())
             .service(app.clone());
         let hyper_service = TowerToHyperService::new(service);

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -982,6 +982,49 @@ async fn spawn_serve(config: ServerConfig) -> SocketAddr {
     addr
 }
 
+/// [GPT-5.6] sq-rejk9: the bespoke TCP loop must preserve axum's peer-address contract just as
+/// the HTTP/3 dispatch path does. A missing extension makes the extractor reject this request,
+/// while checking the exact source socket prevents a placeholder address from satisfying it.
+#[tokio::test]
+async fn tcp_serve_injects_peer_connect_info() {
+    use axum::extract::ConnectInfo;
+    use axum::routing::get;
+
+    async fn peer(ConnectInfo(addr): ConnectInfo<SocketAddr>) -> String {
+        addr.to_string()
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_addr = listener.local_addr().unwrap();
+    let app = axum::Router::new().route("/peer", get(peer));
+    tokio::spawn(async move {
+        sparq_server::serve(listener, app, None, None, std::future::pending::<()>())
+            .await
+            .unwrap();
+    });
+
+    let mut socket = TcpStream::connect(server_addr).await.unwrap();
+    let expected_peer = socket.local_addr().unwrap();
+    socket
+        .write_all(b"GET /peer HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+
+    let mut response = String::new();
+    tokio::time::timeout(Duration::from_secs(5), socket.read_to_string(&mut response))
+        .await
+        .expect("TCP response timed out")
+        .unwrap();
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "response: {response:?}"
+    );
+    assert!(
+        response.ends_with(&expected_peer.to_string()),
+        "handler saw the wrong peer; expected {expected_peer}, response: {response:?}"
+    );
+}
+
 /// A slow-loris connection: open a socket, send a partial request line + ONE header, then
 /// never send the terminating blank line. With a short `header_read_timeout` the SERVER must
 /// close the connection (a read returns 0 / a reset) within roughly the deadline. Without the


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-rejk9** — sparq-server TCP serve path should inject ConnectInfo(peer_addr) for parity with the h3 path (latent fail-open for future ConnectInfo-based middleware)
sq-rejk9.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-rejk9","crate":"sparq-server","committed":true,"gates_green":true,"branch":"feat/sq-rejk9-codex-gpt56","non_vacuity_verified":true,"notes":"commit 71c194c1; clippy_preexisting_drift:sparq-server/tests/wire_contract.rs"}
```

Not armed — the orchestrator arms after review.