### PR TITLE
ci(sparq-mcp): gate solid plus jsonld composition (sq-19f1i) [GPT-5.6]

### DIFF
--- a/.github/feature-matrix.d/sparq-mcp.yml
+++ b/.github/feature-matrix.d/sparq-mcp.yml
@@ -53,6 +53,14 @@
   features: "solid"
   test: true
 
+# [GPT-5.6] sq-19f1i: retain the solid-only leg above to execute the
+# `not(feature = "jsonld")` behavior, and separately gate the composed feature
+# state that accepts and ingests JSON-LD for Solid resources.
+- name: "sparq-mcp (solid, jsonld — pod CRUD with JSON-LD resource ingestion)"
+  crate: "sparq-mcp"
+  features: "solid,jsonld"
+  test: true
+
 # [FABLE-5] sq-lsp7k.10: the template + full-text-search tool surfaces. `templates`
 # (template_list / template_invoke over sparq-engine's `templates` module — typed
 # fail-closed JSON binding; UPDATE templates behind the same allow_update gate as the raw


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds a required `sparq-mcp` feature-matrix leg for `solid,jsonld` while preserving the existing `solid`-only leg, so CI executes both sides of the JSON-LD cfg composition.

Gates passed:
- `cargo nextest list -p sparq-mcp --features solid,jsonld` includes `rdf_format_accepts_jsonld_when_feature_on` and `resource_put_ingests_jsonld_into_the_named_resource_graph`
- `cargo build`, `cargo test`, and strict all-targets `cargo clippy` passed with `--features solid`
- `cargo build`, `cargo test`, and strict all-targets `cargo clippy` passed with `--features solid,jsonld`
- feature-matrix assembly validation passed