### PR TITLE
packages/solid-server: add a prepack build guardrail so the npm tarbal
sq-hcy7c [GPT-5.6]

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -127,13 +127,14 @@ jobs:
       # (http/auth/server/oidc, including the npx spin-up round-trip in server.test.mjs). The wasm
       # build MUST precede `npm test`: src/index.js statically imports ../wasm/sparq_lws_wasm.js,
       # so server.test.mjs / oidc.test.mjs (which `import { startSolidServer } from '../src/index.js'`)
-      # fail module resolution without the built wasm/ tree. No `check:package` step — this package
-      # ships no guardrail script (mirrors its package.json, which has only build:lws-wasm + test).
-      - name: solid-server package (build wasm + node:test)
+      # fail module resolution without the built wasm/ tree. [GPT-5.6] sq-hcy7c also checks the
+      # exact dry-run tarball file list so neither the allowlist nor the artifact can regress.
+      - name: solid-server package (build wasm + node:test + package guardrail)
         working-directory: packages/solid-server
         run: |
           npm run build:lws-wasm
           npm test
+          npm run check:package
 
       # Publish guardrail + git-pin verification (sq-bkag): `prepare` wired, the
       # `files` allowlist intact, and the packed tarball actually ships dist/ + wasm/.

--- a/packages/solid-server/guardrails/check-package.mjs
+++ b/packages/solid-server/guardrails/check-package.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// [GPT-5.6] sq-hcy7c: refuse to pack @jeswr/solid-server without its wasm runtime.
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const expectedName = '@jeswr/solid-server';
+const failures = [];
+const fail = (message) => failures.push(message);
+const manifest = JSON.parse(readFileSync(resolve(packageDir, 'package.json'), 'utf8'));
+
+if (manifest.name !== expectedName) {
+  fail(`package name is "${manifest.name}", expected "${expectedName}"`);
+}
+
+const prepack = manifest.scripts?.prepack ?? '';
+const buildPosition = prepack.indexOf('build:lws-wasm');
+const checkPosition = prepack.indexOf('check:package');
+if (buildPosition === -1) {
+  fail('prepack must run build:lws-wasm so an ad-hoc publish cannot omit the wasm runtime');
+}
+if (checkPosition === -1) {
+  fail('prepack must run check:package so publishing verifies the packed file list');
+}
+if (buildPosition !== -1 && checkPosition !== -1 && buildPosition > checkPosition) {
+  fail('prepack must build the wasm runtime before checking the packed file list');
+}
+
+if (!(manifest.files ?? []).includes('wasm')) {
+  fail('the files allowlist must include "wasm"');
+}
+
+let packedFiles;
+try {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+    cwd: packageDir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  });
+  packedFiles = JSON.parse(output)[0]?.files ?? [];
+} catch (error) {
+  fail(`npm pack --dry-run failed: ${error.message}`);
+}
+
+if (packedFiles) {
+  const packed = new Map(packedFiles.map((file) => [file.path, file]));
+  const requireFile = (path, description) => {
+    const file = packed.get(path);
+    if (!file) {
+      fail(`packed tarball is missing ${description} (${path})`);
+    } else if (!Number.isFinite(file.size) || file.size <= 0) {
+      fail(`packed ${description} is empty (${path})`);
+    }
+  };
+
+  requireFile((manifest.main ?? '').replace(/^\.\//, ''), 'JavaScript entrypoint');
+  requireFile((manifest.types ?? '').replace(/^\.\//, ''), 'type entrypoint');
+  for (const [name, path] of Object.entries(manifest.bin ?? {})) {
+    requireFile(path.replace(/^\.\//, ''), `executable "${name}"`);
+  }
+  requireFile('wasm/sparq_lws_wasm.js', 'wasm JavaScript glue');
+  requireFile('wasm/sparq_lws_wasm_bg.wasm', 'wasm runtime');
+}
+
+if (failures.length > 0) {
+  console.error(`check:package FAILED for ${expectedName}:\n${failures.map((message) => `  - ${message}`).join('\n')}`);
+  process.exit(1);
+}
+
+console.log(`check:package OK — ${expectedName} ships its entrypoints and non-empty wasm runtime.`);

--- a/packages/solid-server/package.json
+++ b/packages/solid-server/package.json
@@ -48,6 +48,8 @@
     "_copy:wasm": "rm -rf wasm && mkdir wasm && cp ../../crates/sparq-lws-wasm/pkg/sparq_lws_wasm.js ../../crates/sparq-lws-wasm/pkg/sparq_lws_wasm.d.ts ../../crates/sparq-lws-wasm/pkg/sparq_lws_wasm_bg.wasm ../../crates/sparq-lws-wasm/pkg/sparq_lws_wasm_bg.wasm.d.ts wasm/",
     "build:lws-wasm": "wasm-pack build ../../crates/sparq-lws-wasm --target web --profile release-wasm --config profile.release-wasm.strip=false && npm run _copy:wasm",
     "build:lws-wasm-core": "wasm-pack build ../../crates/sparq-lws-wasm --target web --profile release-wasm --config profile.release-wasm.strip=false && npm run _copy:wasm",
+    "check:package": "node guardrails/check-package.mjs",
+    "prepack": "npm run build:lws-wasm && npm run check:package",
     "test": "node --test test/*.test.mjs"
   },
   "keywords": [


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-hcy7c** — packages/solid-server: add a prepack build guardrail so the npm tarball always ships the built wasm (an ad-hoc npm publish without build:lws-wasm ships a wasm-less tarball that crashes on import)
sq-hcy7c.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-hcy7c","crate":"@jeswr/solid-server","committed":true,"gates_green":true,"branch":"feat/sq-hcy7c-codex-gpt56","non_vacuity_verified":true,"notes":"prepack builds wasm; package guard, pack dry-run, and Node acceptance passed"}
```

Not armed — the orchestrator arms after review.