### PR TITLE
Alt-Svc HTTP/3 advertising layer (both servers), gated on http3 being 
sq-oprna.4 [GPT-5.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4952,6 +4952,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tower",
+ "tower-http 0.7.0",
 ]
 
 [[package]]

--- a/crates/sparq-http3/Cargo.toml
+++ b/crates/sparq-http3/Cargo.toml
@@ -31,6 +31,7 @@ server = [
     "dep:thiserror",
     "dep:tokio",
     "dep:tower",
+    "dep:tower-http",
 ]
 
 [dependencies]
@@ -46,6 +47,7 @@ rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", 
 thiserror = { version = "2", optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "rt", "sync"], optional = true }
 tower = { version = "0.5", default-features = false, features = ["util"], optional = true }
+tower-http = { version = "0.7", default-features = false, features = ["set-header"], optional = true }
 
 [dev-dependencies]
 rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs"] }

--- a/crates/sparq-http3/README.md
+++ b/crates/sparq-http3/README.md
@@ -1,9 +1,13 @@
 <!-- [GPT-5.6] sq-oprna.1: internal-stub README for a publish=false crate. -->
 # sparq-http3
 
+## 🚀 Quick start
+
 Internal, unstable HTTP/3-over-QUIC transport bridge shared by sparq's axum servers.
 Its default-off `server` feature contains the pre-1.0 `h3`/`h3-quinn` stack and Quinn,
 so a default workspace build does not pull those dependencies.
+
+## ✨ Capabilities
 
 Enable `server` to convert an aws-lc-rs-backed rustls server configuration and dispatch
 HTTP/3 requests into a cloned `axum::Router`. The bridge injects the QUIC peer address as
@@ -11,10 +15,12 @@ HTTP/3 requests into a cloned `axum::Router`. The bridge injects the QUIC peer a
 safe by default: `serve_h3` applies global and per-IP concurrent-connection caps, while
 `serve_h3_with_limits` accepts custom `H3ConnectionLimits`. Internal IPs are exempt from the per-IP
 default but remain covered by the global cap. The generated Quinn configuration also uses a bounded
-connection receive window.
+connection receive window. After a QUIC endpoint binds, `alt_svc_layer` adds the exact
+`Alt-Svc: h3=":<port>"; ma=86400` advertisement to the separate HTTP/1.1 or HTTP/2 router.
 
-WebSocket-over-HTTP/3 is outside this helper's scope; clients use the existing HTTP/1.1 or
-HTTP/2 listener for WebSocket upgrades.
+WebSocket-over-HTTP/3 is outside this helper's scope; clients use TCP for WebSocket upgrades.
+
+## 📚 Documentation
 
 See `skills/http3-server/SKILL.md` for the embedding API and
 `research/http3-quic-servers-design.md` for the transport architecture.

--- a/crates/sparq-http3/src/lib.rs
+++ b/crates/sparq-http3/src/lib.rs
@@ -10,5 +10,6 @@ mod server;
 
 #[cfg(feature = "server")]
 pub use server::{
-    quic_server_config, serve_h3, serve_h3_with_limits, H3ConnectionLimits, Http3ConfigError,
+    alt_svc_layer, quic_server_config, serve_h3, serve_h3_with_limits, H3ConnectionLimits,
+    Http3ConfigError,
 };

--- a/crates/sparq-http3/src/server.rs
+++ b/crates/sparq-http3/src/server.rs
@@ -9,7 +9,7 @@ use std::{
 use axum::{
     body::Body,
     extract::ConnectInfo,
-    http::{Request, Response},
+    http::{HeaderName, HeaderValue, Request, Response},
     Router,
 };
 use bytes::{Buf, Bytes};
@@ -19,6 +19,7 @@ use http_body_util::BodyExt as _;
 use quinn::crypto::rustls::{NoInitialCipherSuite, QuicServerConfig};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tower::ServiceExt as _;
+use tower_http::set_header::SetResponseHeaderLayer;
 
 /// Default ceiling for concurrently served HTTP/3 connections.
 const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
@@ -28,6 +29,9 @@ const DEFAULT_MAX_CONNECTIONS_PER_IP: usize = 512;
 
 /// Connection-level QUIC receive window used by [`quic_server_config`].
 const RECEIVE_WINDOW_BYTES: u32 = 16 * 1024 * 1024;
+
+/// Lifetime advertised for the HTTP/3 alternative service, in seconds.
+const ALT_SVC_MAX_AGE_SECONDS: u32 = 86_400;
 
 type PerIpCounts = Arc<Mutex<HashMap<IpAddr, usize>>>;
 
@@ -71,6 +75,19 @@ pub enum Http3ConfigError {
     /// The configured crypto provider lacks QUIC's required initial cipher suite.
     #[error("rustls server configuration is not QUIC-compatible: {0}")]
     NoInitialCipherSuite(#[from] NoInitialCipherSuite),
+}
+
+/// Builds a response-header layer advertising HTTP/3 on `port`.
+///
+/// The layer writes `Alt-Svc: h3=":<port>"; ma=86400` on every response and replaces any
+/// pre-existing value. Apply it to the HTTP/1.1 or HTTP/2 router only after the corresponding QUIC
+/// endpoint has bound successfully. Constructing this layer from configuration alone can advertise
+/// a listener that does not exist.
+// [GPT-5.6] sq-oprna.4: one exact advertisement format shared by both TCP servers.
+pub fn alt_svc_layer(port: u16) -> SetResponseHeaderLayer<HeaderValue> {
+    let value = HeaderValue::from_str(&format!("h3=\":{port}\"; ma={ALT_SVC_MAX_AGE_SECONDS}"))
+        .expect("a u16 port and fixed Alt-Svc syntax always form a valid header value");
+    SetResponseHeaderLayer::overriding(HeaderName::from_static("alt-svc"), value)
 }
 
 /// Converts an aws-lc-rs-backed rustls server configuration into Quinn's server config.

--- a/crates/sparq-http3/tests/h3_round_trip.rs
+++ b/crates/sparq-http3/tests/h3_round_trip.rs
@@ -3,7 +3,7 @@
 use std::{error::Error, future::poll_fn, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
-    body::Bytes,
+    body::{Body, Bytes},
     extract::ConnectInfo,
     http::{Method, Request, StatusCode},
     routing::{get, post},
@@ -15,8 +15,10 @@ use quinn::crypto::rustls::QuicClientConfig;
 use rcgen::{generate_simple_self_signed, CertifiedKey};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use sparq_http3::{
-    quic_server_config, serve_h3, serve_h3_with_limits, H3ConnectionLimits, Http3ConfigError,
+    alt_svc_layer, quic_server_config, serve_h3, serve_h3_with_limits, H3ConnectionLimits,
+    Http3ConfigError,
 };
+use tower::ServiceExt as _;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
 
@@ -109,6 +111,25 @@ fn config_replaces_quinns_unbounded_connection_receive_window() -> TestResult {
             quinn::VarInt::MAX.into_inner()
         )),
         "the connection receive window must not retain Quinn's VarInt::MAX default: {transport}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn alt_svc_layer_emits_the_exact_advertisement_and_replaces_stale_values() -> TestResult {
+    let app = Router::new()
+        .route("/", get(|| async { [("alt-svc", "h2=\":8443\"; ma=60")] }))
+        .layer(alt_svc_layer(443));
+    let response = app
+        .oneshot(Request::builder().uri("/").body(Body::empty())?)
+        .await?;
+
+    assert_eq!(
+        response
+            .headers()
+            .get("alt-svc")
+            .and_then(|value| value.to_str().ok()),
+        Some("h3=\":443\"; ma=86400")
     );
     Ok(())
 }

--- a/crates/sparq-lws-core/src/main.rs
+++ b/crates/sparq-lws-core/src/main.rs
@@ -888,18 +888,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Endpoint construction happens before the TCP listener is handed off: a UDP bind/config
             // failure aborts startup rather than silently serving only the unadvertised TCP subset.
             #[cfg(feature = "http3")]
-            let http3_server = {
+            let (app, http3_server) = {
                 let endpoint = bind_http3_endpoint(&config, http3_addr)?;
                 let bound_addr = endpoint.local_addr()?;
+                // [GPT-5.6] sq-oprna.4: an Alt-Svc promise is created only after UDP bind succeeds,
+                // and names the endpoint's actual port. The unlayered clone remains the h3 router.
+                let h3_app = app.clone();
+                let tcp_app = app.layer(sparq_http3::alt_svc_layer(bound_addr.port()));
                 eprintln!(
                     "  HTTP/3: QUIC listener ACTIVE on udp://{bound_addr} (ALPN h3; shared LDP router; \
                      WebSocket extended CONNECT is out of scope)."
                 );
-                tokio::spawn(sparq_http3::serve_h3(
+                let server = tokio::spawn(sparq_http3::serve_h3(
                     endpoint,
-                    app.clone(),
+                    h3_app,
                     shutdown_signal(),
-                ))
+                ));
+                (tcp_app, server)
             };
 
             // axum-server wants a blocking `std::net::TcpListener`; converting the tokio one keeps the

--- a/crates/sparq-lws-core/tests/http3_ldp.rs
+++ b/crates/sparq-lws-core/tests/http3_ldp.rs
@@ -13,7 +13,7 @@ mod common;
 
 use std::{error::Error, future::poll_fn, sync::Arc, time::Duration};
 
-use axum::body::Bytes;
+use axum::body::{Body, Bytes};
 use axum::http::{Method, Request, StatusCode};
 use bytes::Buf as _;
 use common::{jwks_provider, KeyKit, BASE_URL};
@@ -31,6 +31,7 @@ use sparq_lws_core::overload::AdmissionControl;
 use sparq_lws_core::rate_limit::RateLimiter;
 use sparq_lws_core::store::{CompositeStore, InMemoryBlobStore, InMemorySparqClient, Store};
 use sparq_lws_core::tls::{build_rustls_config, TlsMode};
+use tower::ServiceExt as _;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
 
@@ -156,10 +157,13 @@ async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
     let mut quic_tls = (*tcp_tls.get_inner()).clone();
     quic_tls.alpn_protocols = vec![b"h3".to_vec()];
     let h3_endpoint = quinn::Endpoint::server(quic_server_config(quic_tls)?, server_addr)?;
+    let h3_addr = h3_endpoint.local_addr()?;
 
     let tcp_handle = axum_server::Handle::new();
     let tcp_server_handle = tcp_handle.clone();
-    let tcp_app = app.clone();
+    let tcp_app = app
+        .clone()
+        .layer(sparq_http3::alt_svc_layer(h3_addr.port()));
     let tcp_server = tokio::spawn(async move {
         axum_server::from_tcp_rustls(std_listener, tcp_tls)
             .expect("construct TLS server")
@@ -184,6 +188,15 @@ async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
     let resource_uri = format!("https://localhost:{}/pub", server_addr.port());
     let h1_response = h1_client.get(&resource_uri).send().await?;
     assert_eq!(h1_response.version(), reqwest::Version::HTTP_11);
+    let expected_alt_svc = format!("h3=\":{}\"; ma=86400", h3_addr.port());
+    assert_eq!(
+        h1_response
+            .headers()
+            .get("alt-svc")
+            .and_then(|value| value.to_str().ok()),
+        Some(expected_alt_svc.as_str()),
+        "the h1 GET response must advertise the live h3 listener port"
+    );
     let h1_status = h1_response.status();
     let h1_body = h1_response.bytes().await?;
     assert_eq!(h1_status, StatusCode::OK);
@@ -219,5 +232,24 @@ async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
     drop(h1_client);
     tcp_handle.graceful_shutdown(Some(Duration::from_secs(1)));
     tokio::time::timeout(Duration::from_secs(5), tcp_server).await???;
+    Ok(())
+}
+
+#[tokio::test]
+async fn unconfigured_http3_router_does_not_advertise_alt_svc() -> TestResult {
+    let app = production_router(100.0, 100.0).await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("{BASE_URL}/pub"))
+                .body(Body::empty())?,
+        )
+        .await?;
+
+    assert!(
+        response.headers().get("alt-svc").is_none(),
+        "the original TCP router must not advertise HTTP/3 before a QUIC endpoint binds"
+    );
     Ok(())
 }

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -1079,6 +1079,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let key = tls_key.as_deref().expect("validated with --http3");
         let endpoint = bind_http3_endpoint(http3_addr, cert, key)?;
         let bound_addr = endpoint.local_addr()?;
+        // [GPT-5.6] sq-oprna.4: derive the advertisement from the successfully bound endpoint, not
+        // from requested configuration. Keep the h3 router unlayered: Alt-Svc is discovery for the
+        // TCP response path, and both routers still share the same application handlers.
+        let tcp_app = app
+            .clone()
+            .layer(sparq_http3::alt_svc_layer(bound_addr.port()));
         eprintln!("sparq-server HTTP/3 listening on https://{bound_addr} (QUIC/UDP; WebSocket subscriptions remain HTTP/1.1-only)");
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -1090,7 +1096,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let h3_shutdown = wait_for_shutdown(shutdown_rx);
         let tcp = sparq_server::serve(
             listener,
-            app.clone(),
+            tcp_app,
             header_read_timeout,
             body_read_timeout,
             tcp_shutdown,

--- a/crates/sparq-server/tests/http3.rs
+++ b/crates/sparq-server/tests/http3.rs
@@ -162,6 +162,17 @@ async fn h3_sparql_response_matches_the_unchanged_http1_listener() -> TestResult
             return Err(format!("server did not become ready: {stderr}").into());
         }
     };
+    let health = http.get(format!("http://{tcp_addr}/health")).send().await?;
+    assert_eq!(health.version(), reqwest::Version::HTTP_11);
+    let expected_alt_svc = format!("h3=\":{}\"; ma=86400", udp_addr.port());
+    assert_eq!(
+        health
+            .headers()
+            .get("alt-svc")
+            .and_then(|value| value.to_str().ok()),
+        Some(expected_alt_svc.as_str()),
+        "the h1 GET response must advertise the successfully bound QUIC port"
+    );
     let h1_status = http1.status().as_u16();
     let h1_content_type = http1
         .headers()
@@ -190,4 +201,39 @@ async fn h3_sparql_response_matches_the_unchanged_http1_listener() -> TestResult
     endpoint.close(quinn::VarInt::from_u32(0), b"test complete");
     tokio::time::timeout(Duration::from_secs(5), driver).await??;
     Ok(())
+}
+
+#[tokio::test]
+async fn http3_runtime_off_does_not_advertise_alt_svc() -> TestResult {
+    let tcp_addr = free_tcp_addr()?;
+    let child = Command::new(env!("CARGO_BIN_EXE_sparq-server"))
+        .arg("--addr")
+        .arg(tcp_addr.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut server = ChildGuard(child);
+
+    let http = reqwest::Client::new();
+    let url = format!("http://{tcp_addr}/health");
+    for _ in 0..100 {
+        match http.get(&url).send().await {
+            Ok(response) => {
+                assert!(
+                    response.headers().get("alt-svc").is_none(),
+                    "a feature-on binary without --http3 must not advertise an unbound listener"
+                );
+                return Ok(());
+            }
+            Err(_) => tokio::time::sleep(Duration::from_millis(25)).await,
+        }
+    }
+
+    let _ = server.0.kill();
+    let mut stderr = String::new();
+    if let Some(mut pipe) = server.0.stderr.take() {
+        pipe.read_to_string(&mut stderr)?;
+    }
+    let _ = server.0.wait();
+    Err(format!("server did not become ready: {stderr}").into())
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -51,8 +51,9 @@ Both PEM paths are required when `--http3` is set, and malformed or mismatched m
 fails startup. QUIC is mandatorily encrypted, while the TCP listener remains plain HTTP for
 proxy/backward compatibility. The pre-1.0 h3 stack is contained behind the default-off
 feature. `/subscriptions` WebSockets remain HTTP/1.1-only; clients must fall back because
-HTTP/3 extended CONNECT is not implemented. This phase does not advertise `Alt-Svc`, so clients
-connect directly to the configured QUIC address. [GPT-5.6] sq-oprna.3
+HTTP/3 extended CONNECT is not implemented. Once the UDP endpoint has bound, every plain-HTTP TCP
+response advertises its live port as `Alt-Svc: h3=":<port>"; ma=86400`; no header is emitted when
+`--http3` is absent or startup cannot bind the QUIC listener. [GPT-5.6] sq-oprna.4
 
 > **Security: optional Bearer-token write gate; loopback by default.** With no token
 > configured, every endpoint is unauthenticated (the back-compat default). Set

--- a/skills/http3-server/SKILL.md
+++ b/skills/http3-server/SKILL.md
@@ -81,6 +81,23 @@ That extension is load-bearing for request policies keyed by the remote socket a
 Protocol failures are isolated to their connection or stream; resolving the shutdown
 future closes the endpoint and waits for its QUIC connections to drain.
 
+## Advertise a bound endpoint to TCP clients
+
+After the QUIC endpoint has bound successfully, apply the shared response layer to the separate
+HTTP/1.1 or HTTP/2 router. Derive the advertised port from `Endpoint::local_addr`; do not use the
+requested configuration because binding port `0` may select a different live port:
+
+```rust
+let endpoint = quinn::Endpoint::server(quic, udp_addr)?;
+let bound_addr = endpoint.local_addr()?;
+let h3_router = router.clone();
+let tcp_router = router.layer(sparq_http3::alt_svc_layer(bound_addr.port()));
+```
+
+`alt_svc_layer` overwrites `Alt-Svc` with `h3=":<port>"; ma=86400`. Serve `tcp_router` only
+while the bound endpoint is also being served; use the unlayered `h3_router` for `serve_h3`.
+Feature-enabled but unconfigured servers must keep serving the original router without this layer.
+
 ## Solid/LDP server integration
 
 `sparq-lws-core` carries this bridge behind its default-off `http3` feature
@@ -111,7 +128,8 @@ HTTP/1.1 or HTTP/2 because RFC 9220 extended CONNECT is outside this integration
 - `h3` and `h3-quinn` are pre-1.0 dependencies; keep all direct use inside this helper.
 - WebSocket-over-HTTP/3 extended CONNECT is not implemented. WebSocket clients fall back
   to the existing TCP listener.
-- Do not advertise `Alt-Svc` until the UDP listener has successfully bound.
+- Do not call `alt_svc_layer` until the UDP listener has successfully bound, and remove the
+  advertisement whenever that listener is not served.
 
 ## Related material
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-oprna.4** — Alt-Svc HTTP/3 advertising layer (both servers), gated on http3 being enabled AND an h3 listener actually bound
sq-oprna.4.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-oprna.4","crate":"sparq-http3,sparq-server,sparq-lws-core","committed":true,"gates_green":true,"branch":"feat/sq-oprna.4-codex-gpt56","non_vacuity_verified":true,"notes":"commit 297812e6; all scoped gates and workspace checks green"}
```

Not armed — the orchestrator arms after review.