### PR TITLE
feat(gui): expose native workspace form derivation over Tauri IPC (sq-1cnox) [GPT-5.6]

### DIFF
--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -1112,9 +1112,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3364,15 +3366,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sparq-forms"
+version = "0.1.0"
+dependencies = [
+ "getrandom 0.3.4",
+ "oxrdf",
+ "serde",
+ "sparq-core",
+ "sparq-shacl",
+]
+
+[[package]]
 name = "sparq-gui"
 version = "0.1.0"
 dependencies = [
  "bzip2",
  "flate2",
+ "oxrdf",
  "serde",
  "serde_json",
  "sparq-core",
  "sparq-engine",
+ "sparq-forms",
  "sparq-hdt",
  "sparq-policy",
  "sparq-solid",
@@ -3418,6 +3433,19 @@ dependencies = [
  "rustc-hash",
  "sparq-core",
  "sparq-substrate",
+]
+
+[[package]]
+name = "sparq-shacl"
+version = "0.1.0"
+dependencies = [
+ "oxrdf",
+ "oxttl",
+ "regex",
+ "rustc-hash",
+ "spargebra",
+ "sparq-core",
+ "sparq-engine",
 ]
 
 [[package]]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -70,6 +70,11 @@ federation = ["sparq-engine/service"]
 # honestly to a native-only message in the browser). Lean builds register a stub that fails
 # loudly with a rebuild hint (odrl.rs).
 odrl = ["dep:sparq-policy", "dep:sparq-solid"]
+# [GPT-5.6] sq-1cnox — native SHACL-to-form derivation for the Forms tool. OFF by
+# default so the standalone desktop shell stays lean unless a release explicitly
+# opts into the sparq-forms + SHACL model stack. Lean builds still register the
+# command, whose stub returns an actionable unavailable error (forms.rs).
+forms = ["dep:oxrdf", "dep:sparq-forms"]
 # [FABLE-5] sq-t6492 — embed + serve the frontendDist static export instead of connecting to
 # `devUrl` (http://localhost:3001). Tauri's build script sets `cfg(dev) = !custom-protocol`
 # (tauri build.rs: `let dev = !custom_protocol`), and in dev mode the webview navigates to
@@ -117,6 +122,12 @@ sparq-hdt = { path = "../../crates/sparq-hdt", optional = true }
 # by the `odrl-bridge` materialization). Pulled in only under this crate's `odrl` feature.
 sparq-policy = { path = "../../crates/sparq-policy", optional = true }
 sparq-solid = { path = "../../crates/sparq-solid", features = ["odrl-bridge"], optional = true }
+
+# [GPT-5.6] sq-1cnox — optional native Forms bridge. oxrdf is named directly because the
+# Tauri boundary validates the serialized focus/shape nodes into typed RDF terms before it
+# calls sparq_forms::derive_form; neither dependency enters the default desktop build.
+oxrdf = { version = "0.3", features = ["rdf-12"], optional = true }
+sparq-forms = { path = "../../crates/sparq-forms", optional = true }
 
 # [OPUS-4.8] sq-ixc3.13 — streaming decompression for the native disk loader: gzip + bzip2 +
 # zstd, the SAME codec matrix the CLI's `open_reader` handles (crates/sparq-cli/src/main.rs).

--- a/gui/src-tauri/src/forms.rs
+++ b/gui/src-tauri/src/forms.rs
@@ -1,0 +1,210 @@
+// [GPT-5.6] sq-1cnox — feature-gated native workspace FormDescription derivation.
+//
+// The webview sends serialized snapshots of the active workspace's data and shapes graphs,
+// plus an RDF focus node, mode, and optional explicit shape. Feature-on builds parse those
+// inputs, call sparq_forms::derive_form, and return its serde JSON verbatim. Feature-off
+// builds keep the same registered Tauri command but fail loudly with a rebuild hint; they
+// never substitute a demo or fabricated description.
+
+/// Derive one complete `sparq_forms::FormDescription` from the active workspace snapshots.
+///
+/// `dataset` and `shapes` use `format` (the operational GUI sends N-Quads). `focus` and
+/// `shape` are structured RDF-node strings: an absolute IRI or a `_:`-prefixed blank-node
+/// label. `mode` is `"edit"` or `"view"`. The returned string is the direct serde JSON for
+/// the native description; the frontend must not reconstruct keys, groups, or widgets.
+#[tauri::command]
+pub fn derive_form(
+    dataset: String,
+    shapes: String,
+    format: String,
+    focus: String,
+    mode: String,
+    shape: Option<String>,
+) -> Result<String, String> {
+    run_derive_form(&dataset, &shapes, &format, &focus, &mode, shape.as_deref())
+}
+
+#[cfg(feature = "forms")]
+fn run_derive_form(
+    dataset: &str,
+    shapes: &str,
+    format: &str,
+    focus: &str,
+    mode: &str,
+    shape: Option<&str>,
+) -> Result<String, String> {
+    use sparq_forms::{FormOptions, Mode};
+
+    let data = sparq_core::Graph::load_dataset(dataset, format).map_err(|error| {
+        format!("Could not parse the workspace data graph as {format}: {error}")
+    })?;
+    let shapes = sparq_core::Graph::load_dataset(shapes, format).map_err(|error| {
+        format!("Could not parse the workspace shapes graph as {format}: {error}")
+    })?;
+    let focus = parse_node(focus, "focus")?;
+    let mode = match mode {
+        "edit" => Mode::Edit,
+        "view" => Mode::View,
+        other => {
+            return Err(format!(
+                "Unsupported form mode {other:?}; expected \"edit\" or \"view\"."
+            ));
+        }
+    };
+    let shape = shape.map(|value| parse_node(value, "shape")).transpose()?;
+    let options = FormOptions {
+        mode,
+        shape,
+        ..FormOptions::default()
+    };
+    let description = sparq_forms::derive_form(&data, &shapes, &focus, &options);
+    serde_json::to_string(&description)
+        .map_err(|error| format!("Could not serialize the derived form description: {error}"))
+}
+
+#[cfg(feature = "forms")]
+fn parse_node(value: &str, field: &str) -> Result<oxrdf::Term, String> {
+    if let Some(label) = value.strip_prefix("_:") {
+        return oxrdf::BlankNode::new(label)
+            .map(oxrdf::Term::from)
+            .map_err(|error| format!("Invalid {field} blank node {value:?}: {error}"));
+    }
+    oxrdf::NamedNode::new(value)
+        .map(oxrdf::Term::from)
+        .map_err(|error| format!("Invalid {field} IRI {value:?}: {error}"))
+}
+
+/// Lean-build stub: form derivation is absent, so report an actionable unavailable state
+/// instead of returning a no-op or demo FormDescription.
+#[cfg(not(feature = "forms"))]
+fn run_derive_form(
+    _dataset: &str,
+    _shapes: &str,
+    _format: &str,
+    _focus: &str,
+    _mode: &str,
+    _shape: Option<&str>,
+) -> Result<String, String> {
+    Err(
+        "Form derivation is unavailable in this build — rebuild the desktop app with \
+         `cargo build --features forms` to enable the native forms bridge."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "forms")]
+    const DATA: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice a ex:Person ; ex:name "Alice" ; ex:audit "reviewed" .
+    "#;
+
+    #[cfg(feature = "forms")]
+    const SHAPES: &str = r#"
+        @prefix ex: <http://example.org/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+
+        ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:name "Person" ;
+            sh:property [ sh:path ex:name ; sh:name "Name" ; sh:minCount 1 ] .
+
+        ex:AuditShape a sh:NodeShape ;
+            sh:name "Audit" ;
+            sh:property [ sh:path ex:audit ; sh:name "Audit status" ] .
+    "#;
+
+    #[cfg(feature = "forms")]
+    fn direct_description(mode: sparq_forms::Mode, shape: Option<&str>) -> String {
+        let data = sparq_core::Graph::load_dataset(DATA, "turtle").expect("data fixture parses");
+        let shapes =
+            sparq_core::Graph::load_dataset(SHAPES, "turtle").expect("shapes fixture parses");
+        let focus = oxrdf::Term::from(oxrdf::NamedNode::new_unchecked("http://example.org/alice"));
+        let options = sparq_forms::FormOptions {
+            mode,
+            shape: shape.map(|iri| oxrdf::Term::from(oxrdf::NamedNode::new_unchecked(iri))),
+            ..sparq_forms::FormOptions::default()
+        };
+        serde_json::to_string(&sparq_forms::derive_form(&data, &shapes, &focus, &options))
+            .expect("direct FormDescription serializes")
+    }
+
+    #[test]
+    #[cfg(feature = "forms")]
+    fn applicable_shape_edit_and_view_match_direct_serialization() {
+        for (mode_text, mode) in [
+            ("edit", sparq_forms::Mode::Edit),
+            ("view", sparq_forms::Mode::View),
+        ] {
+            let actual = run_derive_form(
+                DATA,
+                SHAPES,
+                "turtle",
+                "http://example.org/alice",
+                mode_text,
+                None,
+            )
+            .expect("applicable shape derives");
+            assert_eq!(actual, direct_description(mode, None));
+
+            let json: serde_json::Value =
+                serde_json::from_str(&actual).expect("bridge returns JSON");
+            assert_eq!(json["mode"], mode_text);
+            assert_eq!(json["shape"]["value"], "http://example.org/PersonShape");
+            assert_eq!(json["groups"][0]["fields"][0]["label"], "Name");
+            assert_eq!(
+                json["groups"][0]["fields"][0]["editable"],
+                mode_text == "edit"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "forms")]
+    fn explicit_shape_request_matches_direct_serialization() {
+        const AUDIT_SHAPE: &str = "http://example.org/AuditShape";
+        let actual = run_derive_form(
+            DATA,
+            SHAPES,
+            "turtle",
+            "http://example.org/alice",
+            "edit",
+            Some(AUDIT_SHAPE),
+        )
+        .expect("explicit shape derives");
+        assert_eq!(
+            actual,
+            direct_description(sparq_forms::Mode::Edit, Some(AUDIT_SHAPE))
+        );
+
+        let json: serde_json::Value = serde_json::from_str(&actual).expect("bridge returns JSON");
+        assert_eq!(json["shape"]["value"], AUDIT_SHAPE);
+        assert_eq!(json["shapes"][0]["via"], "explicit");
+        assert_eq!(json["groups"][0]["fields"][0]["label"], "Audit status");
+    }
+
+    #[test]
+    #[cfg(not(feature = "forms"))]
+    fn lean_build_returns_actionable_unavailable_error() {
+        let result = run_derive_form(
+            "not parsed by the stub",
+            "nor are shapes",
+            "nquads",
+            "http://example.org/alice",
+            "edit",
+            None,
+        );
+        let error = result.expect_err("lean build must not fabricate a FormDescription");
+        assert!(
+            error.contains("unavailable"),
+            "error must name the state: {error}"
+        );
+        assert!(
+            error.contains("--features forms"),
+            "error must explain how to enable the bridge: {error}"
+        );
+    }
+}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ mod disk;
 mod engine;
 mod explain;
 mod federation;
+mod forms;
 mod odrl;
 
 use engine::EngineState;
@@ -75,6 +76,11 @@ pub fn run() {
             // pins the STRICT EMPTY egress allowlist so an ANALYZE of a SERVICE-bearing
             // query is refused pre-HTTP, never dialed (explain.rs).
             explain::explain_native,
+            // [GPT-5.6] sq-1cnox — derive the Forms tool's complete serde FormDescription
+            // from serialized snapshots of the active workspace. The sparq-forms stack is
+            // default-OFF behind the `forms` feature; lean builds register the same command
+            // name but return an actionable unavailable error instead of demo content.
+            forms::derive_form,
             // [FABLE-5] sq-ixc3.15 — the ODRL policy tool's ONE native command: parse/validate
             // a Turtle ODRL policy, evaluate the (party, action, target) request, materialize
             // the policy through the odrl-bridge, and run the SAME query per requester through


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds a default-off forms feature to sparq-gui and registers a native derive_form Tauri command. Feature-on builds parse the active workspace data/shapes snapshots, validate focus and optional shape RDF nodes, call sparq_forms::derive_form, and return the direct serde FormDescription JSON. Lean builds retain the command name but return an actionable unavailable error with no fabricated result.

Crate-local acceptance tests compare edit, view, and explicit-shape responses byte-for-byte with direct FormDescription serialization and assert meaningful rendered fields.

Gates passed:
- cargo test --no-default-features
- cargo test --no-default-features --features forms
- cargo clippy -p sparq-gui --all-targets --no-default-features -- -D warnings
- cargo clippy -p sparq-gui --all-targets --no-default-features --features forms -- -D warnings
- rustfmt --edition 2021 --check gui/src-tauri/src/forms.rs