### PR TITLE
sparq-geo: geof:isEmpty registry function (unit-free geometry predicat
sq-lc2io [GPT-5.6]

### DIFF
--- a/crates/sparq-geo/src/geof.rs
+++ b/crates/sparq-geo/src/geof.rs
@@ -20,6 +20,7 @@
 //!   metric radii via a local equirectangular frame).
 //! - [`max_x`] / [`min_x`] / [`max_y`] / [`min_y`] — the bounding-box
 //!   coordinates in the geometry's stored CRS.
+//! - [`is_empty`] — `geof:isEmpty`, a unit-free geometry predicate.
 //! - [`metric_area`] / [`metric_length`] / [`metric_perimeter`] and
 //!   [`centroid`] — metric measurements and the mathematical centroid, using
 //!   the same local equirectangular frame for geographic geometries.
@@ -46,8 +47,8 @@ use crate::GeoError;
 use geo::relate::IntersectionMatrix;
 use geo::{
     Area, BooleanOps, BoundingRect, Buffer, Centroid, Closest, ConvexHull, CoordsIter, Distance,
-    Euclidean, Haversine, HaversineClosestPoint, Intersects, Length, LineIntersection, MapCoords,
-    Relate, Simplify,
+    Euclidean, HasDimensions, Haversine, HaversineClosestPoint, Intersects, Length,
+    LineIntersection, MapCoords, Relate, Simplify,
 };
 use geo_types::{
     Coord, Geometry, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
@@ -522,6 +523,14 @@ de9im_relation!(
 );
 
 // ---- Envelope and bounding-coordinate functions -----------------------------------
+
+/// `geof:isEmpty` — whether the geometry is the empty set.
+///
+/// This predicate is pure geometry introspection and does not depend on the
+/// geometry's CRS or any unit convention. [GPT-5.6] sq-lc2io
+pub fn is_empty(g: &GeoGeometry) -> Result<bool, GeoError> {
+    Ok(g.geometry.is_empty())
+}
 
 fn bounding_box(g: &GeoGeometry) -> Result<geo_types::Rect<f64>, GeoError> {
     g.geometry
@@ -1514,7 +1523,7 @@ pub mod lex {
 
 #[cfg(test)]
 mod tests {
-    use super::{max_x, max_y, min_x, min_y};
+    use super::{is_empty, max_x, max_y, min_x, min_y};
     use crate::{parse_wkt_literal, GeoError, GeoGeometry};
 
     type CoordinateAccessor = fn(&GeoGeometry) -> Result<f64, GeoError>;
@@ -1558,6 +1567,19 @@ mod tests {
                 accessor(&empty),
                 Err(GeoError::Unsupported(_))
             ));
+        }
+    }
+
+    #[test]
+    fn empty_predicate_distinguishes_empty_and_non_empty_geometries() {
+        for (wkt, expected) in [
+            ("POINT(1 2)", false),
+            ("POINT EMPTY", true),
+            ("LINESTRING EMPTY", true),
+            ("POLYGON((0 0,1 0,1 1,0 1,0 0))", false),
+        ] {
+            let geometry = parse_wkt_literal(wkt).expect("geometry WKT");
+            assert_eq!(is_empty(&geometry), Ok(expected), "WKT: {wkt}");
         }
     }
 }

--- a/crates/sparq-geo/src/registry.rs
+++ b/crates/sparq-geo/src/registry.rs
@@ -33,6 +33,7 @@
 //!   `xsd:double` in square metres / metres;
 //! * `geof:maxX`, `minX`, `maxY`, and `minY` return the corresponding envelope
 //!   coordinate as `xsd:double`;
+//! * `geof:isEmpty` returns `xsd:boolean`;
 //! * the `geof:sf*` relations return `xsd:boolean`;
 //! * `geof:envelope` / `geof:boundary` / `geof:centroid` /
 //!   `geof:convexHull` / `geof:simplify` return `geo:wktLiteral`;
@@ -427,6 +428,8 @@ fn num_arg(name: &str, args: &[Term], i: usize) -> Result<f64, String> {
 type GeomUnary = fn(&GeoGeometry) -> Result<GeoGeometry, GeoError>;
 /// A [`crate::geof`] unary numeric measurement function.
 type NumericUnary = fn(&GeoGeometry) -> Result<f64, GeoError>;
+/// A [`crate::geof`] unary boolean geometry predicate.
+type BooleanUnary = fn(&GeoGeometry) -> Result<bool, GeoError>;
 /// A [`crate::geof`] binary set operation (`intersection` / `union` / …).
 type GeomSetOp = fn(&GeoGeometry, &GeoGeometry) -> Result<GeoGeometry, GeoError>;
 
@@ -441,6 +444,7 @@ type GeomSetOp = fn(&GeoGeometry, &GeoGeometry) -> Result<GeoGeometry, GeoError>
 ///   `metricPerimeter(g)` -> metre `xsd:double`;
 /// * `maxX(g)` / `minX(g)` / `maxY(g)` / `minY(g)` -> the corresponding
 ///   envelope coordinate as `xsd:double`;
+/// * `isEmpty(g)` -> `xsd:boolean`;
 /// * the relation families, all `(g1, g2)` -> `xsd:boolean`: simple features
 ///   `sfEquals sfDisjoint sfIntersects sfTouches sfCrosses sfWithin sfContains
 ///   sfOverlaps`, Egenhofer `ehEquals ehDisjoint ehMeet ehOverlap ehCovers
@@ -494,6 +498,16 @@ pub fn geof_registry() -> FunctionRegistry {
         ("minY", geof::min_y),
     ];
     for (name, f) in measurements {
+        reg.register(format!("{GEOF_NS}{name}"), move |args: &[Term]| {
+            arity(name, args, 1)?;
+            let g = geom_arg(name, args, 0)?;
+            Ok(Term::Literal(Literal::from(f(&g).map_err(|e| e.to_string())?)))
+        });
+    }
+
+    // Unary geometry predicates: geometry -> xsd:boolean. [GPT-5.6] sq-lc2io
+    let predicates: [(&'static str, BooleanUnary); 1] = [("isEmpty", geof::is_empty)];
+    for (name, f) in predicates {
         reg.register(format!("{GEOF_NS}{name}"), move |args: &[Term]| {
             arity(name, args, 1)?;
             let g = geom_arg(name, args, 0)?;
@@ -643,11 +657,11 @@ mod tests {
     #[test]
     fn registry_contents() {
         let reg = geof_registry();
-        assert_eq!(reg.len(), 44);
+        assert_eq!(reg.len(), 45);
         for name in [
             "distance", "relate", "getSRID", "buffer",
             "metricArea", "metricLength", "metricPerimeter", "centroid",
-            "maxX", "minX", "maxY", "minY",
+            "maxX", "minX", "maxY", "minY", "isEmpty",
             "sfEquals", "sfDisjoint", "sfIntersects", "sfTouches", "sfCrosses",
             "sfWithin", "sfContains", "sfOverlaps",
             "ehEquals", "ehDisjoint", "ehMeet", "ehOverlap", "ehCovers", "ehCoveredBy",
@@ -696,6 +710,34 @@ mod tests {
         assert_eq!(value.datatype().as_str(), "http://www.w3.org/2001/XMLSchema#double");
         assert!((value.value().parse::<f64>().unwrap() - 4.0).abs() < 1e-12);
         assert!(max_x(&[]).is_err(), "geof:maxX must enforce unary arity");
+    }
+
+    #[test]
+    fn is_empty_term_level() {
+        let reg = geof_registry();
+        let is_empty = reg
+            .get(&format!("{GEOF_NS}isEmpty"))
+            .expect("registered geof:isEmpty");
+
+        for (wkt_lexical, expected) in [
+            ("POINT(1 2)", false),
+            ("POINT EMPTY", true),
+            ("LINESTRING EMPTY", true),
+            ("POLYGON((0 0,1 0,1 1,0 1,0 0))", false),
+        ] {
+            let Term::Literal(value) = is_empty(&[wkt(wkt_lexical)]).unwrap() else {
+                panic!("literal")
+            };
+            assert_eq!(
+                value.datatype().as_str(),
+                "http://www.w3.org/2001/XMLSchema#boolean"
+            );
+            assert_eq!(value.value(), expected.to_string(), "WKT: {wkt_lexical}");
+        }
+        assert!(
+            is_empty(&[]).is_err(),
+            "geof:isEmpty must enforce unary arity"
+        );
     }
 
     #[test]

--- a/skills/geosparql/SKILL.md
+++ b/skills/geosparql/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: geosparql
-description: "Use when adding GeoSPARQL spatial support to the sparq RDF/SPARQL engine — parsing geo:wktLiteral and geo:gmlLiteral (GML Simple-Features) geometries, calling geof: functions (distance, metricArea/metricLength/metricPerimeter/centroid, bounding coordinates, simplify, sf*/eh*/rcc8* DE-9IM relations, geometry/set operations, getSRID) inside SPARQL FILTER/BIND/SELECT via the sparq-engine extension-function registry, or building an R-tree GeoIndex over a Graph for within_distance / nearest / intersects queries. Crate: sparq-geo."
+description: "Use when adding GeoSPARQL spatial support to the sparq RDF/SPARQL engine — parsing geo:wktLiteral and geo:gmlLiteral (GML Simple-Features) geometries, calling geof: functions (distance, metricArea/metricLength/metricPerimeter/centroid, bounding coordinates, isEmpty, simplify, sf*/eh*/rcc8* DE-9IM relations, geometry/set operations, getSRID) inside SPARQL FILTER/BIND/SELECT via the sparq-engine extension-function registry, or building an R-tree GeoIndex over a Graph for within_distance / nearest / intersects queries. Crate: sparq-geo."
 ---
 
 # sparq-geosparql
@@ -30,7 +30,7 @@ let g = Graph::load_str(r#"
     <http://ex/paris>  <http://ex/loc> "POINT(2.3522 48.8566)"^^geo:wktLiteral .
 "#, "turtle").unwrap();
 
-let reg = geof_registry();               // 44 functions; clone-cheap, Send + Sync
+let reg = geof_registry();               // 45 functions; clone-cheap, Send + Sync
 let r = query_with_functions(&g,
     "PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
      PREFIX uom:  <http://www.opengis.net/def/uom/OGC/1.0/>
@@ -92,6 +92,7 @@ pub fn metric_length(g: &GeoGeometry) -> Result<f64, GeoError>;     // metres
 pub fn metric_perimeter(g: &GeoGeometry) -> Result<f64, GeoError>;  // metres
 pub fn centroid(g: &GeoGeometry) -> Result<GeoGeometry, GeoError>;  // POINT, same CRS
 pub fn max_x|min_x|max_y|min_y(g: &GeoGeometry) -> Result<f64, GeoError>; // envelope coordinate, stored CRS
+pub fn is_empty(g: &GeoGeometry) -> Result<bool, GeoError>;         // unit-free geometry predicate
 pub fn simplify(g: &GeoGeometry, tolerance: f64) -> Result<GeoGeometry, GeoError>; // RDP, same CRS
 pub fn sf_within(a, b) -> Result<bool, GeoError>;   // + sf_equals/disjoint/intersects/touches/
                                                     //   crosses/contains/overlaps, eh_*, rcc8_*
@@ -114,7 +115,7 @@ pub fn apply_delta(&mut self, graph: &Graph, inserts: &[[Term;3]], deletes: &[[T
 pub fn entries(&self) -> impl Iterator<Item=&Entry>;  // len() / is_empty() / skipped()
 ```
 
-Function IRIs are all under `http://www.opengis.net/def/function/geosparql/`. Result types in SPARQL: `geof:distance` / `metricArea` / `metricLength` / `metricPerimeter` / `maxX` / `minX` / `maxY` / `minY` → `xsd:double`; the relation families → `xsd:boolean`; `envelope`/`boundary`/`centroid`/`convexHull`/`simplify`/`buffer`/the four set ops → `geo:wktLiteral`; `getSRID` → `xsd:anyURI`.
+Function IRIs are all under `http://www.opengis.net/def/function/geosparql/`. Result types in SPARQL: `geof:distance` / `metricArea` / `metricLength` / `metricPerimeter` / `maxX` / `minX` / `maxY` / `minY` → `xsd:double`; `isEmpty` and the relation families → `xsd:boolean`; `envelope`/`boundary`/`centroid`/`convexHull`/`simplify`/`buffer`/the four set ops → `geo:wktLiteral`; `getSRID` → `xsd:anyURI`. [GPT-5.6] sq-lc2io
 
 ## Common recipes
 
@@ -172,6 +173,7 @@ let km = geof::distance(&a, &b, Unit::Kilometre).unwrap();        // ≈ 343.6
 let inside = geof::sf_within(&b, &parse_wkt_literal(
                 "POLYGON((-1 42.5,7 42.5,7 51,-1 51,-1 42.5))").unwrap()).unwrap();
 let eastern_edge = geof::max_x(&b).unwrap(); // coordinate in b's stored CRS
+let empty = geof::is_empty(&b).unwrap();      // false; no CRS/unit decision involved
 ```
 
 **Parse or serialise a GML literal (or dispatch parsing by datatype):** GML rides the same `GeoGeometry` as WKT, so it works everywhere a parsed geometry does. `to_gml_literal` emits the GML 3 Simple Features form and preserves CRS axis order:


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-lc2io** — sparq-geo: geof:isEmpty registry function (unit-free geometry predicate, parity with maxX/minX unary)
sq-lc2io.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-lc2io","crate":"sparq-geo","committed":true,"gates_green":true,"branch":"feat/sq-lc2io-codex-gpt56","non_vacuity_verified":true,"notes":"geof:isEmpty implemented; all scoped and workspace compatibility gates green; commit 65d86efe"}
```

Not armed — the orchestrator arms after review.