### PR TITLE
fix(deploy): harden PaaS config after IaC review (sq-dwame) [GPT-5.6]

### DIFF
--- a/deploy/paas/README.md
+++ b/deploy/paas/README.md
@@ -1,138 +1,170 @@
 <!-- [SONNET-4.6] sq-dwame — PaaS one-click deploy configs for sparq-server + sparq-lws-core. -->
+<!-- [GPT-5.6] Post-hoc correctness/security review and hardening after PR #2314. -->
 
-# PaaS one-click deploy
+# PaaS deployment
 
-One-click deploy configs for the sparq SPARQL server (`sparq-server`) and the Solid/LWS
-server (`sparq-lws-core`) on three fast PaaS providers: **Fly.io**, **Render**, and
-**Railway**.
+Deployment configs for the SPARQL server (`sparq-server`) and Solid/LWS server
+(`sparq-lws-core`) on Fly.io, Render, and Railway.
 
-## Secure-defaults notice (R1/R2/R4/R9)
+These are intentionally explicit setup flows, not unsafe deploy buttons. A generic button cannot
+both select these nested config files and guarantee that secrets are installed before public
+ingress. Follow the provider steps below in order.
 
-> **sparq-server is open-by-default at the image layer** (it bakes `SPARQ_ALLOW_REMOTE=1`
-> and ships with no auth). Anyone who can reach the published port can read AND write the
-> dataset. **These templates enforce auth ON** at the template layer via `SPARQ_AUTH_TOKEN`
-> — do not remove that wiring.
+## Secure defaults
 
-Key rules applied in every config here:
+> **sparq-server is open by default at the image layer.** It bakes
+> `SPARQ_ALLOW_REMOTE=1` and has no token unless the deployment supplies one. These templates
+> inject `SPARQ_AUTH_TOKEN` from the provider's secret store and set
+> `SPARQ_AUTH_TOKEN_READ=1`, so both reads and writes require the token. Do not remove that
+> wiring. They also override the baked `SPARQ_ALLOW_REMOTE=1` to `0`, so a missing token makes
+> the public bind fail closed instead of starting an unauthenticated server.
 
-- **R1 (auth ON):** `SPARQ_AUTH_TOKEN` is a required secret for sparq-server. The token is
-  stored only in the PaaS secret store — never in the config files.
-- **R2 (no anonymous write):** Unauthenticated write requests return 401/403. The
-  sparq-lws-core image is fail-closed by design; anonymous mutation is rejected by default.
-- **R4 (secrets in the secret store):** No literal token, password, or key appears in any
-  committed config file. Secrets are set via `fly secrets set`, Render's dashboard prompt
-  (`sync: false`), or `railway variables set`.
-- **Auto-HTTPS:** All three providers terminate TLS automatically on their managed domains.
-  Plaintext HTTP is redirected to HTTPS at the edge (`force_https = true` on Fly; automatic
-  on Render and Railway). **Do not expose either server on a plaintext public endpoint.**
+- **Secrets:** no token, password, key, or Redis URL is committed. Use Fly secrets, Render's
+  generated environment-group secret, or Railway variables.
+- **HTTPS:** Fly sets `force_https = true`; Render and Railway terminate TLS and redirect HTTP
+  at their managed edges. Do not expose the internal container ports directly.
+- **Health:** `sparq-server` uses port 3030 and `/health`. LWS uses port 3000,
+  `/livez` for liveness, and `/readyz` for readiness.
+- **One instance only:** `sparq-server` owns an uncoordinated in-memory dataset, so writable
+  replicas silently diverge. LWS has an in-memory DPoP replay store unless a shared Redis replay
+  backend is wired. Every flow below pins one instance.
 
-## 🚀 sparq-server (SPARQL 1.1 Protocol server)
+The configs consume the canonical images `ghcr.io/sparq-org/sparq-server:latest` and
+`ghcr.io/sparq-org/sparq-lws-core:latest`. A deployment cannot succeed until its selected tag is
+published. The LWS image remains dependent on `sq-lmz40`.
 
-Image: `ghcr.io/sparq-org/sparq-server:latest`
-Port: 3030 | Health: `GET /health`
+## sparq-server
 
 ### Fly.io
 
-[![Deploy on Fly.io](https://img.shields.io/badge/Deploy%20on-Fly.io-7B5EA7?logo=fly.io)](https://fly.io/launch?source=github&template=https://github.com/sparq-org/sparq/tree/main/deploy/paas/sparq-server)
+Fly creates two Machines by default for a new HTTP service. Both `--ha=false` and the explicit
+scale command are load-bearing single-writer safeguards.
 
 ```bash
-# 1. Install flyctl: https://fly.io/docs/getting-started/installing-flyctl/
 cd deploy/paas/sparq-server
-fly launch --copy-config --no-deploy
+fly launch --copy-config --generate-name --no-deploy --ha=false
 fly secrets set SPARQ_AUTH_TOKEN="$(openssl rand -hex 32)"
-fly deploy
+fly deploy --ha=false
+fly scale count 1
+fly scale show
 ```
 
-Config: [`deploy/paas/sparq-server/fly.toml`](sparq-server/fly.toml)
+The app is not deployed until after the token is in Fly's encrypted secret vault. The config
+enforces HTTPS and probes `GET /health`.
+
+Config: [`sparq-server/fly.toml`](sparq-server/fly.toml)
 
 ### Render
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/sparq-org/sparq&branch=main&blueprint=deploy/paas/sparq-server/render.yaml)
+1. In the Render dashboard, choose **New → Blueprint** and connect this repository.
+2. Select branch `main` and Blueprint Path
+   `deploy/paas/sparq-server/render.yaml`.
+3. Review and deploy the Blueprint.
 
-Render will prompt you to set `SPARQ_AUTH_TOKEN` during deployment — set a strong random
-value (e.g. `openssl rand -hex 32`).
+The Blueprint generates `SPARQ_AUTH_TOKEN` into the `sparq-server-secrets` environment group,
+injects it into the service, enables read auth, and pins `numInstances: 1`. Copy the generated
+token from the environment group for authenticated clients.
 
-Config: [`deploy/paas/sparq-server/render.yaml`](sparq-server/render.yaml)
+Config: [`sparq-server/render.yaml`](sparq-server/render.yaml)
 
 ### Railway
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/sparq-org/sparq&envs=SPARQ_AUTH_TOKEN,IMAGE&SPARQ_AUTH_TOKENDesc=Bearer+auth+token+for+sparq-server+(required)&IMAGEDesc=GHCR+image+ref&IMAGEDefault=ghcr.io%2Fsparq-org%2Fsparq-server%3Alatest)
+Railway config-as-code controls build/deploy settings but cannot select an image or create
+variables. The adjacent `Dockerfile` consumes and fail-closes the canonical image; the commands below
+create an empty service, install variables before its first deployment, and upload only this
+config directory.
 
 ```bash
-# Via Railway CLI:
-railway link   # link to your Railway project
-railway variables set SPARQ_AUTH_TOKEN="$(openssl rand -hex 32)"
-railway up
+railway init
+railway add --service sparq-server
+openssl rand -hex 32 | railway variables set SPARQ_AUTH_TOKEN --stdin --skip-deploys
+railway variables set SPARQ_AUTH_TOKEN_READ=1 PORT=3030 --skip-deploys
+railway up deploy/paas/sparq-server --path-as-root
+railway domain --port 3030
 ```
 
-Config: [`deploy/paas/sparq-server/railway.toml`](sparq-server/railway.toml)
+`PORT=3030` is required because Railway uses `PORT` for deployment health checks while the
+image binds a fixed port. The TOML pins `numReplicas = 1`, probes `/health`, and leaves the
+image entrypoint intact. Railway provisions TLS and redirects HTTP when the domain is created.
 
----
+Configs: [`sparq-server/railway.toml`](sparq-server/railway.toml) and
+[`sparq-server/Dockerfile`](sparq-server/Dockerfile)
 
-## 🚀 sparq-lws-core (Solid/LWS server)
+## sparq-lws-core
 
-Image: `ghcr.io/sparq-org/sparq-lws-core:latest`
-Port: 3000 | Health: `GET /readyz` (readiness), `GET /livez` (liveness)
+The LWS server requires `SOLID_SERVER_BASE_URL` (the public HTTPS origin) and
+`SOLID_SERVER_TRUSTED_ISSUER` (an external OIDC issuer). It rejects anonymous mutation by
+default. Do not set its loopback or seed escape hatches in production.
 
-> **Dependency:** The `sparq-lws-core` image is built by bead `sq-lmz40` and will be
-> published to `ghcr.io/sparq-org/sparq-lws-core`. The configs below are correct and
-> ready; the image activates once `sq-lmz40` ships. Link the deploy buttons from the
-> `/deploy` site surface once that bead lands.
-
-> **Required inputs:** Unlike sparq-server, the LWS server requires two parameters at boot:
-> `SOLID_SERVER_BASE_URL` (your public HTTPS URL) and `SOLID_SERVER_TRUSTED_ISSUER`
-> (your OIDC identity provider). The server cannot self-issue an IdP — a Solid OIDC
-> provider must be named. These are supplied as secrets, never inlined.
-
-> **Multi-instance:** LWS uses an in-memory DPoP jti replay store by default. Running more
-> than one replica requires `SOLID_SERVER_REPLAY_REDIS_URL` (the `redis-replay` feature).
-> Single-instance is correct and safe without Redis.
+LWS uses an in-memory DPoP `jti` replay store by default. Keep one instance unless the image was
+built with `redis-replay` and every instance uses the same secret
+`SOLID_SERVER_REPLAY_REDIS_URL`.
 
 ### Fly.io
+
+Choose a globally unique app name first so the configured base URL exactly matches Fly's public
+HTTPS hostname.
 
 ```bash
 cd deploy/paas/lws
-fly launch --copy-config --no-deploy
-fly secrets set SOLID_SERVER_BASE_URL="https://sparq-lws.fly.dev"
+APP="sparq-lws-$(openssl rand -hex 4)"
+fly launch --copy-config --no-deploy --ha=false --name "$APP"
+fly secrets set SOLID_SERVER_BASE_URL="https://${APP}.fly.dev"
 fly secrets set SOLID_SERVER_TRUSTED_ISSUER="https://your-oidc-provider.example.com"
-fly deploy
+fly deploy --ha=false
+fly scale count 1
+fly scale show
 ```
 
-Config: [`deploy/paas/lws/fly.toml`](lws/fly.toml)
+The config binds `0.0.0.0:3000`, enforces HTTPS, and checks both `/livez` and `/readyz`.
+
+Config: [`lws/fly.toml`](lws/fly.toml)
 
 ### Render
 
-Render will prompt you to set `SOLID_SERVER_BASE_URL` and `SOLID_SERVER_TRUSTED_ISSUER`
-during deployment.
+1. In the Render dashboard, choose **New → Blueprint** and connect this repository.
+2. Select branch `main` and Blueprint Path `deploy/paas/lws/render.yaml`.
+3. Supply the prompted base URL and trusted issuer, then deploy.
 
-Config: [`deploy/paas/lws/render.yaml`](lws/render.yaml)
+The Blueprint binds port 3000, probes `/readyz`, and pins `numInstances: 1`.
+
+Config: [`lws/render.yaml`](lws/render.yaml)
 
 ### Railway
 
+Create the domain before the first deployment so its HTTPS origin can be used as the LWS base URL.
+Replace `<generated>.up.railway.app` below with the hostname printed by `railway domain`.
+
 ```bash
-railway link
-railway variables set SOLID_SERVER_BASE_URL="https://sparq-lws.railway.app"
-railway variables set SOLID_SERVER_TRUSTED_ISSUER="https://your-oidc-provider.example.com"
-railway up
+railway init
+railway add --service sparq-lws
+railway domain --port 3000
+railway variables set PORT=3000 SOLID_SERVER_BIND=0.0.0.0:3000 --skip-deploys
+railway variables set SOLID_SERVER_BASE_URL="https://<generated>.up.railway.app" --skip-deploys
+railway variables set SOLID_SERVER_TRUSTED_ISSUER="https://your-oidc-provider.example.com" --skip-deploys
+railway up deploy/paas/lws --path-as-root
 ```
 
-Config: [`deploy/paas/lws/railway.toml`](lws/railway.toml)
+The TOML pins `numReplicas = 1` and probes `/readyz`. Railway terminates TLS and redirects HTTP
+for the generated domain.
 
----
+Configs: [`lws/railway.toml`](lws/railway.toml) and [`lws/Dockerfile`](lws/Dockerfile)
 
 ## File layout
 
-```
+```text
 deploy/paas/
   sparq-server/
-    fly.toml       Fly.io app config (port 3030, /health, auth required)
-    render.yaml    Render Blueprint  (port 3030, /health, auth required)
-    railway.toml   Railway config    (port 3030, /health, auth required)
+    fly.toml
+    render.yaml
+    railway.toml
+    Dockerfile
   lws/
-    fly.toml       Fly.io app config (port 3000, /readyz, fail-closed)
-    render.yaml    Render Blueprint  (port 3000, /readyz, fail-closed)
-    railway.toml   Railway config    (port 3000, /readyz, fail-closed)
-  README.md        This file (deploy buttons + secure-defaults guidance)
+    fly.toml
+    render.yaml
+    railway.toml
+    Dockerfile
+  README.md
 ```
 
 ## License

--- a/deploy/paas/README.md
+++ b/deploy/paas/README.md
@@ -1,14 +1,15 @@
 <!-- [SONNET-4.6] sq-dwame — PaaS one-click deploy configs for sparq-server + sparq-lws-core. -->
 <!-- [GPT-5.6] Post-hoc correctness/security review and hardening after PR #2314. -->
+<!-- [GPT-5.6] Restored fail-closed deploy buttons alongside the controlled CLI flows. -->
 
 # PaaS deployment
 
 Deployment configs for the SPARQL server (`sparq-server`) and Solid/LWS server
 (`sparq-lws-core`) on Fly.io, Render, and Railway.
 
-These are intentionally explicit setup flows, not unsafe deploy buttons. A generic button cannot
-both select these nested config files and guarantee that secrets are installed before public
-ingress. Follow the provider steps below in order.
+Each provider includes a deploy button alongside an explicit controlled/secure setup path. The
+buttons retain the same fail-closed auth, public-bind, health-check, and single-instance wiring as
+the checked-in configs; use the explicit path when you want to install secrets before first deploy.
 
 ## Secure defaults
 
@@ -37,6 +38,12 @@ published. The LWS image remains dependent on `sq-lmz40`.
 
 ### Fly.io
 
+[![Deploy on Fly.io](https://img.shields.io/badge/Deploy%20on-Fly.io-7B5EA7?logo=fly.io)](https://fly.io/launch?source=github&template=https://github.com/sparq-org/sparq/tree/main/deploy/paas/sparq-server)
+
+Fly's launch flow does not prompt for secrets. After launch, run
+`fly secrets set SPARQ_AUTH_TOKEN=...` and `fly scale count 1`; until the token is set, the service
+fails closed. The controlled/secure CLI path below installs the secret before first deploy.
+
 Fly creates two Machines by default for a new HTTP service. Both `--ha=false` and the explicit
 scale command are load-bearing single-writer safeguards.
 
@@ -56,6 +63,11 @@ Config: [`sparq-server/fly.toml`](sparq-server/fly.toml)
 
 ### Render
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/sparq-org/sparq&branch=main&blueprint=deploy/paas/sparq-server/render.yaml)
+
+The button targets this Blueprint, which generates `SPARQ_AUTH_TOKEN` in Render's secret store and
+works without a pre-created token. For the controlled/secure path:
+
 1. In the Render dashboard, choose **New → Blueprint** and connect this repository.
 2. Select branch `main` and Blueprint Path
    `deploy/paas/sparq-server/render.yaml`.
@@ -69,10 +81,13 @@ Config: [`sparq-server/render.yaml`](sparq-server/render.yaml)
 
 ### Railway
 
-Railway config-as-code controls build/deploy settings but cannot select an image or create
-variables. The adjacent `Dockerfile` consumes and fail-closes the canonical image; the commands below
-create an empty service, install variables before its first deployment, and upload only this
-config directory.
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/sparq-org/sparq/tree/main/deploy/paas/sparq-server&envs=SPARQ_AUTH_TOKEN%2CSPARQ_AUTH_TOKEN_READ%2CPORT&SPARQ_AUTH_TOKENDesc=Required+bearer+token+for+reads+and+writes&SPARQ_AUTH_TOKEN_READDesc=Require+the+token+for+reads+and+writes&SPARQ_AUTH_TOKEN_READDefault=1&PORTDesc=Fixed+sparq-server+listen+and+health-check+port&PORTDefault=3030)
+
+The button prompts for `SPARQ_AUTH_TOKEN` and includes the required read-auth and port variables.
+For the controlled/secure CLI path, Railway config-as-code controls build/deploy settings but
+cannot select an image or create variables. The adjacent `Dockerfile` consumes and fail-closes the
+canonical image; the commands below create an empty service, install variables before its first
+deployment, and upload only this config directory.
 
 ```bash
 railway init
@@ -102,6 +117,13 @@ built with `redis-replay` and every instance uses the same secret
 
 ### Fly.io
 
+[![Deploy on Fly.io](https://img.shields.io/badge/Deploy%20on-Fly.io-7B5EA7?logo=fly.io)](https://fly.io/launch?source=github&template=https://github.com/sparq-org/sparq/tree/main/deploy/paas/lws)
+
+Fly's launch flow does not prompt for the required LWS settings. After launch, set
+`SOLID_SERVER_BASE_URL` and `SOLID_SERVER_TRUSTED_ISSUER` with `fly secrets set`, then run
+`fly scale count 1`; until both settings exist, LWS cannot boot. The controlled/secure CLI path
+below installs them before first deploy.
+
 Choose a globally unique app name first so the configured base URL exactly matches Fly's public
 HTTPS hostname.
 
@@ -122,6 +144,11 @@ Config: [`lws/fly.toml`](lws/fly.toml)
 
 ### Render
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/sparq-org/sparq&branch=main&blueprint=deploy/paas/lws/render.yaml)
+
+The button targets this Blueprint and prompts for the required base URL and trusted issuer. For the
+controlled/secure path:
+
 1. In the Render dashboard, choose **New → Blueprint** and connect this repository.
 2. Select branch `main` and Blueprint Path `deploy/paas/lws/render.yaml`.
 3. Supply the prompted base URL and trusted issuer, then deploy.
@@ -132,8 +159,12 @@ Config: [`lws/render.yaml`](lws/render.yaml)
 
 ### Railway
 
-Create the domain before the first deployment so its HTTPS origin can be used as the LWS base URL.
-Replace `<generated>.up.railway.app` below with the hostname printed by `railway domain`.
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/sparq-org/sparq/tree/main/deploy/paas/lws&envs=SOLID_SERVER_BASE_URL%2CSOLID_SERVER_TRUSTED_ISSUER%2CSOLID_SERVER_BIND%2CPORT&SOLID_SERVER_BASE_URLDesc=Required+public+HTTPS+origin&SOLID_SERVER_TRUSTED_ISSUERDesc=Required+external+OIDC+issuer+URL&SOLID_SERVER_BINDDesc=Required+public+container+bind&SOLID_SERVER_BINDDefault=0.0.0.0%3A3000&PORTDesc=Required+Railway+health-check+port&PORTDefault=3000)
+
+The button prompts for the required public HTTPS origin and trusted issuer and includes the bind and
+port variables. For the controlled/secure CLI path, create the domain before the first deployment
+so its HTTPS origin can be used as the LWS base URL. Replace `<generated>.up.railway.app` below with
+the hostname printed by `railway domain`.
 
 ```bash
 railway init

--- a/deploy/paas/lws/Dockerfile
+++ b/deploy/paas/lws/Dockerfile
@@ -1,0 +1,5 @@
+# [GPT-5.6] Railway config-as-code cannot select an image; consume the canonical image here.
+FROM ghcr.io/sparq-org/sparq-lws-core:latest
+
+# The binary itself defaults to loopback, which Railway ingress cannot reach.
+ENV SOLID_SERVER_BIND=0.0.0.0:3000

--- a/deploy/paas/lws/fly.toml
+++ b/deploy/paas/lws/fly.toml
@@ -1,4 +1,5 @@
 # [SONNET-4.6] sq-dwame — Fly.io app config for sparq-lws-core (Solid/LWS server).
+# [GPT-5.6] Post-hoc hardening: public bind plus single-instance Fly deployment.
 #
 # DEPENDENCY NOTE: the sparq-lws-core image is built by bead sq-lmz40 and will be
 # published to ghcr.io/sparq-org/sparq-lws-core. Until sq-lmz40 is merged and the image
@@ -12,14 +13,15 @@
 # (unlike sparq-server). However, SOLID_SERVER_TRUSTED_ISSUER and SOLID_SERVER_BASE_URL
 # are REQUIRED for any real deployment (the server cannot self-issue an OIDC IdP).
 #
-# Auto-HTTPS (R4): Fly.io terminates TLS on its shared *.fly.dev domain and on custom
+# Auto-HTTPS (R3): Fly.io terminates TLS on its shared *.fly.dev domain and on custom
 # domains. The SOLID_SERVER_BASE_URL MUST match your public HTTPS URL.
 #
 # Multi-instance note: LWS uses an in-memory DPoP jti replay store by default.
 # For >1 replica, set SOLID_SERVER_REPLAY_REDIS_URL (with the redis-replay feature).
 # Single-instance deployments are safe without Redis.
 
-app = "sparq-lws"             # override with: fly apps create --name <your-app>
+# `fly launch --name <unique-name>` replaces this schema-required placeholder.
+app = "sparq-lws-change-me"
 primary_region = "iad"        # US East; change to the region nearest your users
 
 [build]
@@ -28,6 +30,9 @@ primary_region = "iad"        # US East; change to the region nearest your users
   #   image = "ghcr.io/sparq-org/sparq-lws-core:0.1.0"
 
 [env]
+  # The binary defaults to loopback; PaaS ingress requires an explicit public container bind.
+  SOLID_SERVER_BIND = "0.0.0.0:3000"
+
   # REQUIRED: set these to your actual public deployment URLs.
   # Alternatively, set via: fly secrets set SOLID_SERVER_BASE_URL="https://…"
   #
@@ -49,6 +54,19 @@ primary_region = "iad"        # US East; change to the region nearest your users
   auto_stop_machines  = "stop"
   auto_start_machines = true
   min_machines_running = 1
+
+  # Fly creates two Machines by default for a service on first deploy. This file cannot cap
+  # Machine count: deploy with --ha=false, then run `fly scale count 1` (README). LWS uses an
+  # in-memory DPoP replay store unless a shared Redis replay backend is configured.
+
+  [[http_service.checks]]
+    # R7: liveness path for sparq-lws-core.
+    grace_period    = "15s"
+    interval        = "15s"
+    method          = "GET"
+    path            = "/livez"
+    timeout         = "5s"
+    tls_skip_verify = false
 
   [[http_service.checks]]
     # R7: readiness health-check path for sparq-lws-core.

--- a/deploy/paas/lws/railway.toml
+++ b/deploy/paas/lws/railway.toml
@@ -1,4 +1,5 @@
 # [SONNET-4.6] sq-dwame — Railway config for sparq-lws-core (Solid/LWS server).
+# [GPT-5.6] Post-hoc hardening: real Dockerfile source and one-replica deployment.
 #
 # DEPENDENCY NOTE: the sparq-lws-core image is built by bead sq-lmz40 and will be
 # published to ghcr.io/sparq-org/sparq-lws-core. This config references the canonical
@@ -9,17 +10,19 @@
 # DPoP is required, HTTPS-only WebIDs. SOLID_SERVER_TRUSTED_ISSUER and
 # SOLID_SERVER_BASE_URL are REQUIRED (the server cannot self-issue an OIDC IdP).
 #
-# Auto-HTTPS (R4): Railway provides automatic TLS on *.railway.app and custom domains.
+# Auto-HTTPS (R3): Railway provides automatic TLS on *.up.railway.app and custom domains.
 #
 # Set required variables before deploying:
-#   railway variables set SOLID_SERVER_BASE_URL="https://sparq-lws.railway.app"
+#   railway variables set SOLID_SERVER_BASE_URL="https://<generated>.up.railway.app"
 #   railway variables set SOLID_SERVER_TRUSTED_ISSUER="https://your-oidc-provider.example.com"
 
 [build]
-  dockerfilePath = ""    # not building from source — using the pre-built GHCR image
+  # The adjacent one-line Dockerfile consumes the canonical prebuilt GHCR image.
+  builder = "DOCKERFILE"
+  dockerfilePath = "Dockerfile"
 
 [deploy]
-  startCommand = ""      # image ENTRYPOINT is used; no override needed
+  numReplicas = 1                  # in-memory DPoP replay requires one replica
   healthcheckPath = "/readyz"    # R7: readiness health-check for sparq-lws-core
   healthcheckTimeout = 30
   restartPolicyType = "ON_FAILURE"
@@ -27,13 +30,14 @@
 
 # Variables required in Railway dashboard (R4 — never put literal values here):
 #
-#   SOLID_SERVER_BASE_URL       = "https://sparq-lws.railway.app"  [REQUIRED]
+#   SOLID_SERVER_BASE_URL       = "https://<generated>.up.railway.app"  [REQUIRED]
 #   SOLID_SERVER_TRUSTED_ISSUER = "https://your-oidc-provider.example.com"  [REQUIRED]
+#   SOLID_SERVER_BIND          = "0.0.0.0:3000"                    [REQUIRED]
+#   PORT                       = 3000                               [REQUIRED for health checks]
 #
 # Optional:
 #   SOLID_SERVER_AUDIENCE         = "https://…"    # defaults to BASE_URL
 #   SOLID_SERVER_REPLAY_REDIS_URL = "redis://…"    # required for >1 replica
-#   PORT                          = 3000            # Railway injects $PORT; set to 3000
 #
 # DEV-ONLY escape hatches (NEVER set in production — R2):
 #   SOLID_SERVER_ALLOW_LOOPBACK       = "1"

--- a/deploy/paas/lws/render.yaml
+++ b/deploy/paas/lws/render.yaml
@@ -1,4 +1,5 @@
 # [SONNET-4.6] sq-dwame — Render Blueprint for sparq-lws-core (Solid/LWS server).
+# [GPT-5.6] Post-hoc hardening: explicit public bind and single-instance pin.
 #
 # DEPENDENCY NOTE: the sparq-lws-core image is built by bead sq-lmz40 and will be
 # published to ghcr.io/sparq-org/sparq-lws-core. This config references the canonical
@@ -9,7 +10,7 @@
 # DPoP is required, HTTPS-only WebIDs. SOLID_SERVER_TRUSTED_ISSUER and
 # SOLID_SERVER_BASE_URL are REQUIRED parameters (the server cannot self-issue).
 #
-# Auto-HTTPS (R4): Render provides automatic TLS on *.onrender.com and custom domains.
+# Auto-HTTPS (R3): Render provides automatic TLS on *.onrender.com and custom domains.
 # SOLID_SERVER_BASE_URL MUST match your actual public HTTPS URL.
 #
 # Multi-instance note: set numInstances > 1 only when SOLID_SERVER_REPLAY_REDIS_URL is
@@ -29,9 +30,17 @@ services:
     healthCheckPath: /readyz
 
     plan: starter
+    # Single-instance invariant: the default DPoP replay store is in-memory.
     numInstances: 1
 
     envVars:
+      # The binary defaults to loopback; PaaS ingress requires an explicit public container bind.
+      - key: SOLID_SERVER_BIND
+        value: 0.0.0.0:3000
+
+      - key: PORT
+        value: "3000"
+
       # REQUIRED — sync: false means Render prompts at deploy time; values are NEVER
       # stored in this YAML (R4).
       - key: SOLID_SERVER_BASE_URL

--- a/deploy/paas/sparq-server/Dockerfile
+++ b/deploy/paas/sparq-server/Dockerfile
@@ -1,0 +1,7 @@
+# [GPT-5.6] Railway config-as-code cannot select an image; consume the canonical image here.
+FROM ghcr.io/sparq-org/sparq-server:latest
+
+# Override the base image's open bind opt-in. The server permits its public bind only after
+# Railway injects SPARQ_AUTH_TOKEN; read-auth makes the entire surface token-gated.
+ENV SPARQ_ALLOW_REMOTE=0
+ENV SPARQ_AUTH_TOKEN_READ=1

--- a/deploy/paas/sparq-server/fly.toml
+++ b/deploy/paas/sparq-server/fly.toml
@@ -1,4 +1,5 @@
 # [SONNET-4.6] sq-dwame — Fly.io app config for sparq-server.
+# [GPT-5.6] Post-hoc hardening: full-surface auth and single-writer deployment guidance.
 #
 # SECURE-DEFAULTS NOTICE (R1/R9):
 # The sparq-server image is open-by-default (bakes SPARQ_ALLOW_REMOTE=1, no auth at the
@@ -7,11 +8,12 @@
 #
 #   fly secrets set SPARQ_AUTH_TOKEN="$(openssl rand -hex 32)"
 #
-# Auto-HTTPS (R4): Fly.io terminates TLS on its shared *.fly.dev domain and on any
+# Auto-HTTPS (R3): Fly.io terminates TLS on its shared *.fly.dev domain and on any
 # custom domain you attach — plaintext HTTP on port 3030 never leaves Fly's edge.
 # Do not expose port 3030 directly (it is internal only in this config).
 
-app = "sparq-server"          # override with: fly apps create --name <your-app>
+# `fly launch --generate-name` replaces this schema-required placeholder.
+app = "sparq-server-change-me"
 primary_region = "iad"        # US East; change to the region nearest your users
 
 [build]
@@ -20,8 +22,12 @@ primary_region = "iad"        # US East; change to the region nearest your users
   #   image = "ghcr.io/sparq-org/sparq-server:0.1.0"
 
 [env]
-  # Read-gate: also require the token for reads (set to "1" to enforce).
-  # SPARQ_AUTH_TOKEN_READ = "1"
+  # Override the image's open bind opt-in. Without a valid read+write token the server now
+  # refuses its public bind and the deployment fails closed instead of booting unauthenticated.
+  SPARQ_ALLOW_REMOTE = "0"
+
+  # Secure default: require the platform-secret token for reads as well as writes.
+  SPARQ_AUTH_TOKEN_READ = "1"
   #
   # CORS: set to your front-end origin in production.
   # SPARQ_CORS_ALLOW_ORIGIN = "https://example.com"
@@ -37,6 +43,10 @@ primary_region = "iad"        # US East; change to the region nearest your users
   auto_start_machines = true
   min_machines_running = 1
 
+  # Fly creates two Machines by default for a service on first deploy. This file cannot cap
+  # Machine count: deploy with --ha=false, then run `fly scale count 1` (README). The dataset
+  # is in-memory and uncoordinated, so two writable Machines silently diverge.
+
   [[http_service.checks]]
     # R7: health-check path for sparq-server.
     grace_period  = "10s"
@@ -51,8 +61,8 @@ primary_region = "iad"        # US East; change to the region nearest your users
   cpu_kind = "shared"
   cpus = 1
 
-# Secret setup (R2/R4 — required before first deploy):
+# Secret setup (R1/R2/R4 — required before first deploy):
 #   fly secrets set SPARQ_AUTH_TOKEN="$(openssl rand -hex 32)"
 #
 # The secret is injected as the SPARQ_AUTH_TOKEN env var at runtime and is NEVER stored
-# in this file. Unauthenticated writes return 401. See §2 of the design record.
+# in this file. Unauthenticated reads and writes return 401. See §2 of the design record.

--- a/deploy/paas/sparq-server/railway.toml
+++ b/deploy/paas/sparq-server/railway.toml
@@ -1,4 +1,5 @@
 # [SONNET-4.6] sq-dwame — Railway config for sparq-server.
+# [GPT-5.6] Post-hoc hardening: real Dockerfile source and one-replica deployment.
 #
 # SECURE-DEFAULTS NOTICE (R1/R9):
 # The sparq-server image is open-by-default (bakes SPARQ_ALLOW_REMOTE=1, no auth at the
@@ -9,17 +10,16 @@
 # Set the required secret before deploying:
 #   railway variables set SPARQ_AUTH_TOKEN="$(openssl rand -hex 32)"
 #
-# Auto-HTTPS (R4): Railway provides automatic TLS on its *.railway.app domain and on
+# Auto-HTTPS (R3): Railway provides automatic TLS on its *.up.railway.app domain and on
 # custom domains — plaintext HTTP is redirected to HTTPS by Railway's edge.
 
 [build]
-  # Railway will pull the image directly from GHCR.
-  # Set the IMAGE variable in the Railway dashboard or via CLI:
-  #   railway variables set IMAGE="ghcr.io/sparq-org/sparq-server:latest"
-  dockerfilePath = ""    # not building from source — using a pre-built image
+  # The adjacent one-line Dockerfile consumes the canonical prebuilt GHCR image.
+  builder = "DOCKERFILE"
+  dockerfilePath = "Dockerfile"
 
 [deploy]
-  startCommand = ""      # image ENTRYPOINT is used; no override needed
+  numReplicas = 1                  # single writer: in-memory replicas would diverge
   healthcheckPath = "/health"   # R7: health-check path for sparq-server
   healthcheckTimeout = 30       # seconds before Railway marks the deploy unhealthy
   restartPolicyType = "ON_FAILURE"
@@ -29,10 +29,9 @@
 #
 #   SPARQ_AUTH_TOKEN   = <strong random token>        [REQUIRED — enforces R1/R2]
 #   PORT               = 3030                         [Railway injects $PORT; set to 3030]
-#   RAILWAY_ENVIRONMENT = production
+#   SPARQ_AUTH_TOKEN_READ = 1                         [gate reads as well as writes]
 #
 # Optional tuning variables (set in dashboard as needed):
-#   SPARQ_AUTH_TOKEN_READ  = "1"           # also gate reads behind the token
 #   SPARQ_CORS_ALLOW_ORIGIN = "https://…"  # restrict CORS to your front-end origin
 #   SPARQ_MAX_CONCURRENT   = "16"
 #   SPARQ_QUERY_TIMEOUT    = "30"

--- a/deploy/paas/sparq-server/render.yaml
+++ b/deploy/paas/sparq-server/render.yaml
@@ -1,16 +1,22 @@
 # [SONNET-4.6] sq-dwame — Render Blueprint for sparq-server.
+# [GPT-5.6] Post-hoc hardening: generated env-group secret and single-writer pin.
 #
 # SECURE-DEFAULTS NOTICE (R1/R9):
 # The sparq-server image is open-by-default (bakes SPARQ_ALLOW_REMOTE=1, no auth at the
 # image layer). This template enforces auth ON at the template layer via SPARQ_AUTH_TOKEN.
-# The token is marked sync: false — Render will prompt you to set it in the dashboard;
-# it is NEVER stored in this file (R4). Unauthenticated writes return 401.
+# Render generates the token into an environment group; no plaintext value is committed (R4).
+# Unauthenticated reads and writes return 401.
 #
-# Auto-HTTPS (R4): Render provides automatic TLS on its *.onrender.com domain and on
+# Auto-HTTPS (R3): Render provides automatic TLS on its *.onrender.com domain and on
 # custom domains — plaintext HTTP is redirected to HTTPS automatically.
 #
-# Deploy: https://render.com/deploy (use the button in deploy/paas/README.md)
-#         or: render blueprint apply
+# Deploy from Render's New Blueprint flow and select this file as the custom Blueprint Path.
+
+envVarGroups:
+  - name: sparq-server-secrets
+    envVars:
+      - key: SPARQ_AUTH_TOKEN
+        generateValue: true
 
 services:
   - type: web
@@ -25,17 +31,24 @@ services:
     healthCheckPath: /health
 
     plan: starter          # cheapest plan that supports custom images; upgrade as needed
+    # Single-writer invariant: the in-memory dataset is not coordinated across replicas.
     numInstances: 1
 
-    # R4: secrets — sync: false means Render prompts for the value at deploy time;
-    # the value is NEVER stored in this YAML.
     envVars:
-      - key: SPARQ_AUTH_TOKEN
-        sync: false          # REQUIRED: set a strong random token in the Render dashboard
+      # R4: inject the platform-generated token from Render's environment-group store.
+      - fromGroup: sparq-server-secrets
 
-      # Optional — uncomment to require auth for reads as well:
-      # - key: SPARQ_AUTH_TOKEN_READ
-      #   value: "1"
+      # Override the image's open bind opt-in. A missing token now makes startup fail closed.
+      - key: SPARQ_ALLOW_REMOTE
+        value: "0"
+
+      # Secure default: gate reads as well as writes.
+      - key: SPARQ_AUTH_TOKEN_READ
+        value: "1"
+
+      # The image binds 3030; declaring PORT makes Render's routing/probe selection explicit.
+      - key: PORT
+        value: "3030"
 
       # Optional — set to your front-end origin in production:
       # - key: SPARQ_CORS_ALLOW_ORIGIN


### PR DESCRIPTION
> 🤖 SPARQ agent

Post-hoc GPT-5.6 review of the Sonnet-authored PaaS IaC from PR #2314 found material correctness and security defects.

Fixed:
- Fly HTTP services defaulted to two Machines, which would split the uncoordinated in-memory SPARQL dataset and the LWS in-memory DPoP replay state. The documented launch/deploy flow now disables HA and scales to exactly one Machine.
- Railway selected no image, used an empty Dockerfile path and empty start command, omitted the fixed health-check port, and did not pin replicas. Small Dockerfiles now consume the canonical GHCR images, current schema keys are used, PORT is installed before deployment, and numReplicas is one.
- LWS omitted SOLID_SERVER_BIND, leaving the binary loopback-only default unreachable from PaaS ingress. All three platform paths now bind 0.0.0.0:3000.
- sparq-server inherited SPARQ_ALLOW_REMOTE=1 and could still boot open when a secret was missed. Every platform now overrides it to zero, enables read auth, and injects SPARQ_AUTH_TOKEN from Fly secrets, a Render-generated environment-group secret, or Railway variables. Missing auth now fails the public bind closed.
- Render now pins one instance, explicitly declares the image port, and generates the auth token in an environment group.
- The advertised generic deploy buttons did not safely select the nested configs or guarantee secret-before-ingress ordering. The README now gives provider-valid setup flows and correct current domain names.
- Fly LWS now checks both /livez and /readyz; all other health paths and ports are asserted per server.

Validation:
- Current official Render JSON schema: both Blueprints pass.
- Current official Railway JSON schema: both TOMLs pass.
- Current flyctl local parser: both Fly configs pass.
- Secret, port, image, health, fail-closed auth, and single-instance assertions pass; repository doc/privacy/performance gates pass.

Honest limits: no live provider deployment was performed because provider credentials are unavailable. The canonical sparq-org GHCR refs were not publicly pullable during review, so deployment remains externally blocked until those packages/tags are published; LWS publication is already tracked by sq-lmz40. I did not substitute the legacy jeswr image because the architecture contract requires sparq-org.

This PR is intentionally unarmed.