### PR TITLE
feat(orchestration): Phase 2 — trust containment + static triage (review-hardened) [OPUS-4.8]

### DIFF
--- a/.github/workflows/promote-on-approval.yml
+++ b/.github/workflows/promote-on-approval.yml
@@ -1,0 +1,63 @@
+# [OPUS-4.8] Trust promotion (review S3). GitHub Actions has NO reaction trigger, so this cron polls
+# quarantined (trust:untrusted) issues and promotes any that a maintainer has 👍-approved AFTER the
+# issue's last edit (revision-bound — an edit-after-approval re-quarantines). Uses the tested pure
+# cores scripts/promote.py + scripts/triage.py.
+name: promote-on-approval
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Poll quarantined issues for maintainer approval
+        run: |
+          python3 - <<'PY'
+          import json, os, subprocess, datetime, sys
+          sys.path.insert(0, "scripts")
+          from promote import should_promote
+          from triage import triage
+          REPO = os.environ["REPO"]
+
+          def gh(*a):
+              return subprocess.run(["gh", *a], capture_output=True, text=True)
+
+          def epoch(ts):
+              return int(datetime.datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()) if ts else 0
+
+          def perm(user):
+              r = gh("api", f"repos/{REPO}/collaborators/{user}/permission", "--jq", ".permission")
+              return r.stdout.strip() if r.returncode == 0 else "none"
+
+          issues = json.loads(gh("issue", "list", "-R", REPO, "--label", "trust:untrusted",
+                                 "--state", "open", "--limit", "200",
+                                 "--json", "number,updatedAt,labels").stdout or "[]")
+          for it in issues:
+              n = it["number"]
+              rx = json.loads(gh("api", f"repos/{REPO}/issues/{n}/reactions").stdout or "[]")
+              reactions = [{"content": r["content"], "user": r["user"]["login"],
+                            "created_at": epoch(r["created_at"])} for r in rx]
+              maints = {r["user"] for r in reactions if r["content"] == "+1" and perm(r["user"]) in ("admin", "maintain", "write")}
+              if should_promote(reactions, epoch(it["updatedAt"]), maints):
+                  gh("issue", "edit", str(n), "-R", REPO, "--remove-label", "trust:untrusted")
+                  labels = [lb["name"] for lb in it["labels"] if lb["name"] != "trust:untrusted"]
+                  d = triage(labels, "task", trusted=True)
+                  for l in sorted(d["add"]):
+                      gh("issue", "edit", str(n), "-R", REPO, "--add-label", l)
+                  for l in sorted(d["remove"]):
+                      gh("issue", "edit", str(n), "-R", REPO, "--remove-label", l)
+                  gh("issue", "comment", str(n), "-R", REPO, "--body",
+                     "> 🤖 automation — maintainer-approved (👍 after the last edit); promoted out of quarantine and triaged.")
+                  print(f"promoted #{n}")
+          PY

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -1,0 +1,54 @@
+# [OPUS-4.8] Issue triage + untrusted-input quarantine (review S2/S3). On a new/edited issue:
+# trust-gate by the AUTHOR's repo permission; a third-party author is quarantined (trust:untrusted)
+# and the maintainer is notified — its content is never inspected. A trusted author's issue is
+# statically triaged (role/priority/status) by scripts/triage.py (no model call here).
+name: triage-issue
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      NUM: ${{ github.event.issue.number }}
+      AUTHOR: ${{ github.event.issue.user.login }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Trust-gate the author (repo permission)
+        id: trust
+        run: |
+          perm=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq .permission 2>/dev/null || echo none)
+          case "$perm" in
+            admin|maintain|write) echo "trusted=1" >> "$GITHUB_OUTPUT" ;;
+            *) echo "trusted=0" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Quarantine + notify (untrusted author)
+        if: steps.trust.outputs.trusted != '1'
+        run: |
+          gh issue edit "$NUM" -R "$REPO" --add-label trust:untrusted --add-label status:untriaged || true
+          gh issue comment "$NUM" -R "$REPO" \
+            --body "> 🤖 automation — this issue is from a non-collaborator, so it is **quarantined** (\`trust:untrusted\`) and its content is not acted on. A maintainer can approve it by adding a 👍 reaction (the promote cron picks it up)." || true
+
+      - name: Static triage (trusted author)
+        if: steps.trust.outputs.trusted == '1'
+        run: |
+          labels=$(gh issue view "$NUM" -R "$REPO" --json labels --jq '[.labels[].name]|join(",")')
+          out=$(python3 scripts/triage.py --labels "$labels" --type task)
+          add=$(printf '%s\n' "$out" | sed -n 's/^ADD: //p')
+          rem=$(printf '%s\n' "$out" | sed -n 's/^REMOVE: //p')
+          for l in $add; do gh issue edit "$NUM" -R "$REPO" --add-label "$l" || true; done
+          for l in $rem; do gh issue edit "$NUM" -R "$REPO" --remove-label "$l" || true; done

--- a/scripts/promote.py
+++ b/scripts/promote.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Trust promotion: decide if a quarantined (trust:untrusted) item may be promoted.
+"""promote.py — revision-bound 👍 promotion of third-party content.
+
+GitHub Actions has NO reaction event, so a cron polls quarantined issues and calls this. An item is
+promoted iff a MAINTAINER (write/maintain/admin) added a 👍 reaction **after** the item's last edit —
+so editing the body after approval invalidates it (the review's S3 TOCTOU fix). Reactions before the
+last edit, or from non-maintainers, do not promote.
+
+Pure `should_promote()` is unit-tested; the cron supplies reactions + updated_at + the maintainer set.
+"""
+import sys
+
+
+def should_promote(reactions, updated_at, maintainers):
+    """`reactions`: list of {content, user, created_at (int)}. `updated_at` (int): the item's last
+    edit time. `maintainers`: set of trusted logins. Promote iff some 👍 from a maintainer was created
+    at/after the last edit."""
+    mset = {m.lower() for m in maintainers}
+    for r in reactions:
+        if (r.get("content") in ("+1", "\U0001F44D")  # '+1' is the API name for 👍
+                and str(r.get("user", "")).lower() in mset
+                and int(r.get("created_at", 0)) >= int(updated_at)):
+            return True
+    return False
+
+
+def _self_test():
+    ok = True
+
+    def chk(n, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {'ok  ' if good else 'FAIL'} {n}: {got} (want {want})")
+
+    M = {"jeswr"}
+    chk("maintainer 👍 after edit", should_promote([{"content": "+1", "user": "jeswr", "created_at": 100}], 90, M), True)
+    chk("👍 BEFORE edit (revoked)", should_promote([{"content": "+1", "user": "jeswr", "created_at": 80}], 90, M), False)
+    chk("non-maintainer 👍", should_promote([{"content": "+1", "user": "rando", "created_at": 100}], 90, M), False)
+    chk("wrong reaction", should_promote([{"content": "heart", "user": "jeswr", "created_at": 100}], 90, M), False)
+    chk("no reactions", should_promote([], 90, M), False)
+    chk("exactly at edit time", should_promote([{"content": "+1", "user": "jeswr", "created_at": 90}], 90, M), True)
+    print("promote self-test", "PASSED" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(_self_test() if "--self-test" in sys.argv else 0)

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Issue-native orchestration: static triage (assign role/priority/package + ready-state).
+"""triage.py — the deterministic, no-LLM part of issue triage.
+
+Given an issue's labels + type, decide the labels to ADD/REMOVE and whether it is triage-complete:
+  * role     — from a `kind:*` label or the bead/issue type (feature/bug->impl, docs->docs, ...).
+  * priority — kept if a valid single `priority:P0..P4` is present; otherwise triage is incomplete.
+  * package  — the existing `area:<crate>` labels are the package (kept as-is); a no-package issue is
+               cross-cutting (handled by the readiness engine's global partition), not incomplete.
+  * ready    — an issue is `status:ready` iff it has a valid single priority AND a role AND is not
+               gated/untrusted. Otherwise it becomes `status:untriaged` for the retriage cron / an
+               LLM pass (a model call is only needed when role/priority cannot be derived statically).
+
+Fail-closed: ambiguity or missing role/priority yields `status:untriaged`, never `status:ready`.
+Pure `triage()` is unit-tested; the workflow applies the returned label delta.
+"""
+import re
+import sys
+
+ROLE_BY_KIND = {"docs": "docs", "design": "research", "research": "research", "perf": "perf",
+                "test": "impl", "ci": "ci", "site": "site", "security": "soundness"}
+ROLE_BY_TYPE = {"feature": "impl", "bug": "impl", "task": "impl", "chore": "ci",
+                "spike": "research", "epic": "impl"}
+SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
+_PRIO = re.compile(r"^priority:P([0-4])$")
+
+
+def _valid_priority(labels):
+    ps = {m.group(1) for lb in labels for m in [_PRIO.match(lb)] if m}
+    return len(ps) == 1
+
+
+def _role(labels, issue_type):
+    # a security-surface keyword forces the soundness lane regardless of kind/type
+    if any(k in lb for lb in labels for k in SEC_KEYWORDS):
+        return "soundness"
+    for lb in labels:
+        if lb.startswith("kind:") and lb[5:] in ROLE_BY_KIND:
+            return ROLE_BY_KIND[lb[5:]]
+    return ROLE_BY_TYPE.get(issue_type)
+
+
+def triage(labels, issue_type="task", trusted=True):
+    """Return {add:set, remove:set, ready:bool, role:str|None}. If not trusted, triage is a no-op
+    (the trust layer quarantines/notifies; content is never inspected here)."""
+    labels = set(labels)
+    if not trusted or "trust:untrusted" in labels:
+        return {"add": set(), "remove": set(), "ready": False, "role": None}
+    role = _role(labels, issue_type)
+    add, remove = set(), set()
+    if role:
+        add.add(f"role:{role}")
+    ready = bool(role) and _valid_priority(labels) and "needs:user" not in labels
+    if ready:
+        add.add("status:ready")
+        remove.add("status:untriaged")
+    else:
+        add.add("status:untriaged")   # fail-closed: not dispatchable until complete
+        remove.add("status:ready")
+    return {"add": add - labels, "remove": remove & labels, "ready": ready, "role": role}
+
+
+def _self_test():
+    ok = True
+
+    def chk(n, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {'ok  ' if good else 'FAIL'} {n}: {got} (want {want})")
+
+    # complete: priority + derivable role -> ready
+    r = triage(["priority:P1", "area:sparq-core"], "feature")
+    chk("feature ready", (r["ready"], "role:impl" in r["add"], "status:ready" in r["add"]), (True, True, True))
+    # missing priority -> untriaged
+    r = triage(["area:sparq-core"], "feature")
+    chk("no priority -> untriaged", (r["ready"], "status:untriaged" in r["add"]), (False, True))
+    # ambiguous priority -> untriaged
+    r = triage(["priority:P1", "priority:P2"], "feature")
+    chk("ambiguous priority", r["ready"], False)
+    # docs kind -> role:docs
+    chk("docs role", triage(["priority:P3", "kind:docs"], "task")["role"], "docs")
+    # security keyword forces soundness
+    chk("sec soundness", triage(["priority:P1", "area:sparq-zk"], "feature")["role"], "soundness")
+    # needs:user -> not ready
+    chk("needs:user gated", triage(["priority:P1", "kind:docs", "needs:user"], "task")["ready"], False)
+    # untrusted -> no-op
+    chk("untrusted no-op", triage(["priority:P1", "trust:untrusted"], "feature"), {"add": set(), "remove": set(), "ready": False, "role": None})
+    print("triage self-test", "PASSED" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--labels", default="", help="comma-separated current labels")
+    ap.add_argument("--type", default="task")
+    ap.add_argument("--untrusted", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        return _self_test()
+    labels = [x for x in a.labels.split(",") if x.strip()]
+    r = triage(labels, a.type, trusted=not a.untrusted)
+    print("ADD: " + " ".join(sorted(r["add"])))
+    print("REMOVE: " + " ".join(sorted(r["remove"])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 SPARQ agent

Phase 2: the untrusted-input safeguard + triage, addressing the GPT-5.6 review's fail-open trust findings (S2/S3).

- `scripts/triage.py` — static triage; `status:ready` only with a valid single priority + a role (else fail-closed `status:untriaged`). 7/7.
- `scripts/promote.py` — **revision-bound** 👍 promotion (promote only if the maintainer 👍-reacted *after* the last edit; an edit re-quarantines). 6/6.
- `triage-issue.yml` — trust-gate the author by repo permission; third-party → quarantine + notify (content never inspected); trusted → static triage.
- `promote-on-approval.yml` — cron (GitHub has **no reaction trigger**) that polls for revision-bound maintainer approvals.

Kept **unmerged/dry** until you enable it. Note surfaced: reactions can neither be a mutex (→ lease ledger) nor trigger workflows (→ polled promotion) — both now handled soundly while preserving the 👍 UX.