### PR TITLE
feat(deploy): publish native sparq-lws-core multi-arch image (sq-lmz40) [GPT-5.6]

### DIFF
--- a/.github/workflows/lws-container.yml
+++ b/.github/workflows/lws-container.yml
@@ -1,0 +1,96 @@
+# [GPT-5.6] sq-lmz40 — release the native Solid/LWS image independently of sparq-server.
+name: LWS container release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: smoke + scan + publish LWS container
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Buildx for native gate
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Gate the loadable native artifact before registry login or any multi-arch push.
+      - name: Build native amd64 image for smoke and scan
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: crates/sparq-lws-core/Dockerfile
+          load: true
+          push: false
+          platforms: linux/amd64
+          tags: sparq-lws-core:smoke
+          cache-from: type=gha,scope=sparq-lws-core
+          cache-to: type=gha,mode=max,scope=sparq-lws-core
+          provenance: false
+          sbom: false
+
+      - name: Smoke native image (health, fail-closed mutation, non-root)
+        env:
+          LWS_CONTAINER_SKIP_BUILD: "1"
+        run: crates/sparq-lws-core/tests/container-smoke.sh sparq-lws-core:smoke 3000
+
+      - name: Scan native image (fail on fixable HIGH or CRITICAL)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: sparq-lws-core:smoke
+          scan-type: image
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+          trivyignores: .trivyignore
+
+      # Only after the native artifact passes smoke + vulnerability gates do we
+      # enable emulation, authenticate, and publish the multi-arch image index.
+      - name: Set up QEMU for arm64
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate stable release tags and OCI labels
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/sparq-org/sparq-lws-core
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Publish amd64 + arm64 image index
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: crates/sparq-lws-core/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=sparq-lws-core
+          cache-to: type=gha,mode=max,scope=sparq-lws-core
+          provenance: mode=max
+          sbom: true

--- a/crates/sparq-lws-core/Dockerfile
+++ b/crates/sparq-lws-core/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+# [GPT-5.6] sq-lmz40 — native sparq-lws-core production container.
+#
+# Build from the repository root:
+#   docker build -f crates/sparq-lws-core/Dockerfile -t sparq-lws-core .
+#
+# The builder and runtime intentionally match the repository's sparq-server image:
+# Debian 12 on both sides keeps glibc compatible, cargo-auditable embeds the Rust
+# dependency manifest, and the final distroless image has no shell or package manager.
+
+# -------- builder --------
+# Tag: rust:1.88-slim-bookworm
+FROM rust:1.88-slim-bookworm@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS builder
+
+ARG CARGO_FLAGS=""
+WORKDIR /build
+
+COPY . .
+
+# cargo-auditable's own lockfile pins its install; the workspace build separately
+# uses the committed Cargo.lock and the crate's default feature set.
+RUN cargo install --locked cargo-auditable
+RUN cargo auditable build --release --locked -p sparq-lws-core ${CARGO_FLAGS}
+
+# -------- runtime --------
+# Tag: gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985
+
+LABEL org.opencontainers.image.title="sparq-lws-core" \
+      org.opencontainers.image.description="Native experimental Solid/LDP server backed by the sparq RDF engine" \
+      org.opencontainers.image.source="https://github.com/sparq-org/sparq" \
+      org.opencontainers.image.licenses="MIT OR Apache-2.0" \
+      org.opencontainers.image.documentation="https://github.com/sparq-org/sparq/tree/main/crates/sparq-lws-core#readme"
+
+COPY --from=builder /build/target/release/sparq-lws-core /usr/local/bin/sparq-lws-core
+
+# The distroless nonroot identity is uid/gid 65532. Declare it explicitly so
+# neither a base-image metadata change nor a caller's assumption can make the
+# packaged process root by default.
+USER 65532:65532
+
+ENV SOLID_SERVER_BIND=0.0.0.0:3000
+EXPOSE 3000
+
+# Base URL, TLS, trusted issuer/audience, auth policy, and storage selection are
+# intentionally not baked in. Operators supply the existing SOLID_SERVER_* / PSS_*
+# contract; in particular, no development auth or loopback escape hatch is enabled.
+ENTRYPOINT ["/usr/local/bin/sparq-lws-core"]
+CMD []

--- a/crates/sparq-lws-core/README.md
+++ b/crates/sparq-lws-core/README.md
@@ -31,6 +31,71 @@ module docs on `src/main.rs`. `SOLID_SERVER_RECONCILE_INTERVAL_SECS` is unset by
 default; a positive integer enables one periodic sweep using the unchanged
 one-hour orphan grace period. Invalid or zero values fail boot.
 
+## 📦 Native container image
+
+<!-- [GPT-5.6] sq-lmz40: native image contract; distinct from the wasm/npm development host. -->
+
+Release tags publish `ghcr.io/sparq-org/sparq-lws-core` as a multi-architecture
+image for `linux/amd64` and `linux/arm64`. Use an immutable `X.Y.Z` tag in a
+deployment; releases also publish `X.Y` and `latest` convenience tags.
+
+```bash
+VERSION=0.1.0 # replace with the release to deploy
+IMAGE="ghcr.io/sparq-org/sparq-lws-core:${VERSION}"
+docker pull "${IMAGE}"
+
+# Example with TLS terminated by a trusted reverse proxy.
+docker run --rm --name sparq-lws-core \
+  -p 127.0.0.1:3000:3000 \
+  -e SOLID_SERVER_BASE_URL=https://solid.example \
+  -e SOLID_SERVER_TRUSTED_ISSUER=https://idp.example/realms/solid \
+  -e SOLID_SERVER_AUDIENCE=https://solid.example \
+  "${IMAGE}"
+```
+
+The image binds `0.0.0.0:3000` through `SOLID_SERVER_BIND` and runs as uid/gid
+65532. `GET /livez` and `GET /readyz` are the unauthenticated liveness and
+readiness probes. All other `SOLID_SERVER_*` / `PSS_*` settings pass through to
+the binary; the image enables no auth bypass or development escape hatch.
+
+### Required production configuration
+
+- **Public base URL:** set `SOLID_SERVER_BASE_URL` to the externally visible
+  `https://` origin. Set `SOLID_SERVER_AUDIENCE` when token audience differs;
+  otherwise it defaults to the base URL.
+- **TLS:** either terminate TLS at a trusted ingress/reverse proxy, or mount
+  readable PEM files and set both `SOLID_SERVER_TLS_CERT` and
+  `SOLID_SERVER_TLS_KEY`. Setting only one fails boot. Keep the container port
+  private when TLS terminates upstream.
+- **Authentication and authorization:** set `SOLID_SERVER_TRUSTED_ISSUER` to
+  the production HTTPS Solid-OIDC issuer. DPoP, HTTPS-only WebIDs, anonymous
+  mutation rejection, and strict bidirectional WebID-to-issuer validation are
+  secure defaults. Do not set `SOLID_SERVER_ALLOW_LOOPBACK`, the seed variables,
+  or `SOLID_SERVER_BIDIRECTIONAL=off` in production. Resource access remains
+  controlled by WAC.
+- **Storage:** explicitly review `PSS_SPARQ_BACKEND` before deployment. Its
+  default, `memory`, is ephemeral. The default-feature image also includes the
+  `embedded` backend, selected with `PSS_SPARQ_BACKEND=embedded`; without
+  `SOLID_SERVER_SPARQ_DIR` it is also ephemeral. The current native binary has
+  only an in-memory blob backend and therefore deliberately refuses a durable
+  SPARQ index paired with ephemeral resource bytes. Until a durable BlobStore
+  implementation is available, this image is not suitable for durable
+  production data. The `http` SPARQ and Redis replay backends require opt-in
+  compile-time features and are not present in this default-feature image.
+
+For in-process TLS, mount certificate material read-only and ensure uid 65532
+can read it:
+
+```bash
+docker run --rm -p 3000:3000 \
+  --mount type=bind,src="${PWD}/tls",dst=/run/tls,readonly \
+  -e SOLID_SERVER_BASE_URL=https://solid.example \
+  -e SOLID_SERVER_TRUSTED_ISSUER=https://idp.example/realms/solid \
+  -e SOLID_SERVER_TLS_CERT=/run/tls/tls.crt \
+  -e SOLID_SERVER_TLS_KEY=/run/tls/tls.key \
+  "ghcr.io/sparq-org/sparq-lws-core:${VERSION}"
+```
+
 ## ✨ Features
 
 - **LDP surface** — containers + RDF/non-RDF resources, Turtle / JSON-LD content

--- a/crates/sparq-lws-core/README.md
+++ b/crates/sparq-lws-core/README.md
@@ -35,66 +35,35 @@ one-hour orphan grace period. Invalid or zero values fail boot.
 
 <!-- [GPT-5.6] sq-lmz40: native image contract; distinct from the wasm/npm development host. -->
 
-Release tags publish `ghcr.io/sparq-org/sparq-lws-core` as a multi-architecture
-image for `linux/amd64` and `linux/arm64`. Use an immutable `X.Y.Z` tag in a
-deployment; releases also publish `X.Y` and `latest` convenience tags.
+Release tags publish `ghcr.io/sparq-org/sparq-lws-core` as a multi-arch image
+(`linux/amd64` + `linux/arm64`); pin an immutable `X.Y.Z` tag (also `X.Y` / `latest`).
+It binds `0.0.0.0:3000` via `SOLID_SERVER_BIND`, runs as uid/gid **65532** (non-root),
+serves unauthenticated `GET /livez` + `GET /readyz` probes, and enables **no** auth
+bypass or dev escape hatch — all other `SOLID_SERVER_*` / `PSS_*` settings pass through.
 
 ```bash
-VERSION=0.1.0 # replace with the release to deploy
-IMAGE="ghcr.io/sparq-org/sparq-lws-core:${VERSION}"
-docker pull "${IMAGE}"
-
-# Example with TLS terminated by a trusted reverse proxy.
-docker run --rm --name sparq-lws-core \
-  -p 127.0.0.1:3000:3000 \
+VERSION=0.1.0   # the release to deploy
+docker run --rm --name sparq-lws-core -p 127.0.0.1:3000:3000 \
   -e SOLID_SERVER_BASE_URL=https://solid.example \
   -e SOLID_SERVER_TRUSTED_ISSUER=https://idp.example/realms/solid \
-  -e SOLID_SERVER_AUDIENCE=https://solid.example \
-  "${IMAGE}"
-```
-
-The image binds `0.0.0.0:3000` through `SOLID_SERVER_BIND` and runs as uid/gid
-65532. `GET /livez` and `GET /readyz` are the unauthenticated liveness and
-readiness probes. All other `SOLID_SERVER_*` / `PSS_*` settings pass through to
-the binary; the image enables no auth bypass or development escape hatch.
-
-### Required production configuration
-
-- **Public base URL:** set `SOLID_SERVER_BASE_URL` to the externally visible
-  `https://` origin. Set `SOLID_SERVER_AUDIENCE` when token audience differs;
-  otherwise it defaults to the base URL.
-- **TLS:** either terminate TLS at a trusted ingress/reverse proxy, or mount
-  readable PEM files and set both `SOLID_SERVER_TLS_CERT` and
-  `SOLID_SERVER_TLS_KEY`. Setting only one fails boot. Keep the container port
-  private when TLS terminates upstream.
-- **Authentication and authorization:** set `SOLID_SERVER_TRUSTED_ISSUER` to
-  the production HTTPS Solid-OIDC issuer. DPoP, HTTPS-only WebIDs, anonymous
-  mutation rejection, and strict bidirectional WebID-to-issuer validation are
-  secure defaults. Do not set `SOLID_SERVER_ALLOW_LOOPBACK`, the seed variables,
-  or `SOLID_SERVER_BIDIRECTIONAL=off` in production. Resource access remains
-  controlled by WAC.
-- **Storage:** explicitly review `PSS_SPARQ_BACKEND` before deployment. Its
-  default, `memory`, is ephemeral. The default-feature image also includes the
-  `embedded` backend, selected with `PSS_SPARQ_BACKEND=embedded`; without
-  `SOLID_SERVER_SPARQ_DIR` it is also ephemeral. The current native binary has
-  only an in-memory blob backend and therefore deliberately refuses a durable
-  SPARQ index paired with ephemeral resource bytes. Until a durable BlobStore
-  implementation is available, this image is not suitable for durable
-  production data. The `http` SPARQ and Redis replay backends require opt-in
-  compile-time features and are not present in this default-feature image.
-
-For in-process TLS, mount certificate material read-only and ensure uid 65532
-can read it:
-
-```bash
-docker run --rm -p 3000:3000 \
-  --mount type=bind,src="${PWD}/tls",dst=/run/tls,readonly \
-  -e SOLID_SERVER_BASE_URL=https://solid.example \
-  -e SOLID_SERVER_TRUSTED_ISSUER=https://idp.example/realms/solid \
-  -e SOLID_SERVER_TLS_CERT=/run/tls/tls.crt \
-  -e SOLID_SERVER_TLS_KEY=/run/tls/tls.key \
   "ghcr.io/sparq-org/sparq-lws-core:${VERSION}"
 ```
+
+**Required production configuration:**
+
+- **Base URL:** `SOLID_SERVER_BASE_URL` = the public `https://` origin (set
+  `SOLID_SERVER_AUDIENCE` only if the token audience differs).
+- **TLS:** terminate at a trusted proxy (keep the container port private), or mount PEMs
+  and set both `SOLID_SERVER_TLS_CERT` + `SOLID_SERVER_TLS_KEY` (setting one fails boot;
+  uid 65532 must read them).
+- **Auth:** `SOLID_SERVER_TRUSTED_ISSUER` = the production Solid-OIDC issuer. DPoP,
+  HTTPS-only WebIDs, anonymous-mutation rejection, and strict WebID↔issuer checks are on
+  by default — never set `SOLID_SERVER_ALLOW_LOOPBACK`, the seed vars, or
+  `SOLID_SERVER_BIDIRECTIONAL=off`; access stays WAC-controlled.
+- **Storage:** review `PSS_SPARQ_BACKEND` — its default `memory` (and `embedded` without
+  `SOLID_SERVER_SPARQ_DIR`) is **ephemeral**, and the native binary has only an in-memory
+  blob backend, so this image is **not for durable production data** yet. The `http` and
+  `redis-replay` backends need opt-in compile-time features.
 
 ## ✨ Features
 

--- a/crates/sparq-lws-core/tests/container-smoke.sh
+++ b/crates/sparq-lws-core/tests/container-smoke.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# [GPT-5.6] sq-lmz40 — build and exercise the native sparq-lws-core image.
+#
+# Usage: crates/sparq-lws-core/tests/container-smoke.sh [IMAGE_REF] [HOST_PORT]
+# Set LWS_CONTAINER_SKIP_BUILD=1 only when the caller already built that exact
+# IMAGE_REF (the release workflow does this to share its BuildKit cache).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+IMAGE="${1:-sparq-lws-core:smoke}"
+PORT="${2:-3000}"
+NAME="sparq-lws-smoke-$$"
+BASE="http://127.0.0.1:${PORT}"
+
+cleanup() {
+  echo "::group::container logs (${NAME})"
+  docker logs "${NAME}" 2>&1 || true
+  echo "::endgroup::"
+  docker rm -f "${NAME}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cd "${ROOT}"
+
+if [ "${LWS_CONTAINER_SKIP_BUILD:-0}" != "1" ]; then
+  build_args=()
+  if [ -n "${CARGO_FLAGS:-}" ]; then
+    build_args+=(--build-arg "CARGO_FLAGS=${CARGO_FLAGS}")
+  fi
+  echo ">> building ${IMAGE}"
+  docker build \
+    --file crates/sparq-lws-core/Dockerfile \
+    --tag "${IMAGE}" \
+    "${build_args[@]}" \
+    .
+else
+  echo ">> using caller-built ${IMAGE}"
+fi
+
+# Check the image declaration as well as the live process. An empty/root user is
+# a packaging regression even on a host that happens to remap container uid 0.
+configured_user="$(docker image inspect --format '{{.Config.User}}' "${IMAGE}")"
+case "${configured_user}" in
+  ""|0|0:0|root|root:root)
+    echo "!! image is configured to run as root (${configured_user:-<empty>})" >&2
+    exit 1
+    ;;
+esac
+
+echo ">> running ${IMAGE} as configured user ${configured_user}"
+docker run -d \
+  --name "${NAME}" \
+  -p "127.0.0.1:${PORT}:3000" \
+  "${IMAGE}" >/dev/null
+
+container_pid="$(docker inspect --format '{{.State.Pid}}' "${NAME}")"
+runtime_uid="$(awk '/^Uid:/ { print $2; exit }' "/proc/${container_pid}/status")"
+if [ -z "${runtime_uid}" ] || [ "${runtime_uid}" = "0" ]; then
+  echo "!! container process is running as uid ${runtime_uid:-<unknown>}" >&2
+  exit 1
+fi
+echo ">> process uid ${runtime_uid} is non-root"
+
+for path in livez readyz; do
+  echo ">> waiting for /${path}"
+  reachable=""
+  for attempt in $(seq 1 30); do
+    if [ "$(docker inspect --format '{{.State.Running}}' "${NAME}" 2>/dev/null || echo false)" != "true" ]; then
+      echo "!! container exited before /${path} became reachable" >&2
+      exit 1
+    fi
+    if curl --fail --silent --show-error "${BASE}/${path}" >/dev/null 2>&1; then
+      reachable=1
+      echo ">> /${path} reachable (attempt ${attempt})"
+      break
+    fi
+    sleep 1
+  done
+  if [ -z "${reachable}" ]; then
+    echo "!! /${path} was not reachable within 30 seconds" >&2
+    exit 1
+  fi
+done
+
+echo ">> asserting an anonymous mutation fails closed"
+status="$(curl --silent --show-error \
+  --output /dev/null \
+  --write-out '%{http_code}' \
+  --request PUT \
+  --header 'Content-Type: text/turtle' \
+  --data '<> <https://example.test/predicate> "value" .' \
+  "${BASE}/container-smoke-resource")"
+case "${status}" in
+  401|403)
+    echo ">> anonymous PUT rejected with HTTP ${status}"
+    ;;
+  *)
+    echo "!! anonymous PUT returned HTTP ${status}; expected 401 or 403" >&2
+    exit 1
+    ;;
+esac
+
+echo ">> SMOKE PASS: health reachable, anonymous mutation rejected, process non-root"


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements sq-lmz40 for the native `sparq-lws-core` deployable surface only:

- adds a pinned, locked, cargo-auditable, distroless non-root image with the default feature set and container bind `0.0.0.0:3000`;
- adds a build-and-run smoke test for `/livez`, `/readyz`, anonymous mutation rejection, and the runtime uid;
- documents GHCR multi-arch usage plus required base URL, TLS, Solid-OIDC/auth, and honest storage configuration; and
- adds a dedicated tag workflow that gates an amd64 artifact with runtime smoke + Trivy before publishing amd64/arm64 GHCR manifests with SBOM and max provenance.

Gate status: `actionlint`, `shellcheck`, advisory-registry validation, action-tool validation, typos, and `git diff --check` pass. A local amd64 Docker build was attempted with a four-minute cap; the pinned stages and Dockerfile parsed, `cargo-auditable` installed, and the locked default-feature Rust build began, but compilation did not finish before the cap, so no local runtime smoke is claimed. `.github/workflows/lws-container.yml` performs the authoritative native build/smoke/scan and multi-arch publish in CI.

Out-of-scope image/deployment feature mismatch recorded as #2321.