### PR TITLE
feat(gui): derive Forms from active workspace (sq-3eukz) [GPT-5.6]

### DIFF
--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -16,7 +16,7 @@
     "start": "npx --yes serve out",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/federation.test.ts src/lib/odrl.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts src/lib/rsp-feed.test.ts src/lib/plan-view.test.ts src/lib/query-monitor.test.ts src/lib/proof-view.test.ts src/lib/inferred-facts.test.ts src/lib/form-render-model.test.ts src/lib/file-decompress.test.ts scripts/strip-legacy-polyfills.test.mjs"
+    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts src/lib/federation.test.ts src/lib/odrl.test.ts src/lib/tauri-fs.test.ts src/lib/import-batch.test.ts src/lib/workspace-actions-visibility.test.ts src/lib/rsp-feed.test.ts src/lib/plan-view.test.ts src/lib/query-monitor.test.ts src/lib/proof-view.test.ts src/lib/inferred-facts.test.ts src/lib/form-render-model.test.ts src/lib/forms-bridge.test.ts src/lib/file-decompress.test.ts scripts/strip-legacy-polyfills.test.mjs"
   },
   "dependencies": {
     "buffer": "^6.0.3",

--- a/gui/app/src/components/workbench/forms-tool.tsx
+++ b/gui/app/src/components/workbench/forms-tool.tsx
@@ -1,27 +1,300 @@
 "use client";
-// [GPT-5.6] sq-lsp7k.1.2 — operational shared Forms panel consuming F1 JSON.
+
+// [GPT-5.6] sq-3eukz — operational Forms panel derived from the active live workspace. Focus,
+// mode, shape, and store-epoch changes always request a whole new FormDescription from the
+// runtime host; the browser never rebuilds groups or chooses widgets.
 import * as React from "react";
 import { Braces, FilePenLine, LoaderCircle } from "lucide-react";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { FormRenderer } from "@/components/workbench/form-renderer";
-import { FORMS_DEMO_DESCRIPTION } from "@/data/forms-demo";
-import { parseFormDescription, type FormDescription, type FormMode, type TermRef } from "@/lib/form-description";
+import { useEngine, type FormResource } from "@/lib/engine-context";
+import {
+  deriveForm,
+  FormsBridgeUnavailableError,
+  type DeriveFormResult,
+} from "@/lib/forms-bridge";
+import {
+  parseFormDescription,
+  termKey,
+  termLabel,
+  type FormDescription,
+  type FormMode,
+  type TermRef,
+} from "@/lib/form-description";
+
+interface DeriveSelection {
+  focus: FormResource;
+  mode: FormMode;
+  shape?: TermRef;
+}
+
+type DeriveState =
+  | { kind: "idle" }
+  | { kind: "deriving" }
+  | { kind: "ready"; source: DeriveFormResult["source"] }
+  | { kind: "unavailable"; message: string }
+  | { kind: "error"; message: string };
+
+function resourceKey(resource: FormResource): string {
+  return termKey(resource);
+}
 
 export function FormsTool() {
-  const [description, setDescription] = React.useState<FormDescription>(FORMS_DEMO_DESCRIPTION);
-  const [json, setJson] = React.useState(() => JSON.stringify(FORMS_DEMO_DESCRIPTION, null, 2));
-  const [error, setError] = React.useState<string | null>(null);
-  const [request, setRequest] = React.useState<string | null>(null);
-  const loadJson = () => { try { setDescription(parseFormDescription(json)); setError(null); setRequest(null); } catch (cause) { setError(cause instanceof Error ? cause.message : String(cause)); } };
-  const onModeRequest = (mode: FormMode) => setRequest(mode === description.mode ? null : `Previewing ${mode} mode. A workspace host re-derives FormDescription JSON for a permanent mode change.`);
-  const onShapeRequest = (shape: TermRef) => setRequest(`Shape ${shape.value} requested. The host must re-derive its groups through sparq-forms.`);
-  return <div className="flex h-full flex-col" data-tool-panel="forms">
-    <div className="flex shrink-0 items-center gap-2 border-b bg-card px-3 py-1.5"><FilePenLine className="size-3.5 text-muted-foreground" aria-hidden /><span className="text-xs font-medium text-muted-foreground">Shape-directed form</span><Badge variant="outline" className="h-5 text-[10px]">FormDescription JSON</Badge><Badge variant="muted" className="h-5 text-[10px]">Draft only · F4 commits</Badge></div>
-    <div className="min-h-0 flex-1 overflow-y-auto p-3"><div className="mx-auto max-w-5xl space-y-3">
-      <details className="rounded-md border bg-card" data-form-json-source><summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs font-medium [&::-webkit-details-marker]:hidden"><Braces className="size-3.5 text-muted-foreground" aria-hidden />Load FormDescription JSON<span className="ml-auto text-[10px] font-normal text-muted-foreground">Desktop and hosted web consume the same contract</span></summary><div className="space-y-2 border-t p-3"><textarea value={json} onChange={(event) => setJson(event.currentTarget.value)} className="h-48 w-full resize-y rounded-md border bg-background p-2 font-mono text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label="FormDescription JSON" spellCheck={false} /><div className="flex items-center gap-2"><Button type="button" size="sm" onClick={loadJson} data-load-form-json>Render JSON</Button>{error ? <p role="alert" className="text-xs text-destructive">{error}</p> : null}</div></div></details>
-      {request ? <p className="flex items-start gap-2 rounded-md border border-primary/25 bg-primary/5 p-2 text-xs text-muted-foreground" role="status"><LoaderCircle className="mt-0.5 size-3.5 shrink-0" aria-hidden />{request}</p> : null}
-      <FormRenderer description={description} onDescriptionChange={setDescription} onModeRequest={onModeRequest} onShapeRequest={onShapeRequest} />
-    </div></div>
-  </div>;
+  const {
+    status,
+    storeEpoch,
+    snapshotStore,
+    listFormResources,
+    wasmDeriveForm,
+  } = useEngine();
+  const [resources, setResources] = React.useState<FormResource[]>([]);
+  const [selection, setSelection] = React.useState<DeriveSelection | null>(null);
+  const [description, setDescription] = React.useState<FormDescription | null>(null);
+  const [descriptionOrigin, setDescriptionOrigin] = React.useState<"workspace" | "manual" | null>(
+    null,
+  );
+  const [deriveState, setDeriveState] = React.useState<DeriveState>({ kind: "idle" });
+  const [manualJson, setManualJson] = React.useState("");
+  const [manualError, setManualError] = React.useState<string | null>(null);
+  const requestGeneration = React.useRef(0);
+  const originRef = React.useRef<typeof descriptionOrigin>(null);
+  originRef.current = descriptionOrigin;
+
+  const ready = status.kind === "ready";
+
+  // Every content epoch (workspace hydration, import, or update) replaces the candidate list.
+  // Keeping the selected resource when it still exists lets the derivation effect below refresh
+  // that same description; otherwise the first resource becomes the operational default.
+  React.useEffect(() => {
+    if (!ready) return;
+    try {
+      const next = listFormResources();
+      setResources(next);
+      setSelection((previous) => {
+        if (next.length === 0) return null;
+        const retained = previous
+          ? next.find((candidate) => resourceKey(candidate) === resourceKey(previous.focus))
+          : undefined;
+        if (retained && previous) return { ...previous, focus: retained };
+        return { focus: next[0], mode: previous?.mode ?? "edit" };
+      });
+      if (next.length === 0 && originRef.current === "workspace") {
+        requestGeneration.current += 1;
+        setDescription(null);
+        setDescriptionOrigin(null);
+        setDeriveState({ kind: "idle" });
+      }
+    } catch (cause) {
+      setResources([]);
+      setSelection(null);
+      setDeriveState({
+        kind: "error",
+        message: cause instanceof Error ? cause.message : String(cause),
+      });
+    }
+  }, [listFormResources, ready, storeEpoch]);
+
+  // This is the only operational derivation path. The exact same N-Quads snapshot is the data
+  // and shapes input on both hosts, so a store epoch, focus, mode, or shape change replaces the
+  // entire validated description returned by Tauri/wasm.
+  React.useEffect(() => {
+    if (!ready || selection === null) return;
+    const snapshot = snapshotStore();
+    if (snapshot === null) {
+      setDeriveState({
+        kind: "error",
+        message: "The active workspace could not be serialized for form derivation.",
+      });
+      return;
+    }
+
+    const generation = ++requestGeneration.current;
+    let cancelled = false;
+    setDeriveState({ kind: "deriving" });
+    void deriveForm(
+      {
+        data: snapshot,
+        shapes: snapshot,
+        focus: selection.focus,
+        mode: selection.mode,
+        shape: selection.shape,
+        format: "nquads",
+      },
+      wasmDeriveForm,
+    )
+      .then((result) => {
+        if (cancelled || generation !== requestGeneration.current) return;
+        setDescription(result.description);
+        setDescriptionOrigin("workspace");
+        setManualError(null);
+        setDeriveState({ kind: "ready", source: result.source });
+      })
+      .catch((cause: unknown) => {
+        if (cancelled || generation !== requestGeneration.current) return;
+        if (cause instanceof FormsBridgeUnavailableError) {
+          setDeriveState({ kind: "unavailable", message: cause.message });
+        } else {
+          setDeriveState({
+            kind: "error",
+            message: cause instanceof Error ? cause.message : String(cause),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ready, selection, snapshotStore, storeEpoch, wasmDeriveForm]);
+
+  const loadManualJson = () => {
+    try {
+      const parsed = parseFormDescription(manualJson);
+      requestGeneration.current += 1;
+      setSelection(null);
+      setDescription(parsed);
+      setDescriptionOrigin("manual");
+      setManualError(null);
+      setDeriveState({ kind: "idle" });
+    } catch (cause) {
+      setManualError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const chooseFocus = (key: string) => {
+    const focus = resources.find((candidate) => resourceKey(candidate) === key);
+    if (!focus) {
+      setSelection(null);
+      return;
+    }
+    setSelection({ focus, mode: description?.mode ?? selection?.mode ?? "edit" });
+  };
+
+  const onModeRequest = (mode: FormMode) => {
+    if (descriptionOrigin !== "workspace" || selection === null) return;
+    setSelection({ ...selection, mode, shape: description?.shape });
+  };
+
+  const onShapeRequest = (shape: TermRef) => {
+    if (descriptionOrigin !== "workspace" || selection === null) return;
+    setSelection({ ...selection, mode: description?.mode ?? selection.mode, shape });
+  };
+
+  return (
+    <div className="flex h-full flex-col" data-tool-panel="forms">
+      <div className="flex shrink-0 items-center gap-2 border-b bg-card px-3 py-1.5">
+        <FilePenLine className="size-3.5 text-muted-foreground" aria-hidden />
+        <span className="text-xs font-medium text-muted-foreground">Shape-directed form</span>
+        <Badge variant="outline" className="h-5 text-[10px]">
+          Active workspace
+        </Badge>
+        {deriveState.kind === "ready" ? (
+          <Badge variant="muted" className="h-5 text-[10px]" data-form-derive-source>
+            {deriveState.source === "desktop" ? "Tauri" : "WASM"}
+          </Badge>
+        ) : null}
+        <Badge variant="muted" className="h-5 text-[10px]">
+          Draft only · F4 commits
+        </Badge>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
+        <div className="mx-auto max-w-5xl space-y-3">
+          <section className="rounded-md border bg-card p-3" data-form-workspace-source>
+            <div className="flex flex-wrap items-end gap-2">
+              <label className="min-w-64 flex-1 text-[10px] font-medium text-muted-foreground">
+                Focus resource
+                <select
+                  className="mt-1 h-8 w-full rounded-md border bg-background px-2 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  value={selection ? resourceKey(selection.focus) : ""}
+                  onChange={(event) => chooseFocus(event.currentTarget.value)}
+                  aria-label="Focus resource"
+                  disabled={!ready || resources.length === 0}
+                  data-form-focus-picker
+                >
+                  <option value="">
+                    {ready ? "Select a workspace resource…" : "Waiting for the workspace…"}
+                  </option>
+                  {resources.map((resource) => (
+                    <option key={resourceKey(resource)} value={resourceKey(resource)}>
+                      {resource.kind === "bnode" ? `_:${resource.value}` : termLabel(resource)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <p className="pb-1 text-[10px] text-muted-foreground">
+                Data + shapes: current workspace snapshot
+              </p>
+            </div>
+
+            {deriveState.kind === "deriving" ? (
+              <p className="mt-2 flex items-center gap-2 text-xs text-muted-foreground" role="status">
+                <LoaderCircle className="size-3.5 animate-spin" aria-hidden />
+                Deriving the complete form from the active workspace…
+              </p>
+            ) : null}
+            {deriveState.kind === "unavailable" ? (
+              <p
+                className="mt-2 rounded-md border border-warning/30 bg-warning/5 p-2 text-xs text-muted-foreground"
+                role="status"
+                data-form-unavailable
+              >
+                {deriveState.message}
+              </p>
+            ) : null}
+            {deriveState.kind === "error" ? (
+              <p className="mt-2 text-xs text-destructive" role="alert" data-form-derive-error>
+                {deriveState.message}
+              </p>
+            ) : null}
+            {ready && resources.length === 0 ? (
+              <p className="mt-2 text-xs text-muted-foreground" data-form-no-resources>
+                The active workspace has no subject resources to use as a form focus.
+              </p>
+            ) : null}
+          </section>
+
+          <details className="rounded-md border bg-card" data-form-json-source>
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs font-medium [&::-webkit-details-marker]:hidden">
+              <Braces className="size-3.5 text-muted-foreground" aria-hidden />
+              Manual: load FormDescription JSON
+              <span className="ml-auto text-[10px] font-normal text-muted-foreground">
+                Available even when no derivation bridge is installed
+              </span>
+            </summary>
+            <div className="space-y-2 border-t p-3">
+              <textarea
+                value={manualJson}
+                onChange={(event) => setManualJson(event.currentTarget.value)}
+                className="h-48 w-full resize-y rounded-md border bg-background p-2 font-mono text-[10px] outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                aria-label="FormDescription JSON"
+                placeholder="Paste snake_case FormDescription JSON…"
+                spellCheck={false}
+              />
+              <div className="flex items-center gap-2">
+                <Button type="button" size="sm" onClick={loadManualJson} data-load-form-json>
+                  Render JSON
+                </Button>
+                {manualError ? (
+                  <p role="alert" className="text-xs text-destructive">
+                    {manualError}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </details>
+
+          {description ? (
+            <FormRenderer
+              description={description}
+              onDescriptionChange={setDescription}
+              onModeRequest={descriptionOrigin === "workspace" ? onModeRequest : undefined}
+              onShapeRequest={descriptionOrigin === "workspace" ? onShapeRequest : undefined}
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -92,6 +92,12 @@ export interface GraphSummary {
   count: number;
 }
 
+/** [GPT-5.6] sq-3eukz — one subject resource selectable as a Forms focus node. */
+export interface FormResource {
+  kind: "iri" | "bnode";
+  value: string;
+}
+
 /**
  * The SELECT result the workbench renders. A streamed SELECT keeps at most {@link RunOptions.rowCap}
  * rows in JS (so a large result cannot blow the tab's memory); `truncated` records whether the
@@ -356,6 +362,23 @@ export interface EngineContextValue {
   /** True when the native loader IPC is available (inside the Tauri desktop shell). */
   nativeLoaderAvailable: boolean;
   /**
+   * [GPT-5.6] sq-3eukz — enumerate focus-node candidates from the active live store without
+   * routing an internal picker refresh through the user-visible query-run metrics.
+   */
+  listFormResources: () => FormResource[];
+  /**
+   * [GPT-5.6] sq-3eukz — invoke the optional sparq-wasm `Store.deriveForm` method against the
+   * live runtime. Returns `null` when that feature-detected method is absent; otherwise returns
+   * the host's snake_case FormDescription JSON (or throws its derivation error).
+   */
+  wasmDeriveForm: (
+    data: string,
+    shapes: string,
+    focus: string,
+    format: string,
+    optionsJson: string,
+  ) => string | null;
+  /**
    * [OPUS-4.8] sq-tp1m (#757) — the active per-workspace INFERENCE regime (query-time entailment).
    * `"off"` runs plain SPARQL; `"rdfs"` / `"owl-rl"` forward-chain the deductive closure (via the
    * real `sparq-reason` W-reason bundle) so a query matches entailed triples too. This is the
@@ -522,6 +545,11 @@ function fnv1aHash(s: string): number {
 // graphs are folded exactly as the RDFS/OWL-RL reasoner folds them).
 const ALL_TRIPLES_QUERY =
   "SELECT DISTINCT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }";
+
+// [GPT-5.6] sq-3eukz — subjects in either the default or a named graph are the live workspace's
+// focus-resource candidates. Literal objects are intentionally not candidates for SHACL focus.
+const FORM_RESOURCES_QUERY =
+  "SELECT DISTINCT ?resource WHERE { { ?resource ?p ?o } UNION { GRAPH ?g { ?resource ?p ?o } } } ORDER BY ?resource LIMIT 200";
 
 /**
  * [sq-glo5r] Serialise the whole dataset as N-TRIPLES, folding named graphs into the default
@@ -1418,6 +1446,50 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     return storeToNQuads(store);
   }, []);
 
+  // [GPT-5.6] sq-3eukz — picker resources come directly from the current store so every store
+  // epoch (including workspace hydration) can synchronously replace the candidate list.
+  const listFormResources = React.useCallback((): FormResource[] => {
+    const store = storeRef.current;
+    if (!store) return [];
+    const parsed = JSON.parse(store.query(FORM_RESOURCES_QUERY)) as SparqlResults;
+    const resources: FormResource[] = [];
+    for (const binding of parsed.results?.bindings ?? []) {
+      const term = binding["resource"];
+      if (term?.type === "uri") resources.push({ kind: "iri", value: term.value });
+      if (term?.type === "bnode") resources.push({ kind: "bnode", value: term.value });
+    }
+    return resources;
+  }, []);
+
+  // [GPT-5.6] sq-3eukz — structural feature detection keeps the GUI independently buildable
+  // until the opt-in wasm forms binding lands. Preserve the receiver when invoking wasm-bindgen.
+  const wasmDeriveForm = React.useCallback(
+    (
+      data: string,
+      shapes: string,
+      focus: string,
+      format: string,
+      optionsJson: string,
+    ): string | null => {
+      const store = storeRef.current;
+      if (!store) return null;
+      const derive = (
+        store as unknown as {
+          deriveForm?: (
+            data: string,
+            shapes: string,
+            focus: string,
+            format: string,
+            optionsJson: string,
+          ) => string;
+        }
+      ).deriveForm;
+      if (typeof derive !== "function") return null;
+      return derive.call(store, data, shapes, focus, format, optionsJson);
+    },
+    [],
+  );
+
   // [OPUS-4.8] sq-ixc3.13 — whether the native loader IPC is reachable (inside the Tauri shell).
   // Computed once on mount (the runtime never changes mid-session) so the status bar / drawer can
   // label the loader honestly without re-detecting on every render.
@@ -1450,6 +1522,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       exportStore,
       importRdf,
       nativeLoaderAvailable,
+      listFormResources,
+      wasmDeriveForm,
       snapshotStore,
       storeEpoch,
       hydrateFromSnapshot,
@@ -1477,6 +1551,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       exportStore,
       importRdf,
       nativeLoaderAvailable,
+      listFormResources,
+      wasmDeriveForm,
       snapshotStore,
       storeEpoch,
       hydrateFromSnapshot,

--- a/gui/app/src/lib/forms-bridge.test.ts
+++ b/gui/app/src/lib/forms-bridge.test.ts
@@ -1,0 +1,137 @@
+// [GPT-5.6] sq-3eukz — focused host-routing tests for workspace-derived Forms descriptions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deriveFormWith,
+  FormsBridgeUnavailableError,
+  formOptionsJson,
+  type DeriveFormRequest,
+  type FormHostAdapters,
+} from "./forms-bridge.js";
+
+const DATASET =
+  '<http://example.org/alice> <http://example.org/name> "Alice" .';
+const FOCUS = { kind: "iri", value: "http://example.org/alice" } as const;
+const SHAPE = { kind: "iri", value: "http://example.org/PersonShape" } as const;
+const REQUEST: DeriveFormRequest = {
+  data: DATASET,
+  shapes: DATASET,
+  focus: FOCUS,
+  mode: "edit",
+  format: "nquads",
+};
+
+function response(mode = "edit", shape = SHAPE.value): string {
+  return JSON.stringify({
+    focus: FOCUS,
+    mode,
+    shapes: [{ shape: SHAPE, label: "Person", via: "target-class" }],
+    shape: { kind: "iri", value: shape },
+    groups: [
+      {
+        kind: "declared",
+        label: "Profile",
+        fields: [
+          {
+            path: "<http://example.org/name>",
+            label: "Workspace name",
+            multi: false,
+            editable: mode === "edit",
+            widget: { editor: "http://datashapes.org/dash#TextFieldEditor" },
+            values: [{ term: { kind: "literal", value: "Alice" } }],
+            constraints: {},
+          },
+        ],
+      },
+    ],
+  });
+}
+
+test("formOptionsJson emits the host's snake_case mode/shape options", () => {
+  assert.equal(formOptionsJson(REQUEST), '{"mode":"edit"}');
+  assert.equal(
+    formOptionsJson({ ...REQUEST, mode: "view", shape: SHAPE }),
+    '{"mode":"view","shape":"http://example.org/PersonShape"}',
+  );
+});
+
+test("desktop focus/mode/shape request invokes only Tauri with the expected workspace args", async () => {
+  let desktopArgs: Parameters<FormHostAdapters["desktopDerive"]>[0] | undefined;
+  let webCalls = 0;
+  const result = await deriveFormWith(
+    { ...REQUEST, mode: "view", shape: SHAPE },
+    {
+      desktopAvailable: true,
+      desktopDerive: async (args) => {
+        desktopArgs = args;
+        return response("view");
+      },
+      webDerive: () => {
+        webCalls += 1;
+        return response();
+      },
+    },
+  );
+
+  assert.deepEqual(desktopArgs, {
+    dataset: DATASET,
+    shapes: DATASET,
+    format: "nquads",
+    focus: FOCUS.value,
+    mode: "view",
+    shape: SHAPE.value,
+  });
+  assert.equal(webCalls, 0);
+  assert.equal(result.source, "desktop");
+  assert.equal(result.description.groups[0]?.fields[0]?.label, "Workspace name");
+});
+
+test("desktop and web adapter fixtures parse to equivalent FormDescription content", async () => {
+  const json = response();
+  const common = {
+    desktopDerive: async () => json,
+    webDerive: () => json,
+  };
+  const desktop = await deriveFormWith(REQUEST, { ...common, desktopAvailable: true });
+  const web = await deriveFormWith(REQUEST, { ...common, desktopAvailable: false });
+
+  assert.deepEqual(desktop.description, web.description);
+  assert.equal(web.description.focus.value, FOCUS.value);
+  assert.equal(web.description.groups[0]?.fields[0]?.values[0]?.term.value, "Alice");
+});
+
+test("web mode/shape request invokes deriveForm with data, shapes, focus, format, options", async () => {
+  let webArgs: unknown[] | undefined;
+  await deriveFormWith(
+    { ...REQUEST, mode: "view", shape: SHAPE },
+    {
+      desktopAvailable: false,
+      desktopDerive: async () => null,
+      webDerive: (...args) => {
+        webArgs = args;
+        return response("view");
+      },
+    },
+  );
+
+  assert.deepEqual(webArgs, [
+    DATASET,
+    DATASET,
+    FOCUS.value,
+    "nquads",
+    '{"mode":"view","shape":"http://example.org/PersonShape"}',
+  ]);
+});
+
+test("an absent web bridge is explicit and never supplies demo content", async () => {
+  await assert.rejects(
+    () =>
+      deriveFormWith(REQUEST, {
+        desktopAvailable: false,
+        desktopDerive: async () => null,
+        webDerive: () => null,
+      }),
+    FormsBridgeUnavailableError,
+  );
+});

--- a/gui/app/src/lib/forms-bridge.ts
+++ b/gui/app/src/lib/forms-bridge.ts
@@ -1,0 +1,107 @@
+// [GPT-5.6] sq-3eukz — runtime-selected adapters for deriving the Forms tool from the live
+// workspace. Desktop uses the Tauri `derive_form` command; hosted web uses the optional
+// sparq-wasm `Store.deriveForm` method. The adapter never reconstructs FormDescription content.
+
+import { nativeDeriveForm, hasNativeForms } from "./tauri-ipc.js";
+import {
+  parseFormDescription,
+  type FormDescription,
+  type FormMode,
+  type TermRef,
+} from "./form-description.js";
+
+/** The positional sparq-wasm `Store.deriveForm` contract, when that optional method exists. */
+export type WasmDeriveForm = (
+  data: string,
+  shapes: string,
+  focus: string,
+  format: string,
+  optionsJson: string,
+) => string | null;
+
+/** Everything a host needs to derive one whole FormDescription. */
+export interface DeriveFormRequest {
+  data: string;
+  shapes: string;
+  focus: TermRef;
+  mode: FormMode;
+  shape?: TermRef;
+  format?: string;
+}
+
+export interface DeriveFormResult {
+  description: FormDescription;
+  source: "desktop" | "web";
+}
+
+/** Injectable adapter dependencies keep host selection testable before either bridge lands. */
+export interface FormHostAdapters {
+  desktopAvailable: boolean;
+  desktopDerive: typeof nativeDeriveForm;
+  webDerive: WasmDeriveForm;
+}
+
+/** Stable unavailable error so the tool can render a dedicated, explicit state. */
+export class FormsBridgeUnavailableError extends Error {
+  constructor() {
+    super(
+      "Form derivation is unavailable in this build. Load FormDescription JSON manually below.",
+    );
+    this.name = "FormsBridgeUnavailableError";
+  }
+}
+
+function nodeString(term: TermRef): string {
+  return term.kind === "bnode" ? `_:${term.value}` : term.value;
+}
+
+/** The exact snake_case options JSON consumed by sparq-wasm `deriveForm`. */
+export function formOptionsJson(req: DeriveFormRequest): string {
+  return JSON.stringify({
+    mode: req.mode,
+    ...(req.shape ? { shape: nodeString(req.shape) } : {}),
+  });
+}
+
+/**
+ * Route one request to exactly one runtime host and validate its snake_case response. Desktop
+ * never silently falls through to wasm, and web never falls back to demo data.
+ */
+export async function deriveFormWith(
+  req: DeriveFormRequest,
+  adapters: FormHostAdapters,
+): Promise<DeriveFormResult> {
+  const format = req.format ?? "nquads";
+  const focus = nodeString(req.focus);
+
+  if (adapters.desktopAvailable) {
+    const json = await adapters.desktopDerive({
+      dataset: req.data,
+      shapes: req.shapes,
+      format,
+      focus,
+      mode: req.mode,
+      shape: req.shape ? nodeString(req.shape) : undefined,
+    });
+    if (json === null) throw new FormsBridgeUnavailableError();
+    return { description: parseFormDescription(json), source: "desktop" };
+  }
+
+  const json = await Promise.resolve(
+    adapters.webDerive(req.data, req.shapes, focus, format, formOptionsJson(req)),
+  );
+  if (json === null) throw new FormsBridgeUnavailableError();
+  return { description: parseFormDescription(json), source: "web" };
+}
+
+/** Select the runtime host and derive the complete replacement description. */
+export async function deriveForm(
+  req: DeriveFormRequest,
+  webDerive: WasmDeriveForm,
+): Promise<DeriveFormResult> {
+  return deriveFormWith(req, {
+    desktopAvailable: hasNativeForms(),
+    desktopDerive: nativeDeriveForm,
+    webDerive,
+  });
+}

--- a/gui/app/src/lib/tauri-ipc.ts
+++ b/gui/app/src/lib/tauri-ipc.ts
@@ -230,6 +230,30 @@ export async function nativeOdrlPreview(args: {
 }
 
 /**
+ * [GPT-5.6] sq-3eukz — derive a complete snake_case FormDescription through the optional
+ * desktop `derive_form` command. The frontend sends the same live-workspace snapshot as both
+ * `dataset` and `shapes`; mode/shape changes invoke this command again instead of reshaping JSON.
+ * Returns `null` only outside Tauri, where the hosted-web adapter probes sparq-wasm instead.
+ */
+export async function nativeDeriveForm(args: {
+  dataset: string;
+  shapes: string;
+  format: string;
+  focus: string;
+  mode: string;
+  shape?: string;
+}): Promise<string | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  return invoke<string>("derive_form", args);
+}
+
+/** True when the runtime exposes the Tauri invocation adapter used by `derive_form`. */
+export function hasNativeForms(): boolean {
+  return tauriInvoke() !== null;
+}
+
+/**
  * [OPUS-4.8] sq-cno90 (#820 follow-up) — probe the REAL on-disk byte size of the
  * `$APPLOCALDATA/workspaces` tree through the native `disk_usage` command, or `null` outside the
  * desktop shell (the web target has no native FS — the status bar falls back to the snapshot-bytes

--- a/gui/e2e-playwright/specs/forms-tool.spec.ts
+++ b/gui/e2e-playwright/specs/forms-tool.spec.ts
@@ -1,91 +1,70 @@
-// [GPT-5.6] sq-lsp7k.1.2 — desktop-persona F2 journey over the shared renderer chunk.
-import { test, expect } from "../support/index.ts";
+// [GPT-5.6] sq-3eukz — desktop Forms journey over the active workspace + mocked Tauri adapter.
+import { test, expect, readIpcLog } from "../support/index.ts";
+
+const EX = "http://example.org/";
 
 test.describe("forms-tool (desktop persona)", () => {
   test.beforeEach(async ({ page }) => {
     await page.locator('[data-tool="forms"]').click();
     await expect(page.locator('[data-tool-panel="forms"]')).toBeVisible();
+    await expect(page.locator('[data-form-field="Workspace name"]')).toBeVisible();
   });
 
-  test("renders grouped core DASH editors and nested blank-node details", async ({ page }) => {
-    await expect(page.locator('[data-form-group="declared"]')).toHaveCount(3);
-    for (const [label, kind] of [
-      ["Title", "text"], ["Notes", "textarea"], ["Status", "enum"],
-      ["Active", "boolean"], ["Due date", "date"], ["Reviewed at", "datetime"],
-      ["Customer", "iri-ref"], ["Shipping address", "nested"],
-      ["Related blank node", "blank-node"],
-    ] as const) {
-      await expect(page.locator(`[data-form-field="${label}"] [data-field-editor="${kind}"]`)).toBeVisible();
-    }
-    await expect(page.locator('[data-form-field="Shipping address"] [data-nested-form]')).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Street" })).toHaveValue("1 Coyote Way");
+  test("focus, mode, and shape changes re-invoke Tauri with the complete workspace request", async ({
+    page,
+  }) => {
+    const panel = page.locator('[data-tool-panel="forms"]');
+    const picker = panel.locator("[data-form-focus-picker]");
+    await expect(picker.locator("option")).toHaveCount(5);
+
+    await picker.selectOption(JSON.stringify(["iri", `${EX}bob`, null, null]));
+    await expect(panel.locator("[data-form-focus]")).toContainText(`${EX}bob`);
+    await expect(panel.getByRole("textbox", { name: "Workspace name" })).toHaveValue("Bob");
+
+    let calls = (await readIpcLog(page)).filter((entry) => entry.cmd === "derive_form");
+    let args = calls.at(-1)?.args as Record<string, unknown>;
+    expect(args.focus).toBe(`${EX}bob`);
+    expect(args.dataset).toBe(args.shapes);
+    expect(args.format).toBe("nquads");
+    expect(args.mode).toBe("edit");
+    expect(args.shape).toBeUndefined();
+
+    await panel.locator('[data-form-mode-choice="view"]').click();
+    await expect(panel.locator("[data-form-renderer]")).toHaveAttribute("data-form-mode", "view");
+    calls = (await readIpcLog(page)).filter((entry) => entry.cmd === "derive_form");
+    args = calls.at(-1)?.args as Record<string, unknown>;
+    expect(args.focus).toBe(`${EX}bob`);
+    expect(args.mode).toBe("view");
+    expect(args.shape).toBe(`${EX}PersonShape`);
+
+    await panel.locator("[data-form-shape-switcher]").selectOption({ label: "Auditable" });
+    await expect
+      .poll(async () => {
+        const log = (await readIpcLog(page)).filter((entry) => entry.cmd === "derive_form");
+        return (log.at(-1)?.args as Record<string, unknown>)?.shape;
+      })
+      .toBe(`${EX}AuditableShape`);
   });
 
-  test("cardinality, widget switching and view/edit mode are functional", async ({ page }) => {
-    const title = page.locator('[data-form-field="Title"]');
-    const titleWidget = title.locator("[data-widget-switcher]");
-    await titleWidget.selectOption({ label: "TextAreaEditor" });
-    await title.getByRole("textbox", { name: "Title" }).fill("Edited with alternate widget");
-    await expect(titleWidget).toHaveValue("http://datashapes.org/dash#TextAreaEditor");
-    await expect(title.locator('[data-field-editor="textarea"]')).toBeVisible();
-    await expect(title.getByRole("textbox", { name: "Title" })).toHaveValue("Edited with alternate widget");
-
-    const notes = page.locator('[data-form-field="Notes"]');
-    await expect(notes.locator("textarea")).toHaveCount(1);
-    await notes.locator("[data-add-value]").click();
-    await expect(notes.locator("textarea")).toHaveCount(2);
-    await expect(page.locator('[data-form-field="Title"] [data-add-value]')).toHaveCount(0);
-
-    await page.locator('[data-form-mode-choice="view"]').click();
-    await expect(page.locator('[data-form-renderer]').first()).toHaveAttribute("data-form-mode", "view");
-    await expect(page.locator('[data-form-field="Title"] [data-field-editor]')).toHaveCount(0);
-    await page.locator('[data-form-field="Title"] [data-widget-switcher]').selectOption({ label: "ValueTableViewer" });
-    await expect(page.locator('[data-form-field="Title"] [data-value-table]')).toBeVisible();
-
-    await page.locator('[data-form-field="Customer"] [data-widget-switcher]').selectOption({ label: "HyperlinkViewer" });
-    await expect(page.locator('[data-form-field="Customer"] a')).toHaveAttribute("href", "http://example.org/acme");
+  test("desktop host fixture renders the shared FormDescription content", async ({ page }) => {
+    const panel = page.locator('[data-tool-panel="forms"]');
+    await expect(panel.locator('[data-form-derive-source]')).toContainText("Tauri");
+    await expect(panel.locator('[data-form-group="declared"]')).toContainText("Workspace profile");
+    await expect(panel.getByRole("textbox", { name: "Workspace name" })).toHaveValue("Alice");
   });
 
-  test("shape changes are surfaced to the host for F1 re-derivation", async ({ page }) => {
-    await page.locator("[data-form-shape-switcher]").selectOption({ label: "Auditable item" });
-    const request = page.locator('[data-tool-panel="forms"] p[role="status"]');
-    await expect(request).toContainText("AuditableShape");
-    await expect(request).toContainText("re-derive");
-  });
-
-  test("xsd:boolean numeric lexicals display and update canonically", async ({ page }) => {
-    await page.locator("[data-form-json-source]").evaluate((details: HTMLDetailsElement) => {
+  test("manual JSON remains available and malformed input does not replace the host form", async ({
+    page,
+  }) => {
+    const panel = page.locator('[data-tool-panel="forms"]');
+    await panel.locator("[data-form-json-source]").evaluate((details: HTMLDetailsElement) => {
       details.open = true;
     });
-    const editor = page.getByRole("textbox", { name: "FormDescription JSON" });
-    const description = JSON.parse(await editor.inputValue());
-    const active = description.groups
-      .flatMap((group: { fields: { label: string; values: { term: { value: string } }[] }[] }) => group.fields)
-      .find((field: { label: string }) => field.label === "Active");
-    active.values[0].term.value = "1";
-    await editor.fill(JSON.stringify(description));
-    await page.locator("[data-load-form-json]").click();
-
-    const boolean = page.locator('[data-form-field="Active"] select[aria-label="Active"]');
-    await expect(boolean).toHaveValue("true");
-    await boolean.selectOption("false");
-    await expect(boolean).toHaveValue("false");
-  });
-
-  test("malformed field JSON reports a path and leaves the current form mounted", async ({ page }) => {
-    await page.locator("[data-form-json-source]").evaluate((details: HTMLDetailsElement) => {
-      details.open = true;
-    });
-    const malformed = {
-      focus: { kind: "iri", value: "urn:focus" },
-      mode: "edit",
-      shapes: [],
-      groups: [{ kind: "default", fields: [{}] }],
-    };
-    await page.getByRole("textbox", { name: "FormDescription JSON" }).fill(JSON.stringify(malformed));
-    await page.locator("[data-load-form-json]").click();
-    await expect(page.locator('[data-tool-panel="forms"] p[role="alert"]')).toContainText("groups[0].fields[0].path");
-    await expect(page.locator("[data-form-renderer]").first()).toBeVisible();
-    await expect(page.locator("[data-form-focus]")).toContainText("order42");
+    await panel
+      .getByRole("textbox", { name: "FormDescription JSON" })
+      .fill('{"mode":"edit","groups":[],"shapes":[]}');
+    await panel.locator("[data-load-form-json]").click();
+    await expect(panel.getByRole("alert")).toContainText("focus");
+    await expect(panel.locator("[data-form-focus]")).toContainText(`${EX}alice`);
   });
 });

--- a/gui/e2e-playwright/specs/forms-tool.web.spec.ts
+++ b/gui/e2e-playwright/specs/forms-tool.web.spec.ts
@@ -1,12 +1,82 @@
-// [GPT-5.6] sq-lsp7k.1.2 — hosted-web persona proves the same F2 chunk without Tauri globals.
-import { webTest as test, webExpect as expect } from "../support/index.ts";
+// [GPT-5.6] sq-3eukz — hosted-web Forms journeys: explicit absence and structural wasm adapter.
+import {
+  webTest as test,
+  webExpect as expect,
+  waitForEngineReady,
+} from "../support/index.ts";
+import { wasmFormsMockScript } from "../support/forms-mock.ts";
 
-test("shared Forms renderer works in the hosted web persona", async ({ page }) => {
+const EX = "http://example.org/";
+
+test("an absent wasm bridge is explicit, keeps manual JSON, and never renders demo data", async ({
+  page,
+}) => {
   await page.locator('[data-tool="forms"]').click();
   const panel = page.locator('[data-tool-panel="forms"]');
-  await expect(panel).toBeVisible();
-  await expect(panel.locator('[data-form-field="Status"] [data-field-editor="enum"]')).toBeVisible();
-  await expect(panel.locator('[data-form-field="Shipping address"] [data-nested-form]')).toBeVisible();
+  await expect(panel.locator("[data-form-unavailable]")).toContainText(
+    "Form derivation is unavailable",
+  );
+  await expect(panel.locator("[data-form-renderer]")).toHaveCount(0);
+
+  await panel.locator("[data-form-json-source]").evaluate((details: HTMLDetailsElement) => {
+    details.open = true;
+  });
+  await expect(panel.getByRole("textbox", { name: "FormDescription JSON" })).toHaveValue("");
+  await expect(panel.getByText("order42", { exact: false })).toHaveCount(0);
+});
+
+test("mocked sparq-wasm derives the same content and receives focus/mode/shape requests", async ({
+  page,
+}) => {
+  await page.addInitScript(wasmFormsMockScript);
+  await page.reload();
+  await waitForEngineReady(page);
+  await page.locator('[data-tool="forms"]').click();
+
+  const panel = page.locator('[data-tool-panel="forms"]');
+  await expect(panel.getByRole("textbox", { name: "Workspace name" })).toHaveValue("Alice");
+  await expect(panel.locator('[data-form-derive-source]')).toContainText("WASM");
+  await expect(panel.locator('[data-form-group="declared"]')).toContainText("Workspace profile");
+
+  await panel
+    .locator("[data-form-focus-picker]")
+    .selectOption(JSON.stringify(["iri", `${EX}carol`, null, null]));
+  await expect(panel.locator("[data-form-focus]")).toContainText(`${EX}carol`);
+  await expect(panel.getByRole("textbox", { name: "Workspace name" })).toHaveValue("Carol");
   await panel.locator('[data-form-mode-choice="view"]').click();
-  await expect(panel.locator('[data-form-field="Customer"] [data-field-viewer="label"]')).toContainText("acme");
+  await expect(panel.locator("[data-form-renderer]")).toHaveAttribute("data-form-mode", "view");
+  await panel.locator("[data-form-shape-switcher]").selectOption({ label: "Auditable" });
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const log = (
+          window as unknown as {
+            __SPARQ_FORMS_WASM_LOG__: Array<{
+              data: string;
+              shapes: string;
+              focus: string;
+              format: string;
+              optionsJson: string;
+            }>;
+          }
+        ).__SPARQ_FORMS_WASM_LOG__;
+        return log.at(-1);
+      }),
+    )
+    .toMatchObject({
+      focus: `${EX}carol`,
+      format: "nquads",
+      optionsJson: JSON.stringify({ mode: "view", shape: `${EX}AuditableShape` }),
+    });
+
+  const last = await page.evaluate(() => {
+    const log = (
+      window as unknown as {
+        __SPARQ_FORMS_WASM_LOG__: Array<{ data: string; shapes: string }>;
+      }
+    ).__SPARQ_FORMS_WASM_LOG__;
+    return log.at(-1);
+  });
+  expect(last?.data).toBe(last?.shapes);
 });

--- a/gui/e2e-playwright/support/forms-mock.ts
+++ b/gui/e2e-playwright/support/forms-mock.ts
@@ -1,0 +1,57 @@
+// [GPT-5.6] sq-3eukz — one deterministic FormDescription factory shared by the mocked Tauri
+// command and the structurally mocked sparq-wasm method. Both hosts therefore render equivalent
+// content while still echoing focus/mode/shape so re-derivation assertions are non-vacuous.
+
+export const formsMockPrelude = `
+  function formsMockDescription(focus, mode, selectedShape) {
+    var EX = "http://example.org/";
+    var DASH = "http://datashapes.org/dash#";
+    var shape = selectedShape || EX + "PersonShape";
+    var local = String(focus || "").split(/[\\/#]/).filter(Boolean).pop() || "resource";
+    var label = local.charAt(0).toUpperCase() + local.slice(1);
+    return JSON.stringify({
+      focus: { kind: "iri", value: focus },
+      mode: mode,
+      shapes: [
+        { shape: { kind: "iri", value: EX + "PersonShape" }, label: "Person", via: "target-class" },
+        { shape: { kind: "iri", value: EX + "AuditableShape" }, label: "Auditable", via: "applicable-to-class" }
+      ],
+      shape: { kind: "iri", value: shape },
+      groups: [{
+        kind: "declared",
+        label: "Workspace profile",
+        fields: [{
+          path: "<" + EX + "name>",
+          label: "Workspace name",
+          multi: false,
+          editable: mode === "edit",
+          widget: {
+            editor: mode === "edit" ? DASH + "TextFieldEditor" : undefined,
+            viewer: DASH + "LiteralViewer"
+          },
+          values: [{ term: { kind: "literal", value: label } }],
+          constraints: {}
+        }]
+      }]
+    });
+  }
+`;
+
+/** Install a non-enumerable mock method where every wasm-bindgen Store can structurally see it. */
+export const wasmFormsMockScript = `
+(function () {
+  "use strict";
+  ${formsMockPrelude}
+  var LOG = [];
+  Object.defineProperty(Object.prototype, "deriveForm", {
+    configurable: true,
+    enumerable: false,
+    value: function (data, shapes, focus, format, optionsJson) {
+      var options = JSON.parse(optionsJson || "{}");
+      LOG.push({ data: data, shapes: shapes, focus: focus, format: format, optionsJson: optionsJson });
+      return formsMockDescription(focus, options.mode || "edit", options.shape);
+    }
+  });
+  window.__SPARQ_FORMS_WASM_LOG__ = LOG;
+})();
+`;

--- a/gui/e2e-playwright/support/tauri-mock.ts
+++ b/gui/e2e-playwright/support/tauri-mock.ts
@@ -22,6 +22,8 @@
 //                      prohibition flipped, bob's + the ungated pane keep it)
 //   (any other cmd)  → throws Error (catches unexpected IPC surface drift)
 
+import { formsMockPrelude } from "./forms-mock.ts";
+
 /** The script string injected via page.addInitScript before the page's own scripts run. */
 export const tauriMockScript: string = `
 (function () {
@@ -35,6 +37,7 @@ export const tauriMockScript: string = `
     count: 1,
     format: "turtle"
   };
+  ${formsMockPrelude}
   // The LOG accumulates every invoke call so tests can assert the IPC contract.
   var LOG = [];
 
@@ -92,6 +95,11 @@ export const tauriMockScript: string = `
         if (cmd === "disk_usage")        return Promise.resolve(DISK_FIXTURE);
         if (cmd === "load_text")         return Promise.resolve(LOAD_FIXTURE);
         if (cmd === "load_path")         return Promise.resolve(LOAD_FIXTURE);
+        if (cmd === "derive_form")       return Promise.resolve(formsMockDescription(
+          args && args.focus,
+          (args && args.mode) || "edit",
+          args && args.shape
+        ));
         if (cmd === "plugin:dialog|open") return Promise.resolve("/tmp/test.ttl");
         if (cmd === "query_service") {
           var allow = (args && args.allow) || [];


### PR DESCRIPTION
> 🤖 SPARQ agent

Replaces the Forms operational demo default with focus resources enumerated from the active live workspace. Focus, mode, shape, and store-epoch changes now send the same serialized workspace snapshot through a runtime-selected Tauri derive_form or structurally detected sparq-wasm deriveForm adapter, validate the snake_case response, and replace the whole FormDescription. When neither bridge exists, the panel shows an explicit unavailable state and retains a separate manual JSON loader without demo fallback.

Adds focused unit coverage plus shared desktop/web adapter fixtures and Playwright journeys for request arguments, equivalent rendering, re-derivation, manual loading, and unavailable behavior. This child is GUI-only; no Rust or wasm backend bridge implementation is included.

Gates:
- npm run build:web — pass
- npm run build:tauri — pass
- npm run lint — pass (two pre-existing treeitem aria-selected warnings outside this change)
- gui/app npm run typecheck — pass
- gui/app npm run test:unit — pass (111 tests)
- gui/e2e-playwright npm run typecheck — pass
- focused Forms Playwright desktop + web journeys — pass (5 tests)