### PR TITLE
docs(jsonld): reconcile stale 'stub'/'SCAFFOLD-PHASE STUB' self-descri
sq-ci15w [GPT-5.6]

### DIFF
--- a/crates/sparq-jsonld/Cargo.toml
+++ b/crates/sparq-jsonld/Cargo.toml
@@ -1,6 +1,6 @@
-# [OPUS-4.8] sq-oy1f.23 (epic sq-oy1f) — Phase A scaffold of the document-level
-# W3C JSON-LD 1.1 pipeline (research/jsonld-1.1-design.md §3). Authored by Opus 4.8
-# (Fable unavailable; flag for re-review when Fable returns).
+# [OPUS-4.8] sq-oy1f.23 (epic sq-oy1f) originated the document-level W3C JSON-LD 1.1
+# pipeline (research/jsonld-1.1-design.md §3). Later beads implemented expansion,
+# flattening, compaction, from-RDF conversion, and framing.
 [package]
 name = "sparq-jsonld"
 version.workspace = true
@@ -13,14 +13,11 @@ keywords.workspace = true
 categories.workspace = true
 description = "Native, dependency-free W3C JSON-LD 1.1 document pipeline for sparq (Json AST + error registry + processing options + deny-by-default document loader)"
 readme = "README.md"
-# [OPUS-4.8] SCAFFOLD-PHASE STUB. The algorithms (Context Processing, Expansion,
-# Flattening, Compaction, Framing, from/to-RDF) land in beads sq-oy1f.24+; this crate
-# currently carries only the moved `Json` AST, the error-code registry, the processing
-# options, and the loader trait. `publish = false` keeps it exempt from the new-crate
-# governance gate (G1, scripts/gate-new-crate.py) bench + SKILL requirements until the
-# pipeline is real — exactly the pattern sparq-substrate uses for its own staged build-out.
-# FLIP this to publishable (and add a registered conformance benchmark + a
-# skills/<surface>/SKILL.md) in the epic's closing bead (sq-oy1f.36) once the pipeline lands.
+# [GPT-5.6] sq-ci15w — `publish = false` is the current internal-release posture, not a
+# scaffold marker: compaction and framing are implemented, and the pinned W3C framing
+# lane passes all 92 cases. `to_rdf` and the high-level `api` facade remain documented
+# placeholders. Revisit publication, governance, and benchmark registration in the
+# epic's closing bead (sq-oy1f.36); usage already lives in skills/jsonld/SKILL.md.
 publish = false
 
 # Render the README as the docs.rs front page (src/lib.rs `#![doc = include_str!(...)]`).
@@ -38,7 +35,6 @@ name = "jsonld_conformance"
 test = true
 
 # ZERO mandatory dependencies (design §3.1). The optional `http-loader` / `html`
-# features and their deps arrive with later beads (sq-oy1f.32 / sq-oy1f.33); the
-# scaffold pulls in nothing so a consumer that only needs the `Json` AST + the error
-# registry pays no dependency cost, and the wasm bundle stays lean.
+# features and their dependencies arrive with later beads (sq-oy1f.32 / sq-oy1f.33).
+# The native document algorithms remain dependency-free, and the wasm bundle stays lean.
 [dependencies]

--- a/crates/sparq-jsonld/README.md
+++ b/crates/sparq-jsonld/README.md
@@ -6,7 +6,8 @@ Context Processing, Expansion, Flattening, Compaction, Framing, and RDF
 
 [JSON-LD 1.1]: https://www.w3.org/TR/json-ld11/
 
-> Model: Sonnet 4.6 (sq-90mu3) extending Opus 4.8 scaffold. Flag for re-review with Fable.
+> [GPT-5.6] Build-out status reconciled in `sq-ci15w`; implementation provenance remains
+> recorded on the individual algorithms.
 > Epic `sq-oy1f` (design record `research/jsonld-1.1-design.md`).
 
 ## 🚀 Quickstart
@@ -93,9 +94,16 @@ Compaction** (`compact::compact` / `compact::compact_expanded`): scoped
 against the W3C **expected** documents (the normative oracle; see
 `sparq-conformance`'s `floors::compact` for the honest fail/skip buckets).
 
-The remaining modules (`frame`, `to_rdf`, `api`) are documented stubs, filled by
-dependency-ordered follow-on beads. The crate is `publish = false` until the
-pipeline is real.
+Beads `sq-oy1f.27` / `.29` add the document-level **Framing Algorithm**
+(`frame::frame` / `frame::frame_expanded`): frame matching and value patterns,
+`@embed`, `@explicit` / `@default`, named graphs, list re-emission, and framing error
+validation. Its pinned W3C framing lane passes all 92 cases against the normative
+document oracle; that complete lane is not a blanket conformance claim for remote
+loading, HTML extraction, or other JSON-LD surfaces.
+
+Only `to_rdf` and `api` remain documented stubs. `publish = false` is the crate's
+current internal-release posture, not an indication that compaction or framing is
+unimplemented.
 
 ## 📚 Learn more
 

--- a/crates/sparq-jsonld/src/lib.rs
+++ b/crates/sparq-jsonld/src/lib.rs
@@ -35,12 +35,19 @@
 //! - [`flatten`](mod@flatten) — the document-level **Flattening Algorithm** (bead
 //!   `sq-oy1f.26`, §7.1): [`flatten::flatten`] expands, node-maps, folds named graphs under
 //!   `@graph`, sorts by `@id`, and drops empty nodes, returning the flattened expanded form.
-//!   (Post-flatten compaction against a caller context composes the document-level
-//!   Compaction Algorithm — its own bead `sq-oy1f.27`.)
+//! - [`compact`] — the document-level **Compaction Algorithm** + Value Compaction (bead
+//!   `sq-oy1f.27`), including scoped contexts, container reshaping, keyword aliasing, and
+//!   the `compactArrays` / `compactToRelative` / `ordered` options.
+//! - [`from_rdf`] — **Deserialize RDF as JSON-LD** (bead `sq-oy1f.28`), converting the
+//!   crate-local RDF dataset model into an expanded document, including native types,
+//!   direction handling, JSON literals, and RDF-list reconstruction.
+//! - [`frame`] — the document-level **Framing Algorithm** (beads `sq-oy1f.27` / `.29`),
+//!   including frame matching, value patterns, embedding, defaults, named graphs, and
+//!   framing-specific validation. Its pinned W3C framing lane passes all 92 cases.
 //!
-//! The remaining algorithm modules ([`compact`], [`frame`], [`from_rdf`], [`to_rdf`],
-//! [`api`]) are **stubs**: they carry the spec references and the public shape only, filled
-//! by the dependency-ordered follow-on beads. Nothing panics: the crate is `todo!()`-free.
+//! [GPT-5.6] (`sq-ci15w`) Only [`to_rdf`] and [`api`] remain documented stubs. The
+//! implemented pipeline is `todo!()`-free; remote loading and HTML extraction remain
+//! separate, opt-in follow-on capabilities.
 
 // Real, shipped surfaces.
 pub mod context;
@@ -49,7 +56,8 @@ pub mod json;
 pub mod loader;
 pub mod options;
 
-// Algorithm scaffolds — spec references + public shape only (filled by later beads).
+// Document-level algorithms. `to_rdf` and `api` retain their documented placeholder
+// surfaces; expansion, flattening, compaction, framing, and from-RDF are implemented.
 pub mod api;
 pub mod compact;
 pub mod expand;
@@ -65,6 +73,6 @@ pub use error::{JsonLdError, JsonLdErrorCode};
 pub use expand::expand;
 pub use flatten::{flatten, flatten_expanded};
 pub use json::{Json, JsonParseError};
-pub use node_map::{generate_node_map, BlankNodeIssuer, GraphMap, NodeMap};
 pub use loader::{DocumentLoader, FsLoader, NoopLoader, RemoteDocument};
+pub use node_map::{generate_node_map, BlankNodeIssuer, GraphMap, NodeMap};
 pub use options::{EmbedFlag, JsonLdOptions, ProcessingMode, RdfDirection};


### PR DESCRIPTION
> 🤖 SPARQ agent — written by **GPT-5.6** (codex-cli, run on an ephemeral EC2 worker).

Implements bead **sq-ci15w** — docs(jsonld): reconcile stale 'stub'/'SCAFFOLD-PHASE STUB' self-descriptions in sparq-jsonld src/lib.rs + README.md + Cargo.toml — compact/frame are implemented (frame 92/92 via sq-oy1f.27/.29), no longer stubs; honesty drift found writing the skills/jsonld SKILL (sq-dzgdh)
sq-ci15w.

GPT-5.6 (codex) authored the change on an ephemeral EC2 arm64 instance: it implemented the
bead, ran the crate-scoped gates (clippy -D warnings + tests in both feature states + rustdoc),
and committed the branch. The controller pulled the commit back as a git bundle and pushed +
opened this PR from the trusted box (no gh auth on the worker).

codex final result line:
```
CODEX_RESULT={"bead":"sq-ci15w","crate":"sparq-jsonld","committed":true,"gates_green":true,"branch":"feat/sq-ci15w-codex-gpt56","non_vacuity_verified":true,"notes":"All scoped gates green; cargo was bootstrapped because cargo and bd were initially absent."}
```

Not armed — the orchestrator arms after review.