### PR TITLE
lws-core: wire the orphaned-blob reconciler scheduled sweep (spawn_per
sq-5ruwm [GPT-5.6]

### DIFF
--- a/crates/sparq-lws-core/README.md
+++ b/crates/sparq-lws-core/README.md
@@ -21,11 +21,15 @@ cargo run -p sparq-lws-core
 cargo test -p sparq-lws-core
 # Engine-free profile (in-memory double only)
 cargo test -p sparq-lws-core --no-default-features
+# [GPT-5.6] Opt in to one periodic orphan-blob sweep task (interval in seconds)
+SOLID_SERVER_RECONCILE_INTERVAL_SECS=3600 cargo run -p sparq-lws-core
 ```
 
 The binary is configured entirely by `SOLID_SERVER_*` / `PSS_*` environment
 variables (bind address, TLS PEM paths, backend selection, seeding) — see the
-module docs on `src/main.rs`.
+module docs on `src/main.rs`. `SOLID_SERVER_RECONCILE_INTERVAL_SECS` is unset by
+default; a positive integer enables one periodic sweep using the unchanged
+one-hour orphan grace period. Invalid or zero values fail boot.
 
 ## ✨ Features
 

--- a/crates/sparq-lws-core/src/main.rs
+++ b/crates/sparq-lws-core/src/main.rs
@@ -53,6 +53,9 @@ fn main() {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+mod reconcile_runtime;
+
+#[cfg(not(target_arch = "wasm32"))]
 macro_rules! native_main {
     ($($item:item)*) => {
         $($item)*
@@ -95,6 +98,10 @@ use sparq_lws_core::store::{
 };
 use sparq_lws_core::tls::{self, TlsMode};
 use sparq_lws_core::transport::{ConnectionLimiter, TransportConfig};
+
+use crate::reconcile_runtime::{
+    reconcile_interval_from_env, spawn_periodic_if_configured, SharedStore,
+};
 
 // --- Environment configuration keys ----------------------------------------------------------------
 const ENV_BASE_URL: &str = "SOLID_SERVER_BASE_URL";
@@ -696,16 +703,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .into());
     }
 
-    let app = match backend.as_str() {
+    // [GPT-5.6] Each backend arm returns its router plus at most ONE boot-owned reconciler task.
+    // Crucially, the OFF path keeps the original direct backend construction (no Arc allocation or
+    // indirection); only an explicitly-present interval selects shared handles for request path + sweep.
+    let reconcile_interval = reconcile_interval_from_env()?;
+    let (app, reconcile_task) = match backend.as_str() {
         "memory" => {
             eprintln!("  STORAGE: SPARQ backend = MEMORY (in-memory double — boot-without-SPARQ; the conformance/test default).");
-            let store = CompositeStore::with_body_cache(
+            build_app_for_backend(
                 InMemorySparqClient::new(),
                 InMemoryBlobStore::new(),
-                body_cache_from_env(),
-            );
-            build_app_for_store(
-                store,
+                reconcile_interval,
                 &base_url,
                 &issuer,
                 jwks_cache_ttl,
@@ -723,13 +731,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 )
             })?;
             eprintln!("  STORAGE: SPARQ backend = HTTP (live SPARQL endpoint {endpoint}).");
-            let store = CompositeStore::with_body_cache(
+            build_app_for_backend(
                 HttpSparqClient::new(endpoint),
                 InMemoryBlobStore::new(),
-                body_cache_from_env(),
-            );
-            build_app_for_store(
-                store,
+                reconcile_interval,
                 &base_url,
                 &issuer,
                 jwks_cache_ttl,
@@ -760,13 +765,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         .map_err(|e| format!("failed to init the embedded SPARQ graph: {e}"))?
                 }
             };
-            let store = CompositeStore::with_body_cache(
+            build_app_for_backend(
                 sparq,
                 InMemoryBlobStore::new(),
-                body_cache_from_env(),
-            );
-            build_app_for_store(
-                store,
+                reconcile_interval,
                 &base_url,
                 &issuer,
                 jwks_cache_ttl,
@@ -1029,7 +1031,69 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await?;
         }
     }
+    // The runtime would cancel this task on process exit, but abort explicitly after the listener
+    // drains so the task's ownership/lifetime stays bounded to the server boot that created it.
+    if let Some(task) = reconcile_task {
+        task.abort();
+    }
     Ok(())
+}
+
+/// Build one selected backend in one of two shapes: the original direct store when reconciliation is
+/// OFF, or shared handles owned by both the request path and one periodic task when it is ON. Keeping
+/// the branch here makes the default path allocation- and indirection-identical to the pre-wiring boot.
+#[allow(clippy::too_many_arguments)]
+async fn build_app_for_backend<S, B, J, R>(
+    sparq: S,
+    blob: B,
+    reconcile_interval: Option<Duration>,
+    base_url: &str,
+    issuer: &str,
+    jwks_cache_ttl: Duration,
+    auth: AuthContext<J, R>,
+    overload_config: OverloadConfig,
+    identity: Option<IdentityConfig>,
+) -> Result<(axum::Router, Option<tokio::task::JoinHandle<()>>), Box<dyn std::error::Error>>
+where
+    S: sparq_lws_core::store::SparqClient + 'static,
+    B: sparq_lws_core::store::BlobStore + 'static,
+    J: JwksProvider + Send + Sync + 'static,
+    R: ReplayStore + Send + Sync + 'static,
+{
+    if reconcile_interval.is_some() {
+        let sparq = SharedStore::new(sparq);
+        let blob = SharedStore::new(blob);
+        let store = CompositeStore::with_body_cache(
+            sparq.clone(),
+            blob.clone(),
+            body_cache_from_env(),
+        );
+        let app = build_app_for_store(
+            store,
+            base_url,
+            issuer,
+            jwks_cache_ttl,
+            auth,
+            overload_config,
+            identity,
+        )
+        .await?;
+        let task = spawn_periodic_if_configured(sparq, blob, reconcile_interval);
+        Ok((app, task))
+    } else {
+        let store = CompositeStore::with_body_cache(sparq, blob, body_cache_from_env());
+        let app = build_app_for_store(
+            store,
+            base_url,
+            issuer,
+            jwks_cache_ttl,
+            auth,
+            overload_config,
+            identity,
+        )
+        .await?;
+        Ok((app, None))
+    }
 }
 
 /// Build the application router for a chosen, already-constructed [`Store`] backend — the SAME

--- a/crates/sparq-lws-core/src/reconcile_runtime.rs
+++ b/crates/sparq-lws-core/src/reconcile_runtime.rs
@@ -1,0 +1,174 @@
+// [GPT-5.6] sq-5ruwm: boot-only periodic reconciler wiring shared by every native backend.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use sparq_lws_core::store::{
+    spawn_periodic, BlobEntry, BlobError, BlobStore, DeleteOutcome, ReadPlan, ReconcileOptions,
+    ResourceMeta, SparqClient, SparqError,
+};
+
+pub(crate) const ENV_RECONCILE_INTERVAL_SECS: &str = "SOLID_SERVER_RECONCILE_INTERVAL_SECS";
+
+/// A private shared-owner adapter used to give the request path and the one boot-time reconciler task
+/// the same backend handles. Delegation preserves backend-specific overrides such as `read_plan` and
+/// `stat`; no extra query/list fallback is introduced by sharing a handle.
+pub(crate) struct SharedStore<T>(Arc<T>);
+
+impl<T> SharedStore<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self(Arc::new(inner))
+    }
+}
+
+impl<T> AsRef<T> for SharedStore<T> {
+    fn as_ref(&self) -> &T {
+        self.0.as_ref()
+    }
+}
+
+impl<T> Clone for SharedStore<T> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+#[async_trait]
+impl<T: SparqClient> SparqClient for SharedStore<T> {
+    async fn get_meta(&self, iri: &str) -> Result<ResourceMeta, SparqError> {
+        self.0.get_meta(iri).await
+    }
+
+    async fn put_meta(&self, iri: &str, meta: ResourceMeta) -> Result<(), SparqError> {
+        self.0.put_meta(iri, meta).await
+    }
+
+    async fn exists(&self, iri: &str) -> Result<bool, SparqError> {
+        self.0.exists(iri).await
+    }
+
+    async fn delete_meta(&self, iri: &str) -> Result<(), SparqError> {
+        self.0.delete_meta(iri).await
+    }
+
+    async fn delete_meta_if_empty(
+        &self,
+        iri: &str,
+        parent: Option<&str>,
+    ) -> Result<DeleteOutcome, SparqError> {
+        self.0.delete_meta_if_empty(iri, parent).await
+    }
+
+    async fn create_child(
+        &self,
+        container: &str,
+        child: &str,
+        meta: ResourceMeta,
+    ) -> Result<(), SparqError> {
+        self.0.create_child(container, child, meta).await
+    }
+
+    async fn remove_child(&self, container: &str, child: &str) -> Result<(), SparqError> {
+        self.0.remove_child(container, child).await
+    }
+
+    async fn list_children(&self, container: &str) -> Result<Vec<String>, SparqError> {
+        self.0.list_children(container).await
+    }
+
+    async fn referenced_blob_keys(&self) -> Result<HashSet<String>, SparqError> {
+        self.0.referenced_blob_keys().await
+    }
+
+    async fn read_plan(
+        &self,
+        target: &str,
+        acl_candidates: &[String],
+    ) -> Result<ReadPlan, SparqError> {
+        self.0.read_plan(target, acl_candidates).await
+    }
+}
+
+#[async_trait]
+impl<T: BlobStore> BlobStore for SharedStore<T> {
+    async fn get(&self, key: &str) -> Result<Bytes, BlobError> {
+        self.0.get(key).await
+    }
+
+    async fn put(&self, key: &str, body: Bytes) -> Result<(), BlobError> {
+        self.0.put(key, body).await
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, BlobError> {
+        self.0.exists(key).await
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), BlobError> {
+        self.0.delete(key).await
+    }
+
+    async fn list(&self) -> Result<Vec<BlobEntry>, BlobError> {
+        self.0.list().await
+    }
+
+    async fn stat(&self, key: &str) -> Result<Option<BlobEntry>, BlobError> {
+        self.0.stat(key).await
+    }
+
+    async fn delete_if_unchanged(
+        &self,
+        key: &str,
+        expected_generation: u64,
+    ) -> Result<bool, BlobError> {
+        self.0.delete_if_unchanged(key, expected_generation).await
+    }
+}
+
+/// Parse and validate the opt-in interval before backend construction or dev seeding. Unset means the
+/// original direct-store boot; malformed or zero values fail boot instead of silently disabling an
+/// operator-requested safety job or panicking inside `tokio::time::interval`.
+pub(crate) fn reconcile_interval_from_env() -> Result<Option<Duration>, String> {
+    let raw = match std::env::var(ENV_RECONCILE_INTERVAL_SECS) {
+        Ok(raw) => raw,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(format!(
+                "{ENV_RECONCILE_INTERVAL_SECS} must be valid Unicode containing a positive integer"
+            ));
+        }
+    };
+    let seconds = raw.trim().parse::<u64>().map_err(|_| {
+        format!("{ENV_RECONCILE_INTERVAL_SECS} must be a positive integer number of seconds")
+    })?;
+    if seconds == 0 {
+        return Err(format!(
+            "{ENV_RECONCILE_INTERVAL_SECS} must be greater than zero when set"
+        ));
+    }
+    Ok(Some(Duration::from_secs(seconds)))
+}
+
+/// Start exactly one periodic sweep for a validated interval. `None` returns no handle and performs
+/// no spawn. The sweep always uses `ReconcileOptions::default()`, so the existing one-hour grace
+/// period and fail-closed age handling remain authoritative.
+pub(crate) fn spawn_periodic_if_configured<S, B>(
+    sparq: S,
+    blob: B,
+    interval: Option<Duration>,
+) -> Option<tokio::task::JoinHandle<()>>
+where
+    S: SparqClient + 'static,
+    B: BlobStore + 'static,
+{
+    let interval = interval?;
+    let options = ReconcileOptions::default();
+    eprintln!(
+        "  RECONCILER: periodic orphan sweep ENABLED (interval={}s, grace={}s; one boot task).",
+        interval.as_secs(),
+        options.grace.as_secs()
+    );
+    Some(spawn_periodic(sparq, blob, interval, options))
+}

--- a/crates/sparq-lws-core/src/store/reconcile.rs
+++ b/crates/sparq-lws-core/src/store/reconcile.rs
@@ -114,17 +114,17 @@
 //! - A per-blob delete failure is recorded (`delete_errors`) and the sweep CONTINUES — one bad key
 //!   never aborts the whole GC.
 //!
-//! ## On-demand vs periodic (the best call, documented)
+//! ## On-demand vs periodic
 //! The core [`reconcile_orphans`] is **on-demand**: a pure function over the two seams, callable from a
-//! future admin endpoint / CLI / a one-shot boot sweep. That is the right primary shape — GC is a rare,
-//! operator-or-schedule-triggered maintenance op, not part of the hot request path, and an on-demand
-//! function is trivially testable and composable. A periodic background runner is OFFERED as an
-//! opt-in convenience (`spawn_periodic`, gated behind `SOLID_SERVER_RECONCILE_INTERVAL_SECS`, OFF by
-//! default) for a single-instance deployment that wants a self-driving sweep; in a horizontally-scaled
-//! deployment GC should instead be a single scheduled job (a leader-elected task / a cron hitting the
-//! admin endpoint), NOT a per-replica timer racing N sweeps — which is why periodic is opt-in and
-//! documented, not wired on by default. The in-memory M1 boot does not wire it (a single-process,
-//! never-crashing in-memory store produces no durable orphans), so it stays a seam for the live store.
+//! future admin endpoint / CLI / a one-shot boot sweep. The native server also wires the existing
+//! [`spawn_periodic`] runner behind `SOLID_SERVER_RECONCILE_INTERVAL_SECS`: UNSET (the default) spawns
+//! no task; a positive integer starts exactly one task after router assembly, using
+//! [`ReconcileOptions::default`] and therefore the unchanged one-hour grace window. [GPT-5.6]
+//!
+//! This is intended for a single-instance deployment that wants a self-driving sweep. In a
+//! horizontally-scaled deployment GC should instead be one scheduled job (a leader-elected task / a
+//! cron hitting an admin endpoint), NOT a per-replica timer racing N sweeps — which is why periodic
+//! remains an explicit runtime opt-in rather than a boot default.
 
 use std::collections::HashSet;
 use std::time::{Duration, SystemTime};

--- a/crates/sparq-lws-core/tests/reconcile_periodic.rs
+++ b/crates/sparq-lws-core/tests/reconcile_periodic.rs
@@ -1,0 +1,262 @@
+// [GPT-5.6] sq-5ruwm: mutation-witnessed boot wiring for the opt-in periodic reconciler.
+
+#[path = "../src/reconcile_runtime.rs"]
+mod reconcile_runtime;
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use reconcile_runtime::{
+    reconcile_interval_from_env, spawn_periodic_if_configured, SharedStore,
+    ENV_RECONCILE_INTERVAL_SECS,
+};
+use sparq_lws_core::store::{
+    BlobEntry, BlobError, BlobStore, InMemorySparqClient, ResourceMeta, SparqClient, DEFAULT_GRACE,
+};
+
+#[derive(Clone)]
+struct TestBlob {
+    body: Bytes,
+    last_modified: Option<SystemTime>,
+    generation: u64,
+}
+
+#[derive(Default)]
+struct TestBlobState {
+    entries: HashMap<String, TestBlob>,
+    next_generation: u64,
+}
+
+/// A deterministic blob seam that can represent the backend's fail-closed `last_modified = None`
+/// case. Its compare-and-delete holds one mutex across the comparison and removal, matching the
+/// atomicity contract the production reconciler requires.
+#[derive(Default)]
+struct TestBlobStore {
+    state: Mutex<TestBlobState>,
+}
+
+impl TestBlobStore {
+    fn insert(&self, key: &str, last_modified: Option<SystemTime>) {
+        let mut state = self.state.lock().expect("test blob mutex poisoned");
+        state.next_generation += 1;
+        let generation = state.next_generation;
+        state.entries.insert(
+            key.to_string(),
+            TestBlob {
+                body: Bytes::from_static(b"test"),
+                last_modified,
+                generation,
+            },
+        );
+    }
+}
+
+#[async_trait]
+impl BlobStore for TestBlobStore {
+    async fn get(&self, key: &str) -> Result<Bytes, BlobError> {
+        self.state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?
+            .entries
+            .get(key)
+            .map(|entry| entry.body.clone())
+            .ok_or(BlobError::NotFound)
+    }
+
+    async fn put(&self, key: &str, body: Bytes) -> Result<(), BlobError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?;
+        state.next_generation += 1;
+        let generation = state.next_generation;
+        state.entries.insert(
+            key.to_string(),
+            TestBlob {
+                body,
+                last_modified: Some(SystemTime::now()),
+                generation,
+            },
+        );
+        Ok(())
+    }
+
+    async fn exists(&self, key: &str) -> Result<bool, BlobError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?
+            .entries
+            .contains_key(key))
+    }
+
+    async fn delete(&self, key: &str) -> Result<(), BlobError> {
+        self.state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?
+            .entries
+            .remove(key);
+        Ok(())
+    }
+
+    async fn list(&self) -> Result<Vec<BlobEntry>, BlobError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?
+            .entries
+            .iter()
+            .map(|(key, entry)| BlobEntry {
+                key: key.clone(),
+                last_modified: entry.last_modified,
+                generation: Some(entry.generation),
+            })
+            .collect())
+    }
+
+    async fn stat(&self, key: &str) -> Result<Option<BlobEntry>, BlobError> {
+        Ok(self
+            .state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?
+            .entries
+            .get(key)
+            .map(|entry| BlobEntry {
+                key: key.to_string(),
+                last_modified: entry.last_modified,
+                generation: Some(entry.generation),
+            }))
+    }
+
+    async fn delete_if_unchanged(
+        &self,
+        key: &str,
+        expected_generation: u64,
+    ) -> Result<bool, BlobError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| BlobError::Backend("poisoned".into()))?;
+        let matches = state
+            .entries
+            .get(key)
+            .is_some_and(|entry| entry.generation == expected_generation);
+        if matches {
+            state.entries.remove(key);
+        }
+        Ok(matches)
+    }
+}
+
+struct EnvRestore {
+    previous: Option<OsString>,
+}
+
+impl EnvRestore {
+    fn capture() -> Self {
+        Self {
+            previous: std::env::var_os(ENV_RECONCILE_INTERVAL_SECS),
+        }
+    }
+}
+
+impl Drop for EnvRestore {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(ENV_RECONCILE_INTERVAL_SECS, value),
+            None => std::env::remove_var(ENV_RECONCILE_INTERVAL_SECS),
+        }
+    }
+}
+
+async fn wait_until_deleted(blob: &SharedStore<TestBlobStore>, key: &str) {
+    tokio::time::timeout(Duration::from_secs(4), async {
+        while blob.exists(key).await.expect("probe test blob") {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("periodic reconciler did not reclaim the old orphan");
+}
+
+#[tokio::test]
+async fn runtime_flag_controls_periodic_sweep_without_weakening_delete_safety() {
+    let _env_restore = EnvRestore::capture();
+    let old = SystemTime::now() - DEFAULT_GRACE - Duration::from_secs(60);
+
+    for invalid in ["", "0", "not-a-number"] {
+        std::env::set_var(ENV_RECONCILE_INTERVAL_SECS, invalid);
+        assert!(
+            reconcile_interval_from_env().is_err(),
+            "invalid configured interval {invalid:?} must fail boot"
+        );
+    }
+
+    // Flag ON: one delayed tick must invoke the existing pure sweep with its DEFAULT (one-hour)
+    // grace. The old orphan is the only deletable entry; referenced, young, and undated entries are
+    // mutation witnesses for all three fail-closed retention paths.
+    std::env::set_var(ENV_RECONCILE_INTERVAL_SECS, "1");
+    let interval = reconcile_interval_from_env()
+        .expect("valid periodic reconciler configuration")
+        .expect("a present flag must select the shared boot path");
+    assert_eq!(interval, Duration::from_secs(1));
+    let sparq = SharedStore::new(InMemorySparqClient::new());
+    let blob = SharedStore::new(TestBlobStore::default());
+    blob.as_ref().insert("old-orphan", Some(old));
+    blob.as_ref()
+        .insert("young-write-in-progress", Some(SystemTime::now()));
+    blob.as_ref().insert("undated-orphan", None);
+    blob.as_ref().insert("referenced-live", Some(old));
+    sparq
+        .put_meta(
+            "https://pod.example/live",
+            ResourceMeta {
+                content_type: "text/turtle".into(),
+                blob_key: "referenced-live".into(),
+                etag: "\"live\"".into(),
+                last_modified: Some(SystemTime::now()),
+            },
+        )
+        .await
+        .expect("index live blob");
+
+    let task = spawn_periodic_if_configured(sparq.clone(), blob.clone(), Some(interval))
+        .expect("set interval must spawn exactly one task");
+    wait_until_deleted(&blob, "old-orphan").await;
+    assert!(
+        blob.exists("young-write-in-progress").await.unwrap(),
+        "the unchanged grace period must retain a too-young orphan"
+    );
+    assert!(
+        blob.exists("undated-orphan").await.unwrap(),
+        "an undated blob must remain fail-closed"
+    );
+    assert!(
+        blob.exists("referenced-live").await.unwrap(),
+        "the authoritative referenced-key snapshot must retain live bytes"
+    );
+    task.abort();
+    let _ = task.await;
+
+    // Flag OFF: the helper returns no handle and even an old orphan remains untouched. Removing the
+    // opt-in check (or spawning unconditionally) makes this assertion fail.
+    std::env::remove_var(ENV_RECONCILE_INTERVAL_SECS);
+    let interval = reconcile_interval_from_env().expect("unset interval is valid");
+    assert_eq!(interval, None, "an absent flag must select the direct path");
+    let off_sparq = SharedStore::new(InMemorySparqClient::new());
+    let off_blob = SharedStore::new(TestBlobStore::default());
+    off_blob.as_ref().insert("off-old-orphan", Some(old));
+    assert!(
+        spawn_periodic_if_configured(off_sparq, off_blob.clone(), interval).is_none(),
+        "flag OFF must not spawn a reconciler task"
+    );
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    assert!(
+        off_blob.exists("off-old-orphan").await.unwrap(),
+        "with no task, an old orphan must remain untouched beyond an enabled tick interval"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-5ruwm** — lws-core: wire the orphaned-blob reconciler scheduled sweep (spawn_periodic) into a boot-time o
sq-5ruwm.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-5ruwm","crate":"sparq-lws-core","committed":true,"gates_green":true,"branch":"feat/sq-5ruwm-codex-gpt56","non_vacuity_verified":true,"notes":"commit 91fc6e45; all scoped gates green; no push"}
```

Not armed — the orchestrator arms after review.