### PR TITLE
sparq-arrow: parquet_row_count_from_bytes() metadata-only row count (p
sq-kix7x [GPT-5.6]

### DIFF
--- a/crates/sparq-arrow/README.md
+++ b/crates/sparq-arrow/README.md
@@ -7,8 +7,8 @@
 >
 > [GPT-5.6] Bead `sq-lsp7k.16` adds the checked inverse, `from_record_batch`.
 > [GPT-5.6] Bead `sq-lsp7k.21` adds Parquet byte serialization over that same schema.
-> [GPT-5.6] Bead `sq-r3cab` adds Arrow IPC stream byte serialization.
-> [GPT-5.6] Bead `sq-ksxa2` adds schema-only variable readers for both containers.
+> [GPT-5.6] Beads `sq-r3cab` and `sq-ksxa2` add Arrow IPC bytes and schema-only readers.
+> [GPT-5.6] Bead `sq-kix7x` adds a metadata-only Parquet row-count reader.
 
 **Opt-in / lean-core by construction.** This is a separate leaf crate, and Arrow
 import/export sits behind the `arrow` feature (OFF by default). The `arrow-*` dependency
@@ -45,10 +45,14 @@ To serialize the same term-struct batch as an in-memory Parquet file, enable the
 default-OFF `parquet` feature:
 
 ```rust,ignore
-use sparq_arrow::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
+use sparq_arrow::{
+    from_parquet_bytes, parquet_row_count_from_bytes, parquet_variables_from_bytes,
+    to_parquet_bytes,
+};
 
 let bytes = to_parquet_bytes(&result)?;
 assert_eq!(parquet_variables_from_bytes(&bytes)?, result.vars);
+assert_eq!(parquet_row_count_from_bytes(&bytes)?, result.rows.len());
 let restored = from_parquet_bytes(&bytes)?;
 assert_eq!(restored.vars, result.vars);
 assert_eq!(restored.rows, result.rows);
@@ -89,8 +93,8 @@ metadata return `ArrowError`; they never panic or silently select a fallback ter
 `from_parquet_bytes` validates the recovered schema before decoding any row. Empty
 results retain their variable projection, and multiple row groups keep file order.
 `to_ipc_bytes` and `from_ipc_bytes` provide the equivalent checked Arrow IPC stream.
-The `parquet_variables_from_bytes` and `ipc_variables_from_bytes` schema readers recover
-only the variables without decoding rows.
+The `parquet_variables_from_bytes` and `ipc_variables_from_bytes` schema readers recover only the
+variables without decoding rows. `parquet_row_count_from_bytes` reads the total row count from Parquet metadata without decoding row groups.
 
 ## 📚 Honest boundary / caveats
 

--- a/crates/sparq-arrow/src/lib.rs
+++ b/crates/sparq-arrow/src/lib.rs
@@ -50,7 +50,8 @@
 //!   itself an RDF document.
 //! * With the opt-in `parquet` feature, `to_parquet_bytes` / `from_parquet_bytes`
 //!   serialize and restore this exact RecordBatch projection;
-//!   `parquet_variables_from_bytes` reads only its variables from the stored schema.
+//!   `parquet_variables_from_bytes` reads only its variables from the stored schema,
+//!   while `parquet_row_count_from_bytes` reads only its total row count from metadata.
 //!   Parquet adds a container; it does not define a second RDF-term encoding.
 //! * With the opt-in `ipc` feature, `to_ipc_bytes` / `from_ipc_bytes` do the same through
 //!   the Arrow IPC streaming format, including preservation of an empty result's schema;
@@ -103,7 +104,10 @@ pub use import::{from_record_batch, ArrowError};
 
 #[cfg(feature = "parquet")]
 #[cfg_attr(docsrs, doc(cfg(feature = "parquet")))]
-pub use parquet::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
+pub use parquet::{
+    from_parquet_bytes, parquet_row_count_from_bytes, parquet_variables_from_bytes,
+    to_parquet_bytes,
+};
 
 #[cfg(feature = "ipc")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ipc")))]

--- a/crates/sparq-arrow/src/parquet.rs
+++ b/crates/sparq-arrow/src/parquet.rs
@@ -59,6 +59,20 @@ pub fn parquet_variables_from_bytes(bytes: &[u8]) -> Result<Vec<Variable>, Arrow
     variables_from_schema(builder.schema().as_ref())
 }
 
+/// Read the total row count from a Parquet file's metadata.
+///
+/// This does not build a record-batch reader or decode any row groups.
+///
+/// # Errors
+///
+/// Returns [`ArrowError`] if `bytes` do not contain readable Parquet metadata.
+// [GPT-5.6] Keep the metadata-only path separate from full row decoding.
+pub fn parquet_row_count_from_bytes(bytes: &[u8]) -> Result<usize, ArrowError> {
+    let builder = ParquetRecordBatchReaderBuilder::try_new(Bytes::copy_from_slice(bytes))
+        .map_err(import_error)?;
+    Ok(builder.metadata().file_metadata().num_rows() as usize)
+}
+
 /// Deserialize Parquet bytes containing this crate's RDF-term Arrow projection.
 ///
 /// Every decoded batch is validated through [`from_record_batch`]. This includes files

--- a/crates/sparq-arrow/tests/parquet.rs
+++ b/crates/sparq-arrow/tests/parquet.rs
@@ -7,7 +7,10 @@ use arrow_array::{ArrayRef, RecordBatch, StringArray};
 use arrow_schema::{DataType, Field, Schema};
 use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Triple, Variable};
 use parquet::arrow::ArrowWriter;
-use sparq_arrow::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
+use sparq_arrow::{
+    from_parquet_bytes, parquet_row_count_from_bytes, parquet_variables_from_bytes,
+    to_parquet_bytes,
+};
 use sparq_engine::QueryResult;
 
 fn assert_identity(result: &QueryResult) {
@@ -76,6 +79,36 @@ fn schema_only_reader_recovers_nonempty_result_variables() {
     );
 }
 
+/// [GPT-5.6] Value-pinned mutation witness: the two variables and three rows make a
+/// column-count implementation return 2, while the all-unbound row exercises nullability.
+#[test]
+fn metadata_only_reader_recovers_exact_row_count() {
+    let result = QueryResult {
+        vars: vec![Variable::new("s").unwrap(), Variable::new("o").unwrap()],
+        rows: vec![
+            vec![
+                Some(Term::NamedNode(
+                    NamedNode::new("https://example.test/s").unwrap(),
+                )),
+                Some(Term::Literal(Literal::new_simple_literal("object"))),
+            ],
+            vec![None, None],
+            vec![
+                Some(Term::BlankNode(BlankNode::new("blank-2").unwrap())),
+                None,
+            ],
+        ],
+    };
+    let bytes = to_parquet_bytes(&result).unwrap();
+
+    assert!(matches!(parquet_row_count_from_bytes(&bytes), Ok(3)));
+    let restored = from_parquet_bytes(&bytes).unwrap();
+    assert_eq!(
+        parquet_row_count_from_bytes(&bytes).unwrap(),
+        restored.rows.len()
+    );
+}
+
 #[test]
 fn empty_result_preserves_variable_schema_and_zero_rows() {
     let result = QueryResult {
@@ -88,6 +121,7 @@ fn empty_result_preserves_variable_schema_and_zero_rows() {
 
     let bytes = to_parquet_bytes(&result).unwrap();
     assert_eq!(parquet_variables_from_bytes(&bytes).unwrap(), result.vars);
+    assert_eq!(parquet_row_count_from_bytes(&bytes).unwrap(), 0);
     assert_identity(&result);
 }
 

--- a/skills/arrow-columnar/SKILL.md
+++ b/skills/arrow-columnar/SKILL.md
@@ -14,8 +14,9 @@ Use `sparq-arrow` when a Rust application needs a faithful columnar representati
 
 - Enable `arrow` for `to_record_batch`, `from_record_batch`, `term_schema`, and
   `term_struct_type`.
-- Enable `parquet` for `to_parquet_bytes`, `from_parquet_bytes`, and
-  `parquet_variables_from_bytes`; it implies `arrow`.
+- Enable `parquet` for `to_parquet_bytes`, `from_parquet_bytes`,
+  `parquet_variables_from_bytes`, and `parquet_row_count_from_bytes`; it implies
+  `arrow`.
 - Enable `ipc` for `to_ipc_bytes`, `from_ipc_bytes`, and
   `ipc_variables_from_bytes`; it implies `arrow`.
 - Leave all features disabled to retain only the dependency-free field-name constants.
@@ -40,12 +41,17 @@ Add the feature with `cargo add sparq-arrow --features arrow`.
 ## Use Parquet bytes
 
 ```rust,ignore
-use sparq_arrow::{from_parquet_bytes, parquet_variables_from_bytes, to_parquet_bytes};
+use sparq_arrow::{
+    from_parquet_bytes, parquet_row_count_from_bytes, parquet_variables_from_bytes,
+    to_parquet_bytes,
+};
 
 let bytes: Vec<u8> = to_parquet_bytes(&result)?;
 let variables = parquet_variables_from_bytes(&bytes)?;
+let row_count = parquet_row_count_from_bytes(&bytes)?;
 let restored = from_parquet_bytes(&bytes)?;
 assert_eq!(variables, result.vars);
+assert_eq!(row_count, result.rows.len());
 assert_eq!(restored.vars, result.vars);
 assert_eq!(restored.rows, result.rows);
 # Ok::<(), Box<dyn std::error::Error>>(())
@@ -54,7 +60,8 @@ assert_eq!(restored.rows, result.rows);
 Add the feature with `cargo add sparq-arrow --features parquet`. Parquet is only a
 serialization of the same RecordBatch projection; it does not use a second term
 encoding. `parquet_variables_from_bytes` validates and reads only the stored schema,
-without decoding row groups. `from_parquet_bytes` additionally rejects invalid RDF
+while `parquet_row_count_from_bytes` reads the total row count from file metadata;
+neither decodes row groups. `from_parquet_bytes` additionally rejects invalid RDF
 lexical components while decoding rows.
 
 ## Use Arrow IPC stream bytes
@@ -91,4 +98,4 @@ same schema as the RecordBatch and preserves variable names for an empty result.
 Treat the Arrow batch, Parquet bytes, or IPC stream as a transport projection, not as a
 canonical RDF serialization or an RDF document.
 
-[GPT-5.6] Verified against `sparq-arrow` for bead `sq-r3cab`.
+[GPT-5.6] Verified against `sparq-arrow` for beads `sq-r3cab` and `sq-kix7x`.


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-kix7x** — sparq-arrow: parquet_row_count_from_bytes() metadata-only row count (parity with parquet_variables_from_bytes)
sq-kix7x.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-kix7x","crate":"sparq-arrow","committed":true,"gates_green":true,"branch":"feat/sq-kix7x-codex-gpt56","non_vacuity_verified":true,"notes":"all scoped gates and workspace checks green; no clippy drift"}
```

Not armed — the orchestrator arms after review.