### PR TITLE
sparq-canon: ungated digest_quads_with::<D: Digest>() single-call cano
sq-ddws7 [GPT-5.6]

### DIFF
--- a/crates/sparq-canon/README.md
+++ b/crates/sparq-canon/README.md
@@ -32,10 +32,10 @@ let map = sparq_canon::issued_identifiers(&[q]).unwrap();
 
 ## ✨ Features
 
-- **Dataset API** — [`canonicalize`]/`canonicalize_quads` return the canonical
-  N-Quads `String`; `issued_identifiers`/`issue_quads` return the blank-node
-  issuer map. `*_with::<D: Digest>` selects a non-default hash profile (the spec
-  default is SHA-256; `sha2::Sha384` gives the SHA-384 profile).
+- **Dataset API** — [`canonicalize`]/`canonicalize_quads` return canonical
+  N-Quads; `digest_quads_with::<D>` returns its exact digest bytes; and
+  `issued_identifiers`/`issue_quads` return the blank-node issuer map. The other
+  `*_with::<D: Digest>` functions select a non-default RDFC-1.0 hash profile.
 - **Single-graph API** — `canonicalize_triples` / `canonicalize_graph_content`
   return a `CanonicalGraph` (sorted canonical N-Quads lines + re-parsed
   canonical triples). This is what the ZK per-graph commitment pipeline

--- a/crates/sparq-canon/src/lib.rs
+++ b/crates/sparq-canon/src/lib.rs
@@ -32,9 +32,10 @@
 //! ## API shape
 //!
 //! - Dataset level (the general case): [`canonicalize`] / [`canonicalize_quads`]
-//!   take quads and return the canonical N-Quads `String`; [`issued_identifiers`]
-//!   / [`issue_quads`] return the canonical blank-node issuer map (input label
-//!   → `c14nN`).
+//!   take quads and return the canonical N-Quads `String`;
+//!   [`digest_quads_with`] returns a caller-selected digest of those exact
+//!   canonical bytes; [`issued_identifiers`] / [`issue_quads`] return the
+//!   canonical blank-node issuer map (input label → `c14nN`).
 //! - Single graph (a default-graph-only dataset): [`canonicalize_triples`] /
 //!   [`canonicalize_graph_content`] return a [`CanonicalGraph`] (the sorted
 //!   canonical N-Quads lines + the re-parsed canonical triples), which is what
@@ -147,10 +148,10 @@ pub use rdf12::{
 };
 
 /// The hash-function trait RDFC-1.0 is parameterized over (`digest::Digest`),
-/// re-exported so callers of [`canonicalize_quads_with`] / [`issue_quads_with`]
-/// can name a hasher (e.g. `sha2::Sha256`, `sha2::Sha384`) without taking a
-/// direct `digest` dependency. The spec default is SHA-256
-/// ([`canonicalize_quads`]).
+/// re-exported so callers of [`canonicalize_quads_with`], [`digest_quads_with`],
+/// or [`issue_quads_with`] can name a hasher (e.g. `sha2::Sha256`,
+/// `sha2::Sha384`) without taking a direct `digest` dependency. The spec
+/// default is SHA-256 ([`canonicalize_quads`]).
 pub use digest::Digest;
 
 /// The crate-wide bound on RDF 1.2 triple-term **nesting depth**.
@@ -309,6 +310,19 @@ pub fn canonicalize_quads_with<D: Digest>(dataset: &[Quad]) -> Result<String, Ca
     let opts = rdf_canon::CanonicalizationOptions::default();
     rdf_canon::canonicalize_quads_with::<D>(&quads02, &opts)
         .map_err(|e| CanonError::Canonicalization(e.to_string()))
+}
+
+/// Returns the digest bytes of the exact canonical N-Quads document produced
+/// by [`canonicalize_quads`].
+///
+/// `D` selects only the final digest algorithm; canonicalization retains the
+/// RDFC-1.0 default hash profile. Every canonical byte is hashed, including the
+/// final trailing newline when the dataset is non-empty. [GPT-5.6] sq-ddws7.
+pub fn digest_quads_with<D: Digest>(dataset: &[Quad]) -> Result<Vec<u8>, CanonError> {
+    let c = canonicalize_quads(dataset)?;
+    let mut h = D::new();
+    h.update(c.as_bytes());
+    Ok(h.finalize().to_vec())
 }
 
 /// Like [`issue_quads`] but parameterized over the RDFC-1.0 hash function `D`.

--- a/crates/sparq-canon/tests/digest_quads.rs
+++ b/crates/sparq-canon/tests/digest_quads.rs
@@ -1,0 +1,74 @@
+// [GPT-5.6] sq-ddws7: mutation-witnessed coverage for canonical digest bytes.
+
+use oxrdf::{BlankNode, GraphName, Literal, NamedNode, Quad};
+use sha2::{Digest as _, Sha256, Sha384};
+use sparq_canon::{canonicalize_quads, digest_quads_with};
+
+fn dataset(first: &str, second: &str) -> Vec<Quad> {
+    let first = BlankNode::new(first).unwrap();
+    let second = BlankNode::new(second).unwrap();
+    vec![
+        Quad::new(
+            first,
+            NamedNode::new("http://example.org/p").unwrap(),
+            second.clone(),
+            GraphName::DefaultGraph,
+        ),
+        Quad::new(
+            second,
+            NamedNode::new("http://example.org/q").unwrap(),
+            Literal::new_simple_literal("value"),
+            GraphName::DefaultGraph,
+        ),
+    ]
+}
+
+#[test]
+fn digest_lengths_follow_the_caller_selected_hasher() {
+    let dataset = dataset("b0", "b1");
+    let sha256 = digest_quads_with::<Sha256>(&dataset).unwrap();
+    let sha384 = digest_quads_with::<Sha384>(&dataset).unwrap();
+
+    assert_eq!(sha256.len(), 32);
+    assert_eq!(sha384.len(), 48);
+    assert_ne!(sha256, sha384);
+}
+
+#[test]
+fn digest_is_invariant_under_blank_node_relabelling() {
+    let original = dataset("b0", "b1");
+    let relabelled = dataset("x", "y");
+
+    assert_eq!(
+        digest_quads_with::<Sha256>(&original).unwrap(),
+        digest_quads_with::<Sha256>(&relabelled).unwrap()
+    );
+}
+
+#[test]
+fn digest_is_invariant_under_quad_order() {
+    let original = dataset("b0", "b1");
+    let mut reversed = original.clone();
+    reversed.reverse();
+
+    assert_eq!(
+        digest_quads_with::<Sha256>(&original).unwrap(),
+        digest_quads_with::<Sha256>(&reversed).unwrap()
+    );
+}
+
+#[test]
+fn digest_covers_the_exact_canonical_bytes() {
+    let dataset = dataset("b0", "b1");
+    let canonical = canonicalize_quads(&dataset).unwrap();
+    let exact = Sha256::digest(canonical.as_bytes()).to_vec();
+
+    assert!(canonical.ends_with('\n'));
+    assert_eq!(digest_quads_with::<Sha256>(&dataset).unwrap(), exact);
+
+    let without_final_newline = canonical.strip_suffix('\n').unwrap();
+    assert_ne!(
+        exact,
+        Sha256::digest(without_final_newline.as_bytes()).to_vec()
+    );
+}

--- a/skills/rdf-canon/SKILL.md
+++ b/skills/rdf-canon/SKILL.md
@@ -69,7 +69,7 @@ let canon = sparq_canon::canonicalize_nquads(
 assert!(canon.contains("_:c14n"));
 ```
 
-### Non-default hash profile
+### Hash profiles and final digests
 
 The spec default is SHA-256. To use the SHA-384 profile (or any
 `digest::Digest`), use the `*_with` functions; `Digest` is re-exported so you do
@@ -78,6 +78,20 @@ not need a direct `digest` dependency:
 ```rust
 let nq = sparq_canon::canonicalize_quads_with::<sha2::Sha384>(&dataset).unwrap();
 ```
+
+To hash the exact standard canonical N-Quads bytes in one call, including the
+final newline on a non-empty dataset, supply the final digest algorithm to
+`digest_quads_with`:
+
+```rust
+let digest = sparq_canon::digest_quads_with::<sha2::Sha256>(&dataset).unwrap();
+assert_eq!(digest.len(), 32);
+```
+
+Here `D` selects only the digest of the finished canonical document;
+canonicalization still follows `canonicalize_quads` and its default RDFC-1.0
+hash profile. Callers choose the digest crate and algorithm; `sparq-canon` adds
+no default digest alias.
 
 ## Single-graph API — one graph's triples
 


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-ddws7** — sparq-canon: ungated digest_quads_with::<D: Digest>() single-call canonical digest (caller supplies hasher, NO new dep)
sq-ddws7.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-ddws7","crate":"sparq-canon","committed":true,"gates_green":true,"branch":"feat/sq-ddws7-codex-gpt56","non_vacuity_verified":true,"notes":"all required gates green; no new dependency; raw-serialization and newline-trim mutations killed"}
```

Not armed — the orchestrator arms after review.