### PR TITLE
perf(site+workbench): content-hash public/wasm engine assets via @sparq/client manifest (sq-b66fc) [SONNET]

### DIFF
--- a/gui/app/scripts/sync-wasm.mjs
+++ b/gui/app/scripts/sync-wasm.mjs
@@ -6,9 +6,18 @@
 // @sparq/client loader, which keys its asset URLs off NEXT_PUBLIC_BASE_PATH), so they must live
 // in public/. The core SPARQL + SHACL engine is REQUIRED; the tier-b W-reason bundle (below) is
 // OPTIONAL (the Inference tool degrades honestly without it).
-import { mkdir, copyFile, access, rm } from "node:fs/promises";
+//
+// [SONNET-4.6] sq-b66fc — content-hashing added: every .js/.wasm runtime file gets
+// a hashed copy written alongside the unhashed original, and a wasm-manifest.json is
+// emitted to public/wasm/ so the @sparq/client resolveWasmAsset() loader can request
+// content-addressed URLs (defeating GitHub Pages' ~10 min max-age after redeployment).
+import { mkdir, copyFile, access, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  hashFile,
+  hashedName,
+} from "../../../packages/sparq-client/scripts/hash-asset.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const src = join(here, "..", "..", "..", "js", "wasm");
@@ -43,6 +52,19 @@ for (const f of files) {
 await rmStale(join(dest, "sparq_wasm.d.ts"));
 console.log(`[sync-wasm] copied ${files.length} files → public/wasm/`);
 
+// [SONNET-4.6] sq-b66fc — accumulate manifest entries: logicalName → hashed filename.
+/** @type {Record<string, string>} */
+const manifest = {};
+
+// Hash core runtime files and write hashed copies alongside the originals.
+for (const f of files) {
+  const destPath = join(dest, f);
+  const hash = await hashFile(destPath);
+  const hashed = hashedName(f, hash);
+  await copyFile(destPath, join(dest, hashed));
+  manifest[f] = hashed;
+}
+
 // [OPUS-4.8] sq-tp1m (#757) — also sync the tier-b "W-reason" bundle that powers the Inference
 // tool (crates/sparq-reason-wasm, built with `--features explain` by `js/`'s `build:reason-wasm`,
 // exactly as the marketing site syncs it). Its wasm-pack output stays in the crate's own pkg/
@@ -65,6 +87,14 @@ try {
   console.log(
     `[sync-wasm] copied ${reasonFiles.length} files → public/wasm/reason/ (W-reason)`,
   );
+  // [SONNET-4.6] sq-b66fc — hash W-reason runtime files.
+  for (const f of reasonFiles) {
+    const destPath = join(reasonDest, f);
+    const hash = await hashFile(destPath);
+    const hashed = hashedName(f, hash);
+    await copyFile(destPath, join(reasonDest, hashed));
+    manifest[`reason/${f}`] = hashed;
+  }
 } catch {
   console.warn(
     `[sync-wasm] W-reason bundle not found at ${reasonSrc}; the Inference tool will not run\n` +
@@ -92,6 +122,14 @@ try {
   console.log(
     `[sync-wasm] copied ${textFiles.length} files → public/wasm/text/ (W-text)`,
   );
+  // [SONNET-4.6] sq-b66fc — hash W-text runtime files.
+  for (const f of textFiles) {
+    const destPath = join(textDest, f);
+    const hash = await hashFile(destPath);
+    const hashed = hashedName(f, hash);
+    await copyFile(destPath, join(textDest, hashed));
+    manifest[`text/${f}`] = hashed;
+  }
 } catch {
   console.warn(
     `[sync-wasm] W-text bundle not found at ${textSrc}; the Full-text tool will not run\n` +
@@ -119,9 +157,27 @@ try {
   console.log(
     `[sync-wasm] copied ${rspFiles.length} files → public/wasm/rsp/ (W-rsp)`,
   );
+  // [SONNET-4.6] sq-b66fc — hash W-rsp runtime files.
+  for (const f of rspFiles) {
+    const destPath = join(rspDest, f);
+    const hash = await hashFile(destPath);
+    const hashed = hashedName(f, hash);
+    await copyFile(destPath, join(rspDest, hashed));
+    manifest[`rsp/${f}`] = hashed;
+  }
 } catch {
   console.warn(
     `[sync-wasm] W-rsp bundle not found at ${rspSrc}; the Streaming tool will not run\n` +
       `            live. Build it:  (cd ../../js && npm run build:rsp-wasm)`,
   );
 }
+
+// [SONNET-4.6] sq-b66fc — write the manifest. Same contract as the site sync: maps
+// each logical runtime filename (relative to public/wasm/) to its content-hashed copy.
+// The @sparq/client resolveWasmAsset() loader reads this once and caches it; falls back
+// to the unhashed name when absent (Tauri local disk / dev mode).
+const manifestPath = join(dest, "wasm-manifest.json");
+await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+console.log(
+  `[sync-wasm] wrote wasm-manifest.json with ${Object.keys(manifest).length} entries → public/wasm/`,
+);

--- a/packages/sparq-client/scripts/hash-asset.mjs
+++ b/packages/sparq-client/scripts/hash-asset.mjs
@@ -1,0 +1,31 @@
+// [SONNET-4.6] sq-b66fc — shared content-hash utility for the wasm sync scripts.
+// Both site/scripts/sync-wasm.mjs and gui/app/scripts/sync-wasm.mjs import this to
+// produce content-addressed filenames + the wasm-manifest.json that the @sparq/client
+// resolveWasmAsset() loader uses to defeat GitHub Pages (~10 min max-age) stale-glue
+// / new-wasm mismatches after a redeploy.
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+/**
+ * Returns the first 12 hex chars of SHA-256(fileBytes).
+ * @param {string} filePath  absolute or cwd-relative path to the file
+ * @returns {Promise<string>}
+ */
+export async function hashFile(filePath) {
+  const bytes = await readFile(filePath);
+  return createHash("sha256").update(bytes).digest("hex").slice(0, 12);
+}
+
+/**
+ * Given a filename like "sparq_wasm_bg.wasm", returns "sparq_wasm_bg-{hash}.wasm".
+ * If the filename has no dot extension the hash suffix is appended directly.
+ * @param {string} filename  bare filename (no directory component)
+ * @param {string} hash      12-hex-char SHA-256 prefix
+ * @returns {string}
+ */
+export function hashedName(filename, hash) {
+  const dot = filename.lastIndexOf(".");
+  return dot === -1
+    ? `${filename}-${hash}`
+    : `${filename.slice(0, dot)}-${hash}${filename.slice(dot)}`;
+}

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -159,6 +159,107 @@ export interface LoadSparqOptions {
   basePath?: string;
 }
 
+// ---------------------------------------------------------------------------
+// [SONNET-4.6] sq-b66fc — wasm-manifest.json resolution.
+//
+// The sync scripts emit public/wasm/wasm-manifest.json mapping each logical runtime
+// filename (e.g. "sparq_wasm.js") to its content-hashed copy (e.g.
+// "sparq_wasm-a1b2c3d4ef56.js"). The loader resolves asset URLs through this manifest
+// so every redeploy to GitHub Pages (~10 min max-age) gets a fresh content-addressed
+// URL — eliminating stale-glue / new-wasm mismatches. When the manifest is absent
+// (dev mode / local disk / Tauri), we fall back to the unhashed URL transparently.
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps logical wasm runtime filename → content-hashed filename (just the bare filename,
+ * not the full path). For tier-b bundles the key includes the subdirectory prefix,
+ * e.g. `"reason/sparq_reason_wasm.js"`.
+ *
+ * @example
+ * ```json
+ * {
+ *   "sparq_wasm.js": "sparq_wasm-a1b2c3d4ef56.js",
+ *   "sparq_wasm_bg.wasm": "sparq_wasm_bg-7890abcdef01.wasm",
+ *   "reason/sparq_reason_wasm.js": "sparq_reason_wasm-deadbeef1234.js"
+ * }
+ * ```
+ */
+export interface WasmManifest {
+  [logicalName: string]: string;
+}
+
+// Module-level cache: basePath → resolved manifest (or null on 404/fetch failure).
+const manifestCache = new Map<string, WasmManifest | null>();
+
+/**
+ * [SONNET-4.6] sq-b66fc — resolve a wasm asset URL through the content-hash manifest.
+ *
+ * Loads `${basePath}/wasm/wasm-manifest.json` once per basePath and caches the result.
+ * If the manifest has an entry for `logicalName`, returns the full content-addressed URL;
+ * otherwise falls back to the unhashed URL (dev mode / Tauri / absent manifest).
+ *
+ * In a non-browser environment (SSR / Node), fetch may be unavailable — falls back
+ * directly to the unhashed URL without attempting a network call.
+ *
+ * @param logicalName  The bare filename (or `"subdir/filename"` for tier-b bundles),
+ *                     e.g. `"sparq_wasm.js"` or `"reason/sparq_reason_wasm.js"`.
+ * @param basePath     The URL prefix (same as {@link LoadSparqOptions.basePath}).
+ *                     Defaults to the same `defaultBasePath()` the loader uses.
+ */
+export async function resolveWasmAsset(
+  logicalName: string,
+  basePath?: string,
+): Promise<string> {
+  const base = basePath ?? defaultBasePath();
+  // Non-browser environment: skip the network fetch and fall back immediately.
+  if (typeof fetch === "undefined") {
+    return `${base}/wasm/${logicalName}`;
+  }
+
+  if (!manifestCache.has(base)) {
+    const manifestUrl = `${base}/wasm/wasm-manifest.json`;
+    try {
+      const resp = await fetch(manifestUrl);
+      if (!resp.ok) {
+        // 404 or any non-2xx → treat as "no manifest" (dev mode / Tauri).
+        manifestCache.set(base, null);
+      } else {
+        manifestCache.set(base, (await resp.json()) as WasmManifest);
+      }
+    } catch {
+      // Network failure or JSON parse error → silent fallback.
+      manifestCache.set(base, null);
+    }
+  }
+
+  const manifest = manifestCache.get(base) ?? null;
+  return resolveWasmAssetWithManifest(logicalName, manifest, base);
+}
+
+/**
+ * [SONNET-4.6] sq-b66fc — pure resolution helper: resolve a wasm asset URL given an
+ * already-loaded manifest (or `null` when the manifest is absent). This function is
+ * exported so tests can call it directly without any network mocking.
+ *
+ * @param logicalName  The bare filename (or `"subdir/filename"` for tier-b bundles).
+ * @param manifest     A pre-loaded {@link WasmManifest}, or `null` to force the fallback.
+ * @param basePath     The URL prefix.
+ */
+export function resolveWasmAssetWithManifest(
+  logicalName: string,
+  manifest: WasmManifest | null,
+  basePath: string,
+): string {
+  // Determine the subdirectory and bare filename from the logical name.
+  const lastSlash = logicalName.lastIndexOf("/");
+  const subdir = lastSlash === -1 ? "" : logicalName.slice(0, lastSlash + 1);
+  const bareName = lastSlash === -1 ? logicalName : logicalName.slice(lastSlash + 1);
+
+  const hashedFilename = manifest?.[logicalName];
+  const resolvedName = hashedFilename ?? bareName;
+  return `${basePath}/wasm/${subdir}${resolvedName}`;
+}
+
 function defaultBasePath(): string {
   // The Next.js site sets basePath '/sparq'; mirror it for the runtime asset URLs.
   // Empty in local `next dev` without basePath, '/sparq' on Pages. A GUI host passes its
@@ -180,14 +281,20 @@ let modulePromiseBase: string | null = null;
  * plain ESM module at runtime, and the wasm URL is passed explicitly (the glue's own
  * `new URL('./sparq_wasm_bg.wasm', import.meta.url)` resolution is bypassed). If the
  * resolved base path changes between calls (e.g. site vs GUI), the module is re-loaded.
+ *
+ * [SONNET-4.6] sq-b66fc — glue and wasm paths are now resolved through the content-hash
+ * manifest via {@link resolveWasmAsset} so redeployments to GitHub Pages get fresh
+ * content-addressed URLs, eliminating stale-glue / new-wasm mismatches.
  */
 export async function loadSparq(opts: LoadSparqOptions = {}): Promise<WasmStoreCtor> {
   const base = opts.basePath ?? defaultBasePath();
   if (!modulePromise || modulePromiseBase !== base) {
     modulePromiseBase = base;
     modulePromise = (async () => {
-      const gluePath = `${base}/wasm/sparq_wasm.js`;
-      const wasmPath = `${base}/wasm/sparq_wasm_bg.wasm`;
+      // [SONNET-4.6] sq-b66fc — resolve through the manifest so a redeployed GitHub Pages
+      // site always fetches the content-addressed glue+wasm pair.
+      const gluePath = await resolveWasmAsset("sparq_wasm.js", base);
+      const wasmPath = await resolveWasmAsset("sparq_wasm_bg.wasm", base);
       // webpackIgnore keeps the glue out of the bundle: it's fetched as a plain ESM
       // module from the static asset root at runtime.
       const mod = (await import(/* webpackIgnore: true */ gluePath)) as WasmModule;

--- a/packages/sparq-client/test/wasm-manifest.test.mjs
+++ b/packages/sparq-client/test/wasm-manifest.test.mjs
@@ -1,0 +1,95 @@
+// [SONNET-4.6] sq-b66fc — non-vacuous tests for the wasm-manifest resolution logic.
+//
+// We test resolveWasmAssetWithManifest() directly (no fetch mocking needed) since it is
+// the pure core of the resolution logic. resolveWasmAsset() wraps it with a fetch + cache
+// layer whose integration is covered by tests 1–2 via a globalThis.fetch mock.
+import assert from "node:assert/strict";
+import { test, beforeEach, afterEach } from "node:test";
+
+import {
+  resolveWasmAsset,
+  resolveWasmAssetWithManifest,
+} from "../src/index.ts";
+
+// ---------------------------------------------------------------------------
+// Test 1: resolveWasmAssetWithManifest returns hashed URL when manifest has the entry
+// ---------------------------------------------------------------------------
+test("resolveWasmAssetWithManifest returns hashed URL when manifest has the entry", () => {
+  const manifest = {
+    "sparq_wasm.js": "sparq_wasm-a1b2c3d4ef56.js",
+    "sparq_wasm_bg.wasm": "sparq_wasm_bg-7890abcdef01.wasm",
+  };
+  const result = resolveWasmAssetWithManifest("sparq_wasm.js", manifest, "/sparq");
+  assert.equal(result, "/sparq/wasm/sparq_wasm-a1b2c3d4ef56.js");
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: resolveWasmAsset falls back to unhashed URL when manifest is absent (fetch 404)
+// ---------------------------------------------------------------------------
+test("resolveWasmAsset falls back to unhashed URL when manifest fetch returns 404", async () => {
+  // Install a fetch mock that returns 404 for the manifest URL.
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (String(url).endsWith("wasm-manifest.json")) {
+      return { ok: false, status: 404 };
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+
+  try {
+    // Use a unique basePath so the module-level cache has no entry for this call.
+    const result = await resolveWasmAsset("sparq_wasm_bg.wasm", "/sparq-test-404");
+    assert.equal(result, "/sparq-test-404/wasm/sparq_wasm_bg.wasm");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: changed asset content changes the resolved URL
+//   Two manifests with different hashes for the same logical name must resolve
+//   to different URLs — proving that content-addressing is actually respected.
+// ---------------------------------------------------------------------------
+test("changed asset content changes the resolved URL (different hash → different URL)", () => {
+  const manifestV1 = { "sparq_wasm_bg.wasm": "sparq_wasm_bg-aaa111bbb222.wasm" };
+  const manifestV2 = { "sparq_wasm_bg.wasm": "sparq_wasm_bg-ccc333ddd444.wasm" };
+  const base = "/sparq";
+
+  const urlV1 = resolveWasmAssetWithManifest("sparq_wasm_bg.wasm", manifestV1, base);
+  const urlV2 = resolveWasmAssetWithManifest("sparq_wasm_bg.wasm", manifestV2, base);
+
+  // Different manifests → different resolved URLs (core cacheability claim).
+  assert.notEqual(urlV1, urlV2);
+  assert.equal(urlV1, "/sparq/wasm/sparq_wasm_bg-aaa111bbb222.wasm");
+  assert.equal(urlV2, "/sparq/wasm/sparq_wasm_bg-ccc333ddd444.wasm");
+});
+
+// ---------------------------------------------------------------------------
+// Test 4 (mutation / non-vacuity): loader respects the manifest — returns the
+//   UNHASHED fallback when the manifest has no entry for the key.
+//   This test would FAIL if the loader returned a hashed name regardless of the manifest.
+// ---------------------------------------------------------------------------
+test("loader respects the manifest — returns fallback when manifest has no entry for the key", () => {
+  // Manifest exists but has NO entry for "sparq_wasm.js".
+  const manifestWithoutGlue = {
+    "sparq_wasm_bg.wasm": "sparq_wasm_bg-deadbeef0000.wasm",
+  };
+  const result = resolveWasmAssetWithManifest(
+    "sparq_wasm.js",
+    manifestWithoutGlue,
+    "/sparq",
+  );
+  // Must return the UNHASHED fallback, not any hashed name.
+  assert.equal(result, "/sparq/wasm/sparq_wasm.js");
+  // Sanity: if the manifest had an entry, the result WOULD be different — proving the
+  // test actually fails when the fallback is bypassed.
+  const manifestWithGlue = {
+    "sparq_wasm.js": "sparq_wasm-abc123def456.js",
+  };
+  const hashedResult = resolveWasmAssetWithManifest(
+    "sparq_wasm.js",
+    manifestWithGlue,
+    "/sparq",
+  );
+  assert.notEqual(result, hashedResult); // proves the test discriminates
+});

--- a/site/scripts/sync-wasm.mjs
+++ b/site/scripts/sync-wasm.mjs
@@ -4,14 +4,27 @@
 //
 // Kept out of the bundler: the REPL loads these as plain static assets from
 // /public at runtime (see src/lib/sparq-wasm.ts), so they must live in public/.
-import { mkdir, copyFile, access } from "node:fs/promises";
+//
+// [SONNET-4.6] sq-b66fc — content-hashing added: every .js/.wasm runtime file gets
+// a hashed copy written alongside the unhashed original, and a wasm-manifest.json is
+// emitted to public/wasm/ so the @sparq/client resolveWasmAsset() loader can request
+// content-addressed URLs (defeating GitHub Pages' ~10 min max-age after redeployment).
+import { mkdir, copyFile, access, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  hashFile,
+  hashedName,
+} from "../../packages/sparq-client/scripts/hash-asset.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const src = join(here, "..", "..", "js", "wasm");
 const dest = join(here, "..", "public", "wasm");
-const files = ["sparq_wasm.js", "sparq_wasm_bg.wasm", "sparq_wasm.d.ts"];
+// Runtime files (.js + .wasm) are content-hashed; .d.ts files are dev-only declarations
+// that nothing fetches at runtime — do NOT hash them.
+const runtimeFiles = ["sparq_wasm.js", "sparq_wasm_bg.wasm"];
+const devFiles = ["sparq_wasm.d.ts"];
+const files = [...runtimeFiles, ...devFiles];
 
 try {
   await access(join(src, "sparq_wasm_bg.wasm"));
@@ -29,6 +42,21 @@ for (const f of files) {
 }
 console.log(`[sync-wasm] copied ${files.length} files → public/wasm/`);
 
+// [SONNET-4.6] sq-b66fc — accumulate manifest entries: logicalName → hashed filename.
+// The logical name is the subdirectory-relative path (e.g. "sparq_wasm.js" for the
+// core bundle, "reason/sparq_reason_wasm.js" for the W-reason tier-b bundle).
+/** @type {Record<string, string>} */
+const manifest = {};
+
+// Hash core runtime files and write hashed copies alongside the originals.
+for (const f of runtimeFiles) {
+  const destPath = join(dest, f);
+  const hash = await hashFile(destPath);
+  const hashed = hashedName(f, hash);
+  await copyFile(destPath, join(dest, hashed));
+  manifest[f] = hashed;
+}
+
 // [OPUS-4.8] sq-0po6 — also sync the tier-b "W-reason" bundle that drives
 // /surface/inference (crates/sparq-reason-wasm, built with `--features explain` by
 // `js/`'s `build:reason-wasm`). Its wasm-pack output stays in the crate's own pkg/
@@ -38,6 +66,7 @@ console.log(`[sync-wasm] copied ${files.length} files → public/wasm/`);
 // page surfaces a clear "bundle failed to load" state at runtime in that case.
 const reasonSrc = join(here, "..", "..", "crates", "sparq-reason-wasm", "pkg");
 const reasonDest = join(dest, "reason");
+const reasonRuntime = ["sparq_reason_wasm.js", "sparq_reason_wasm_bg.wasm"];
 const reasonFiles = [
   "sparq_reason_wasm.js",
   "sparq_reason_wasm_bg.wasm",
@@ -53,6 +82,14 @@ try {
   console.log(
     `[sync-wasm] copied ${reasonFiles.length} files → public/wasm/reason/ (W-reason)`,
   );
+  // [SONNET-4.6] sq-b66fc — hash W-reason runtime files.
+  for (const f of reasonRuntime) {
+    const destPath = join(reasonDest, f);
+    const hash = await hashFile(destPath);
+    const hashed = hashedName(f, hash);
+    await copyFile(destPath, join(reasonDest, hashed));
+    manifest[`reason/${f}`] = hashed;
+  }
 } catch {
   console.warn(
     `[sync-wasm] W-reason bundle not found at ${reasonSrc}; /surface/inference will not\n` +
@@ -68,6 +105,7 @@ try {
 // skips rather than failing — the streaming page then surfaces a clear load-failure state.
 const rspSrc = join(here, "..", "..", "crates", "sparq-rsp-wasm", "pkg");
 const rspDest = join(dest, "rsp");
+const rspRuntime = ["sparq_rsp_wasm.js", "sparq_rsp_wasm_bg.wasm"];
 const rspFiles = [
   "sparq_rsp_wasm.js",
   "sparq_rsp_wasm_bg.wasm",
@@ -83,6 +121,14 @@ try {
   console.log(
     `[sync-wasm] copied ${rspFiles.length} files → public/wasm/rsp/ (W-rsp)`,
   );
+  // [SONNET-4.6] sq-b66fc — hash W-rsp runtime files.
+  for (const f of rspRuntime) {
+    const destPath = join(rspDest, f);
+    const hash = await hashFile(destPath);
+    const hashed = hashedName(f, hash);
+    await copyFile(destPath, join(rspDest, hashed));
+    manifest[`rsp/${f}`] = hashed;
+  }
 } catch {
   console.warn(
     `[sync-wasm] W-rsp bundle not found at ${rspSrc}; /surface/streaming-rsp will not\n` +
@@ -99,6 +145,7 @@ try {
 // load-failure state.
 const textSrc = join(here, "..", "..", "crates", "sparq-text-wasm", "pkg");
 const textDest = join(dest, "text");
+const textRuntime = ["sparq_text_wasm.js", "sparq_text_wasm_bg.wasm"];
 const textFiles = [
   "sparq_text_wasm.js",
   "sparq_text_wasm_bg.wasm",
@@ -114,9 +161,28 @@ try {
   console.log(
     `[sync-wasm] copied ${textFiles.length} files → public/wasm/text/ (W-text)`,
   );
+  // [SONNET-4.6] sq-b66fc — hash W-text runtime files.
+  for (const f of textRuntime) {
+    const destPath = join(textDest, f);
+    const hash = await hashFile(destPath);
+    const hashed = hashedName(f, hash);
+    await copyFile(destPath, join(textDest, hashed));
+    manifest[`text/${f}`] = hashed;
+  }
 } catch {
   console.warn(
     `[sync-wasm] W-text bundle not found at ${textSrc}; /surface/full-text will not\n` +
       `            run live. Build it:  (cd ../js && npm run build:text-wasm)`,
   );
 }
+
+// [SONNET-4.6] sq-b66fc — write the manifest. The manifest maps each logical runtime
+// filename (relative to public/wasm/, e.g. "sparq_wasm.js") to its content-hashed copy
+// (just the filename, not the full path). The @sparq/client resolveWasmAsset() loader
+// reads this once and caches it to resolve content-addressed URLs, falling back to the
+// unhashed name when the manifest is absent (dev mode / Tauri / local disk).
+const manifestPath = join(dest, "wasm-manifest.json");
+await writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf8");
+console.log(
+  `[sync-wasm] wrote wasm-manifest.json with ${Object.keys(manifest).length} entries → public/wasm/`,
+);


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead sq-b66fc (content-hash wasm assets for hosted-web cacheability).

## Problem

`public/wasm/*` (the ~3MB sparq engine + tier-b bundles) is synced with fixed filenames. On the GitHub Pages hosted target (~10min max-age), a redeploy risks stale-glue/new-wasm mismatches — the browser may serve an old `sparq_wasm.js` glue with a new `sparq_wasm_bg.wasm` binary, causing silent failures or panics.

`_next/static/*` is already content-hashed by Next.js; this PR extends the same discipline to the `public/wasm/` assets.

## Fix

**Content-hash at sync time, resolve through manifest at load time — done once in the shared `@sparq/client` loader.**

### Sync scripts (`site/scripts/sync-wasm.mjs`, `gui/app/scripts/sync-wasm.mjs`)

After copying each `.js`/`.wasm` runtime file, the script now:
1. Computes `SHA-256(fileBytes).slice(0, 12)` via `packages/sparq-client/scripts/hash-asset.mjs`
2. Writes a hashed copy alongside the original (e.g. `sparq_wasm_bg-a4764de595c7.wasm`)
3. Accumulates entries `{ logicalName → hashedFilename }` for all present bundles
4. Emits `public/wasm/wasm-manifest.json` at the end

Unhashed originals remain as fallback — no existing behaviour broken.

### Shared loader (`packages/sparq-client/src/index.ts`) — [SONNET-4.6]

New exports:
- `WasmManifest` interface (logical name → hashed filename)
- `resolveWasmAssetWithManifest(logicalName, manifest, basePath)` — pure core (no network), exported for testability
- `resolveWasmAsset(logicalName, basePath?)` — fetches `wasm-manifest.json` once per basePath, caches it, resolves through the manifest; silently falls back to the unhashed URL on 404 / fetch failure / non-browser environment

`loadSparq()` now resolves both the glue path and the wasm path through `resolveWasmAsset`, so every load on GitHub Pages gets content-addressed URLs that can be cached with `Cache-Control: immutable`. A redeploy changes the hashes, so clients fetch the new assets immediately.

The Tauri/local-disk path is unaffected: when the manifest fetch fails (Tauri `tauri://` origin, local dev), the fallback to unhashed filenames is transparent.

## Tests (`packages/sparq-client/test/wasm-manifest.test.mjs`) — 4 non-vacuous tests

| # | Test | Confirms |
|---|------|----------|
| 9 | `resolveWasmAssetWithManifest` returns hashed URL when manifest has the entry | Happy path |
| 10 | `resolveWasmAsset` falls back to unhashed URL when manifest fetch returns 404 | Graceful degradation |
| 11 | Changed asset content changes the resolved URL (different hash → different URL) | Core cacheability claim |
| 12 | Loader respects the manifest — returns fallback when manifest has no entry for the key | **Mutation check**: test fails if loader ignores the manifest |

Non-vacuity confirmed: test 12 also asserts that if a manifest entry IS present the result is different — proving the test discriminates between the two paths. A mutant that always returns the unhashed name would cause test 9 and test 11 to fail.

## Gates

- `packages/sparq-client` typecheck: clean
- `packages/sparq-client` test suite: 4/4 new tests pass (2 pre-existing bzip2 failures on origin/main unchanged)
- `site/` lint: clean (`✔ No ESLint warnings or errors`)
- `site/` typecheck: clean
- `site/` static export (`npm run build`): passes end-to-end including `[check-bundle] PASS`
- `gui/app/` typecheck: clean
- `gui/app/` web build (`npm run build:web`): passes
- Existing routes unbroken: `/`, `/benchmarks/*`, `/papers`, `/try`, `/surface/*`, `/showcase/*`
- Backward-compatible: manifest-absent fallback keeps dev mode / Tauri working

## Files changed

| File | Role |
|------|------|
| `packages/sparq-client/scripts/hash-asset.mjs` | Shared SHA-256 hashing utility |
| `packages/sparq-client/src/index.ts` | Manifest types + `resolveWasmAsset` + `resolveWasmAssetWithManifest` + `loadSparq` wired through manifest |
| `packages/sparq-client/test/wasm-manifest.test.mjs` | 4 non-vacuous manifest-resolution tests |
| `site/scripts/sync-wasm.mjs` | Hashing + `wasm-manifest.json` emission |
| `gui/app/scripts/sync-wasm.mjs` | Hashing + `wasm-manifest.json` emission |

No new npm dependencies. No Rust code touched. `basePath` (`/sparq`) correct throughout.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>