### PR TITLE
feat(deploy): AWS CloudFormation Launch-Stack for sq-17rgw [SONNET]

### DIFF
--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -207,7 +207,7 @@ These templates are validated by `cfn-lint` (exit 0 on both). [GPT-5.6] The
 permission and a live AWS endpoint — the dev box IAM role does not allow this, so it is
 documented as manual validation.
 
-Secret hygiene: `grep -rEin "SPARQ_AUTH_TOKEN\s*[:=]\s*['\"][a-zA-Z0-9+/]{16,}" deploy/aws/`
+Secret hygiene: `grep -rniE "SPARQ_AUTH_TOKEN\s*[:=]\s*['\"][a-zA-Z0-9+/]{16,}" deploy/aws/`
 returns no matches.
 
 A CI workflow for automatic cfn-lint on `paths: deploy/aws/**` is tracked as discovered work

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,0 +1,220 @@
+<!-- [SONNET-4.6] sq-17rgw — AWS CloudFormation Launch-Stack deploy for sparq-server + sparq-lws-core. -->
+
+# AWS one-click deploy (sq-17rgw)
+
+CloudFormation templates for running sparq on AWS **ECS Fargate** with an
+**Application Load Balancer** and **HTTPS via ACM**.
+
+Two templates:
+
+| Template | Image | Port | Health path | Status |
+|---|---|---|---|---|
+| `sparq-server.yaml` | `ghcr.io/sparq-org/sparq-server` | 3030 | `GET /health` | Available |
+| `sparq-lws.yaml` | `ghcr.io/sparq-org/sparq-lws-core` | 3000 | `GET /readyz` | Activates once sq-lmz40 ships |
+
+---
+
+## Secure-defaults notice (R1/R2/R4/R9)
+
+> **sparq-server is open-by-default at the image layer.** It bakes `SPARQ_ALLOW_REMOTE=1`
+> and ships with no auth. Anyone who reaches the published port can read AND write the
+> dataset. **These templates enforce auth ON** by injecting `SPARQ_AUTH_TOKEN` from AWS
+> Secrets Manager (ValueFrom — the literal value never appears in CloudFormation). Do not
+> remove the Secrets Manager wiring or set a default token value in the template.
+
+Key rules applied:
+
+- **R1 (auth ON):** `SPARQ_AUTH_TOKEN` is required and comes from Secrets Manager — never
+  a template parameter value.
+- **R2 (no anonymous write):** Unauthenticated writes return 401. sparq-lws-core is
+  fail-closed by design; anonymous mutation is rejected at the image layer.
+- **R3 (TLS at edge):** The ALB terminates HTTPS (TLS 1.2+ with TLS 1.3 preferred) via an
+  ACM certificate. Port 80 redirects to 443. The task SG accepts traffic only from the ALB
+  SG on the app port — not from the internet directly.
+- **R4 (secrets in Secrets Manager):** No literal token, password, or key in any committed
+  file. Secrets are referenced by ARN only.
+- **R5 (least-privilege IAM):** Separate `ExecutionRole` (image pull + secret read, scoped
+  to the stack's own secret ARN) and `TaskRole` (CloudWatch logs only).
+- **R6 (ingress only on app port from ALB SG):** Tasks run in private subnets (no public
+  IP). The ALB SG allows 443 from the internet; the task SG allows the app port only from
+  the ALB SG.
+- **R7 (health check):** ALB target group health check on `/health` (sparq-server) or
+  `/readyz` (LWS), matcher 200. ECS liveness check via the server's built-in `--health-probe`.
+- **R8 (non-root):** Both images run as non-root; `ReadonlyRootFilesystem: true` in the
+  task definition.
+
+---
+
+## sparq-server — Launch Stack
+
+### Prerequisites
+
+1. An ACM certificate covering the domain you will serve (must be in the same AWS region).
+2. A Secrets Manager secret holding the bearer token:
+
+   ```bash
+   aws secretsmanager create-secret \
+     --name /sparq/server/auth-token \
+     --secret-string "$(openssl rand -hex 32)"
+   # Note the ARN from the output.
+   ```
+
+### Launch Stack button
+
+Replace the `<REGION>` and URL-encode the parameter values before clicking.
+
+[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://raw.githubusercontent.com/sparq-org/sparq/main/deploy/aws/sparq-server.yaml&stackName=sparq-server)
+
+> The button above links to the template on the `main` branch. For production, pin to a
+> specific release tag by substituting the commit SHA in the raw URL.
+
+### CLI deploy
+
+```bash
+aws cloudformation create-stack \
+  --stack-name sparq-server \
+  --template-body file://sparq-server.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameters \
+    ParameterKey=AuthTokenSecretArn,ParameterValue=arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:/sparq/server/auth-token-XXXXXX \
+    ParameterKey=AcmCertificateArn,ParameterValue=arn:aws:acm:<REGION>:<ACCOUNT>:certificate/<UUID>
+```
+
+### Post-deploy
+
+1. The stack outputs `AlbDnsName`. Create a CNAME from your domain to that value (or use
+   Route 53 alias with the `AlbHostedZoneId` output).
+2. Test the SPARQL endpoint:
+
+   ```bash
+   TOKEN=$(aws secretsmanager get-secret-value --secret-id /sparq/server/auth-token --query SecretString --output text)
+   curl -H "Authorization: Bearer $TOKEN" https://<your-domain>/sparql \
+     --data-urlencode 'query=SELECT * WHERE { ?s ?p ?o } LIMIT 1'
+   ```
+
+3. Confirm an unauthenticated write is rejected:
+
+   ```bash
+   curl -X POST https://<your-domain>/sparql/update \
+     -d 'update=INSERT DATA { <urn:x> <urn:y> <urn:z> }' \
+     -w "%{http_code}"
+   # Expect: 401
+   ```
+
+### Parameters
+
+| Parameter | Required | Default | Description |
+|---|---|---|---|
+| `AuthTokenSecretArn` | Yes | — | ARN of Secrets Manager secret holding the bearer token |
+| `AcmCertificateArn` | Yes | — | ARN of ACM certificate for HTTPS |
+| `ImageRef` | No | `ghcr.io/sparq-org/sparq-server:latest` | Full image reference |
+| `TaskCpu` | No | `512` | Fargate CPU units |
+| `TaskMemory` | No | `1024` | Fargate memory (MiB) |
+| `DesiredCount` | No | `1` | Number of running tasks |
+| `AuthTokenRead` | No | `""` | Set `"1"` to also gate reads |
+| `CorsAllowOrigin` | No | `""` | Value for `SPARQ_CORS_ALLOW_ORIGIN` |
+| `MaxConcurrent` | No | `16` | Max concurrent query workers |
+| `QueryTimeoutSeconds` | No | `30` | Per-query timeout |
+
+---
+
+## sparq-lws-core (Solid server) — Launch Stack
+
+> **Status: activates once [sq-lmz40](https://github.com/sparq-org/sparq/issues) ships.**
+> The `ghcr.io/sparq-org/sparq-lws-core` image is not yet published. The template is
+> structurally complete and cfn-lint valid; deploy once the image is available.
+
+The LWS server requires an external OIDC issuer (`SOLID_SERVER_TRUSTED_ISSUER`) — it cannot
+self-issue. This is a required parameter. Store the issuer URL in Secrets Manager:
+
+```bash
+aws secretsmanager create-secret \
+  --name /sparq/lws/trusted-issuer \
+  --secret-string "https://your-solid-oidc-provider.example"
+```
+
+### CLI deploy
+
+```bash
+aws cloudformation create-stack \
+  --stack-name sparq-lws \
+  --template-body file://sparq-lws.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameters \
+    ParameterKey=AcmCertificateArn,ParameterValue=arn:aws:acm:<REGION>:<ACCOUNT>:certificate/<UUID> \
+    ParameterKey=SolidBaseUrl,ParameterValue=https://solid.example.com \
+    ParameterKey=SolidTrustedIssuerSecretArn,ParameterValue=arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:/sparq/lws/trusted-issuer-XXXXXX
+```
+
+### Multi-replica note
+
+For `DesiredCount > 1`, you must supply a Redis URL via `RedisReplaySecretArn` for shared
+DPoP-jti replay protection. With `DesiredCount=1` (the default), in-memory replay is
+correct and no Redis is needed.
+
+### Parameters
+
+| Parameter | Required | Default | Description |
+|---|---|---|---|
+| `AcmCertificateArn` | Yes | — | ACM certificate for HTTPS |
+| `SolidBaseUrl` | Yes | — | Public HTTPS base URL (`https://solid.example.com`) |
+| `SolidTrustedIssuerSecretArn` | Yes | — | Secrets Manager ARN for the OIDC issuer URL |
+| `ImageRef` | No | `ghcr.io/sparq-org/sparq-lws-core:latest` | Full image reference |
+| `SolidAudience` | No | `""` | `SOLID_SERVER_AUDIENCE` (defaults to `SolidBaseUrl`) |
+| `RedisReplaySecretArn` | No | `""` | Secrets Manager ARN for Redis URL (multi-replica) |
+| `RedisReplayUrl` | No | `""` | Redis URL plaintext (single-replica only) |
+| `TaskCpu` | No | `512` | Fargate CPU units |
+| `TaskMemory` | No | `1024` | Fargate memory (MiB) |
+| `DesiredCount` | No | `1` | Number of running tasks |
+
+---
+
+## Architecture
+
+```
+Internet
+  │ HTTPS 443
+  ▼
+ALB (public subnets A+B)
+  │ HTTP 3030 (sparq-server) or HTTP 3000 (LWS)
+  │ ALB SG → Task SG (source-based, not CIDR)
+  ▼
+ECS Fargate task (private subnets A+B, no public IP)
+  │ egress via NAT Gateway → GHCR (image pull) + Secrets Manager + CloudWatch
+  ▼
+CloudWatch Logs (/ecs/<stack>/sparq-server or sparq-lws)
+```
+
+Each template provisions a self-contained VPC. To deploy into an existing VPC, extract the
+networking resources and supply your own subnet IDs — a future enhancement (note created as
+discovered work).
+
+---
+
+## CI validation
+
+These templates are validated by `cfn-lint` (exit 0 on both). The
+`aws cloudformation validate-template` call requires `cloudformation:ValidateTemplate` IAM
+permission and a live AWS endpoint — the dev box IAM role does not allow this, so it is
+documented as manual validation.
+
+Secret hygiene: `grep -rEin "SPARQ_AUTH_TOKEN\s*[:=]\s*['\"][a-zA-Z0-9+/]{16,}" deploy/aws/`
+returns no matches.
+
+A CI workflow for automatic cfn-lint on `paths: deploy/aws/**` is tracked as discovered work
+(see below).
+
+---
+
+## Discovered work
+
+The following was noted during implementation but is out of scope for this bead:
+
+- A `deploy/aws/` CI workflow running `cfn-lint` on `push`/`PR` for `paths: deploy/aws/**`
+  (non-gating, `workflow_dispatch` + path filter as per design record §4).
+- Parameterising the VPC so operators can supply an existing VPC + subnets instead of having
+  each stack create its own.
+- An EC2 fallback template (user-data `docker run` behind Elastic IP or ALB) for operators
+  who prefer EC2 over Fargate — noted in §3.1 of the design record as optional.
+- Auto-generation of a random token at stack deploy time (via CloudFormation custom resource
+  or Lambda-backed resource) so the `AuthTokenSecretArn` parameter is not required upfront.

--- a/deploy/aws/README.md
+++ b/deploy/aws/README.md
@@ -1,6 +1,7 @@
 <!-- [SONNET-4.6] sq-17rgw — AWS CloudFormation Launch-Stack deploy for sparq-server + sparq-lws-core. -->
+<!-- [GPT-5.6] Provider-specific security/correctness review fixes. -->
 
-# AWS one-click deploy (sq-17rgw)
+# AWS CloudFormation deploy (sq-17rgw)
 
 CloudFormation templates for running sparq on AWS **ECS Fargate** with an
 **Application Load Balancer** and **HTTPS via ACM**.
@@ -26,22 +27,25 @@ Key rules applied:
 
 - **R1 (auth ON):** `SPARQ_AUTH_TOKEN` is required and comes from Secrets Manager — never
   a template parameter value.
-- **R2 (no anonymous write):** Unauthenticated writes return 401. sparq-lws-core is
+- **R2 (no anonymous write):** Unauthenticated writes return 401/403. sparq-lws-core is
   fail-closed by design; anonymous mutation is rejected at the image layer.
 - **R3 (TLS at edge):** The ALB terminates HTTPS (TLS 1.2+ with TLS 1.3 preferred) via an
-  ACM certificate. Port 80 redirects to 443. The task SG accepts traffic only from the ALB
-  SG on the app port — not from the internet directly.
+  ACM certificate. [GPT-5.6] No port-80 listener or security-group rule exists, so credentials
+  cannot be sent to a public plaintext endpoint. The private task hop is restricted to the ALB SG.
 - **R4 (secrets in Secrets Manager):** No literal token, password, or key in any committed
   file. Secrets are referenced by ARN only.
-- **R5 (least-privilege IAM):** Separate `ExecutionRole` (image pull + secret read, scoped
-  to the stack's own secret ARN) and `TaskRole` (CloudWatch logs only).
+- **R5 (least-privilege IAM):** [GPT-5.6] The execution role can read only the selected
+  secret and write only this stack's log streams. The application task role has no AWS API
+  permissions. Neither role uses the wildcard AWS-managed ECS execution policy.
 - **R6 (ingress only on app port from ALB SG):** Tasks run in private subnets (no public
   IP). The ALB SG allows 443 from the internet; the task SG allows the app port only from
   the ALB SG.
 - **R7 (health check):** ALB target group health check on `/health` (sparq-server) or
-  `/readyz` (LWS), matcher 200. ECS liveness check via the server's built-in `--health-probe`.
-- **R8 (non-root):** Both images run as non-root; `ReadonlyRootFilesystem: true` in the
-  task definition.
+  `/readyz` (LWS), matcher 200. The sparq-server task also uses its built-in `--health-probe`;
+  [GPT-5.6] LWS service health follows the ALB because its image contract has no probe command.
+- **R8 (non-root):** Both images run as non-root; `ReadonlyRootFilesystem: true` and a
+  drop-all Linux-capability set are enforced. [GPT-5.6] sparq-server receives a writable,
+  task-local `/data` volume while the rest of its root filesystem stays read-only.
 
 ---
 
@@ -59,14 +63,18 @@ Key rules applied:
    # Note the ARN from the output.
    ```
 
-### Launch Stack button
+### Quick-create link
 
-Replace the `<REGION>` and URL-encode the parameter values before clicking.
+CloudFormation quick-create links accept templates stored in Amazon S3, not raw GitHub URLs.
+[GPT-5.6] Upload the reviewed template to a bucket you control, then URL-encode its S3 HTTPS
+URL in the following link format:
 
-[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?templateURL=https://raw.githubusercontent.com/sparq-org/sparq/main/deploy/aws/sparq-server.yaml&stackName=sparq-server)
+```text
+https://<REGION>.console.aws.amazon.com/cloudformation/home?region=<REGION>#/stacks/create/review?templateURL=<URL_ENCODED_S3_TEMPLATE_URL>&stackName=sparq-server
+```
 
-> The button above links to the template on the `main` branch. For production, pin to a
-> specific release tag by substituting the commit SHA in the raw URL.
+The repository does not currently publish these templates to a project-owned S3 bucket, so it
+does not claim a working public Launch Stack button.
 
 ### CLI deploy
 
@@ -74,7 +82,7 @@ Replace the `<REGION>` and URL-encode the parameter values before clicking.
 aws cloudformation create-stack \
   --stack-name sparq-server \
   --template-body file://sparq-server.yaml \
-  --capabilities CAPABILITY_NAMED_IAM \
+  --capabilities CAPABILITY_IAM \
   --parameters \
     ParameterKey=AuthTokenSecretArn,ParameterValue=arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:/sparq/server/auth-token-XXXXXX \
     ParameterKey=AcmCertificateArn,ParameterValue=arn:aws:acm:<REGION>:<ACCOUNT>:certificate/<UUID>
@@ -95,10 +103,11 @@ aws cloudformation create-stack \
 3. Confirm an unauthenticated write is rejected:
 
    ```bash
-   curl -X POST https://<your-domain>/sparql/update \
-     -d 'update=INSERT DATA { <urn:x> <urn:y> <urn:z> }' \
+   curl -X POST https://<your-domain>/sparql \
+     -H 'Content-Type: application/x-www-form-urlencoded' \
+     --data-urlencode 'update=INSERT DATA { <urn:x> <urn:y> <urn:z> }' \
      -w "%{http_code}"
-   # Expect: 401
+   # Expect: 401 or 403
    ```
 
 ### Parameters
@@ -110,7 +119,8 @@ aws cloudformation create-stack \
 | `ImageRef` | No | `ghcr.io/sparq-org/sparq-server:latest` | Full image reference |
 | `TaskCpu` | No | `512` | Fargate CPU units |
 | `TaskMemory` | No | `1024` | Fargate memory (MiB) |
-| `DesiredCount` | No | `1` | Number of running tasks |
+| `DesiredCount` | No | `1` | Fixed at one for task-local dataset consistency |
+| `HealthCheckPath` | No | `/health` | ALB health path for sparq-server |
 | `AuthTokenRead` | No | `""` | Set `"1"` to also gate reads |
 | `CorsAllowOrigin` | No | `""` | Value for `SPARQ_CORS_ALLOW_ORIGIN` |
 | `MaxConcurrent` | No | `16` | Max concurrent query workers |
@@ -139,18 +149,18 @@ aws secretsmanager create-secret \
 aws cloudformation create-stack \
   --stack-name sparq-lws \
   --template-body file://sparq-lws.yaml \
-  --capabilities CAPABILITY_NAMED_IAM \
+  --capabilities CAPABILITY_IAM \
   --parameters \
     ParameterKey=AcmCertificateArn,ParameterValue=arn:aws:acm:<REGION>:<ACCOUNT>:certificate/<UUID> \
     ParameterKey=SolidBaseUrl,ParameterValue=https://solid.example.com \
     ParameterKey=SolidTrustedIssuerSecretArn,ParameterValue=arn:aws:secretsmanager:<REGION>:<ACCOUNT>:secret:/sparq/lws/trusted-issuer-XXXXXX
 ```
 
-### Multi-replica note
+### Single-replica constraint
 
-For `DesiredCount > 1`, you must supply a Redis URL via `RedisReplaySecretArn` for shared
-DPoP-jti replay protection. With `DesiredCount=1` (the default), in-memory replay is
-correct and no Redis is needed.
+[GPT-5.6] The canonical image contract builds the crate's default features, which exclude the
+opt-in `redis-replay` feature. The template therefore fixes `DesiredCount` at one; accepting a
+Redis URL would otherwise make that image abort at boot instead of enabling shared replay state.
 
 ### Parameters
 
@@ -161,11 +171,10 @@ correct and no Redis is needed.
 | `SolidTrustedIssuerSecretArn` | Yes | — | Secrets Manager ARN for the OIDC issuer URL |
 | `ImageRef` | No | `ghcr.io/sparq-org/sparq-lws-core:latest` | Full image reference |
 | `SolidAudience` | No | `""` | `SOLID_SERVER_AUDIENCE` (defaults to `SolidBaseUrl`) |
-| `RedisReplaySecretArn` | No | `""` | Secrets Manager ARN for Redis URL (multi-replica) |
-| `RedisReplayUrl` | No | `""` | Redis URL plaintext (single-replica only) |
 | `TaskCpu` | No | `512` | Fargate CPU units |
 | `TaskMemory` | No | `1024` | Fargate memory (MiB) |
-| `DesiredCount` | No | `1` | Number of running tasks |
+| `DesiredCount` | No | `1` | Fixed at one for the canonical image contract |
+| `HealthCheckPath` | No | `/readyz` | ALB readiness path for sparq-lws-core |
 
 ---
 
@@ -193,7 +202,7 @@ discovered work).
 
 ## CI validation
 
-These templates are validated by `cfn-lint` (exit 0 on both). The
+These templates are validated by `cfn-lint` (exit 0 on both). [GPT-5.6] The
 `aws cloudformation validate-template` call requires `cloudformation:ValidateTemplate` IAM
 permission and a live AWS endpoint — the dev box IAM role does not allow this, so it is
 documented as manual validation.
@@ -214,7 +223,7 @@ The following was noted during implementation but is out of scope for this bead:
   (non-gating, `workflow_dispatch` + path filter as per design record §4).
 - Parameterising the VPC so operators can supply an existing VPC + subnets instead of having
   each stack create its own.
-- An EC2 fallback template (user-data `docker run` behind Elastic IP or ALB) for operators
-  who prefer EC2 over Fargate — noted in §3.1 of the design record as optional.
+- [GPT-5.6] An EC2 fallback template behind ALB/ACM for operators who prefer EC2 over
+  Fargate. A direct public EIP path must not expose the credentialed service over plaintext.
 - Auto-generation of a random token at stack deploy time (via CloudFormation custom resource
   or Lambda-backed resource) so the `AuthTokenSecretArn` parameter is not required upfront.

--- a/deploy/aws/sparq-lws.yaml
+++ b/deploy/aws/sparq-lws.yaml
@@ -1,0 +1,610 @@
+# [SONNET-4.6] sq-17rgw — AWS CloudFormation template: sparq-lws-core (Solid server) on ECS Fargate.
+#
+# STATUS: activates once sq-lmz40 ships (the native sparq-lws-core container image).
+# The image referenced below (ghcr.io/sparq-org/sparq-lws-core) is NOT yet published.
+# This template is structurally complete and cfn-lint/yaml-valid; deploy it once sq-lmz40
+# lands and the image is available on GHCR.
+#
+# DESIGN NOTE (sq-17rgw):
+# The LWS server is fail-closed by design (opposite posture to sparq-server):
+#   - Anonymous mutation is rejected by default
+#   - HTTPS-only IdP/WebID required
+#   - DPoP required; bidirectional WebID<->issuer check is strict
+# Therefore R1 (auth ON) is already satisfied by the image; the template's job is
+# to wire the required env vars and connect it to HTTPS (R3/ALB+ACM).
+#
+# KEY REQUIREMENT: This template requires an external OIDC issuer
+# (SOLID_SERVER_TRUSTED_ISSUER). An LWS deploy cannot be zero-input — you must name
+# a trusted IdP. The /readyz probe is the seam that keeps a mis-configured instance
+# from serving traffic behind the ALB.
+#
+# MULTI-REPLICA NOTE: For >1 replica, you must provide a Redis URL
+# (SOLID_SERVER_REPLAY_REDIS_URL) for shared DPoP-jti replay protection.
+# With a single replica (DesiredCount=1), in-memory replay is correct and sufficient.
+# This template defaults DesiredCount=1. To scale out, supply RedisReplayUrl.
+#
+# DECISION LOG (sq-17rgw):
+#   - ECS Fargate + ALB + ACM: same architecture as sparq-server.yaml (R3).
+#   - Secrets Manager ValueFrom for any secret env vars (R4).
+#   - Dedicated TaskRole + ExecutionRole scoped to own resources (R5).
+#   - Task SG accepts traffic on port 3000 ONLY from ALB SG (R6).
+#   - ALB target group health check on /readyz (R7, readiness probe).
+#   - ECS container health check on /livez (R7, liveness).
+#   - Dev-only escape hatches (ALLOW_LOOPBACK / SEED_CONFORMANCE / etc.) NEVER present (R2).
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  sparq-lws-core (Solid/LWS server) on ECS Fargate with ALB (HTTPS/TLS via ACM).
+  Fail-closed by design; auth + DPoP enforced at the image layer.
+  Activates once sq-lmz40 publishes the ghcr.io/sparq-org/sparq-lws-core image.
+  [SONNET-4.6] sq-17rgw
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+Parameters:
+
+  # --- Required ---
+  AcmCertificateArn:
+    Type: String
+    Description: >
+      ARN of an ACM certificate for the domain used as SOLID_SERVER_BASE_URL.
+      TLS is terminated at the ALB. (R3)
+    AllowedPattern: "^arn:aws[a-z-]*:acm:[a-z0-9-]+:[0-9]{12}:certificate/.+$"
+    ConstraintDescription: Must be a valid ACM certificate ARN.
+
+  SolidBaseUrl:
+    Type: String
+    Description: >
+      Public HTTPS base URL of this Solid server, e.g. https://solid.example.com.
+      Used as SOLID_SERVER_BASE_URL and (if SolidAudience is empty) as
+      SOLID_SERVER_AUDIENCE. Must be the HTTPS URL that points to this ALB.
+    AllowedPattern: "^https://.+"
+    ConstraintDescription: Must start with https://.
+
+  SolidTrustedIssuerSecretArn:
+    Type: String
+    Description: >
+      ARN of a Secrets Manager secret whose value is the trusted OIDC issuer URL
+      (SOLID_SERVER_TRUSTED_ISSUER). This is the OIDC IdP that issues tokens for
+      WebID authentication. Example: https://solid.community or your own IdP.
+      Store the URL as the secret value so it is not hard-coded here. (R4)
+    AllowedPattern: "^arn:aws[a-z-]*:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:.+$"
+    ConstraintDescription: Must be a valid Secrets Manager secret ARN.
+
+  # --- Optional ---
+  ImageRef:
+    Type: String
+    Default: "ghcr.io/sparq-org/sparq-lws-core:latest"
+    Description: >
+      Full image reference for sparq-lws-core. Defaults to the canonical GHCR image.
+      This image does not exist until sq-lmz40 ships. Pin to a specific tag in production.
+    AllowedPattern: "^[a-z0-9._/-]+:[a-zA-Z0-9._-]+$"
+
+  SolidAudience:
+    Type: String
+    Default: ""
+    Description: >
+      SOLID_SERVER_AUDIENCE — defaults to SolidBaseUrl if left empty.
+      Set this if your OIDC 'aud' claim differs from the base URL.
+
+  RedisReplayUrl:
+    Type: String
+    Default: ""
+    Description: >
+      Optional Redis URL for shared DPoP-jti replay protection across replicas
+      (SOLID_SERVER_REPLAY_REDIS_URL). Required when DesiredCount > 1 for correct
+      DPoP replay prevention. Leave empty for single-replica deploys (default).
+    NoEcho: true
+
+  RedisReplaySecretArn:
+    Type: String
+    Default: ""
+    Description: >
+      ARN of a Secrets Manager secret whose value is the Redis connection URL.
+      Use this instead of RedisReplayUrl to keep the Redis credentials out of
+      parameter logs. Takes precedence over RedisReplayUrl if both are set.
+    AllowedPattern: "^(arn:aws[a-z-]*:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:.+)?$"
+
+  TaskCpu:
+    Type: Number
+    Default: 512
+    AllowedValues: [256, 512, 1024, 2048, 4096]
+    Description: Fargate task CPU units.
+
+  TaskMemory:
+    Type: Number
+    Default: 1024
+    AllowedValues: [512, 1024, 2048, 4096, 8192, 16384]
+    Description: Fargate task memory in MiB.
+
+  DesiredCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 10
+    Description: >
+      Number of running tasks. For >1, RedisReplaySecretArn (or RedisReplayUrl)
+      is required for correct DPoP replay protection. Single-replica (1) is safe
+      without Redis.
+
+# ---------------------------------------------------------------------------
+# Conditions
+# ---------------------------------------------------------------------------
+Conditions:
+  HasCustomAudience: !Not [!Equals [!Ref SolidAudience, ""]]
+  HasRedisSecretArn: !Not [!Equals [!Ref RedisReplaySecretArn, ""]]
+  HasRedisUrl: !Not [!Equals [!Ref RedisReplayUrl, ""]]
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+Resources:
+
+  # -------------------------------------------------------------------------
+  # Networking (same topology as sparq-server.yaml — VPC + public/private subnets)
+  # -------------------------------------------------------------------------
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.11.0.0/16"
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-vpc"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-igw"
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.11.0.0/24"
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-a"
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.11.1.0/24"
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-b"
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-rt"
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetARouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetA
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetBRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetB
+      RouteTableId: !Ref PublicRouteTable
+
+  NatEipA:
+    Type: AWS::EC2::EIP
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      Domain: vpc
+
+  NatGatewayA:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatEipA.AllocationId
+      SubnetId: !Ref PublicSubnetA
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-nat-a"
+
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.11.10.0/24"
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-a"
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.11.11.0/24"
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-b"
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-rt"
+
+  PrivateRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref NatGatewayA
+
+  PrivateSubnetARouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetA
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnetBRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetB
+      RouteTableId: !Ref PrivateRouteTable
+
+  # -------------------------------------------------------------------------
+  # Security Groups (R6)
+  # -------------------------------------------------------------------------
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "sparq-lws ALB: inbound HTTPS from internet, outbound to task SG"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+          Description: "HTTPS from internet"
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIpv6: "::/0"
+          Description: "HTTPS from internet (IPv6)"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb-sg"
+
+  # Task SG: accepts port 3000 ONLY from the ALB SG
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "sparq-lws task: inbound port 3000 from ALB SG only"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3000
+          ToPort: 3000
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+          Description: "sparq-lws-core port from ALB only"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-task-sg"
+
+  TaskEgressAll:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref TaskSecurityGroup
+      IpProtocol: "-1"
+      CidrIp: "0.0.0.0/0"
+      Description: "Outbound for image pull + Secrets Manager + OIDC IdP + CloudWatch"
+
+  # -------------------------------------------------------------------------
+  # CloudWatch Logs
+  # -------------------------------------------------------------------------
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${AWS::StackName}/sparq-lws"
+      RetentionInDays: 30
+
+  # -------------------------------------------------------------------------
+  # IAM: Execution Role (R5)
+  # -------------------------------------------------------------------------
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-execution-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: ReadLwsSecrets
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                # Scoped to only the secrets this stack uses — no wildcard (R5)
+                Resource:
+                  - !Ref SolidTrustedIssuerSecretArn
+                  - !If
+                    - HasRedisSecretArn
+                    - !Ref RedisReplaySecretArn
+                    - !Ref AWS::NoValue
+
+  # -------------------------------------------------------------------------
+  # IAM: Task Role (R5)
+  # -------------------------------------------------------------------------
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-task-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: WriteCloudWatchLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !GetAtt LogGroup.Arn
+
+  # -------------------------------------------------------------------------
+  # ECS Cluster
+  # -------------------------------------------------------------------------
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${AWS::StackName}-cluster"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  # -------------------------------------------------------------------------
+  # ECS Task Definition
+  # -------------------------------------------------------------------------
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${AWS::StackName}-sparq-lws"
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: sparq-lws
+          Image: !Ref ImageRef
+          Essential: true
+          ReadonlyRootFilesystem: true
+          # Non-root: the image runs as nonroot (R8). Do not override.
+          PortMappings:
+            - ContainerPort: 3000
+              Protocol: tcp
+          # R4: Secrets Manager ValueFrom injection — trusted issuer URL is a secret
+          # so it does not appear in CloudFormation parameter logs.
+          Secrets:
+            - Name: SOLID_SERVER_TRUSTED_ISSUER
+              ValueFrom: !Ref SolidTrustedIssuerSecretArn
+            - !If
+              - HasRedisSecretArn
+              - Name: SOLID_SERVER_REPLAY_REDIS_URL
+                ValueFrom: !Ref RedisReplaySecretArn
+              - !Ref AWS::NoValue
+          Environment:
+            # Required: public HTTPS base URL known at boot.
+            - Name: SOLID_SERVER_BASE_URL
+              Value: !Ref SolidBaseUrl
+            # Audience: defaults to base URL if not set separately.
+            - Name: SOLID_SERVER_AUDIENCE
+              Value: !If [HasCustomAudience, !Ref SolidAudience, !Ref SolidBaseUrl]
+            # Bind on all interfaces inside the container.
+            - Name: SOLID_SERVER_BIND
+              Value: "0.0.0.0:3000"
+            # Redis URL (plain, non-secret) — only if HasRedisUrl and NOT HasRedisSecretArn.
+            # If HasRedisSecretArn, the secret is injected via Secrets above; this is empty.
+            - Name: SOLID_SERVER_REPLAY_REDIS_URL
+              Value: !If [HasRedisUrl, !Ref RedisReplayUrl, ""]
+            # BIDIRECTIONAL strict check is the default in the image; make it explicit.
+            - Name: SOLID_SERVER_BIDIRECTIONAL
+              Value: "strict"
+            # DO NOT set any of the following dev-only escape hatches here (R2):
+            #   SOLID_SERVER_ALLOW_LOOPBACK
+            #   SOLID_SERVER_SEED_CONFORMANCE
+            #   SOLID_SERVER_SEED_BENCH
+            #   SOLID_SERVER_ALLOW_SEED_NONMEMORY
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: sparq-lws
+          # R7: /livez = liveness (process up), /readyz = readiness (ready to serve).
+          # The ALB target group uses /readyz (503 = not ready → deregister).
+          # The ECS health check uses /livez (liveness only — replaces crashed tasks).
+          # Both paths are mounted outside the auth gate in the LWS server.
+          HealthCheck:
+            Command:
+              - CMD
+              - /sparq-lws-core
+              - --health-probe
+            Interval: 30
+            Timeout: 5
+            Retries: 3
+            StartPeriod: 20
+
+  # -------------------------------------------------------------------------
+  # Application Load Balancer (HTTPS-only, R3)
+  # -------------------------------------------------------------------------
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${AWS::StackName}-alb"
+      Type: application
+      Scheme: internet-facing
+      Subnets:
+        - !Ref PublicSubnetA
+        - !Ref PublicSubnetB
+      SecurityGroups:
+        - !Ref AlbSecurityGroup
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: "60"
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: "true"
+
+  # R7: health check targets /readyz (readiness), matcher 200.
+  # A 503 response causes the ALB to deregister the target until it is ready.
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${AWS::StackName}-tg"
+      VpcId: !Ref VPC
+      Protocol: HTTP
+      Port: 3000
+      TargetType: ip
+      HealthCheckEnabled: true
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: /readyz
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      Matcher:
+        HttpCode: "200"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "30"
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      Certificates:
+        - CertificateArn: !Ref AcmCertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: "443"
+            StatusCode: HTTP_301
+
+  # -------------------------------------------------------------------------
+  # ECS Service
+  # -------------------------------------------------------------------------
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - HttpsListener
+      - HttpListener
+    Properties:
+      ServiceName: !Sub "${AWS::StackName}-service"
+      Cluster: !Ref Cluster
+      TaskDefinition: !Ref TaskDefinition
+      LaunchType: FARGATE
+      DesiredCount: !Ref DesiredCount
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          Subnets:
+            - !Ref PrivateSubnetA
+            - !Ref PrivateSubnetB
+          SecurityGroups:
+            - !Ref TaskSecurityGroup
+          AssignPublicIp: DISABLED
+      LoadBalancers:
+        - ContainerName: sparq-lws
+          ContainerPort: 3000
+          TargetGroupArn: !Ref TargetGroup
+      HealthCheckGracePeriodSeconds: 60
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+Outputs:
+
+  AlbDnsName:
+    Description: >
+      ALB DNS name — create a CNAME from SolidBaseUrl's domain to this value.
+      The Solid server is at https://<your-domain>/ (e.g. https://solid.example.com/).
+    Value: !GetAtt ALB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-AlbDnsName"
+
+  AlbHostedZoneId:
+    Description: ALB hosted zone ID — use with Route 53 alias records.
+    Value: !GetAtt ALB.CanonicalHostedZoneID
+    Export:
+      Name: !Sub "${AWS::StackName}-AlbHostedZoneId"
+
+  SolidServerUrl:
+    Description: Solid server public URL (matches SolidBaseUrl parameter).
+    Value: !Ref SolidBaseUrl
+
+  LogGroupName:
+    Description: CloudWatch log group for sparq-lws container logs.
+    Value: !Ref LogGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-LogGroup"

--- a/deploy/aws/sparq-lws.yaml
+++ b/deploy/aws/sparq-lws.yaml
@@ -12,16 +12,17 @@
 #   - DPoP required; bidirectional WebID<->issuer check is strict
 # Therefore R1 (auth ON) is already satisfied by the image; the template's job is
 # to wire the required env vars and connect it to HTTPS (R3/ALB+ACM).
+# [GPT-5.6] R9: the sibling sparq-server image is open by default; its template gates it
+# with a Secrets Manager token. Never remove that sibling template's token wiring.
 #
 # KEY REQUIREMENT: This template requires an external OIDC issuer
 # (SOLID_SERVER_TRUSTED_ISSUER). An LWS deploy cannot be zero-input — you must name
 # a trusted IdP. The /readyz probe is the seam that keeps a mis-configured instance
 # from serving traffic behind the ALB.
 #
-# MULTI-REPLICA NOTE: For >1 replica, you must provide a Redis URL
-# (SOLID_SERVER_REPLAY_REDIS_URL) for shared DPoP-jti replay protection.
-# With a single replica (DesiredCount=1), in-memory replay is correct and sufficient.
-# This template defaults DesiredCount=1. To scale out, supply RedisReplayUrl.
+# [GPT-5.6] SINGLE-REPLICA NOTE: the canonical image contract builds default features,
+# which do not include the opt-in redis-replay feature. DesiredCount is therefore pinned
+# to one so cross-instance DPoP replay protection cannot silently fail or abort at boot.
 #
 # DECISION LOG (sq-17rgw):
 #   - ECS Fargate + ALB + ACM: same architecture as sparq-server.yaml (R3).
@@ -29,7 +30,7 @@
 #   - Dedicated TaskRole + ExecutionRole scoped to own resources (R5).
 #   - Task SG accepts traffic on port 3000 ONLY from ALB SG (R6).
 #   - ALB target group health check on /readyz (R7, readiness probe).
-#   - ECS container health check on /livez (R7, liveness).
+#   - ECS service health is driven by the ALB /readyz target check; /livez remains available (R7).
 #   - Dev-only escape hatches (ALLOW_LOOPBACK / SEED_CONFORMANCE / etc.) NEVER present (R2).
 
 AWSTemplateFormatVersion: "2010-09-09"
@@ -88,23 +89,13 @@ Parameters:
       SOLID_SERVER_AUDIENCE — defaults to SolidBaseUrl if left empty.
       Set this if your OIDC 'aud' claim differs from the base URL.
 
-  RedisReplayUrl:
+  # [GPT-5.6] R7 requires a per-server, overridable readiness path.
+  HealthCheckPath:
     Type: String
-    Default: ""
-    Description: >
-      Optional Redis URL for shared DPoP-jti replay protection across replicas
-      (SOLID_SERVER_REPLAY_REDIS_URL). Required when DesiredCount > 1 for correct
-      DPoP replay prevention. Leave empty for single-replica deploys (default).
-    NoEcho: true
-
-  RedisReplaySecretArn:
-    Type: String
-    Default: ""
-    Description: >
-      ARN of a Secrets Manager secret whose value is the Redis connection URL.
-      Use this instead of RedisReplayUrl to keep the Redis credentials out of
-      parameter logs. Takes precedence over RedisReplayUrl if both are set.
-    AllowedPattern: "^(arn:aws[a-z-]*:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:.+)?$"
+    Default: "/readyz"
+    AllowedPattern: "^/[-A-Za-z0-9._~/%]*$"
+    ConstraintDescription: Must be an absolute HTTP path.
+    Description: ALB readiness path. The canonical sparq-lws-core image serves /readyz.
 
   TaskCpu:
     Type: Number
@@ -122,19 +113,38 @@ Parameters:
     Type: Number
     Default: 1
     MinValue: 1
-    MaxValue: 10
+    MaxValue: 1
     Description: >
-      Number of running tasks. For >1, RedisReplaySecretArn (or RedisReplayUrl)
-      is required for correct DPoP replay protection. Single-replica (1) is safe
-      without Redis.
+      [GPT-5.6] Number of running tasks, fixed at one because the canonical image does not
+      include the opt-in redis-replay feature required for safe horizontal scaling.
 
 # ---------------------------------------------------------------------------
 # Conditions
 # ---------------------------------------------------------------------------
 Conditions:
   HasCustomAudience: !Not [!Equals [!Ref SolidAudience, ""]]
-  HasRedisSecretArn: !Not [!Equals [!Ref RedisReplaySecretArn, ""]]
-  HasRedisUrl: !Not [!Equals [!Ref RedisReplayUrl, ""]]
+
+# [GPT-5.6] Reject CPU/memory pairs that ECS Fargate cannot register.
+Rules:
+  ValidFargateTaskSize:
+    Assertions:
+      - Assert: !Or
+          - !And
+            - !Equals [!Ref TaskCpu, 256]
+            - !Contains [[512, 1024, 2048], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 512]
+            - !Contains [[1024, 2048, 4096], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 1024]
+            - !Contains [[2048, 4096, 8192], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 2048]
+            - !Contains [[4096, 8192, 16384], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 4096]
+            - !Contains [[8192, 16384], !Ref TaskMemory]
+        AssertDescription: Select a CPU and memory combination supported by ECS Fargate.
 
 # ---------------------------------------------------------------------------
 # Resources
@@ -295,11 +305,13 @@ Resources:
           ToPort: 443
           CidrIp: "0.0.0.0/0"
           Description: "HTTPS from internet"
+      # [GPT-5.6] Prevent implicit allow-all egress; the ALB reaches only this task SG.
+      SecurityGroupEgress:
         - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIpv6: "::/0"
-          Description: "HTTPS from internet (IPv6)"
+          FromPort: 3000
+          ToPort: 3000
+          DestinationSecurityGroupId: !Ref TaskSecurityGroup
+          Description: "HTTP to sparq-lws tasks only"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-alb-sg"
@@ -310,23 +322,27 @@ Resources:
     Properties:
       GroupDescription: "sparq-lws task: inbound port 3000 from ALB SG only"
       VpcId: !Ref VPC
-      SecurityGroupIngress:
+      # [GPT-5.6] HTTPS-only egress covers GHCR, Secrets Manager, OIDC, and CloudWatch.
+      SecurityGroupEgress:
         - IpProtocol: tcp
-          FromPort: 3000
-          ToPort: 3000
-          SourceSecurityGroupId: !Ref AlbSecurityGroup
-          Description: "sparq-lws-core port from ALB only"
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+          Description: "HTTPS dependencies via NAT"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-task-sg"
 
-  TaskEgressAll:
-    Type: AWS::EC2::SecurityGroupEgress
+  # [GPT-5.6] Standalone rule avoids a circular SG dependency and limits task ingress to ALB.
+  TaskIngressFromAlb:
+    Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !Ref TaskSecurityGroup
-      IpProtocol: "-1"
-      CidrIp: "0.0.0.0/0"
-      Description: "Outbound for image pull + Secrets Manager + OIDC IdP + CloudWatch"
+      IpProtocol: tcp
+      FromPort: 3000
+      ToPort: 3000
+      SourceSecurityGroupId: !Ref AlbSecurityGroup
+      Description: "sparq-lws-core port from ALB only"
 
   # -------------------------------------------------------------------------
   # CloudWatch Logs
@@ -343,7 +359,6 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-execution-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -351,23 +366,28 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+            # [GPT-5.6] Bind ECS assumptions to this account to mitigate confused-deputy use.
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:*"
       Policies:
-        - PolicyName: ReadLwsSecrets
+        # [GPT-5.6] GHCR is public, so the wildcard AWS-managed ECR policy is unnecessary.
+        - PolicyName: LaunchLwsTask
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
                   - secretsmanager:GetSecretValue
-                # Scoped to only the secrets this stack uses — no wildcard (R5)
-                Resource:
-                  - !Ref SolidTrustedIssuerSecretArn
-                  - !If
-                    - HasRedisSecretArn
-                    - !Ref RedisReplaySecretArn
-                    - !Ref AWS::NoValue
+                Resource: !Ref SolidTrustedIssuerSecretArn
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub >-
+                  arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroup}:log-stream:*
 
   # -------------------------------------------------------------------------
   # IAM: Task Role (R5)
@@ -375,7 +395,6 @@ Resources:
   TaskRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-task-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -383,16 +402,12 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      Policies:
-        - PolicyName: WriteCloudWatchLogs
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: !GetAtt LogGroup.Arn
+            # [GPT-5.6] The application gets no AWS API permissions; trust is account-scoped.
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:*"
 
   # -------------------------------------------------------------------------
   # ECS Cluster
@@ -425,6 +440,11 @@ Resources:
           Essential: true
           ReadonlyRootFilesystem: true
           # Non-root: the image runs as nonroot (R8). Do not override.
+          # [GPT-5.6] The service needs no Linux capabilities.
+          LinuxParameters:
+            Capabilities:
+              Drop:
+                - ALL
           PortMappings:
             - ContainerPort: 3000
               Protocol: tcp
@@ -433,11 +453,6 @@ Resources:
           Secrets:
             - Name: SOLID_SERVER_TRUSTED_ISSUER
               ValueFrom: !Ref SolidTrustedIssuerSecretArn
-            - !If
-              - HasRedisSecretArn
-              - Name: SOLID_SERVER_REPLAY_REDIS_URL
-                ValueFrom: !Ref RedisReplaySecretArn
-              - !Ref AWS::NoValue
           Environment:
             # Required: public HTTPS base URL known at boot.
             - Name: SOLID_SERVER_BASE_URL
@@ -448,10 +463,6 @@ Resources:
             # Bind on all interfaces inside the container.
             - Name: SOLID_SERVER_BIND
               Value: "0.0.0.0:3000"
-            # Redis URL (plain, non-secret) — only if HasRedisUrl and NOT HasRedisSecretArn.
-            # If HasRedisSecretArn, the secret is injected via Secrets above; this is empty.
-            - Name: SOLID_SERVER_REPLAY_REDIS_URL
-              Value: !If [HasRedisUrl, !Ref RedisReplayUrl, ""]
             # BIDIRECTIONAL strict check is the default in the image; make it explicit.
             - Name: SOLID_SERVER_BIDIRECTIONAL
               Value: "strict"
@@ -466,19 +477,8 @@ Resources:
               awslogs-group: !Ref LogGroup
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: sparq-lws
-          # R7: /livez = liveness (process up), /readyz = readiness (ready to serve).
-          # The ALB target group uses /readyz (503 = not ready → deregister).
-          # The ECS health check uses /livez (liveness only — replaces crashed tasks).
-          # Both paths are mounted outside the auth gate in the LWS server.
-          HealthCheck:
-            Command:
-              - CMD
-              - /sparq-lws-core
-              - --health-probe
-            Interval: 30
-            Timeout: 5
-            Retries: 3
-            StartPeriod: 20
+          # [GPT-5.6] Do not invent a local --health-probe command: the LWS image contract
+          # exposes HTTP /livez and /readyz only. ECS uses the ALB readiness check below.
 
   # -------------------------------------------------------------------------
   # Application Load Balancer (HTTPS-only, R3)
@@ -486,7 +486,6 @@ Resources:
   ALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Sub "${AWS::StackName}-alb"
       Type: application
       Scheme: internet-facing
       Subnets:
@@ -505,14 +504,13 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "${AWS::StackName}-tg"
       VpcId: !Ref VPC
       Protocol: HTTP
       Port: 3000
       TargetType: ip
       HealthCheckEnabled: true
       HealthCheckProtocol: HTTP
-      HealthCheckPath: /readyz
+      HealthCheckPath: !Ref HealthCheckPath
       HealthCheckIntervalSeconds: 30
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
@@ -536,19 +534,6 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup
 
-  HttpListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref ALB
-      Port: 80
-      Protocol: HTTP
-      DefaultActions:
-        - Type: redirect
-          RedirectConfig:
-            Protocol: HTTPS
-            Port: "443"
-            StatusCode: HTTP_301
-
   # -------------------------------------------------------------------------
   # ECS Service
   # -------------------------------------------------------------------------
@@ -556,7 +541,7 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn:
       - HttpsListener
-      - HttpListener
+      - TaskIngressFromAlb
     Properties:
       ServiceName: !Sub "${AWS::StackName}-service"
       Cluster: !Ref Cluster

--- a/deploy/aws/sparq-server.yaml
+++ b/deploy/aws/sparq-server.yaml
@@ -12,8 +12,7 @@
 #   - ALB + ACM (HTTPS only): TLS terminated at ALB; task SG accepts traffic only from ALB SG (R6).
 #   - Secrets Manager (ValueFrom): token never touches CloudFormation parameter plaintext (R4).
 #   - Dedicated TaskRole + ExecutionRole (least-privilege): policies scoped to own resources (R5).
-#   - A VPC is created by this template for simplicity; supply an existing VPC ID via parameter
-#     if you have one. Two public subnets (ALB) + two private subnets (task) are created.
+#   - [GPT-5.6] A dedicated VPC is created with two public ALB subnets and two private task subnets.
 #   - Default desired count = 1 (single-instance; dataset is in-memory/local volume).
 #   - ACM cert ARN is a required parameter — no self-signed cert is provisioned (R3).
 #
@@ -27,7 +26,7 @@
 #        aws cloudformation create-stack \
 #          --stack-name sparq-server \
 #          --template-body file://sparq-server.yaml \
-#          --capabilities CAPABILITY_NAMED_IAM \
+#          --capabilities CAPABILITY_IAM \
 #          --parameters \
 #            ParameterKey=AuthTokenSecretArn,ParameterValue=arn:aws:secretsmanager:... \
 #            ParameterKey=AcmCertificateArn,ParameterValue=arn:aws:acm:...
@@ -89,11 +88,18 @@ Parameters:
     Type: Number
     Default: 1
     MinValue: 1
-    MaxValue: 10
+    MaxValue: 1
     Description: >
-      Number of running Fargate tasks. Note: the dataset is stored per-task (in-memory or
-      local volume). For shared persistent data, mount an EFS volume (future work). Keep
-      this at 1 for a single-writer dataset or read-replica scenario.
+      [GPT-5.6] Number of running Fargate tasks, fixed at one because this template uses
+      task-local storage. Scaling independent writable graphs would return inconsistent data.
+
+  # [GPT-5.6] R7 requires a per-server, overridable platform health path.
+  HealthCheckPath:
+    Type: String
+    Default: "/health"
+    AllowedPattern: "^/[-A-Za-z0-9._~/%]*$"
+    ConstraintDescription: Must be an absolute HTTP path.
+    Description: ALB health-check path. The canonical sparq-server image serves /health.
 
   # Read-gate: also require the token for reads (set "1" to enforce).
   AuthTokenRead:
@@ -133,6 +139,28 @@ Parameters:
 Conditions:
   EnableAuthRead: !Equals [!Ref AuthTokenRead, "1"]
   HasCorsOrigin: !Not [!Equals [!Ref CorsAllowOrigin, ""]]
+
+# [GPT-5.6] Reject CPU/memory pairs that ECS Fargate cannot register.
+Rules:
+  ValidFargateTaskSize:
+    Assertions:
+      - Assert: !Or
+          - !And
+            - !Equals [!Ref TaskCpu, 256]
+            - !Contains [[512, 1024, 2048], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 512]
+            - !Contains [[1024, 2048, 4096], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 1024]
+            - !Contains [[2048, 4096, 8192], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 2048]
+            - !Contains [[4096, 8192, 16384], !Ref TaskMemory]
+          - !And
+            - !Equals [!Ref TaskCpu, 4096]
+            - !Contains [[8192, 16384], !Ref TaskMemory]
+        AssertDescription: Select a CPU and memory combination supported by ECS Fargate.
 
 # ---------------------------------------------------------------------------
 # Resources
@@ -298,11 +326,13 @@ Resources:
           ToPort: 443
           CidrIp: "0.0.0.0/0"
           Description: "HTTPS from internet"
+      # [GPT-5.6] Prevent EC2's implicit allow-all egress; the ALB reaches only this task SG.
+      SecurityGroupEgress:
         - IpProtocol: tcp
-          FromPort: 443
-          ToPort: 443
-          CidrIpv6: "::/0"
-          Description: "HTTPS from internet (IPv6)"
+          FromPort: 3030
+          ToPort: 3030
+          DestinationSecurityGroupId: !Ref TaskSecurityGroup
+          Description: "HTTP to sparq-server tasks only"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-alb-sg"
@@ -313,24 +343,27 @@ Resources:
     Properties:
       GroupDescription: "sparq-server task: inbound port 3030 from ALB SG only"
       VpcId: !Ref VPC
-      SecurityGroupIngress:
+      # [GPT-5.6] HTTPS-only egress covers GHCR, Secrets Manager, and CloudWatch via NAT.
+      SecurityGroupEgress:
         - IpProtocol: tcp
-          FromPort: 3030
-          ToPort: 3030
-          SourceSecurityGroupId: !Ref AlbSecurityGroup
-          Description: "sparq-server port from ALB only"
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+          Description: "HTTPS dependencies via NAT"
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-task-sg"
 
-  # Egress: allow tasks to reach GHCR (image pull via NAT) and Secrets Manager (VPC endpoint if present)
-  TaskEgressAll:
-    Type: AWS::EC2::SecurityGroupEgress
+  # [GPT-5.6] Standalone rule avoids a circular SG dependency while restricting task ingress to ALB.
+  TaskIngressFromAlb:
+    Type: AWS::EC2::SecurityGroupIngress
     Properties:
       GroupId: !Ref TaskSecurityGroup
-      IpProtocol: "-1"
-      CidrIp: "0.0.0.0/0"
-      Description: "Outbound for image pull + Secrets Manager + CloudWatch"
+      IpProtocol: tcp
+      FromPort: 3030
+      ToPort: 3030
+      SourceSecurityGroupId: !Ref AlbSecurityGroup
+      Description: "sparq-server port from ALB only"
 
   # -------------------------------------------------------------------------
   # CloudWatch Logs
@@ -342,12 +375,11 @@ Resources:
       RetentionInDays: 30
 
   # -------------------------------------------------------------------------
-  # IAM: Execution Role (ECS pulls image + reads secrets) — R5
+  # [GPT-5.6] IAM execution role: inject the secret and write logs; public GHCR needs no IAM pull grant.
   # -------------------------------------------------------------------------
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-execution-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -355,11 +387,15 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      ManagedPolicyArns:
-        # Required for ECS to pull images from ECR / GHCR and write logs
-        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+            # [GPT-5.6] Bind ECS assumptions to this account to mitigate confused-deputy use.
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:*"
       Policies:
-        - PolicyName: ReadAuthTokenSecret
+        # [GPT-5.6] GHCR is public, so the wildcard AWS-managed ECR policy is unnecessary.
+        - PolicyName: LaunchSparqTask
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
@@ -368,6 +404,12 @@ Resources:
                   - secretsmanager:GetSecretValue
                 # Scoped to ONLY this stack's secret — no wildcard (R5)
                 Resource: !Ref AuthTokenSecretArn
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub >-
+                  arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${LogGroup}:log-stream:*
 
   # -------------------------------------------------------------------------
   # IAM: Task Role (the running container's identity) — R5
@@ -375,7 +417,6 @@ Resources:
   TaskRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-task-role"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -383,19 +424,12 @@ Resources:
             Principal:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
-      Policies:
-        - PolicyName: WriteCloudWatchLogs
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:CreateLogStream
-                  - logs:PutLogEvents
-                Resource: !GetAtt LogGroup.Arn
-      # No additional permissions: the running container only needs to write logs.
-      # It does NOT need access to Secrets Manager at runtime (the execution role
-      # injects the secret value at task launch via ValueFrom — it is never runtime-fetched).
+            # [GPT-5.6] The application gets no AWS API permissions; trust is account-scoped.
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnLike:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:*"
 
   # -------------------------------------------------------------------------
   # ECS Cluster
@@ -422,6 +456,9 @@ Resources:
         - FARGATE
       ExecutionRoleArn: !GetAtt ExecutionRole.Arn
       TaskRoleArn: !GetAtt TaskRole.Arn
+      # [GPT-5.6] Keep /data writable while the container root filesystem stays read-only (R8).
+      Volumes:
+        - Name: data
       ContainerDefinitions:
         - Name: sparq-server
           Image: !Ref ImageRef
@@ -429,9 +466,18 @@ Resources:
           ReadonlyRootFilesystem: true
           # Non-root: the distroless image already runs as nonroot (uid 65532). (R8)
           # Do NOT add privileged: true or user: root.
+          # [GPT-5.6] The service needs no Linux capabilities.
+          LinuxParameters:
+            Capabilities:
+              Drop:
+                - ALL
           PortMappings:
             - ContainerPort: 3030
               Protocol: tcp
+          MountPoints:
+            - SourceVolume: data
+              ContainerPath: /data
+              ReadOnly: false
           # R1/R4: SPARQ_AUTH_TOKEN is NEVER a literal — always injected from Secrets Manager.
           Secrets:
             - Name: SPARQ_AUTH_TOKEN
@@ -468,7 +514,7 @@ Resources:
           HealthCheck:
             Command:
               - CMD
-              - /sparq-server
+              - /usr/local/bin/sparq-server
               - --health-probe
             Interval: 30
             Timeout: 5
@@ -481,7 +527,6 @@ Resources:
   ALB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !Sub "${AWS::StackName}-alb"
       Type: application
       Scheme: internet-facing
       Subnets:
@@ -500,7 +545,6 @@ Resources:
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      Name: !Sub "${AWS::StackName}-tg"
       VpcId: !Ref VPC
       Protocol: HTTP
       Port: 3030
@@ -508,7 +552,7 @@ Resources:
       # R7: health check on /health, expects "ok" (200)
       HealthCheckEnabled: true
       HealthCheckProtocol: HTTP
-      HealthCheckPath: /health
+      HealthCheckPath: !Ref HealthCheckPath
       HealthCheckIntervalSeconds: 30
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
@@ -533,20 +577,6 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup
 
-  # HTTP→HTTPS redirect (R3: no plaintext Bearer token in transit)
-  HttpListener:
-    Type: AWS::ElasticLoadBalancingV2::Listener
-    Properties:
-      LoadBalancerArn: !Ref ALB
-      Port: 80
-      Protocol: HTTP
-      DefaultActions:
-        - Type: redirect
-          RedirectConfig:
-            Protocol: HTTPS
-            Port: "443"
-            StatusCode: HTTP_301
-
   # -------------------------------------------------------------------------
   # ECS Service
   # -------------------------------------------------------------------------
@@ -554,7 +584,7 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn:
       - HttpsListener
-      - HttpListener
+      - TaskIngressFromAlb
     Properties:
       ServiceName: !Sub "${AWS::StackName}-service"
       Cluster: !Ref Cluster
@@ -609,10 +639,6 @@ Outputs:
     Value: !GetAtt Service.Name
     Export:
       Name: !Sub "${AWS::StackName}-ServiceName"
-
-  SparqlEndpoint:
-    Description: "SPARQL 1.1 Protocol endpoint (requires Authorization: Bearer <token> header)."
-    Value: !Sub "https://${ALB.DNSName}/sparql"
 
   LogGroupName:
     Description: CloudWatch log group for sparq-server container logs.

--- a/deploy/aws/sparq-server.yaml
+++ b/deploy/aws/sparq-server.yaml
@@ -1,0 +1,621 @@
+# [SONNET-4.6] sq-17rgw — AWS CloudFormation template: sparq-server on ECS Fargate + ALB.
+#
+# SECURE-DEFAULTS NOTICE (R1/R9):
+# The sparq-server image is open-by-default at the image layer (bakes SPARQ_ALLOW_REMOTE=1,
+# no auth). Anyone reaching the published port can read AND write the dataset.
+# This template enforces auth ON at the template layer:
+#   - SPARQ_AUTH_TOKEN is injected from AWS Secrets Manager (ValueFrom) — never a literal.
+#   - Do NOT remove the Secrets Manager wiring. Do NOT set a default token value here.
+#
+# DECISION LOG (sq-17rgw):
+#   - ECS Fargate (not EC2): managed, serverless; no OS patching, no bastion needed.
+#   - ALB + ACM (HTTPS only): TLS terminated at ALB; task SG accepts traffic only from ALB SG (R6).
+#   - Secrets Manager (ValueFrom): token never touches CloudFormation parameter plaintext (R4).
+#   - Dedicated TaskRole + ExecutionRole (least-privilege): policies scoped to own resources (R5).
+#   - A VPC is created by this template for simplicity; supply an existing VPC ID via parameter
+#     if you have one. Two public subnets (ALB) + two private subnets (task) are created.
+#   - Default desired count = 1 (single-instance; dataset is in-memory/local volume).
+#   - ACM cert ARN is a required parameter — no self-signed cert is provisioned (R3).
+#
+# USAGE:
+#   1. Create your Secrets Manager secret:
+#        aws secretsmanager create-secret \
+#          --name /sparq/server/auth-token \
+#          --secret-string "$(openssl rand -hex 32)"
+#   2. Request or import an ACM certificate for your domain.
+#   3. Launch the stack:
+#        aws cloudformation create-stack \
+#          --stack-name sparq-server \
+#          --template-body file://sparq-server.yaml \
+#          --capabilities CAPABILITY_NAMED_IAM \
+#          --parameters \
+#            ParameterKey=AuthTokenSecretArn,ParameterValue=arn:aws:secretsmanager:... \
+#            ParameterKey=AcmCertificateArn,ParameterValue=arn:aws:acm:...
+#   4. The stack outputs the ALB DNS name. Point your domain's CNAME to it.
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  sparq-server on ECS Fargate with an Application Load Balancer (HTTPS/TLS via ACM).
+  Enforces auth-on-by-default (R1) via Secrets Manager ValueFrom injection (R4).
+  Least-privilege task/execution roles (R5). ALB health check on /health (R7).
+  [SONNET-4.6] sq-17rgw
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+Parameters:
+
+  # --- Required ---
+  AuthTokenSecretArn:
+    Type: String
+    Description: >
+      ARN of the AWS Secrets Manager secret whose SecretString is the SPARQ_AUTH_TOKEN
+      bearer token. The task reads this at launch via ECS ValueFrom injection.
+      NEVER paste the token value here; only its ARN. (R1/R4)
+    AllowedPattern: "^arn:aws[a-z-]*:secretsmanager:[a-z0-9-]+:[0-9]{12}:secret:.+$"
+    ConstraintDescription: Must be a valid Secrets Manager secret ARN.
+
+  AcmCertificateArn:
+    Type: String
+    Description: >
+      ARN of an ACM certificate covering the domain you will use. Required for the
+      HTTPS listener. The ALB terminates TLS; the task receives plain HTTP on port 3030
+      inside the VPC (the task SG allows traffic only from the ALB SG). (R3)
+    AllowedPattern: "^arn:aws[a-z-]*:acm:[a-z0-9-]+:[0-9]{12}:certificate/.+$"
+    ConstraintDescription: Must be a valid ACM certificate ARN.
+
+  # --- Optional tuning ---
+  ImageRef:
+    Type: String
+    Default: "ghcr.io/sparq-org/sparq-server:latest"
+    Description: >
+      Full image reference (registry/image:tag). Defaults to the canonical GHCR image.
+      Pin to a specific version tag in production (e.g. ghcr.io/sparq-org/sparq-server:0.1.0).
+    AllowedPattern: "^[a-z0-9._/-]+:[a-zA-Z0-9._-]+$"
+
+  TaskCpu:
+    Type: Number
+    Default: 512
+    AllowedValues: [256, 512, 1024, 2048, 4096]
+    Description: Fargate task CPU units (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU, …)
+
+  TaskMemory:
+    Type: Number
+    Default: 1024
+    AllowedValues: [512, 1024, 2048, 4096, 8192, 16384]
+    Description: Fargate task memory in MiB.
+
+  DesiredCount:
+    Type: Number
+    Default: 1
+    MinValue: 1
+    MaxValue: 10
+    Description: >
+      Number of running Fargate tasks. Note: the dataset is stored per-task (in-memory or
+      local volume). For shared persistent data, mount an EFS volume (future work). Keep
+      this at 1 for a single-writer dataset or read-replica scenario.
+
+  # Read-gate: also require the token for reads (set "1" to enforce).
+  AuthTokenRead:
+    Type: String
+    Default: ""
+    AllowedValues: ["", "1"]
+    Description: >
+      Set to "1" to also gate read queries behind the auth token (SPARQ_AUTH_TOKEN_READ=1).
+      Leave empty to allow unauthenticated reads while gating writes.
+
+  # CORS
+  CorsAllowOrigin:
+    Type: String
+    Default: ""
+    Description: >
+      Value for SPARQ_CORS_ALLOW_ORIGIN. Set to your front-end origin in production
+      (e.g. https://example.com). Leave empty to disable CORS headers.
+
+  # Query limits
+  MaxConcurrent:
+    Type: Number
+    Default: 16
+    MinValue: 1
+    MaxValue: 256
+    Description: Maximum concurrent SPARQL query workers (SPARQ_MAX_CONCURRENT).
+
+  QueryTimeoutSeconds:
+    Type: Number
+    Default: 30
+    MinValue: 5
+    MaxValue: 300
+    Description: Per-query timeout in seconds (SPARQ_QUERY_TIMEOUT).
+
+# ---------------------------------------------------------------------------
+# Conditions
+# ---------------------------------------------------------------------------
+Conditions:
+  EnableAuthRead: !Equals [!Ref AuthTokenRead, "1"]
+  HasCorsOrigin: !Not [!Equals [!Ref CorsAllowOrigin, ""]]
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+Resources:
+
+  # -------------------------------------------------------------------------
+  # Networking: VPC, subnets, IGW, route tables, NAT
+  # -------------------------------------------------------------------------
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: "10.10.0.0/16"
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-vpc"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-igw"
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  # Public subnets (ALB lives here)
+  PublicSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.10.0.0/24"
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-a"
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.10.1.0/24"
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-b"
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-public-rt"
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetARouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetA
+      RouteTableId: !Ref PublicRouteTable
+
+  PublicSubnetBRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PublicSubnetB
+      RouteTableId: !Ref PublicRouteTable
+
+  # NAT Gateway so private-subnet tasks can pull images from GHCR
+  NatEipA:
+    Type: AWS::EC2::EIP
+    DependsOn: VPCGatewayAttachment
+    Properties:
+      Domain: vpc
+
+  NatGatewayA:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatEipA.AllocationId
+      SubnetId: !Ref PublicSubnetA
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-nat-a"
+
+  # Private subnets (ECS tasks live here — no direct public IP)
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.10.10.0/24"
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-a"
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: "10.10.11.0/24"
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-b"
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-private-rt"
+
+  PrivateRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: !Ref NatGatewayA
+
+  PrivateSubnetARouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetA
+      RouteTableId: !Ref PrivateRouteTable
+
+  PrivateSubnetBRouteTableAssoc:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      SubnetId: !Ref PrivateSubnetB
+      RouteTableId: !Ref PrivateRouteTable
+
+  # -------------------------------------------------------------------------
+  # Security Groups (R6: inbound only on intended ports from intended sources)
+  # -------------------------------------------------------------------------
+
+  # ALB SG: accepts HTTPS (443) from the internet only
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "sparq ALB: inbound HTTPS from internet, outbound to task SG"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: "0.0.0.0/0"
+          Description: "HTTPS from internet"
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIpv6: "::/0"
+          Description: "HTTPS from internet (IPv6)"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-alb-sg"
+
+  # Task SG: accepts traffic on port 3030 ONLY from the ALB SG (R6)
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "sparq-server task: inbound port 3030 from ALB SG only"
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 3030
+          ToPort: 3030
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+          Description: "sparq-server port from ALB only"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-task-sg"
+
+  # Egress: allow tasks to reach GHCR (image pull via NAT) and Secrets Manager (VPC endpoint if present)
+  TaskEgressAll:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref TaskSecurityGroup
+      IpProtocol: "-1"
+      CidrIp: "0.0.0.0/0"
+      Description: "Outbound for image pull + Secrets Manager + CloudWatch"
+
+  # -------------------------------------------------------------------------
+  # CloudWatch Logs
+  # -------------------------------------------------------------------------
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/${AWS::StackName}/sparq-server"
+      RetentionInDays: 30
+
+  # -------------------------------------------------------------------------
+  # IAM: Execution Role (ECS pulls image + reads secrets) — R5
+  # -------------------------------------------------------------------------
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-execution-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # Required for ECS to pull images from ECR / GHCR and write logs
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: ReadAuthTokenSecret
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                # Scoped to ONLY this stack's secret — no wildcard (R5)
+                Resource: !Ref AuthTokenSecretArn
+
+  # -------------------------------------------------------------------------
+  # IAM: Task Role (the running container's identity) — R5
+  # -------------------------------------------------------------------------
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-task-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: WriteCloudWatchLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !GetAtt LogGroup.Arn
+      # No additional permissions: the running container only needs to write logs.
+      # It does NOT need access to Secrets Manager at runtime (the execution role
+      # injects the secret value at task launch via ValueFrom — it is never runtime-fetched).
+
+  # -------------------------------------------------------------------------
+  # ECS Cluster
+  # -------------------------------------------------------------------------
+  Cluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "${AWS::StackName}-cluster"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+
+  # -------------------------------------------------------------------------
+  # ECS Task Definition
+  # -------------------------------------------------------------------------
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "${AWS::StackName}-sparq-server"
+      Cpu: !Ref TaskCpu
+      Memory: !Ref TaskMemory
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      ExecutionRoleArn: !GetAtt ExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: sparq-server
+          Image: !Ref ImageRef
+          Essential: true
+          ReadonlyRootFilesystem: true
+          # Non-root: the distroless image already runs as nonroot (uid 65532). (R8)
+          # Do NOT add privileged: true or user: root.
+          PortMappings:
+            - ContainerPort: 3030
+              Protocol: tcp
+          # R1/R4: SPARQ_AUTH_TOKEN is NEVER a literal — always injected from Secrets Manager.
+          Secrets:
+            - Name: SPARQ_AUTH_TOKEN
+              ValueFrom: !Ref AuthTokenSecretArn
+          Environment:
+            # Only non-secret env vars go here.
+            - Name: SPARQ_ALLOW_REMOTE
+              Value: "1"
+            - Name: SPARQ_MAX_CONCURRENT
+              Value: !Sub "${MaxConcurrent}"
+            - Name: SPARQ_QUERY_TIMEOUT
+              Value: !Sub "${QueryTimeoutSeconds}"
+            # Read-gate: set to "1" to gate reads behind the auth token too.
+            # The !If emits an empty string ("") when disabled, which the server
+            # ignores (only "1" activates it).
+            - Name: SPARQ_AUTH_TOKEN_READ
+              Value: !If [EnableAuthRead, "1", ""]
+            # CORS: empty string means no CORS header is emitted by sparq-server.
+            - Name: SPARQ_CORS_ALLOW_ORIGIN
+              Value: !If [HasCorsOrigin, !Ref CorsAllowOrigin, ""]
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: sparq-server
+          # Health check via the sparq-server --health-probe binary (R7).
+          # The distroless image has no shell, so CMD-SHELL is unavailable.
+          # Instead, invoke the server's own built-in health probe subcommand,
+          # which exits 0 when the server is healthy (health_probe.rs, default
+          # target 127.0.0.1:3030/health). CMD form (no shell) is required.
+          # The ALB target-group /health check is the primary drain; this is
+          # defence-in-depth so ECS detects a crashed container without the ALB.
+          HealthCheck:
+            Command:
+              - CMD
+              - /sparq-server
+              - --health-probe
+            Interval: 30
+            Timeout: 5
+            Retries: 3
+            StartPeriod: 15
+
+  # -------------------------------------------------------------------------
+  # Application Load Balancer (HTTPS-only, R3)
+  # -------------------------------------------------------------------------
+  ALB:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Name: !Sub "${AWS::StackName}-alb"
+      Type: application
+      Scheme: internet-facing
+      Subnets:
+        - !Ref PublicSubnetA
+        - !Ref PublicSubnetB
+      SecurityGroups:
+        - !Ref AlbSecurityGroup
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: "60"
+        # Drop invalid HTTP headers — hardens against header-injection
+        - Key: routing.http.drop_invalid_header_fields.enabled
+          Value: "true"
+
+  # Target group: forwards to the ECS service on port 3030
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub "${AWS::StackName}-tg"
+      VpcId: !Ref VPC
+      Protocol: HTTP
+      Port: 3030
+      TargetType: ip
+      # R7: health check on /health, expects "ok" (200)
+      HealthCheckEnabled: true
+      HealthCheckProtocol: HTTP
+      HealthCheckPath: /health
+      HealthCheckIntervalSeconds: 30
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
+      UnhealthyThresholdCount: 3
+      Matcher:
+        HttpCode: "200"
+      TargetGroupAttributes:
+        - Key: deregistration_delay.timeout_seconds
+          Value: "30"
+
+  # HTTPS listener — TLS terminated here with the ACM cert (R3)
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06  # TLS 1.2+ with TLS 1.3 preferred
+      Certificates:
+        - CertificateArn: !Ref AcmCertificateArn
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  # HTTP→HTTPS redirect (R3: no plaintext Bearer token in transit)
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref ALB
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: redirect
+          RedirectConfig:
+            Protocol: HTTPS
+            Port: "443"
+            StatusCode: HTTP_301
+
+  # -------------------------------------------------------------------------
+  # ECS Service
+  # -------------------------------------------------------------------------
+  Service:
+    Type: AWS::ECS::Service
+    DependsOn:
+      - HttpsListener
+      - HttpListener
+    Properties:
+      ServiceName: !Sub "${AWS::StackName}-service"
+      Cluster: !Ref Cluster
+      TaskDefinition: !Ref TaskDefinition
+      LaunchType: FARGATE
+      DesiredCount: !Ref DesiredCount
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          Subnets:
+            - !Ref PrivateSubnetA
+            - !Ref PrivateSubnetB
+          SecurityGroups:
+            - !Ref TaskSecurityGroup
+          # Tasks are in private subnets — no public IP needed; they egress via NAT (R6)
+          AssignPublicIp: DISABLED
+      LoadBalancers:
+        - ContainerName: sparq-server
+          ContainerPort: 3030
+          TargetGroupArn: !Ref TargetGroup
+      HealthCheckGracePeriodSeconds: 30
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 100
+        MaximumPercent: 200
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+Outputs:
+
+  AlbDnsName:
+    Description: >
+      ALB DNS name — create a CNAME from your domain to this value.
+      The SPARQL endpoint is at https://<your-domain>/sparql
+    Value: !GetAtt ALB.DNSName
+    Export:
+      Name: !Sub "${AWS::StackName}-AlbDnsName"
+
+  AlbHostedZoneId:
+    Description: ALB hosted zone ID — use with Route 53 alias records.
+    Value: !GetAtt ALB.CanonicalHostedZoneID
+    Export:
+      Name: !Sub "${AWS::StackName}-AlbHostedZoneId"
+
+  ClusterName:
+    Description: ECS Cluster name.
+    Value: !Ref Cluster
+    Export:
+      Name: !Sub "${AWS::StackName}-ClusterName"
+
+  ServiceName:
+    Description: ECS Service name.
+    Value: !GetAtt Service.Name
+    Export:
+      Name: !Sub "${AWS::StackName}-ServiceName"
+
+  SparqlEndpoint:
+    Description: "SPARQL 1.1 Protocol endpoint (requires Authorization: Bearer <token> header)."
+    Value: !Sub "https://${ALB.DNSName}/sparql"
+
+  LogGroupName:
+    Description: CloudWatch log group for sparq-server container logs.
+    Value: !Ref LogGroup
+    Export:
+      Name: !Sub "${AWS::StackName}-LogGroup"


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) implementing bead sq-17rgw.

## Summary

CloudFormation templates for deploying sparq on **AWS ECS Fargate + ALB** under `deploy/aws/`. Two templates: `sparq-server.yaml` (available now) and `sparq-lws.yaml` (activates once sq-lmz40 ships).

## Decisions made per design record (not declined)

- **ECS Fargate + ALB**: managed compute, no OS patching, no bastion. EC2 fallback documented as discovered work in README.
- **ACM certificate ARN as required parameter**: R3 (TLS at edge). No self-signed cert provisioned — operators must supply an ACM cert.
- **Secrets Manager `ValueFrom`** for `SPARQ_AUTH_TOKEN` (sparq-server): R1/R4 — the token literal never appears in CloudFormation parameters, stack events, or template files. `AuthTokenSecretArn` is a required parameter with no default (option (b) from R1).
- **VPC provisioned by template**: two public subnets (ALB) + two private subnets (tasks, no public IP) + NAT Gateway. Operators can adapt to an existing VPC; parameterisation is noted as discovered work.
- **`DesiredCount=1` default for LWS**: in-memory DPoP replay is correct at single replica. Multi-replica requires Redis; `RedisReplaySecretArn` parameter wires it.
- **`SPARQ_AUTH_TOKEN_READ` and `SPARQ_CORS_ALLOW_ORIGIN`** always present in task `Environment` but empty-string when not enabled (CFN does not allow conditional list-item splicing at the sequence level; an empty string is ignored by the server).
- **sparq-lws.yaml marked pending sq-lmz40**: template is structurally complete and cfn-lint valid; deploy once `ghcr.io/sparq-org/sparq-lws-core` is published.
- **`--health-probe` CMD (no shell)**: distroless image has no shell; ECS `HealthCheck` uses CMD form invoking the server's built-in health probe binary.

## Secure defaults satisfied

| Rule | Mechanism |
|---|---|
| R1 (auth ON) | `AuthTokenSecretArn` required; `ValueFrom` injection; no default token |
| R2 (no anonymous write) | sparq-server: 401 on unauth write; LWS: fail-closed by image design; no dev escape hatches |
| R3 (TLS at edge) | ALB HTTPS listener (TLS 1.3-preferred policy); port 80 → 301 → 443 |
| R4 (secrets in secret store) | Secrets Manager ValueFrom; no literal in template |
| R5 (least-privilege IAM) | ExecutionRole: pull image + GetSecretValue scoped to own ARN only; TaskRole: CloudWatch logs only |
| R6 (app port only from ALB SG) | Task SG: source = ALB SG (not CIDR); tasks in private subnets |
| R7 (health check per-server) | ALB TG: `/health` (sparq-server) / `/readyz` (LWS); ECS liveness via `--health-probe` |
| R8 (non-root) | `ReadonlyRootFilesystem: true`; image already non-root; no privilege override |
| R9 (honest posture) | Header comment + README both state the open-by-default caveat |

## Static gate status (honest)

- **cfn-lint 1.53.0**: exit 0 on both templates — no errors, no warnings. [SONNET-4.6]
- **`aws cloudformation validate-template`**: unavailable — dev box IAM role lacks `cloudformation:ValidateTemplate`. cfn-lint performs equivalent offline structural + schema validation.
- **Secret-literal grep**: `grep -rEin "SPARQ_AUTH_TOKEN\s*[:=]\s*'\"[a-zA-Z0-9+/]{16,}" deploy/aws/` → no matches. Earlier grep on "secret-string" matched only the CLI example comment, not an inlined value.
- **YAML validity**: both files parse with CFN-aware YAML loader (all CFN tags registered).
- **No workflow changes**: `ci-summary` gate aggregator unaffected. No new gating check added. Changes are `deploy/aws/**` only.

## Discovered work (not creating beads from CI context — captured here for orchestrator)

- A `deploy-aws-lint.yml` workflow running `cfn-lint` on `paths: deploy/aws/**` (`workflow_dispatch` + path filter, non-gating to Rust gate per design §4).
- Parameterise VPC: accept existing VPC ID + subnet IDs instead of always creating a new VPC.
- EC2 fallback template (single `t3`/`t4g` instance, user-data `docker run`, EIP or ALB) per §3.1 of the design record.
- Auto-generate the auth token at stack deploy time (Lambda-backed custom resource) to remove the pre-creation requirement.

🤖 SPARQ agent

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>