### PR TITLE
sparq-vectors rewrite::term_to_ground: map vec: VALUES to triple-terms
sq-1ijoc [GPT-5.6]

### DIFF
--- a/crates/sparq-vectors/src/rewrite.rs
+++ b/crates/sparq-vectors/src/rewrite.rs
@@ -646,12 +646,17 @@ fn require_var(t: &TermPattern, what: &str) -> Result<Variable, String> {
 }
 
 /// Maps a dictionary [`Term`] to a [`GroundTerm`] for a VALUES row, or `None`
-/// for a blank node / triple term (not expressible in a VALUES neighbour slot).
+/// for a blank node (including one nested inside a triple term).
 fn term_to_ground(t: Term) -> Option<GroundTerm> {
     match t {
         Term::NamedNode(n) => Some(GroundTerm::NamedNode(n)),
         Term::Literal(l) => Some(GroundTerm::Literal(l)),
-        _ => None,
+        // [GPT-5.6] sq-1ijoc: SPARQL 1.2 VALUES admits ground triple terms;
+        // spargebra's conversion recursively rejects any nested blank node.
+        Term::Triple(t) => spargebra::term::GroundTriple::try_from(*t)
+            .ok()
+            .map(|t| GroundTerm::Triple(Box::new(t))),
+        Term::BlankNode(_) => None,
     }
 }
 

--- a/crates/sparq-vectors/tests/vec_predicate.rs
+++ b/crates/sparq-vectors/tests/vec_predicate.rs
@@ -3,7 +3,7 @@
 //! `.spqv` vector store, asserting the expected neighbours. [OPUS-4.8]
 #![cfg(feature = "vec-predicate")]
 
-use oxrdf::{NamedNode, Term};
+use oxrdf::{NamedNode, Term, Triple};
 use sparq_core::Graph;
 use sparq_vectors::{query_vec, QueryResult, VectorStore};
 
@@ -123,6 +123,45 @@ fn nearest_joins_to_surrounding_bgp() {
         vec!["beta".to_string(), "epsilon".to_string()],
         "{r:?}"
     );
+}
+
+/// [GPT-5.6] sq-1ijoc: RDF 1.2 ground triple terms returned by vector search
+/// must survive the rewrite's inline VALUES table, including nested terms.
+#[test]
+fn nearest_returns_nested_ground_triple_term() {
+    let g = Graph::load_str(
+        r#"
+        <http://ex/r> <http://ex/reifies> <<( <http://ex/s> <http://ex/p> <<( <http://ex/a> <http://ex/q> <http://ex/o> )>> )>> .
+        "#,
+        "ntriples",
+    )
+    .unwrap();
+    let named = |iri: &str| NamedNode::new(iri).unwrap();
+    let inner = Term::Triple(Box::new(Triple::new(
+        named("http://ex/a"),
+        named("http://ex/q"),
+        named("http://ex/o"),
+    )));
+    let expected = Term::Triple(Box::new(Triple::new(
+        named("http://ex/s"),
+        named("http://ex/p"),
+        inner,
+    )));
+    let triple_id = g
+        .id_of(&expected)
+        .expect("fixture triple term must be dictionary encoded");
+    let mut store = VectorStore::create(tmp_path("triple_term"), 2).unwrap();
+    store.put(triple_id, &[1.0, 0.0]).unwrap();
+
+    let r = query_vec(
+        &g,
+        "PREFIX vec: <http://sparq.dev/vec#>
+         SELECT ?node WHERE { ?node vec:nearest ( \"1,0\" 1 ) }",
+        &store,
+    )
+    .unwrap();
+
+    assert_eq!(r.rows, vec![vec![Some(expected)]], "{r:?}");
 }
 
 #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-1ijoc** — sparq-vectors rewrite::term_to_ground: map vec: VALUES to triple-terms via spargebra GroundTerm::Triple (sparql-12 feature) — follow-up to PR #2132 / issue #2149
sq-1ijoc.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-1ijoc","crate":"sparq-vectors","committed":true,"gates_green":true,"branch":"feat/sq-1ijoc-codex-gpt56","non_vacuity_verified":true,"notes":"Ground triple-term VALUES mapping implemented; all scoped gates green; commit 62dfa643."}
```

Not armed — the orchestrator arms after review.