### PR TITLE
sparq-algos: num_strongly_connected_components(labels) count accessor 
sq-awq7n [GPT-5.6]

### DIFF
--- a/crates/sparq-algos/README.md
+++ b/crates/sparq-algos/README.md
@@ -17,7 +17,8 @@ use sparq_algos::{
     degree_centrality, Direction, top_k,
     betweenness_centrality, closeness_centrality,
     weakly_connected_components, label_propagation, LabelPropConfig, num_communities,
-    is_acyclic, strongly_connected_components, topological_sort,
+    is_acyclic, num_strongly_connected_components, strongly_connected_components,
+    topological_sort,
 };
 
 // Project the RDF graph onto a directed node graph (subjects + entity objects = nodes,
@@ -44,6 +45,7 @@ let k    = num_communities(&comm);
 
 // Directed topology; requires feature `topology`.
 let scc = strongly_connected_components(&g);              // dense component id per node
+let scc_count = num_strongly_connected_components(&scc);  // number of components
 let dag = is_acyclic(&g);                                  // false for any directed cycle
 let order = topological_sort(&g)?;                         // Err(CycleError) on a cycle
 ```
@@ -68,9 +70,10 @@ let order = topological_sort(&g)?;                         // Err(CycleError) on
 - **Community detection** — exact weakly-connected components (near-linear union-find) and
   a deterministic label-propagation heuristic; dense, ascending-order community ids.
 - **Directed topology** — with the default-OFF `topology` feature, iterative Tarjan
-  strongly connected components and a canonical topological sort. SCC ids are densified by
-  ascending node index; topological-sort ties choose the smallest ready node and cycles,
-  including self-loops, return `CycleError`; `is_acyclic` exposes the same check as a boolean.
+  strongly connected components, their count accessor, and a canonical topological sort.
+  SCC ids are densified by ascending node index; topological-sort ties choose the smallest
+  ready node and cycles, including self-loops, return `CycleError`; `is_acyclic` exposes the
+  same check as a boolean. [GPT-5.6] sq-awq7n.
 - **Opt-in & lean** — consumes only sparq-core's public read API; the only dependencies
   are `sparq-core`, `oxrdf`, and `rustc-hash`. The heavier all-pairs algorithms are behind
   `centrality-extended`, and directed topology is behind `topology`; both features are OFF

--- a/crates/sparq-algos/src/lib.rs
+++ b/crates/sparq-algos/src/lib.rs
@@ -19,7 +19,10 @@ pub use community::{
 pub use graph::{NodeFilter, NodeGraph};
 pub use pagerank::{pagerank, PageRankConfig};
 #[cfg(feature = "topology")]
-pub use topology::{is_acyclic, strongly_connected_components, topological_sort, CycleError};
+pub use topology::{
+    is_acyclic, num_strongly_connected_components, strongly_connected_components, topological_sort,
+    CycleError,
+};
 
 #[cfg(test)]
 mod tests {

--- a/crates/sparq-algos/src/topology.rs
+++ b/crates/sparq-algos/src/topology.rs
@@ -115,6 +115,13 @@ pub fn strongly_connected_components(g: &NodeGraph) -> Vec<usize> {
     densify_roots(&component_root)
 }
 
+/// [GPT-5.6] sq-awq7n: Returns the number of strongly connected components in a
+/// labelling produced by `strongly_connected_components` (dense ids, so this is
+/// `max + 1`, or `0` for an empty labelling).
+pub fn num_strongly_connected_components(labels: &[usize]) -> usize {
+    labels.iter().copied().max().map_or(0, |m| m + 1)
+}
+
 fn discover(
     node: usize,
     indices: &mut [usize],

--- a/crates/sparq-algos/tests/topology.rs
+++ b/crates/sparq-algos/tests/topology.rs
@@ -4,7 +4,8 @@
 
 use proptest::prelude::*;
 use sparq_algos::{
-    is_acyclic, strongly_connected_components, topological_sort, CycleError, NodeGraph,
+    is_acyclic, num_strongly_connected_components, strongly_connected_components, topological_sort,
+    CycleError, NodeGraph,
 };
 use sparq_core::Graph;
 
@@ -30,6 +31,36 @@ fn directed_cycle_and_isolated_node_have_two_components() {
     );
     assert_eq!(strongly_connected_components(&graph), vec![0, 0, 0, 1]);
     assert_eq!(topological_sort(&graph), Err(CycleError));
+}
+
+/// [GPT-5.6] sq-awq7n: value-pins the dense-label count, including its empty-input
+/// sentinel. The reciprocal d/e pair is the second SCC; a one-way edge would instead
+/// make d and e separate singleton SCCs, as `one_way_edge_does_not_merge_strong_components`
+/// verifies below.
+#[test]
+fn strongly_connected_component_count_handles_two_three_and_zero() {
+    let two_components = build(
+        r#"
+<http://e/a> <http://p/edge> <http://e/b> .
+<http://e/b> <http://p/edge> <http://e/c> .
+<http://e/c> <http://p/edge> <http://e/a> .
+<http://e/d> <http://p/edge> <http://e/e> .
+<http://e/e> <http://p/edge> <http://e/d> .
+"#,
+    );
+    let two_labels = strongly_connected_components(&two_components);
+    assert_eq!(num_strongly_connected_components(&two_labels), 2);
+
+    let three_components = build(
+        r#"
+<http://e/a> <http://p/edge> <http://e/a> .
+<http://e/b> <http://p/edge> <http://e/b> .
+<http://e/c> <http://p/edge> <http://e/c> .
+"#,
+    );
+    let three_labels = strongly_connected_components(&three_components);
+    assert_eq!(num_strongly_connected_components(&three_labels), 3);
+    assert_eq!(num_strongly_connected_components(&[]), 0);
 }
 
 #[test]

--- a/skills/graph-analytics/SKILL.md
+++ b/skills/graph-analytics/SKILL.md
@@ -45,7 +45,8 @@ use sparq_algos::{
     degree_centrality, degree_centrality_normalized, Direction, top_k,
     betweenness_centrality, closeness_centrality, core_number,
     weakly_connected_components, label_propagation, LabelPropConfig, num_communities,
-    is_acyclic, strongly_connected_components, topological_sort,
+    is_acyclic, num_strongly_connected_components, strongly_connected_components,
+    topological_sort,
 };
 
 // Project the RDF graph onto a directed node graph.
@@ -75,6 +76,7 @@ let k    = num_communities(&comm);                         // distinct community
 
 // --- Directed topology ---
 let scc   = strongly_connected_components(&g);             // dense component id per node
+let scc_k = num_strongly_connected_components(&scc);       // number of components
 let dag   = is_acyclic(&g);                                 // false for any directed cycle
 let order = topological_sort(&g)?;                         // canonical DAG order; Err on cycle
 ```
@@ -99,6 +101,7 @@ let order = topological_sort(&g)?;                         // canonical DAG orde
 | `label_propagation(&g, LabelPropConfig)` | heuristic community labels (`Vec<usize>`) |
 | `num_communities(&labels)` | distinct community count |
 | `strongly_connected_components(&g)` | directed SCC id per node; requires `topology` |
+| `num_strongly_connected_components(&labels)` | directed SCC count; requires `topology` |
 | `is_acyclic(&g)` | whether the directed graph has no cycle; requires `topology` |
 | `topological_sort(&g)` | canonical `Result<Vec<usize>, CycleError>`; requires `topology` |
 
@@ -137,3 +140,4 @@ let order = topological_sort(&g)?;                         // canonical DAG orde
   RAM (CSR forward + reverse adjacency keyed by dense `u32` node indices); it does not
   reference the source graph after building, except `term()` which needs the dict.
 - Opt-in, workspace v0.1.0, `#![forbid(unsafe_code)]`. [OPUS-4.8] pending re-review.
+  [GPT-5.6] `sq-awq7n` added the SCC count accessor.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-awq7n** — sparq-algos: num_strongly_connected_components(labels) count accessor (parity with num_communities)
sq-awq7n.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-awq7n","crate":"sparq-algos","committed":true,"gates_green":true,"branch":"feat/sq-awq7n-codex-gpt56","non_vacuity_verified":true,"notes":"All gates passed; corrected contradictory two-SCC fixture to d<->e; both mutations failed as intended."}
```

Not armed — the orchestrator arms after review.