### PR TITLE
fix(reason): define Datalog float aggregate semantics (sq-r2nor) [GPT-5.6]

### DIFF
--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -63,6 +63,10 @@ let g = Graph::from_parts(dict, triples);
   track): single or grouped `NOT { atom, atom }` (negation as failure),
   `AGGREGATE … BIND COUNT(DISTINCT ?v)/SUM/MIN/MAX/AVG(?v) AS ?c`, variable
   predicates, and numeric `FILTER` over the shared exact/float/double tower. The
+  numeric aggregates intentionally accept all four XSD tiers: `SUM`/`AVG` use XPath
+  promotion and propagate IEEE specials, while `MIN`/`MAX` use the shared total order
+  (NaN first, signed zeros equal) and preserve an original extremal term; the lexical
+  representative of an equal-value tie is unspecified. <!-- [GPT-5.6] sq-r2nor --> The
   **stratification checker** rejects cycles through NOT/AGGREGATE and conservatively
   couples variable predicates to every relation; the semi-naive evaluator and
   incremental maintainer share that invariant. <!-- [GPT-5.6] sq-a7bmo -->

--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -8,13 +8,12 @@
 
 **Opt-in RDFS / OWL-RL / Notation3 reasoning** for the [sparq](../../README.md) RDF engine.
 
-It forward-chains the deductive closure (RDFS, the OWL 2 RL property/class axioms, or
-user-supplied N3 rules — including RDF 1.2 `<< s p o >>` quoted-triple terms in rule
-bodies and heads) over dictionary-encoded triples and **materializes** the entailed
-facts, so querying stays exactly as fast as before. Reasoning runs over integer ids (joins
-on fixed-width keys); the closure can be maintained incrementally under inserts/deletes, and
-the non-default `explain` feature answers `why(triple)` with a proof tree. This crate is
-**isolated** — depend on it to get reasoning; the core engine and wasm build carry zero cost.
+It forward-chains the deductive closure (RDFS, the OWL 2 RL property/class axioms, or user-supplied N3 rules —
+including RDF 1.2 `<< s p o >>` quoted-triple terms in rule bodies and heads) over dictionary-encoded triples
+and **materializes** the entailed facts, so querying stays exactly as fast as before. Reasoning runs over
+integer ids (joins on fixed-width keys); the closure can be maintained incrementally under inserts/deletes,
+and the non-default `explain` feature answers `why(triple)` with a proof tree. This crate is **isolated** —
+depend on it to get reasoning; the core engine and wasm build carry zero cost.
 
 ## 🚀 Quickstart
 
@@ -27,16 +26,14 @@ use sparq_reason::{materialize, Profile};
 let (mut dict, mut triples) = Graph::parse_to_triples(turtle, "turtle")?;
 let _added = materialize(Profile::Rdfs, &mut dict, &mut triples); // OwlRl includes RDFS
 let g = Graph::from_parts(dict, triples);
-# let _ = g;
-# Ok(()) }
+# let _ = g; Ok(()) }
 # const turtle: &str = "<http://ex/a> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://ex/b> .";
 ```
 
 ## ✨ Features
 
 - **RDFS entailment** — the non-explosive subset (rdfs2/3/5/7/9/11), materialized in one pass.
-- **OWL 2 RL** — property/class axioms over the same fixpoint engine; use `sparq-reason-el`
-  for complete class classification.
+- **OWL 2 RL** — property/class axioms over the same fixpoint engine; use `sparq-reason-el` for complete class classification.
 - **D-entailment** (opt-in `d-entail`) — `Profile::D`: rdfD1 datatype-typing rule under a
   recognized 30-XSD-datatype map (string/normalizedString/token + the
   language/Name/NCName/NMTOKEN pattern-restricted types, boolean, 13 integer types, decimal,
@@ -90,8 +87,7 @@ let g = Graph::from_parts(dict, triples);
   engine drives, supplying the reasoner's own key projection + budget monomorphically.
   Also covers the OWL-RL semi-naive Δ⋈full adjacency (`prp-fp`, `prp-ifp`, `prp-trp`): a
   persistent `DeltaAdj` (two `DeltaTable`s, `sq-qonbz.2`) replaces the per-round `FxHashMap`
-  probes — same closure output, only the join machinery changes.
-  Off by default; byte/bundle ratchets unchanged.
+  probes — same closure output, only the join machinery changes. Off by default; byte/bundle ratchets unchanged.
 - **Shared term total order** (opt-in `substrate-compare`) — `compare::IdTerm` implements the
   substrate's `CompareTerm` for dictionary ids, so ordering entailed solutions
   (`compare::sort_ids` / `compare::compare_ids`) is parity-identical to the SPARQL engine's `ORDER BY`

--- a/crates/sparq-reason/src/datalog/eval.rs
+++ b/crates/sparq-reason/src/datalog/eval.rs
@@ -297,6 +297,12 @@ fn join_rows(
 /// variables and fold the selected aggregate, minting computed numeric results.
 /// Returns rows `[on₀ … onₖ₋₁, value]` in the OUTER join
 /// layout (`ON` columns first, in `ON` order). Empty groups produce no row.
+///
+/// [GPT-5.6] Floating operands deliberately stay on the shared numeric tower:
+/// `SUM`/`AVG` use XPath promotion and IEEE arithmetic (including special-value
+/// propagation), while `MIN`/`MAX` use `Num::cmp_total` so NaN is least and signed
+/// zeros compare equal. An equal-value tie keeps an original input term; its lexical
+/// representative is unspecified because Datalog relations are unordered sets.
 fn aggregate_table(dict: &mut Dict, agg: &AggAtom, store: &FactStore) -> Vec<Row> {
     let empty: Row = std::iter::repeat_n(NO_ID, agg.n_slots).collect();
     let mut rows: Vec<Row> = vec![empty];

--- a/crates/sparq-reason/src/datalog/mod.rs
+++ b/crates/sparq-reason/src/datalog/mod.rs
@@ -40,6 +40,12 @@
 //!   de-duplicates `?v`; there are no rows for empty groups) by the `ON` variables and
 //!   binds the count (an `xsd:integer`) to `?c`. Body variables other
 //!   than the `ON` list are aggregate-local. `ON` may be omitted for a global count.
+//! * **Numeric aggregates** accept `xsd:integer`/`decimal`/`float`/`double`. `SUM` and
+//!   `AVG` use XPath promotion, so a float/double operand promotes the result and IEEE
+//!   `INF`/`-INF`/`NaN` values propagate. `MIN`/`MAX` preserve an original extremal
+//!   term and use the shared exact-rational total order: NaN sorts first and signed
+//!   zeros compare equal. If equal-valued original terms differ lexically (including
+//!   `-0.0` and `0.0`), which representative is preserved is unspecified. [GPT-5.6]
 //! * **`FILTER(x op y)`** compares two bound-or-constant XSD numeric values with
 //!   `= != < <= > >=` via [`sparq_substrate::numeric::Num::cmp_relational`].
 //!   Float/double operands participate with XPath promotion; NaN and non-numeric

--- a/crates/sparq-reason/src/datalog/tests.rs
+++ b/crates/sparq-reason/src/datalog/tests.rs
@@ -805,6 +805,123 @@ fn avg_of_integers_is_decimal() {
     assert_eq!(got, [[g, avg, one_half]].into_iter().collect());
 }
 
+/// [GPT-5.6] Floating aggregates are intentional numeric-tower behavior, not an
+/// accidental f64 coercion: float-only arithmetic remains float and a double operand
+/// promotes the result to double. Exact term assertions make datatype mutations fail.
+#[test]
+fn sum_avg_float_double_follow_xpath_promotion() {
+    const XSD_FLOAT: &str = "http://www.w3.org/2001/XMLSchema#float";
+    const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+
+    let mut d = Dict::new();
+    let (float_group, double_group, value, sum, avg) = (
+        iri(&mut d, "floatGroup"),
+        iri(&mut d, "doubleGroup"),
+        iri(&mut d, "value"),
+        iri(&mut d, "sum"),
+        iri(&mut d, "avg"),
+    );
+    let one = int(&mut d, 1);
+    let one_half_float = d.intern_lit("1.5", XSD_FLOAT, None);
+    let two_half_double = d.intern_lit("2.5", XSD_DOUBLE, None);
+    let facts = vec![
+        [float_group, value, one],
+        [float_group, value, one_half_float],
+        [double_group, value, one_half_float],
+        [double_group, value, two_half_double],
+    ];
+    let got = derived(
+        &mut d,
+        &facts,
+        &format!(
+            "{P}[?g, ex:sum, ?v] :- AGGREGATE([?g, ex:value, ?n] ON ?g BIND SUM(?n) AS ?v) .\n\
+             [?g, ex:avg, ?v] :- AGGREGATE([?g, ex:value, ?n] ON ?g BIND AVG(?n) AS ?v) ."
+        ),
+    );
+    let float_sum = d.intern_lit("2.5E0", XSD_FLOAT, None);
+    let float_avg = d.intern_lit("1.25E0", XSD_FLOAT, None);
+    let double_sum = d.intern_lit("4.0E0", XSD_DOUBLE, None);
+    let double_avg = d.intern_lit("2.0E0", XSD_DOUBLE, None);
+    assert_eq!(
+        got,
+        [
+            [float_group, sum, float_sum],
+            [float_group, avg, float_avg],
+            [double_group, sum, double_sum],
+            [double_group, avg, double_avg],
+        ]
+        .into_iter()
+        .collect()
+    );
+}
+
+/// [GPT-5.6] Aggregate float-edge policy: IEEE arithmetic propagates NaN, whereas
+/// MIN/MAX use the shared total order with NaN least. A lone negative zero remains
+/// the original extremal term; when both signed zeros occur they compare equal and
+/// the native dialect deliberately does not promise which lexical representative wins.
+#[test]
+fn floating_aggregates_pin_nan_and_negative_zero_policy() {
+    const XSD_DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+
+    let mut d = Dict::new();
+    let (nan_group, zero_group, value, sum, avg, min, max) = (
+        iri(&mut d, "nanGroup"),
+        iri(&mut d, "zeroGroup"),
+        iri(&mut d, "value"),
+        iri(&mut d, "sum"),
+        iri(&mut d, "avg"),
+        iri(&mut d, "min"),
+        iri(&mut d, "max"),
+    );
+    let nan = d.intern_lit("NaN", XSD_DOUBLE, None);
+    let neg_zero = d.intern_lit("-0.0E0", XSD_DOUBLE, None);
+    let one = int(&mut d, 1);
+    let facts = vec![
+        [nan_group, value, nan],
+        [nan_group, value, one],
+        [zero_group, value, neg_zero],
+    ];
+    let got = derived(
+        &mut d,
+        &facts,
+        &format!(
+            "{P}[?g, ex:sum, ?v] :- AGGREGATE([?g, ex:value, ?n] ON ?g BIND SUM(?n) AS ?v) .\n\
+             [?g, ex:avg, ?v] :- AGGREGATE([?g, ex:value, ?n] ON ?g BIND AVG(?n) AS ?v) .\n\
+             [?g, ex:min, ?v] :- AGGREGATE([?g, ex:value, ?n] ON ?g BIND MIN(?n) AS ?v) .\n\
+             [?g, ex:max, ?v] :- AGGREGATE([?g, ex:value, ?n] ON ?g BIND MAX(?n) AS ?v) ."
+        ),
+    );
+    assert!(
+        got.contains(&[nan_group, sum, nan]),
+        "SUM must propagate NaN"
+    );
+    assert!(
+        got.contains(&[nan_group, avg, nan]),
+        "AVG must propagate NaN"
+    );
+    assert!(got.contains(&[nan_group, min, nan]), "NaN is least for MIN");
+    assert!(
+        got.contains(&[nan_group, max, one]),
+        "finite 1 is above NaN for MAX"
+    );
+    assert!(
+        got.contains(&[zero_group, sum, neg_zero]),
+        "SUM preserves IEEE -0"
+    );
+    assert!(
+        got.contains(&[zero_group, avg, neg_zero]),
+        "AVG preserves IEEE -0"
+    );
+    assert!(
+        got.contains(&[zero_group, min, neg_zero]),
+        "MIN preserves its input term"
+    );
+    assert!(
+        got.contains(&[zero_group, max, neg_zero]),
+        "MAX preserves its input term"
+    );
+}
+
 #[test]
 fn empty_group_yields_no_row_for_sum() {
     let mut d = Dict::new();

--- a/research/stratified-datalog-rules.md
+++ b/research/stratified-datalog-rules.md
@@ -80,6 +80,11 @@ Load-bearing details, each pinned by a test:
   (set semantics — Datalog relations are sets); `COUNT(DISTINCT ?v)` de-duplicates the
   projected value within each group; empty groups produce no row, and counts
   mint `xsd:integer` literals into the caller's `Dict`.
+- **Numeric aggregates.** `SUM`/`AVG` accept the shared integer/decimal/float/double
+  tower with XPath promotion and IEEE special-value propagation. `MIN`/`MAX` use
+  `Num::cmp_total` (NaN first, signed zeros equal), preserve an original extremal
+  term, and leave the lexical representative unspecified for equal-valued terms.
+  <!-- [GPT-5.6] sq-r2nor -->
 - **FILTER** compares exact/float/double numerics through the shared substrate
   `Num::cmp_relational`; non-numeric values and NaN fail the row.
 - **Variable predicates.** The dependency checker maps them to a conservative top

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -259,8 +259,12 @@ also fails the row (including `!=`). Head/FILTER vars must be bound positively;
 non-`ON` aggregate-body vars are aggregate-local (name collisions rejected). `COUNT(?v)`
 counts distinct full-body matches per group; `COUNT(DISTINCT ?v)` de-duplicates the
 projected value within each group. Counts mint `xsd:integer` literals. `SUM`
-and `AVG` follow SPARQL numeric promotion (`AVG` of integers is `xsd:decimal`), while
-`MIN`/`MAX` preserve the original extremal term id. Semi-naive rounds run per stratum.
+and `AVG` follow SPARQL numeric promotion (`AVG` of integers is `xsd:decimal`).
+Float/double operands promote the result and propagate IEEE `INF`/`-INF`/`NaN`.
+`MIN`/`MAX` preserve an original extremal term under the shared exact-rational total
+order: NaN sorts first and signed zeros compare equal. The lexical representative of
+an equal-valued tie is unspecified. <!-- [GPT-5.6] sq-r2nor --> Semi-naive rounds run
+per stratum.
 Incremental maintenance is differential-pinned (closure == from-scratch `eval` after
 every randomized insert/delete step) and skips strata whose input predicates did not
 change; its per-update set/index bookkeeping is O(affected visible input) — the


### PR DESCRIPTION
> 🤖 SPARQ agent

Defines the existing Datalog aggregate numeric-tower behavior as intentional: SUM/AVG use XPath promotion and IEEE special propagation; MIN/MAX use the shared NaN-first total order, treat signed zeros as equal, and preserve an unspecified original representative on equal-value ties. Adds exact datatype/lexical regression tests for float/double promotion plus NaN and negative-zero behavior, and updates the reasoner module docs, crate README, design record, and inference skill.

Gate status: PASS
- cargo clippy -p sparq-reason --all-targets -- -D warnings
- cargo test -p sparq-reason
- cargo clippy -p sparq-reason --all-targets --features datalog -- -D warnings
- cargo test -p sparq-reason --features datalog