### PR TITLE
sparq-lws-core: bound the in-memory Solid store (byte/resource cap + u
sq-3ah7j [GPT-5.6]

### DIFF
--- a/crates/sparq-lws-core/src/error.rs
+++ b/crates/sparq-lws-core/src/error.rs
@@ -73,6 +73,10 @@ pub enum ServerError {
     /// A failure in the storage layer (SPARQ index or blob store).
     #[error("storage error: {0}")]
     Storage(String),
+
+    /// A write would exceed a configured in-memory storage limit.
+    #[error("insufficient storage")]
+    InsufficientStorage,
 }
 
 impl ServerError {
@@ -93,6 +97,7 @@ impl ServerError {
             ServerError::UnprocessablePatch(_) => StatusCode::UNPROCESSABLE_ENTITY,
             ServerError::UnsupportedMediaType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             ServerError::Storage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            ServerError::InsufficientStorage => StatusCode::INSUFFICIENT_STORAGE,
         }
     }
 }
@@ -125,6 +130,7 @@ impl IntoResponse for ServerError {
             StatusCode::NOT_ACCEPTABLE => "not acceptable",
             StatusCode::UNPROCESSABLE_ENTITY => "unprocessable entity",
             StatusCode::UNSUPPORTED_MEDIA_TYPE => "unsupported media type",
+            StatusCode::INSUFFICIENT_STORAGE => "insufficient storage",
             _ => "bad request",
         };
         (status, public_body).into_response()

--- a/crates/sparq-lws-core/src/store/blob.rs
+++ b/crates/sparq-lws-core/src/store/blob.rs
@@ -14,11 +14,16 @@ use std::time::SystemTime;
 use async_trait::async_trait;
 use bytes::Bytes;
 
+use super::{InMemoryStoreLimits, StoreUsage};
+
 /// A blob-store error (kept opaque so it never leaks backend detail to a client).
 #[derive(Debug, thiserror::Error)]
 pub enum BlobError {
     #[error("blob not found")]
     NotFound,
+    /// The configured in-memory byte or entry ceiling would be exceeded.
+    #[error("in-memory blob-store quota exceeded")]
+    QuotaExceeded,
     #[error("blob backend error: {0}")]
     Backend(String),
 }
@@ -178,6 +183,14 @@ struct StoredBlob {
     generation: u64,
 }
 
+/// Blob entries and their exact aggregate body-byte usage, protected by one lock so admission and
+/// accounting are atomic under concurrent PUTs.
+#[derive(Default)]
+struct BlobState {
+    entries: HashMap<String, StoredBlob>,
+    total_bytes: usize,
+}
+
 /// An in-memory [`BlobStore`] for tests and the M1 boot-without-S3 path.
 ///
 /// Each [`put`](InMemoryBlobStore::put) stamps the wall-clock insert time, mirroring an object store's
@@ -191,9 +204,8 @@ struct StoredBlob {
 /// STRICTLY DIFFERENT generation. That generation is the CAS witness the reconciler deletes on, making
 /// [`delete_if_unchanged`](BlobStore::delete_if_unchanged) race-free AND clock-independent (the HIGH fix:
 /// a `SystemTime` is not a unique write version, a monotonic generation is).
-#[derive(Default)]
 pub struct InMemoryBlobStore {
-    inner: Mutex<HashMap<String, StoredBlob>>,
+    inner: Mutex<BlobState>,
     /// Store-wide monotonic write counter. Every write does `fetch_add(1)` and stamps the returned value
     /// onto the entry's `generation`, so generations are globally unique + strictly increasing across the
     /// store. The bump is done WHILE the store `Mutex` is held (Finding 2: `bump_generation_locked`), in
@@ -202,11 +214,81 @@ pub struct InMemoryBlobStore {
     /// The `AtomicU64` type is retained only to keep the bump callable through the `&self` API; all
     /// ordering/visibility comes from the surrounding `Mutex`, so `Relaxed` suffices.
     next_generation: AtomicU64,
+    /// [GPT-5.6] Immutable admission ceilings; checks happen under `inner`'s lock.
+    limits: InMemoryStoreLimits,
+}
+
+impl Default for InMemoryBlobStore {
+    fn default() -> Self {
+        Self::with_limits(InMemoryStoreLimits::default())
+    }
 }
 
 impl InMemoryBlobStore {
+    /// Build with the bounded default limits.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Build with explicit aggregate byte and stored-entry limits.
+    pub fn with_limits(limits: InMemoryStoreLimits) -> Self {
+        Self {
+            inner: Mutex::new(BlobState::default()),
+            next_generation: AtomicU64::new(0),
+            limits,
+        }
+    }
+
+    /// Return exact physical usage, including unreferenced versions awaiting reconciliation.
+    pub fn usage(&self) -> Result<StoreUsage, BlobError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?;
+        Ok(StoreUsage {
+            total_bytes: guard.total_bytes,
+            resource_count: guard.entries.len(),
+        })
+    }
+
+    /// Return the immutable admission limits configured for this store.
+    pub fn quota(&self) -> InMemoryStoreLimits {
+        self.limits
+    }
+
+    /// Insert one body while atomically enforcing byte and entry ceilings and updating accounting.
+    fn put_at(&self, key: &str, body: Bytes, last_modified: SystemTime) -> Result<(), BlobError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?;
+        let previous_bytes = guard.entries.get(key).map_or(0, |blob| blob.body.len());
+        let is_new = !guard.entries.contains_key(key);
+        if is_new && guard.entries.len() >= self.limits.max_resource_count {
+            return Err(BlobError::QuotaExceeded);
+        }
+        let retained_bytes = guard
+            .total_bytes
+            .checked_sub(previous_bytes)
+            .ok_or_else(|| BlobError::Backend("blob byte accounting underflow".into()))?;
+        let next_total = retained_bytes
+            .checked_add(body.len())
+            .ok_or(BlobError::QuotaExceeded)?;
+        if next_total > self.limits.max_total_bytes {
+            return Err(BlobError::QuotaExceeded);
+        }
+
+        let generation = self.bump_generation_locked(&guard);
+        guard.entries.insert(
+            key.to_string(),
+            StoredBlob {
+                body,
+                last_modified,
+                generation,
+            },
+        );
+        guard.total_bytes = next_total;
+        Ok(())
     }
 
     /// The next strictly-increasing generation, read+incremented WHILE the store `Mutex` is held (the
@@ -222,7 +304,7 @@ impl InMemoryBlobStore {
     /// provides the ordering/visibility — the atomic's own ordering carries no additional guarantee here.
     /// (The `AtomicU64` is retained over a plain `u64` only to avoid threading a `&mut` field through the
     /// `&self` API; correctness comes entirely from the surrounding lock.)
-    fn bump_generation_locked(&self, _guard: &HashMap<String, StoredBlob>) -> u64 {
+    fn bump_generation_locked(&self, _guard: &BlobState) -> u64 {
         self.next_generation.fetch_add(1, Ordering::Relaxed)
     }
 
@@ -233,20 +315,13 @@ impl InMemoryBlobStore {
     /// Still stamps a FRESH monotonic `generation` (the CAS witness) on every call, exactly like `put` —
     /// so two `put_with_time` calls with the SAME `last_modified` are correctly distinguished by their
     /// generations (the property the grace-vs-CAS separation relies on).
-    pub fn put_with_time(&self, key: &str, body: Bytes, last_modified: SystemTime) {
-        // Finding 2: bump AND stamp the generation while holding the SAME lock as the insert, so the
-        // counter increment + the entry insertion are one atomic critical section ⇒ generations are
-        // strictly WRITE-ORDERED (no interleave between bump and insert).
-        let mut guard = self.inner.lock().expect("blob store mutex poisoned");
-        let generation = self.bump_generation_locked(&guard);
-        guard.insert(
-            key.to_string(),
-            StoredBlob {
-                body,
-                last_modified,
-                generation,
-            },
-        );
+    pub fn put_with_time(
+        &self,
+        key: &str,
+        body: Bytes,
+        last_modified: SystemTime,
+    ) -> Result<(), BlobError> {
+        self.put_at(key, body, last_modified)
     }
 
     /// Read the current stamped generation of a key (test helper — lets a test capture the CAS witness a
@@ -254,7 +329,7 @@ impl InMemoryBlobStore {
     /// generation and is therefore refused by `delete_if_unchanged`).
     pub fn generation_of(&self, key: &str) -> Option<u64> {
         let guard = self.inner.lock().expect("blob store mutex poisoned");
-        guard.get(key).map(|b| b.generation)
+        guard.entries.get(key).map(|b| b.generation)
     }
 }
 
@@ -266,31 +341,14 @@ impl BlobStore for InMemoryBlobStore {
             .lock()
             .map_err(|_| BlobError::Backend("poisoned".into()))?;
         guard
+            .entries
             .get(key)
             .map(|b| b.body.clone())
             .ok_or(BlobError::NotFound)
     }
 
     async fn put(&self, key: &str, body: Bytes) -> Result<(), BlobError> {
-        // Finding 2: bump AND stamp the generation WHILE holding the lock, so the counter increment + the
-        // insert are one atomic critical section ⇒ generations are strictly WRITE-ORDERED (a write stamped
-        // generation N is the one that inserts it; no other write interleaves between the bump and the
-        // insert). Every put — overwrite or not — still gets a strictly different generation, so a
-        // same-timestamp overwrite has a distinct CAS witness.
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| BlobError::Backend("poisoned".into()))?;
-        let generation = self.bump_generation_locked(&guard);
-        guard.insert(
-            key.to_string(),
-            StoredBlob {
-                body,
-                last_modified: crate::clock::now(),
-                generation,
-            },
-        );
-        Ok(())
+        self.put_at(key, body, crate::clock::now())
     }
 
     async fn exists(&self, key: &str) -> Result<bool, BlobError> {
@@ -298,7 +356,7 @@ impl BlobStore for InMemoryBlobStore {
             .inner
             .lock()
             .map_err(|_| BlobError::Backend("poisoned".into()))?;
-        Ok(guard.contains_key(key))
+        Ok(guard.entries.contains_key(key))
     }
 
     async fn delete(&self, key: &str) -> Result<(), BlobError> {
@@ -306,7 +364,12 @@ impl BlobStore for InMemoryBlobStore {
             .inner
             .lock()
             .map_err(|_| BlobError::Backend("poisoned".into()))?;
-        guard.remove(key);
+        if let Some(blob) = guard.entries.remove(key) {
+            guard.total_bytes = guard
+                .total_bytes
+                .checked_sub(blob.body.len())
+                .ok_or_else(|| BlobError::Backend("blob byte accounting underflow".into()))?;
+        }
         Ok(())
     }
 
@@ -316,6 +379,7 @@ impl BlobStore for InMemoryBlobStore {
             .lock()
             .map_err(|_| BlobError::Backend("poisoned".into()))?;
         Ok(guard
+            .entries
             .iter()
             .map(|(key, blob)| BlobEntry {
                 key: key.clone(),
@@ -333,7 +397,7 @@ impl BlobStore for InMemoryBlobStore {
             .inner
             .lock()
             .map_err(|_| BlobError::Backend("poisoned".into()))?;
-        Ok(guard.get(key).map(|blob| BlobEntry {
+        Ok(guard.entries.get(key).map(|blob| BlobEntry {
             key: key.to_string(),
             last_modified: Some(blob.last_modified),
             generation: Some(blob.generation),
@@ -359,9 +423,16 @@ impl BlobStore for InMemoryBlobStore {
             .lock()
             .map_err(|_| BlobError::Backend("poisoned".into()))?;
         // Compare the CURRENT generation to the witness, then remove, all while still holding the lock.
-        match guard.get(key) {
+        match guard.entries.get(key) {
             Some(blob) if blob.generation == expected_generation => {
-                guard.remove(key);
+                let blob = guard
+                    .entries
+                    .remove(key)
+                    .expect("entry was present under the same lock");
+                guard.total_bytes = guard
+                    .total_bytes
+                    .checked_sub(blob.body.len())
+                    .ok_or_else(|| BlobError::Backend("blob byte accounting underflow".into()))?;
                 Ok(true)
             }
             // Key gone, or its generation moved since the witness was observed (a rewrite landed — even a
@@ -387,13 +458,16 @@ mod tests {
         let blob = InMemoryBlobStore::new();
         let same_stamp = SystemTime::now() - Duration::from_secs(3600);
 
-        blob.put_with_time("k", Bytes::from_static(b"v1"), same_stamp);
+        blob.put_with_time("k", Bytes::from_static(b"v1"), same_stamp)
+            .unwrap();
         let g1 = blob.generation_of("k").expect("v1 exists");
         // A same-key OVERWRITE at the IDENTICAL last_modified still bumps the generation.
-        blob.put_with_time("k", Bytes::from_static(b"v2"), same_stamp);
+        blob.put_with_time("k", Bytes::from_static(b"v2"), same_stamp)
+            .unwrap();
         let g2 = blob.generation_of("k").expect("v2 exists");
         // A DIFFERENT key advances the same store-wide counter.
-        blob.put_with_time("other", Bytes::from_static(b"o"), same_stamp);
+        blob.put_with_time("other", Bytes::from_static(b"o"), same_stamp)
+            .unwrap();
         let g3 = blob.generation_of("other").expect("other exists");
 
         assert!(
@@ -403,6 +477,85 @@ mod tests {
         assert!(
             g2 < g3,
             "the store-wide generation counter is strictly increasing across keys too"
+        );
+    }
+
+    #[tokio::test]
+    async fn byte_and_entry_limits_fail_without_mutating_usage() {
+        // [GPT-5.6] Mutation witness: removing either admission check makes its corresponding
+        // rejected put succeed and changes the pinned usage below.
+        let limits = InMemoryStoreLimits::new(4, 2);
+        let blob = InMemoryBlobStore::with_limits(limits);
+
+        blob.put("a", Bytes::from_static(b"123")).await.unwrap();
+        assert_eq!(
+            blob.usage().unwrap(),
+            StoreUsage {
+                total_bytes: 3,
+                resource_count: 1,
+            }
+        );
+        assert!(matches!(
+            blob.put("b", Bytes::from_static(b"45")).await,
+            Err(BlobError::QuotaExceeded)
+        ));
+        assert_eq!(blob.usage().unwrap().total_bytes, 3);
+
+        // Replacing a key subtracts its old body before testing the aggregate byte ceiling.
+        blob.put("a", Bytes::from_static(b"1234")).await.unwrap();
+        blob.put("b", Bytes::new()).await.unwrap();
+        assert!(matches!(
+            blob.put("c", Bytes::new()).await,
+            Err(BlobError::QuotaExceeded)
+        ));
+        assert_eq!(
+            blob.usage().unwrap(),
+            StoreUsage {
+                total_bytes: 4,
+                resource_count: 2,
+            }
+        );
+
+        blob.delete("a").await.unwrap();
+        assert_eq!(
+            blob.usage().unwrap(),
+            StoreUsage {
+                total_bytes: 0,
+                resource_count: 1,
+            }
+        );
+        assert_eq!(blob.quota(), limits);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_puts_cannot_over_admit_the_limits() {
+        // [GPT-5.6] The check and insert share one lock: a racing burst can fill, never overshoot.
+        let blob = Arc::new(InMemoryBlobStore::with_limits(InMemoryStoreLimits::new(
+            8, 8,
+        )));
+        let mut handles = Vec::new();
+        for n in 0..64 {
+            let blob = Arc::clone(&blob);
+            handles.push(tokio::spawn(async move {
+                blob.put(&format!("k{n}"), Bytes::from_static(b"x")).await
+            }));
+        }
+
+        let mut admitted = 0;
+        for handle in handles {
+            match handle.await.unwrap() {
+                Ok(()) => admitted += 1,
+                Err(BlobError::QuotaExceeded) => {}
+                Err(other) => panic!("unexpected blob error: {other}"),
+            }
+        }
+        assert_eq!(admitted, 8);
+        assert_eq!(
+            blob.usage().unwrap(),
+            StoreUsage {
+                total_bytes: 8,
+                resource_count: 8,
+            }
         );
     }
 

--- a/crates/sparq-lws-core/src/store/limits.rs
+++ b/crates/sparq-lws-core/src/store/limits.rs
@@ -1,0 +1,52 @@
+// [GPT-5.6] Bounded in-memory storage configuration and observability.
+
+/// Default aggregate body-byte ceiling for the in-memory Solid store (64 MiB).
+pub const DEFAULT_IN_MEMORY_MAX_TOTAL_BYTES: usize = 64 * 1024 * 1024;
+
+/// Default stored-entry ceiling for each in-memory storage map.
+pub const DEFAULT_IN_MEMORY_MAX_RESOURCE_COUNT: usize = 4_096;
+
+/// Hard admission limits for the in-memory metadata and blob stores.
+///
+/// The byte ceiling applies to bytes physically retained by [`super::InMemoryBlobStore`], including
+/// unreferenced versions awaiting reconciliation. The count ceiling is enforced independently by
+/// both in-memory maps, so zero-byte writes and metadata-only growth are bounded too. A zero value
+/// deliberately admits no new entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InMemoryStoreLimits {
+    /// Maximum aggregate bytes physically retained by the blob store.
+    pub max_total_bytes: usize,
+    /// Maximum entries retained by either the blob or metadata store.
+    pub max_resource_count: usize,
+}
+
+impl InMemoryStoreLimits {
+    /// Construct explicit byte and entry ceilings.
+    pub const fn new(max_total_bytes: usize, max_resource_count: usize) -> Self {
+        Self {
+            max_total_bytes,
+            max_resource_count,
+        }
+    }
+}
+
+impl Default for InMemoryStoreLimits {
+    fn default() -> Self {
+        Self::new(
+            DEFAULT_IN_MEMORY_MAX_TOTAL_BYTES,
+            DEFAULT_IN_MEMORY_MAX_RESOURCE_COUNT,
+        )
+    }
+}
+
+/// A point-in-time in-memory store usage view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StoreUsage {
+    /// Aggregate bytes physically retained by the blob store.
+    pub total_bytes: usize,
+    /// Occupied entry slots at the fuller of the blob and metadata maps.
+    ///
+    /// This includes unreferenced blob versions awaiting reconciliation, because they consume the
+    /// same bounded capacity as live resources.
+    pub resource_count: usize,
+}

--- a/crates/sparq-lws-core/src/store/mod.rs
+++ b/crates/sparq-lws-core/src/store/mod.rs
@@ -27,6 +27,7 @@ pub mod embedded;
 // engine in-process (`embedded` above) instead of paying an HTTP round-trip per index operation.
 #[cfg(all(feature = "http-sparq", not(target_arch = "wasm32")))]
 pub mod http;
+mod limits;
 pub mod reconcile;
 pub mod sparq;
 pub mod sparql;
@@ -47,6 +48,10 @@ pub use counting::{
 pub use embedded::EmbeddedSparqClient;
 #[cfg(all(feature = "http-sparq", not(target_arch = "wasm32")))]
 pub use http::{HttpSparqClient, SparqHttpError};
+pub use limits::{
+    InMemoryStoreLimits, StoreUsage, DEFAULT_IN_MEMORY_MAX_RESOURCE_COUNT,
+    DEFAULT_IN_MEMORY_MAX_TOTAL_BYTES,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use reconcile::spawn_periodic;
 pub use reconcile::{
@@ -277,6 +282,7 @@ impl<S: SparqClient, B: BlobStore> CompositeStore<S, B> {
         let body = self.blob.get(&meta.blob_key).await.map_err(|e| match e {
             // The index says it exists but bytes are missing: a reconciler-class inconsistency.
             BlobError::NotFound => ServerError::Storage("byte/index inconsistency".into()),
+            BlobError::QuotaExceeded => ServerError::InsufficientStorage,
             BlobError::Backend(msg) => ServerError::Storage(msg),
         })?;
         self.body_cache.insert(&meta.blob_key, &meta.etag, &body);
@@ -354,6 +360,46 @@ impl<S: SparqClient, B: BlobStore> CompositeStore<S, B> {
     }
 }
 
+// [GPT-5.6] The concrete wasm/dev-store pair exposes one combined limits and usage view without
+// widening the production backend traits, whose remote stores have backend-specific quota models.
+impl CompositeStore<InMemorySparqClient, InMemoryBlobStore> {
+    /// Build a bounded in-memory store with the same limits enforced at both storage seams.
+    pub fn in_memory_with_limits(limits: InMemoryStoreLimits) -> Self {
+        Self::new(
+            InMemorySparqClient::with_limits(limits),
+            InMemoryBlobStore::with_limits(limits),
+        )
+    }
+
+    /// Return physical byte usage and the fuller storage map's occupied-entry count.
+    pub fn usage(&self) -> ServerResult<StoreUsage> {
+        let blob = self.blob.usage().map_err(|error| match error {
+            BlobError::NotFound => ServerError::Storage("blob usage lookup failed".into()),
+            BlobError::QuotaExceeded => ServerError::InsufficientStorage,
+            BlobError::Backend(message) => ServerError::Storage(message),
+        })?;
+        let indexed = self.sparq.usage().map_err(|error| match error {
+            SparqError::NotFound => ServerError::Storage("index usage lookup failed".into()),
+            SparqError::QuotaExceeded => ServerError::InsufficientStorage,
+            SparqError::Backend(message) => ServerError::Storage(message),
+        })?;
+        Ok(StoreUsage {
+            total_bytes: blob.total_bytes,
+            resource_count: blob.resource_count.max(indexed),
+        })
+    }
+
+    /// Return the effective limits; mismatched manually-constructed backends report the tighter cap.
+    pub fn quota(&self) -> InMemoryStoreLimits {
+        let blob = self.blob.quota();
+        let index = self.sparq.quota();
+        InMemoryStoreLimits::new(
+            blob.max_total_bytes,
+            blob.max_resource_count.min(index.max_resource_count),
+        )
+    }
+}
+
 #[async_trait]
 impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
     async fn read(&self, iri: &str) -> ServerResult<Resource> {
@@ -363,6 +409,7 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         let meta = match self.sparq.get_meta(iri).await {
             Ok(m) => m,
             Err(SparqError::NotFound) => return Err(ServerError::NotFound),
+            Err(SparqError::QuotaExceeded) => return Err(ServerError::InsufficientStorage),
             Err(SparqError::Backend(e)) => return Err(ServerError::Storage(e)),
         };
         let body = self.fetch_body(&meta).await?;
@@ -373,6 +420,7 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         match self.sparq.get_meta(iri).await {
             Ok(m) => Ok(Some(m)),
             Err(SparqError::NotFound) => Ok(None),
+            Err(SparqError::QuotaExceeded) => Err(ServerError::InsufficientStorage),
             Err(SparqError::Backend(e)) => Err(ServerError::Storage(e)),
         }
     }
@@ -404,10 +452,10 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         // key) — the write errors instead, so the no-two-writes-share-a-key invariant holds even then.
         let blob_key = Self::mint_blob_key(iri)?;
         let etag = Self::etag_for(&body);
-        self.blob
-            .put(&blob_key, body)
-            .await
-            .map_err(|e| ServerError::Storage(format!("{e}")))?;
+        self.blob.put(&blob_key, body).await.map_err(|e| match e {
+            BlobError::QuotaExceeded => ServerError::InsufficientStorage,
+            other => ServerError::Storage(format!("{other}")),
+        })?;
         let meta = ResourceMeta {
             content_type: content_type.to_string(),
             blob_key,
@@ -419,7 +467,10 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         self.sparq
             .put_meta(iri, meta.clone())
             .await
-            .map_err(|e| ServerError::Storage(format!("{e}")))?;
+            .map_err(|e| match e {
+                SparqError::QuotaExceeded => ServerError::InsufficientStorage,
+                other => ServerError::Storage(format!("{other}")),
+            })?;
         Ok(meta)
     }
 
@@ -444,10 +495,10 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         // key), so the no-shared-key invariant holds even then.
         let blob_key = Self::mint_blob_key(child)?;
         let etag = Self::etag_for(&body);
-        self.blob
-            .put(&blob_key, body)
-            .await
-            .map_err(|e| ServerError::Storage(format!("{e}")))?;
+        self.blob.put(&blob_key, body).await.map_err(|e| match e {
+            BlobError::QuotaExceeded => ServerError::InsufficientStorage,
+            other => ServerError::Storage(format!("{other}")),
+        })?;
         let meta = ResourceMeta {
             content_type: content_type.to_string(),
             blob_key,
@@ -463,6 +514,7 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         {
             Ok(()) => Ok(meta),
             Err(SparqError::NotFound) => Err(ServerError::NotFound),
+            Err(SparqError::QuotaExceeded) => Err(ServerError::InsufficientStorage),
             Err(SparqError::Backend(e)) => Err(ServerError::Storage(e)),
         }
     }
@@ -472,6 +524,7 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
         let blob_key = match self.sparq.get_meta(iri).await {
             Ok(m) => Some(m.blob_key),
             Err(SparqError::NotFound) => None,
+            Err(SparqError::QuotaExceeded) => return Err(ServerError::InsufficientStorage),
             Err(SparqError::Backend(e)) => return Err(ServerError::Storage(e)),
         };
         // Detach from the parent's containment first, then drop the index record, then the bytes.
@@ -539,6 +592,7 @@ impl<S: SparqClient, B: BlobStore> Store for CompositeStore<S, B> {
             .await
             .map_err(|e| match e {
                 SparqError::NotFound => ServerError::NotFound,
+                SparqError::QuotaExceeded => ServerError::InsufficientStorage,
                 SparqError::Backend(msg) => ServerError::Storage(msg),
             })
     }

--- a/crates/sparq-lws-core/src/store/reconcile.rs
+++ b/crates/sparq-lws-core/src/store/reconcile.rs
@@ -631,7 +631,8 @@ mod tests {
         let sparq = InMemorySparqClient::new();
         let blob = InMemoryBlobStore::new();
         // An orphan: bytes exist, NO index row references "orphan". Back-dated past the grace window.
-        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600));
+        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600))
+            .unwrap();
 
         let report = reconcile_orphans(&sparq, &blob, &opts()).await.unwrap();
         assert_eq!(report.scanned, 1);
@@ -647,7 +648,8 @@ mod tests {
         let blob = InMemoryBlobStore::new();
         // A LIVE resource: an index row references "live-key", and its bytes are old.
         sparq.put_meta("iri", meta("live-key")).await.unwrap();
-        blob.put_with_time("live-key", Bytes::from_static(b"x"), ago(99999));
+        blob.put_with_time("live-key", Bytes::from_static(b"x"), ago(99999))
+            .unwrap();
 
         let report = reconcile_orphans(&sparq, &blob, &opts()).await.unwrap();
         assert_eq!(report.scanned, 1);
@@ -666,7 +668,8 @@ mod tests {
         // (bytes PUT, index row not yet committed) — it MUST be protected.
         let sparq = InMemorySparqClient::new();
         let blob = InMemoryBlobStore::new();
-        blob.put_with_time("fresh-orphan", Bytes::from_static(b"x"), ago(1)); // 1s < 60s grace
+        blob.put_with_time("fresh-orphan", Bytes::from_static(b"x"), ago(1))
+            .unwrap(); // 1s < 60s grace
 
         let report = reconcile_orphans(&sparq, &blob, &opts()).await.unwrap();
         assert_eq!(report.scanned, 1);
@@ -685,14 +688,18 @@ mod tests {
         let blob = InMemoryBlobStore::new();
         // 1 referenced (old), 1 old orphan (deleted), 1 young orphan (kept), 1 unknown-age orphan (kept).
         sparq.put_meta("iri", meta("ref")).await.unwrap();
-        blob.put_with_time("ref", Bytes::from_static(b"r"), ago(99999));
-        blob.put_with_time("old-orphan", Bytes::from_static(b"o"), ago(3600));
-        blob.put_with_time("young-orphan", Bytes::from_static(b"y"), ago(1));
+        blob.put_with_time("ref", Bytes::from_static(b"r"), ago(99999))
+            .unwrap();
+        blob.put_with_time("old-orphan", Bytes::from_static(b"o"), ago(3600))
+            .unwrap();
+        blob.put_with_time("young-orphan", Bytes::from_static(b"y"), ago(1))
+            .unwrap();
         blob.put_with_time(
             "undated-orphan",
             Bytes::from_static(b"u"),
             SystemTime::now(),
-        );
+        )
+        .unwrap();
         // Force the unknown-age path by listing-time stamping is awkward; instead assert the
         // partition algebra on the known stamps. (The unknown-age branch is covered separately below.)
 
@@ -734,7 +741,8 @@ mod tests {
     async fn idempotent_second_run_deletes_nothing() {
         let sparq = InMemorySparqClient::new();
         let blob = InMemoryBlobStore::new();
-        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600));
+        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600))
+            .unwrap();
 
         let first = reconcile_orphans(&sparq, &blob, &opts()).await.unwrap();
         assert_eq!(first.deleted, 1);
@@ -752,9 +760,12 @@ mod tests {
         let blob = InMemoryBlobStore::new();
         // 1 deletable orphan (old), 1 too-young orphan, 1 referenced — so the partition has >1 term.
         sparq.put_meta("iri", meta("ref")).await.unwrap();
-        blob.put_with_time("ref", Bytes::from_static(b"r"), ago(99999));
-        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600));
-        blob.put_with_time("young", Bytes::from_static(b"y"), ago(1));
+        blob.put_with_time("ref", Bytes::from_static(b"r"), ago(99999))
+            .unwrap();
+        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600))
+            .unwrap();
+        blob.put_with_time("young", Bytes::from_static(b"y"), ago(1))
+            .unwrap();
 
         let dry = ReconcileOptions {
             grace: Duration::from_secs(60),
@@ -800,7 +811,8 @@ mod tests {
         // the fresh re-check it WOULD be classified deletable and removed — the mutation-check.
         let sparq = ToggleReferencedSparq::new(["orphan"]);
         let blob = InMemoryBlobStore::new();
-        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600));
+        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600))
+            .unwrap();
 
         let report = reconcile_orphans(&sparq, &blob, &opts()).await.unwrap();
         assert_eq!(report.scanned, 1);
@@ -897,7 +909,8 @@ mod tests {
 
         // Write #1 at `same_stamp`. Capture its generation — the witness a reconciler would carry from a
         // stat taken right after this write.
-        blob.put_with_time("k", Bytes::from_static(b"v1"), same_stamp);
+        blob.put_with_time("k", Bytes::from_static(b"v1"), same_stamp)
+            .unwrap();
         let witness_gen_v1 = blob.generation_of("k").expect("v1 must exist");
         let stamp_v1 = blob
             .stat("k")
@@ -909,7 +922,8 @@ mod tests {
 
         // OVERWRITE at the IDENTICAL last_modified (clock granularity / rollback). The generation MUST
         // bump even though the timestamp did not.
-        blob.put_with_time("k", Bytes::from_static(b"v2"), same_stamp);
+        blob.put_with_time("k", Bytes::from_static(b"v2"), same_stamp)
+            .unwrap();
         let stamp_v2 = blob
             .stat("k")
             .await
@@ -1083,7 +1097,8 @@ mod tests {
         // sweep would abort with ReferencedSet — the mutation-check.
         let sparq = SecondCallFailsSparq::new();
         let blob = InMemoryBlobStore::new();
-        blob.put_with_time("young-orphan", Bytes::from_static(b"x"), ago(1)); // < 60s grace ⇒ too-young
+        blob.put_with_time("young-orphan", Bytes::from_static(b"x"), ago(1))
+            .unwrap(); // < 60s grace ⇒ too-young
 
         let report = reconcile_orphans(&sparq, &blob, &opts())
             .await
@@ -1183,7 +1198,8 @@ mod tests {
         // "nothing is referenced"). The blob list is never even consulted.
         let sparq = FailingSparq;
         let blob = InMemoryBlobStore::new();
-        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600));
+        blob.put_with_time("orphan", Bytes::from_static(b"x"), ago(3600))
+            .unwrap();
 
         let err = reconcile_orphans(&sparq, &blob, &opts()).await.unwrap_err();
         assert!(matches!(err, ReconcileError::ReferencedSet(_)));
@@ -1735,7 +1751,9 @@ mod tests {
     impl UndatedBlobStore {
         fn with_key(key: &str) -> Self {
             let inner = InMemoryBlobStore::new();
-            inner.put_with_time(key, Bytes::from_static(b"x"), SystemTime::now());
+            inner
+                .put_with_time(key, Bytes::from_static(b"x"), SystemTime::now())
+                .unwrap();
             Self {
                 key: key.to_string(),
                 inner,

--- a/crates/sparq-lws-core/src/store/sparq.rs
+++ b/crates/sparq-lws-core/src/store/sparq.rs
@@ -16,6 +16,8 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 
+use super::InMemoryStoreLimits;
+
 /// The authoritative metadata SPARQ holds for a resource (the index record, not the bytes).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResourceMeta {
@@ -82,6 +84,9 @@ pub enum DeleteOutcome {
 pub enum SparqError {
     #[error("resource not indexed")]
     NotFound,
+    /// The configured in-memory resource-count ceiling would be exceeded.
+    #[error("in-memory index quota exceeded")]
+    QuotaExceeded,
     #[error("sparq backend error: {0}")]
     Backend(String),
 }
@@ -100,8 +105,9 @@ impl From<super::sparql::BuildError> for SparqError {
 /// ([`SparqClient::delete_meta`]) and containment membership ([`SparqClient::create_child`] /
 /// [`remove_child`](SparqClient::remove_child) / [`list_children`](SparqClient::list_children)) —
 /// SPARQ is authoritative for containment, so POST (mint a child) + the empty-container DELETE check
-/// flow through it, never an S3 LIST. M2-next: the `usage()` quota view + the WAC/ACP ACL-document
-/// graphs the (future) access-evaluation step reads.
+/// flow through it, never an S3 LIST. [GPT-5.6] The in-memory implementation exposes its concrete
+/// `usage()` and `quota()` views without imposing that backend-specific model on this trait. M2-next
+/// retains the WAC/ACP ACL-document graphs the (future) access-evaluation step reads.
 #[async_trait]
 pub trait SparqClient: Send + Sync {
     /// Fetch the authoritative metadata for a resource IRI, or [`SparqError::NotFound`].
@@ -221,9 +227,16 @@ pub trait SparqClient: Send + Sync {
 /// Holds the metadata records AND the containment edges (container IRI → ordered child IRIs) behind
 /// a single lock, so a POST/DELETE that touches both stays internally consistent under the test
 /// double's coarse locking.
-#[derive(Default)]
 pub struct InMemorySparqClient {
     inner: Mutex<Index>,
+    /// [GPT-5.6] Immutable admission ceiling, enforced under the index lock.
+    limits: InMemoryStoreLimits,
+}
+
+impl Default for InMemorySparqClient {
+    fn default() -> Self {
+        Self::with_limits(InMemoryStoreLimits::default())
+    }
 }
 
 /// The in-memory index state: metadata records + containment membership.
@@ -235,8 +248,39 @@ struct Index {
 }
 
 impl InMemorySparqClient {
+    /// Build with the bounded default limits.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Build with an explicit resource-count limit.
+    pub fn with_limits(limits: InMemoryStoreLimits) -> Self {
+        Self {
+            inner: Mutex::new(Index::default()),
+            limits,
+        }
+    }
+
+    /// Return the exact number of indexed resources.
+    pub fn usage(&self) -> Result<usize, SparqError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|_| SparqError::Backend("poisoned".into()))?;
+        Ok(guard.meta.len())
+    }
+
+    /// Return the immutable admission limits configured for this index.
+    pub fn quota(&self) -> InMemoryStoreLimits {
+        self.limits
+    }
+
+    /// Reserve a metadata slot for a new IRI, or fail without mutating the index.
+    fn admit_resource(&self, index: &Index, iri: &str) -> Result<(), SparqError> {
+        if !index.meta.contains_key(iri) && index.meta.len() >= self.limits.max_resource_count {
+            return Err(SparqError::QuotaExceeded);
+        }
+        Ok(())
     }
 }
 
@@ -255,6 +299,7 @@ impl SparqClient for InMemorySparqClient {
             .inner
             .lock()
             .map_err(|_| SparqError::Backend("poisoned".into()))?;
+        self.admit_resource(&guard, iri)?;
         guard.meta.insert(iri.to_string(), meta);
         Ok(())
     }
@@ -337,6 +382,7 @@ impl SparqClient for InMemorySparqClient {
         if !guard.meta.contains_key(container) {
             return Err(SparqError::NotFound);
         }
+        self.admit_resource(&guard, child)?;
         guard.meta.insert(child.to_string(), meta);
         let entry = guard.children.entry(container.to_string()).or_default();
         if !entry.iter().any(|c| c == child) {
@@ -393,5 +439,68 @@ impl SparqClient for InMemorySparqClient {
                 .map(|c| (c.clone(), guard.meta.get(c).map(|m| m.etag.clone())))
                 .collect(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn meta(blob_key: &str) -> ResourceMeta {
+        ResourceMeta {
+            content_type: "text/plain".into(),
+            blob_key: blob_key.into(),
+            etag: "\"etag\"".into(),
+            last_modified: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn resource_limit_rejects_new_records_but_allows_replacement() {
+        // [GPT-5.6] Mutation witness: removing `admit_resource` makes the second IRI succeed and
+        // changes usage from the configured one-resource ceiling.
+        let limits = InMemoryStoreLimits::new(usize::MAX, 1);
+        let index = InMemorySparqClient::with_limits(limits);
+
+        index.put_meta("urn:a", meta("a1")).await.unwrap();
+        assert_eq!(index.usage().unwrap(), 1);
+        assert!(matches!(
+            index.put_meta("urn:b", meta("b")).await,
+            Err(SparqError::QuotaExceeded)
+        ));
+        assert_eq!(index.usage().unwrap(), 1);
+
+        index.put_meta("urn:a", meta("a2")).await.unwrap();
+        assert_eq!(index.get_meta("urn:a").await.unwrap().blob_key, "a2");
+        assert_eq!(index.quota(), limits);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_metadata_writes_cannot_over_admit_resource_limit() {
+        // [GPT-5.6] Admission and insertion happen under one lock, so racing writers cannot each
+        // observe a spare final slot.
+        let index = Arc::new(InMemorySparqClient::with_limits(InMemoryStoreLimits::new(
+            usize::MAX,
+            8,
+        )));
+        let mut handles = Vec::new();
+        for n in 0..64 {
+            let index = Arc::clone(&index);
+            handles.push(tokio::spawn(async move {
+                index.put_meta(&format!("urn:{n}"), meta("blob")).await
+            }));
+        }
+
+        let mut admitted = 0;
+        for handle in handles {
+            match handle.await.unwrap() {
+                Ok(()) => admitted += 1,
+                Err(SparqError::QuotaExceeded) => {}
+                Err(other) => panic!("unexpected index error: {other}"),
+            }
+        }
+        assert_eq!(admitted, 8);
+        assert_eq!(index.usage().unwrap(), 8);
     }
 }

--- a/crates/sparq-lws-core/tests/ldp_http.rs
+++ b/crates/sparq-lws-core/tests/ldp_http.rs
@@ -24,6 +24,7 @@ use sparq_lws_core::ldp::handler::LdpState;
 #[cfg(not(feature = "embedded-sparq"))]
 use sparq_lws_core::store::InMemorySparqClient;
 use sparq_lws_core::store::{CompositeStore, InMemoryBlobStore};
+use sparq_lws_core::store::{InMemoryStoreLimits, SparqClient};
 use tower::ServiceExt;
 
 const TURTLE: &str =
@@ -54,8 +55,8 @@ fn backend_sparq_client() -> BackendSparqClient {
 /// the now-enforced WAC engine. Written through the store as an auxiliary `.acl` resource (built as a
 /// Turtle string — a test fixture, not production RDF construction). This mirrors the pod-root
 /// owner-default the real conformance seed (`seed_conformance`) writes per user.
-async fn seed_root_owner_acl(
-    store: &CompositeStore<BackendSparqClient, InMemoryBlobStore>,
+async fn seed_root_owner_acl<S: SparqClient>(
+    store: &CompositeStore<S, InMemoryBlobStore>,
     base_url: &str,
     owner_webid: &str,
 ) {
@@ -86,13 +87,27 @@ struct Harness {
 
 impl Harness {
     async fn new() -> Self {
+        Self::with_store(CompositeStore::new(
+            backend_sparq_client(),
+            InMemoryBlobStore::new(),
+        ))
+        .await
+    }
+
+    /// Build the real HTTP stack over a deliberately small in-memory quota.
+    async fn with_memory_limits(limits: InMemoryStoreLimits) -> Self {
+        Self::with_store(CompositeStore::in_memory_with_limits(limits)).await
+    }
+
+    async fn with_store<S: SparqClient + 'static>(
+        store: CompositeStore<S, InMemoryBlobStore>,
+    ) -> Self {
         let issuer_key = KeyKit::generate();
         let client_key = KeyKit::generate();
         let config = VerifierConfig::new(vec![common::ISSUER.to_string()], BASE_URL);
         let replay = InMemoryReplayStore::with_window(config.replay_ttl());
         let verifier = Verifier::new(config, jwks_provider(&issuer_key), replay).unwrap();
         let ctx = AuthContext::new(verifier, BASE_URL);
-        let store = CompositeStore::new(backend_sparq_client(), InMemoryBlobStore::new());
         // WAC is now ENFORCED, so the test caller (Alice, `common::WEBID`) needs an effective ACL
         // granting her access to every path these tests exercise. Seed a ROOT `.acl` granting Alice
         // Read/Write/Control on the base root AND on all descendants (`acl:default`), so every
@@ -217,6 +232,45 @@ async fn put_creates_then_get_reads_it_back() {
     );
     let bytes = to_bytes(get.into_body(), usize::MAX).await.unwrap();
     assert_eq!(&bytes[..], TURTLE.as_bytes());
+}
+
+#[tokio::test]
+async fn put_flood_beyond_resource_cap_is_refused_with_507() {
+    // [GPT-5.6] The seed ACL and any implicit ancestor containers consume the same bounded store.
+    // Keep issuing unique, zero-ish-body resources until the deliberately tiny cap trips; at least
+    // one write must land first, and every later admission must fail closed as HTTP 507.
+    let limits = InMemoryStoreLimits::new(1024 * 1024, 8);
+    let h = Harness::with_memory_limits(limits).await;
+    let mut accepted = 0;
+    let mut refused = false;
+
+    for n in 0..=limits.max_resource_count {
+        let path = format!("/quota-{n}.txt");
+        let response = h
+            .request("PUT", &path, Some("text/plain"), Body::from("x"))
+            .await;
+        if response.status() == StatusCode::INSUFFICIENT_STORAGE {
+            refused = true;
+            break;
+        }
+        assert_eq!(response.status(), StatusCode::CREATED);
+        accepted += 1;
+    }
+
+    assert!(
+        accepted > 0,
+        "the test must fill a live store before refusal"
+    );
+    assert!(refused, "a unique-resource PUT flood must hit the hard cap");
+    let retry = h
+        .request(
+            "PUT",
+            "/quota-after-cap.txt",
+            Some("text/plain"),
+            Body::from("x"),
+        )
+        .await;
+    assert_eq!(retry.status(), StatusCode::INSUFFICIENT_STORAGE);
 }
 
 #[tokio::test]

--- a/crates/sparq-lws-core/tests/store.rs
+++ b/crates/sparq-lws-core/tests/store.rs
@@ -10,7 +10,7 @@ use sparq_lws_core::error::ServerError;
 use sparq_lws_core::ldp::content::{classify, validate_rdf, RdfFormat};
 use sparq_lws_core::store::{
     BlobError, BlobStore, CompositeStore, DeleteOutcome, InMemoryBlobStore, InMemorySparqClient,
-    ResourceMeta, SparqClient, SparqError, Store,
+    InMemoryStoreLimits, ResourceMeta, SparqClient, SparqError, Store, StoreUsage,
 };
 
 const IRI: &str = "https://pod.example/alice/data";
@@ -47,6 +47,41 @@ async fn write_then_read_round_trips_bytes_and_content_type() {
     assert_eq!(resource.body, body);
     assert_eq!(resource.meta.content_type, "text/turtle");
     assert_eq!(resource.meta.etag, meta.etag);
+}
+
+#[tokio::test]
+async fn bounded_store_reports_usage_and_refuses_bytes_beyond_quota() {
+    // [GPT-5.6] Mutation witness: removing the aggregate-byte admission check makes the second write
+    // succeed, so both the error and unchanged usage assertions fail.
+    let limits = InMemoryStoreLimits::new(5, 4);
+    let s = CompositeStore::in_memory_with_limits(limits);
+
+    s.write("urn:a", Bytes::from_static(b"123"), "text/plain")
+        .await
+        .unwrap();
+    assert_eq!(
+        s.usage().unwrap(),
+        StoreUsage {
+            total_bytes: 3,
+            resource_count: 1,
+        }
+    );
+
+    let error = s
+        .write("urn:b", Bytes::from_static(b"456"), "text/plain")
+        .await
+        .unwrap_err();
+    assert!(matches!(error, ServerError::InsufficientStorage));
+    assert_eq!(error.status(), axum::http::StatusCode::INSUFFICIENT_STORAGE);
+    assert_eq!(
+        s.usage().unwrap(),
+        StoreUsage {
+            total_bytes: 3,
+            resource_count: 1,
+        }
+    );
+    assert_eq!(s.quota(), limits);
+    assert!(!s.exists("urn:b").await.unwrap());
 }
 
 #[tokio::test]

--- a/skills/javascript-wasm/SKILL.md
+++ b/skills/javascript-wasm/SKILL.md
@@ -129,6 +129,16 @@ The host MUST complete OIDC validation before supplying an authenticated WebID; 
 owner parameter only provisions WAC and is not authentication. Do not enable or stub
 `solid-oidc-verifier` inside wasm: its pinned crypto backend is native-only.
 
+[GPT-5.6] The in-memory Solid store is bounded by default: its physical blob map admits at most
+64 MiB in aggregate and 4,096 stored entries, and its metadata map independently admits at most
+4,096 indexed resources. Physical usage includes unreferenced blob versions awaiting reconciliation,
+so repeated overwrites cannot bypass the ceiling. A PUT/POST that would exceed either limit fails
+closed with HTTP 507; deleting a current blob releases its bytes and entry slot. Rust embedders can
+configure both ceilings with `InMemoryStoreLimits::new(max_total_bytes, max_resource_count)` and
+`CompositeStore::in_memory_with_limits(limits)`, then inspect the concrete store's `usage()` and
+`quota()` views. The current JS `SolidServer` constructor uses the bounded Rust defaults and does not
+yet expose per-instance limit options.
+
 [GPT-5.6] `@jeswr/solid-server` supplies the local Node host. Install and run it with
 `npx @jeswr/solid-server --port 3000 --base-url http://127.0.0.1:3000 --owner-webid
 https://id.example/alice#me`, or import `startSolidServer({ port, baseUrl, ownerWebid })`; it resolves


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-3ah7j** — sparq-lws-core: bound the in-memory Solid store (byte/resource cap + usage/quota) — unbounded store OOMs the pod via a PUT-flood in default fixed-owner mode
sq-3ah7j.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-3ah7j","crate":"sparq-lws-core","committed":true,"gates_green":true,"branch":"feat/sq-3ah7j-codex-gpt56","non_vacuity_verified":true,"notes":"default/no-default tests and clippy, rustdoc, typos, formatting, and workspace checks green"}
```

Not armed — the orchestrator arms after review.