### PR TITLE
difftest: escalation-direction carried by arg POSITION only — add a 
sq-ur7zu [GPT-5.6]

### DIFF
--- a/crates/sparq-difftest/src/decision.rs
+++ b/crates/sparq-difftest/src/decision.rs
@@ -9,13 +9,16 @@
 //!
 //! Two things are computed:
 //!
-//! * [`decision_diff`] — the full structural diff: allows/denies added or dropped by side B
-//!   relative to side A, and whether the two outcomes are the *same* decision.
+//! * [`decision_diff`] — the full structural diff: allows/denies added or dropped by the
+//!   [`Candidate`] relative to the [`Baseline`], and whether the two outcomes are the *same*
+//!   decision.
 //! * [`fail_closed_asymmetry`] — the **privilege-escalation direction** only: every tuple side
-//!   B **allows** that side A did **not** allow (A either denied it or omitted it entirely —
-//!   under a fail-closed policy, absence is a deny, so both are escalations). By construction
-//!   this is exactly `B.allow \ A.allow`, so it has zero false negatives on that direction:
-//!   a tuple escapes the report iff A already allowed it.
+//!   the candidate **allows** that the baseline did **not** allow (the baseline either denied
+//!   it or omitted it entirely — under a fail-closed policy, absence is a deny, so both are
+//!   escalations). By construction this is exactly `candidate.allow \ baseline.allow`, so it
+//!   has zero false negatives on that direction: a tuple escapes the report iff the baseline
+//!   already allowed it. Distinct [`Baseline`] / [`Candidate`] argument types make an
+//!   accidental positional swap a compile-time error.
 //!
 //! # Honesty
 //!
@@ -58,7 +61,35 @@ impl<T: Ord> DecisionOutcome<T> {
     }
 }
 
-/// The structural diff between two decision outcomes (side B relative to side A).
+/// The trusted reference outcome in a directional decision comparison. [GPT-5.6]
+///
+/// This is intentionally a distinct type from [`Candidate`]: callers must name which outcome
+/// defines the no-escalation boundary, so swapping the two arguments cannot compile.
+#[derive(Debug, Clone, Copy)]
+pub struct Baseline<'a, T: Ord>(&'a DecisionOutcome<T>);
+
+impl<'a, T: Ord> Baseline<'a, T> {
+    /// Mark `outcome` as the trusted baseline for a directional comparison.
+    pub const fn new(outcome: &'a DecisionOutcome<T>) -> Self {
+        Self(outcome)
+    }
+}
+
+/// The outcome being checked against a trusted [`Baseline`].
+///
+/// This is intentionally a distinct type from [`Baseline`]: callers must name the outcome
+/// whose newly admitted tuples would be privilege escalations.
+#[derive(Debug, Clone, Copy)]
+pub struct Candidate<'a, T: Ord>(&'a DecisionOutcome<T>);
+
+impl<'a, T: Ord> Candidate<'a, T> {
+    /// Mark `outcome` as the candidate in a directional comparison.
+    pub const fn new(outcome: &'a DecisionOutcome<T>) -> Self {
+        Self(outcome)
+    }
+}
+
+/// The structural diff between two decision outcomes (candidate relative to baseline).
 ///
 /// `same` is `true` iff **all four** diff sets are empty — i.e. the allow sets are equal *and*
 /// the deny sets are equal. The escalation direction (`added_allow`) is exactly what
@@ -77,18 +108,30 @@ pub struct DecisionDiff<T: Ord> {
     pub dropped_deny: BTreeSet<T>,
 }
 
-/// Compute the full structural [`DecisionDiff`] of side `b` relative to side `a`.
+/// Compute the full structural [`DecisionDiff`] of `candidate` relative to `baseline`.
 ///
-/// Pure set arithmetic: `added_allow = b.allow \ a.allow`, `dropped_allow = a.allow \ b.allow`,
-/// and likewise for the deny sets. `same` iff every diff set is empty.
+/// Pure set arithmetic: `added_allow = candidate.allow \ baseline.allow`,
+/// `dropped_allow = baseline.allow \ candidate.allow`, and likewise for the deny sets. `same`
+/// iff every diff set is empty. The distinct argument types prevent a positional swap from
+/// silently reversing every directional field.
 pub fn decision_diff<T: Ord + Clone>(
-    a: &DecisionOutcome<T>,
-    b: &DecisionOutcome<T>,
+    baseline: Baseline<'_, T>,
+    candidate: Candidate<'_, T>,
 ) -> DecisionDiff<T> {
-    let added_allow: BTreeSet<T> = b.allow.difference(&a.allow).cloned().collect();
-    let dropped_allow: BTreeSet<T> = a.allow.difference(&b.allow).cloned().collect();
-    let added_deny: BTreeSet<T> = b.deny.difference(&a.deny).cloned().collect();
-    let dropped_deny: BTreeSet<T> = a.deny.difference(&b.deny).cloned().collect();
+    let baseline = baseline.0;
+    let candidate = candidate.0;
+    let added_allow: BTreeSet<T> = candidate
+        .allow
+        .difference(&baseline.allow)
+        .cloned()
+        .collect();
+    let dropped_allow: BTreeSet<T> = baseline
+        .allow
+        .difference(&candidate.allow)
+        .cloned()
+        .collect();
+    let added_deny: BTreeSet<T> = candidate.deny.difference(&baseline.deny).cloned().collect();
+    let dropped_deny: BTreeSet<T> = baseline.deny.difference(&candidate.deny).cloned().collect();
     let same = added_allow.is_empty()
         && dropped_allow.is_empty()
         && added_deny.is_empty()
@@ -102,20 +145,38 @@ pub fn decision_diff<T: Ord + Clone>(
     }
 }
 
-/// Report every tuple side `b` **allows** that side `a` did **not** allow — the
+/// Report every tuple `candidate` **allows** that `baseline` did **not** allow — the
 /// privilege-escalation (fail-closed-violation) direction.
 ///
-/// A tuple lands in the result whether side A explicitly *denied* it or merely *omitted* it:
-/// under a fail-closed policy both mean "not admitted", so a B-side allow is an escalation
-/// either way. Equivalently this is `b.allow \ a.allow`, so the check has **zero false
-/// negatives** in this direction: the only tuples excluded are those A itself already allowed.
-/// An empty result means B admits nothing beyond A (B may still be *stricter* — dropped
-/// allows are the safe direction and are reported by [`decision_diff`], not here).
+/// A tuple lands in the result whether the baseline explicitly *denied* it or merely *omitted*
+/// it: under a fail-closed policy both mean "not admitted", so a candidate allow is an
+/// escalation either way. Equivalently this is `candidate.allow \ baseline.allow`, so the check
+/// has **zero false negatives** in this direction: the only tuples excluded are those the
+/// baseline itself already allowed. An empty result means the candidate admits nothing beyond
+/// the baseline (the candidate may still be *stricter* — dropped allows are the safe direction
+/// and are reported by [`decision_diff`], not here).
+///
+/// The direction is part of the argument types. A swapped call does not compile:
+///
+/// ```compile_fail
+/// use sparq_difftest::{
+///     fail_closed_asymmetry, Baseline, Candidate, DecisionOutcome,
+/// };
+///
+/// let baseline = DecisionOutcome::new([1_u8], []);
+/// let candidate = DecisionOutcome::new([1_u8, 2], []);
+/// fail_closed_asymmetry(Candidate::new(&candidate), Baseline::new(&baseline));
+/// ```
 pub fn fail_closed_asymmetry<T: Ord + Clone>(
-    a: &DecisionOutcome<T>,
-    b: &DecisionOutcome<T>,
+    baseline: Baseline<'_, T>,
+    candidate: Candidate<'_, T>,
 ) -> BTreeSet<T> {
-    b.allow.difference(&a.allow).cloned().collect()
+    candidate
+        .0
+        .allow
+        .difference(&baseline.0.allow)
+        .cloned()
+        .collect()
 }
 
 #[cfg(test)]
@@ -151,7 +212,7 @@ mod tests {
             [t("alice", "Read", "/a"), t("eve", "Read", "/e")],
             [t("bob", "Write", "/a"), t("frank", "Write", "/f")],
         );
-        let d = decision_diff(&a, &b);
+        let d = decision_diff(Baseline::new(&a), Candidate::new(&b));
         assert!(!d.same);
         assert_eq!(d.added_allow, BTreeSet::from([t("eve", "Read", "/e")]));
         assert_eq!(d.dropped_allow, BTreeSet::from([t("carol", "Read", "/c")]));
@@ -175,7 +236,7 @@ mod tests {
             ],
             [],
         );
-        let esc = fail_closed_asymmetry(&a, &b);
+        let esc = fail_closed_asymmetry(Baseline::new(&a), Candidate::new(&b));
         assert_eq!(
             esc,
             BTreeSet::from([t("bob", "Write", "/a"), t("mallory", "Read", "/s")])

--- a/crates/sparq-difftest/src/lib.rs
+++ b/crates/sparq-difftest/src/lib.rs
@@ -51,6 +51,15 @@
 //! fail-closed-asymmetry comparator ([`decision`]) shared by the trust/WAC/ODRL differential
 //! tests (a structural check, not a soundness proof).
 //!
+//! # Admission-decision overlap boundary
+//!
+//! [GPT-5.6] Admission-decision comparisons deliberately do not validate or reconcile a
+//! producer's contradictory `allow ∩ deny` outcome. In particular, a reference/baseline tuple
+//! present in both sets counts as already allowed for the structural
+//! `candidate.allow \ baseline.allow` check, so that overlap can mask a deny-to-allow escalation.
+//! Rejecting or normalising contradictory outcomes belongs to the producing policy harness and
+//! is a documented non-goal of this engine-independent comparator.
+//!
 //! Deliberately **not** here (separate DAG nodes / beads): blank-node isomorphism across oracles
 //! (`sq-qcnn.7`), wiring these comparators into the fuzz harness (`sq-qcnn.5`), the query/data
 //! generator extension (`sq-qcnn.6`), and the pluggable second-oracle adapter (`sq-qcnn.8`).
@@ -62,7 +71,9 @@ pub mod numeric;
 pub mod temporal;
 pub mod term;
 
-pub use decision::{decision_diff, fail_closed_asymmetry, DecisionDiff, DecisionOutcome};
+pub use decision::{
+    decision_diff, fail_closed_asymmetry, Baseline, Candidate, DecisionDiff, DecisionOutcome,
+};
 pub use json::{parse_results_json, QueryResults, Solution};
 pub use multiset::{multiset_equal, order_by_equal};
 pub use numeric::{canonical_double_string, numeric_equal, parse_numeric, NumericValue};

--- a/crates/sparq-difftest/tests/decision_equiv.rs
+++ b/crates/sparq-difftest/tests/decision_equiv.rs
@@ -5,7 +5,7 @@
 
 use std::collections::BTreeSet;
 
-use sparq_difftest::{decision_diff, fail_closed_asymmetry, DecisionOutcome};
+use sparq_difftest::{decision_diff, fail_closed_asymmetry, Baseline, Candidate, DecisionOutcome};
 
 type Tuple = (&'static str, &'static str, &'static str);
 
@@ -23,13 +23,13 @@ fn identical_decisions_yield_empty_diff() {
     );
     let b = a.clone();
 
-    let d = decision_diff(&a, &b);
+    let d = decision_diff(Baseline::new(&a), Candidate::new(&b));
     assert!(d.same);
     assert!(d.added_allow.is_empty());
     assert!(d.dropped_allow.is_empty());
     assert!(d.added_deny.is_empty());
     assert!(d.dropped_deny.is_empty());
-    assert!(fail_closed_asymmetry(&a, &b).is_empty());
+    assert!(fail_closed_asymmetry(Baseline::new(&a), Candidate::new(&b)).is_empty());
 }
 
 /// Acceptance (2): an added allow on side B — whether A explicitly denied the tuple or merely
@@ -49,13 +49,13 @@ fn added_allow_on_b_is_flagged_as_escalation() {
         [],
     );
 
-    let esc = fail_closed_asymmetry(&a, &b);
+    let esc = fail_closed_asymmetry(Baseline::new(&a), Candidate::new(&b));
     assert_eq!(
         esc,
         BTreeSet::from([t("bob", "Write", "/doc"), t("mallory", "Read", "/priv")])
     );
     // The full diff agrees: the escalation direction IS added_allow, and same == false.
-    let d = decision_diff(&a, &b);
+    let d = decision_diff(Baseline::new(&a), Candidate::new(&b));
     assert!(!d.same);
     assert_eq!(d.added_allow, esc);
 }
@@ -75,8 +75,8 @@ fn dropped_allow_only_yields_empty_asymmetry() {
         [t("bob", "Write", "/doc")],
     );
 
-    assert!(fail_closed_asymmetry(&a, &b).is_empty());
-    let d = decision_diff(&a, &b);
+    assert!(fail_closed_asymmetry(Baseline::new(&a), Candidate::new(&b)).is_empty());
+    let d = decision_diff(Baseline::new(&a), Candidate::new(&b));
     assert!(!d.same); // the decisions DO differ…
     assert_eq!(
         d.dropped_allow,
@@ -98,7 +98,7 @@ fn deny_changes_classified_correctly() {
         [t("bob", "Write", "/doc"), t("erin", "Control", "/doc")],
     );
 
-    let d = decision_diff(&a, &b);
+    let d = decision_diff(Baseline::new(&a), Candidate::new(&b));
     assert!(!d.same);
     assert_eq!(d.added_deny, BTreeSet::from([t("erin", "Control", "/doc")]));
     assert_eq!(
@@ -107,5 +107,5 @@ fn deny_changes_classified_correctly() {
     );
     assert!(d.added_allow.is_empty());
     assert!(d.dropped_allow.is_empty());
-    assert!(fail_closed_asymmetry(&a, &b).is_empty());
+    assert!(fail_closed_asymmetry(Baseline::new(&a), Candidate::new(&b)).is_empty());
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-ur7zu** — difftest: escalation-direction carried by arg POSITION only — add a type/named-field guard against caller swap
sq-ur7zu.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-ur7zu","crate":"sparq-difftest","committed":true,"gates_green":true,"branch":"feat/sq-ur7zu-codex-gpt56","non_vacuity_verified":true,"notes":"typed Baseline/Candidate guard; mutation-witnessed compile-fail doctest; all scoped gates and workspace check green"}
```

Not armed — the orchestrator arms after review.