### PR TITLE
feat(site): add secure deployment surface (sq-44ga1) [GPT-5.6]

### DIFF
--- a/docs/deploy-ci.md
+++ b/docs/deploy-ci.md
@@ -1,0 +1,68 @@
+<!-- [GPT-5.6] sq-44ga1 — orchestration contract for deployment-template validation. -->
+
+# Deployment CI orchestration
+
+This document maps every deployment family to the strongest useful check that can run without
+standing cloud credentials. It is the control plane for `deploy/**`; provider templates remain
+owned by their provider directories.
+
+Deployment validation is deliberately separate from the native Rust workspace gate. Dedicated
+deploy workflows use path filters plus `workflow_dispatch`, and their advisory jobs are not part
+of `ci-summary`. A cloud CLI outage or unavailable provider account therefore cannot turn the
+engine workspace red.
+
+## Common smoke contract
+
+Every live smoke that can boot a server must exercise the same minimum sequence:
+
+1. Start the exact image or rendered template under test.
+2. Poll the server-specific health endpoint until it is ready:
+   `GET /health` for `sparq-server`; `GET /livez` and `GET /readyz` for Solid/LWS.
+3. Send one representative request. For `sparq-server`, issue an authenticated SPARQL `ASK`.
+   For Solid/LWS, a fully authenticated request needs an external OIDC issuer, so the
+   credential-free smoke may use a read plus the fail-closed mutation check instead.
+4. Prove the public-write invariant: an unauthenticated SPARQL Update returns 401/403, or an
+   anonymous Solid mutation returns 401/403.
+5. Stop the workload and print logs on failure.
+
+The smoke token must be generated for the job and passed through the runtime secret mechanism; it
+must not be committed to a manifest or printed. Health endpoints remain ungated. A smoke that boots
+the bare open-by-default `sparq-server` image proves packaging only; it does not prove the
+template-layer authentication contract.
+
+## Orchestration matrix
+
+| Family | Credential-free validation | Live boot and one request | Workflow / entry point |
+|---|---|---|---|
+| AWS CloudFormation | `cfn-lint` both YAML templates. `aws cloudformation validate-template` is a manual account-backed check because the API call requires IAM credentials. | Provider deployment only; after launch run the common smoke against the ALB HTTPS hostname. | `deploy/aws/README.md`; provider CI remains separate from the Rust gate. |
+| Azure Bicep/ARM | Build and lint both Bicep sources, then compare/review the compiled ARM artifacts. | Provider deployment only; after launch run the common smoke against Container Apps HTTPS ingress. | `deploy/azure/README.md`; provider CI remains separate from the Rust gate. |
+| GCP Cloud Run | Validate both service YAML documents and assert the Secret Manager reference, dedicated service account, per-server probes, and single-instance annotations. | Provider deployment only; after `gcloud run services replace`, run the common smoke against the `run.app` HTTPS URL. | `deploy/gcp/README.md`; provider CI remains separate from the Rust gate. |
+| Terraform | `terraform init -backend=false`, `terraform validate`, and recursive `terraform fmt -check` for the root and all three provider modules; scan for literal credentials and verify sensitive inputs. | A plan/apply requires provider credentials. Run the common smoke after an account-backed apply. | `.github/workflows/deploy-terraform-lint.yml` (`push`/PR path filters + manual dispatch). |
+| Helm / Kubernetes | `helm lint`, render SPARQL and Solid/LWS variants, assert fail-closed values, run strict Kubernetes schema validation, and scan for literal credentials. | Where a runner can load the images, install into `kind`, wait on `/health` or `/readyz`, port-forward, then run the common smoke. | `.github/workflows/deploy-lint.yml` (`push`/PR path filters + manual dispatch). |
+| Fly.io | Parse both `fly.toml` files and assert HTTPS forcing, per-server probes, required bind/auth posture, and one-Machine configuration. | Provider credentials are required. Run the common smoke after the secret-first CLI flow. | `deploy/paas/README.md`; provider CI remains separate from the Rust gate. |
+| Render | Parse both Blueprint YAML files and assert secret inputs/generation, per-server health paths, and one-instance configuration. | Provider credentials are required. Run the common smoke after Blueprint deployment. | `deploy/paas/README.md`; provider CI remains separate from the Rust gate. |
+| Railway | Parse both `railway.toml` files and assert per-server health paths, ports, restart policy, and one-replica configuration. | Provider credentials are required. Run the common smoke after variables are installed and the service deploys. | `deploy/paas/README.md`; provider CI remains separate from the Rust gate. |
+| Shared `sparq-server` image | Build the release Dockerfile, run it, poll `/health`, and issue a SPARQL `ASK`. This is a packaging smoke of the bare image, not the token-gated template posture. | Runs locally in Docker on relevant Rust or Docker changes. | `.github/workflows/ci.yml` → `scripts/docker-smoke.sh`. |
+| Shared Solid/LWS image | Build the release Dockerfile, assert non-root execution, poll `/livez` and `/readyz`, and prove anonymous mutation is rejected. | Runs on release tags before the image is published. | `.github/workflows/lws-container.yml` → `crates/sparq-lws-core/tests/container-smoke.sh`. |
+
+## Provider workflow checklist
+
+A provider-specific deploy job is complete only when all applicable items below are explicit:
+
+- It is in a dedicated deploy workflow, with `workflow_dispatch` and a narrow `deploy/**` path
+  filter, and is not aggregated into `ci-summary`.
+- Tool versions are pinned; downloaded tools are checksum-verified where the repository installs
+  binaries directly.
+- Both `sparq-server` and Solid/LWS variants are parsed, rendered, or synthesized.
+- Static assertions cover token/secret references, HTTPS ingress, least-privilege identity,
+  server-specific health paths, and the current single-instance constraint.
+- The secret-hygiene scan rejects committed credential values without rejecting secret-reference
+  names.
+- No credential-free job claims to have deployed a cloud resource. Account-backed validation is
+  documented as manual and should clean up resources in the same run.
+- A feasible local Docker or `kind` smoke follows the common contract above and emits logs when it
+  fails.
+
+The page at `/deploy` links to these provider-owned assets and repeats the essential posture:
+`sparq-server` is open by default at the image layer, while the templates gate it with a token.
+Removing that wiring changes the security posture and is not a supported production default.

--- a/site/src/app/deploy/copy-command.tsx
+++ b/site/src/app/deploy/copy-command.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+// [GPT-5.6] sq-44ga1 — small route-local copy affordance for deploy commands.
+
+import * as React from "react";
+import { Check, Copy } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function CopyCommand({
+  command,
+  label,
+}: {
+  command: string;
+  label: string;
+}) {
+  const [copied, setCopied] = React.useState(false);
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    [],
+  );
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), 1600);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-background">
+      <div className="flex items-center justify-between gap-3 border-b bg-muted/40 px-3 py-2">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={copy}
+          aria-label={`Copy ${label}`}
+        >
+          {copied ? <Check aria-hidden /> : <Copy aria-hidden />}
+          <span aria-live="polite">{copied ? "Copied" : "Copy"}</span>
+        </Button>
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-relaxed">
+        <code>{command}</code>
+      </pre>
+    </div>
+  );
+}

--- a/site/src/app/deploy/deploy-options.ts
+++ b/site/src/app/deploy/deploy-options.ts
@@ -1,0 +1,248 @@
+// [GPT-5.6] sq-44ga1 — canonical data for the statically exported /deploy surface.
+
+export type DeployTarget = "sparq-server" | "solid-lws";
+
+export interface DeployButton {
+  label: string;
+  target: DeployTarget;
+  href: string;
+}
+
+export interface DeployOption {
+  id:
+    | "aws"
+    | "azure"
+    | "gcp"
+    | "fly"
+    | "render"
+    | "railway"
+    | "terraform"
+    | "helm";
+  name: string;
+  mode: "One-click" | "One-click + CLI" | "CLI / IaC";
+  summary: string;
+  security: string;
+  docsHref: string;
+  buttons: readonly DeployButton[];
+  commandLabel?: string;
+  command?: string;
+  caveat?: string;
+}
+
+const REPO = "https://github.com/sparq-org/sparq";
+
+export const OPEN_BY_DEFAULT_CAVEAT =
+  "sparq-server is open-by-default at the image layer; these templates gate it with a token — do not remove the token wiring.";
+
+export const SECURE_DEFAULTS = [
+  {
+    rule: "Auth on",
+    detail:
+      "Public sparq-server deployments inject a token from the provider secret store. Anonymous writes must return 401 or 403.",
+  },
+  {
+    rule: "HTTPS only",
+    detail:
+      "Terminate TLS at the managed edge. Never send a bearer token to a public plaintext endpoint.",
+  },
+  {
+    rule: "Secrets stay secret",
+    detail:
+      "Templates reference Secrets Manager, Key Vault, Secret Manager, Kubernetes Secrets, or the PaaS vault; they do not commit credential values.",
+  },
+  {
+    rule: "Server-specific health",
+    detail:
+      "Probe /health for sparq-server, and /livez plus /readyz for Solid/LWS. Keep the checked-in single-instance defaults unless shared state is configured.",
+  },
+] as const;
+
+export const DEPLOY_OPTIONS: readonly DeployOption[] = [
+  {
+    id: "aws",
+    name: "AWS",
+    mode: "CLI / IaC",
+    summary: "ECS Fargate behind an HTTPS Application Load Balancer.",
+    security:
+      "The task reads its token from Secrets Manager; ACM terminates TLS and the task port accepts traffic only from the load balancer.",
+    docsHref: `${REPO}/tree/main/deploy/aws`,
+    buttons: [],
+    commandLabel: "CloudFormation starter",
+    command: [
+      "aws cloudformation create-stack \\",
+      "  --stack-name sparq-server \\",
+      "  --template-body file://deploy/aws/sparq-server.yaml \\",
+      "  --capabilities CAPABILITY_IAM \\",
+      "  --parameters ParameterKey=AuthTokenSecretArn,ParameterValue=<SECRET_ARN> \\",
+      "               ParameterKey=AcmCertificateArn,ParameterValue=<ACM_CERT_ARN>",
+    ].join("\n"),
+    caveat:
+      "CloudFormation Launch Stack requires an S3-hosted template. sparq does not publish one to a project-owned bucket, so this page does not present a non-working launch button.",
+  },
+  {
+    id: "azure",
+    name: "Azure",
+    mode: "One-click + CLI",
+    summary: "Azure Container Apps with managed HTTPS ingress.",
+    security:
+      "The template stores the token in Key Vault, uses a dedicated managed identity, and pins the writable service to one replica.",
+    docsHref: `${REPO}/tree/main/deploy/azure`,
+    buttons: [
+      {
+        label: "Deploy SPARQL to Azure",
+        target: "sparq-server",
+        href: "https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsparq-org%2Fsparq%2Fmain%2Fdeploy%2Fazure%2Fsparq-server%2Fazuredeploy.json",
+      },
+      {
+        label: "Deploy Solid/LWS to Azure",
+        target: "solid-lws",
+        href: "https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsparq-org%2Fsparq%2Fmain%2Fdeploy%2Fazure%2Flws%2Fazuredeploy.json",
+      },
+    ],
+    commandLabel: "Azure CLI starter",
+    command: [
+      "az group create --name sparq-rg --location eastus",
+      "az deployment group create \\",
+      "  --resource-group sparq-rg \\",
+      "  --template-file deploy/azure/sparq-server/main.bicep \\",
+      '  --parameters authToken="$(openssl rand -hex 32)"',
+    ].join("\n"),
+  },
+  {
+    id: "gcp",
+    name: "Google Cloud",
+    mode: "CLI / IaC",
+    summary: "Cloud Run with managed HTTPS and provider-native health probes.",
+    security:
+      "The manifest references Secret Manager through a dedicated runtime service account and gates both reads and writes with the application token.",
+    docsHref: `${REPO}/tree/main/deploy/gcp`,
+    buttons: [],
+    commandLabel: "Cloud Run deploy after prerequisites",
+    command: [
+      'RENDERED="$(mktemp)"',
+      'trap \'rm -f "${RENDERED}"\' EXIT',
+      "sed -e \"s/PROJECT_ID/${PROJECT_ID}/g\" \\",
+      "    -e \"s/PROJECT_NUMBER/${PROJECT_NUMBER}/g\" \\",
+      '    deploy/gcp/sparq-server.yaml >"${RENDERED}"',
+      "gcloud run services replace \"${RENDERED}\" \\",
+      '  --region="${REGION}" --project="${PROJECT_ID}"',
+    ].join("\n"),
+    caveat:
+      "Cloud Run Button source-builds a repository directory; it cannot safely apply these manifests and their IAM/Secret Manager prerequisites. Use the reviewed guide instead.",
+  },
+  {
+    id: "fly",
+    name: "Fly.io",
+    mode: "One-click + CLI",
+    summary: "A small managed deployment with automatic HTTPS.",
+    security:
+      "The config fails closed until required secrets exist, forces HTTPS, and keeps one Machine for the current process-local stores.",
+    docsHref: `${REPO}/blob/main/deploy/paas/README.md#flyio`,
+    buttons: [
+      {
+        label: "Deploy SPARQL on Fly.io",
+        target: "sparq-server",
+        href: `https://fly.io/launch?source=github&template=${REPO}/tree/main/deploy/paas/sparq-server`,
+      },
+      {
+        label: "Deploy Solid/LWS on Fly.io",
+        target: "solid-lws",
+        href: `https://fly.io/launch?source=github&template=${REPO}/tree/main/deploy/paas/lws`,
+      },
+    ],
+    commandLabel: "Secure Fly CLI path",
+    command: [
+      "cd deploy/paas/sparq-server",
+      "fly launch --copy-config --generate-name --no-deploy --ha=false",
+      'fly secrets set SPARQ_AUTH_TOKEN="$(openssl rand -hex 32)"',
+      "fly deploy --ha=false && fly scale count 1",
+    ].join("\n"),
+  },
+  {
+    id: "render",
+    name: "Render",
+    mode: "One-click",
+    summary: "Blueprint deployments with automatic HTTPS.",
+    security:
+      "The SPARQL Blueprint generates its token in a secret environment group, requires it for reads and writes, and pins one instance.",
+    docsHref: `${REPO}/blob/main/deploy/paas/README.md#render`,
+    buttons: [
+      {
+        label: "Deploy SPARQL to Render",
+        target: "sparq-server",
+        href: `https://render.com/deploy?repo=${REPO}&branch=main&blueprint=deploy/paas/sparq-server/render.yaml`,
+      },
+      {
+        label: "Deploy Solid/LWS to Render",
+        target: "solid-lws",
+        href: `https://render.com/deploy?repo=${REPO}&branch=main&blueprint=deploy/paas/lws/render.yaml`,
+      },
+    ],
+  },
+  {
+    id: "railway",
+    name: "Railway",
+    mode: "One-click + CLI",
+    summary: "Config-as-code deployments with managed TLS.",
+    security:
+      "The template prompts for required variables before launch, enables read auth for sparq-server, and pins one replica.",
+    docsHref: `${REPO}/blob/main/deploy/paas/README.md#railway`,
+    buttons: [
+      {
+        label: "Deploy SPARQL on Railway",
+        target: "sparq-server",
+        href: `https://railway.com/new/template?template=${REPO}/tree/main/deploy/paas/sparq-server&envs=SPARQ_AUTH_TOKEN%2CSPARQ_AUTH_TOKEN_READ%2CPORT&SPARQ_AUTH_TOKENDesc=Required+bearer+token+for+reads+and+writes&SPARQ_AUTH_TOKEN_READDesc=Require+the+token+for+reads+and+writes&SPARQ_AUTH_TOKEN_READDefault=1&PORTDesc=Fixed+sparq-server+listen+and+health-check+port&PORTDefault=3030`,
+      },
+      {
+        label: "Deploy Solid/LWS on Railway",
+        target: "solid-lws",
+        href: `https://railway.com/new/template?template=${REPO}/tree/main/deploy/paas/lws&envs=SOLID_SERVER_BASE_URL%2CSOLID_SERVER_TRUSTED_ISSUER%2CSOLID_SERVER_BIND%2CPORT&SOLID_SERVER_BASE_URLDesc=Required+public+HTTPS+origin&SOLID_SERVER_TRUSTED_ISSUERDesc=Required+external+OIDC+issuer+URL&SOLID_SERVER_BINDDesc=Required+public+container+bind&SOLID_SERVER_BINDDefault=0.0.0.0%3A3000&PORTDesc=Required+Railway+health-check+port&PORTDefault=3000`,
+      },
+    ],
+    commandLabel: "Secure Railway CLI path",
+    command: [
+      "railway init && railway add --service sparq-server",
+      "openssl rand -hex 32 | railway variables set SPARQ_AUTH_TOKEN --stdin --skip-deploys",
+      "railway variables set SPARQ_AUTH_TOKEN_READ=1 PORT=3030 --skip-deploys",
+      "railway up deploy/paas/sparq-server --path-as-root",
+    ].join("\n"),
+  },
+  {
+    id: "terraform",
+    name: "Terraform",
+    mode: "CLI / IaC",
+    summary: "One module selecting AWS, Azure, or GCP.",
+    security:
+      "The module generates a token when omitted, stores it in the selected cloud secret store, and marks supplied token input sensitive.",
+    docsHref: `${REPO}/tree/main/deploy/terraform`,
+    buttons: [],
+    commandLabel: "Terraform starter",
+    command: [
+      "cd deploy/terraform",
+      "terraform init",
+      "terraform apply -var target=azure -var azure_location=eastus",
+    ].join("\n"),
+  },
+  {
+    id: "helm",
+    name: "Kubernetes / Helm",
+    mode: "CLI / IaC",
+    summary: "A secure-default chart plus a plain-manifest quickstart.",
+    security:
+      "The chart requires an existing Secret, uses a minimal ServiceAccount, keeps the Service cluster-internal, and requires TLS for its ingress.",
+    docsHref: `${REPO}/tree/main/deploy/helm`,
+    buttons: [],
+    commandLabel: "Helm starter",
+    command: [
+      "kubectl create namespace sparq",
+      "openssl rand -hex 32 | tr -d '\\n' | kubectl create secret generic sparq-auth-token \\",
+      "  --namespace sparq --from-file=SPARQ_AUTH_TOKEN=/dev/stdin",
+      "helm install sparq ./deploy/helm/sparq --namespace sparq \\",
+      "  --set auth.existingSecret=sparq-auth-token",
+    ].join("\n"),
+  },
+];
+
+export const ONE_CLICK_BUTTONS = DEPLOY_OPTIONS.flatMap((option) =>
+  option.buttons.map((button) => ({ provider: option.id, ...button })),
+);

--- a/site/src/app/deploy/page.tsx
+++ b/site/src/app/deploy/page.tsx
@@ -1,0 +1,269 @@
+import type { Metadata } from "next";
+import {
+  Boxes,
+  Cloud,
+  ExternalLink,
+  HeartPulse,
+  KeyRound,
+  Layers3,
+  LockKeyhole,
+  Rocket,
+  Server,
+  ShieldCheck,
+  ShipWheel,
+  TriangleAlert,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from "@/components/ui/card";
+
+import { CopyCommand } from "./copy-command";
+import {
+  DEPLOY_OPTIONS,
+  OPEN_BY_DEFAULT_CAVEAT,
+  SECURE_DEFAULTS,
+  type DeployOption,
+} from "./deploy-options";
+
+// [GPT-5.6] sq-44ga1 — static /deploy route over the provider-owned templates.
+export const metadata: Metadata = {
+  title: "Deploy",
+  description:
+    "Deploy sparq-server or the Solid/LWS server with reviewed cloud, PaaS, Terraform, and Helm templates that keep auth and HTTPS wiring visible.",
+};
+
+const PROVIDER_ICONS = {
+  aws: Cloud,
+  azure: Layers3,
+  gcp: Cloud,
+  fly: Rocket,
+  render: Server,
+  railway: ShipWheel,
+  terraform: Boxes,
+  helm: ShipWheel,
+} satisfies Record<DeployOption["id"], typeof Cloud>;
+
+const SECURE_DEFAULT_ICONS = {
+  "Auth on": KeyRound,
+  "HTTPS only": LockKeyhole,
+  "Secrets stay secret": ShieldCheck,
+  "Server-specific health": HeartPulse,
+} satisfies Record<(typeof SECURE_DEFAULTS)[number]["rule"], typeof KeyRound>;
+
+export default function DeployPage() {
+  return (
+    <div className="space-y-14">
+      <section aria-labelledby="deploy-heading" className="space-y-6 py-4">
+        <Badge variant="warning">Native server deployments</Badge>
+        <div className="max-w-3xl space-y-4">
+          <h1
+            id="deploy-heading"
+            className="text-4xl font-semibold tracking-tight md:text-5xl"
+          >
+            Deploy sparq without hiding the security wiring.
+          </h1>
+          <p className="text-lg leading-relaxed text-muted-foreground">
+            Pick a managed cloud, a fast PaaS, or portable infrastructure as
+            code. Every link below points at the provider-owned template in this
+            repository; the site does not generate or rewrite deployment assets.
+          </p>
+        </div>
+
+        <div
+          className="flex max-w-4xl gap-3 rounded-xl border border-warning/40 bg-warning/10 p-4"
+          role="note"
+          aria-label="sparq-server authentication caveat"
+        >
+          <TriangleAlert
+            className="mt-0.5 size-5 shrink-0 text-warning"
+            aria-hidden
+          />
+          <div className="space-y-1">
+            <p className="font-semibold">Keep the token wiring.</p>
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              {OPEN_BY_DEFAULT_CAVEAT} Anyone who can reach an ungated image can
+              read and write its dataset.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="providers-heading" className="space-y-6">
+        <div className="space-y-2">
+          <h2 id="providers-heading" className="text-2xl font-semibold">
+            Choose a deployment path
+          </h2>
+          <p className="max-w-3xl text-muted-foreground">
+            Buttons are shown only where the checked-in provider asset supports a
+            real one-click flow. The Solid/LWS templates require a trusted OIDC
+            issuer and public HTTPS base URL; confirm the selected container tag
+            is published before launch.
+          </p>
+        </div>
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          {DEPLOY_OPTIONS.map((option) => {
+            const Icon = PROVIDER_ICONS[option.id];
+            return (
+              <Card
+                key={option.id}
+                id={`provider-${option.id}`}
+                data-provider={option.id}
+                className="transition-shadow hover:shadow-elevation-2"
+              >
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                      <span className="rounded-lg bg-primary/10 p-2 text-primary">
+                        <Icon className="size-5" aria-hidden />
+                      </span>
+                      <h3 className="font-semibold leading-none tracking-tight">
+                        {option.name}
+                      </h3>
+                    </div>
+                    <Badge variant={option.buttons.length ? "success" : "muted"}>
+                      {option.mode}
+                    </Badge>
+                  </div>
+                  <CardDescription>{option.summary}</CardDescription>
+                </CardHeader>
+
+                <CardContent className="flex flex-1 flex-col gap-4">
+                  <div className="flex gap-2 text-sm leading-relaxed text-muted-foreground">
+                    <ShieldCheck
+                      className="mt-0.5 size-4 shrink-0 text-primary"
+                      aria-hidden
+                    />
+                    <p>{option.security}</p>
+                  </div>
+
+                  {option.buttons.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {option.buttons.map((button) => (
+                        <Button key={button.href} size="sm" asChild>
+                          <a
+                            href={button.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            data-deploy-target={button.target}
+                          >
+                            {button.label}
+                            <ExternalLink aria-hidden />
+                          </a>
+                        </Button>
+                      ))}
+                    </div>
+                  )}
+
+                  {option.caveat && (
+                    <p className="rounded-lg bg-muted/60 p-3 text-xs leading-relaxed text-muted-foreground">
+                      {option.caveat}
+                    </p>
+                  )}
+
+                  {option.command && option.commandLabel && (
+                    <CopyCommand
+                      command={option.command}
+                      label={option.commandLabel}
+                    />
+                  )}
+
+                  <Button variant="link" className="mt-auto w-fit px-0" asChild>
+                    <a
+                      href={option.docsHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Read the reviewed {option.name} guide
+                      <ExternalLink aria-hidden />
+                    </a>
+                  </Button>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </section>
+
+      <section aria-labelledby="defaults-heading" className="space-y-6">
+        <div className="space-y-2">
+          <h2 id="defaults-heading" className="text-2xl font-semibold">
+            Secure defaults to preserve
+          </h2>
+          <p className="max-w-3xl text-muted-foreground">
+            These are template-layer controls, not claims that the bare server
+            images provide a production perimeter by themselves.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {SECURE_DEFAULTS.map((item) => {
+            const Icon = SECURE_DEFAULT_ICONS[item.rule];
+            return (
+              <div
+                key={item.rule}
+                className="flex gap-3 rounded-xl border bg-card p-4 shadow-elevation-1"
+              >
+                <Icon className="mt-0.5 size-5 shrink-0 text-primary" aria-hidden />
+                <div className="space-y-1">
+                  <h3 className="font-semibold">{item.rule}</h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    {item.detail}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="operations-heading"
+        className="grid gap-5 border-t pt-8 md:grid-cols-2"
+      >
+        <div className="space-y-3">
+          <h2 id="operations-heading" className="text-xl font-semibold">
+            Verify the deployment
+          </h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            The deployment CI contract records which templates can be checked
+            without cloud credentials and where a live boot, health probe, one
+            request, and anonymous-write rejection are feasible.
+          </p>
+          <Button variant="outline" asChild>
+            <a
+              href="https://github.com/sparq-org/sparq/blob/main/docs/deploy-ci.md"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Deployment CI contract
+              <ExternalLink aria-hidden />
+            </a>
+          </Button>
+        </div>
+
+        <div className="space-y-3 rounded-xl bg-muted/50 p-5">
+          <h2 className="text-xl font-semibold">Local Solid development</h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Need a loopback-only development pod instead of a cloud container?
+            The npm host is in-memory local-development software, defaults to a
+            fixed owner, and must not be exposed as a production server.
+          </p>
+          <CopyCommand
+            label="Local-only npm host"
+            command={[
+              "npx @jeswr/solid-server --port 3000 \\",
+              "  --base-url http://127.0.0.1:3000 \\",
+              "  --owner-webid https://id.example/alice#me",
+            ].join("\n")}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/site/test/deploy.test.mjs
+++ b/site/test/deploy.test.mjs
@@ -1,0 +1,58 @@
+// [GPT-5.6] sq-44ga1 — pin the provider/button and secure-default matrices rendered by /deploy.
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  DEPLOY_OPTIONS,
+  ONE_CLICK_BUTTONS,
+  OPEN_BY_DEFAULT_CAVEAT,
+  SECURE_DEFAULTS,
+} from "../src/app/deploy/deploy-options.ts";
+
+test("deploy surface covers every provider family in architecture order", () => {
+  assert.deepEqual(
+    DEPLOY_OPTIONS.map((option) => option.id),
+    ["aws", "azure", "gcp", "fly", "render", "railway", "terraform", "helm"],
+  );
+  assert.ok(DEPLOY_OPTIONS.every((option) => option.docsHref.startsWith("https://")));
+  assert.ok(DEPLOY_OPTIONS.every((option) => option.security.length > 40));
+});
+
+test("every checked-in one-click button is wired for both server targets", () => {
+  assert.deepEqual(
+    ONE_CLICK_BUTTONS.map(({ provider, target }) => `${provider}:${target}`),
+    [
+      "azure:sparq-server",
+      "azure:solid-lws",
+      "fly:sparq-server",
+      "fly:solid-lws",
+      "render:sparq-server",
+      "render:solid-lws",
+      "railway:sparq-server",
+      "railway:solid-lws",
+    ],
+  );
+  assert.ok(ONE_CLICK_BUTTONS.every((button) => button.href.startsWith("https://")));
+});
+
+test("AWS and GCP do not invent unsupported public launch buttons", () => {
+  for (const id of ["aws", "gcp"]) {
+    const option = DEPLOY_OPTIONS.find((candidate) => candidate.id === id);
+    assert.ok(option);
+    assert.deepEqual(option.buttons, []);
+    assert.match(option.caveat, /does not|cannot/);
+    assert.ok(option.command);
+  }
+});
+
+test("secure-default copy pins the image-layer caveat and operational controls", () => {
+  assert.equal(
+    OPEN_BY_DEFAULT_CAVEAT,
+    "sparq-server is open-by-default at the image layer; these templates gate it with a token — do not remove the token wiring.",
+  );
+  assert.deepEqual(
+    SECURE_DEFAULTS.map(({ rule }) => rule),
+    ["Auth on", "HTTPS only", "Secrets stay secret", "Server-specific health"],
+  );
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds the statically exported `/deploy` surface for all eight provider/IaC families, wiring the eight real Azure/Fly/Render/Railway buttons for both server targets plus reviewed copy-paste CLI paths. AWS and GCP deliberately link their checked-in guides instead of presenting unsupported one-click buttons. The page states the sparq-server image-layer open-by-default caveat, token/anonymous-write/TLS/secret/health guidance, and the local-only status of the npm Solid host.

Adds `docs/deploy-ci.md` as the non-gating deployment validation and live-smoke orchestration contract. No template or frontend dependency was added; the only client code is the small route-local copy control.

Gates: `npm --workspace sparq-site run lint` ✅; `npm --workspace sparq-site run typecheck` ✅; `npm --workspace sparq-site run build` ✅ (static `/deploy` export + bundle guard); `npm --workspace sparq-site run test:unit` ✅ (345 tests); no-perf-numbers, terminology, and privacy-claims honesty checks ✅.