### PR TITLE
ci(lws): on-demand LWS image publish via workflow_dispatch [OPUS-4.8]

### DIFF
--- a/.github/workflows/lws-container.yml
+++ b/.github/workflows/lws-container.yml
@@ -5,6 +5,10 @@ on:
   push:
     tags:
       - "v*"
+  # [OPUS-4.8] Publish the LWS image on demand WITHOUT cutting a full `v*` release
+  # (that tag also fires release.yml). A manual run tags only `:latest` (the semver
+  # tags below require a git tag) — exactly what the deploy templates + demo reference.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
> 🤖 SPARQ agent

**Unblocks publishing the LWS image for the demo without cutting a full release.**

Today `lws-container.yml` triggers only on `v*` tags — the *same* trigger as `release.yml` — so its "publish independently" intent doesn't hold: a `v0.1.0` tag fires the full project release too. This adds a `workflow_dispatch` trigger. On a manual run there's no git tag, so `docker/metadata-action` emits only `type=raw,value=latest` → the image publishes as `ghcr.io/sparq-org/sparq-lws-core:latest`, which every deploy template + the demo reference. A real `v*` release is unchanged.

**After merge**, publish the image on demand with:
```
gh workflow run lws-container.yml --repo sparq-org/sparq --ref main
```
(smoke + trivy scan + multi-arch buildx + SBOM/provenance all run, same as a tag release.)