### PR TITLE
test(fuzz): pin canonicalize_nquads dup-quad reproducer + regression test (sq-40apk) [GPT-5.6]

### DIFF
--- a/fuzz/fuzz_targets/canonicalize_nquads.rs
+++ b/fuzz/fuzz_targets/canonicalize_nquads.rs
@@ -20,7 +20,9 @@
 // inputs). DISTINCT, not raw: an RDF dataset is a SET of quads, so RDFC-1.0
 // canonicalization correctly deduplicates a repeated input line — the randomized
 // lane caught the earlier raw-count assert on exactly that (a duplicated quad,
-// 5 parsed -> 4 canonical; sq-t8z0r / GH #1903). Distinct counts ARE preserved:
+// 5 parsed -> 4 canonical; sq-t8z0r / GH #1903). The exact follow-up reproducer
+// from run 29152138161 is pinned in the seed corpus by sq-40apk. [GPT-5.6]
+// Distinct counts ARE preserved:
 // canonical blank-node relabelling is injective, so distinct quads stay distinct.
 //
 // INVARIANT: any input must produce `Ok(...)` or a clean `Err(...)` — never a panic,

--- a/fuzz/seeds/canonicalize_nquads/24694f1d7701250710a0fec7432dc1b8c562ee99
+++ b/fuzz/seeds/canonicalize_nquads/24694f1d7701250710a0fec7432dc1b8c562ee99
@@ -1,0 +1,5 @@
+<http://eg/s> <Http://exa,ple.org/p> <http://exae.orp://1plorg/g> .
+_:b0 <http:/6e.org/s> <http://exampg> .
+_:b0 <http://e.org/s> <http:t//example.orp://1plorg/g> .
+_:b0 <http:/6e.org/s> <http://exampg> .
+_:b0 <http://e.org/s> <http:t//examr> .

--- a/fuzz/tests/canonicalize_nquads.rs
+++ b/fuzz/tests/canonicalize_nquads.rs
@@ -1,0 +1,36 @@
+//! Regression checks for committed `canonicalize_nquads` fuzz seeds. [GPT-5.6]
+
+use std::collections::HashSet;
+
+/// [GPT-5.6] sq-40apk: RDFC-1.0 canonicalization applies RDF dataset set
+/// semantics, so the duplicate quad in the CI reproducer must collapse.
+#[test]
+fn duplicate_quad_reproducer_preserves_distinct_count() {
+    let input =
+        include_str!("../seeds/canonicalize_nquads/24694f1d7701250710a0fec7432dc1b8c562ee99");
+    let input_quads = sparq_canon::parse_nquads(input).expect("reproducer must parse");
+    let distinct_input_quads = input_quads
+        .iter()
+        .map(ToString::to_string)
+        .collect::<HashSet<_>>();
+
+    assert_eq!(
+        input_quads.len(),
+        5,
+        "reproducer must retain its duplicate on parse"
+    );
+    assert_eq!(
+        distinct_input_quads.len(),
+        4,
+        "one repeated quad must collapse under dataset set semantics"
+    );
+
+    let canonical = sparq_canon::canonicalize_nquads(input).expect("reproducer must canonicalize");
+    let canonical_quads =
+        sparq_canon::parse_nquads(&canonical).expect("canonical output must parse");
+    assert_eq!(
+        canonical_quads.len(),
+        distinct_input_quads.len(),
+        "canonicalization must preserve the deduplicated quad count"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes the sq-40apk follow-up. The `canonicalize_nquads` fuzz assertion is **already** dedup-aware (distinct-count comparison via HashSet, from sq-t8z0r / #1903), so the raw==canon bug the bead describes was already fixed. This is the remaining hardening:
- adds the exact CI reproducer (run 29152138161, crash `24694f1d…`) to the seed corpus;
- adds a direct regression test asserting the duplicate quad collapses (5 parsed → 4 distinct → 4 canonical) under RDFC-1.0 dataset set semantics.

Scoped gates green: `cargo test -p sparq-fuzz` (1 passed) + `cargo clippy -p sparq-fuzz --bin canonicalize_nquads --test canonicalize_nquads -D warnings`. (The libFuzzer replay needs the nightly sanitizer toolchain not present on the dev box — CI's fuzz lane covers it.)