### PR TITLE
ci: wire @jeswr/solid-server build+test + trusted-publish (sq-6xasp.11) [OPUS-4.8]

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -120,6 +120,21 @@ jobs:
           npm test
           npm run check:package
 
+      # [OPUS-4.8] sq-6xasp.11 (epic sq-6xasp): the @jeswr/solid-server package — a local-dev
+      # Solid/LDP pod backed by the sparq-lws wasm handler. Build the wasm bundle
+      # (crates/sparq-lws-wasm, matched by the `crates/sparq-*-wasm/**` paths filter above) with
+      # the same wasm-pack installed earlier in this job, then run the package's node:test suite
+      # (http/auth/server/oidc, including the npx spin-up round-trip in server.test.mjs). The wasm
+      # build MUST precede `npm test`: src/index.js statically imports ../wasm/sparq_lws_wasm.js,
+      # so server.test.mjs / oidc.test.mjs (which `import { startSolidServer } from '../src/index.js'`)
+      # fail module resolution without the built wasm/ tree. No `check:package` step — this package
+      # ships no guardrail script (mirrors its package.json, which has only build:lws-wasm + test).
+      - name: solid-server package (build wasm + node:test)
+        working-directory: packages/solid-server
+        run: |
+          npm run build:lws-wasm
+          npm test
+
       # Publish guardrail + git-pin verification (sq-bkag): `prepare` wired, the
       # `files` allowlist intact, and the packed tarball actually ships dist/ + wasm/.
       - name: Package guardrail check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,10 @@ on:
         description: "Publish @sparq-org/eyereasoner-compat to npm (needs the one-time npm-side bootstrap — see job)"
         type: boolean
         default: false
+      publish_solid_server:
+        description: "Publish @jeswr/solid-server to npm (needs the one-time npm-side bootstrap — see job)"
+        type: boolean
+        default: false
       attest_crates:
         description: "Package + attest publishable crates (crates.io bytes)"
         type: boolean
@@ -234,6 +238,81 @@ jobs:
           echo "$att"
           if [ -z "$att" ] || [ "$att" = "undefined" ]; then
             echo "::error::no provenance attestation recorded for @sparq-org/eyereasoner-compat@${ver}"
+            exit 1
+          fi
+          echo "Provenance attestation present. Consumers verify with: npm audit signatures"
+
+  # ---- npm: @jeswr/solid-server via OIDC TRUSTED PUBLISHING (no NPM_TOKEN) ----
+  # [OPUS-4.8] sq-6xasp.11 (epic sq-6xasp). The WebAssembly Solid server package
+  # (packages/solid-server) — a local-dev Solid/LDP pod backed by the sparq-lws wasm handler,
+  # which ships INSIDE the tarball (the `files` allowlist packs bin/ + src/ + the built wasm/ +
+  # README). Same tokenless OIDC trusted-publishing pattern as the @jeswr/sparq job above:
+  # `id-token: write` lets the npm CLI mint a short-lived publish credential + record a
+  # Sigstore-signed SLSA provenance statement; no NPM_TOKEN is stored.
+  #
+  # GRACEFUL-SKIP: this job runs ONLY on an explicit manual `workflow_dispatch` with
+  # `publish_solid_server=true` — NOT on `release: published`. So a release never fails because
+  # the npm-side bootstrap below is not yet done; the maintainer triggers it once ready.
+  #
+  # ONE-TIME needs:user step (registry-side config — cannot be a repo file). npm trusted
+  # publishing can only be configured on a package that ALREADY EXISTS, and this is a NEW package,
+  # so the maintainer does exactly this ONCE, then every CI publish is tokenless:
+  #   1. Bootstrap-publish the first version with a granular token (or `npm login`) — build the
+  #      wasm first so the tarball ships wasm/ (the `files` allowlist expects it):
+  #        cd packages/solid-server && npm run build:lws-wasm && npm publish --access public
+  #   2. Register the Trusted Publisher on
+  #      npmjs.com/package/@jeswr/solid-server/access → "Trusted Publisher":
+  #        GitHub organisation/user `jeswr`, repository `sparq`, workflow FILENAME `publish.yml`
+  #        (filename only, with extension — NOT a path), environment left blank.
+  #      Then remove the granular token. Every publish this job triggers thereafter is tokenless.
+  # Until step 1–2 are done, DO NOT trigger this job (the publish would fail to mint a credential
+  # by design — no static token is stored). See docs/release.md.
+  npm-solid-server:
+    name: npm publish @jeswr/solid-server (OIDC trusted publishing)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' && inputs.publish_solid_server
+    permissions:
+      contents: read
+      id-token: write # OIDC token npm exchanges for a short-lived publish credential + provenance signing
+    defaults:
+      run:
+        working-directory: packages/solid-server
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+      # OIDC trusted publishing requires npm CLI >= 11.5.1 (Node 22 bundles an older npm).
+      - name: Pin npm CLI >= 11.5.1 (trusted-publishing floor)
+        run: |
+          npm install -g 'npm@^11.5.1'
+          npm --version
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+      # Build the wasm bundle so the `files` allowlist packs a populated wasm/ tree. This package
+      # has NO `prepack`/`build` script (unlike @jeswr/sparq / eyereasoner-compat), so the wasm is
+      # NOT rebuilt automatically on `npm publish` — build it explicitly here, before publish.
+      - name: Build wasm bundle
+        run: npm run build:lws-wasm
+      # `npm publish` packs ONLY the `files` allowlist (bin/ + src/ + wasm/ + README); runtime
+      # dependencies are resolved by the consumer at install time and are not bundled, so no npm
+      # install is needed for a correct tarball. Provenance is emitted by default under trusted
+      # publishing (--provenance is belt-and-suspenders). --access public: scoped package.
+      - name: Publish to npm (OIDC trusted publishing + provenance)
+        run: npm publish --provenance --access public
+      - name: Verify published provenance attestation
+        run: |
+          set -euo pipefail
+          ver=$(node -p "require('./package.json').version")
+          att=$(npm view "@jeswr/solid-server@${ver}" dist.attestations 2>/dev/null || true)
+          echo "$att"
+          if [ -z "$att" ] || [ "$att" = "undefined" ]; then
+            echo "::error::no provenance attestation recorded for @jeswr/solid-server@${ver}"
             exit 1
           fi
           echo "Provenance attestation present. Consumers verify with: npm audit signatures"


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Opus 4.8, ci-infra). This is the final CI plumbing for the WASM-Solid-server-on-npm epic **sq-6xasp** — child bead **sq-6xasp.11**. The `@jeswr/solid-server` package + OIDC host already landed on main (#2243/#2247); this PR wires the two remaining CI legs.

## What this does

**`.github/workflows/js.yml`** — a gating build+test leg for `packages/solid-server`, mirroring the existing `eyereasoner-compat` leg (`working-directory`-scoped, same shape):
- `npm run build:lws-wasm` — builds `crates/sparq-lws-wasm` with the wasm-pack already installed earlier in the `js` job (the `packages/**` + `crates/sparq-*-wasm/**` paths filter already matches these surfaces; no filter change).
- `npm test` — the package's `node --test` suite (`http`/`auth`/`server`/`oidc`, including the `npx` spin-up round-trip in `server.test.mjs`).
- **Ordering is load-bearing:** `src/index.js` statically imports `../wasm/sparq_lws_wasm.js`, and `server.test.mjs`/`oidc.test.mjs` top-level `import { startSolidServer } from '../src/index.js'` — so `node --test` fails module resolution without a prior wasm build. The build step therefore precedes the tests. The root `npm ci` step (already present in the job) installs the package's workspace deps (`jose`, `@solid/access-token-verifier`), so no install change is needed. No `check:package` step — this package ships no guardrail script.

**`.github/workflows/publish.yml`** — a `npm-solid-server` OIDC trusted-publishing job mirroring the `@sparq-org/eyereasoner-compat` job:
- Tokenless: `id-token: write`, **no `NPM_TOKEN`** secret in the workflow — the npm CLI mints a short-lived publish credential from the GitHub Actions OIDC token and records a Sigstore-signed SLSA provenance statement.
- Manual `workflow_dispatch` only (new `publish_solid_server` input), **never on `release: published`** — a release can never fail on the not-yet-bootstrapped package.
- Builds the wasm explicitly before publish (this package has no `prepack`/`build` hook, unlike `@jeswr/sparq`), then `npm publish --provenance --access public`, then verifies the registry recorded a provenance attestation.

## Maintainer action required (first publish only)

npm Trusted Publishing can only be configured on a package that **already exists**, so `@jeswr/solid-server` needs a one-time bootstrap by the maintainer, after which every CI publish is tokenless (documented in the job comment + this PR):

1. Bootstrap-publish the first version with a granular token (build the wasm first so the tarball ships `wasm/`):
   ```
   cd packages/solid-server && npm run build:lws-wasm && npm publish --access public
   ```
2. Register the Trusted Publisher on `npmjs.com/package/@jeswr/solid-server/access` → "Trusted Publisher": GitHub org/user `jeswr`, repo `sparq`, workflow **filename** `publish.yml` (filename only, with extension — NOT a path), environment left blank. Then remove the granular token.

Until steps 1–2 are done, the `npm-solid-server` job is not triggered (it would correctly fail to mint a credential — no static token is stored). This mirrors the `@sparq-org/eyereasoner-compat` bootstrap exactly.

## Gates checked locally

- **Valid YAML** — `python3 -c "import yaml; yaml.safe_load(...)"` passes for both files.
- **actionlint** — clean (exit 0) on both files.
- **SHA-pin discipline** — every action in the diff is SHA-pinned (40-hex + version comment); I introduced **no new action**, only reused the existing pins (`actions/checkout`, `dtolnay/rust-toolchain`, `actions/setup-node`).
- **Gate aggregator intact** — the `js` check name is unchanged and carries no `advisory`/`informational` token, so `ci-summary / gate` still treats it as a HARD required gate. The path filter still lets non-JS PRs skip the leg.
- **Not run locally (by design):** the full wasm-pack compile + `npm ci` are RAM-heavy; per the bead this was validated by reading (import-chain + script + toolchain-presence verification) rather than by running the full pipeline. The wasm build + node:test legs are **validate-on-first-CI-run**.

## Compliance / provenance level

npm publish under OIDC Trusted Publishing is a **provenance-emitting path** (Sigstore-signed in-toto SLSA provenance recorded by the registry; consumers verify with `npm audit signatures`) — the same posture as the existing `@jeswr/sparq` / `@sparq-org/eyereasoner-compat` jobs. This closes the CI-wiring gap of epic sq-6xasp for the new package.

Closes sq-6xasp.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)