### PR TITLE
Cross-protocol conformance/integration test: h3 request == h1 response
sq-oprna.5 [GPT-5.6]

### DIFF
--- a/crates/sparq-lws-core/tests/http3_ldp.rs
+++ b/crates/sparq-lws-core/tests/http3_ldp.rs
@@ -1,11 +1,12 @@
-// [GPT-5.6] sq-oprna.2
+// [GPT-5.6] sq-oprna.2, sq-oprna.5
 //! HTTP/3 integration coverage for the Solid/LDP server's default-off `http3` feature.
 //!
 //! The test serves one production `build_router_with_overload` router over both the existing TLS
 //! TCP path and the QUIC helper. A throwaway test CA anchors the checked-in localhost certificate.
-//! It proves a public LDP GET has the same status and body over HTTP/1.1 and HTTP/3, then exhausts a
-//! tight per-IP bucket. The following HTTP/3 request must be 429: if the QUIC peer is not injected as
-//! `ConnectInfo<SocketAddr>`, the limiter fails open to the public LDP handler and returns 200 instead.
+//! It compares a representative response matrix over HTTP/1.1 and HTTP/3, proves WebSocket-over-h3
+//! is refused while the TCP WebSocket fallback works, and separately exhausts a tight per-IP bucket.
+//! If the QUIC peer is not injected as `ConnectInfo<SocketAddr>`, that limiter test fails open to the
+//! public LDP handler and returns 200 instead of 429.
 
 #![cfg(feature = "http3")]
 
@@ -14,9 +15,9 @@ mod common;
 use std::{error::Error, future::poll_fn, sync::Arc, time::Duration};
 
 use axum::body::{Body, Bytes};
-use axum::http::{Method, Request, StatusCode};
+use axum::http::{Method, Request, StatusCode, Version};
 use bytes::Buf as _;
-use common::{jwks_provider, KeyKit, BASE_URL};
+use common::{BASE_URL, KeyKit, jwks_provider};
 use h3::quic::OpenStreams;
 use quinn::crypto::rustls::QuicClientConfig;
 use rustls_pemfile::certs;
@@ -24,13 +25,14 @@ use solid_oidc_verifier::config::VerifierConfig;
 use solid_oidc_verifier::replay::InMemoryReplayStore;
 use solid_oidc_verifier::verifier::Verifier;
 use sparq_http3::{quic_server_config, serve_h3};
-use sparq_lws_core::app::{build_router_with_overload, AppState, OverloadConfig};
+use sparq_lws_core::app::{AppState, OverloadConfig, build_router_with_overload};
 use sparq_lws_core::auth::AuthContext;
 use sparq_lws_core::ldp::handler::LdpState;
+use sparq_lws_core::notifications::NotificationHub;
 use sparq_lws_core::overload::AdmissionControl;
 use sparq_lws_core::rate_limit::RateLimiter;
 use sparq_lws_core::store::{CompositeStore, InMemoryBlobStore, InMemorySparqClient, Store};
-use sparq_lws_core::tls::{build_rustls_config, TlsMode};
+use sparq_lws_core::tls::{TlsMode, build_rustls_config};
 use tower::ServiceExt as _;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
@@ -41,7 +43,24 @@ const CA_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test-
 const RESOURCE_BODY: &str =
     "<https://pod.example/pub#me> <http://xmlns.com/foaf/0.1/name> \"Alice\" .";
 
-async fn production_router(rate: f64, burst: f64) -> axum::Router {
+// [GPT-5.6] sq-oprna.5: the invariant deliberately excludes transport-only headers such as Alt-Svc.
+#[derive(Debug, PartialEq, Eq)]
+struct ResponseSnapshot {
+    status: StatusCode,
+    content_type: Option<String>,
+    body: Bytes,
+}
+
+struct RequestCase {
+    name: &'static str,
+    method: Method,
+    path: &'static str,
+    accept: Option<&'static str>,
+    expected_status: StatusCode,
+    body_witness: &'static [u8],
+}
+
+async fn production_router(rate: f64, burst: f64) -> (axum::Router, NotificationHub) {
     let issuer_key = KeyKit::generate();
     let config = VerifierConfig::new(vec![common::ISSUER.to_string()], BASE_URL);
     let replay = InMemoryReplayStore::with_window(config.replay_ttl());
@@ -83,7 +102,11 @@ async fn production_router(rate: f64, burst: f64) -> axum::Router {
         body_limit_bytes: sparq_lws_core::body_limit::DEFAULT_MAX_BODY_BYTES,
     };
     let ldp = LdpState::new(store, BASE_URL);
-    build_router_with_overload(AppState::new(auth, ldp), overload)
+    let notifications = ldp.notifications.clone();
+    (
+        build_router_with_overload(AppState::new(auth, ldp), overload),
+        notifications,
+    )
 }
 
 fn fixture_roots() -> TestResult<rustls::RootCertStore> {
@@ -95,46 +118,97 @@ fn fixture_roots() -> TestResult<rustls::RootCertStore> {
     Ok(roots)
 }
 
-fn h3_client_endpoint() -> TestResult<quinn::Endpoint> {
+fn client_tls_config(alpn: &[u8]) -> TestResult<rustls::ClientConfig> {
     let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
     let mut tls = rustls::ClientConfig::builder_with_provider(provider)
         .with_protocol_versions(&[&rustls::version::TLS13])?
         .with_root_certificates(fixture_roots()?)
         .with_no_client_auth();
-    tls.alpn_protocols = vec![b"h3".to_vec()];
+    tls.alpn_protocols = vec![alpn.to_vec()];
+    Ok(tls)
+}
 
+fn h3_client_endpoint() -> TestResult<quinn::Endpoint> {
+    let tls = client_tls_config(b"h3")?;
     let client_config = quinn::ClientConfig::new(Arc::new(QuicClientConfig::try_from(tls)?));
     let mut endpoint = quinn::Endpoint::client("127.0.0.1:0".parse()?)?;
     endpoint.set_default_client_config(client_config);
     Ok(endpoint)
 }
 
-async fn h3_get<O>(
+async fn h3_request<O>(
     sender: &mut h3::client::SendRequest<O, Bytes>,
+    method: Method,
     uri: &str,
-) -> TestResult<(StatusCode, Bytes)>
+    accept: Option<&str>,
+    headers: &[(&str, &str)],
+) -> TestResult<ResponseSnapshot>
 where
     O: OpenStreams<Bytes>,
 {
-    let request = Request::builder().method(Method::GET).uri(uri).body(())?;
+    let mut request = Request::builder().method(method).uri(uri);
+    if let Some(value) = accept {
+        request = request.header(axum::http::header::ACCEPT, value);
+    }
+    for &(name, value) in headers {
+        request = request.header(name, value);
+    }
+    let request = request.body(())?;
     let mut stream = sender.send_request(request).await?;
     stream.finish().await?;
 
     let response = stream.recv_response().await?;
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
     let mut body = Vec::new();
     while let Some(mut chunk) = stream.recv_data().await? {
         let remaining = chunk.remaining();
         body.extend_from_slice(&chunk.copy_to_bytes(remaining));
     }
-    Ok((response.status(), Bytes::from(body)))
+    Ok(ResponseSnapshot {
+        status,
+        content_type,
+        body: Bytes::from(body),
+    })
+}
+
+async fn h1_request(
+    client: &reqwest::Client,
+    server_addr: std::net::SocketAddr,
+    case: &RequestCase,
+) -> TestResult<ResponseSnapshot> {
+    let mut request = client.request(
+        reqwest::Method::from_bytes(case.method.as_str().as_bytes())?,
+        format!("https://localhost:{}{}", server_addr.port(), case.path),
+    );
+    if let Some(value) = case.accept {
+        request = request.header(reqwest::header::ACCEPT, value);
+    }
+    let response = request.send().await?;
+    assert_eq!(response.version(), reqwest::Version::HTTP_11);
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let body = response.bytes().await?;
+    Ok(ResponseSnapshot {
+        status,
+        content_type,
+        body,
+    })
 }
 
 #[tokio::test]
-async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
+async fn h3_response_matrix_matches_h1_and_websocket_falls_back() -> TestResult {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-    // Two requests fit: one h1 baseline and one h3 parity request. The next h3 request must be 429.
-    let app = production_router(0.0001, 2.0).await;
+    let (app, notifications) = production_router(100.0, 100.0).await;
     let mode = TlsMode::Tls {
         cert_path: CERT_PATH.into(),
         key_path: KEY_PATH.into(),
@@ -186,21 +260,16 @@ async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
         .http1_only()
         .build()?;
     let resource_uri = format!("https://localhost:{}/pub", server_addr.port());
-    let h1_response = h1_client.get(&resource_uri).send().await?;
-    assert_eq!(h1_response.version(), reqwest::Version::HTTP_11);
+    let advertised = h1_client.get(&resource_uri).send().await?;
     let expected_alt_svc = format!("h3=\":{}\"; ma=86400", h3_addr.port());
     assert_eq!(
-        h1_response
+        advertised
             .headers()
             .get("alt-svc")
             .and_then(|value| value.to_str().ok()),
         Some(expected_alt_svc.as_str()),
         "the h1 GET response must advertise the live h3 listener port"
     );
-    let h1_status = h1_response.status();
-    let h1_body = h1_response.bytes().await?;
-    assert_eq!(h1_status, StatusCode::OK);
-    assert_eq!(h1_body, RESOURCE_BODY);
 
     let client_endpoint = h3_client_endpoint()?;
     let connection = client_endpoint.connect(server_addr, "localhost")?.await?;
@@ -209,17 +278,133 @@ async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
         let _ = poll_fn(|context| driver.poll_close(context)).await;
     });
 
-    let (h3_status, h3_body) = h3_get(&mut sender, &resource_uri).await?;
-    assert_eq!(h3_status, h1_status, "h3 and h1 LDP status must match");
-    assert_eq!(h3_body, h1_body, "h3 and h1 LDP bodies must match");
+    let cases = [
+        RequestCase {
+            name: "LDP GET",
+            method: Method::GET,
+            path: "/pub",
+            accept: Some("text/turtle"),
+            expected_status: StatusCode::OK,
+            body_witness: b"Alice",
+        },
+        RequestCase {
+            name: "LDP HEAD",
+            method: Method::HEAD,
+            path: "/pub",
+            accept: Some("text/turtle"),
+            expected_status: StatusCode::OK,
+            body_witness: b"",
+        },
+        RequestCase {
+            name: "notification discovery",
+            method: Method::GET,
+            path: "/.well-known/solid",
+            accept: Some("text/turtle"),
+            expected_status: StatusCode::OK,
+            body_witness: b"notificationChannel",
+        },
+        RequestCase {
+            name: "liveness",
+            method: Method::GET,
+            path: "/livez",
+            accept: None,
+            expected_status: StatusCode::OK,
+            body_witness: b"live\n",
+        },
+        RequestCase {
+            name: "malformed notification receive",
+            method: Method::GET,
+            path: "/.notifications/WebSocketChannel2023/receive",
+            accept: None,
+            expected_status: StatusCode::BAD_REQUEST,
+            body_witness: b"missing topic",
+        },
+    ];
 
-    let (limited_status, _) = h3_get(&mut sender, &resource_uri).await?;
+    for case in &cases {
+        let h1 = h1_request(&h1_client, server_addr, case).await?;
+        let h3 = h3_request(
+            &mut sender,
+            case.method.clone(),
+            &format!("https://localhost:{}{}", h3_addr.port(), case.path),
+            case.accept,
+            &[],
+        )
+        .await?;
+        assert_eq!(h1.status, case.expected_status, "{}", case.name);
+        if case.body_witness.is_empty() {
+            assert!(h1.body.is_empty(), "{} must have an empty body", case.name);
+        } else {
+            assert!(
+                h1.body
+                    .windows(case.body_witness.len())
+                    .any(|window| window == case.body_witness),
+                "{} must exercise a non-vacuous response: {:?}",
+                case.name,
+                h1.body
+            );
+        }
+        assert_eq!(
+            h3, h1,
+            "{} must be byte-equivalent over h3 and h1",
+            case.name
+        );
+    }
+
+    let topic = "https://pod.example/pub";
+    let token = notifications
+        .mint_receive_token("https://alice.example/#me", topic)
+        .await;
+    let mut websocket_url = url::Url::parse(&format!(
+        "wss://localhost:{}/.notifications/WebSocketChannel2023/receive",
+        server_addr.port()
+    ))?;
+    websocket_url
+        .query_pairs_mut()
+        .append_pair("topic", topic)
+        .append_pair("token", &token);
+    let h3_websocket_uri = websocket_url.as_str().replacen("wss://", "https://", 1);
+    let refused = h3_request(
+        &mut sender,
+        Method::GET,
+        &h3_websocket_uri,
+        None,
+        &[
+            ("sec-websocket-version", "13"),
+            ("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="),
+        ],
+    )
+    .await?;
     assert_eq!(
-        limited_status,
-        StatusCode::TOO_MANY_REQUESTS,
-        "the third same-IP request must be rate-limited; a missing QUIC ConnectInfo would fail open \
-         to the public handler and return 200"
+        refused.status,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "WebSocket over h3 must be cleanly refused until extended CONNECT is implemented"
     );
+    let after_refusal = h3_request(
+        &mut sender,
+        Method::GET,
+        &format!("https://localhost:{}/livez", h3_addr.port()),
+        None,
+        &[],
+    )
+    .await?;
+    assert_eq!(after_refusal.status, StatusCode::OK);
+
+    let tcp = tokio::net::TcpStream::connect(server_addr).await?;
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(client_tls_config(b"http/1.1")?));
+    let server_name = rustls::pki_types::ServerName::try_from("localhost")?.to_owned();
+    let tls = connector.connect(server_name, tcp).await?;
+    let (mut websocket, upgrade) =
+        tokio_tungstenite::client_async(websocket_url.as_str(), tls).await?;
+    assert_eq!(upgrade.status(), StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(upgrade.version(), Version::HTTP_11);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while notifications.subscriber_count(topic).await != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await?;
+    websocket.close(None).await?;
 
     drop(sender);
     client_endpoint.close(quinn::VarInt::from_u32(0), b"test complete");
@@ -236,8 +421,55 @@ async fn h3_ldp_get_matches_h1_and_carries_peer_connect_info() -> TestResult {
 }
 
 #[tokio::test]
+async fn h3_requests_carry_peer_connect_info() -> TestResult {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    let (app, _) = production_router(0.0001, 1.0).await;
+    let mode = TlsMode::Tls {
+        cert_path: CERT_PATH.into(),
+        key_path: KEY_PATH.into(),
+    };
+    let tcp_tls = build_rustls_config(&mode, false)
+        .await?
+        .expect("TLS mode yields a config");
+    let mut quic_tls = (*tcp_tls.get_inner()).clone();
+    quic_tls.alpn_protocols = vec![b"h3".to_vec()];
+    let h3_endpoint =
+        quinn::Endpoint::server(quic_server_config(quic_tls)?, "127.0.0.1:0".parse()?)?;
+    let h3_addr = h3_endpoint.local_addr()?;
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve_h3(h3_endpoint, app, async move {
+        let _ = shutdown_rx.await;
+    }));
+
+    let client_endpoint = h3_client_endpoint()?;
+    let connection = client_endpoint.connect(h3_addr, "localhost")?.await?;
+    let (mut driver, mut sender) = h3::client::new(h3_quinn::Connection::new(connection)).await?;
+    let driver = tokio::spawn(async move {
+        let _ = poll_fn(|context| driver.poll_close(context)).await;
+    });
+    let uri = format!("https://localhost:{}/pub", h3_addr.port());
+    let first = h3_request(&mut sender, Method::GET, &uri, None, &[]).await?;
+    assert_eq!(first.status, StatusCode::OK);
+    let limited = h3_request(&mut sender, Method::GET, &uri, None, &[]).await?;
+    assert_eq!(
+        limited.status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "the second same-IP request must be rate-limited; missing QUIC ConnectInfo fails open"
+    );
+
+    drop(sender);
+    client_endpoint.close(quinn::VarInt::from_u32(0), b"test complete");
+    tokio::time::timeout(Duration::from_secs(5), driver).await??;
+    shutdown_tx
+        .send(())
+        .map_err(|()| "h3 server stopped before shutdown")?;
+    tokio::time::timeout(Duration::from_secs(5), server).await???;
+    Ok(())
+}
+
+#[tokio::test]
 async fn unconfigured_http3_router_does_not_advertise_alt_svc() -> TestResult {
-    let app = production_router(100.0, 100.0).await;
+    let (app, _) = production_router(100.0, 100.0).await;
     let response = app
         .oneshot(
             Request::builder()

--- a/crates/sparq-server/tests/http3.rs
+++ b/crates/sparq-server/tests/http3.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "http3")]
-//! [GPT-5.6] sq-oprna.3: production-binary HTTP/3 wiring and cross-protocol parity.
+//! [GPT-5.6] sq-oprna.3/.5: production HTTP/3 wiring and cross-protocol conformance.
 
 use std::{
     error::Error,
@@ -13,13 +13,41 @@ use std::{
 };
 
 use bytes::{Buf as _, Bytes};
+use futures_util::{SinkExt as _, StreamExt as _};
 use h3::quic::OpenStreams;
 use quinn::crypto::rustls::QuicClientConfig;
 
 type TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>;
 
-const QUERY: &str = "SELECT ?x WHERE { VALUES ?x { <http://example.com/http3> } }";
 const RESULTS_JSON: &str = "application/sparql-results+json";
+
+// [GPT-5.6] sq-oprna.5: compare the transport-neutral response contract, not incidental headers.
+#[derive(Debug, PartialEq, Eq)]
+struct ResponseSnapshot {
+    status: u16,
+    content_type: Option<String>,
+    body: Bytes,
+}
+
+struct RequestCase {
+    name: &'static str,
+    method: axum::http::Method,
+    path: &'static str,
+    content_type: Option<&'static str>,
+    accept: Option<&'static str>,
+    body: &'static [u8],
+    expected_status: axum::http::StatusCode,
+    body_witness: &'static [u8],
+}
+
+struct H3Request<'a> {
+    method: axum::http::Method,
+    path: &'a str,
+    content_type: Option<&'a str>,
+    accept: Option<&'a str>,
+    headers: &'a [(&'a str, &'a str)],
+    body: &'a [u8],
+}
 
 struct ChildGuard(Child);
 
@@ -64,23 +92,32 @@ fn h3_client(ca_path: &std::path::Path) -> TestResult<quinn::Endpoint> {
     Ok(endpoint)
 }
 
-async fn h3_query<O>(
+async fn h3_request<O>(
     sender: &mut h3::client::SendRequest<O, Bytes>,
     addr: SocketAddr,
-) -> TestResult<(u16, Option<String>, Bytes)>
+    request: H3Request<'_>,
+) -> TestResult<ResponseSnapshot>
 where
     O: OpenStreams<Bytes>,
 {
-    let request = axum::http::Request::builder()
-        .method(axum::http::Method::POST)
-        .uri(format!("https://localhost:{}/sparql", addr.port()))
-        .header(axum::http::header::CONTENT_TYPE, "application/sparql-query")
-        .header(axum::http::header::ACCEPT, RESULTS_JSON)
-        .body(())?;
-    let mut stream = sender.send_request(request).await?;
-    stream
-        .send_data(Bytes::from_static(QUERY.as_bytes()))
-        .await?;
+    let mut builder = axum::http::Request::builder()
+        .method(request.method)
+        .uri(format!("https://localhost:{}{}", addr.port(), request.path));
+    if let Some(value) = request.content_type {
+        builder = builder.header(axum::http::header::CONTENT_TYPE, value);
+    }
+    if let Some(value) = request.accept {
+        builder = builder.header(axum::http::header::ACCEPT, value);
+    }
+    for &(name, value) in request.headers {
+        builder = builder.header(name, value);
+    }
+    let mut stream = sender.send_request(builder.body(())?).await?;
+    if !request.body.is_empty() {
+        stream
+            .send_data(Bytes::copy_from_slice(request.body))
+            .await?;
+    }
     stream.finish().await?;
 
     let response = stream.recv_response().await?;
@@ -95,7 +132,45 @@ where
         let remaining = chunk.remaining();
         body.extend_from_slice(&chunk.copy_to_bytes(remaining));
     }
-    Ok((status, content_type, Bytes::from(body)))
+    Ok(ResponseSnapshot {
+        status,
+        content_type,
+        body: Bytes::from(body),
+    })
+}
+
+async fn h1_request(
+    client: &reqwest::Client,
+    addr: SocketAddr,
+    case: &RequestCase,
+) -> TestResult<ResponseSnapshot> {
+    let mut request = client.request(
+        reqwest::Method::from_bytes(case.method.as_str().as_bytes())?,
+        format!("http://{addr}{}", case.path),
+    );
+    if let Some(value) = case.content_type {
+        request = request.header(reqwest::header::CONTENT_TYPE, value);
+    }
+    if let Some(value) = case.accept {
+        request = request.header(reqwest::header::ACCEPT, value);
+    }
+    if !case.body.is_empty() {
+        request = request.body(case.body.to_vec());
+    }
+    let response = request.send().await?;
+    assert_eq!(response.version(), reqwest::Version::HTTP_11);
+    let status = response.status().as_u16();
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let body = response.bytes().await?;
+    Ok(ResponseSnapshot {
+        status,
+        content_type,
+        body,
+    })
 }
 
 #[test]
@@ -113,7 +188,7 @@ fn http3_requires_both_certificate_and_key_flags() -> TestResult {
 }
 
 #[tokio::test]
-async fn h3_sparql_response_matches_the_unchanged_http1_listener() -> TestResult {
+async fn h3_response_matrix_matches_h1_and_websocket_falls_back() -> TestResult {
     let tcp_addr = free_tcp_addr()?;
     let udp_addr = free_udp_addr()?;
     let child = Command::new(env!("CARGO_BIN_EXE_sparq-server"))
@@ -132,36 +207,26 @@ async fn h3_sparql_response_matches_the_unchanged_http1_listener() -> TestResult
     let mut server = ChildGuard(child);
 
     let http = reqwest::Client::new();
-    let url = format!("http://{tcp_addr}/sparql");
-    let mut http1 = None;
+    let readiness_url = format!("http://{tcp_addr}/health");
+    let mut ready = false;
     for _ in 0..100 {
-        match http
-            .post(&url)
-            .header(reqwest::header::CONTENT_TYPE, "application/sparql-query")
-            .header(reqwest::header::ACCEPT, RESULTS_JSON)
-            .body(QUERY)
-            .send()
-            .await
-        {
-            Ok(response) => {
-                http1 = Some(response);
+        match http.get(&readiness_url).send().await {
+            Ok(_) => {
+                ready = true;
                 break;
             }
             Err(_) => tokio::time::sleep(Duration::from_millis(25)).await,
         }
     }
-    let http1 = match http1 {
-        Some(response) => response,
-        None => {
-            let _ = server.0.kill();
-            let mut stderr = String::new();
-            if let Some(mut pipe) = server.0.stderr.take() {
-                pipe.read_to_string(&mut stderr)?;
-            }
-            let _ = server.0.wait();
-            return Err(format!("server did not become ready: {stderr}").into());
+    if !ready {
+        let _ = server.0.kill();
+        let mut stderr = String::new();
+        if let Some(mut pipe) = server.0.stderr.take() {
+            pipe.read_to_string(&mut stderr)?;
         }
-    };
+        let _ = server.0.wait();
+        return Err(format!("server did not become ready: {stderr}").into());
+    }
     let health = http.get(format!("http://{tcp_addr}/health")).send().await?;
     assert_eq!(health.version(), reqwest::Version::HTTP_11);
     let expected_alt_svc = format!("h3=\":{}\"; ma=86400", udp_addr.port());
@@ -173,29 +238,154 @@ async fn h3_sparql_response_matches_the_unchanged_http1_listener() -> TestResult
         Some(expected_alt_svc.as_str()),
         "the h1 GET response must advertise the successfully bound QUIC port"
     );
-    let h1_status = http1.status().as_u16();
-    let h1_content_type = http1
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .map(str::to_owned);
-    let h1_body = http1.bytes().await?;
-
     let endpoint = h3_client(&fixture("http3-ca.pem"))?;
     let connection = endpoint.connect(udp_addr, "localhost")?.await?;
     let (mut driver, mut sender) = h3::client::new(h3_quinn::Connection::new(connection)).await?;
     let driver = tokio::spawn(async move {
         let _ = poll_fn(|context| driver.poll_close(context)).await;
     });
-    let (h3_status, h3_content_type, h3_body) = h3_query(&mut sender, udp_addr).await?;
+    let cases = [
+        RequestCase {
+            name: "health",
+            method: axum::http::Method::GET,
+            path: "/health",
+            content_type: None,
+            accept: None,
+            body: b"",
+            expected_status: axum::http::StatusCode::OK,
+            body_witness: b"ok",
+        },
+        RequestCase {
+            name: "GET SELECT as CSV",
+            method: axum::http::Method::GET,
+            path: "/sparql?query=SELECT%20%3Fx%20WHERE%20%7B%20VALUES%20%3Fx%20%7B%20%3Chttp%3A%2F%2Fexample.com%2Fhttp3-get%3E%20%7D%20%7D",
+            content_type: None,
+            accept: Some("text/csv"),
+            body: b"",
+            expected_status: axum::http::StatusCode::OK,
+            body_witness: b"http://example.com/http3-get",
+        },
+        RequestCase {
+            name: "POST ASK as SPARQL JSON",
+            method: axum::http::Method::POST,
+            path: "/sparql",
+            content_type: Some("application/sparql-query"),
+            accept: Some(RESULTS_JSON),
+            body: b"ASK { }",
+            expected_status: axum::http::StatusCode::OK,
+            body_witness: b"\"boolean\":true",
+        },
+        RequestCase {
+            name: "not-found error",
+            method: axum::http::Method::GET,
+            path: "/not-an-endpoint",
+            content_type: None,
+            accept: None,
+            body: b"",
+            expected_status: axum::http::StatusCode::NOT_FOUND,
+            body_witness: b"not found",
+        },
+    ];
 
-    assert_eq!(h3_status, h1_status);
-    assert_eq!(h3_content_type, h1_content_type);
-    assert_eq!(h3_body, h1_body);
-    assert!(
-        String::from_utf8_lossy(&h3_body).contains("http://example.com/http3"),
-        "the parity assertion must cover a non-empty query result"
+    for case in &cases {
+        let h1 = h1_request(&http, tcp_addr, case).await?;
+        let h3 = h3_request(
+            &mut sender,
+            udp_addr,
+            H3Request {
+                method: case.method.clone(),
+                path: case.path,
+                content_type: case.content_type,
+                accept: case.accept,
+                headers: &[],
+                body: case.body,
+            },
+        )
+        .await?;
+        assert_eq!(h1.status, case.expected_status.as_u16(), "{}", case.name);
+        assert!(
+            h1.body
+                .windows(case.body_witness.len())
+                .any(|window| window == case.body_witness),
+            "{} must exercise a non-vacuous response: {:?}",
+            case.name,
+            h1.body
+        );
+        assert_eq!(
+            h3, h1,
+            "{} must be byte-equivalent over h3 and h1",
+            case.name
+        );
+    }
+
+    // HTTP/1.1 Upgrade headers are illegal in h3. Axum consequently requires RFC 9220 CONNECT for
+    // this HTTP version, but the server deliberately exposes no extended-CONNECT route: the h3 GET
+    // is refused with 405 without closing the connection, then the client falls back to TCP.
+    let refused = h3_request(
+        &mut sender,
+        udp_addr,
+        H3Request {
+            method: axum::http::Method::GET,
+            path: "/subscriptions",
+            content_type: None,
+            accept: None,
+            headers: &[
+                ("sec-websocket-version", "13"),
+                ("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ=="),
+            ],
+            body: b"",
+        },
+    )
+    .await?;
+    assert_eq!(
+        refused.status,
+        axum::http::StatusCode::METHOD_NOT_ALLOWED.as_u16(),
+        "WebSocket over h3 must be cleanly refused until extended CONNECT is implemented"
     );
+    let after_refusal = h3_request(
+        &mut sender,
+        udp_addr,
+        H3Request {
+            method: axum::http::Method::GET,
+            path: "/health",
+            content_type: None,
+            accept: None,
+            headers: &[],
+            body: b"",
+        },
+    )
+    .await?;
+    assert_eq!(after_refusal.status, axum::http::StatusCode::OK.as_u16());
+
+    let (mut websocket, upgrade) =
+        tokio_tungstenite::connect_async(format!("ws://{tcp_addr}/subscriptions")).await?;
+    assert_eq!(
+        upgrade.status(),
+        axum::http::StatusCode::SWITCHING_PROTOCOLS
+    );
+    assert_eq!(upgrade.version(), axum::http::Version::HTTP_11);
+    websocket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            serde_json::json!({ "subscribe": { "query": "SELECT ?x WHERE { VALUES ?x { <http://example.com/ws-fallback> } }" } })
+                .to_string()
+                .into(),
+        ))
+        .await?;
+    let subscribed = tokio::time::timeout(Duration::from_secs(5), websocket.next())
+        .await?
+        .ok_or_else(|| std::io::Error::other("WebSocket closed before subscribed response"))??;
+    let subscribed: serde_json::Value = serde_json::from_str(subscribed.to_text()?)?;
+    assert!(subscribed.get("subscribed").is_some(), "{subscribed}");
+    let initial = tokio::time::timeout(Duration::from_secs(5), websocket.next())
+        .await?
+        .ok_or_else(|| std::io::Error::other("WebSocket closed before initial notification"))??;
+    assert!(
+        initial
+            .to_text()?
+            .contains("http://example.com/ws-fallback"),
+        "the h1 fallback must carry a real subscription result"
+    );
+    websocket.close(None).await?;
 
     drop(sender);
     endpoint.close(quinn::VarInt::from_u32(0), b"test complete");


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-oprna.5** — Cross-protocol conformance/integration test: h3 request == h1 response per server + a WS-over-h3 fallback assertion
sq-oprna.5.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-oprna.5","crate":"sparq-server+sparq-lws-core","committed":true,"gates_green":true,"branch":"feat/sq-oprna.5-codex-gpt56","non_vacuity_verified":true,"notes":"h1/h3 matrices and h3 WS refusal with live h1 fallback; all scoped gates green"}
```

Not armed — the orchestrator arms after review.