### PR TITLE
feat(sparq-lws): wasm panic-hook + Node-host trap recovery/instance-recycle (sq-250si) [SONNET]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "console_log"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5105,6 +5115,7 @@ name = "sparq-lws-wasm"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "console_error_panic_hook",
  "futures-executor",
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/crates/sparq-lws-wasm/Cargo.toml
+++ b/crates/sparq-lws-wasm/Cargo.toml
@@ -13,6 +13,11 @@ crate-type = ["cdylib", "rlib"]
 # wasm32 is the opt-in: it does not add Solid-server code to sparq-core, sparq-engine, or sparq-wasm.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 axum = { version = "0.8", default-features = false }
+# [SONNET-4.6] sq-250si: emit a diagnostic to console.error on panic (panic=abort in release
+# lowers to an unreachable trap — this hook fires in dev/debug builds where unwinding is
+# available, giving the host a readable message before the trap). One line of glue over wasm-bindgen;
+# no new transitive crates (wasm-bindgen is already in the tree).
+console_error_panic_hook = "0.1"
 futures-executor = "0.3"
 http = "1"
 oxrdf.workspace = true

--- a/crates/sparq-lws-wasm/README.md
+++ b/crates/sparq-lws-wasm/README.md
@@ -56,6 +56,9 @@ console.log(response.status);
 - The default-off `sparql-endpoint` feature adds query-only GET/POST `/sparql`
   over the resources that the supplied WebID may read. SELECT/ASK return
   SPARQL-results JSON; CONSTRUCT returns N-Triples.
+- [SONNET-4.6] A `console_error_panic_hook` is installed at module init so any
+  Rust panic emits a diagnostic to `console.error` before the wasm `unreachable`
+  trap propagates to the host as `WebAssembly.RuntimeError`.
 - No Tokio reactor, native listener, filesystem, TLS, OIDC verifier, PoP,
   notifications, or network backend is linked into the wasm artifact.
 
@@ -68,6 +71,9 @@ console.log(response.status);
 - [GPT-5.6] The [`@jeswr/solid-server`](../../packages/solid-server/) package owns
   the loopback Node listener and `npx` entry. Its fixed-owner mode is for local
   development only; OIDC verification remains outside this wasm crate.
+- [SONNET-4.6] The Node host catches `WebAssembly.RuntimeError` and recycles the
+  `SolidServer` instance before the next request (sq-250si). A single wasm trap no
+  longer bricks the process; the triggering request receives HTTP 503.
 
 ## License
 

--- a/crates/sparq-lws-wasm/src/lib.rs
+++ b/crates/sparq-lws-wasm/src/lib.rs
@@ -1,4 +1,5 @@
 // [GPT-5.6] sq-6xasp.3: wasm host adapter over the real LWS router.
+// [SONNET-4.6] sq-250si: wasm panic hook + host trap-recovery boundary.
 #![forbid(unsafe_code)]
 #![deny(rust_2018_idioms)]
 //! WebAssembly request entry for the in-memory Solid/LDP server core.
@@ -6,6 +7,19 @@
 //! Building this dedicated crate is the opt-in boundary. On wasm32, `SolidServer` owns the real axum
 //! router over the in-memory SPARQ metadata and blob stores. JavaScript remains responsible for the
 //! HTTP listener and OIDC verification; each request supplies only an already-authenticated WebID.
+//!
+//! # Panic and trap behaviour
+//!
+//! The release profile uses `panic=abort`, so a Rust panic lowers to a `wasm32` `unreachable`
+//! trap rather than unwinding. The `lws_init` function registered via `#[wasm_bindgen(start)]`
+//! installs a `console_error_panic_hook` that forwards the panic message to `console.error`
+//! before the trap fires — giving the host a readable diagnostic in environments where the
+//! hook can run (debug builds, `wasm-bindgen-test`). In `panic=abort` release builds the hook
+//! fires before the abort and the message appears in the browser or Node console.
+//!
+//! The Node host (`@jeswr/solid-server`) catches the resulting `WebAssembly.RuntimeError` and
+//! recreates the `SolidServer` before the next request, so a single trap does not permanently
+//! brick the process. See `packages/solid-server/src/index.js`.
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
@@ -25,6 +39,17 @@ mod wasm {
 
     const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
     const ACL: &str = "http://www.w3.org/ns/auth/acl#";
+
+    /// Called once by the wasm-bindgen runtime when the module is first loaded.
+    ///
+    /// Installs a panic hook that writes the panic message to `console.error` before the
+    /// `unreachable` trap propagates to the host as a `WebAssembly.RuntimeError`. The hook
+    /// is idempotent — safe to call from any context, and a no-op if already installed.
+    // [SONNET-4.6] sq-250si: set_once is idempotent; safe for concurrent (future) init paths.
+    #[wasm_bindgen(start)]
+    pub fn lws_init() {
+        console_error_panic_hook::set_once();
+    }
 
     /// A response returned across the wasm boundary.
     ///
@@ -137,10 +162,10 @@ mod wasm {
         }
 
         let method = Method::from_bytes(method.as_bytes())
-            .map_err(|error| format!("invalid HTTP method: {error}"))?;
+            .map_err(|error| format!("invalid HTTP method: {}", error))?;
         let uri: Uri = path
             .parse()
-            .map_err(|error| format!("invalid request path: {error}"))?;
+            .map_err(|error| format!("invalid request path: {}", error))?;
         if uri.scheme().is_some() || uri.authority().is_some() || !uri.path().starts_with('/') {
             return Err("path must be an origin-form URI beginning with '/'".to_owned());
         }
@@ -149,12 +174,12 @@ mod wasm {
             .method(method)
             .uri(uri)
             .body(Body::from(body))
-            .map_err(|error| format!("could not build request: {error}"))?;
+            .map_err(|error| format!("could not build request: {}", error))?;
         for pair in headers.chunks_exact(2) {
             let name = HeaderName::from_bytes(pair[0].as_bytes())
-                .map_err(|error| format!("invalid header name {:?}: {error}", pair[0]))?;
+                .map_err(|error| format!("invalid header name {:?}: {}", pair[0], error))?;
             let value = HeaderValue::from_str(&pair[1])
-                .map_err(|error| format!("invalid value for header {}: {error}", pair[0]))?;
+                .map_err(|error| format!("invalid value for header {}: {}", pair[0], error))?;
             request.headers_mut().append(name, value);
         }
         if let Some(webid) = authenticated_webid {
@@ -184,11 +209,11 @@ mod wasm {
         base_url: &str,
         owner_webid: &str,
     ) -> Result<(), String> {
-        let root = format!("{base_url}/");
-        let acl_doc = format!("{root}.acl");
-        let auth = named_node(&format!("{acl_doc}#owner"))?;
+        let root = format!("{}/", base_url);
+        let acl_doc = format!("{}.acl", root);
+        let auth = named_node(&format!("{}#owner", acl_doc))?;
         let root_node = named_node(&root)?;
-        let mode = |local: &str| named_node(&format!("{ACL}{local}"));
+        let mode = |local: &str| named_node(&format!("{}{}", ACL, local));
         let triples = vec![
             Triple::new(auth.clone(), named_node(RDF_TYPE)?, mode("Authorization")?),
             Triple::new(auth.clone(), mode("agent")?, named_node(owner_webid)?),
@@ -199,16 +224,16 @@ mod wasm {
             Triple::new(auth, mode("mode")?, mode("Control")?),
         ];
         let bytes = serialize_triples(RdfFormat::Turtle, &triples)
-            .map_err(|error| format!("could not serialize owner ACL: {error}"))?;
+            .map_err(|error| format!("could not serialize owner ACL: {}", error))?;
         store
             .write(&acl_doc, Bytes::from(bytes), RdfFormat::Turtle.media_type())
             .await
-            .map_err(|error| format!("could not provision owner ACL: {error}"))?;
+            .map_err(|error| format!("could not provision owner ACL: {}", error))?;
         Ok(())
     }
 
     fn named_node(iri: &str) -> Result<NamedNode, String> {
-        NamedNode::new(iri).map_err(|error| format!("invalid IRI {iri:?}: {error}"))
+        NamedNode::new(iri).map_err(|error| format!("invalid IRI {:?}: {}", iri, error))
     }
 }
 

--- a/packages/solid-server/src/index.js
+++ b/packages/solid-server/src/index.js
@@ -1,16 +1,12 @@
 // [GPT-5.6] sq-6xasp.9/.10: loopback Node listener with optional verified identity into wasm.
-import { createServer } from 'node:http';
+// [SONNET-4.6] sq-250si: trap recovery — catch WebAssembly.RuntimeError and recycle the instance.
 import { readFile } from 'node:fs/promises';
 
 import initWasm, { SolidServer } from '../wasm/sparq_lws_wasm.js';
 import { createOidcAuthenticator } from './auth.js';
-import {
-  RequestBodyTooLargeError,
-  copyWasmResponse,
-  flattenRequestHeaders,
-  readRequestBody,
-  writeNodeResponse,
-} from './http.js';
+import { attachTrapRecoveryHandler, isWasmTrap } from './trap-recovery.js';
+
+export { attachTrapRecoveryHandler, isWasmTrap };
 
 const DEFAULT_PORT = 3000;
 const DEFAULT_OWNER_WEBID = 'https://example.invalid/profile/card#me';
@@ -66,18 +62,21 @@ function normalizeOidc(value) {
   throw new TypeError('oidc must be a boolean');
 }
 
-async function closeServer(server) {
-  await new Promise((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-}
-
 /**
  * Start a loopback-only Solid/LDP development server.
  *
  * The default fixed-owner mode is deliberately not authentication. With `oidc: true`, the Node
  * host verifies each credential and anonymous requests remain anonymous.
  * The returned Node server owns one in-memory wasm pod until `server.close()` completes.
+ *
+ * ## Trap recovery (sq-250si)
+ *
+ * A Rust panic or allocation failure inside the wasm module raises a `WebAssembly.RuntimeError`
+ * that permanently poisons the current `SolidServer` instance. When this happens, the host
+ * automatically frees the poisoned instance, allocates a fresh one (state loss is acceptable for
+ * the ephemeral development server), and responds to the triggering request with HTTP 503. The
+ * next request is served by the new instance — a single trap no longer bricks the process
+ * indefinitely. Trap events are logged to `console.error`.
  */
 export async function startSolidServer(options = {}) {
   const port = normalizePort(options.port);
@@ -86,41 +85,11 @@ export async function startSolidServer(options = {}) {
   const oidc = normalizeOidc(options.oidc);
 
   await init();
-  const pod = new SolidServer(baseUrl, ownerWebid);
+
   const authenticate = oidc ? createOidcAuthenticator(baseUrl) : async () => ownerWebid;
-  let podFreed = false;
-  const freePod = () => {
-    if (!podFreed) {
-      podFreed = true;
-      pod.free?.();
-    }
-  };
+  const makePod = () => new SolidServer(baseUrl, ownerWebid);
 
-  const server = createServer((request, response) => {
-    void (async () => {
-      try {
-        const wasmResponse = await pod.handleRequest(
-          request.method ?? 'GET',
-          request.url ?? '/',
-          flattenRequestHeaders(request.rawHeaders),
-          await readRequestBody(request),
-          await authenticate(request),
-        );
-        writeNodeResponse(response, copyWasmResponse(wasmResponse));
-      } catch (error) {
-        if (response.headersSent) {
-          response.destroy();
-          return;
-        }
-        response.statusCode = error instanceof RequestBodyTooLargeError ? 413 : 500;
-        response.setHeader('content-type', 'text/plain; charset=utf-8');
-        response.end(error instanceof RequestBodyTooLargeError ? 'request body too large\n' : 'internal server error\n');
-      }
-    })();
-  });
-
-  server.once('close', freePod);
-  server.closeAsync = () => closeServer(server);
+  const { server, freePod } = attachTrapRecoveryHandler(makePod, { authenticate });
 
   try {
     await new Promise((resolve, reject) => {

--- a/packages/solid-server/src/trap-recovery.js
+++ b/packages/solid-server/src/trap-recovery.js
@@ -1,0 +1,113 @@
+// [SONNET-4.6] sq-250si: trap-recovery utilities extracted so tests can import them without a
+// real wasm binary. `index.js` re-exports everything; callers should import from index.js.
+import { createServer } from 'node:http';
+
+import {
+  RequestBodyTooLargeError,
+  copyWasmResponse,
+  flattenRequestHeaders,
+  readRequestBody,
+  writeNodeResponse,
+} from './http.js';
+
+/**
+ * Returns true when an error is a wasm trap — a `WebAssembly.RuntimeError` thrown by the engine
+ * after `panic=abort` lowers to an `unreachable` instruction or after an allocation failure at the
+ * wasm32 linear-memory ceiling. A trapped instance is permanently poisoned and must be replaced.
+ *
+ * [SONNET-4.6] sq-250si: the check is intentionally conservative — only exact
+ * `WebAssembly.RuntimeError` instances are treated as traps, not generic `Error`s.
+ */
+export function isWasmTrap(error) {
+  return typeof WebAssembly !== 'undefined' &&
+    typeof WebAssembly.RuntimeError === 'function' &&
+    error instanceof WebAssembly.RuntimeError;
+}
+
+async function closeServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+/**
+ * Attach the trap-recovery HTTP request dispatcher to a Node `http.Server` using the provided
+ * pod factory. The `makePod()` factory is called once at startup and again after each trap to
+ * recycle the wasm instance.
+ *
+ * Exported for unit testing without a real wasm binary; production callers use `startSolidServer`.
+ *
+ * [SONNET-4.6] sq-250si: trap-recovery core, separated from wasm init for testability.
+ *
+ * @param {() => { handleRequest: Function, free?: Function }} makePod - Factory that constructs a
+ *   fresh pod. Called once at startup and again after each wasm trap.
+ * @param {{ authenticate: Function }} opts - `authenticate(request)` resolves to a WebID string
+ *   or `undefined`.
+ * @returns {{ server: import('node:http').Server, freePod: () => void }}
+ */
+export function attachTrapRecoveryHandler(makePod, { authenticate }) {
+  // [SONNET-4.6] sq-250si: `state.pod` is the live instance. On a trap it is replaced with a
+  // fresh instance so subsequent requests are not permanently served by a poisoned module.
+  const state = { pod: makePod(), freed: false };
+
+  const freePod = () => {
+    if (!state.freed) {
+      state.freed = true;
+      state.pod.free?.();
+    }
+  };
+
+  const server = createServer((request, response) => {
+    void (async () => {
+      try {
+        const wasmResponse = await state.pod.handleRequest(
+          request.method ?? 'GET',
+          request.url ?? '/',
+          flattenRequestHeaders(request.rawHeaders),
+          await readRequestBody(request),
+          await authenticate(request),
+        );
+        writeNodeResponse(response, copyWasmResponse(wasmResponse));
+      } catch (error) {
+        // [SONNET-4.6] sq-250si: recycle the wasm instance on a trap so the next request is
+        // served by a fresh pod. State loss is acceptable — this is a local-dev-only server.
+        if (isWasmTrap(error)) {
+          console.error('[sparq-lws] wasm trap — recycling SolidServer instance:', error);
+          try {
+            state.pod.free?.();
+          } catch (_freeError) {
+            // ignore errors freeing a poisoned instance
+          }
+          try {
+            state.pod = makePod();
+          } catch (recreateError) {
+            console.error('[sparq-lws] failed to recreate SolidServer after trap:', recreateError);
+          }
+        }
+
+        if (response.headersSent) {
+          response.destroy();
+          return;
+        }
+        if (error instanceof RequestBodyTooLargeError) {
+          response.statusCode = 413;
+          response.setHeader('content-type', 'text/plain; charset=utf-8');
+          response.end('request body too large\n');
+        } else if (isWasmTrap(error)) {
+          // Respond with 503 rather than 500 to distinguish a transient trap from a logic error.
+          response.statusCode = 503;
+          response.setHeader('content-type', 'text/plain; charset=utf-8');
+          response.end('server temporarily unavailable (wasm trap)\n');
+        } else {
+          response.statusCode = 500;
+          response.setHeader('content-type', 'text/plain; charset=utf-8');
+          response.end('internal server error\n');
+        }
+      }
+    })();
+  });
+
+  server.once('close', freePod);
+  server.closeAsync = () => closeServer(server);
+  return { server, freePod };
+}

--- a/packages/solid-server/test/trap-recovery.test.mjs
+++ b/packages/solid-server/test/trap-recovery.test.mjs
@@ -1,0 +1,205 @@
+// [SONNET-4.6] sq-250si: trap-recovery unit tests for the Node host's instance-recycle path.
+//
+// These tests exercise the real `attachTrapRecoveryHandler` and `isWasmTrap` logic in
+// src/trap-recovery.js using a stubbed pod factory — no wasm binary is needed. The module is
+// intentionally imported from trap-recovery.js (not index.js) to avoid the wasm binary import
+// in index.js that would fail in CI before the wasm artifact is built.
+//
+// Non-vacuity: the "next request succeeds" assertion FAILS when the recycle assignment
+// (`state.pod = makePod()`) is removed from attachTrapRecoveryHandler — verified manually by
+// reverting the assignment and observing that both the trap request and the subsequent request
+// return 503, not 503 then 200. Without recovery the server stays permanently broken.
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { attachTrapRecoveryHandler, isWasmTrap } from '../src/trap-recovery.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function listenerUrl(server) {
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string', 'server must be bound');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function startOn(server, port = 0) {
+  await new Promise((resolve, reject) => {
+    const onError = (error) => { server.off('listening', onListening); reject(error); };
+    const onListening = () => { server.off('error', onError); resolve(); };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+async function stopServer(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+/**
+ * Build a fake pod whose `handleRequest` delegates to the provided function.
+ * A `free()` call is recorded for later assertion.
+ */
+function fakePod(handleFn) {
+  return {
+    freed: false,
+    handleRequest: handleFn,
+    free() { this.freed = true; },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isWasmTrap
+// ---------------------------------------------------------------------------
+
+test('isWasmTrap returns false for a generic Error', () => {
+  assert.equal(isWasmTrap(new Error('boom')), false);
+});
+
+test('isWasmTrap returns false for null', () => {
+  assert.equal(isWasmTrap(null), false);
+});
+
+test('isWasmTrap returns true for a WebAssembly.RuntimeError', () => {
+  // [SONNET-4.6] sq-250si: WebAssembly.RuntimeError is available in Node >= 12.
+  const trap = new WebAssembly.RuntimeError('unreachable');
+  assert.equal(isWasmTrap(trap), true);
+});
+
+// ---------------------------------------------------------------------------
+// Trap recovery: instance recycle
+// ---------------------------------------------------------------------------
+
+test(
+  'a wasm trap on one request is recovered: the next request succeeds via a fresh instance',
+  { timeout: 10_000 },
+  async () => {
+    // [SONNET-4.6] sq-250si: arrange — first pod throws a trap; the factory then supplies a fresh
+    // pod that returns HTTP 200. This verifies the recycle path in attachTrapRecoveryHandler.
+    let callCount = 0;
+    const pods = [];
+
+    // Pod 1: throws a wasm trap on its first (and only) call.
+    const pod1 = fakePod(async () => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+    pods.push(pod1);
+
+    // Pod 2: the recycled instance — returns a minimal 200 OK.
+    const pod2 = fakePod(async (_method, _path) => {
+      return {
+        status: 200,
+        headers: ['content-type', 'text/plain; charset=utf-8'],
+        body: new Uint8Array(Buffer.from('ok\n')),
+        free() {},
+      };
+    });
+    pods.push(pod2);
+
+    let podIdx = 0;
+    const makePod = () => {
+      callCount++;
+      return pods[podIdx++];
+    };
+
+    const { server } = attachTrapRecoveryHandler(makePod, {
+      authenticate: async () => 'https://id.example/alice#me',
+    });
+
+    await startOn(server);
+    const url = listenerUrl(server);
+    try {
+      // First request — triggers the trap path; must get 503 (not 500 from generic error).
+      const trap = await fetch(`${url}/trigger-trap`, { method: 'GET' });
+      assert.equal(trap.status, 503, 'a wasm trap responds with 503');
+
+      // The old pod must have been freed during recycle.
+      assert.equal(pod1.freed, true, 'the poisoned pod is freed on trap');
+
+      // The factory must have been called twice: once at startup, once for the recycle.
+      assert.equal(callCount, 2, 'makePod is called again to produce the replacement instance');
+
+      // Second request — served by the fresh instance; must succeed (not 500/503-forever).
+      const ok = await fetch(`${url}/any-path`, { method: 'GET' });
+      assert.equal(ok.status, 200, 'next request after trap recycle succeeds');
+    } finally {
+      await stopServer(server);
+    }
+  },
+);
+
+test(
+  'a non-trap error does NOT recycle the instance (plain 500 path)',
+  { timeout: 10_000 },
+  async () => {
+    // [SONNET-4.6] sq-250si: a generic Error must not trigger the recycle path.
+    let makeCount = 0;
+    let handleCount = 0;
+
+    const pod = fakePod(async () => {
+      handleCount++;
+      throw new Error('internal logic error');
+    });
+
+    const { server } = attachTrapRecoveryHandler(
+      () => { makeCount++; return pod; },
+      { authenticate: async () => undefined },
+    );
+
+    await startOn(server);
+    const url = listenerUrl(server);
+    try {
+      const r = await fetch(`${url}/any`, { method: 'GET' });
+      assert.equal(r.status, 500, 'a non-trap error returns 500');
+      assert.equal(makeCount, 1, 'the pod factory is NOT called again on a non-trap error');
+      assert.equal(pod.freed, false, 'the pod is NOT freed on a non-trap error');
+      assert.equal(handleCount, 1, 'handleRequest was called exactly once');
+    } finally {
+      await stopServer(server);
+    }
+  },
+);
+
+test(
+  'server close frees the current pod even after a recycle',
+  { timeout: 10_000 },
+  async () => {
+    // [SONNET-4.6] sq-250si: after a trap, the replacement pod is freed on server.close().
+    const pods = [];
+
+    const pod1 = fakePod(async () => {
+      throw new WebAssembly.RuntimeError('unreachable');
+    });
+    pods.push(pod1);
+
+    const pod2 = fakePod(async () => ({
+      status: 200,
+      headers: [],
+      body: new Uint8Array(0),
+      free() {},
+    }));
+    pods.push(pod2);
+
+    let podIdx = 0;
+    const { server } = attachTrapRecoveryHandler(
+      () => pods[podIdx++],
+      { authenticate: async () => undefined },
+    );
+
+    await startOn(server);
+    const url = listenerUrl(server);
+
+    // Induce a trap so the server holds pod2 as the live instance.
+    await fetch(`${url}/trap`, { method: 'GET' });
+    assert.equal(pod1.freed, true, 'pod1 freed during recycle');
+    assert.equal(pod2.freed, false, 'pod2 not yet freed');
+
+    // Close the server — the freePod hook must free the current pod (pod2).
+    await stopServer(server);
+    assert.equal(pod2.freed, true, 'pod2 freed when server closes');
+  },
+);

--- a/skills/javascript-wasm/SKILL.md
+++ b/skills/javascript-wasm/SKILL.md
@@ -170,6 +170,16 @@ Use the package only for local development, do not expose it as a production ser
 data to disappear on shutdown. TLS termination, persistent storage, and notifications remain
 absent; OIDC verification runs in Node, not wasm.
 
+[SONNET-4.6] **Trap recovery (sq-250si).** The wasm artifact uses `panic=abort` (release profile):
+a Rust panic or allocation failure at the wasm32 linear-memory ceiling lowers to an `unreachable`
+trap that the host sees as `WebAssembly.RuntimeError`. Before the abort fires, a `console_error_panic_hook`
+installed at module init emits the panic message to `console.error`. The Node host catches the
+`WebAssembly.RuntimeError`, frees the poisoned `SolidServer`, constructs a fresh instance (state
+loss is acceptable for the ephemeral dev server), and returns HTTP 503 for the triggering request.
+The next request is served by the new instance — a single trap no longer bricks the server process
+indefinitely. The `attachTrapRecoveryHandler` and `isWasmTrap` helpers are exported from
+`@jeswr/solid-server/src/trap-recovery.js` for testing without a real wasm binary.
+
 ## Common recipes
 
 **Decompress a browser dataset before loading it (`@sparq/client`).** The shared site/GUI client

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -274,6 +274,11 @@ notes = "shared async-compression core in the all-features tower-http graph; fro
 version = "2.5.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.console_error_panic_hook]]
+version = "0.1.7"
+criteria = "safe-to-deploy"
+notes = "[SONNET-4.6] sq-250si: wasm32-only panic diagnostic hook (sparq-lws-wasm). Tiny crate (~30 lines) that routes Rust panics to console.error via wasm-bindgen. MIT, Rust+WASM WG. No unsafe code. Not in the host/native build graph."
+
 [[exemptions.console_log]]
 version = "1.0.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-250si, model SONNET-4.6

## Availability bug

The `sparq-lws` wasm artifact inherits `panic=abort` (release profile), so a Rust
panic or allocation failure at the wasm32 linear-memory ceiling lowers to a `wasm32`
`unreachable` trap. The Node host (`index.js`) previously held ONE long-lived
`SolidServer` and reused it for every request. After the first trap the poisoned
instance backed all future `handleRequest` calls, causing the server to 500 forever
while the process stayed up — process-liveness health checks missed the permanent
failure. Found in the @jeswr/solid-server pre-publish audit (epic sq-6xasp).

## Mitigations implemented

### 1. Panic hook (Rust, `sparq-lws-wasm`)

Added `console_error_panic_hook::set_once()` in a `#[wasm_bindgen(start)]` fn
(`lws_init`) so any Rust panic emits a diagnostic to `console.error` before the
`unreachable` trap propagates to the host as `WebAssembly.RuntimeError`. The hook is
idempotent and safe to call at module load. New wasm32-only dep:
`console_error_panic_hook 0.1.7` (MIT, Rust+WASM WG; ~30 lines; added supply-chain
exemption).

### 2. Trap recovery / instance-recycle (Node host)

Extracted the request dispatcher into `src/trap-recovery.js` exporting
`attachTrapRecoveryHandler(makePod, { authenticate })` and `isWasmTrap(error)`. On a
caught `WebAssembly.RuntimeError` the host:
1. Logs a `console.error` diagnostic.
2. Frees the poisoned instance.
3. Calls `makePod()` to construct a fresh `SolidServer`.
4. Responds to the triggering request with HTTP **503** (not 500, to distinguish a
   transient trap from a logic error).

The next request is served by the new instance. State loss is acceptable for the
ephemeral local-dev server. Generic (non-trap) errors still return 500 without
triggering a recycle.

### 3. Bounded allocator (not implemented)

A custom global allocator returning 507 on memory-ceiling failures was not
implemented — it risks the wasm build stability and the wasm32 allocator API is
constrained. Captured as a follow-up bead for the maintainer's consideration.

## Tests (non-vacuous)

`packages/solid-server/test/trap-recovery.test.mjs` — 6 tests, no wasm binary needed
(imports from `src/trap-recovery.js` directly):

| Test | What it checks |
|------|---------------|
| `isWasmTrap` returns false for generic Error | classifier sanity |
| `isWasmTrap` returns false for null | classifier sanity |
| `isWasmTrap` returns true for `WebAssembly.RuntimeError` | classifier correct |
| **trap → recycle → next request succeeds** | core availability fix |
| non-trap error returns 500, no recycle | non-trap path unchanged |
| server.close() frees pod after recycle | close lifecycle correct |

Non-vacuity confirmed: removing `state.pod = makePod()` from
`attachTrapRecoveryHandler` makes tests 4 and 6 red.

## Gates

| Gate | Result |
|------|--------|
| `cargo clippy --workspace --all-targets -- -D warnings` | GREEN |
| `cargo clippy -p sparq-lws-wasm --all-targets -- -D warnings` (default features) | GREEN |
| `cargo clippy -p sparq-lws-wasm --all-targets --features sparql-endpoint -- -D warnings` | GREEN |
| `cargo test -p sparq-lws-wasm` (both feature states) | GREEN (0 host tests; wasm tests require wasm32 target) |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p sparq-lws-wasm` | GREEN |
| `python3 scripts/check-readme-template.py --enforce` | 0 deviations |
| `typos` on changed files | clean |
| `cargo vet --locked` | Vetting Succeeded |
| `node --test test/trap-recovery.test.mjs` | 6/6 PASS |
| Non-vacuity (mutation test) | CONFIRMED RED on tests 4+6 |

## Files changed

- `crates/sparq-lws-wasm/Cargo.toml`: add `console_error_panic_hook 0.1.7` (wasm32-only)
- `crates/sparq-lws-wasm/src/lib.rs`: add `lws_init` `#[wasm_bindgen(start)]` fn; convert `format!("{x}")` to `format!("{}", x)` for CodeQL
- `crates/sparq-lws-wasm/README.md`: document panic hook and trap recovery
- `packages/solid-server/src/trap-recovery.js`: new — `attachTrapRecoveryHandler` + `isWasmTrap`
- `packages/solid-server/src/index.js`: refactored to use `attachTrapRecoveryHandler`
- `packages/solid-server/test/trap-recovery.test.mjs`: new — 6 trap-recovery tests
- `skills/javascript-wasm/SKILL.md`: document trap recovery behaviour
- `supply-chain/config.toml`: add `console_error_panic_hook` exemption