### PR TITLE
sparq-prov: prov_turtle() on Derivation + UpdateDerivation (parity wit
sq-ijw35 [GPT-5.6]

### DIFF
--- a/crates/sparq-prov/Cargo.toml
+++ b/crates/sparq-prov/Cargo.toml
@@ -38,6 +38,9 @@ sparq-core = { path = "../sparq-core" }
 # The CONSTRUCT derivation we wrap (and, by extension, DESCRIBE).
 sparq-engine = { path = "../sparq-engine" }
 oxrdf = { workspace = true }
+# Prefix-compacted Turtle output for `Derivation` and `UpdateDerivation`.
+# [GPT-5.6] sq-ijw35: promoted from the test-only dependency below; no new crate.
+oxttl = { workspace = true }
 # Parsed BGP algebra, only for the opt-in missing-answer explainer.
 spargebra = { workspace = true, optional = true }
 # Reasoner proof trees (`why()`), only under the `reason` feature. `explain` is the
@@ -46,8 +49,5 @@ spargebra = { workspace = true, optional = true }
 sparq-reason = { path = "../sparq-reason", features = ["explain"], optional = true }
 
 [dev-dependencies]
-# Round-trip the emitted PROV-O graph back through the loader to prove it is
-# well-formed RDF (Turtle ⊇ N-Triples).
-oxttl = { workspace = true }
 # [GPT-5.6] sq-hggpo: generate derivation shapes for structural PROV-O properties.
 proptest = "1"

--- a/crates/sparq-prov/README.md
+++ b/crates/sparq-prov/README.md
@@ -34,7 +34,8 @@ let d = derive_construct(
 
 let derived = d.triples();          // the data the operation produced
 let lineage = d.prov_graph();       // its PROV-O record (Vec<Triple>)
-let turtle  = d.prov_ntriples();    // …serialised (N-Triples ⊂ Turtle)
+let turtle  = d.prov_turtle();      // …serialised as prefix-compacted Turtle
+let nt      = d.prov_ntriples();    // …or canonical N-Triples
 ```
 
 ## ✨ Features

--- a/crates/sparq-prov/src/lib.rs
+++ b/crates/sparq-prov/src/lib.rs
@@ -91,6 +91,30 @@ pub use why_not::{why_not, MissingPattern, WhyNotError};
 // ── PROV-O vocabulary IRIs ─────────────────────────────────────────────────
 const PROV: &str = "http://www.w3.org/ns/prov#";
 
+// [GPT-5.6] sq-ijw35: one Turtle writer for both derivation surfaces so they
+// always serialise the identical `prov_graph()` triple set with the same prefixes.
+fn triples_to_prov_turtle(triples: &[Triple]) -> String {
+    let serializer = oxttl::TurtleSerializer::new()
+        .with_prefix("prov", PROV)
+        .expect("the PROV namespace must be a valid prefix IRI")
+        .with_prefix("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+        .expect("the RDF namespace must be a valid prefix IRI")
+        .with_prefix("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
+        .expect("the RDFS namespace must be a valid prefix IRI")
+        .with_prefix("xsd", "http://www.w3.org/2001/XMLSchema#")
+        .expect("the XSD namespace must be a valid prefix IRI");
+    let mut writer = serializer.for_writer(Vec::new());
+    for triple in triples {
+        writer
+            .serialize_triple(triple)
+            .expect("serialising Turtle into memory must succeed");
+    }
+    let bytes = writer
+        .finish()
+        .expect("finishing Turtle serialisation into memory must succeed");
+    String::from_utf8(bytes).expect("Turtle output must be valid UTF-8")
+}
+
 /// `prov:` term IRI (`http://www.w3.org/ns/prov#{local}`).
 fn prov(local: &str) -> NamedNode {
     NamedNode::new_unchecked(format!("{PROV}{local}"))
@@ -276,6 +300,14 @@ impl Derivation {
     /// The PROV-O lineage serialised as N-Triples (also a valid Turtle document).
     pub fn prov_ntriples(&self) -> String {
         sparq_engine::triples_to_ntriples(&self.prov_graph())
+    }
+
+    /// The same PROV-O lineage as [`prov_graph`](Self::prov_graph), serialised as
+    /// prefix-compacted Turtle.
+    ///
+    /// [GPT-5.6] sq-ijw35
+    pub fn prov_turtle(&self) -> String {
+        triples_to_prov_turtle(&self.prov_graph())
     }
 
     /// Start/end wall-clock instants of the derivation activity.

--- a/crates/sparq-prov/src/tests.rs
+++ b/crates/sparq-prov/src/tests.rs
@@ -128,6 +128,35 @@ fn prov_graph_is_valid_rdf_and_round_trips() {
     assert_eq!(parsed.len(), d.prov_graph().len());
 }
 
+/// [GPT-5.6] sq-ijw35: the Derivation Turtle method preserves every provenance
+/// triple, and the generation edge uses the registered prefix.
+#[test]
+fn prov_turtle_round_trips_the_exact_derivation_graph() {
+    let d = derive_construct(
+        &g(),
+        "PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+        cfg(),
+    )
+    .unwrap();
+
+    let turtle = d.prov_turtle();
+    assert!(
+        turtle.contains("prov:wasGeneratedBy"),
+        "expected the prefix-compacted generation predicate in {turtle}"
+    );
+
+    let parsed: Vec<_> = oxttl::TurtleParser::new()
+        .for_slice(turtle.as_bytes())
+        .collect::<Result<_, _>>()
+        .expect("emitted lineage must be well-formed Turtle");
+    let expected = d.prov_graph();
+    assert_eq!(parsed.len(), expected.len());
+    assert_eq!(
+        parsed.into_iter().collect::<HashSet<_>>(),
+        expected.into_iter().collect::<HashSet<_>>()
+    );
+}
+
 #[test]
 fn explicit_iris_and_agent_are_honoured() {
     let activity = NamedNode::new_unchecked("http://ex/act/1");

--- a/crates/sparq-prov/src/update.rs
+++ b/crates/sparq-prov/src/update.rs
@@ -221,6 +221,14 @@ impl UpdateDerivation {
     pub fn prov_ntriples(&self) -> String {
         sparq_engine::triples_to_ntriples(&self.prov_graph())
     }
+
+    /// The same PROV-O lineage as [`prov_graph`](Self::prov_graph), serialised as
+    /// prefix-compacted Turtle.
+    ///
+    /// [GPT-5.6] sq-ijw35
+    pub fn prov_turtle(&self) -> String {
+        crate::triples_to_prov_turtle(&self.prov_graph())
+    }
 }
 
 /// Apply a SPARQL UPDATE to `graph` **in place**, capturing W3C PROV-O lineage for the
@@ -681,6 +689,36 @@ mod tests {
             .collect::<Result<_, _>>()
             .expect("emitted lineage must be well-formed N-Triples");
         assert_eq!(parsed.len(), d.prov_graph().len());
+    }
+
+    /// [GPT-5.6] sq-ijw35: the UpdateDerivation Turtle method preserves every
+    /// provenance triple, and the inserted-result entity uses the registered prefix.
+    #[test]
+    fn prov_turtle_round_trips_the_exact_update_graph() {
+        let mut graph = g();
+        let d = derive_update(
+            &mut graph,
+            "PREFIX ex: <http://ex/> INSERT { ?s ex:years ?a } WHERE { ?s ex:age ?a }",
+            cfg(),
+        )
+        .unwrap();
+
+        let turtle = d.prov_turtle();
+        assert!(
+            turtle.contains("prov:Entity"),
+            "expected the prefix-compacted result entity in {turtle}"
+        );
+
+        let parsed: Vec<_> = oxttl::TurtleParser::new()
+            .for_slice(turtle.as_bytes())
+            .collect::<Result<_, _>>()
+            .expect("emitted lineage must be well-formed Turtle");
+        let expected = d.prov_graph();
+        assert_eq!(parsed.len(), expected.len());
+        assert_eq!(
+            parsed.into_iter().collect::<HashSet<_>>(),
+            expected.into_iter().collect::<HashSet<_>>()
+        );
     }
 
     #[test]

--- a/skills/prov-lineage/SKILL.md
+++ b/skills/prov-lineage/SKILL.md
@@ -47,7 +47,8 @@ let d = derive_construct(
 let derived = d.triples();       // the derived data (Vec<Triple>)
 let inputs  = d.used_inputs();   // configured input IRIs, in order (&[NamedNode])
 let lineage = d.prov_graph();    // its PROV-O record (Vec<Triple>)
-let turtle  = d.prov_ntriples(); // …serialised (N-Triples ⊂ Turtle)
+let turtle  = d.prov_turtle();   // …prefix-compacted Turtle
+let nt      = d.prov_ntriples(); // …or canonical N-Triples
 ```
 
 ## The emitted PROV-O shape
@@ -96,6 +97,7 @@ let inserted = d.inserted();    // the generated (derived) triples
 let deleted  = d.deleted();     // the retracted (invalidated) triples
 let inputs   = d.used_inputs(); // configured input IRIs, in order
 let lineage  = d.prov_graph();  // its PROV-O record (Vec<Triple>)
+let turtle   = d.prov_turtle(); // prefix-compacted Turtle for that same graph
 ```
 
 Emitted shape — for update activity `A`, generated entity `E` (the inserts), inputs `Iᵢ`:


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-ijw35** — sparq-prov: prov_turtle() on Derivation + UpdateDerivation (parity with prov_ntriples/prov_graph)
sq-ijw35.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-ijw35","crate":"sparq-prov","committed":true,"gates_green":true,"branch":"feat/sq-ijw35-codex-gpt56","non_vacuity_verified":true,"notes":"commit e9b9d261; bd unavailable; no clippy drift"}
```

Not armed — the orchestrator arms after review.