### PR TITLE
fix(solid): close ODRL bare-assignee widening in conditional bridge (sq-9n1q4) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -872,8 +872,11 @@ fn recipient_principal_allowed(p: &str) -> bool {
 /// re-checked by [`crate::AuthIndex::accessible`]: a session whose agent is the
 /// recipient is granted; any other agent (or anonymous) is denied — **without**
 /// re-running the ODRL evaluator. A recipient *set* emits one grant per member (the
-/// auth view unions the allows). When the rule has NO recipient constraint, the grant
-/// head is `auth:Public` (any session) — only valid because the action/target/duties
+/// auth view unions the allows). When the rule has NO recipient constraint but carries
+/// an `odrl:assignee` PROPERTY, the grant head is scoped to that one assignee ([OPUS-4.8]
+/// sq-9n1q4 — a bare-assignee rule grants ONLY the assignee, never `auth:Public`). Only
+/// when the rule has NO recipient constraint AND NO assignee is the grant head
+/// `auth:Public` (any session) — legitimately public because the action/target/duties
 /// were already satisfied at materialization.
 ///
 /// # Fail-closed
@@ -1131,11 +1134,35 @@ pub fn materialize_prohibition_conditional(
 }
 
 /// The principal-space `auth:agent` heads for a faithful recipient set, dropping any
-/// reserved-encoded recipient. An empty recipient list means the rule had NO agent
-/// restriction → a single `auth:Public` head (any session matches).
-fn condition_agents(_rule: &Rule, recipients: &[String]) -> Vec<String> {
+/// reserved-encoded recipient.
+///
+/// When the recipient CONSTRAINT set is empty, the rule's `odrl:assignee` PROPERTY (a
+/// distinct field on [`Rule`], not an `odrl:recipient`/`odrl:assignee` *constraint*
+/// block) still scopes the rule to a single party: fold it in as the sole head so a
+/// bare-assignee rule grants/denies ONLY that assignee. [OPUS-4.8] sq-9n1q4 — WIDENING
+/// FIX: this slot previously ignored `rule.assignee` and defaulted an empty set to
+/// `auth:Public`, so a permission scoped to one assignee granted EVERYONE (incl.
+/// anonymous) and the prohibition dual over-denied everyone. The assignee is normalised
+/// and reserved-encoding-filtered exactly like a recipient (so an all-reserved assignee
+/// yields an empty set, which the callers already treat as fail-closed).
+///
+/// Only when there is NO recipient constraint AND NO assignee does the head fall back to
+/// a single `auth:Public` head (any session matches) — a legitimately public rule whose
+/// action/target/duties were already satisfied at materialization.
+fn condition_agents(rule: &Rule, recipients: &[String]) -> Vec<String> {
     if recipients.is_empty() {
-        return vec![PUBLIC.to_owned()];
+        // [OPUS-4.8] sq-9n1q4: a bare `odrl:assignee` PROPERTY scopes the head to that
+        // one party — it is NOT an unrestricted (auth:Public) rule.
+        match &rule.assignee {
+            Some(assignee) if recipient_principal_allowed(assignee) => {
+                return vec![normalise_recipient_principal(assignee)];
+            }
+            // An all-reserved-encoded assignee → empty head → the caller fails closed
+            // (an empty grant/deny head is never widened to auth:Public here).
+            Some(_) => return Vec::new(),
+            // No recipient AND no assignee → legitimately public.
+            None => return vec![PUBLIC.to_owned()],
+        }
     }
     recipients
         .iter()

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -2548,3 +2548,110 @@ fn isanyof_prohibition_persists_conditional_deny_per_member() {
     assert!(reads(&mut store, ALICE), "alice (not in set) keeps the public allow");
     assert!(reads(&mut store, DAVE), "dave (not in set) keeps the public allow");
 }
+
+// ===========================================================================
+// [OPUS-4.8] sq-9n1q4 — a BARE odrl:assignee (the rule PROPERTY, not an
+// odrl:assignee CONSTRAINT block) with ZERO constraints must NOT widen to
+// auth:Public through the conditional entry points. Regression guard for the
+// access-control WIDENING bug: `condition_agents` used to ignore `rule.assignee`
+// and default an empty recipient set to auth:Public, so a permission scoped to
+// ONE assignee granted EVERYONE (incl. anonymous), and a prohibition scoped to
+// one assignee DENIED everyone (over-deny). Both are closed by folding
+// `rule.assignee` into the condition head when there is no recipient constraint.
+// ===========================================================================
+
+// 30. WIDENING CLOSED (permission): a bare-assignee permission (assignee=alice,
+//     ZERO constraints) via the CONDITIONAL entry point grants ONLY alice — bob
+//     AND an anonymous session are DENIED accessible()/query_as for the target.
+//     Before the fix this granted auth:Public (bob + anonymous read n1).
+#[test]
+fn bare_assignee_permission_conditional_scopes_to_assignee_not_public() {
+    // The rule carries `odrl:assignee alice` as a PROPERTY and no constraint block.
+    // (`read_policy()` in this file is exactly this shape.)
+    let pol = read_policy();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+
+    // Free-function form: the ConditionalGrant head is ALICE, NOT auth:Public.
+    let mut g = pod();
+    let out = materialize_permission_conditional(&mut g, &pol, &req);
+    assert!(out.granted, "bare-assignee permission still grants: {out:?}");
+    assert_eq!(
+        cond_grants_for(&g, Some("https://sparq.dev/ns/auth#Public")),
+        0,
+        "NO auth:Public head — the assignee restriction is honoured"
+    );
+    assert_eq!(cond_grants_for(&g, Some(ALICE)), 1, "the grant head is scoped to alice");
+
+    // Through the real enforcement path: only alice reads n1.
+    let mut store = PodStore::new(pod());
+    assert!(store.materialize_odrl_permission_conditional(&pol, &req).granted);
+    assert!(reads(&mut store, ALICE), "the assignee (alice) is granted");
+    assert!(!reads(&mut store, BOB), "bob (not the assignee) is DENIED — widening closed");
+    assert!(
+        store.accessible(&Session::default(), Mode::Read).is_empty(),
+        "an anonymous session is DENIED — widening closed"
+    );
+
+    // End-to-end through query_as: only alice sees the content.
+    let sel = "SELECT ?t WHERE { GRAPH ?g { ?s <https://ex.dev/ns#title> ?t } }";
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None, now: None };
+    let bob = Session { agent: Some(BOB), client: None, issuer: None, now: None };
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 1);
+    assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 0);
+    assert_eq!(
+        store.query_as(&Session::default(), Mode::Read, sel).unwrap().rows.len(),
+        0,
+        "anonymous query sees nothing"
+    );
+}
+
+// 31. WIDENING CLOSED (prohibition dual): a bare-assignee prohibition
+//     (assignee=alice, ZERO constraints) via the CONDITIONAL entry point denies
+//     ONLY alice — bob keeps a pre-existing public allow. Before the fix this
+//     materialized a PUBLIC deny (over-deny: everyone, incl. bob, denied).
+#[test]
+fn bare_assignee_prohibition_conditional_scopes_to_assignee_not_public() {
+    let mut store = PodStore::new(pod());
+    // Baseline PUBLIC allow so we can observe the deny biting only the assignee.
+    let permit = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pub> a odrl:Set ; odrl:permission [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ] ."#,
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission_conditional(&permit, &req).granted);
+    assert!(reads(&mut store, BOB), "bob reads via the public allow before the deny");
+
+    // A bare-assignee prohibition: `odrl:assignee alice`, ZERO constraints.
+    let prohib = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pbare> a odrl:Set ; odrl:prohibition [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ;
+            odrl:assignee <https://alice.ex/card#me> ] ."#,
+        "turtle",
+    )
+    .unwrap();
+
+    // Free-function form: the deny head is ALICE, NOT auth:Public.
+    let mut g = pod();
+    assert!(materialize_permission_conditional(&mut g, &permit, &req).granted);
+    let dout = materialize_prohibition_conditional(&mut g, &prohib, &req);
+    assert!(dout.prohibited, "bare-assignee prohibition materialises a deny: {dout:?}");
+    assert_eq!(
+        cond_denies_for(&g, Some("https://sparq.dev/ns/auth#Public")),
+        0,
+        "NO auth:Public deny — the deny is scoped to the assignee"
+    );
+    assert_eq!(cond_denies_for(&g, Some(ALICE)), 1, "the deny head is scoped to alice");
+
+    // Through the real enforcement path: deny-overrides removes ONLY alice's access.
+    assert!(store.materialize_odrl_prohibition_conditional(&prohib, &req).prohibited);
+    assert!(!reads(&mut store, ALICE), "alice (the assignee) is denied — deny-overrides");
+    assert!(reads(&mut store, BOB), "bob keeps the public allow — NOT over-denied");
+    assert!(
+        !store.accessible(&Session::default(), Mode::Read).is_empty(),
+        "an anonymous session keeps the public allow — NOT over-denied"
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -302,7 +302,11 @@ Materialize the authorization view from the access-control documents, then enfor
   immediately, no `refresh_odrl_grant` needed); `odrl:purpose`/`count`/a *strict* `dateTime`
   bound have no faithful analogue and STAY one-shot; a rule mixing mappable + unmappable
   constraints falls back **entirely** to one-shot (fail-safe — never drops a bound). A
-  dateTime window is mapped only on an **allow** (a lapsed *deny* would fail open). Mapping
+  dateTime window is mapped only on an **allow** (a lapsed *deny* would fail open). A bare
+  `odrl:assignee` **rule PROPERTY** (with zero constraints) scopes the grant head to that ONE
+  assignee — **not** `auth:Public` ([OPUS-4.8] sq-9n1q4; the deny dual likewise scopes to the
+  assignee, never an over-broad public deny). Only a rule with **no** recipient constraint AND
+  **no** assignee grants `auth:Public`. Mapping
   table in the [`usage-control-policy`](../usage-control-policy/SKILL.md) skill.
 - `store.refresh_odrl_grant(&Policy, &Request, BridgeKind)` / `refresh_odrl_grants()` —
   **opt-in** (`odrl-bridge`; [OPUS-4.8] sq-dpk4): re-evaluate **bridged** ODRL grants when


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus tier) — a P1 access-control **widening** fix in the opt-in `sparq-solid` `odrl-bridge` feature (OFF by default). Bead **sq-9n1q4**. **UNARMED** — the orchestrator adversarially verifies security fixes before arming.

## The widening (probe-verified on origin/main)

An ODRL permission `[action read; target n1; assignee alice]` with **ZERO constraints**, materialized through `PodStore::materialize_odrl_permission_conditional`, emitted a `ConditionalGrant` headed by **`auth:Public`**. So **bob** AND an **anonymous** session then passed `accessible()` / `query_as` for `n1` — a permission scoped to one assignee granted *everyone*.

## Root cause

The conditional bridge computes its grant head via `condition_agents(_rule, recipients)`, where `recipients` is the recipient/assignee **CONSTRAINT** set produced by `map_constraints_to_agents` (which iterates only `rule.constraints`). With zero constraints that set is empty, and `condition_agents` defaulted an empty set to a single `auth:Public` head — its doc claimed "the rule had NO agent restriction", which is **false** when the `rule.assignee` **PROPERTY** (a distinct field on `Rule`) is set. `rule_action_target_match` deliberately defers the assignee "to the persisted condition", but no condition was ever persisted for the bare property, so the assignee restriction silently vanished.

## The fix (minimal, single-site)

Fold `rule.assignee` into the condition head when the recipient constraint set is empty: a bare-assignee rule now heads the grant with **only that assignee**, never `auth:Public`. The assignee is normalised + reserved-encoding-filtered exactly like a recipient (an all-reserved assignee → empty head → the callers already fail closed). **Preserved:** a rule with NO recipient constraint AND NO assignee still maps to `auth:Public` (legitimately public — action/target/duties were already satisfied at materialization).

## Prohibition dual — same root cause, one fix

`materialize_prohibition_conditional` shares the same `condition_agents` slot, so a bare-assignee prohibition previously became a **PUBLIC deny** (over-deny: everyone denied, not just the assignee — less dangerous but wrong). The single-site fix scopes that deny to the assignee too. No separate change was needed — the dual is fixed by the same edit.

## Before/after test evidence (both fail RED on the unfixed code, pass after)

Verified by running each test against the pre-fix `condition_agents` (both asserted the `auth:Public` head count was 1, expected 0) and again after the fix.

| Test | Before (unfixed) | After (fixed) |
|---|---|---|
| `bare_assignee_permission_conditional_scopes_to_assignee_not_public` | RED — grant head `auth:Public` (bob + anonymous read `n1`) | GREEN — grant head scoped to alice; bob + anonymous **denied** `accessible()` / `query_as` |
| `bare_assignee_prohibition_conditional_scopes_to_assignee_not_public` | RED — deny head `auth:Public` (over-deny) | GREEN — deny head scoped to alice; bob keeps the public allow |

Both tests exercise the **real enforcement path** (`PodStore::accessible` / `query_as`), not a mock. Existing test 19 (`no_constraint_conditional_grants_public` — the legitimate no-constraint AND no-assignee → `auth:Public` case) still passes.

## Gates (GREEN in BOTH feature states)

Feature flag: **`odrl-bridge`** (OFF by default; the whole `sparq-solid` ODRL surface + its test file are gated behind it).

- `cargo clippy -p sparq-solid --all-targets -- -D warnings` — clean (feature OFF)
- `cargo clippy -p sparq-solid --all-targets --features odrl-bridge -- -D warnings` — clean (feature ON)
- `cargo test -p sparq-solid --features odrl-bridge` — 68/68 integration + doctests + lib unit tests pass
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-solid --no-deps --all-features` — clean
- `scripts/check-readme-template.py --enforce` — 0 deviations (README unchanged)
- `sparq-solid` line coverage **94.32%** (floor 89) — the modified `condition_agents` branch is directly exercised by both new tests

## Docs

Updated `skills/access-control/SKILL.md` (the public-API surface) and the `condition_agents` / `materialize_permission_conditional` rustdoc to state the bare-assignee scoping and the deny dual.

## Discovered work (out of scope — captured, not fixed here)

The conditional bridge ignores `rule.logical_constraints` entirely (`map_constraints_to_agents` iterates only `rule.constraints`). A permission carrying an `odrl:and`/`odrl:or`/`odrl:xone` **compound** constraint but no atomic constraints would map `Faithful` with an empty recipient set — the compound constraint is silently dropped from the conditional path, a distinct pre-existing widening hazard. Not introduced by this change and not the assignee root cause; flagged for a follow-up bead.