### PR TITLE
feat(gui): explain inferred facts across graph and text views (sq-l54uy) [GPT-5.6]

### DIFF
--- a/gui/app/src/components/workbench/graph-view-tool.tsx
+++ b/gui/app/src/components/workbench/graph-view-tool.tsx
@@ -19,7 +19,8 @@ import { Play, Loader2, Network } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useEngine, type QueryOutcome } from "@/lib/engine-context";
-import { GraphView } from "@/components/workbench/graph-view";
+import { GraphView, type InferredAffordance } from "@/components/workbench/graph-view";
+import { ProofPanel, type ExplainTarget } from "@/components/workbench/proof-panel";
 import { WorkbenchSparqlEditor } from "@/components/workbench/sparql-editor";
 
 // [FABLE-5] sq-qgkwy.2 — the override lives in the sibling `.meta.ts` (eagerly bundled for the
@@ -31,11 +32,25 @@ export { GRAPH_VIEW_TOOL_OVERRIDE } from "@/components/workbench/graph-view-tool
 const DEFAULT_CONSTRUCT = `CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100`;
 
 export function GraphViewTool() {
-  const { run, status } = useEngine();
+  const { run, status, entailedTripleKeys, inferenceMode, inferenceStatus } = useEngine();
   const [query, setQuery] = React.useState(DEFAULT_CONSTRUCT);
   const [running, setRunning] = React.useState(false);
   const [outcome, setOutcome] = React.useState<QueryOutcome | null>(null);
+  // [GPT-5.6] The standalone Graph tool owns its proof overlay just as QueryWorkbench does.
+  const [explainTarget, setExplainTarget] = React.useState<ExplainTarget | null>(null);
   const abortRef = React.useRef<AbortController | null>(null);
+
+  // [GPT-5.6] Exact closure-minus-base membership; an asserted edge never gains why().
+  const inferred = React.useMemo<InferredAffordance | null>(() => {
+    if (inferenceMode === "off" || inferenceStatus.kind !== "ready") return null;
+    const keys = entailedTripleKeys();
+    if (!keys || keys.size === 0) return null;
+    return { keys, onExplain: setExplainTarget };
+  }, [inferenceMode, inferenceStatus, entailedTripleKeys]);
+
+  React.useEffect(() => {
+    setExplainTarget(null);
+  }, [inferenceMode]);
 
   const onRun = React.useCallback(async () => {
     // A run already in flight: ignore (no parallel runs for this tool).
@@ -103,7 +118,7 @@ export function GraphViewTool() {
       </div>
 
       {/* Result area */}
-      <div className="min-h-0 flex-1 overflow-auto" data-graph-view-result>
+      <div className="relative min-h-0 flex-1 overflow-auto" data-graph-view-result>
         {outcome === null ? (
           <p className="p-4 text-sm text-muted-foreground">
             {ready
@@ -111,7 +126,7 @@ export function GraphViewTool() {
               : "Waiting for the engine to warm…"}
           </p>
         ) : outcome.kind === "graph" ? (
-          <GraphView ntriples={outcome.ntriples} />
+          <GraphView ntriples={outcome.ntriples} inferred={inferred} />
         ) : outcome.kind === "error" ? (
           <pre
             className="overflow-auto whitespace-pre-wrap p-3 font-mono text-xs text-destructive"
@@ -128,6 +143,10 @@ export function GraphViewTool() {
             <code className="rounded bg-muted px-1 py-0.5">DESCRIBE</code> query to generate a
             graph result that can be visualised here.
           </p>
+        )}
+        {/* [GPT-5.6] why() overlay for an inferred edge clicked in this standalone tool. */}
+        {explainTarget && (
+          <ProofPanel target={explainTarget} onClose={() => setExplainTarget(null)} />
         )}
       </div>
     </div>

--- a/gui/app/src/components/workbench/inference-tool.tsx
+++ b/gui/app/src/components/workbench/inference-tool.tsx
@@ -26,9 +26,11 @@ import { useWorkspace } from "@/lib/workspace-context";
 import { INFERENCE_MODE_META } from "@/lib/reason-wasm";
 import { toolById, TIER_META } from "@/data/tools";
 import { InferenceControl } from "@/components/workbench/inference-control";
+import { ProofPanel, type ExplainTarget } from "@/components/workbench/proof-panel";
 import { WorkbenchTurtleEditor } from "@/components/workbench/turtle-editor";
 import { Dropzone } from "@/components/workbench/dropzone";
 import type { IngestResult } from "@/lib/file-ingest";
+import type { InferredFact } from "@/lib/inferred-facts";
 
 /** One labelled measured count in the stats strip. */
 function Stat({ label, value }: { label: string; value: number }) {
@@ -234,15 +236,107 @@ function N3RulesPanel() {
   );
 }
 
+const ENTAILED_FACT_PAGE_SIZE = 50;
+
+/** [GPT-5.6] Browse the exact closure-added set and open why() on any retained fact. */
+function EntailedFactsBrowser({
+  facts,
+  onExplain,
+}: {
+  facts: readonly InferredFact[];
+  onExplain: (target: ExplainTarget) => void;
+}) {
+  const [visibleCount, setVisibleCount] = React.useState(ENTAILED_FACT_PAGE_SIZE);
+
+  React.useEffect(() => {
+    setVisibleCount(ENTAILED_FACT_PAGE_SIZE);
+  }, [facts]);
+
+  const visibleFacts = facts.slice(0, visibleCount);
+  return (
+    <section className="space-y-2" data-entailed-facts-browser>
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Entailed facts
+        </h3>
+        <span className="text-[11px] text-muted-foreground">
+          {facts.length.toLocaleString()} closure additions
+        </span>
+      </div>
+      {facts.length === 0 ? (
+        <p className="rounded-md border bg-background p-3 text-xs text-muted-foreground">
+          This regime added no facts over the asserted store.
+        </p>
+      ) : (
+        <div className="overflow-hidden rounded-md border bg-background">
+          <ol className="max-h-72 divide-y overflow-auto" aria-label="Entailed facts">
+            {visibleFacts.map((fact) => (
+              <li
+                key={fact.key}
+                className="flex items-start gap-2 px-3 py-1.5"
+                data-entailed-fact
+              >
+                <code
+                  className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap text-[11px]"
+                  title={fact.ntriples}
+                >
+                  {fact.ntriples}
+                </code>
+                <button
+                  type="button"
+                  className="shrink-0 rounded border border-transparent bg-primary/10 px-1.5 py-0 font-mono text-[10px] text-primary hover:bg-primary/20"
+                  onClick={() => onExplain(fact)}
+                  aria-label={`Explain inferred fact: ${fact.ntriples}`}
+                  title="Explain this inferred fact"
+                  data-entailed-fact-explain
+                >
+                  why?
+                </button>
+              </li>
+            ))}
+          </ol>
+          {visibleFacts.length < facts.length ? (
+            <div className="border-t px-3 py-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setVisibleCount((count) => count + ENTAILED_FACT_PAGE_SIZE)}
+                data-entailed-facts-more
+              >
+                Show more
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      )}
+      <p className="text-[11px] text-muted-foreground">
+        Closure additions only — asserted facts are excluded. Choose why? to inspect one witness
+        derivation.
+      </p>
+    </section>
+  );
+}
+
 export function InferenceTool() {
-  const { inferenceStatus, status } = useEngine();
+  const { inferenceStatus, status, entailedTripleFacts } = useEngine();
   const { inference } = useWorkspace();
+  // [GPT-5.6] The status object is the reactive signal that a new exact closure cache is ready.
+  const entailedFacts = React.useMemo(
+    () => (inferenceStatus.kind === "ready" ? (entailedTripleFacts() ?? []) : []),
+    [inferenceStatus, entailedTripleFacts],
+  );
+  const [explainTarget, setExplainTarget] = React.useState<ExplainTarget | null>(null);
+
+  React.useEffect(() => {
+    setExplainTarget(null);
+  }, [inference]);
   const tool = toolById("inference");
   const tier = tool ? TIER_META[tool.tier] : null;
   const modeMeta = INFERENCE_MODE_META[inference];
 
   return (
-    <div className="h-full overflow-auto">
+    <div className="relative h-full overflow-auto">
       <div className="mx-auto max-w-2xl space-y-5 p-6">
         {/* Header. */}
         <div className="space-y-1">
@@ -313,6 +407,11 @@ export function InferenceTool() {
           </p>
         )}
 
+        {/* [GPT-5.6] RDFox-style browser over the exact closure-minus-base set. */}
+        {inferenceStatus.kind === "ready" ? (
+          <EntailedFactsBrowser facts={entailedFacts} onExplain={setExplainTarget} />
+        ) : null}
+
         {/* Honest caveats. */}
         <div className="space-y-1.5 rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
           <div className="flex items-center gap-1.5 font-medium text-foreground">
@@ -340,6 +439,9 @@ export function InferenceTool() {
           </div>
         </div>
       </div>
+      {explainTarget ? (
+        <ProofPanel target={explainTarget} onClose={() => setExplainTarget(null)} />
+      ) : null}
     </div>
   );
 }

--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -62,7 +62,12 @@ import { GraphView, type InferredAffordance } from "@/components/workbench/graph
 // [FABLE-5] sq-ixc3.20 — click-to-explain inferred facts: the why() proof-tree panel + the
 // canonical triple identity that gates the affordance (membership in the closure-added set).
 import { ProofPanel, type ExplainTarget } from "@/components/workbench/proof-panel";
-import { termToNT, tripleKeyOfBindings } from "@/lib/inferred-facts";
+import {
+  inferredFactsMatchingKeys,
+  termToNT,
+  tripleKeyOfBindings,
+  type InferredFact,
+} from "@/lib/inferred-facts";
 // [OPUS-4.8] sq-tp1m (#757) — the per-workspace inference (RDFS / OWL 2 RL) selector, in the
 // action row so the active entailment regime is visible + controllable while querying.
 import { InferenceControl } from "@/components/workbench/inference-control";
@@ -316,37 +321,102 @@ const TURTLE_TOKEN_CLASS: Record<TurtleToken["type"], string> = {
   plain: "",
 };
 
-/** A highlighted RDF document (pretty Turtle by default, raw N-Triples otherwise). */
-function RdfDocument({ ntriples, pretty }: { ntriples: string; pretty: boolean }) {
+/** [GPT-5.6] Highlight one RDF text fragment without changing its line/triple identity. */
+function RdfTokens({ text }: { text: string }) {
+  const tokens = React.useMemo(() => tokenizeTurtle(text), [text]);
+  return tokens.map((t, i) => {
+    const cls = TURTLE_TOKEN_CLASS[t.type];
+    return cls ? (
+      <span key={i} className={cls}>
+        {t.text}
+      </span>
+    ) : (
+      <React.Fragment key={i}>{t.text}</React.Fragment>
+    );
+  });
+}
+
+/** A highlighted pretty-Turtle document. */
+function RdfDocument({ ntriples }: { ntriples: string }) {
   const text = React.useMemo(() => {
-    if (!pretty) return ntriples;
     try {
       return prettyTurtle(ntriples);
     } catch {
       // The serialiser never throws by design, but degrade to the raw form if it ever does.
       return ntriples;
     }
-  }, [ntriples, pretty]);
-  const tokens = React.useMemo(() => tokenizeTurtle(text), [text]);
+  }, [ntriples]);
   return (
     <pre className="overflow-auto whitespace-pre p-3 font-mono text-xs">
-      {tokens.map((t, i) => {
-        const cls = TURTLE_TOKEN_CLASS[t.type];
-        return cls ? (
-          <span key={i} className={cls}>
-            {t.text}
-          </span>
-        ) : (
-          <React.Fragment key={i}>{t.text}</React.Fragment>
-        );
-      })}
+      <RdfTokens text={text} />
     </pre>
   );
 }
 
+/** [GPT-5.6] One raw result line plus its exact inferred membership, if any. */
+interface NTriplesLine {
+  text: string;
+  fact: InferredFact | null;
+}
+
+/** [GPT-5.6] Raw N-Triples keeps one statement per line, so why() can be attached precisely. */
+function RawNTriplesDocument({
+  lines,
+  onExplain,
+}: {
+  lines: readonly NTriplesLine[];
+  onExplain?: (target: ExplainTarget) => void;
+}) {
+  return (
+    <div className="min-w-max py-2 font-mono text-xs" data-ntriples-lines>
+      {lines.map(({ text, fact }, index) => (
+        <div
+          key={index}
+          className={cn(
+            "flex min-h-5 items-start gap-2 px-3",
+            fact && "border-l-2 border-primary bg-primary/5 pl-2.5",
+          )}
+          {...(fact ? { "data-inferred-line": true } : {})}
+        >
+          <pre className="min-w-0 flex-1 whitespace-pre">
+            <RdfTokens text={text} />
+          </pre>
+          {fact && onExplain ? (
+            <button
+              type="button"
+              className="sticky right-2 shrink-0 rounded border border-transparent bg-primary/10 px-1.5 py-0 text-[10px] text-primary hover:bg-primary/20"
+              onClick={() => onExplain(fact)}
+              aria-label={`Explain inferred fact: ${fact.ntriples}`}
+              title="This fact is inferred (not asserted) — see its derivation"
+              data-explain-trigger
+              data-ntriples-explain
+            >
+              why?
+            </button>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 /** The N-Triples / Turtle view, with a pretty-Turtle ⇄ raw-N-Triples toggle. */
-function GraphTextView({ ntriples }: { ntriples: string }) {
+function GraphTextView({
+  ntriples,
+  inferred,
+}: {
+  ntriples: string;
+  /** [GPT-5.6] Exact inferred-line membership + proof-panel opener. */
+  inferred?: InferredAffordance | null;
+}) {
   const [pretty, setPretty] = React.useState(true);
+  const lines = React.useMemo<readonly NTriplesLine[]>(() => {
+    return ntriples.split("\n").map((text) => ({
+      text,
+      fact: inferred ? (inferredFactsMatchingKeys(text, inferred.keys)[0] ?? null) : null,
+    }));
+  }, [ntriples, inferred]);
+  const hasInferredLines = lines.some((line) => line.fact !== null);
   if (!ntriples.trim()) {
     return <p className="p-3 text-sm text-muted-foreground">(empty graph)</p>;
   }
@@ -359,7 +429,9 @@ function GraphTextView({ ntriples }: { ntriples: string }) {
         ].map((opt) => (
           <button
             key={String(opt.id)}
+            type="button"
             onClick={() => setPretty(opt.id)}
+            aria-pressed={pretty === opt.id}
             className={cn(
               "rounded px-2 py-0.5 text-[11px]",
               pretty === opt.id
@@ -370,9 +442,23 @@ function GraphTextView({ ntriples }: { ntriples: string }) {
             {opt.label}
           </button>
         ))}
+        {hasInferredLines ? (
+          <span
+            className="ml-auto text-[10px] text-muted-foreground"
+            data-text-inferred-hint
+          >
+            {pretty
+              ? "Switch to N-Triples to explain inferred facts."
+              : "Marked lines are inferred — choose why? for a derivation."}
+          </span>
+        ) : null}
       </div>
       <div className="min-h-0 flex-1 overflow-auto">
-        <RdfDocument ntriples={ntriples} pretty={pretty} />
+        {pretty ? (
+          <RdfDocument ntriples={ntriples} />
+        ) : (
+          <RawNTriplesDocument lines={lines} onExplain={inferred?.onExplain} />
+        )}
       </div>
     </div>
   );
@@ -415,7 +501,7 @@ function ResultBody({
 }: {
   outcome: QueryOutcome;
   view: ResultView;
-  /** [FABLE-5] sq-ixc3.20 — the inferred-fact affordance (table + graph views). */
+  /** [GPT-5.6] sq-l54uy — the inferred-fact affordance (table + graph + N-Triples views). */
   inferred?: InferredAffordance | null;
 }) {
   if (outcome.kind === "error") {
@@ -494,7 +580,7 @@ function ResultBody({
     }
     return (
       <div className="h-full" data-result-kind="graph">
-        <GraphTextView ntriples={outcome.ntriples} />
+        <GraphTextView ntriples={outcome.ntriples} inferred={inferred} />
       </div>
     );
   }

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -57,12 +57,13 @@ import {
 // query engine pays nothing until a workspace turns inference on.
 import { loadReasoner, modeToProfile, type WasmReasoner } from "@/lib/reason-wasm";
 // [FABLE-5] sq-ixc3.20 — canonical triple identity for the inferred-fact affordance (the
-// entailed-key set the results views consult) + the shared N-Triples term writer (moved out
+// entailed fact cache the results views consult) + the shared N-Triples term writer (moved out
 // of this file so the click-to-explain path and the snapshot writer share ONE writer).
 import {
-  entailedKeysFromClosure,
+  entailedFactsFromClosure,
   termToNT,
   tripleKeysOfNTriples,
+  type InferredFact,
 } from "@/lib/inferred-facts";
 
 /**
@@ -383,6 +384,12 @@ export interface EngineContextValue {
    */
   entailedTripleKeys: () => ReadonlySet<string> | null;
   /**
+   * [GPT-5.6] The same exact closure-added set as {@link entailedTripleKeys}, retained in the
+   * N-Triples term spelling accepted by {@link explainWhy}. Used by the Inference tool's fact
+   * browser; guarded by the same active closure cache key, so stale facts are never exposed.
+   */
+  entailedTripleFacts: () => readonly InferredFact[] | null;
+  /**
    * [FABLE-5] sq-ixc3.20 — ONE derivation ("why?") of the triple `(s, p, o)` under the
    * ACTIVE inference regime, as `sparq-reason`'s proof-tree JSON (parse with
    * @/lib/proof-view `parseProofJson`; the string `"null"` means "not entailed"). `s`/`p`/`o`
@@ -667,11 +674,15 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   // changes (warm / import / update) so a stale closure is rebuilt automatically.
   const reasonedStoreRef = React.useRef<WasmStore | null>(null);
   const reasonedKeyRef = React.useRef<string | null>(null);
-  // [FABLE-5] sq-ixc3.20 — the canonical keys of the triples the ACTIVE closure ADDED
+  // [GPT-5.6] sq-l54uy — the canonical keys + displayable facts the ACTIVE closure ADDED
   // (closure − base), computed alongside the closure build and cached under the SAME
   // `mode:epoch[:rulesHash]` key so it can never describe a different store than
   // `reasonedStoreRef` (the guard in `entailedTripleKeys` checks the key, not just presence).
-  const entailedKeysRef = React.useRef<{ key: string; keys: Set<string> } | null>(null);
+  const entailedCacheRef = React.useRef<{
+    key: string;
+    keys: Set<string>;
+    facts: InferredFact[];
+  } | null>(null);
   // [OPUS-4.8] sq-tp1m — the SINGLE-FLIGHT slot for an in-flight closure build, keyed by the
   // same `mode:epoch`. Overlapping callers (the applyInferenceMode effect + a run(), or two
   // run()s) that request the same key while the first materialisation is still awaiting share
@@ -741,7 +752,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       reasonedStoreRef.current = null;
       reasonedKeyRef.current = null;
       reasonedBuildRef.current = null;
-      entailedKeysRef.current = null;
+      entailedCacheRef.current = null;
       storeEpochRef.current += 1;
       setStoreEpoch(storeEpochRef.current);
       const { size, graphs: gs } = summariseGraphs(store);
@@ -876,7 +887,10 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
           const reasoned = Store.load(closure || " ", "ntriples");
           // [FABLE-5] sq-ixc3.20 — the derived lines ARE the entailed set for N3 mode;
           // reduce them to canonical keys for the inferred-fact affordance.
-          entailedKeysRef.current = { key, keys: tripleKeysOfNTriples(derived) };
+          // [GPT-5.6] Retain the same exact derived set as explainable N-Triples facts for the
+          // Inference tool browser. An empty base is correct because reasonN3 returns additions.
+          const entailed = entailedFactsFromClosure(derived, new Set<string>());
+          entailedCacheRef.current = { key, ...entailed };
           reasonedStoreRef.current = reasoned;
           reasonedKeyRef.current = key;
           return reasoned;
@@ -912,10 +926,10 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
         // [FABLE-5] sq-ixc3.20 — entailed = closure − base at CANONICAL key level (the two
         // texts come from different writers — Rust vs the JS termToNT — so identity is the
         // decoded key, never the raw line; see @/lib/inferred-facts).
-        entailedKeysRef.current = {
-          key,
-          keys: entailedKeysFromClosure(closure, tripleKeysOfNTriples(snapshot)),
-        };
+        // [GPT-5.6] Compute closure-minus-base once, retaining both membership keys and the
+        // exact N-Triples terms needed by the entailed-facts browser and why() panel.
+        const entailed = entailedFactsFromClosure(closure, tripleKeysOfNTriples(snapshot));
+        entailedCacheRef.current = { key, ...entailed };
         reasonedStoreRef.current = reasoned;
         reasonedKeyRef.current = key;
         return reasoned;
@@ -942,7 +956,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       if (mode === "off") {
         reasonedStoreRef.current = null;
         reasonedKeyRef.current = null;
-        entailedKeysRef.current = null;
+        entailedCacheRef.current = null;
         setInferenceStatus({ kind: "off" });
         return;
       }
@@ -982,7 +996,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
         if (gen !== inferenceGenRef.current) return;
         reasonedStoreRef.current = null;
         reasonedKeyRef.current = null;
-        entailedKeysRef.current = null;
+        entailedCacheRef.current = null;
         setInferenceStatus({
           kind: "error",
           message: err instanceof Error ? err.message : String(err),
@@ -1011,9 +1025,17 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   // The key guard makes staleness impossible: the set is only handed out while it describes
   // exactly the closure `run()` queries against (same `mode:epoch[:rulesHash]` key).
   const entailedTripleKeys = React.useCallback((): ReadonlySet<string> | null => {
-    const cached = entailedKeysRef.current;
+    const cached = entailedCacheRef.current;
     if (!cached || cached.key !== reasonedKeyRef.current) return null;
     return cached.keys;
+  }, []);
+
+  // [GPT-5.6] Displayable/provable facts for the ACTIVE closure, with the identical stale-key
+  // guard as entailedTripleKeys. The cached array is immutable by convention to consumers.
+  const entailedTripleFacts = React.useCallback((): readonly InferredFact[] | null => {
+    const cached = entailedCacheRef.current;
+    if (!cached || cached.key !== reasonedKeyRef.current) return null;
+    return cached.facts;
   }, []);
 
   // [FABLE-5] sq-ixc3.20 — one witness derivation of a clicked triple under the active
@@ -1457,6 +1479,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       inferenceStatus,
       setInferenceMode,
       entailedTripleKeys,
+      entailedTripleFacts,
       explainWhy,
       setN3Rules,
       setServiceAllowlist,
@@ -1484,6 +1507,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       inferenceStatus,
       setInferenceMode,
       entailedTripleKeys,
+      entailedTripleFacts,
       explainWhy,
       setN3Rules,
       setServiceAllowlist,

--- a/gui/app/src/lib/inferred-facts.test.ts
+++ b/gui/app/src/lib/inferred-facts.test.ts
@@ -9,7 +9,9 @@ import { test } from "node:test";
 import { parseNTriples, type SparqlTerm } from "@sparq/client";
 
 import {
+  entailedFactsFromClosure,
   entailedKeysFromClosure,
+  inferredFactsMatchingKeys,
   keyOfRdfTerm,
   keyOfSparqlTerm,
   termToNT,
@@ -99,4 +101,28 @@ test("entailedKeysFromClosure is exactly closure minus base", () => {
   assert.ok(entailed.has(keyOfLine("<http://ex/a> <http://ex/q> <http://ex/b> .")));
   // Membership is the affordance gate: the asserted triple is NOT marked.
   assert.ok(!entailed.has(keyOfLine("<http://ex/a> <http://ex/p> <http://ex/b> .")));
+});
+
+test("entailed facts retain one exact, explainable N-Triples line per added triple", () => {
+  // [GPT-5.6] Exact expected values make this non-vacuous: changing q→r, retaining the asserted
+  // p fact, or failing to fold the duplicate named-graph statement makes the test fail.
+  const base = tripleKeysOfNTriples("<http://ex/a> <http://ex/p> <http://ex/b> .");
+  const closure = [
+    "<http://ex/a> <http://ex/p> <http://ex/b> .",
+    '<http://ex/a> <http://ex/q> "entailed"@en .',
+    '<http://ex/a> <http://ex/q> "entailed"@en <http://ex/graph> .',
+  ].join("\n");
+  const entailed = entailedFactsFromClosure(closure, base);
+
+  assert.equal(entailed.keys.size, 1);
+  assert.deepEqual(entailed.facts, [
+    {
+      key: keyOfLine('<http://ex/a> <http://ex/q> "entailed"@en .'),
+      s: "<http://ex/a>",
+      p: "<http://ex/q>",
+      o: '"entailed"@en',
+      ntriples: '<http://ex/a> <http://ex/q> "entailed"@en .',
+    },
+  ]);
+  assert.deepEqual(inferredFactsMatchingKeys(closure, entailed.keys), entailed.facts);
 });

--- a/gui/app/src/lib/inferred-facts.ts
+++ b/gui/app/src/lib/inferred-facts.ts
@@ -21,6 +21,23 @@ const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
  *  on both sides of any comparison — the key stays injective per term kind). */
 const SEP = "";
 
+/** [GPT-5.6] One closure-added fact in the exact N-Triples term form accepted by why(). */
+export interface InferredFact {
+  /** Canonical decoded identity used by every inferred-fact affordance. */
+  key: string;
+  s: string;
+  p: string;
+  o: string;
+  /** A displayable N-Triples statement (the reasoner folds named graphs to s/p/o). */
+  ntriples: string;
+}
+
+/** [GPT-5.6] The exact closure-minus-base result retained for UI membership + browsing. */
+export interface EntailedFacts {
+  keys: Set<string>;
+  facts: InferredFact[];
+}
+
 // ---------------------------------------------------------------------------
 // N-Triples term writing (the engine wire shape) — moved here from engine-context so the
 // click-to-explain path and the snapshot writer share ONE writer.
@@ -143,6 +160,17 @@ export function tripleKeyOfTerms(s: RdfTerm, p: RdfTerm, o: RdfTerm): string {
   return `${keyOfRdfTerm(s)} ${keyOfRdfTerm(p)} ${keyOfRdfTerm(o)}`;
 }
 
+/** [GPT-5.6] Preserve a parsed statement in the term spelling required by the proof API. */
+function inferredFactOfTerms(s: RdfTerm, p: RdfTerm, o: RdfTerm): InferredFact {
+  return {
+    key: tripleKeyOfTerms(s, p, o),
+    s: s.nt,
+    p: p.nt,
+    o: o.nt,
+    ntriples: `${s.nt} ${p.nt} ${o.nt} .`,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Entailed-set construction (fed by the closure build in engine-context).
 // ---------------------------------------------------------------------------
@@ -162,6 +190,50 @@ export function tripleKeysOfNTriples(text: string): Set<string> {
 }
 
 /**
+ * [GPT-5.6] Facts in an N-Triples/N-Quads document whose canonical identities are in
+ * `includedKeys`. The first occurrence wins, so named-graph folding and duplicate closure
+ * emission still produce one browser row per distinct inferred triple.
+ */
+export function inferredFactsMatchingKeys(
+  text: string,
+  includedKeys: ReadonlySet<string>,
+): InferredFact[] {
+  if (!text.trim() || includedKeys.size === 0) return [];
+  const facts: InferredFact[] = [];
+  const seen = new Set<string>();
+  const { statements } = parseNTriples(text);
+  for (const st of statements) {
+    const fact = inferredFactOfTerms(st.s, st.p, st.o);
+    if (!includedKeys.has(fact.key) || seen.has(fact.key)) continue;
+    seen.add(fact.key);
+    facts.push(fact);
+  }
+  return facts;
+}
+
+/**
+ * [GPT-5.6] Compute closure minus base once while retaining both canonical membership keys and
+ * displayable/provable N-Triples facts. This is the shared source for result affordances and the
+ * Inference tool's entailed-facts browser.
+ */
+export function entailedFactsFromClosure(
+  closureText: string,
+  baseKeys: ReadonlySet<string>,
+): EntailedFacts {
+  const keys = new Set<string>();
+  const facts: InferredFact[] = [];
+  if (!closureText.trim()) return { keys, facts };
+  const { statements } = parseNTriples(closureText);
+  for (const st of statements) {
+    const fact = inferredFactOfTerms(st.s, st.p, st.o);
+    if (baseKeys.has(fact.key) || keys.has(fact.key)) continue;
+    keys.add(fact.key);
+    facts.push(fact);
+  }
+  return { keys, facts };
+}
+
+/**
  * The ENTAILED triple keys: every key of `closureText` that is not a key of `baseKeys`
  * (set difference — `closureText` is the reasoner's base+entailed output; what remains is
  * exactly what reasoning added).
@@ -171,6 +243,6 @@ export function entailedKeysFromClosure(
   baseKeys: ReadonlySet<string>,
 ): Set<string> {
   const keys = tripleKeysOfNTriples(closureText);
-  for (const k of baseKeys) keys.delete(k);
+  for (const key of baseKeys) keys.delete(key);
   return keys;
 }

--- a/gui/e2e-playwright/specs/why-proof-tree.web.spec.ts
+++ b/gui/e2e-playwright/specs/why-proof-tree.web.spec.ts
@@ -9,6 +9,8 @@
 //   (b) GRAPH view: a CONSTRUCT of the same closure renders the inferred edges dashed with
 //       the legend, and clicking an inferred edge opens the same panel. Turning inference
 //       Off removes every affordance (asserted-only results carry nothing to explain).
+//   (c) [GPT-5.6] The standalone Graph tool, raw N-Triples result lines, and the Inference
+//       tool's entailed-facts browser expose the same exact click-to-explain contract.
 //
 // NON-VACUOUS by design: the gating Playwright lane (gui.yml) BUILDS the W-reason bundle
 // (npm run build:reason-wasm, `--features explain`) before exporting the app, so `why()` is
@@ -20,6 +22,8 @@
 //   [data-inferred-row]           — a table row whose s/p/o the closure ADDED
 //   [data-entailed-edge]          — an inferred (dashed, clickable) GRAPH edge
 //   [data-graph-inferred-legend]  — the graph view's inferred-edge legend strip
+//   [data-inferred-line] / [data-ntriples-explain] — raw inferred result line + why?
+//   [data-entailed-facts-browser] / [data-entailed-fact] — closure-additions browser
 //   [data-proof-panel] / [data-proof-node] / [data-proof-rule=…] / [data-proof-note]
 //   [data-proof-triple] / [data-proof-full-triple] / [data-proof-close]
 //
@@ -201,5 +205,85 @@ test.describe("why-proof-tree", () => {
     await expect(page.locator("[data-entailed-edge]")).toHaveCount(0);
     await runQuery(page, SELECT_ALL, '[data-result-view="table"]');
     await expect(page.locator("[data-explain-trigger]")).toHaveCount(0);
+  });
+
+  test("(c) Graph tool, N-Triples lines, and entailed-facts browser explain exact additions", async ({
+    page,
+  }) => {
+    // [GPT-5.6] One multi-step closure drives all three newly-covered surfaces.
+    await importPasteReplace(page, CHAIN_TTL);
+    const inferencePanel = await selectRdfsReady(page);
+
+    // Inference tool: browse closure additions only; asserted rex a Dog is absent, while
+    // inferred rex a Animal is present and opens a real proof.
+    const browser = inferencePanel.locator("[data-entailed-facts-browser]");
+    await expect(browser).toBeVisible();
+    const entailedFacts = browser.locator("[data-entailed-fact]");
+    await expect
+      .poll(async () => await entailedFacts.count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(2);
+    await expect(
+      entailedFacts.filter({ hasText: "rex" }).filter({ hasText: "Dog" }),
+    ).toHaveCount(0);
+    const browserAnimal = entailedFacts
+      .filter({ hasText: "rex" })
+      .filter({ hasText: "Animal" });
+    await expect(browserAnimal).toHaveCount(1);
+    await browserAnimal.locator("[data-entailed-fact-explain]").click();
+    let proof = page.locator("[data-proof-panel]");
+    await expect(
+      proof.locator('[data-proof-node][data-proof-rule="asserted"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await proof.locator("[data-proof-close]").click();
+
+    // Standalone Graph tool: its own run result receives the inferred-edge prop and hosts the
+    // same proof overlay (the original follow-up's one-prop wiring gap).
+    await page.locator('[data-tool="graph-view"]').click();
+    const graphTool = page.locator('[data-tool-panel="graph-view"]');
+    await expect(graphTool).toBeVisible();
+    await fillReactTextarea(page, "#graph-view-query", CONSTRUCT_REX);
+    await graphTool.getByRole("button", { name: "Run", exact: true }).click();
+    await expect(graphTool.locator("[data-graph-inferred-legend]")).toBeVisible({
+      timeout: 60_000,
+    });
+    const toolEdges = graphTool.locator("[data-entailed-edge]");
+    await expect
+      .poll(async () => await toolEdges.count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(2);
+    await toolEdges.first().click();
+    proof = graphTool.locator("[data-proof-panel]");
+    await expect(
+      proof.locator('[data-proof-node][data-proof-rule="asserted"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
+    await proof.locator("[data-proof-close]").click();
+
+    // Query text view: raw N-Triples preserves the one-line-one-fact identity. Inferred lines
+    // are marked and explainable; the asserted rex a Dog line has neither marker nor button.
+    // The Query tool remembers its selected result tab; wait for the graph result itself rather
+    // than a table-view-only wrapper before switching explicitly to the text view.
+    await runQuery(page, CONSTRUCT_REX, '[data-tab="query"] [data-result-view="graph"]');
+    await page.getByRole("button", { name: "N-Triples / Turtle", exact: true }).click();
+    await page.getByRole("button", { name: "N-Triples", exact: true }).click();
+    const raw = page.locator("[data-ntriples-lines]");
+    await expect(raw).toBeVisible();
+    const inferredLines = raw.locator("[data-inferred-line]");
+    await expect
+      .poll(async () => await inferredLines.count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(2);
+    const assertedLine = raw
+      .locator(":scope > div")
+      .filter({ hasText: "rex" })
+      .filter({ hasText: "Dog" });
+    await expect(assertedLine).toHaveCount(1);
+    await expect(assertedLine.locator("[data-ntriples-explain]")).toHaveCount(0);
+    const rawAnimal = inferredLines
+      .filter({ hasText: "rex" })
+      .filter({ hasText: "Animal" });
+    await expect(rawAnimal).toHaveCount(1);
+    await rawAnimal.locator("[data-ntriples-explain]").click();
+    proof = page.locator('[data-tab="query"] [data-proof-panel]');
+    await expect(
+      proof.locator('[data-proof-node][data-proof-rule="asserted"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
   });
 });


### PR DESCRIPTION
> 🤖 SPARQ agent

Extends the existing exact closure-minus-base why() affordance to every surface named by sq-l54uy:

- wires inferred edges and the ProofPanel into the standalone Graph View tool;
- marks exact inferred lines in raw N-Triples results and opens their derivations;
- adds a paged entailed-facts browser to the Inference tool, excluding asserted facts;
- retains displayable/provable N-Triples facts beside the existing canonical membership keys under the same stale-cache guard.

No new dependency was added; all code stays inside the already-lazy GUI tool/query chunks. The optional proof-tree premise re-rooting note is intentionally not included because it is outside the bead title's three concrete surfaces.

Gates run and green:

- `npm run lint` in `gui/app` (only the two existing treeitem aria-selected warnings)
- `npm run typecheck` in `gui/app`
- `npm run test:unit` in `gui/app`
- `npm run build:web` in `gui/app`, with the explain-enabled W-reason bundle synced
- `npm run build:tauri` in `gui/app`
- `npm run typecheck` and `npm run no-timeout-gate` in `gui/e2e-playwright`
- focused Chromium web-persona proof suite: `why-proof-tree.web.spec.ts`

The new unit assertion is non-vacuous: changing the expected predicate, retaining the asserted fact, or failing named-graph de-duplication fails it. The end-to-end journey also proves asserted facts lack affordances while all three new surfaces open a real derivation.
