### PR TITLE
ci(server): publish multi-arch GHCR image (sq-fvzi6) [GPT-5.6]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,6 +582,12 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # [GPT-5.6] sq-fvzi6: register the arm64 binfmt emulator before Buildx so the final
+      # release push can build both target platforms on this native amd64 runner.
+      - name: Set up QEMU for arm64
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Log in to ghcr.io
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -608,6 +614,9 @@ jobs:
           context: .
           load: true
           push: false
+          # [GPT-5.6] sq-fvzi6: keep the pre-push runtime and Trivy gate native/loadable;
+          # the final step reuses this amd64 cache and adds the arm64 descriptor.
+          platforms: linux/amd64
           tags: sparq-server:smoke
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -661,6 +670,9 @@ jobs:
         with:
           context: .
           push: true
+          # [GPT-5.6] sq-fvzi6: one OCI image index per metadata tag, with both supported
+          # runtime descriptors. Buildx pushes the index only after both builds succeed.
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/scripts/tests/test_release_container_multiarch.py
+++ b/scripts/tests/test_release_container_multiarch.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# [GPT-5.6] sq-fvzi6: hermetic regression test for the sparq-server release image contract.
+#
+# The workflow itself is the executable publication surface, so this test parses its docker
+# job and pins the load-bearing shape: QEMU before Buildx, a native load/smoke/Trivy gate,
+# semver/minor/latest tags, and one amd64+arm64 push with SBOM + provenance. The mutation test
+# proves the platform assertion is non-vacuous.
+#
+# Run: python3 scripts/tests/test_release_container_multiarch.py
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _step_named(steps: list[dict], name: str) -> tuple[int, dict]:
+    """Return one named workflow step and fail if the contract is absent or ambiguous."""
+    matches = [(index, step) for index, step in enumerate(steps) if step.get("name") == name]
+    assert len(matches) == 1, f"expected exactly one {name!r} step, found {len(matches)}"
+    return matches[0]
+
+
+def assert_release_container_contract(workflow_text: str) -> None:
+    """Assert the release job emits the documented multi-platform image without losing gates."""
+    workflow = yaml.safe_load(workflow_text)
+    steps = workflow["jobs"]["docker"]["steps"]
+
+    qemu_index, qemu = _step_named(steps, "Set up QEMU for arm64")
+    buildx_indices = [
+        index
+        for index, step in enumerate(steps)
+        if str(step.get("uses", "")).startswith("docker/setup-buildx-action@")
+    ]
+    assert len(buildx_indices) == 1, "release docker job must set up Buildx exactly once"
+    assert qemu_index < buildx_indices[0], "QEMU must be registered before Buildx"
+    assert re.fullmatch(
+        r"docker/setup-qemu-action@[0-9a-f]{40}", qemu.get("uses", "")
+    ), "QEMU action must be pinned to a full commit SHA"
+    assert qemu.get("with", {}).get("platforms") == "arm64"
+
+    _, metadata = _step_named(steps, "Image metadata (tags + OCI labels from the git tag)")
+    tags = set(metadata["with"]["tags"].splitlines())
+    assert tags == {
+        "type=semver,pattern={{version}}",
+        "type=semver,pattern={{major}}.{{minor}}",
+        "type=raw,value=latest",
+    }, "release image tags must preserve full semver, major.minor, and latest"
+
+    _, smoke = _step_named(steps, "Build image for smoke test (load locally)")
+    smoke_with = smoke["with"]
+    assert smoke_with.get("load") is True and smoke_with.get("push") is False
+    assert smoke_with.get("platforms") == "linux/amd64"
+    assert smoke_with.get("tags") == "sparq-server:smoke"
+
+    _, smoke_run = _step_named(steps, "Smoke test the image (docker run + /health + ASK query)")
+    assert smoke_run.get("run") == "scripts/docker-smoke.sh sparq-server:smoke 3030"
+
+    _, trivy = _step_named(
+        steps, "Trivy scan released image (fail on fixable HIGH/CRITICAL)"
+    )
+    assert trivy["with"].get("image-ref") == "sparq-server:smoke"
+    assert trivy["with"].get("exit-code") == "1", "Trivy release scan must remain gating"
+
+    _, push = _step_named(steps, "Build and push")
+    push_with = push["with"]
+    assert push_with.get("push") is True
+    platforms = {value.strip() for value in push_with.get("platforms", "").split(",")}
+    assert platforms == {"linux/amd64", "linux/arm64"}
+    assert push_with.get("tags") == "${{ steps.meta.outputs.tags }}"
+    assert push_with.get("labels") == "${{ steps.meta.outputs.labels }}"
+    assert push_with.get("provenance") == "mode=max"
+    assert push_with.get("sbom") is True
+
+
+class ReleaseContainerMultiarch(unittest.TestCase):
+    def test_live_release_workflow_has_multiarch_manifest_and_native_gates(self):
+        assert_release_container_contract(WORKFLOW.read_text(encoding="utf-8"))
+
+    def test_dropping_arm64_descriptor_fails_contract(self):
+        original = WORKFLOW.read_text(encoding="utf-8")
+        mutated = original.replace(
+            "platforms: linux/amd64,linux/arm64", "platforms: linux/amd64", 1
+        )
+        self.assertNotEqual(mutated, original, "mutation fixture did not alter the workflow")
+        with self.assertRaises(AssertionError):
+            assert_release_container_contract(mutated)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -877,11 +877,14 @@ resource applies an atomic modify to the addressed graph, with two body dialects
   feature-on adds NO new crate. Success → `204`. `PATCH` is a WRITE, gated by `--auth-token` like an
   UPDATE.
 
-**5b. Container (ghcr.io).** Published on every release tag (`ghcr.io/jeswr/sparq-server`,
-distroless). The image sets `SPARQ_ALLOW_REMOTE=1` so the `0.0.0.0` bind it needs (loopback
-is unreachable through Docker's port map) boots out of the box — running the container is the
-operator's explicit choice to publish a surface. **This default has NO auth.** Because every
-`SPARQ_*` var is read from the environment, secure it with `-e` (no flag wiring):
+**5b. Container (ghcr.io).** Published on every `vX.Y.Z` release tag as a distroless OCI image
+index at `ghcr.io/jeswr/sparq-server`, with `linux/amd64` and `linux/arm64` runtime images.
+[GPT-5.6] `sq-fvzi6`: each release publishes `:X.Y.Z` (pin this for reproducible deployments),
+`:X.Y` (tracks the newest patch in that minor line), and `:latest` (tracks the newest release);
+an omitted tag selects `:latest`. The image sets `SPARQ_ALLOW_REMOTE=1` so the `0.0.0.0` bind it
+needs (loopback is unreachable through Docker's port map) boots out of the box — running the
+container is the operator's explicit choice to publish a surface. **This default has NO auth.**
+Because every `SPARQ_*` var is read from the environment, secure it with `-e` (no flag wiring):
 
 ```sh
 docker run --rm -p 3030:3030 ghcr.io/jeswr/sparq-server                       # empty graph, no auth


### PR DESCRIPTION
> 🤖 SPARQ agent

Publish each sparq-server release tag as one GHCR OCI image index with linux/amd64 and linux/arm64 descriptors while preserving the full-semver, major.minor, and latest tags. The native amd64 load remains the pre-push docker-smoke + Trivy artifact; the final Buildx push adds arm64 through SHA-pinned QEMU and retains max-mode provenance plus SBOM attestations. The HTTP-server skill now documents the supported tags and platforms, and a hermetic mutation test fails when arm64 or any preserved release gate is removed.

Gates passed:
- `cargo clippy -p sparq-server --all-targets -- -D warnings`
- `cargo test -p sparq-server`
- `python3 scripts/tests/test_release_container_multiarch.py` (includes a failing arm64-removal mutation)
- `actionlint .github/workflows/release.yml`
- skill frontmatter, terminology, markdownlint, typos, no-perf-numbers, privacy-claims, and `git diff --check`

Both SHA-pinned Docker base-image indexes were registry-verified to contain linux/amd64 and linux/arm64, so the Dockerfile remains unchanged. The local host does not have the Docker Buildx plugin, so the image build/smoke/Trivy steps were not re-executed locally; their existing release-CI gates are preserved and pinned by the new workflow test.