### PR TITLE
sparq-mcp: no-LLM 'classes' MCP tool listing class profiles (parity wi
sq-cekgj [GPT-5.6]

### DIFF
--- a/crates/sparq-mcp/README.md
+++ b/crates/sparq-mcp/README.md
@@ -8,7 +8,7 @@
 </p>
 
 A **Model Context Protocol (MCP)** server exposing a sparq RDF graph as **agent tools** —
-an **opt-in** crate. An LLM/agent can use `query`, `introspect`, `stats`, `prefixes`, and `void` over a
+an **opt-in** crate. An LLM/agent can use `query`, `introspect`, `stats`, `classes`, `prefixes`, and `void` over a
 dataset as first-class MCP tools; SPARQL **`update` is OFF by default**. It is a thin
 wrapper over the existing engine read API (`sparq-engine` query path + `sparq-introspect`
 schema mining): nothing in the workspace depends on it, the default engine build does not
@@ -45,14 +45,14 @@ transport (line-delimited JSON-RPC 2.0 over this process's stdin/stdout).
 - **`query`** — run a read-only SELECT/ASK; returns SPARQL 1.1 Query Results JSON. Bounded by a configurable `QueryBudget` (default 30 s / 1M rows).
 - **`construct`** — run a read-only CONSTRUCT/DESCRIBE; returns N-Triples text.
 - **`introspect`** — the effective schema the graph actually uses (classes, predicates,
-  prefixes, characteristic sets) as full JSON or a token-budgeted text summary for LLM
-  grounding — exact counts from the store indexes, no sampling.
+  prefixes, characteristic sets) as JSON or token-budgeted text; exact counts, no sampling.
 - **`shapes`** — given a class IRI, the data-grounded SHACL-style shape of that class:
   the valid predicates, their datatypes/object-kinds, observed range, and the
   cardinalities the data supports (`min_count`/`max_count` only when proven, never
   fabricated). Structured grounding so a **client** LLM can write NL→SPARQL — **no
   server-side model**. Ships in the default build.
 - **`stats`** — dataset totals (triples, distinct subjects, typed entities, class / predicate / namespace counts).
+- **`classes`** — list class IRIs with instance and predicate counts, largest class first. <!-- [GPT-5.6] sq-cekgj -->
 - **`prefixes`** — list detected namespace declarations and distinct IRI term counts, largest namespace first. <!-- [GPT-5.6] sq-kx5b0 -->
 - **`void`** — emit a W3C VoID dataset descriptor as N-Triples, optionally including characteristic-set statistics; `dataset` defaults to `urn:sparq:dataset`.
 - **`ask`** *(feature `nlq`, OFF by default)* — answer a natural-language question

--- a/crates/sparq-mcp/src/server.rs
+++ b/crates/sparq-mcp/src/server.rs
@@ -230,6 +230,7 @@ impl McpServer {
             "introspect" => self.tool_introspect(&args),
             "shapes" => self.tool_shapes(&args),
             "stats" => self.tool_stats(),
+            "classes" => self.tool_classes(),
             "prefixes" => self.tool_prefixes(),
             "void" => self.tool_void(&args),
             #[cfg(feature = "nlq")]
@@ -322,6 +323,29 @@ impl McpServer {
             "namespaces": ix.vocabularies.distinct,
         });
         Ok(serde_json::to_string_pretty(&stats).unwrap_or_else(|_| stats.to_string()))
+    }
+
+    /// [GPT-5.6] sq-cekgj: `classes`, class profiles ranked by instance count.
+    fn tool_classes(&self) -> Result<String, String> {
+        let ix = Introspection::build(&self.graph);
+        let mut profiles = ix.classes;
+        let distinct_classes = profiles.len();
+        profiles.sort_by(|a, b| b.instances.cmp(&a.instances).then(a.class.cmp(&b.class)));
+        let classes: Vec<Value> = profiles
+            .into_iter()
+            .map(|profile| {
+                json!({
+                    "class": profile.class,
+                    "instances": profile.instances,
+                    "predicate_count": profile.predicates.len(),
+                })
+            })
+            .collect();
+        let result = json!({
+            "distinct_classes": distinct_classes,
+            "classes": classes,
+        });
+        Ok(serde_json::to_string_pretty(&result).unwrap_or_else(|_| result.to_string()))
     }
 
     /// [GPT-5.6] sq-kx5b0: `prefixes`, namespace declarations ranked by term count.

--- a/crates/sparq-mcp/src/tools.rs
+++ b/crates/sparq-mcp/src/tools.rs
@@ -12,6 +12,7 @@
 //!   cardinality constraints for one class IRI; structured grounding for a client LLM —
 //!   no server-side model). [OPUS-4.8] sq-zak4f
 //! - `stats` → graph triple count + introspection totals.
+//! - `classes` → per-class instance and predicate counts.
 //! - `prefixes` → namespace declarations + per-namespace distinct-IRI term counts.
 //! - `void` → `sparq_introspect::Introspection::to_void` (W3C VoID N-Triples).
 //! - `validate` (feature `shacl`, OFF by default) → `sparq_shacl::validate` over
@@ -165,6 +166,23 @@ pub const STATS: ToolSpec = ToolSpec {
                   distinct subjects, typed entities, and the number of distinct \
                   classes / predicates / namespaces. Cheap, structured counts for \
                   deciding how to query the dataset.",
+    input_schema: || {
+        json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false
+        })
+    },
+};
+
+/// [GPT-5.6] sq-cekgj: class profiles ranked by instance count.
+pub const CLASSES: ToolSpec = ToolSpec {
+    name: "classes",
+    description: "Return the classes detected in the loaded graph: each class IRI, its \
+                  instance count, and the number of predicates used by its instances, \
+                  sorted by instance count descending then class IRI ascending. Also \
+                  returns the total number of classes as distinct_classes. No LLM is \
+                  involved.",
     input_schema: || {
         json!({
             "type": "object",
@@ -413,6 +431,7 @@ pub const READ_ONLY: &[&ToolSpec] = &[
     &INTROSPECT,
     &SHAPES,
     &STATS,
+    &CLASSES,
     &PREFIXES,
     &VOID,
 ];

--- a/crates/sparq-mcp/tests/roundtrip.rs
+++ b/crates/sparq-mcp/tests/roundtrip.rs
@@ -1,8 +1,8 @@
 //! [OPUS-4.8] (sq-0z43i, gh #909) Real MCP round-trip over an in-memory store:
 //! initialize → tools/list → tools/call. Exercises the actual dispatch core
 //! (`McpServer::handle_message`) — no mock bypasses the engine; `query` runs through
-//! the real `sparq-engine` query path and `introspect`/`stats`/`prefixes` through the real
-//! `sparq-introspect` schema miner. The load-bearing invariants asserted here:
+//! the real `sparq-engine` query path and `introspect`/`stats`/`classes`/`prefixes`
+//! through the real `sparq-introspect` schema miner. The load-bearing invariants asserted here:
 //!   - read-only by DEFAULT: `update` is absent from `tools/list` and a `tools/call`
 //!     for it is refused (fail-closed mutation surface);
 //!   - with update enabled, `update` is advertised AND actually mutates the graph,
@@ -26,12 +26,26 @@ const PREFIXES_TTL: &str = r#"@prefix schema: <https://schema.org/> .
 schema:alice schema:knows schema:bob ; foaf:name "Alice" .
 "#;
 
+// [GPT-5.6] sq-cekgj: two classes with unequal populations and predicate profiles give
+// the `classes` tool mutation-witnessed ordering and count assertions.
+const CLASSES_TTL: &str = r#"@prefix ex: <http://ex/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+ex:a1 rdf:type ex:A ; ex:p "one" ; ex:q ex:o .
+ex:a2 rdf:type ex:A ; ex:p "two" .
+ex:a3 rdf:type ex:A .
+ex:b1 rdf:type ex:B ; ex:p "three" .
+"#;
+
 fn graph() -> Graph {
     Graph::load_str(TTL, "turtle").expect("load turtle")
 }
 
 fn prefixes_graph() -> Graph {
     Graph::load_str(PREFIXES_TTL, "turtle").expect("load prefixes turtle")
+}
+
+fn classes_graph() -> Graph {
+    Graph::load_str(CLASSES_TTL, "turtle").expect("load classes turtle")
 }
 
 /// Parse a server response line into JSON.
@@ -80,6 +94,7 @@ fn read_only_server_lists_read_tools_only() {
     assert!(names.contains(&"introspect"));
     assert!(names.contains(&"shapes"));
     assert!(names.contains(&"stats"));
+    assert!(names.contains(&"classes"));
     assert!(names.contains(&"prefixes"));
     assert!(names.contains(&"void"));
     // [GPT-5.6] sq-lsp7k.22: the validator dependency and tool stay opt-in.
@@ -217,6 +232,30 @@ fn prefixes_tool_lists_namespaces_by_descending_term_count() {
     assert_eq!(prefixes[1]["prefix"], "foaf");
     assert_eq!(prefixes[1]["namespace"], "http://xmlns.com/foaf/0.1/");
     assert_eq!(prefixes[1]["term_count"], 1);
+}
+
+#[test]
+fn classes_tool_lists_profiles_by_descending_instance_count() {
+    let mut server = McpServer::new(classes_graph());
+    let response = call(
+        &mut server,
+        r#"{"jsonrpc":"2.0","id":19,"method":"tools/call","params":{"name":"classes","arguments":{}}}"#,
+    );
+    let result = &response["result"];
+    assert_eq!(result["isError"], false, "{response}");
+    let payload: Value =
+        serde_json::from_str(result["content"][0]["text"].as_str().unwrap()).unwrap();
+
+    assert_eq!(payload["distinct_classes"], 2);
+    let classes = payload["classes"].as_array().unwrap();
+    assert_eq!(classes.len(), 2);
+    assert_eq!(classes[0]["class"], "http://ex/A");
+    assert_eq!(classes[0]["instances"], 3);
+    // ClassProfile predicates include rdf:type alongside the two descriptive predicates.
+    assert_eq!(classes[0]["predicate_count"], 3);
+    assert_eq!(classes[1]["class"], "http://ex/B");
+    assert_eq!(classes[1]["instances"], 1);
+    assert_eq!(classes[1]["predicate_count"], 2);
 }
 
 #[test]

--- a/skills/agent-tools/SKILL.md
+++ b/skills/agent-tools/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-tools
-description: Use when an LLM/agent should access a sparq RDF dataset over the Model Context Protocol (MCP) as first-class tools — run SPARQL queries, mine the dataset schema, list namespace prefixes, read stats or a VoID descriptor, optionally SHACL-validate against caller-supplied shapes, and (gated, off by default) apply SPARQL updates. Covers the opt-in sparq-mcp crate — a JSON-RPC 2.0 MCP server (initialize, tools/list, tools/call) exposing query (SELECT/ASK to SPARQL-JSON), construct (CONSTRUCT/DESCRIBE to N-Triples), introspect (effective schema as JSON or token-budgeted text), stats, prefixes (namespace declarations and term counts), void (W3C VoID N-Triples), an opt-in read-only validate tool, and a gated update tool that is OFF by default; the transport-agnostic handle_message dispatch core plus the optional stdio feature; and the honest trust model (a local agent-tool server with no built-in auth, read-only by default, queries bounded by a QueryBudget). Also covers the opt-in solid feature — SolidMcpServer, a pod-backed server over sparq-solid's PodStore with WAC/ACP-authorized session-scoped query plus LDP resource tools (resource_get, container_list from stored ldp:contains data, and gated resource_put/resource_delete/container_create with existence non-disclosure and atomic ACL write-through). Complements genai-retrieval (sparq-nlq/sparq-introspect) — that is the NL-to-SPARQL loop; this is the MCP front door.
+description: Use when an LLM/agent should access a sparq RDF dataset over the Model Context Protocol (MCP) as first-class tools — run SPARQL queries, mine the dataset schema, list class profiles or namespace prefixes, read stats or a VoID descriptor, optionally SHACL-validate against caller-supplied shapes, and (gated, off by default) apply SPARQL updates. Covers the opt-in sparq-mcp crate — a JSON-RPC 2.0 MCP server (initialize, tools/list, tools/call) exposing query (SELECT/ASK to SPARQL-JSON), construct (CONSTRUCT/DESCRIBE to N-Triples), introspect (effective schema as JSON or token-budgeted text), stats, classes (class IRIs with instance and predicate counts), prefixes (namespace declarations and term counts), void (W3C VoID N-Triples), an opt-in read-only validate tool, and a gated update tool that is OFF by default; the transport-agnostic handle_message dispatch core plus the optional stdio feature; and the honest trust model (a local agent-tool server with no built-in auth, read-only by default, queries bounded by a QueryBudget). Also covers the opt-in solid feature — SolidMcpServer, a pod-backed server over sparq-solid's PodStore with WAC/ACP-authorized session-scoped query plus LDP resource tools (resource_get, container_list from stored ldp:contains data, and gated resource_put/resource_delete/container_create with existence non-disclosure and atomic ACL write-through). Complements genai-retrieval (sparq-nlq/sparq-introspect) — that is the NL-to-SPARQL loop; this is the MCP front door.
 ---
 
 # sparq agent-tools (MCP)
@@ -23,6 +23,7 @@ heavy MCP-SDK dependency.
 | `introspect` | `sparq_introspect::Introspection` | effective schema — JSON or token-budgeted text |
 | `shapes` | `sparq_introspect::Introspection` (per-class) | data-grounded SHACL-style shape for one class IRI |
 | `stats` | graph count + introspection totals | small JSON object |
+| `classes` | `sparq_introspect::Introspection` | class IRIs + instance and predicate counts, largest first |
 | `prefixes` | `sparq_introspect::Introspection` | namespace declarations + distinct IRI term counts, largest first |
 | `void` | `sparq_introspect::Introspection` | W3C VoID N-Triples; optional characteristic sets |
 | `ask` *(feature `nlq`, OFF by default)* | `sparq_nlq` NL→SPARQL loop | executed SPARQL + real result rows (+ citations) |
@@ -144,7 +145,7 @@ you, the operator, establish, and whoever can speak to the server has exactly th
 was configured with.
 
 - **Read-only by default** — a default `McpServer` advertises and accepts only
-  `query` / `construct` / `introspect` / `shapes` / `stats` / `prefixes` / `void`; it
+  `query` / `construct` / `introspect` / `shapes` / `stats` / `classes` / `prefixes` / `void`; it
   cannot mutate the dataset.
 - **`update` is a mutation surface**, exposed **only** when `ServerConfig::allow_update`
   is set (or a binary's `--allow-update` flag). It is the single write switch; there is no
@@ -155,8 +156,9 @@ was configured with.
 
 ## Status / scope
 
-Opt-in crate at workspace v0.1.0; verified against branch `main` (default `prefixes` tool
-2026-07-13 [GPT-5.6], sq-kx5b0; default `void` tool 2026-07-12 [GPT-5.6], sq-2kkym;
+Opt-in crate at workspace v0.1.0; verified against branch `main` (default `classes` tool
+2026-07-13 [GPT-5.6], sq-cekgj; default `prefixes` tool 2026-07-13 [GPT-5.6], sq-kx5b0;
+default `void` tool 2026-07-12 [GPT-5.6], sq-2kkym;
 pod mode 2026-07-11 [FABLE-5]).
 Tested by a real in-memory MCP round-trip (default features) **and** a real stdio
 serve-loop round-trip (feature `stdio`). Only the **stdio** transport plus the embeddable


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-cekgj** — sparq-mcp: no-LLM 'classes' MCP tool listing class profiles (parity with stats/prefixes/void)
sq-cekgj.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-cekgj","crate":"sparq-mcp","committed":true,"gates_green":true,"branch":"feat/sq-cekgj-codex-gpt56","non_vacuity_verified":true,"notes":"commit eab49efe; all gates green; reversed-sort mutation failed as expected"}
```

Not armed — the orchestrator arms after review.