### PR TITLE
feat(gui): decompress URL imports before RDF parse (sq-n18o5) [GPT-5.6]

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -97,15 +97,18 @@ engine calls directly. The foundation frontend runs the in-tab WASM engine in BO
 total for the status bar's disk gauge (least-privilege — confined in Rust to that subtree, follows
 no symlink out of it; the byte-summing walk is unit-tested directly).
 
+<!-- [GPT-5.6] sq-n18o5 — browser URL imports now share the compressed-file decoder. -->
 For **ingest**, the Import drawer (`sq-ixc3.13`) calls the engine's **native loader** IPC
 (`load_path` / `load_text`) when running in the desktop shell: a disk file — including
 **compressed** (`.gz` / `.bz2` / `.zst`) streams and **native-only HDT** (`.hdt` / `.hdt.gz`,
 behind the crate's opt-in `hdt` feature) — is decoded by the native engine (threads, no ~2 GiB
 wasm-tab ceiling) and handed back as N-Quads for the in-tab store to merge (named-graph-
-preserving). On the hosted web target, the drawer's paste/URL tabs parse in the in-tab WASM
-engine instead (no compressed-file / HDT path — the drawer says so). A successful import records a
-`WorkspaceSourceMeta` + a workspace snapshot (the `sq-atb0` save/open cache). The full on-disk
-workspace persistence path activates once the shell grants the `fs` capability (`sq-ixc3.6`).
+preserving). On the hosted web target, the drawer parses paste, file uploads, and URL responses in
+the in-tab WASM engine; compressed uploads and URL responses (`.gz` / `.zip` / `.zst` / `.bz2`)
+are decoded in the browser before parsing, while HDT remains native-only. A successful import
+records a `WorkspaceSourceMeta` + a workspace snapshot (the `sq-atb0` save/open cache). The full
+on-disk workspace persistence path activates once the shell grants the `fs` capability
+(`sq-ixc3.6`).
 
 For **federation** (`sq-ixc3.14`), a SERVICE-bearing SELECT/ASK in the Query tool routes to the
 native `query_service` command (behind the crate's opt-in `federation` feature, which forwards to

--- a/gui/app/src/components/workbench/import-drawer.tsx
+++ b/gui/app/src/components/workbench/import-drawer.tsx
@@ -18,6 +18,10 @@
 //   drawer no longer tells web users "compressed files need the desktop app" for these four
 //   formats. Native-only HDT still requires the desktop (no JS/WASM bead for it).
 //
+// [GPT-5.6] sq-n18o5 — the URL tab now fetches response bytes with `arrayBuffer()` and sends
+//   them through that same decompression path before RDF parsing. Format detection uses the
+//   served RDF Content-Type when available, otherwise the decompressed archive's inner name.
+//
 // Three tabs:
 //   * FILE  — web: browser File upload (incl. compressed .gz/.zip/.zst/.bz2); desktop: native
 //             loader (every format incl. HDT), off the main thread.
@@ -57,7 +61,7 @@ import { hasNativeLoader, pickRdfFile } from "@/lib/tauri-ipc";
 import { hasDraggedFiles } from "@/lib/file-ingest";
 import type { IngestedFile, RejectedFile, IngestResult } from "@/lib/file-ingest";
 // [SONNET-4.6] sq-1y04h — decompression shim; codec chunks loaded lazily on demand.
-import { maybeDecompressFile } from "@/lib/file-decompress";
+import { fetchRdfDocument, maybeDecompressFile } from "@/lib/file-decompress";
 import type { WorkspaceSourceMeta } from "@sparq/client";
 
 // ── Open-state context (so the rail / top bar / Cmd-K can open the drawer) ─────────────────────
@@ -346,18 +350,17 @@ function ImportDrawer({
     const target = url.trim();
     if (!target) return;
     void finishImport("url", async () => {
-      const res = await fetch(target);
-      if (!res.ok) throw new Error(`Fetch failed: HTTP ${res.status} ${res.statusText}`);
-      const body = await res.text();
+      // [GPT-5.6] sq-n18o5 — keep compressed response bytes intact until after codec detection.
+      const document = await fetchRdfDocument(target);
       const format =
-        formatFromContentType(res.headers.get("content-type")) ?? guessFormat(target);
+        formatFromContentType(document.contentType) ?? guessFormat(document.effectiveName);
       const result = await importRdf({
         kind: "url",
         mode,
         preserveGraphs,
         label: urlLabel(target),
         format,
-        text: body,
+        text: document.text,
         url: target,
       });
       const source: WorkspaceSourceMeta = {
@@ -964,9 +967,9 @@ function UrlPane({ url, onUrl }: { url: string; onUrl: (v: string) => void }) {
   return (
     <div className="space-y-3">
       <p className="text-xs text-muted-foreground">
-        Fetch an RDF document from a URL and load it into the store. The source is recorded as a
-        re-fetchable workspace source. The format is auto-detected from the served{" "}
-        <code>Content-Type</code> (or the URL extension).
+        Fetch an RDF document, including a compressed archive, from a URL and load it into the
+        store. The source is recorded as a re-fetchable workspace source. The format is
+        auto-detected from the served <code>Content-Type</code> (or the inner file extension).
       </p>
       <input
         type="url"

--- a/gui/app/src/lib/file-decompress.test.ts
+++ b/gui/app/src/lib/file-decompress.test.ts
@@ -10,7 +10,8 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { gzipSync } from "node:zlib";
 
-import { maybeDecompressFile } from "./file-decompress.js";
+import { fetchRdfDocument, maybeDecompressFile } from "./file-decompress.js";
+import { formatFromContentType, guessFormat } from "./rdf-format.js";
 
 // ── Sample RDF content ────────────────────────────────────────────────────────────────────────
 
@@ -96,4 +97,46 @@ test("[SONNET-4.6] sq-1y04h: gzip by magic bytes (file named .nt but gzip-compre
 
   assert.strictEqual(result.wasDecompressed, true, "magic-bytes probe must detect gzip regardless of extension");
   assert.strictEqual(result.text, SAMPLE_NT, "decompressed text must match original");
+});
+
+test("[GPT-5.6] sq-n18o5: compressed URL is fetched as binary and decompressed before format detection", async () => {
+  const compressed = gzipSync(Buffer.from(SAMPLE_NT, "utf8"));
+  let arrayBufferCalls = 0;
+
+  // [GPT-5.6] The response deliberately has no text() method: a regression to text-first fetch
+  // fails instead of silently feeding corrupted compressed bytes to the RDF parser.
+  const document = await fetchRdfDocument(
+    "https://example.org/dataset.nt.gz?download=1",
+    async (url) => {
+      assert.strictEqual(url, "https://example.org/dataset.nt.gz?download=1");
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers({ "content-type": "application/gzip" }),
+        arrayBuffer: async () => {
+          arrayBufferCalls += 1;
+          return compressed.buffer.slice(
+            compressed.byteOffset,
+            compressed.byteOffset + compressed.byteLength,
+          ) as ArrayBuffer;
+        },
+      };
+    },
+  );
+
+  assert.strictEqual(arrayBufferCalls, 1, "the URL response must be consumed exactly once as binary");
+  assert.strictEqual(document.wasDecompressed, true);
+  assert.strictEqual(document.codec, "gzip");
+  assert.strictEqual(document.text, SAMPLE_NT, "URL decompression must recover the exact RDF text");
+  assert.notStrictEqual(
+    new TextDecoder("utf-8", { fatal: false }).decode(compressed),
+    document.text,
+    "mutation check: decoding the fetched archive without decompression must produce different text",
+  );
+  assert.strictEqual(
+    formatFromContentType(document.contentType) ?? guessFormat(document.effectiveName),
+    "ntriples",
+    "the decompressed inner .nt name must select N-Triples before RDF parse",
+  );
 });

--- a/gui/app/src/lib/file-decompress.ts
+++ b/gui/app/src/lib/file-decompress.ts
@@ -9,7 +9,7 @@
 // binary payloads (compressed streams are NOT valid UTF-8). Reading as `arrayBuffer` first
 // and decoding only AFTER decompression is the only correct path for compressed inputs.
 //
-// Used by the import-drawer.tsx `WebFilePane` so the web persona can import
+// Used by the import-drawer.tsx `WebFilePane` and URL tab so the web persona can import
 // `.gz`, `.zip`, `.zst`, and `.bz2` datasets without the desktop app (native loader).
 // The native Tauri path (gui/src-tauri open_reader) is unchanged — leave it.
 
@@ -33,6 +33,87 @@ export interface MaybeDecompressedFile {
 
 const decoder = new TextDecoder("utf-8", { fatal: false });
 
+// [GPT-5.6] sq-n18o5 — the response subset required by binary URL import. Keeping this
+// structural makes the fetch/decompress path unit-testable without a browser Response global.
+type BinaryFetchResponse = Pick<
+  Response,
+  "ok" | "status" | "statusText" | "headers" | "arrayBuffer"
+>;
+
+type BinaryFetcher = (url: string) => Promise<BinaryFetchResponse>;
+
+/** A fetched RDF document, decoded only after optional archive decompression. */
+export interface FetchedRdfDocument extends MaybeDecompressedFile {
+  /** The server's response media type, retained for RDF format detection. */
+  contentType: string | null;
+}
+
+/**
+ * [GPT-5.6] sq-n18o5 — fetch a URL as binary and decompress a supported dataset archive before
+ * UTF-8 decoding. The effective inner name lets the caller detect RDF syntax from `data.nt`
+ * rather than the outer `data.nt.gz` / `data.zip` container name.
+ *
+ * Binary-first is load-bearing: calling `Response.text()` would irreversibly corrupt compressed
+ * bytes before the codec sees them.
+ */
+export async function fetchRdfDocument(
+  url: string,
+  fetcher: BinaryFetcher = (target) => fetch(target),
+): Promise<FetchedRdfDocument> {
+  const response = await fetcher(url);
+  if (!response.ok) {
+    throw new Error(
+      `Fetch failed: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  return {
+    ...(await maybeDecompressBytes(bytes, url)),
+    contentType: response.headers.get("content-type"),
+  };
+}
+
+/**
+ * [GPT-5.6] sq-n18o5 — decode source bytes after decompressing any supported archive. Shared by
+ * browser Files and URL responses so both import tabs use identical codec detection and errors.
+ */
+export async function maybeDecompressBytes(
+  bytes: Uint8Array,
+  sourceName: string,
+): Promise<MaybeDecompressedFile> {
+  // Try decompress — decompressDatasetBytes throws when it sees no recognised magic/extension.
+  // Catch the "Unrecognised compressed payload" error to fall through to the uncompressed path.
+  let result: Awaited<ReturnType<typeof decompressDatasetBytes>> | null = null;
+  try {
+    result = await decompressDatasetBytes(bytes, sourceName);
+  } catch (err) {
+    // "Unrecognised compressed payload" means the source is not compressed — fall through.
+    // Any other error (e.g. corrupt archive) is re-thrown so the import drawer surfaces it.
+    if (
+      !(err instanceof Error) ||
+      !err.message.startsWith("Unrecognised compressed payload")
+    ) {
+      throw err;
+    }
+  }
+
+  if (result !== null) {
+    return {
+      text: decoder.decode(result.bytes),
+      effectiveName: result.innerName ?? sourceName,
+      wasDecompressed: true,
+      codec: result.codec,
+    };
+  }
+
+  return {
+    text: decoder.decode(bytes),
+    effectiveName: sourceName,
+    wasDecompressed: false,
+  };
+}
+
 /**
  * [SONNET-4.6] sq-1y04h — read a browser `File` and decompress it if it is a recognised
  * compressed dataset archive (.gz, .zip, .zst, .bz2). Uncompressed files are returned as-is
@@ -50,36 +131,5 @@ export async function maybeDecompressFile(file: File): Promise<MaybeDecompressed
   // typical RDF documents and is the only correct approach for compressed inputs.
   const buffer = await file.arrayBuffer();
   const bytes = new Uint8Array(buffer);
-
-  // Try decompress — decompressDatasetBytes throws when it sees no recognised magic/extension.
-  // Catch the "Unrecognised compressed payload" error to fall through to the uncompressed path.
-  let result: Awaited<ReturnType<typeof decompressDatasetBytes>> | null = null;
-  try {
-    result = await decompressDatasetBytes(bytes, file.name);
-  } catch (err) {
-    // "Unrecognised compressed payload" means the file is not compressed — fall through.
-    // Any other error (e.g. corrupt archive) is re-thrown so the import drawer surfaces it.
-    if (
-      !(err instanceof Error) ||
-      !err.message.startsWith("Unrecognised compressed payload")
-    ) {
-      throw err;
-    }
-  }
-
-  if (result !== null) {
-    return {
-      text: decoder.decode(result.bytes),
-      effectiveName: result.innerName ?? file.name,
-      wasDecompressed: true,
-      codec: result.codec,
-    };
-  }
-
-  // Uncompressed: decode directly.
-  return {
-    text: decoder.decode(bytes),
-    effectiveName: file.name,
-    wasDecompressed: false,
-  };
+  return maybeDecompressBytes(bytes, file.name);
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

Extends the GUI Import drawer URL tab to fetch response bodies as binary, reuse the existing compressed-dataset decoder, and detect RDF syntax from the decompressed inner filename before parsing. This prevents gzip/zip/zstd/bzip2 URL payloads from being corrupted by text-first fetch handling. No new dependency was added; optional zstd/bzip2 codecs remain behind the existing invocation-time dynamic imports in @sparq/client.

Adds a non-vacuous gzip URL unit test whose response exposes arrayBuffer() but no text(), verifies exact RDF recovery and inner-name format detection, and includes a mutation assertion proving raw compressed bytes decode differently. Updates the GUI README and URL-tab copy.

Gates:
- PASS: npm run build:web (optimized production build + static export)
- PASS: npm run lint (two pre-existing warnings in untouched plan-tree.tsx and proof-panel.tsx)
- PASS: npm run typecheck
- PASS: npm run test:unit (107/107)

Commit: cc5e76004