### PR TITLE
feat(site): surface native capabilities (sq-vw3ax.15) [GPT-5.6]

### DIFF
--- a/site/e2e/capabilities-smoke.spec.ts
+++ b/site/e2e/capabilities-smoke.spec.ts
@@ -32,6 +32,46 @@ const THEMES = [
   "Serve & embed",
 ];
 
+// [GPT-5.6] sq-vw3ax.15 — exact native-row contract. Mutating a title, snippet, or link makes
+// this smoke fail, so the coverage is non-vacuous and guards the content the bead added.
+const NATIVE_ROWS = [
+  {
+    slug: "graph-analytics",
+    title: "Graph analytics",
+    snippet: "let ranks = sparq_algos::pagerank(&graph, Default::default());",
+    readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-algos",
+    skill: "https://github.com/jeswr/sparq/blob/main/skills/graph-analytics/SKILL.md",
+  },
+  {
+    slug: "rdf-canon",
+    title: "RDFC-1.0 canonicalization",
+    snippet: "let canonical = sparq_canon::canonicalize(&quads)?;",
+    readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-canon",
+    skill: "https://github.com/jeswr/sparq/blob/main/skills/rdf-canon/SKILL.md",
+  },
+  {
+    slug: "arrow-columnar",
+    title: "Arrow export",
+    snippet: "let batch = sparq_arrow::to_record_batch(&result)?;",
+    readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-arrow",
+    skill: "https://github.com/jeswr/sparq/blob/main/skills/arrow-columnar/SKILL.md",
+  },
+  {
+    slug: "prov-lineage",
+    title: "PROV-O lineage",
+    snippet: "let derivation = sparq_prov::derive_construct(&graph, query, config)?;",
+    readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-prov",
+    skill: "https://github.com/jeswr/sparq/blob/main/skills/prov-lineage/SKILL.md",
+  },
+  {
+    slug: "mcp-server",
+    title: "MCP server",
+    snippet: "let mut server = sparq_mcp::McpServer::new(graph);",
+    readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-mcp",
+    skill: "https://github.com/jeswr/sparq/blob/main/skills/agent-tools/SKILL.md",
+  },
+] as const;
+
 /** Collect every `console.error` the page emits, so the test can assert there were none. */
 function trackConsoleErrors(page: Page): string[] {
   const errors: string[] = [];
@@ -73,6 +113,24 @@ test("the showcase renders its hero, flagship band and all five theme sections w
   // theme fails this loudly — the showcase's load-bearing structural invariant.
   for (const theme of THEMES) {
     await expect(page.getByRole("heading", { name: theme })).toBeVisible();
+  }
+
+  // Every newly surfaced native crate renders as a real row with the native honesty badge,
+  // its exact API line, and both working deep-link targets.
+  for (const expected of NATIVE_ROWS) {
+    const row = page.locator(`[data-capability="${expected.slug}"]`);
+    await expect(row).toBeVisible();
+    await expect(row.getByText(expected.title, { exact: true })).toBeVisible();
+    await expect(row.getByText("Native crate", { exact: true })).toBeVisible();
+    await expect(row.locator("code")).toHaveText(expected.snippet);
+    await expect(row.getByRole("link", { name: /Crate \/ source/i })).toHaveAttribute(
+      "href",
+      expected.readme,
+    );
+    await expect(row.getByRole("link", { name: /SKILL\.md/i })).toHaveAttribute(
+      "href",
+      expected.skill,
+    );
   }
 
   // No demo BODY is eagerly mounted on entry (the lazy-mount invariant is fully owned by

--- a/site/e2e/command-palette.spec.ts
+++ b/site/e2e/command-palette.spec.ts
@@ -102,6 +102,27 @@ test("clicking a result row navigates to its surface", async ({ page }) => {
   expect(new URL(page.url()).pathname).toContain("/showcase/zk-car-hire");
 });
 
+test("finds every built native capability", async ({ page }) => {
+  // [GPT-5.6] sq-vw3ax.15 — these entries derive from GROUPS, so this proves the shared IA
+  // source reaches Cmd-K as promised. An expected-title mutation fails the visible-row check.
+  const titles = [
+    "Graph analytics",
+    "RDFC-1.0 canonicalization",
+    "PROV-O lineage",
+    "Arrow export",
+    "MCP server",
+  ];
+
+  await page.keyboard.press(`${MOD}+KeyK`);
+  const dialog = palette(page);
+  const input = dialog.getByPlaceholder("Search surfaces, pages, actions…");
+
+  for (const title of titles) {
+    await input.fill(title);
+    await expect(dialog.getByText(title, { exact: true })).toBeVisible();
+  }
+});
+
 // ── palette → /app hard-navigation guard (regression) ──────────────────────────────────────────
 //
 // [FABLE-5] sq-vw3ax.11.1 — /app is served in production by a SEPARATE Next.js build (gui/app)

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -38,6 +38,8 @@ const TIER_LEGEND: { tier: Tier; note: string }[] = [
   { tier: "live-bbjs", note: "in-tab proving via the 3rd-party bb.js UltraHonk prover" },
   { tier: "live-sim", note: "a faithful in-tab JS simulation of a native protocol" },
   { tier: "hosted", note: "a small hosted sparq-server where a wasm rebuild is uneconomic" },
+  // [GPT-5.6] sq-vw3ax.15 — the dot used by built opt-in crates has an explicit legend.
+  { tier: "native", note: "a built, opt-in Rust crate with code and docs linked from this site" },
   { tier: "walkthrough", note: "real, captured engine output replayed (native-only surface)" },
 ];
 

--- a/site/src/components/capabilities/capability-row.tsx
+++ b/site/src/components/capabilities/capability-row.tsx
@@ -10,6 +10,7 @@
 //             body out as a full-content-width row instead of squeezing it into a half-column
 //             tile (sq-67qji — issue #1675). The lane grid (capability-lane-grid.tsx) owns the
 //             open/mounted state and pairs each button with its body by slug.
+//   * native → a static built-crate row with a one-line API snippet + crate/SKILL deep links.
 //   * soon  → a non-interactive "Coming soon" row that links out to GitHub.
 //
 // [OPUS-4.8] sq-vw3ax — BOLD redesign: each affordance renders as a depth TILE (the approved
@@ -28,7 +29,7 @@ import { ArrowRight, ChevronRight, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { TIER_LABEL, TIER_VARIANT, type Surface } from "@/data/surfaces";
-import { surfaceBySlug } from "@/data/capabilities";
+import { surfaceBySlug, type CapabilityKind } from "@/data/capabilities";
 import {
   LazyDemo,
   hasLazyDemo,
@@ -122,12 +123,15 @@ function TileShell({
   surface,
   accent,
   cta,
+  details,
   interactive = true,
   active = false,
 }: {
   surface: Surface;
   accent: string;
   cta: React.ReactNode;
+  /** Optional compact proof/deep-link block for a built native-only capability. */
+  details?: React.ReactNode;
   interactive?: boolean;
   /** Pins the accent + elevation on (used while a demo tile's body is open). */
   active?: boolean;
@@ -135,6 +139,7 @@ function TileShell({
   const Icon = surface.icon;
   return (
     <div
+      data-capability={surface.slug}
       className={cn(
         "relative flex items-start gap-3 overflow-hidden rounded-[var(--radius-lg)] border bg-card px-4 py-3.5 transition-all duration-150",
         interactive &&
@@ -160,12 +165,54 @@ function TileShell({
         <div className="mt-1 text-[12.7px] leading-snug text-muted-foreground">
           {surface.blurb}
         </div>
+        {details}
       </div>
       <div className="flex shrink-0 flex-col items-end gap-2">
         <TierBadge surface={surface} />
         {cta}
       </div>
     </div>
+  );
+}
+
+/** [GPT-5.6] sq-vw3ax.15 — built native crate: copyable API proof + direct depth links,
+ *  without inventing a demo, route, or browser bundle. */
+function NativeTile({ surface, accent }: { surface: Surface; accent: string }) {
+  const native = surface.native;
+  if (!native) return null;
+
+  return (
+    <TileShell
+      surface={surface}
+      accent={accent}
+      interactive={false}
+      cta={null}
+      details={
+        <div className="mt-3 space-y-2 border-t pt-2.5">
+          <code className="block overflow-x-auto rounded-md bg-muted px-2.5 py-2 font-mono text-[11.5px] text-foreground">
+            {native.snippet}
+          </code>
+          <div className="flex flex-wrap gap-x-3 gap-y-1 text-[12px]">
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={native.readme}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Crate / source <ExternalLink className="size-3" aria-hidden />
+            </a>
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={native.skill}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              SKILL.md <ExternalLink className="size-3" aria-hidden />
+            </a>
+          </div>
+        </div>
+      }
+    />
   );
 }
 
@@ -367,7 +414,7 @@ export function CapabilityRowItem({
   onToggle,
 }: {
   slug: string;
-  kind: "deep" | "demo" | "soon";
+  kind: CapabilityKind;
   accent?: string;
   /** Controlled disclosure state for a demo tile — owned by the lane grid (sq-67qji). */
   open?: boolean;
@@ -376,6 +423,7 @@ export function CapabilityRowItem({
   const surface = surfaceBySlug(slug);
   if (!surface) return null; // data drift — a row for an unknown surface; render nothing.
   if (kind === "deep") return <DeepTile surface={surface} accent={accent} />;
+  if (kind === "native") return <NativeTile surface={surface} accent={accent} />;
   if (kind === "soon") return <SoonTile surface={surface} accent={accent} />;
   // demo — guard against a data drift where a "demo" surface lacks a registered demo.
   if (hasLazyDemo(surface.slug)) {

--- a/site/src/components/capabilities/tier-legend.tsx
+++ b/site/src/components/capabilities/tier-legend.tsx
@@ -16,6 +16,7 @@ const TIER_ORDER: Tier[] = [
   "live-bbjs",
   "live-sim",
   "hosted",
+  "native",
   "walkthrough",
   "soon",
 ];
@@ -27,6 +28,7 @@ const TIER_GLOSS: Record<Tier, string> = {
   "live-bbjs": "in-tab proving via 3rd-party bb.js UltraHonk",
   "live-sim": "a faithful in-tab JS simulation of the native protocol",
   hosted: "a sparq-server endpoint",
+  native: "a built, opt-in Rust crate with code and docs linked from this static site",
   walkthrough: "captured, verbatim engine output replayed (no backend on a static site)",
   soon: "not built yet — an honest placeholder",
 };

--- a/site/src/data/capabilities.ts
+++ b/site/src/data/capabilities.ts
@@ -9,6 +9,8 @@
 //     whose existing interactive component is now lazily mounted in-place on /capabilities
 //     (see components/capabilities/lazy-demo.tsx). Its old route ships a client redirect stub
 //     to /capabilities#<theme> (static export cannot 301).
+//   * a NATIVE row — a built opt-in Rust crate with one API snippet + crate/SKILL deep links;
+//     it has no dense site page and adds no browser implementation to the static bundle.
 //   * a SOON row — a surface with no built page yet (cli, python); a plain "coming soon" row
 //     that links out to GitHub. Its old /surface/<slug> route is a placeholder today and is
 //     redirected too.
@@ -33,7 +35,7 @@ export const DEEP_PAGE_SLUGS = new Set([
   "inference",
 ]);
 
-export type CapabilityKind = "deep" | "demo" | "soon";
+export type CapabilityKind = "deep" | "demo" | "native" | "soon";
 
 export interface CapabilityRow {
   surface: Surface;
@@ -45,6 +47,8 @@ export interface CapabilityRow {
 /** Classify one surface for the gallery. `built === false` (cli/python) → "soon". */
 export function classify(surface: Surface): CapabilityKind {
   if (DEEP_PAGE_SLUGS.has(surface.slug)) return "deep";
+  // [GPT-5.6] sq-vw3ax.15 — native metadata is the explicit built-without-a-site-demo seam.
+  if (surface.native) return "native";
   if (surface.built === false || surface.built === undefined) {
     // cli / python have no `built: true` flag and no page → honest "coming soon" row.
     return surface.slug === "cli" || surface.slug === "python" ? "soon" : "demo";

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -38,8 +38,18 @@ export type Tier =
   | "live-bbjs" // (c) 3rd-party WASM (bb.js UltraHonk proving)
   | "live-sim" // (d) faithful in-tab JS simulation
   | "hosted" // (e) hosted sparq-server
+  | "native" // built, opt-in native Rust crate; linked from the static site
   | "walkthrough" // (e) captured-I/O replay (different host / native-only)
   | "soon"; // not yet built — honest placeholder
+
+// [GPT-5.6] sq-vw3ax.15 — compact native-only rows carry their proof-of-existence inline:
+// one copyable API line plus direct crate and Agent Skill links. Keeping this metadata beside
+// the surface makes /capabilities, Home, and Cmd-K update from the same IA source.
+export interface NativeSurfaceMeta {
+  snippet: string;
+  readme: string;
+  skill: string;
+}
 
 export interface Surface {
   slug: string;
@@ -49,6 +59,7 @@ export interface Surface {
   tier: Tier;
   icon: LucideIcon;
   built?: boolean; // does a real page exist yet?
+  native?: NativeSurfaceMeta;
 }
 
 export interface SurfaceGroup {
@@ -66,6 +77,7 @@ export const TIER_LABEL: Record<Tier, string> = {
   "live-bbjs": "Live via bb.js",
   "live-sim": "Live simulation",
   hosted: "Hosted",
+  native: "Native crate",
   walkthrough: "Walkthrough",
   soon: "Coming soon",
 };
@@ -79,6 +91,7 @@ export const TIER_VARIANT: Record<
   "live-bbjs": "success",
   "live-sim": "default",
   hosted: "warning",
+  native: "muted",
   walkthrough: "muted",
   soon: "muted",
 };
@@ -119,12 +132,12 @@ export const FLAGSHIPS: Surface[] = [
 // [OPUS-4.8] sq-vw3ax.2 — the 5 capability THEMES (research/website-redesign.md §2).
 // Surfaces are mapped to themes by what they DO, keeping every existing surface, route,
 // blurb and tier verbatim:
-//   1. Query & data      — SPARQL + the data-format/JS-WASM/geo query surfaces
-//   2. Reason & validate — inference + SHACL
+//   1. Query & data      — SPARQL + formats/JS-WASM/geo + native analytics/canon/Arrow
+//   2. Reason & validate — inference + SHACL + native PROV-O lineage
 //   3. Search & GenAI    — full-text BM25, vector, GenAI/NLQ
 //   4. Privacy (ZK / MPC)— ZK query proofs + MPC federation (the Solid flagship sits in
 //      /showcase; it is surfaced via FLAGSHIPS, not duplicated as a /surface row here)
-//   5. Serve & embed     — HTTP server, CLI, Python, streaming RSP-QL
+//   5. Serve & embed     — HTTP/MCP servers, CLI, Python, streaming RSP-QL
 // The redesign's aspirational extra rows became beads, not fabricated nav entries: the
 // federation row landed via sq-vw3ax.13 (a captured-output demo row under Serve & embed);
 // structural-similarity remains unbuilt and is still NOT invented here.
@@ -135,7 +148,7 @@ export const GROUPS: SurfaceGroup[] = [
     // [OPUS-4.8] sq-4hiqe — the in-tab workbench now lives at /app (the /try REPL was removed);
     // this description is user-facing copy, so it stays clean (no route/bead cross-reference).
     description:
-      "Run SPARQL 1.1/1.2 over RDF — the query engine and the formats it ingests.",
+      "Query, exchange, and analyse RDF — SPARQL 1.1/1.2, data formats, canonicalization, and graph algorithms.",
     surfaces: [
       {
         slug: "sparql",
@@ -179,13 +192,57 @@ export const GROUPS: SurfaceGroup[] = [
         icon: MapPin,
         built: true,
       },
+      // [GPT-5.6] sq-vw3ax.15 — shipped native capabilities stay compact: no dense surface
+      // page, only an honest native tier, one API line, and direct code/docs links.
+      {
+        slug: "graph-analytics",
+        href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-algos",
+        title: "Graph analytics",
+        blurb:
+          "PageRank, centrality, communities, SCCs, and topological order over a directed RDF projection.",
+        tier: "native",
+        icon: Network,
+        native: {
+          snippet: "let ranks = sparq_algos::pagerank(&graph, Default::default());",
+          readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-algos",
+          skill: "https://github.com/jeswr/sparq/blob/main/skills/graph-analytics/SKILL.md",
+        },
+      },
+      {
+        slug: "rdf-canon",
+        href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-canon",
+        title: "RDFC-1.0 canonicalization",
+        blurb:
+          "Canonical blank-node labelling for stable N-Quads, hashing, signing, and graph isomorphism.",
+        tier: "native",
+        icon: Binary,
+        native: {
+          snippet: "let canonical = sparq_canon::canonicalize(&quads)?;",
+          readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-canon",
+          skill: "https://github.com/jeswr/sparq/blob/main/skills/rdf-canon/SKILL.md",
+        },
+      },
+      {
+        slug: "arrow-columnar",
+        href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-arrow",
+        title: "Arrow export",
+        blurb:
+          "Faithful SPARQL SELECT interchange through Arrow RecordBatch, Parquet, and Arrow IPC.",
+        tier: "native",
+        icon: Database,
+        native: {
+          snippet: "let batch = sparq_arrow::to_record_batch(&result)?;",
+          readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-arrow",
+          skill: "https://github.com/jeswr/sparq/blob/main/skills/arrow-columnar/SKILL.md",
+        },
+      },
     ],
   },
   {
     id: "reason-validate",
     label: "Reason & validate",
     description:
-      "Derive new triples and check graphs against shapes — RDFS / OWL 2 RL / N3 closure and SHACL.",
+      "Derive, trace, and validate RDF — RDFS / OWL 2 RL / N3 closure, PROV-O lineage, and SHACL.",
     surfaces: [
       {
         slug: "inference",
@@ -204,6 +261,21 @@ export const GROUPS: SurfaceGroup[] = [
         tier: "live",
         icon: ShieldCheck,
         built: true,
+      },
+      {
+        // [GPT-5.6] sq-vw3ax.15 — PROV-O is a built opt-in crate, not an in-tab demo.
+        slug: "prov-lineage",
+        href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-prov",
+        title: "PROV-O lineage",
+        blurb:
+          "PROV-O derivations for CONSTRUCT, DESCRIBE, UPDATE, and optional reasoner proof trees.",
+        tier: "native",
+        icon: Waypoints,
+        native: {
+          snippet: "let derivation = sparq_prov::derive_construct(&graph, query, config)?;",
+          readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-prov",
+          skill: "https://github.com/jeswr/sparq/blob/main/skills/prov-lineage/SKILL.md",
+        },
       },
     ],
   },
@@ -283,7 +355,7 @@ export const GROUPS: SurfaceGroup[] = [
     id: "serve-embed",
     label: "Serve & embed",
     description:
-      "Run sparq as a service or embed it — the HTTP endpoint, the CLI, Python bindings, and streaming RSP-QL.",
+      "Run sparq as a service or embed it — HTTP, MCP, CLI, Python, and streaming RSP-QL.",
     surfaces: [
       {
         slug: "http-server",
@@ -322,6 +394,21 @@ export const GROUPS: SurfaceGroup[] = [
         tier: "walkthrough",
         icon: Waypoints,
         built: true,
+      },
+      {
+        // [GPT-5.6] sq-vw3ax.15 — the MCP front door is native and read-only by default.
+        slug: "mcp-server",
+        href: "https://github.com/jeswr/sparq/tree/main/crates/sparq-mcp",
+        title: "MCP server",
+        blurb:
+          "Read-only-by-default MCP tools for SPARQL, schema introspection, stats, prefixes, and VoID.",
+        tier: "native",
+        icon: Server,
+        native: {
+          snippet: "let mut server = sparq_mcp::McpServer::new(graph);",
+          readme: "https://github.com/jeswr/sparq/tree/main/crates/sparq-mcp",
+          skill: "https://github.com/jeswr/sparq/blob/main/skills/agent-tools/SKILL.md",
+        },
       },
       {
         slug: "cli",


### PR DESCRIPTION
> 🤖 SPARQ agent

Surfaces five built opt-in native crates in the shared capability IA: graph analytics, RDFC-1.0 canonicalization, PROV-O lineage, Arrow export, and the MCP server. Each /capabilities row carries the honest Native crate tier, a compact API snippet, and direct crate/SKILL.md links; Home and Cmd-K inherit the same grouped data. No new route, dependency, demo, or optional bundle was added.

Gates: npm run lint ✅; npm run typecheck ✅; npm run build ✅ (static export + check-bundle, 0 heavy chunks on /capabilities first load); targeted Playwright 7/7 ✅; full npm run test:e2e 127/127 ✅.