### PR TITLE
feat(sparq-server): opt-in running-query registry + list/kill routes (sq-qsm5z) [SONNET]

### DIFF
--- a/.github/feature-matrix.d/sparq-server.yml
+++ b/.github/feature-matrix.d/sparq-server.yml
@@ -225,3 +225,20 @@
   crate: "sparq-server"
   features: "templates"
   test: true
+
+# [SONNET-4.6] sq-qsm5z: the OPT-IN running-query registry (`GET /queries` list +
+# `DELETE /queries/{id}` cooperative cancel). The `QueryRegistry` struct, `QueryGuard` RAII
+# type, `registry_fingerprint` helper, `list_queries_handler` + `cancel_query_handler` handlers,
+# the `AppState::running_queries` field, the route mounts, and the 7 in-module
+# `query_registry_tests` unit tests are ALL `#[cfg(feature = "query-registry")]`, so the
+# DEFAULT build never compiled, clippy'd or tested this code. This leg builds it, runs
+# `clippy --all-targets -D warnings` with the feature ON (the real gate), and runs the
+# crate's unit tests — which now include all 7 gated `query_registry_tests` (fingerprint
+# stability + distinctness, RAII guard cleanup on normal return, RAII guard cleanup on unwind,
+# cancel flips the flag to true, cancel unknown id returns false, multiple entries listed and
+# individually cancellable). `query-registry` pulls only `server` (no new dependency). Zero
+# cost when feature is OFF: no `AppState` fields, no routes, byte-identical to before.
+- name: "sparq-server (query-registry — GET /queries list + DELETE /queries/{id} cancel)"
+  crate: "sparq-server"
+  features: "query-registry"
+  test: true

--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -77,6 +77,16 @@ algebra-rewrite = ["sparq-engine/algebra-rewrite"]
 # integration test. Production builds never enable it (the seam field + constructor
 # vanish), so production behaviour is byte-identical to a build without this feature.
 test-seams = []
+# [SONNET-4.6] (sq-qsm5z) `query-registry` (default OFF): opt-in in-memory running-query
+# registry: each executing SELECT/ASK/CONSTRUCT/DESCRIBE registers on start and deregisters on
+# completion or error (RAII). `GET /queries` lists active queries (id, start timestamp, a
+# NON-REVERSIBLE fingerprint — never raw text per the #241 / sq-m9prn redaction posture,
+# elapsed ms) behind the READ auth gate (fail-closed). `DELETE /queries/{id}` cooperatively
+# cancels one query by flipping the `sq-kq9ia` cross-thread `Arc<AtomicBool>` cancel flag
+# already wired into the engine's `QueryBudget`, behind the WRITE auth gate (fail-closed).
+# Zero cost when compiled out: no fields in `AppState`, no routes, byte-identical to before.
+# Pulls no new dependencies beyond those already present via `server`.
+query-registry = ["server"]
 # [OPUS-4.8] (sq-0bxp) `audit-log` (default OFF): compiles the OPT-IN per-query access
 # audit log (CDMC CD-2 / ISO 27001 A.8.15 / EU CRA logging). With the feature on, the
 # server can emit a structured `tracing` record under target `sparq_server::audit` for

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -57,7 +57,7 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   `backup` (no-stop-the-world `/admin/backup` snapshot + PITR delta `/admin/backup/delta` +
   `/admin/restore` — single-flight: a second concurrent restore is an explicit `409`; on `--persist`,
   `?persist=true`/`--restore-persist` writes the restore through to disk crash-safely so it survives a restart), `change-stream` (durable CDC — commits recorded to a segmented fsync'd log + the Neptune-`GetRecords`-shaped `GET /streams` poll, `--change-stream DIR`),
-  `audit-log`/`access-audit`, `zlib-ng`, `http2`, and `http3` (encrypted QUIC/UDP; see below).
+  `audit-log`/`access-audit`, `query-registry` (`GET /queries` list + `DELETE /queries/{id}` cooperative cancel — both admin/auth-gated, fingerprint-only, no raw text; [SONNET-4.6] sq-qsm5z), `zlib-ng`, `http2`, and `http3` (encrypted QUIC/UDP; see below).
 - **HTTP/2 transport** ([GPT-5.6] sq-oprna.6) — `--features http2` switches TCP to HTTP/1.1+h2c; add `--tls-cert cert.pem --tls-key key.pem` for TLS 1.3 with ALPN `h2,http/1.1`. Omitting both PEM flags preserves cleartext; WebSocket upgrades keep using HTTP/1.1; the slow-loris header deadline remains active.
 - **HTTP/3 transport** ([GPT-5.6] sq-oprna.3/.4) — `--features http3` + `--http3 --tls-cert cert.pem --tls-key key.pem` adds encrypted QUIC/UDP on the same router and advertises its live port with `Alt-Svc`; combine `http2,http3` to use the PEM pair for both TLS TCP and QUIC. Detail in the SKILL.
 - **Default-on JSON-LD** ([OPUS-4.8] sq-oy1f.4) — `jsonld` is in the **default** set: `application/ld+json`

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -2352,6 +2352,150 @@ pub struct AppState {
     /// invocations (reads) dominate and never block each other.
     #[cfg(feature = "templates")]
     templates: Arc<std::sync::RwLock<std::collections::BTreeMap<String, sparq_engine::templates::Template>>>,
+    /// [SONNET-4.6] (sq-qsm5z) The opt-in running-query registry backing `GET /queries` and
+    /// `DELETE /queries/{id}`. Compiled only with the `query-registry` feature. The registry
+    /// stores cancellation handles and metadata but never raw query text; cloned `AppState`
+    /// values share one registry (the `Arc`).
+    #[cfg(feature = "query-registry")]
+    running_queries: Arc<QueryRegistry>,
+}
+
+// ---------------------------------------------------------------------------
+// [SONNET-4.6] (sq-qsm5z) Running-query registry — feature `query-registry`.
+// ---------------------------------------------------------------------------
+
+/// [SONNET-4.6] (sq-qsm5z) Metadata and cooperative-cancel handles for currently executing
+/// queries. The mutex is never held while engine code runs — registration and deregistration
+/// are the only critical sections, and they are short (HashMap insert / remove). Listing clones
+/// the small per-entry view; cancellation flips an atomic flag while holding the lock.
+#[cfg(feature = "query-registry")]
+#[derive(Default)]
+struct QueryRegistry {
+    next_id: std::sync::atomic::AtomicU64,
+    entries: std::sync::Mutex<std::collections::HashMap<String, RegistryEntry>>,
+}
+
+/// [SONNET-4.6] (sq-qsm5z) One row in the registry. The `cancel` flag is wired into the
+/// `QueryBudget` passed to the engine, so flipping it trips the engine's cooperative-cancellation
+/// poll site on the next iteration.
+#[cfg(feature = "query-registry")]
+struct RegistryEntry {
+    /// Unix epoch in milliseconds — serialised to the `GET /queries` response.
+    started_at_unix_ms: u64,
+    /// Monotonic start — used to compute elapsed ms without clock-skew noise.
+    started: std::time::Instant,
+    /// FNV-1a non-reversible fingerprint of the raw SPARQL text (trimmed). Never the raw text.
+    fingerprint: String,
+    /// The `sq-kq9ia` cross-thread cancel flag shared with the engine's `QueryBudget`.
+    cancel: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// [SONNET-4.6] (sq-qsm5z) RAII membership token. Moving it into the `spawn_blocking` closure
+/// means the registry row is present exactly while the engine is running; any return path —
+/// normal, panic, or engine abort — fires `Drop` and removes the row.
+#[cfg(feature = "query-registry")]
+pub(crate) struct QueryGuard {
+    id: String,
+    registry: Arc<QueryRegistry>,
+}
+
+#[cfg(feature = "query-registry")]
+impl Drop for QueryGuard {
+    fn drop(&mut self) {
+        self.registry
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .remove(&self.id);
+    }
+}
+
+#[cfg(feature = "query-registry")]
+impl QueryRegistry {
+    /// Register a new query and return a cancel flag + RAII guard.
+    /// The returned `Arc<AtomicBool>` should be installed into the `QueryBudget`; the
+    /// guard should be held for the entire duration of the engine call.
+    pub(crate) fn register(
+        self: &Arc<Self>,
+        sparql: &str,
+    ) -> (Arc<std::sync::atomic::AtomicBool>, QueryGuard) {
+        use std::sync::atomic::Ordering;
+        let seq = self.next_id.fetch_add(1, Ordering::Relaxed).wrapping_add(1);
+        let id = format!("{:016x}", seq);
+        let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let started_at_unix_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+            .try_into()
+            .unwrap_or(u64::MAX);
+        self.entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .insert(
+                id.clone(),
+                RegistryEntry {
+                    started_at_unix_ms,
+                    started: std::time::Instant::now(),
+                    fingerprint: registry_fingerprint(sparql),
+                    cancel: Arc::clone(&cancel),
+                },
+            );
+        let guard = QueryGuard { id, registry: Arc::clone(self) };
+        (cancel, guard)
+    }
+
+    /// List all currently registered queries as JSON-ready values, sorted by id.
+    pub(crate) fn list(&self) -> Vec<serde_json::Value> {
+        let mut entries: Vec<_> = self
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .iter()
+            .map(|(id, e)| {
+                serde_json::json!({
+                    "id": id,
+                    "start": e.started_at_unix_ms,
+                    "fingerprint": e.fingerprint,
+                    "elapsed_ms": u64::try_from(e.started.elapsed().as_millis())
+                        .unwrap_or(u64::MAX),
+                })
+            })
+            .collect();
+        entries.sort_unstable_by(|a, b| {
+            a["id"].as_str().cmp(&b["id"].as_str())
+        });
+        entries
+    }
+
+    /// Flip the cancel flag for a registered query. Returns `false` if the id is not found.
+    pub(crate) fn cancel_query(&self, id: &str) -> bool {
+        use std::sync::atomic::Ordering;
+        let entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        match entries.get(id) {
+            Some(e) => {
+                e.cancel.store(true, Ordering::Release);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// [SONNET-4.6] (sq-qsm5z) FNV-1a non-reversible fingerprint of the SPARQL query text
+/// (trimmed). Satisfies the #241 / sq-m9prn audit-log discipline: the `GET /queries` listing
+/// exposes only this hash, never raw query text.
+#[cfg(feature = "query-registry")]
+fn registry_fingerprint(sparql: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in sparql.trim().as_bytes() {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{:016x}", hash)
 }
 
 /// [FABLE-5] (sq-fy8ci) RAII permit for the SINGLE-FLIGHT restore guard: while one of these is
@@ -2559,6 +2703,10 @@ impl AppState {
             // seed graph in main.rs BEFORE this state exists, so it never holds the permit).
             #[cfg(feature = "backup")]
             restore_in_flight: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            // [SONNET-4.6] (sq-qsm5z) Empty registry at boot; queries self-register when
+            // the `query-registry` feature is compiled in.
+            #[cfg(feature = "query-registry")]
+            running_queries: Arc::new(QueryRegistry::default()),
         })
     }
 
@@ -3144,6 +3292,15 @@ pub fn router(state: AppState) -> Router {
     // [`streams_endpoint`].
     #[cfg(feature = "change-stream")]
     let routes = routes.route("/streams", get(streams_endpoint).head(streams_endpoint));
+    // [SONNET-4.6] (sq-qsm5z) OPT-IN running-query registry admin routes.
+    // `GET /queries` — admin READ-gated list; `DELETE /queries/{id}` — admin WRITE-gated kill.
+    // Both compiled only with the `query-registry` feature; without it the routes are absent
+    // and the fallback handler produces the standard 404. No runtime flag needed: the routes
+    // are always active when the feature is compiled in (the feature IS the opt-in).
+    #[cfg(feature = "query-registry")]
+    let routes = routes
+        .route("/queries", get(list_queries_handler))
+        .route("/queries/{id}", axum::routing::delete(cancel_query_handler));
     // [FABLE-5] sq-snopa.6 (issue #992 FR-4): OPT-IN Solid WAC/ACP HTTP authorization surface.
     // Compiled only with the `solid-authz` feature; even then each handler refuses (404) unless the
     // config flag is set. POST only — a thin HTTP shell over the `sparq-solid` library authoriser
@@ -5989,7 +6146,19 @@ async fn run_query_pinned(
                 Err(_) => return not_acceptable_response(head_only),
             };
             let is_ask = prepared.form == QueryForm::Ask;
-            let budget = make_budget(&config, !is_ask);
+            // [SONNET-4.6] (sq-qsm5z) Register with the running-query registry (feature
+            // `query-registry`). The RAII guard is boxed as `Box<dyn Any + Send>` so the
+            // call site is uniform in both feature states; it is moved into the blocking
+            // closure and held alive for the entire engine call, then dropped on exit.
+            #[cfg(feature = "query-registry")]
+            let (budget, qr_guard): (QueryBudget, Option<Box<dyn std::any::Any + Send>>) = {
+                let base = make_budget(&config, !is_ask);
+                let (cancel, guard) = state.running_queries.register(sparql);
+                (base.with_cancel(cancel), Some(Box::new(guard)))
+            };
+            #[cfg(not(feature = "query-registry"))]
+            let (budget, qr_guard): (QueryBudget, Option<Box<dyn std::any::Any + Send>>) =
+                (make_budget(&config, !is_ask), None);
             let cfg = config.clone();
             let allow = allow.clone();
             // [OPUS-4.8] (sq-7d3dj.34.2) SELECT → SPARQL-results JSON streams its body: the
@@ -6001,12 +6170,14 @@ async fn run_query_pinned(
             // algebra already parsed in `prepare` via the engine's `*_prepared` entry points —
             // no second parse per request.
             if !is_ask && fmt == Format::Json {
-                return stream_select_json(gen, prepared.query, budget, head_only, allow, &config)
+                return stream_select_json(gen, prepared.query, budget, head_only, allow, qr_guard, &config)
                     .await;
             }
             let pquery = prepared.query;
             let select = prepared.runnable;
             let task = tokio::task::spawn_blocking(move || {
+                // Hold qr_guard alive for the duration of the engine call.
+                let _guard = qr_guard;
                 with_engine_scope_allow(&allow, || {
                     if is_ask {
                         match sparq_engine::ask_prepared_with_budget(
@@ -6047,9 +6218,19 @@ async fn run_query_pinned(
                 Err(_) => return not_acceptable_response(head_only),
             };
             let query = prepared.runnable;
-            let budget = make_budget(&config, true);
+            // [SONNET-4.6] (sq-qsm5z) Register with the running-query registry.
+            #[cfg(feature = "query-registry")]
+            let (budget, qr_guard): (QueryBudget, Option<Box<dyn std::any::Any + Send>>) = {
+                let base = make_budget(&config, true);
+                let (cancel, guard) = state.running_queries.register(sparql);
+                (base.with_cancel(cancel), Some(Box::new(guard)))
+            };
+            #[cfg(not(feature = "query-registry"))]
+            let (budget, qr_guard): (QueryBudget, Option<Box<dyn std::any::Any + Send>>) =
+                (make_budget(&config, true), None);
             let cfg = config.clone();
             let task = tokio::task::spawn_blocking(move || {
+                let _guard = qr_guard;
                 // [OPUS-4.8] sq-rt6v: produce the triple list once, then serialise it in the
                 // negotiated graph syntax — N-Triples (default), prefix-compacting Turtle, or
                 // RDF/XML — rather than always emitting N-Triples.
@@ -6321,11 +6502,17 @@ async fn stream_select_json(
     budget: QueryBudget,
     head_only: bool,
     allow: crate::service_config::ServiceAllowlist,
+    // [SONNET-4.6] (sq-qsm5z) The RAII registry guard, as a type-erased send-able box so the
+    // signature compiles in both feature states without a conditional type. Moved into the worker
+    // so the row is present for the full streaming evaluation; dropped when the worker exits.
+    qr_guard: Option<Box<dyn std::any::Any + Send>>,
     config: &ServerConfig,
 ) -> Response {
     let ct = Format::Json.select_content_type();
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Result<Bytes, String>>(STREAM_CHANNEL_CAP);
     tokio::task::spawn_blocking(move || {
+        // Hold the registry guard alive for the entire streaming evaluation.
+        let _guard = qr_guard;
         with_engine_scope_allow(&allow, || {
             let graph = gen.snapshot();
             let mut sink = |chunk: String| match tx.blocking_send(Ok(Bytes::from(chunk.into_bytes()))) {
@@ -8342,6 +8529,149 @@ mod bind_posture_tests {
         for f in ["", "0", "false", "no", "off", "2", "maybe"] {
             assert!(!env_truthy(f), "{f:?} should be falsy");
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [SONNET-4.6] sq-qsm5z — running-query registry HTTP handlers
+// ---------------------------------------------------------------------------
+
+/// [SONNET-4.6] (sq-qsm5z) `GET /queries` — list currently executing SPARQL queries.
+///
+/// Returns a JSON object `{"queries": [...]}` where each entry carries `id`, `start`
+/// (Unix epoch ms), `fingerprint` (FNV-1a hex — never raw query text), and `elapsed_ms`.
+/// Entries are sorted by `id` (registration order). An empty registry returns `{"queries":[]}`.
+///
+/// **Auth:** READ-gated (fail-closed). Mirrors the posture of every other admin route.
+#[cfg(feature = "query-registry")]
+async fn list_queries_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Response {
+    if let Some(resp) = auth_gate(state.config(), &headers, Operation::Read) {
+        return resp;
+    }
+    let body = serde_json::json!({ "queries": state.running_queries.list() }).to_string();
+    text_response(StatusCode::OK, "application/json", body, false)
+}
+
+/// [SONNET-4.6] (sq-qsm5z) `DELETE /queries/{id}` — cooperatively cancel one executing query.
+///
+/// Flips the `sq-kq9ia` `Arc<AtomicBool>` cancel flag that was wired into the query's
+/// `QueryBudget` at registration time. The engine observes the flag at its next cooperative
+/// poll site and aborts with `"query budget exceeded (cancelled)"`. The registry row stays
+/// until the worker exits and the RAII `QueryGuard` fires its `Drop`.
+///
+/// - `204 No Content` — the cancel flag was flipped.
+/// - `404 Not Found` — no query with that id in the registry (already finished, or bad id).
+///
+/// **Auth:** WRITE-gated (fail-closed). An unauthenticated or wrongly-authenticated request
+/// receives a `401` identical for missing vs. wrong token.
+#[cfg(feature = "query-registry")]
+async fn cancel_query_handler(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if let Some(resp) = auth_gate(state.config(), &headers, Operation::Write) {
+        return resp;
+    }
+    if state.running_queries.cancel_query(&id) {
+        Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(axum::body::Body::empty())
+            .unwrap()
+    } else {
+        json_error(StatusCode::NOT_FOUND, "running query not found")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [SONNET-4.6] sq-qsm5z — registry unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(all(test, feature = "query-registry"))]
+mod query_registry_tests {
+    use super::{QueryRegistry, registry_fingerprint};
+    use std::sync::Arc;
+
+    // Fingerprint must be stable across calls with the same input.
+    #[test]
+    fn fingerprint_is_stable() {
+        let a = registry_fingerprint("SELECT * WHERE { ?s ?p ?o }");
+        let b = registry_fingerprint("SELECT * WHERE { ?s ?p ?o }");
+        assert_eq!(a, b, "fingerprint must be deterministic");
+        // 16 hex chars for a 64-bit hash.
+        assert_eq!(a.len(), 16);
+    }
+
+    // Different queries must produce different fingerprints.
+    #[test]
+    fn fingerprint_differs_for_distinct_queries() {
+        let a = registry_fingerprint("SELECT * WHERE { ?s ?p ?o }");
+        let b = registry_fingerprint("ASK WHERE { ?s ?p ?o }");
+        assert_ne!(a, b, "distinct queries must yield distinct fingerprints");
+    }
+
+    // The RAII guard removes the entry on normal return.
+    #[test]
+    fn guard_removes_entry_on_normal_return() {
+        let registry = Arc::new(QueryRegistry::default());
+        {
+            let (_cancel, _guard) = registry.register("SELECT * WHERE { ?s ?p ?o }");
+            assert_eq!(registry.list().len(), 1, "entry must be present while guard is alive");
+        }
+        assert_eq!(registry.list().len(), 0, "entry must be removed after guard drops");
+    }
+
+    // The RAII guard removes the entry even during a panic / unwind.
+    #[test]
+    fn guard_removes_entry_during_panic_unwind() {
+        let registry = Arc::new(QueryRegistry::default());
+        let r2 = Arc::clone(&registry);
+        let result = std::thread::spawn(move || {
+            let (_cancel, _guard) = r2.register("SELECT 1 WHERE {}");
+            panic!("witness panic");
+        })
+        .join();
+        assert!(result.is_err(), "thread must have panicked");
+        assert_eq!(registry.list().len(), 0, "entry must be cleaned up after unwind");
+    }
+
+    // Cancelling an entry flips the flag (non-vacuous: verify the flag starts false).
+    #[test]
+    fn cancel_flips_flag_to_true() {
+        use std::sync::atomic::Ordering;
+        let registry = Arc::new(QueryRegistry::default());
+        let (cancel, _guard) = registry.register("SELECT * WHERE { ?s ?p ?o }");
+        assert!(!cancel.load(Ordering::Acquire), "flag must start false");
+        let id = registry.list()[0]["id"].as_str().unwrap().to_owned();
+        let found = registry.cancel_query(&id);
+        assert!(found, "cancel must return true for a known id");
+        assert!(cancel.load(Ordering::Acquire), "flag must be true after cancel");
+    }
+
+    // Cancelling an unknown id returns false (the 404 path).
+    #[test]
+    fn cancel_unknown_id_returns_false() {
+        let registry = Arc::new(QueryRegistry::default());
+        assert!(!registry.cancel_query("0000000000000000"), "unknown id must return false");
+    }
+
+    // Multiple simultaneous entries are all listed and all individually cancellable.
+    #[test]
+    fn multiple_entries_listed_and_cancellable() {
+        use std::sync::atomic::Ordering;
+        let registry = Arc::new(QueryRegistry::default());
+        let (c1, _g1) = registry.register("SELECT ?a WHERE { ?a ?b ?c }");
+        let (c2, _g2) = registry.register("ASK WHERE { ?x ?y ?z }");
+        let list = registry.list();
+        assert_eq!(list.len(), 2, "both entries must be present");
+        let id0 = list[0]["id"].as_str().unwrap().to_owned();
+        registry.cancel_query(&id0);
+        // Exactly one flag is now set.
+        let set_count = [c1, c2].iter().filter(|f| f.load(Ordering::Acquire)).count();
+        assert_eq!(set_count, 1, "exactly one cancel flag must be set");
     }
 }
 

--- a/crates/sparq-server/tests/query_registry.rs
+++ b/crates/sparq-server/tests/query_registry.rs
@@ -1,0 +1,195 @@
+//! [SONNET-4.6] (sq-qsm5z) Integration tests for the `query-registry` feature's
+//! `GET /queries` and `DELETE /queries/{id}` HTTP routes.
+//!
+//! These exercise the REAL HTTP path (not a mock): boot the server, drive it over
+//! HTTP with `reqwest`, and assert:
+//!   * both routes are fail-closed on auth — no token => 401, wrong token => 401;
+//!   * no token-enumeration: the 401 for a missing token is identical to a wrong token;
+//!   * `GET /queries` with the correct READ token => 200 + well-formed `{"queries":[...]}`;
+//!   * `DELETE /queries/{id}` with the correct WRITE token => 404 for unknown id.
+//!
+//! Harness: same pattern as `tests/auth.rs` (spawn_with / reqwest / ephemeral port).
+//!
+//! Run: `cargo test -p sparq-server --features query-registry --test query_registry`
+//!
+//! 🤖 SPARQ agent
+
+#![cfg(feature = "query-registry")]
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+/// The single shared Bearer token — used for both reads (when `auth_token_read=true`)
+/// and writes, matching the `ServerConfig::auth_token` / `auth_check` model exactly.
+const TOKEN: &str = "s3cr3t-registry-token";
+const WRONG: &str = "definitely-not-the-token";
+
+/// Boots a real axum server with a write+read gate (both routes are auth-gated).
+/// Returns the base URL.
+async fn spawn_gated() -> String {
+    let graph = Graph::load_str("", "turtle").unwrap();
+    // auth_token: the single token for all operations.
+    // auth_token_read: true so that GET /queries (Operation::Read) is also gated.
+    let config = ServerConfig {
+        auth_token: Some(TOKEN.to_string()),
+        auth_token_read: true,
+        ..ServerConfig::default()
+    };
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+// ---------------------------------------------------------------------------
+// GET /queries — auth gate
+// ---------------------------------------------------------------------------
+
+/// `GET /queries` with NO Authorization header => 401 (fail-closed).
+#[tokio::test]
+async fn list_queries_no_token_is_401() {
+    let base = spawn_gated().await;
+    let resp = client()
+        .get(format!("{base}/queries"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "GET /queries with no token must be 401"
+    );
+    // WWW-Authenticate: Bearer is the standard fail-closed signal.
+    assert_eq!(
+        resp.headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer"),
+        "GET /queries 401 must carry WWW-Authenticate: Bearer"
+    );
+}
+
+/// `GET /queries` with the WRONG token => 401 (indistinguishable from missing-token 401,
+/// so no enumeration is possible).
+#[tokio::test]
+async fn list_queries_wrong_token_is_401() {
+    let base = spawn_gated().await;
+    let resp = client()
+        .get(format!("{base}/queries"))
+        .header("authorization", format!("Bearer {WRONG}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "GET /queries with wrong token must be 401 (no enumeration)"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer"),
+        "wrong-token 401 must carry the same WWW-Authenticate: Bearer"
+    );
+}
+
+/// `GET /queries` with the correct token => 200 + `{"queries":[...]}` body.
+#[tokio::test]
+async fn list_queries_correct_token_is_200_with_body() {
+    let base = spawn_gated().await;
+    let resp = client()
+        .get(format!("{base}/queries"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "GET /queries with correct token must be 200"
+    );
+    // Body must be well-formed JSON with a top-level "queries" array.
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body.get("queries").and_then(|v| v.as_array()).is_some(),
+        "response body must be {{\"queries\":[...]}}; got: {body}"
+    );
+    // On an idle server with no executing queries the list must be empty.
+    let queries = body["queries"].as_array().unwrap();
+    assert!(
+        queries.is_empty(),
+        "idle server must report an empty query list"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /queries/{id} — auth gate
+// ---------------------------------------------------------------------------
+
+/// `DELETE /queries/{id}` with NO token => 401.
+#[tokio::test]
+async fn cancel_query_no_token_is_401() {
+    let base = spawn_gated().await;
+    let resp = client()
+        .delete(format!("{base}/queries/0000000000000000"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "DELETE /queries/{{id}} with no token must be 401"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("www-authenticate")
+            .and_then(|v| v.to_str().ok()),
+        Some("Bearer"),
+        "DELETE 401 must carry WWW-Authenticate: Bearer"
+    );
+}
+
+/// `DELETE /queries/{id}` with the WRONG token => 401.
+#[tokio::test]
+async fn cancel_query_wrong_token_is_401() {
+    let base = spawn_gated().await;
+    let resp = client()
+        .delete(format!("{base}/queries/0000000000000000"))
+        .header("authorization", format!("Bearer {WRONG}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "DELETE /queries/{{id}} with wrong token must be 401 (no enumeration)"
+    );
+}
+
+/// `DELETE /queries/{id}` with the correct WRITE token but an unknown id => 404.
+/// This proves the auth gate PASSES and the handler logic runs (non-vacuous: the gate
+/// did not short-circuit to 401 for a valid token, and the 404 comes from the registry).
+#[tokio::test]
+async fn cancel_query_correct_token_unknown_id_is_404() {
+    let base = spawn_gated().await;
+    let resp = client()
+        .delete(format!("{base}/queries/0000000000000000"))
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::NOT_FOUND,
+        "DELETE /queries/{{id}} with correct token + unknown id must be 404"
+    );
+}

--- a/scripts/tests/feature-matrix-legnames.golden.txt
+++ b/scripts/tests/feature-matrix-legnames.golden.txt
@@ -105,6 +105,7 @@ opt-in sparq-server (federation-descriptors, service, time-travel, geo, test-sea
 opt-in sparq-server (http2)
 opt-in sparq-server (http3)
 opt-in sparq-server (odrl-authz — ODRL lane on POST /authz/query)
+opt-in sparq-server (query-registry — GET /queries list + DELETE /queries/{id} cancel)
 opt-in sparq-server (response-compression)
 opt-in sparq-server (solid-authz — POST /authz/* WAC/ACP HTTP surface)
 opt-in sparq-server (solid-authz-trust — stateless trust-graph /authz/decide extension)

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -815,6 +815,33 @@ no anchor is a fail-closed `400` (never a silent replay-all). With the feature o
 recording hook are `#[cfg]`-stripped (byte-identical); recording serialises updates only while the
 stream is on. The `ChangeSink` broker trait stays a separate later opt-in (`sq-l6zks`).
 
+**`GET /queries` + `DELETE /queries/{id}` — running-query registry (`sparq-server` feature
+`query-registry`, default OFF; sq-qsm5z, [SONNET-4.6]).** An opt-in in-memory registry of
+currently executing SPARQL queries, providing GraphDB query-monitoring and kill parity.
+
+- **`GET /queries`** — READ-gated (fail-closed). Returns `{"queries":[…]}` where each entry
+  carries `id` (opaque hex), `start` (Unix epoch ms), `fingerprint` (FNV-1a hex — a
+  NON-REVERSIBLE hash of the trimmed query text, never raw text per the #241 / sq-m9prn
+  audit-log posture), and `elapsed_ms`. Sorted by `id` (registration order).
+- **`DELETE /queries/{id}`** — WRITE-gated (fail-closed). Cooperatively cancels the named
+  query by flipping the `sq-kq9ia` `Arc<AtomicBool>` cancel flag wired into its `QueryBudget`.
+  The engine observes it at the next poll site and aborts. Returns `204 No Content` on success;
+  `404` if the id is not found (already finished or bad id).
+- **RAII lifetime**: each executing SELECT/ASK/CONSTRUCT/DESCRIBE registers on start and
+  deregisters on completion, error, or panic — the entry is always cleaned up.
+- **Fingerprint-only**: the `GET /queries` listing NEVER exposes raw query text; only the
+  non-reversible fingerprint is visible, satisfying the audit-log discipline.
+- **Zero cost when feature is OFF**: no `AppState` fields, no routes; byte-identical to before.
+
+```sh
+# (--features query-registry required at build time)
+# List running queries:
+curl -H 'Authorization: Bearer <TOKEN>' http://127.0.0.1:3030/queries
+
+# Cancel a query by id:
+curl -X DELETE -H 'Authorization: Bearer <TOKEN>' http://127.0.0.1:3030/queries/0000000000000001
+```
+
 GSP **writes** translate into a server-minted SPARQL Update (`DROP`/`CLEAR` + `INSERT
 DATA`) and submit through the SAME sequenced group-commit writer the
 `application/sparql-update` operation uses — so they share its atomicity, snapshot


### PR DESCRIPTION
> 🤖 SPARQ agent implementing bead sq-qsm5z: an opt-in in-memory running-query registry for `sparq-server`, providing GraphDB query-monitoring and cooperative-kill parity.

## Summary

- **New feature `query-registry`** (default OFF, pulls no new deps). When compiled in, every executing SELECT/ASK/CONSTRUCT/DESCRIBE (including the streaming JSON SELECT path) registers itself at start and deregisters on completion, error, or panic via a RAII `QueryGuard`.
- **`GET /queries`** — admin READ-gated (fail-closed), returns `{"queries":[…]}` with `id`, `start` (Unix epoch ms), `fingerprint` (FNV-1a hex — NEVER raw query text, per the #241/sq-m9prn audit-log posture), `elapsed_ms`. Sorted by registration order.
- **`DELETE /queries/{id}`** — admin WRITE-gated (fail-closed), flips the `sq-kq9ia` `Arc<AtomicBool>` cancel flag wired into the query's `QueryBudget`; the engine observes it at the next cooperative poll site. Returns `204 No Content` on success, `404` for unknown/finished id.
- **Auth-gating is fail-closed** — mirrors the existing `auth_gate(state.config(), &headers, Operation::Read/Write)` pattern used by every other admin route (`/admin/compact`, `/admin/backup`, etc.).
- **Wiring only, no engine internals** — the cancel flag is the already-merged `sq-kq9ia` `Arc<AtomicBool>` field on `QueryBudget::cancel`; this PR only wires it at registration.
- **Zero cost when feature is OFF**: no `AppState` fields, no routes, byte-identical to before.

## Gate status (BOTH feature states verified in-worktree)

| Gate | Feature OFF | Feature ON |
|------|------------|-----------|
| `cargo build -p sparq-server` | GREEN | GREEN |
| `cargo clippy -p sparq-server --all-targets -- -D warnings` | GREEN | GREEN |
| `cargo test -p sparq-server` (25 integration + 231 lib tests) | GREEN | GREEN |
| `cargo test -p sparq-server --lib query_registry` (7 unit tests) | — | GREEN (7/7) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --package sparq-server --no-deps --all-features` | — | GREEN |
| `python3 scripts/check-readme-template.py --enforce` | 0 deviations | — |
| Golden legnames match assembled matrix | — | OK |

## Tests (non-vacuous)
7 direct unit tests in `http::query_registry_tests`:
1. `fingerprint_is_stable` — same input → same 16-char hex output
2. `fingerprint_differs_for_distinct_queries` — different SPARQL → different fingerprint
3. `guard_removes_entry_on_normal_return` — entry cleaned up after `Drop`
4. `guard_removes_entry_during_panic_unwind` — entry cleaned up after thread unwind
5. `cancel_flips_flag_to_true` — flag starts `false`, `cancel_query` sets it to `true` (non-vacuous: assertion on initial state + post-cancel state)
6. `cancel_unknown_id_returns_false` — 404 path
7. `multiple_entries_listed_and_cancellable` — exactly one flag set per cancel call

## Honest boundaries
- Cooperative cancellation — the engine only observes the flag at poll sites (not immediate); this matches the existing `sq-kq9ia` semantics documented in `QueryBudget`.
- The EXPLAIN ANALYZE path is NOT registered (it uses a bare `make_budget` without cancel wiring); it is a planning/analysis operation, not a normal query execution. If desired, that is a follow-up bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)