### PR TITLE
feat(deploy): GCP Cloud Run one-click for sq-agolp [SONNET]

### DIFF
--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -6,6 +6,12 @@ Cloud Run service specs for running sparq on GCP **Cloud Run** (fully managed) w
 automatic HTTPS, Secret Manager auth injection, and a dedicated least-privilege service
 account.
 
+<!-- [GPT-5.6] Cloud Run's writable filesystem is ephemeral; these services are single-instance. -->
+> **Durability limit:** both servers currently keep mutable state in the container instance.
+> Cloud Run can restart that instance at any time, so this deployment is suitable for evaluation
+> and reloadable datasets, not durable production storage. Both manifests cap scaling at one
+> instance to prevent divergent copies of state.
+
 Two service specs:
 
 | Spec | Image | Port | Health path | Status |
@@ -26,7 +32,7 @@ Two service specs:
 Key rules applied:
 
 - **R1 (auth ON):** `SPARQ_AUTH_TOKEN` is required and comes from Secret Manager — never
-  a spec parameter value or plaintext env var.
+  a spec parameter value or plaintext env var. `SPARQ_AUTH_TOKEN_READ=1` also gates reads.
 - **R2 (no anonymous write):** Unauthenticated writes return 401. sparq-lws-core is
   fail-closed by design; anonymous mutation is rejected at the image layer.
 - **R3 (TLS at edge):** Cloud Run provides HTTPS automatically on the `run.app` URL —
@@ -37,11 +43,21 @@ Key rules applied:
 - **R5 (least-privilege SA):** A dedicated service account (`sparq-server-sa` /
   `sparq-lws-sa`) is created with `roles/secretmanager.secretAccessor` on its own secret
   only — not the Compute default SA, not a project-level role.
+- **R6 (intended ingress only):** Only the declared application port is exposed. Public
+  invocation is explicit because application auth consumes the `Authorization` header.
 - **R7 (health check):** Startup + liveness probes on `/health` (sparq-server) or
-  `/livez` (LWS); readiness on `/readyz` (LWS). `min-instances: 1` keeps the server warm
-  so health probes never hit a cold-start timeout.
-- **R8 (non-root):** Both images run as non-root (distroless nonroot base). Cloud Run does
-  not override this.
+  `/readyz` + `/livez` (LWS); readiness on `/readyz` (LWS). Custom probes use
+  instance-based CPU allocation, and `min-instances: 1` avoids cold starts. The LWS
+  manifest explicitly opts into Cloud Run's BETA launch stage for its Preview readiness probe.
+- **R8 (non-root):** Both images run as non-root. Cloud Run rejects Kubernetes
+  `securityContext`/`readOnlyRootFilesystem`, but removes added capabilities and privilege
+  escalation. Its writable root overlay is ephemeral.
+
+<!-- [GPT-5.6] App Bearer auth and Cloud Run IAM cannot both occupy Authorization. -->
+The manifests disable Cloud Run's Invoker IAM check and expose only the managed HTTPS endpoint.
+This is intentional: requiring a Google identity token at the edge would consume the same
+`Authorization` header used by sparq's Bearer token. If you make a service IAM-private instead,
+put an authenticating proxy in front of it rather than removing application auth.
 
 ---
 
@@ -55,78 +71,108 @@ Key rules applied:
    gcloud services enable run.googleapis.com secretmanager.googleapis.com
    ```
 
+   Set deployment variables (the deployer principal may instead be a service account):
+
+   ```bash
+   PROJECT_ID="$(gcloud config get-value project)"
+   PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
+   REGION="us-central1"
+   DEPLOYER_MEMBER="user:$(gcloud config get-value account)"
+   ```
+
 2. Create the auth token secret in Secret Manager:
 
    ```bash
-   echo -n "$(openssl rand -hex 32)" | \
+   # [GPT-5.6] Strip openssl's newline so the stored token matches the HTTP header exactly.
+   openssl rand -hex 32 | tr -d '\n' | \
      gcloud secrets create sparq-auth-token \
        --replication-policy=automatic \
-       --data-file=-
+       --data-file=- \
+       --project="${PROJECT_ID}"
    ```
 
 3. Create a dedicated least-privilege service account (R5):
 
    ```bash
    gcloud iam service-accounts create sparq-server-sa \
-     --display-name="sparq-server Cloud Run runtime SA"
+     --display-name="sparq-server Cloud Run runtime SA" \
+     --project="${PROJECT_ID}"
 
    gcloud secrets add-iam-policy-binding sparq-auth-token \
      --member="serviceAccount:sparq-server-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
-     --role="roles/secretmanager.secretAccessor"
+     --role="roles/secretmanager.secretAccessor" \
+     --project="${PROJECT_ID}"
    ```
 
-4. Grant Cloud Run the ability to act as the service account:
+4. Grant only the deployer permission to attach the runtime service account:
 
    ```bash
-   gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-     --member="serviceAccount:sparq-server-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
-     --role="roles/run.invoker" 2>/dev/null || true
+   gcloud iam service-accounts add-iam-policy-binding \
+     "sparq-server-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+     --member="${DEPLOYER_MEMBER}" \
+     --role="roles/iam.serviceAccountUser" \
+     --project="${PROJECT_ID}"
    ```
+
+   <!-- [GPT-5.6] This replaces the invalid runtime-SA roles/run.invoker grant. -->
+   Do not grant `roles/run.invoker` to the runtime service account; that neither authorizes
+   the deployer to attach it nor makes the service public.
 
 ### One-liner deploy
 
-Replace `PROJECT_ID` and `REGION` with your values, then edit `serviceAccountName` in
-`sparq-server.yaml` to substitute your project ID, and run:
+Render the project-scoped service-account and secret references into a temporary file, then
+replace the Cloud Run service:
 
 ```bash
-gcloud run services replace deploy/gcp/sparq-server.yaml \
-  --region REGION \
-  --project PROJECT_ID
+RENDERED="$(mktemp)"
+trap 'rm -f "${RENDERED}"' EXIT
+sed -e "s/PROJECT_ID/${PROJECT_ID}/g" \
+    -e "s/PROJECT_NUMBER/${PROJECT_NUMBER}/g" \
+    deploy/gcp/sparq-server.yaml >"${RENDERED}"
+gcloud run services replace "${RENDERED}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}"
 ```
 
 The command outputs the service URL (`https://<hash>.run.app`). Your SPARQL endpoint
 is at `https://<hash>.run.app/sparql`.
 
-### "Run on Google Cloud" button
+### Why there is no Cloud Run Button
 
-> The Cloud Run Button requires a public GitHub repo. Replace `<YOUR_BRANCH>` with the
-> branch or tag you want to deploy from (default: `main`).
-
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run/?git_repo=https://github.com/sparq-org/sparq&dir=deploy/gcp)
-
-> **Note:** The Cloud Run Button launches Cloud Shell and runs `gcloud run services replace`
-> from the repo. You must still complete the secret creation and service account setup
-> (steps 1–3 above) before clicking, and edit `sparq-server.yaml` to set your `PROJECT_ID`
-> in the `serviceAccountName` field.
+<!-- [GPT-5.6] The removed button tried to source-build deploy/gcp and never applied this YAML. -->
+The Cloud Run Button builds a container from the selected repository directory; it does not
+apply these service manifests or safely provision their Secret Manager and IAM prerequisites.
+Pointing it at `deploy/gcp/` would therefore fail or deploy the wrong artifact. Use the commands
+above, which deploy the published image without rebuilding it and never put the token in plaintext
+service configuration.
 
 ### Verify the deploy
 
 ```bash
+SERVICE_URL="$(gcloud run services describe sparq-server \
+  --region="${REGION}" --project="${PROJECT_ID}" --format='value(status.url)')"
+
 # Health check (ungated — should return "ok"):
-curl https://<hash>.run.app/health
+curl "${SERVICE_URL}/health"
 
 # Authenticated SPARQL query:
 curl -H "Authorization: Bearer $(gcloud secrets versions access latest \
-       --secret=sparq-auth-token)" \
+       --secret=sparq-auth-token --project="${PROJECT_ID}")" \
      -H "Accept: application/sparql-results+json" \
      --data-urlencode "query=SELECT * WHERE { ?s ?p ?o } LIMIT 1" \
-     "https://<hash>.run.app/sparql"
+     "${SERVICE_URL}/sparql"
+
+# Unauthenticated read must return 401 (SPARQ_AUTH_TOKEN_READ=1):
+curl -sS -o /dev/null -w '%{http_code}\n' \
+  --data-urlencode "query=SELECT * WHERE { ?s ?p ?o } LIMIT 1" \
+  "${SERVICE_URL}/sparql"
 
 # Unauthenticated write must return 401 (R2 acceptance check):
-curl -X POST -H "Content-Type: application/sparql-update" \
+curl -sS -o /dev/null -w '%{http_code}\n' \
+     -X POST -H "Content-Type: application/sparql-update" \
      --data "INSERT DATA { <urn:test> <urn:p> <urn:o> }" \
-     "https://<hash>.run.app/sparql"
-# Expected: HTTP 401
+     "${SERVICE_URL}/sparql"
+# Expected for both unauthenticated requests: 401
 ```
 
 ---
@@ -143,30 +189,53 @@ flows through OIDC/DPoP.
 
 ### Prerequisites
 
-LWS requires two values that cannot be defaulted:
+LWS requires one operator-supplied value and one deterministic Cloud Run value:
 
-1. **`SOLID_SERVER_BASE_URL`** — the public HTTPS URL where the server will be reachable.
-   After the first Cloud Run deploy, note the `run.app` URL and update `sparq-lws.yaml`;
-   or map a custom domain first.
+1. **`SOLID_SERVER_BASE_URL`** — rendered as Cloud Run's deterministic HTTPS URL,
+   `https://sparq-lws-PROJECT_NUMBER.REGION.run.app`; use a custom HTTPS domain if needed.
 2. **`SOLID_SERVER_TRUSTED_ISSUER`** — the URL of a trusted OIDC provider. LWS cannot
    self-issue tokens. Use your organisation's Solid-OIDC provider or a public provider.
 
-Edit `sparq-lws.yaml` to set both values and your `PROJECT_ID`, then:
+Set variables, create the dedicated identity, and authorize only the deployer to attach it:
 
 ```bash
-gcloud services enable run.googleapis.com
-gcloud iam service-accounts create sparq-lws-sa \
-  --display-name="sparq-lws Cloud Run runtime SA"
+PROJECT_ID="$(gcloud config get-value project)"
+PROJECT_NUMBER="$(gcloud projects describe "${PROJECT_ID}" --format='value(projectNumber)')"
+REGION="us-central1"
+TRUSTED_ISSUER="https://issuer.example.com"
+DEPLOYER_MEMBER="user:$(gcloud config get-value account)"
 
-gcloud run services replace deploy/gcp/sparq-lws.yaml \
-  --region REGION \
-  --project PROJECT_ID
+case "${TRUSTED_ISSUER}" in https://*) ;; *) echo "TRUSTED_ISSUER must use HTTPS" >&2; exit 1;; esac
+
+gcloud services enable run.googleapis.com --project="${PROJECT_ID}"
+gcloud iam service-accounts create sparq-lws-sa \
+  --display-name="sparq-lws Cloud Run runtime SA" \
+  --project="${PROJECT_ID}"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  "sparq-lws-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --member="${DEPLOYER_MEMBER}" \
+  --role="roles/iam.serviceAccountUser" \
+  --project="${PROJECT_ID}"
+
+RENDERED="$(mktemp)"
+trap 'rm -f "${RENDERED}"' EXIT
+sed -e "s/PROJECT_ID/${PROJECT_ID}/g" \
+    -e "s/PROJECT_NUMBER/${PROJECT_NUMBER}/g" \
+    -e "s/REGION/${REGION}/g" \
+    -e "s|TRUSTED_ISSUER_URL|${TRUSTED_ISSUER}|g" \
+    deploy/gcp/sparq-lws.yaml >"${RENDERED}"
+gcloud run services replace "${RENDERED}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}"
 ```
 
 **Multi-instance note:** `max-instances` defaults to 1 because the in-memory DPoP replay
 store does not survive across instances. To run multiple instances, provision a Redis
 instance and set `SOLID_SERVER_REPLAY_REDIS_URL` via a Secret Manager secretKeyRef
-(see the commented block in `sparq-lws.yaml`).
+(see the two commented blocks in `sparq-lws.yaml`). Create the secret, grant only
+`sparq-lws-sa` `roles/secretmanager.secretAccessor` on that secret, pin its version, and
+uncomment both the `run.googleapis.com/secrets` alias and the environment reference.
 
 ---
 
@@ -181,11 +250,13 @@ These decisions were made by the SPARQ agent without waiting for a maintainer gr
 | Secret wiring | Secret Manager `secretKeyRef` | R4: token literal never in YAML, env-var plaintext, or logs |
 | Service account | Dedicated SA per server (`sparq-server-sa` / `sparq-lws-sa`) | R5: `secretAccessor` on own secret only; not the Compute default SA |
 | `min-instances` | 1 (default) | R7: avoids cold-start on startup/liveness probe; dataset stays warm |
-| `max-instances` | 10 (sparq-server), 1 (LWS) | LWS replay-store constraint (§1.3); sparq-server stateless within a request |
+| `max-instances` | 1 for both | Both hold instance-local state; LWS additionally needs shared Redis replay protection before scale-out |
 | CPU/memory | 2 vCPU / 2 GiB | Reasonable default for analytical SPARQL; increase for larger in-memory datasets |
 | LWS `min-instances` | 1 | Same cold-start rationale; Solid server must be warm for WebID-TLS exchanges |
 | Probes | startup (6 × 5 s = 30 s budget) + liveness (10 s period) | Matches sparq-server's typical startup time; aggressive enough to catch hangs |
-| Cloud Run `--no-allow-unauthenticated` | Not set (service-level) | Noted in spec as an option for internal use; sparq-server token is the auth layer |
+| Cloud Run Invoker IAM check | Disabled explicitly | Public managed HTTPS reaches each server's application auth without competing for the Bearer header |
+| Billing | Instance-based CPU | Required by Cloud Run custom health probes; `min-instances: 1` incurs standing cost |
+| Root filesystem | Cloud Run writable ephemeral overlay | Cloud Run does not support `readOnlyRootFilesystem`; images remain non-root and the platform removes elevated capabilities |
 | LWS image tag | `:latest` (parameterised comment to pin) | Image not yet published; operators must pin to a release tag in production |
 
 ---

--- a/deploy/gcp/README.md
+++ b/deploy/gcp/README.md
@@ -1,0 +1,196 @@
+<!-- [SONNET-4.6] sq-agolp — GCP Cloud Run one-click deploy for sparq-server + sparq-lws-core. -->
+
+# GCP Cloud Run deploy (sq-agolp)
+
+Cloud Run service specs for running sparq on GCP **Cloud Run** (fully managed) with
+automatic HTTPS, Secret Manager auth injection, and a dedicated least-privilege service
+account.
+
+Two service specs:
+
+| Spec | Image | Port | Health path | Status |
+|---|---|---|---|---|
+| `sparq-server.yaml` | `ghcr.io/sparq-org/sparq-server` | 3030 | `GET /health` | Available |
+| `sparq-lws.yaml` | `ghcr.io/sparq-org/sparq-lws-core` | 3000 | `GET /livez` + `GET /readyz` | Activates once sq-lmz40 ships |
+
+---
+
+## Secure-defaults notice (R1/R2/R4/R9)
+
+> **sparq-server is open-by-default at the image layer.** It bakes `SPARQ_ALLOW_REMOTE=1`
+> and ships with no auth. Anyone who reaches the published port can read AND write the
+> dataset. **This spec enforces auth ON** by injecting `SPARQ_AUTH_TOKEN` from GCP Secret
+> Manager (secretKeyRef — the literal value never appears in the YAML). Do not remove the
+> Secret Manager wiring or set a default token value in the spec.
+
+Key rules applied:
+
+- **R1 (auth ON):** `SPARQ_AUTH_TOKEN` is required and comes from Secret Manager — never
+  a spec parameter value or plaintext env var.
+- **R2 (no anonymous write):** Unauthenticated writes return 401. sparq-lws-core is
+  fail-closed by design; anonymous mutation is rejected at the image layer.
+- **R3 (TLS at edge):** Cloud Run provides HTTPS automatically on the `run.app` URL —
+  no certificate management required. For custom domains, map your domain via Cloud Run
+  domain mapping (also automatic HTTPS via Google-managed certs).
+- **R4 (secrets in Secret Manager):** No literal token, password, or key in any committed
+  file. The auth token is referenced by secret name only.
+- **R5 (least-privilege SA):** A dedicated service account (`sparq-server-sa` /
+  `sparq-lws-sa`) is created with `roles/secretmanager.secretAccessor` on its own secret
+  only — not the Compute default SA, not a project-level role.
+- **R7 (health check):** Startup + liveness probes on `/health` (sparq-server) or
+  `/livez` (LWS); readiness on `/readyz` (LWS). `min-instances: 1` keeps the server warm
+  so health probes never hit a cold-start timeout.
+- **R8 (non-root):** Both images run as non-root (distroless nonroot base). Cloud Run does
+  not override this.
+
+---
+
+## sparq-server — Cloud Run deploy
+
+### Prerequisites
+
+1. Enable the required APIs:
+
+   ```bash
+   gcloud services enable run.googleapis.com secretmanager.googleapis.com
+   ```
+
+2. Create the auth token secret in Secret Manager:
+
+   ```bash
+   echo -n "$(openssl rand -hex 32)" | \
+     gcloud secrets create sparq-auth-token \
+       --replication-policy=automatic \
+       --data-file=-
+   ```
+
+3. Create a dedicated least-privilege service account (R5):
+
+   ```bash
+   gcloud iam service-accounts create sparq-server-sa \
+     --display-name="sparq-server Cloud Run runtime SA"
+
+   gcloud secrets add-iam-policy-binding sparq-auth-token \
+     --member="serviceAccount:sparq-server-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+     --role="roles/secretmanager.secretAccessor"
+   ```
+
+4. Grant Cloud Run the ability to act as the service account:
+
+   ```bash
+   gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+     --member="serviceAccount:sparq-server-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+     --role="roles/run.invoker" 2>/dev/null || true
+   ```
+
+### One-liner deploy
+
+Replace `PROJECT_ID` and `REGION` with your values, then edit `serviceAccountName` in
+`sparq-server.yaml` to substitute your project ID, and run:
+
+```bash
+gcloud run services replace deploy/gcp/sparq-server.yaml \
+  --region REGION \
+  --project PROJECT_ID
+```
+
+The command outputs the service URL (`https://<hash>.run.app`). Your SPARQL endpoint
+is at `https://<hash>.run.app/sparql`.
+
+### "Run on Google Cloud" button
+
+> The Cloud Run Button requires a public GitHub repo. Replace `<YOUR_BRANCH>` with the
+> branch or tag you want to deploy from (default: `main`).
+
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run/?git_repo=https://github.com/sparq-org/sparq&dir=deploy/gcp)
+
+> **Note:** The Cloud Run Button launches Cloud Shell and runs `gcloud run services replace`
+> from the repo. You must still complete the secret creation and service account setup
+> (steps 1–3 above) before clicking, and edit `sparq-server.yaml` to set your `PROJECT_ID`
+> in the `serviceAccountName` field.
+
+### Verify the deploy
+
+```bash
+# Health check (ungated — should return "ok"):
+curl https://<hash>.run.app/health
+
+# Authenticated SPARQL query:
+curl -H "Authorization: Bearer $(gcloud secrets versions access latest \
+       --secret=sparq-auth-token)" \
+     -H "Accept: application/sparql-results+json" \
+     --data-urlencode "query=SELECT * WHERE { ?s ?p ?o } LIMIT 1" \
+     "https://<hash>.run.app/sparql"
+
+# Unauthenticated write must return 401 (R2 acceptance check):
+curl -X POST -H "Content-Type: application/sparql-update" \
+     --data "INSERT DATA { <urn:test> <urn:p> <urn:o> }" \
+     "https://<hash>.run.app/sparql"
+# Expected: HTTP 401
+```
+
+---
+
+## sparq-lws (Solid/LWS server) — Cloud Run deploy
+
+**Status: activates once sq-lmz40 ships** (the `ghcr.io/sparq-org/sparq-lws-core` image
+is not yet published). The spec `sparq-lws.yaml` is structurally complete; deploy once the
+image is available.
+
+The LWS server is **fail-closed by design** — anonymous mutation is rejected, DPoP is
+required, WebID verification is strict. No `SPARQ_AUTH_TOKEN` equivalent is needed; auth
+flows through OIDC/DPoP.
+
+### Prerequisites
+
+LWS requires two values that cannot be defaulted:
+
+1. **`SOLID_SERVER_BASE_URL`** — the public HTTPS URL where the server will be reachable.
+   After the first Cloud Run deploy, note the `run.app` URL and update `sparq-lws.yaml`;
+   or map a custom domain first.
+2. **`SOLID_SERVER_TRUSTED_ISSUER`** — the URL of a trusted OIDC provider. LWS cannot
+   self-issue tokens. Use your organisation's Solid-OIDC provider or a public provider.
+
+Edit `sparq-lws.yaml` to set both values and your `PROJECT_ID`, then:
+
+```bash
+gcloud services enable run.googleapis.com
+gcloud iam service-accounts create sparq-lws-sa \
+  --display-name="sparq-lws Cloud Run runtime SA"
+
+gcloud run services replace deploy/gcp/sparq-lws.yaml \
+  --region REGION \
+  --project PROJECT_ID
+```
+
+**Multi-instance note:** `max-instances` defaults to 1 because the in-memory DPoP replay
+store does not survive across instances. To run multiple instances, provision a Redis
+instance and set `SOLID_SERVER_REPLAY_REDIS_URL` via a Secret Manager secretKeyRef
+(see the commented block in `sparq-lws.yaml`).
+
+---
+
+## Decisions made (sq-agolp)
+
+These decisions were made by the SPARQ agent without waiting for a maintainer greenlight
+(per the standing proceed-without-greenlight rule). Corrections welcome post-hoc.
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Compute | Cloud Run (fully managed) | R3: automatic HTTPS on run.app; no VPC/firewall config needed; serverless |
+| Secret wiring | Secret Manager `secretKeyRef` | R4: token literal never in YAML, env-var plaintext, or logs |
+| Service account | Dedicated SA per server (`sparq-server-sa` / `sparq-lws-sa`) | R5: `secretAccessor` on own secret only; not the Compute default SA |
+| `min-instances` | 1 (default) | R7: avoids cold-start on startup/liveness probe; dataset stays warm |
+| `max-instances` | 10 (sparq-server), 1 (LWS) | LWS replay-store constraint (§1.3); sparq-server stateless within a request |
+| CPU/memory | 2 vCPU / 2 GiB | Reasonable default for analytical SPARQL; increase for larger in-memory datasets |
+| LWS `min-instances` | 1 | Same cold-start rationale; Solid server must be warm for WebID-TLS exchanges |
+| Probes | startup (6 × 5 s = 30 s budget) + liveness (10 s period) | Matches sparq-server's typical startup time; aggressive enough to catch hangs |
+| Cloud Run `--no-allow-unauthenticated` | Not set (service-level) | Noted in spec as an option for internal use; sparq-server token is the auth layer |
+| LWS image tag | `:latest` (parameterised comment to pin) | Image not yet published; operators must pin to a release tag in production |
+
+---
+
+*[SONNET-4.6] sq-agolp. Grounded against `research/cloud-deploy-architecture.md` §3.3 + §1
++ §2. House pattern follows `deploy/aws/` (sq-17rgw) and `deploy/paas/` (sq-dwame).*
+
+*SPARQ agent 🤖 — do not remove the Secret Manager wiring.*

--- a/deploy/gcp/sparq-lws.yaml
+++ b/deploy/gcp/sparq-lws.yaml
@@ -1,0 +1,150 @@
+# [SONNET-4.6] sq-agolp — GCP Cloud Run service spec: sparq-lws-core (Solid/LWS server).
+#
+# STATUS: Activates once sq-lmz40 ships (the ghcr.io/sparq-org/sparq-lws-core image is not
+# yet published). The spec is structurally complete and schema-valid. Deploy once sq-lmz40
+# lands and the image is available at ghcr.io/sparq-org/sparq-lws-core.
+#
+# SECURE-DEFAULTS NOTICE (R2/R9):
+# The LWS server is fail-closed by design — anonymous mutation is rejected, HTTPS-only
+# WebIDs, DPoP required, strict bidirectional WebID/issuer check — all default-on.
+# This spec relies on the image's fail-closed posture. DO NOT set any of the following
+# dev-only escape hatches in a production deploy:
+#   SOLID_SERVER_ALLOW_LOOPBACK, SOLID_SERVER_SEED_CONFORMANCE,
+#   SOLID_SERVER_SEED_BENCH, SOLID_SERVER_ALLOW_SEED_NONMEMORY
+#
+# PREREQUISITES:
+#   1. Enable Cloud Run + Secret Manager APIs:
+#        gcloud services enable run.googleapis.com secretmanager.googleapis.com
+#
+#   2. Set your public HTTPS base URL and trusted OIDC issuer before deploying:
+#      These are required parameters — LWS cannot self-issue tokens and needs an
+#      external OIDC provider (see §1.3 of research/cloud-deploy-architecture.md).
+#
+#   3. Create a dedicated runtime service account (least-privilege, R5):
+#        gcloud iam service-accounts create sparq-lws-sa \
+#          --display-name="sparq-lws Cloud Run runtime SA"
+#
+#      If storing any secrets in Secret Manager for LWS (e.g. Redis URL):
+#        gcloud secrets add-iam-policy-binding <secret-name> \
+#          --member="serviceAccount:sparq-lws-sa@PROJECT_ID.iam.gserviceaccount.com" \
+#          --role="roles/secretmanager.secretAccessor"
+#
+#   4. Deploy (replace PROJECT_ID, REGION, BASE_URL, TRUSTED_ISSUER):
+#        gcloud run services replace deploy/gcp/sparq-lws.yaml \
+#          --region REGION
+#
+# DECISIONS (sq-agolp):
+#   - Cloud Run (fully managed): automatic HTTPS on run.app domain (R3). The run.app
+#     HTTPS URL is used as SOLID_SERVER_BASE_URL; set it after first deploy or use a
+#     custom domain mapped via Cloud Run domain mapping.
+#   - max-instances: 1 default. Multi-instance requires Redis DPoP replay store
+#     (SOLID_SERVER_REPLAY_REDIS_URL + redis-replay feature, §1.3 of the design record).
+#     Do NOT increase max-instances without wiring Redis first.
+#   - Dedicated service account sparq-lws-sa with minimal permissions only (R5).
+#   - Health: /livez (liveness) + /readyz (readiness) — asymmetric from sparq-server (R7).
+#   - No Secret Manager reference by default (LWS has no equivalent of SPARQ_AUTH_TOKEN;
+#     its auth is the OIDC issuer contract). Add a secretKeyRef for Redis URL if scaling.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  # [SONNET-4.6] sq-agolp
+  name: sparq-lws
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/description: >
+      sparq Solid/LWS server (sq-agolp, activates once sq-lmz40 ships). Fail-closed by
+      design: anonymous mutation rejected, DPoP required, HTTPS-only WebIDs. R2 enforced
+      at the image layer. Do not set dev-only escape hatches in production.
+spec:
+  template:
+    metadata:
+      annotations:
+        # Min 1 instance: keeps the Solid server warm; avoids cold-start on /readyz.
+        autoscaling.knative.dev/minScale: "1"
+        # Max 1 instance: DPoP replay protection requires single-instance or Redis.
+        # Increase ONLY after wiring SOLID_SERVER_REPLAY_REDIS_URL (§1.3).
+        autoscaling.knative.dev/maxScale: "1"
+    spec:
+      # Dedicated least-privilege service account (R5).
+      # Replace PROJECT_ID with your GCP project ID.
+      serviceAccountName: sparq-lws-sa@PROJECT_ID.iam.gserviceaccount.com
+
+      containerConcurrency: 80
+      timeoutSeconds: 300
+
+      containers:
+        - name: sparq-lws
+          # Image: activates once sq-lmz40 ships.
+          # Replace :latest with a specific release tag in production.
+          image: ghcr.io/sparq-org/sparq-lws-core:latest
+
+          ports:
+            - name: http1
+              containerPort: 3000
+
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+
+          env:
+            # Required: public HTTPS base URL for this Solid server.
+            # After first deploy, Cloud Run assigns a run.app URL; use that here, or
+            # configure a custom domain and use the custom domain URL.
+            # Replace https://your-lws-domain.example.com with your actual public URL.
+            - name: SOLID_SERVER_BASE_URL
+              value: "https://your-lws-domain.example.com"
+
+            # Required: trusted OIDC issuer (external IdP). LWS cannot self-issue tokens.
+            # Example: a public Solid-OIDC provider. Replace with your actual IdP URL.
+            - name: SOLID_SERVER_TRUSTED_ISSUER
+              value: "https://your-oidc-provider.example.com"
+
+            # Optional: override the audience claim (defaults to SOLID_SERVER_BASE_URL).
+            # - name: SOLID_SERVER_AUDIENCE
+            #   value: "https://your-lws-domain.example.com"
+
+            # Optional: Redis URL for DPoP replay store across multiple instances.
+            # Required if max-instances > 1. Use Secret Manager secretKeyRef for the URL.
+            # - name: SOLID_SERVER_REPLAY_REDIS_URL
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: sparq-lws-redis-url
+            #       key: latest
+
+            # NEVER set in production (dev-only escape hatches — R2):
+            # SOLID_SERVER_ALLOW_LOOPBACK, SOLID_SERVER_SEED_CONFORMANCE,
+            # SOLID_SERVER_SEED_BENCH, SOLID_SERVER_ALLOW_SEED_NONMEMORY
+
+          # Startup probe: uses /livez (process-up check, ungated — verified in app.rs:56).
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+            timeoutSeconds: 3
+
+          # Liveness probe: /livez — restarts if the process is unresponsive.
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 3000
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+
+          # Readiness probe: /readyz — keeps traffic away until the server is configured.
+          # Cloud Run uses the liveness probe for traffic routing; readyz is advisory here
+          # but is the correct path (503 = not ready per design record §1.2).
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3

--- a/deploy/gcp/sparq-lws.yaml
+++ b/deploy/gcp/sparq-lws.yaml
@@ -5,6 +5,9 @@
 # lands and the image is available at ghcr.io/sparq-org/sparq-lws-core.
 #
 # SECURE-DEFAULTS NOTICE (R2/R9):
+# The sparq-server image is open-by-default at the image layer. This spec does not deploy that
+# image; use sparq-server.yaml, which gates it with a Secret Manager token. [GPT-5.6]
+#
 # The LWS server is fail-closed by design — anonymous mutation is rejected, HTTPS-only
 # WebIDs, DPoP required, strict bidirectional WebID/issuer check — all default-on.
 # This spec relies on the image's fail-closed posture. DO NOT set any of the following
@@ -29,14 +32,17 @@
 #          --member="serviceAccount:sparq-lws-sa@PROJECT_ID.iam.gserviceaccount.com" \
 #          --role="roles/secretmanager.secretAccessor"
 #
-#   4. Deploy (replace PROJECT_ID, REGION, BASE_URL, TRUSTED_ISSUER):
-#        gcloud run services replace deploy/gcp/sparq-lws.yaml \
-#          --region REGION
+#   4. Grant the deployer principal roles/iam.serviceAccountUser on sparq-lws-sa so it can
+#      attach the runtime identity. Do not grant roles/run.invoker to the runtime identity.
+#
+#   5. Render PROJECT_ID, PROJECT_NUMBER, REGION, and TRUSTED_ISSUER_URL into a temporary
+#      copy and deploy it using the commands in deploy/gcp/README.md.
 #
 # DECISIONS (sq-agolp):
 #   - Cloud Run (fully managed): automatic HTTPS on run.app domain (R3). The run.app
-#     HTTPS URL is used as SOLID_SERVER_BASE_URL; set it after first deploy or use a
-#     custom domain mapped via Cloud Run domain mapping.
+#     deterministic HTTPS URL is used as SOLID_SERVER_BASE_URL. [GPT-5.6]
+#   - Public invocation is explicit because LWS performs its own OIDC/DPoP authorization.
+#     [GPT-5.6]
 #   - max-instances: 1 default. Multi-instance requires Redis DPoP replay store
 #     (SOLID_SERVER_REPLAY_REDIS_URL + redis-replay feature, §1.3 of the design record).
 #     Do NOT increase max-instances without wiring Redis first.
@@ -52,6 +58,10 @@ metadata:
   name: sparq-lws
   annotations:
     run.googleapis.com/ingress: all
+    # [GPT-5.6] Cloud Run readiness probes are Preview and require the BETA launch stage.
+    run.googleapis.com/launch-stage: BETA
+    # [GPT-5.6] Public invocation is intentional; LWS OIDC/DPoP is the front door.
+    run.googleapis.com/invoker-iam-disabled: "true"
     run.googleapis.com/description: >
       sparq Solid/LWS server (sq-agolp, activates once sq-lmz40 ships). Fail-closed by
       design: anonymous mutation rejected, DPoP required, HTTPS-only WebIDs. R2 enforced
@@ -65,6 +75,10 @@ spec:
         # Max 1 instance: DPoP replay protection requires single-instance or Redis.
         # Increase ONLY after wiring SOLID_SERVER_REPLAY_REDIS_URL (§1.3).
         autoscaling.knative.dev/maxScale: "1"
+        # [GPT-5.6] Cloud Run custom probes require instance-based CPU allocation.
+        run.googleapis.com/cpu-throttling: "false"
+        # [GPT-5.6] If Redis replay is enabled, uncomment this exact secret alias mapping.
+        # run.googleapis.com/secrets: sparq-lws-redis-url:projects/PROJECT_ID/secrets/sparq-lws-redis-url
     spec:
       # Dedicated least-privilege service account (R5).
       # Replace PROJECT_ID with your GCP project ID.
@@ -90,16 +104,15 @@ spec:
 
           env:
             # Required: public HTTPS base URL for this Solid server.
-            # After first deploy, Cloud Run assigns a run.app URL; use that here, or
-            # configure a custom domain and use the custom domain URL.
-            # Replace https://your-lws-domain.example.com with your actual public URL.
+            # [GPT-5.6] Cloud Run's deterministic URL is known before first deployment.
+            # Replace PROJECT_NUMBER and REGION, or use a mapped custom HTTPS domain.
             - name: SOLID_SERVER_BASE_URL
-              value: "https://your-lws-domain.example.com"
+              value: "https://sparq-lws-PROJECT_NUMBER.REGION.run.app"
 
             # Required: trusted OIDC issuer (external IdP). LWS cannot self-issue tokens.
-            # Example: a public Solid-OIDC provider. Replace with your actual IdP URL.
+            # [GPT-5.6] Required placeholder: replace with the complete HTTPS issuer URL.
             - name: SOLID_SERVER_TRUSTED_ISSUER
-              value: "https://your-oidc-provider.example.com"
+              value: "TRUSTED_ISSUER_URL"
 
             # Optional: override the audience claim (defaults to SOLID_SERVER_BASE_URL).
             # - name: SOLID_SERVER_AUDIENCE
@@ -111,16 +124,16 @@ spec:
             #   valueFrom:
             #     secretKeyRef:
             #       name: sparq-lws-redis-url
-            #       key: latest
+            #       key: "1"
 
             # NEVER set in production (dev-only escape hatches — R2):
             # SOLID_SERVER_ALLOW_LOOPBACK, SOLID_SERVER_SEED_CONFORMANCE,
             # SOLID_SERVER_SEED_BENCH, SOLID_SERVER_ALLOW_SEED_NONMEMORY
 
-          # Startup probe: uses /livez (process-up check, ungated — verified in app.rs:56).
+          # [GPT-5.6] Startup must establish readiness before Cloud Run can route traffic.
           startupProbe:
             httpGet:
-              path: /livez
+              path: /readyz
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -137,14 +150,15 @@ spec:
             failureThreshold: 3
             timeoutSeconds: 3
 
-          # Readiness probe: /readyz — keeps traffic away until the server is configured.
-          # Cloud Run uses the liveness probe for traffic routing; readyz is advisory here
-          # but is the correct path (503 = not ready per design record §1.2).
+          # [GPT-5.6] Readiness failures remove the instance from traffic without restarting it.
           readinessProbe:
             httpGet:
               path: /readyz
               port: 3000
-            initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 3
             timeoutSeconds: 3
+
+          # [GPT-5.6] Cloud Run rejects container securityContext/readOnlyRootFilesystem.
+          # The published image remains non-root, and Cloud Run removes added capabilities and
+          # privilege escalation; its writable root overlay is ephemeral.

--- a/deploy/gcp/sparq-server.yaml
+++ b/deploy/gcp/sparq-server.yaml
@@ -1,0 +1,130 @@
+# [SONNET-4.6] sq-agolp — GCP Cloud Run service spec: sparq-server.
+#
+# SECURE-DEFAULTS NOTICE (R1/R9):
+# The sparq-server image is open-by-default at the image layer (bakes SPARQ_ALLOW_REMOTE=1,
+# no auth). Anyone reaching the published port can read AND write the dataset.
+# This spec enforces auth ON at the template layer:
+#   - SPARQ_AUTH_TOKEN is injected from GCP Secret Manager (secretKeyRef) — never a literal.
+#   - Do NOT remove the Secret Manager wiring. Do NOT set a default token value here.
+#
+# PREREQUISITES:
+#   1. Enable Cloud Run + Secret Manager APIs:
+#        gcloud services enable run.googleapis.com secretmanager.googleapis.com
+#
+#   2. Create the auth token secret:
+#        echo -n "$(openssl rand -hex 32)" | \
+#          gcloud secrets create sparq-auth-token \
+#            --replication-policy=automatic \
+#            --data-file=-
+#
+#   3. Create a dedicated runtime service account (least-privilege, R5):
+#        gcloud iam service-accounts create sparq-server-sa \
+#          --display-name="sparq-server Cloud Run runtime SA"
+#
+#        gcloud secrets add-iam-policy-binding sparq-auth-token \
+#          --member="serviceAccount:sparq-server-sa@PROJECT_ID.iam.gserviceaccount.com" \
+#          --role="roles/secretmanager.secretAccessor"
+#
+#   4. Deploy (replace PROJECT_ID and REGION):
+#        gcloud run services replace deploy/gcp/sparq-server.yaml \
+#          --region REGION
+#
+#      Or use the one-liner in deploy/gcp/README.md.
+#
+# DECISIONS (sq-agolp):
+#   - Cloud Run (fully managed): automatic HTTPS on run.app, no VPC/firewall config needed (R3).
+#   - Secret Manager secretKeyRef: token is never in the YAML or env-var plaintext (R4).
+#   - Dedicated service account sparq-server-sa with secretAccessor on own secret only (R5).
+#   - min-instances: 1 to avoid cold-start on health-probe path (R7 + bead acceptance).
+#   - max-instances: 10 default (adjust to workload; reduce to 1 for single-writer datasets).
+#   - containerConcurrency: 80 (Cloud Run default; reduce for memory-heavy analytical loads).
+#   - Cloud Run ingress defaults to "all" (public). For internal-only, set ingress: internal.
+#   - SPARQ_AUTH_TOKEN_READ left commented out: read-gating is opt-in per design (R1 requires
+#     writes gated; read-gating is an operator choice).
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  # [SONNET-4.6] sq-agolp
+  name: sparq-server
+  annotations:
+    # Cloud Run region must be set at deploy time via --region flag or gcloud config;
+    # this annotation is set by Cloud Run on the returned resource — do not set it here.
+    run.googleapis.com/ingress: all
+    run.googleapis.com/description: >
+      sparq SPARQL 1.1 server (sq-agolp). Auth enforced via Secret Manager (R1/R4).
+      Secure-defaults: open-by-default image gated with token at deploy layer.
+      Do not remove the SPARQ_AUTH_TOKEN secret wiring.
+spec:
+  template:
+    metadata:
+      annotations:
+        # Min 1 instance: avoids cold-start on health-probe path; dataset stays warm.
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "10"
+    spec:
+      # Dedicated least-privilege service account (R5).
+      # Replace PROJECT_ID with your GCP project ID.
+      serviceAccountName: sparq-server-sa@PROJECT_ID.iam.gserviceaccount.com
+
+      # Each container instance handles up to 80 concurrent requests (Cloud Run default).
+      containerConcurrency: 80
+
+      # Request timeout: 300 s (matches sparq-server's default SPARQ_QUERY_TIMEOUT headroom).
+      timeoutSeconds: 300
+
+      containers:
+        - name: sparq-server
+          # Image: multi-arch (linux/amd64 + linux/arm64). Pin to a release tag in production.
+          # Replace :latest with a specific version tag (e.g. :0.5.0) for reproducible deploys.
+          image: ghcr.io/sparq-org/sparq-server:latest
+
+          ports:
+            - name: http1
+              containerPort: 3030
+
+          resources:
+            limits:
+              # 2 vCPU + 2 GiB RAM: reasonable default for analytical SPARQL workloads.
+              # Increase memory for large in-memory datasets.
+              cpu: "2"
+              memory: 2Gi
+
+          env:
+            # Auth token (R1/R4): injected from Secret Manager — never a literal value.
+            # Secret name "sparq-auth-token" must exist in the same project (see PREREQUISITES).
+            - name: SPARQ_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: sparq-auth-token
+                  key: latest
+
+            # Optional: also gate read requests behind the same token.
+            # Uncomment to require Bearer auth on GET /sparql as well.
+            # - name: SPARQ_AUTH_TOKEN_READ
+            #   value: "1"
+
+            # Optional: CORS allowed origin (e.g. your frontend domain).
+            # - name: SPARQ_CORS_ALLOW_ORIGIN
+            #   value: "https://your-frontend.example.com"
+
+          # Startup probe: wait up to 30 s for the server to come up before liveness kicks in.
+          # Uses the ungated /health endpoint (returns 200 "ok" — verified in http.rs:3236).
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 3030
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+            timeoutSeconds: 3
+
+          # Liveness probe: restart the container if /health stops responding.
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3030
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3

--- a/deploy/gcp/sparq-server.yaml
+++ b/deploy/gcp/sparq-server.yaml
@@ -11,8 +11,9 @@
 #   1. Enable Cloud Run + Secret Manager APIs:
 #        gcloud services enable run.googleapis.com secretmanager.googleapis.com
 #
-#   2. Create the auth token secret:
-#        echo -n "$(openssl rand -hex 32)" | \
+#   2. Create the auth token secret (version 1 is pinned below):
+#        # [GPT-5.6] Strip openssl's newline so the stored token matches HTTP headers.
+#        openssl rand -hex 32 | tr -d '\n' | \
 #          gcloud secrets create sparq-auth-token \
 #            --replication-policy=automatic \
 #            --data-file=-
@@ -25,9 +26,12 @@
 #          --member="serviceAccount:sparq-server-sa@PROJECT_ID.iam.gserviceaccount.com" \
 #          --role="roles/secretmanager.secretAccessor"
 #
-#   4. Deploy (replace PROJECT_ID and REGION):
-#        gcloud run services replace deploy/gcp/sparq-server.yaml \
-#          --region REGION
+#   4. The deployer needs iam.serviceAccounts.actAs on this runtime identity. Grant
+#      roles/iam.serviceAccountUser on this service account to the deployer principal;
+#      do not grant roles/run.invoker to the runtime identity.
+#
+#   5. Render PROJECT_ID and PROJECT_NUMBER into a temporary copy using the commands in
+#      deploy/gcp/README.md. The committed manifest intentionally has no project default.
 #
 #      Or use the one-liner in deploy/gcp/README.md.
 #
@@ -36,11 +40,13 @@
 #   - Secret Manager secretKeyRef: token is never in the YAML or env-var plaintext (R4).
 #   - Dedicated service account sparq-server-sa with secretAccessor on own secret only (R5).
 #   - min-instances: 1 to avoid cold-start on health-probe path (R7 + bead acceptance).
-#   - max-instances: 10 default (adjust to workload; reduce to 1 for single-writer datasets).
+#     Cloud Run may still restart it; in-memory state is not durable. [GPT-5.6]
 #   - containerConcurrency: 80 (Cloud Run default; reduce for memory-heavy analytical loads).
-#   - Cloud Run ingress defaults to "all" (public). For internal-only, set ingress: internal.
-#   - SPARQ_AUTH_TOKEN_READ left commented out: read-gating is opt-in per design (R1 requires
-#     writes gated; read-gating is an operator choice).
+#   - Public invocation is explicit so the application Bearer token reaches the server; Cloud Run
+#     IAM and the application cannot both consume the single Authorization header. [GPT-5.6]
+#   - SPARQ_AUTH_TOKEN_READ=1 gates reads as well as writes by default. [GPT-5.6]
+#   - max-instances: 1 because the current server state is in-memory and is not shared between
+#     Cloud Run instances; the filesystem is also ephemeral. [GPT-5.6]
 
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -51,6 +57,8 @@ metadata:
     # Cloud Run region must be set at deploy time via --region flag or gcloud config;
     # this annotation is set by Cloud Run on the returned resource — do not set it here.
     run.googleapis.com/ingress: all
+    # [GPT-5.6] Public invocation is intentional; SPARQ auth below is the front door.
+    run.googleapis.com/invoker-iam-disabled: "true"
     run.googleapis.com/description: >
       sparq SPARQL 1.1 server (sq-agolp). Auth enforced via Secret Manager (R1/R4).
       Secure-defaults: open-by-default image gated with token at deploy layer.
@@ -59,9 +67,14 @@ spec:
   template:
     metadata:
       annotations:
-        # Min 1 instance: avoids cold-start on health-probe path; dataset stays warm.
+        # Min 1 instance avoids cold starts; it does not make in-memory state durable.
         autoscaling.knative.dev/minScale: "1"
-        autoscaling.knative.dev/maxScale: "10"
+        # [GPT-5.6] Independent instances would diverge because the graph is in-memory.
+        autoscaling.knative.dev/maxScale: "1"
+        # [GPT-5.6] Cloud Run custom probes require instance-based CPU allocation.
+        run.googleapis.com/cpu-throttling: "false"
+        # [GPT-5.6] Resolve the v1 secret alias to this exact same-project secret.
+        run.googleapis.com/secrets: sparq-auth-token:projects/PROJECT_NUMBER/secrets/sparq-auth-token
     spec:
       # Dedicated least-privilege service account (R5).
       # Replace PROJECT_ID with your GCP project ID.
@@ -97,12 +110,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: sparq-auth-token
-                  key: latest
+                  # [GPT-5.6] Pin env-var secrets; deploy a new revision to rotate.
+                  key: "1"
 
-            # Optional: also gate read requests behind the same token.
-            # Uncomment to require Bearer auth on GET /sparql as well.
-            # - name: SPARQ_AUTH_TOKEN_READ
-            #   value: "1"
+            # [GPT-5.6] Secure default: require Bearer auth on reads as well as writes.
+            - name: SPARQ_AUTH_TOKEN_READ
+              value: "1"
 
             # Optional: CORS allowed origin (e.g. your frontend domain).
             # - name: SPARQ_CORS_ALLOW_ORIGIN
@@ -118,6 +131,10 @@ spec:
             periodSeconds: 5
             failureThreshold: 6
             timeoutSeconds: 3
+
+          # [GPT-5.6] Cloud Run rejects container securityContext/readOnlyRootFilesystem.
+          # The published image remains non-root, and Cloud Run removes added capabilities and
+          # privilege escalation; its writable root overlay is ephemeral.
 
           # Liveness probe: restart the container if /health stops responding.
           livenessProbe:


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) implementing bead sq-agolp.

## Summary

Cloud Run service specs for running sparq on **GCP Cloud Run** (fully managed) under `deploy/gcp/**` — disjoint from `deploy/aws/` (sq-17rgw) and `deploy/paas/` (sq-dwame).

Three files:

| File | Purpose |
|---|---|
| `deploy/gcp/sparq-server.yaml` | Knative `serving.knative.dev/v1` Cloud Run spec: port 3030, `/health` startup+liveness probes, `SPARQ_AUTH_TOKEN` from Secret Manager, dedicated SA, `min-instances=1` |
| `deploy/gcp/sparq-lws.yaml` | Cloud Run spec for LWS: port 3000, `/livez`+`/readyz` probes, `min-instances=1`, `max-instances=1` (DPoP replay constraint), activates once sq-lmz40 ships |
| `deploy/gcp/README.md` | Prerequisites, `gcloud run services replace` one-liner, "Run on Google Cloud" button, verify-deploy commands, decisions table, secure-defaults notice |

## Decisions made (per design — not declined)

| Decision | Choice | Rationale |
|---|---|---|
| Compute | Cloud Run (fully managed) | R3: automatic HTTPS on run.app; no VPC/firewall setup; serverless |
| Secret wiring | Secret Manager `secretKeyRef` | R4: token literal never in YAML, env-var plaintext, or logs |
| Service account | Dedicated SA per server (`sparq-server-sa` / `sparq-lws-sa`) | R5: `secretAccessor` on own secret only; not the Compute default SA |
| `min-instances` | 1 | R7: avoids cold-start on health probe; dataset stays warm |
| `max-instances` sparq-server | 10 | Reasonable default for analytical SPARQL; stateless per request |
| `max-instances` LWS | 1 | DPoP in-memory replay store cannot span instances (§1.3 design record); Redis required to scale |
| CPU/memory | 2 vCPU / 2 GiB | Reasonable default; increase for larger in-memory datasets |
| `--no-allow-unauthenticated` | Not set in spec | Noted as an option for internal use; the `SPARQ_AUTH_TOKEN` bearer layer is the auth surface per R1 |
| Probe budget | startup: 6×5s=30s, liveness: 10s period | Matches sparq-server typical startup; aggressive enough to catch hangs |

## Secure-defaults satisfied

| Rule | Mechanism |
|---|---|
| R1 (auth ON) | `SPARQ_AUTH_TOKEN` injected via `secretKeyRef` referencing Secret Manager secret `sparq-auth-token`; no default token |
| R2 (no anon write) | sparq-server: 401 on unauth write; LWS: fail-closed by image design; no dev escape hatches in spec |
| R3 (TLS at edge) | Cloud Run automatic HTTPS on `run.app` — no cert management required |
| R4 (secrets in secret store) | `secretKeyRef` reference only; no literal in any committed file; grep clean |
| R5 (least-privilege SA) | Dedicated `sparq-server-sa` / `sparq-lws-sa`; `secretAccessor` on own secret only |
| R7 (health check) | `startupProbe` + `livenessProbe` on `/health` (sparq-server) / `/livez`+`/readyz` (LWS) |
| R8 (non-root) | Both images run distroless nonroot; not overridden |
| R9 (honest posture) | Open-by-default caveat in every spec header + README |

## Static gate status (honest)

- **YAML valid** (`python3 yaml.safe_load`): both specs pass. [SONNET-4.6]
- **Knative v1 structural check**: `apiVersion`, `kind`, `metadata.name`, `containers`, `ports`, probes, SA, `minScale` all verified programmatically.
- **`secretKeyRef` wiring verified**: `SPARQ_AUTH_TOKEN` has `valueFrom.secretKeyRef`, no `value:` field.
- **Secret-literal grep**: clean — no `SPARQ_AUTH_TOKEN[:=]<literal>`, no high-entropy value strings.
- **Typos gate**: clean — no `DELETEd`/`DROPped`/`invokable`/`ANDed`.
- **readme-template gate**: 0 deviations across 61 crate READMEs (unchanged). `deploy/gcp/README.md` is not a crate README.
- **`gcloud run services replace --dry-run`**: unavailable (gcloud not installed on dev box). YAML schema validated against Knative serving v1 spec manually and structurally. Marked: documented-untested on live Cloud Run deploy; validate on first CI run.
- **No workflow changes**: `ci-summary` gate aggregator untouched. No new gating check added. `deploy/gcp/**` only; path filter correctly skips Rust jobs.
- **actionlint**: available on dev box; no workflow files changed so not invoked.

## Honest notes

- Live Cloud Run deploy untested (no GCP project credentials on dev box; design record §4 explicitly states "Cloud Run: `gcloud --dry-run` / YAML schema lint" as the static gate).
- The "Run on Google Cloud" button requires a public GitHub repo and Cloud Shell access; the button URL uses `deploy.cloud.run` pointing at the repo root with `dir=deploy/gcp`.
- LWS `SOLID_SERVER_BASE_URL` cannot be pre-populated — operators must set it after seeing the first `run.app` URL or mapping a custom domain. This is inherent to LWS (§1.3 design record).

## Discovered work (for orchestrator, not creating beads here)

- A `deploy-gcp-lint.yml` workflow running `python3 -c yaml.safe_load` on `paths: deploy/gcp/**` (`workflow_dispatch` + path filter, non-gating to Rust gate per design §4).
- Once `sq-lmz40` ships: update `sparq-lws.yaml` status comment and add LWS to the README table as "Available".
- Cloud Run domain mapping instructions for custom domains (currently noted as a follow-up step).

🤖 SPARQ agent

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>