### PR TITLE
fix(solid): close compound odrl:LogicalConstraint widening in conditional bridge (sq-izzak) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -714,7 +714,29 @@ enum AgentMapping {
 /// `isNoneOf`, or a numeric/dateTime operand under `isNoneOf` (the evaluator never
 /// satisfies those — `set_negation_representable` — so persisting an exception for
 /// them would widen access). Any one such constraint forces the whole rule one-shot.
+///
+/// **Unmappable (→ stay one-shot): a COMPOUND `odrl:LogicalConstraint`** ([OPUS-4.8]
+/// sq-izzak — WIDENING FIX). A rule that carries ANY `odrl:and`/`odrl:or`/`odrl:xone`
+/// (`rule.logical_constraints`) has no faithful single-head ACP analogue and MUST stay
+/// one-shot, even when it has ZERO atomic constraints. A grant head is a UNION of
+/// `auth:agent` allows, so: an `odrl:and` of recipient constraints is an INTERSECTION
+/// (folding it as a union widens — wrong direction); an `odrl:or` may mix a recipient
+/// operand with a non-recipient dimension (time/purpose) that has no head analogue; and
+/// `odrl:xone` (exactly-one) has no ACP analogue at all. Over-approximating any compound
+/// agent-restriction into the head would grant unlisted/anonymous agents — the very
+/// widening this classification prevents. Before this fix the loop below examined only
+/// `rule.constraints`, so a rule whose ONLY restriction was a compound constraint mapped
+/// `Faithful` with an EMPTY recipient set → an `auth:Public` head (the compound
+/// restriction silently DROPPED). Fail-closed: any `logical_constraints` forces the whole
+/// rule to the one-shot path ([`materialize_permission`]/[`materialize_prohibition`]),
+/// whose evaluator DOES enforce the compound constraint (frozen) — never dropping it.
 fn map_constraints_to_agents(rule: &Rule) -> AgentMapping {
+    // [OPUS-4.8] sq-izzak: a rule carrying any compound `odrl:LogicalConstraint` has no
+    // faithful ACP-condition head — stay one-shot so the compound restriction is enforced
+    // (frozen) rather than silently dropped by folding an empty recipient set to public.
+    if !rule.logical_constraints.is_empty() {
+        return AgentMapping::Unmappable;
+    }
     let mut agents: Vec<String> = Vec::new();
     let mut except: Vec<String> = Vec::new();
     let mut window = TimeWindow::default();

--- a/crates/sparq-solid/tests/odrl_bridge.rs
+++ b/crates/sparq-solid/tests/odrl_bridge.rs
@@ -2548,3 +2548,147 @@ fn isanyof_prohibition_persists_conditional_deny_per_member() {
     assert!(reads(&mut store, ALICE), "alice (not in set) keeps the public allow");
     assert!(reads(&mut store, DAVE), "dave (not in set) keeps the public allow");
 }
+
+// ===========================================================================
+// [OPUS-4.8] sq-izzak — a rule whose ONLY restriction is a COMPOUND
+// `odrl:LogicalConstraint` (`odrl:and`/`odrl:or`/`odrl:xone`) with ZERO atomic
+// constraints must NOT widen to auth:Public through the conditional entry
+// points. Regression guard for the access-control WIDENING bug:
+// `map_constraints_to_agents` used to examine ONLY `rule.constraints`, so a rule
+// carrying only a compound constraint mapped `Faithful` with an EMPTY recipient
+// set → an auth:Public head, silently DROPPING the compound restriction (a
+// permission granted EVERYONE incl. anonymous; the prohibition dual over-denied
+// everyone). Closed by classifying any `logical_constraints` as Unmappable →
+// the one-shot path (which DOES enforce the compound, frozen).
+//
+// A `recipient eq alice` sub-constraint is used so the one-shot fallback grants/
+// denies EXACTLY alice (the evaluator reads Request::party as recipient evidence),
+// while bob and an anonymous session are structurally excluded.
+// ===========================================================================
+
+/// A permission whose ONLY restriction is a compound `odrl:and` (one operand: a
+/// `recipient eq alice` sub-constraint). ZERO atomic `rule.constraints`, NO bare
+/// `odrl:assignee` property → the pre-fix conditional path folded an empty
+/// recipient set to auth:Public, dropping the compound restriction.
+fn compound_recipient_permit_policy() -> sparq_policy::Policy {
+    parse_policy_str(
+        r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/cand> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ;
+    odrl:target <https://pod.ex/notes/n1> ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:and
+        [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+          odrl:rightOperand <https://alice.ex/card#me> ] ] ] .
+"#,
+        "turtle",
+    )
+    .expect("policy parses")
+}
+
+// 32. WIDENING CLOSED (permission): a compound-only permission (an `odrl:and`
+//     of a single `recipient eq alice`, ZERO atomic constraints) via the
+//     CONDITIONAL entry point grants ONLY alice — no auth:Public head, and bob
+//     AND an anonymous session are DENIED through accessible()/query_as. Before
+//     the fix `map_constraints_to_agents` ignored the compound → Faithful with an
+//     empty recipient set → an auth:Public grant (bob + anonymous read n1).
+#[test]
+fn compound_only_permission_conditional_scopes_not_public() {
+    // Sanity: the policy really carries a compound constraint and NO atomic one.
+    let pol = compound_recipient_permit_policy();
+    assert_eq!(pol.permissions[0].constraints.len(), 0, "no atomic constraint");
+    assert_eq!(pol.permissions[0].logical_constraints.len(), 1, "one compound constraint");
+    assert!(pol.permissions[0].assignee.is_none(), "no bare assignee property");
+
+    // Free-function form: NO auth:Public head is materialized (the compound forces
+    // the one-shot fallback, which freezes a grant scoped to the materializing party).
+    let mut g = pod();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    let out = materialize_permission_conditional(&mut g, &pol, &req);
+    assert!(out.granted, "compound-only permission still grants alice one-shot: {out:?}");
+    assert_eq!(
+        cond_grants_for(&g, Some("https://sparq.dev/ns/auth#Public")),
+        0,
+        "NO auth:Public head — the compound restriction is NOT dropped"
+    );
+
+    // Through the real enforcement path: only alice reads n1; bob + anonymous denied.
+    let mut store = PodStore::new(pod());
+    assert!(store.materialize_odrl_permission_conditional(&pol, &req).granted);
+    assert!(reads(&mut store, ALICE), "the compound recipient (alice) is granted");
+    assert!(!reads(&mut store, BOB), "bob (not the recipient) is DENIED — widening closed");
+    assert!(
+        store.accessible(&Session::default(), Mode::Read).is_empty(),
+        "an anonymous session is DENIED — widening closed"
+    );
+
+    // End-to-end through query_as: only alice sees the content.
+    let sel = "SELECT ?t WHERE { GRAPH ?g { ?s <https://ex.dev/ns#title> ?t } }";
+    let alice = Session { agent: Some(ALICE), client: None, issuer: None, now: None };
+    let bob = Session { agent: Some(BOB), client: None, issuer: None, now: None };
+    assert_eq!(store.query_as(&alice, Mode::Read, sel).unwrap().rows.len(), 1);
+    assert_eq!(store.query_as(&bob, Mode::Read, sel).unwrap().rows.len(), 0);
+    assert_eq!(
+        store.query_as(&Session::default(), Mode::Read, sel).unwrap().rows.len(),
+        0,
+        "anonymous query sees nothing"
+    );
+}
+
+// 33. WIDENING CLOSED (prohibition dual): a compound-only prohibition (an
+//     `odrl:xone` of a single `recipient eq alice`, ZERO atomic constraints) via
+//     the CONDITIONAL entry point denies ONLY alice — bob AND an anonymous session
+//     keep a pre-existing public allow. Before the fix this materialized a PUBLIC
+//     deny (over-deny: everyone, incl. bob + anonymous, denied). `odrl:xone` is
+//     used to exercise a second combinator (satisfied iff exactly one operand
+//     holds — here the single `recipient eq alice`).
+#[test]
+fn compound_only_prohibition_conditional_scopes_not_public() {
+    let mut store = PodStore::new(pod());
+    // Baseline PUBLIC allow so we can observe the deny biting only the recipient.
+    let permit = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pub> a odrl:Set ; odrl:permission [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ] ."#,
+        "turtle",
+    )
+    .unwrap();
+    let req = Request::new(odrl("read")).on(N1).by(ALICE);
+    assert!(store.materialize_odrl_permission_conditional(&permit, &req).granted);
+    assert!(reads(&mut store, BOB), "bob reads via the public allow before the deny");
+
+    // A compound-only prohibition: `odrl:xone` of one `recipient eq alice`, ZERO atomic.
+    let prohib = parse_policy_str(
+        r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+        <urn:pol/pxone> a odrl:Set ; odrl:prohibition [
+            odrl:action odrl:read ; odrl:target <https://pod.ex/notes/n1> ;
+            odrl:constraint [ a odrl:LogicalConstraint ; odrl:xone
+                [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+                  odrl:rightOperand <https://alice.ex/card#me> ] ] ] ."#,
+        "turtle",
+    )
+    .unwrap();
+    assert_eq!(prohib.prohibitions[0].constraints.len(), 0, "no atomic constraint");
+    assert_eq!(prohib.prohibitions[0].logical_constraints.len(), 1, "one compound constraint");
+
+    // Free-function form: NO auth:Public deny head — the deny is scoped to alice
+    // (one-shot fallback freezes a deny for the materializing party iff it matches).
+    let mut g = pod();
+    assert!(materialize_permission_conditional(&mut g, &permit, &req).granted);
+    let dout = materialize_prohibition_conditional(&mut g, &prohib, &req);
+    assert!(dout.prohibited, "compound-only prohibition materialises a deny for alice: {dout:?}");
+    assert_eq!(
+        cond_denies_for(&g, Some("https://sparq.dev/ns/auth#Public")),
+        0,
+        "NO auth:Public deny — the compound restriction is NOT dropped"
+    );
+
+    // Through the real enforcement path: deny-overrides removes ONLY alice's access.
+    assert!(store.materialize_odrl_prohibition_conditional(&prohib, &req).prohibited);
+    assert!(!reads(&mut store, ALICE), "alice (the recipient) is denied — deny-overrides");
+    assert!(reads(&mut store, BOB), "bob keeps the public allow — NOT over-denied");
+    assert!(
+        !store.accessible(&Session::default(), Mode::Read).is_empty(),
+        "an anonymous session keeps the public allow — NOT over-denied"
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -300,7 +300,9 @@ Materialize the authorization view from the access-control documents, then enfor
   (`lteq` → `auth:notAfter`, `gteq` → `auth:notBefore`) maps to a **live-clock window**
   re-checked against `Session::now` per request ([OPUS-4.8] sq-0q7n — a lapsed window denies
   immediately, no `refresh_odrl_grant` needed); `odrl:purpose`/`count`/a *strict* `dateTime`
-  bound have no faithful analogue and STAY one-shot; a rule mixing mappable + unmappable
+  bound, **and any compound `odrl:LogicalConstraint`** (`odrl:and`/`odrl:or`/`odrl:xone` —
+  no faithful single-head analogue; [OPUS-4.8] sq-izzak) have no faithful analogue and STAY
+  one-shot; a rule mixing mappable + unmappable
   constraints falls back **entirely** to one-shot (fail-safe — never drops a bound). A
   dateTime window is mapped only on an **allow** (a lapsed *deny* would fail open). Mapping
   table in the [`usage-control-policy`](../usage-control-policy/SKILL.md) skill.


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus tier). This closes P1 access-control widening bead **sq-izzak** — the sibling of sq-9n1q4 (#2330). Opt-in `odrl-bridge` feature (OFF by default). **Unarmed** pending review.

## Hazard (access-control WIDENING + over-deny)

An ODRL permission whose ONLY restriction is a **compound** `odrl:and`/`odrl:or`/`odrl:xone` constraint — with ZERO atomic `rule.constraints` and no bare `odrl:assignee` — mapped through the conditional bridge to `Faithful` with an **empty recipient set**, which folded to an `auth:Public` grant head. The compound restriction was **silently DROPPED**, so unlisted/anonymous agents were **granted**. The prohibition dual materialised a **public deny** (over-denied everyone). A distinct pre-existing widening hazard, NOT introduced by #2330.

## Root cause

`map_constraints_to_agents` (the Faithful/Unmappable classifier feeding both `materialize_permission_conditional` and `materialize_prohibition_conditional`) iterated only `rule.constraints` and **never** examined `rule.logical_constraints`. A rule carrying only a compound constraint therefore looked constraint-free → `Faithful { agents: [] }` → empty head → public.

## Fix: fail-closed FALL-BACK (not faithful fold) — and why

A rule carrying any `logical_constraints` now classifies **`Unmappable`**, routing both conditional entry points to the one-shot `materialize_permission`/`materialize_prohibition` path, whose evaluator **DOES** enforce the compound constraint (frozen — verified in `sparq-policy` eval, `logical_constraint_status` folds into the same three-valued classify).

Faithful folding was **deliberately rejected** as itself a widening risk:
- An ACP grant head is a **UNION** of `auth:agent` allows. An `odrl:and` of recipient constraints is an **INTERSECTION** → folding it as a union widens in the **wrong direction**.
- An `odrl:or` may mix a recipient operand with a **non-recipient** dimension (time/purpose) that has no head analogue.
- `odrl:xone` (exactly-one) has **no ACP analogue** at all.

Over-approximating any compound agent-restriction into the head would grant unlisted agents — the very widening this classification exists to prevent. Fall-back is provably correct and minimal (the one-shot path never drops the bound). This matches the crate's existing doctrine ("a rule mixing mappable + unmappable constraints falls back entirely to one-shot — never drops a bound").

The refresh path is consistent too: a compound-constraint prohibition now returns `false` from `prohibition_maps_faithfully`, so refresh routes through the deny-retraction-aware `refresh_prohibition` (fail-closed), not a fail-open one-shot.

## Test evidence (non-vacuous — RED before / GREEN after)

Both exercise the REAL enforcement path (`PodStore::accessible` + `query_as`), mirroring #2330's regression test. A `recipient eq alice` sub-constraint makes the one-shot fallback grant/deny EXACTLY alice while bob and anonymous are structurally excluded.

| test | before fix | after fix |
|---|---|---|
| `compound_only_permission_conditional_scopes_not_public` (`odrl:and`) | **RED** — auth:Public head=1, bob + anonymous read n1 | **GREEN** — only alice granted; bob + anonymous DENIED |
| `compound_only_prohibition_conditional_scopes_not_public` (`odrl:xone`) | **RED** — auth:Public deny head=1 (over-deny) | **GREEN** — only alice denied; bob + anonymous keep the public allow |

Confirmed RED on pre-fix code by stashing the src change:
```
test compound_only_permission_conditional_scopes_not_public ... FAILED
  assertion `left == right` failed: NO auth:Public head — the compound restriction is NOT dropped
  left: 1  right: 0
test compound_only_prohibition_conditional_scopes_not_public ... FAILED
  assertion `left == right` failed: NO auth:Public deny — the compound restriction is NOT dropped
  left: 1  right: 0
```

**Prohibition-dual verdict:** audited and closed. The pre-fix over-deny (public deny head dropping the compound recipient scope) is proven by test 33's RED→GREEN; the fix scopes the frozen deny to exactly the intended party via the one-shot fallback, so bob + anonymous keep their allow.

## Gates (both feature states)

- `cargo clippy -p sparq-solid --all-targets -- -D warnings` — GREEN (feature **OFF**)
- `cargo clippy -p sparq-solid --all-targets --features odrl-bridge -- -D warnings` — GREEN (feature **ON**)
- `cargo test -p sparq-solid --features odrl-bridge` — GREEN (68/68 `odrl_bridge` integration tests + 35 lib/doctests)
- `cargo test -p sparq-solid` (feature OFF) — the test file is `#![cfg(feature = "odrl-bridge")]`, so it no-ops OFF; the crate builds + tests clean OFF
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-solid --no-deps --all-features` — GREEN (all doc-links intra-crate to `pub` items)
- The legit no-constraint→`auth:Public` case (`no_constraint_conditional_grants_public`) still passes — the fix is scoped to rules carrying `logical_constraints`.

## Coordination with #2330 (still OPEN)

Branched off current `origin/main`. My src edit is in `map_constraints_to_agents` — a **different function** from #2330's `condition_agents` edit. The SKILL.md edit lands in the "STAY one-shot" clause, not #2330's "fail open → Mapping" region. Test additions are appended at file end (both PRs append; trivially mergeable). No line overlap.

Feature flags: **`odrl-bridge`** (sparq-solid, OFF by default).