### PR TITLE
sparq-shacl scs: owl:Ontology subject keeps a dangling empty fragment 
sq-0g57x [GPT-5.6]

### DIFF
--- a/crates/sparq-shacl/src/scs.rs
+++ b/crates/sparq-shacl/src/scs.rs
@@ -615,9 +615,10 @@ impl Parser {
                 _ => break,
             }
         }
-        // The ontology triple: `?baseURI rdf:type owl:Ontology`. (Imports were
-        // already attached to this same base subject during the directive phase.)
-        let base_term = Term::NamedNode(NamedNode::new_unchecked(&self.base));
+        // [GPT-5.6] (sq-0g57x) The document IRI is the empty reference resolved
+        // against the final base, so RFC 3986 resolution removes its fragment.
+        // Imports were already emitted against the base in effect at each directive.
+        let base_term = Term::NamedNode(NamedNode::new_unchecked(self.resolve("")));
         self.add(
             iri_subject(&base_term)?,
             RDF_TYPE,
@@ -1543,6 +1544,36 @@ mod tests {
         match &t.subject {
             NamedOrBlankNode::NamedNode(n) => assert_eq!(n.as_str(), DEFAULT_BASE),
             other => panic!("expected named ontology subject, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ontology_subject_resolves_empty_reference_against_effective_base() {
+        // [GPT-5.6] (sq-0g57x) The document production resolves an empty
+        // reference against the final base, which strips any fragment.
+        for (source, expected) in [
+            ("BASE <#>\n", "urn:x-base:default"),
+            (
+                "BASE <http://example.org/basic-shape-with-targets#thing>\n",
+                "http://example.org/basic-shape-with-targets",
+            ),
+        ] {
+            let triples = parse(source, DEFAULT_BASE).unwrap();
+            let ontology = triples
+                .iter()
+                .find(|triple| {
+                    triple.predicate.as_str() == RDF_TYPE
+                        && matches!(
+                            &triple.object,
+                            Term::NamedNode(node)
+                                if node.as_str() == "http://www.w3.org/2002/07/owl#Ontology"
+                        )
+                })
+                .expect("document ontology triple");
+            match &ontology.subject {
+                NamedOrBlankNode::NamedNode(node) => assert_eq!(node.as_str(), expected),
+                other => panic!("expected named ontology subject, got {other:?}"),
+            }
         }
     }
 

--- a/crates/sparq-shaclc/tests/differential_scs.rs
+++ b/crates/sparq-shaclc/tests/differential_scs.rs
@@ -17,24 +17,7 @@ use sparq_shaclc::{parse_strict, DEFAULT_BASE};
 /// tracking bead. An entry here asserts the divergence STILL EXISTS, so
 /// fixing sparq-shacl turns this test red until the entry is deleted —
 /// the list can only shrink, never rot.
-const KNOWN_DIVERGENCES: &[(&str, &str)] = &[
-    (
-        "relative-base",
-        "sq-0g57x: after `BASE <#>` the hand-rolled scs emits its stored base verbatim as the \
-         owl:Ontology subject (urn:x-base:default#); RFC 3986 empty-reference resolution strips \
-         the empty fragment (urn:x-base:default) — generated parser + oxttl + shaclc-parse agree",
-    ),
-    (
-        "relativeHash",
-        "sq-0g57x (same root cause): a fragment-carrying BASE keeps its #fragment in the \
-         hand-rolled owl:Ontology subject; empty-reference resolution strips it",
-    ),
-    (
-        "relativePrefixFragmentThing",
-        "sq-0g57x (same root cause): a fragment-carrying BASE keeps its #fragment in the \
-         hand-rolled owl:Ontology subject; empty-reference resolution strips it",
-    ),
-];
+const KNOWN_DIVERGENCES: &[(&str, &str)] = &[];
 
 #[test]
 fn generated_parser_matches_the_hand_rolled_scs_parser_on_the_shared_corpus() {


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-0g57x** — sparq-shacl scs: owl:Ontology subject keeps a dangling empty fragment after BASE <#> (RFC 3986 empty-reference resolution not applied)
sq-0g57x.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-0g57x","crate":"sparq-shacl","committed":true,"gates_green":true,"branch":"feat/sq-0g57x-codex-gpt56","non_vacuity_verified":true,"notes":"Fixed ontology empty-reference resolution; all three differential fixtures pass."}
```

Not armed — the orchestrator arms after review.