### PR TITLE
feat(server): record streams on writer commit hook (sq-kqofk) [GPT-5.6]

### DIFF
--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -311,9 +311,10 @@ terse = ["server", "dep:sparq-terse"]
 # change-stream (sq-b4fns / #1223, in sparq-serve). The endpoint reads the segmented, fsync'd
 # append-only `ChangeLog` and returns the ordered change records (op / quads / seq / generation /
 # timestamp) as JSON from a given offset, with a continuation token, driven by `iteratorType` /
-# `at` / `after` / `limit` parameters. The same feature also turns on RECORDING: when the durable
-# log directory is configured, every committed SPARQL Update appends one ordered change record to
-# the log (the in-server publish path), so the endpoint serves a live, resumable feed. It turns on
+# `at` / `after` / `limit` parameters. The same feature also turns on RECORDING:
+# [GPT-5.6] (sq-kqofk) with a configured log directory, every published group-commit generation
+# appends one ordered record on the writer thread (possibly covering several concurrent SPARQL
+# Updates), so the endpoint serves a live, resumable feed without serialising submitters. It turns on
 # `sparq-serve/change-stream` (the segmented log + N-Quads same-lineage quad-set diff + the backup
 # family's self-contained FNV-1a digest — std-only IO, NO new external dependency, no extra HTTP/
 # async beyond the already-present axum + serde_json). STILL OFF AT RUNTIME by default even when

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -759,14 +759,16 @@ pub struct ServerConfig {
     /// `SPARQ_TEMPLATES_FILE`.
     #[cfg(feature = "templates")]
     pub templates_file: Option<std::path::PathBuf>,
-    /// [OPUS-4.8] (sq-2999l, gh-906) OPT-IN durable CDC change-stream directory. When `Some(dir)`,
-    /// the server (1) RECORDS every committed SPARQL Update as one ordered change record to the
-    /// segmented, fsync'd append-only `sparq_serve::ChangeLog` rooted at `dir`, and (2) serves the
-    /// Amazon-Neptune-Streams `GetRecords`-shaped poll endpoint `GET /streams` over that log
-    /// (`iteratorType` / `at` / `after` / `limit`, returning the ordered records + a continuation
-    /// token). `None` (the default) leaves both off: `/streams` is `404` and nothing is recorded —
-    /// byte-identical to before. The log resumes after a restart (`ChangeLog::open` re-reads the
-    /// segments), so pointing the server at an existing dir continues the same stream gaplessly.
+    /// [GPT-5.6] (sq-kqofk, gh-906) OPT-IN durable CDC change-stream directory. When `Some(dir)`,
+    /// the server (1) RECORDS every published update generation as one ordered change record on
+    /// the writer thread to the segmented, fsync'd append-only `sparq_serve::ChangeLog` rooted at
+    /// `dir`, and (2) serves the Amazon-Neptune-Streams `GetRecords`-shaped poll endpoint
+    /// `GET /streams` over that log (`iteratorType` / `at` / `after` / `limit`, returning the
+    /// ordered records + a continuation token). A group-committed generation may contain several
+    /// concurrent SPARQL Updates. `None` (the default) leaves both off: `/streams` is `404` and
+    /// nothing is recorded — byte-identical to before. The log resumes after a restart
+    /// (`ChangeLog::open` re-reads the segments), so pointing the server at an existing dir
+    /// continues the same stream gaplessly.
     ///
     /// This field exists only with the `change-stream` cargo feature (like [`tpf`](Self::tpf)
     /// under `tpf`); a build without that feature compiles no change-stream code and pays zero
@@ -2264,6 +2266,76 @@ struct ServingCore {
     writer: Arc<Writer<String, Graph>>,
 }
 
+/// [GPT-5.6] (sq-kqofk) The opt-in server adapter around the writer-thread CDC hook. The
+/// append-capable `ChangeLog` is consumed by `into_commit_hook`; the separate handle is read-only
+/// by convention and may safely `poll` concurrently because polling never mutates the log. The
+/// hook mutex is writer-thread-side only: it keeps the single log writer safe across an online
+/// backup restore's briefly-overlapping old/new writer threads, and is never held by submitters.
+#[cfg(feature = "change-stream")]
+struct ChangeStreamState {
+    reader: sparq_serve::ChangeLog,
+    hook: Arc<std::sync::Mutex<Box<ChangeStreamHook>>>,
+    next_seq: Arc<std::sync::atomic::AtomicU64>,
+}
+
+/// [GPT-5.6] (sq-kqofk) Named to keep the optional state's writer-thread callback readable.
+#[cfg(feature = "change-stream")]
+type ChangeStreamHook = dyn FnMut(&Generation<Graph>, &Generation<Graph>) + Send + 'static;
+
+#[cfg(feature = "change-stream")]
+impl ChangeStreamState {
+    /// [GPT-5.6] (sq-kqofk) Opens separate writer/read handles before the writer thread starts,
+    /// then consumes the append handle into the production `ChangeLog` commit hook. The tracked
+    /// tail advances only after a successful durable append, so `LATEST` remains an O(1) lookup.
+    fn open(dir: &std::path::Path) -> Result<Self, sparq_serve::BackupError> {
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+        let writer_log = sparq_serve::ChangeLog::open(dir)?;
+        let reader = sparq_serve::ChangeLog::open(dir)?;
+        let next_seq = Arc::new(AtomicU64::new(writer_log.next_seq()));
+        let append_failed = Arc::new(AtomicBool::new(false));
+
+        let failed_on_error = append_failed.clone();
+        let mut record = writer_log.into_commit_hook(move |e| {
+            failed_on_error.store(true, Ordering::Relaxed);
+            tracing::warn!(target: "sparq_server", detail = %e, "change-stream record append failed (update committed; record dropped)");
+        });
+        let failed_for_hook = append_failed;
+        let next_for_hook = next_seq.clone();
+        let tracked_hook = move |from: &Generation<Graph>, to: &Generation<Graph>| {
+            failed_for_hook.store(false, Ordering::Relaxed);
+            record(from, to);
+            if !failed_for_hook.load(Ordering::Relaxed) {
+                next_for_hook.fetch_add(1, Ordering::Release);
+            }
+        };
+
+        Ok(Self {
+            reader,
+            hook: Arc::new(std::sync::Mutex::new(Box::new(tracked_hook))),
+            next_seq,
+        })
+    }
+
+    /// [GPT-5.6] (sq-kqofk) Gives each sequenced writer a lightweight adapter to the one durable
+    /// hook. Normal serving has one writer; online restore may briefly retain the old one too.
+    fn commit_hook(&self) -> impl FnMut(&Generation<Graph>, &Generation<Graph>) + Send + 'static {
+        let hook = self.hook.clone();
+        move |from, to| {
+            let mut hook = hook.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            hook(from, to);
+        }
+    }
+
+    fn poll(&self, from_seq: u64) -> Result<Vec<sparq_serve::ChangeRecord>, String> {
+        self.reader.poll(from_seq).map_err(|e| e.to_string())
+    }
+
+    fn next_seq(&self) -> u64 {
+        self.next_seq.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
 /// [OPUS-4.8] (sq-o5bi) Builds the ring's retention config from the server config — the default
 /// concurrency-only retention, or, under the `time-travel` feature, the extended retention so
 /// `?generation=N` has history to serve. Shared by the constructor and the online restore so a
@@ -2284,6 +2356,28 @@ fn build_ring_config(config: &ServerConfig) -> sparq_serve::RingConfig {
             ..sparq_serve::RingConfig::default()
         }
     }
+}
+
+/// [GPT-5.6] (sq-kqofk) Spawns the server's sequenced writer, installing the optional durable
+/// change-stream hook on the writer thread. Without `change-stream`, the conditional parameter and
+/// branch are compiled out and this remains the original `Writer::spawn` path.
+fn spawn_server_writer(
+    ring: Arc<GenerationRing<Graph>>,
+    applier: ServerApplier,
+    config: WriterConfig,
+    #[cfg(feature = "change-stream")] change_stream: Option<&ChangeStreamState>,
+) -> Arc<Writer<String, Graph>> {
+    #[cfg(feature = "change-stream")]
+    if let Some(change_stream) = change_stream {
+        return Arc::new(Writer::spawn_with_commit_hook(
+            ring,
+            applier,
+            config,
+            change_stream.commit_hook(),
+        ));
+    }
+
+    Arc::new(Writer::spawn(ring, applier, config))
 }
 
 #[derive(Clone)]
@@ -2325,15 +2419,11 @@ pub struct AppState {
     /// configured one (`--access-audit` / `SPARQ_ACCESS_AUDIT`); shared across handlers.
     #[cfg(feature = "access-audit")]
     access_audit_sink: Option<Arc<dyn crate::access_audit::AuditSink>>,
-    /// [OPUS-4.8] (sq-2999l) The opt-in durable CDC change-stream log. `Some(mutex)` only when the
-    /// operator configured a directory (`--change-stream` / `SPARQ_CHANGE_STREAM`); shared across
-    /// handlers behind a [`std::sync::Mutex`] because the log is single-writer (it serialises the
-    /// commit-recording append) while a concurrent reader [`poll`](sparq_serve::ChangeLog::poll)s
-    /// the SAME on-disk directory through a separate `ChangeLog::open` handle in the endpoint. The
-    /// recording path holds this lock across an update's pre/post generation pin so the recorded
-    /// `(from, to)` pair is exactly that commit (gapless, monotonic — the `ChangeLog` contract).
+    /// [GPT-5.6] (sq-kqofk) The opt-in durable CDC adapter. The append handle lives inside the
+    /// writer-thread commit hook, while handlers poll through a separate read handle. Recording
+    /// therefore rides group commit and never holds a caller-side lock across `submit`.
     #[cfg(feature = "change-stream")]
-    change_log: Option<Arc<std::sync::Mutex<sparq_serve::ChangeLog>>>,
+    change_stream: Option<Arc<ChangeStreamState>>,
     /// [FABLE-5] (sq-fy8ci) SINGLE-FLIGHT restore permit. `true` while a restore is in flight.
     /// Two concurrent restores were previously silently serialized by the single writer thread
     /// (each individually crash-safe, last-writer-wins) — harmless but surprising: an operator
@@ -2641,11 +2731,24 @@ impl AppState {
             }
             None => ServerApplier::new(config.clone()),
         };
-        let writer = Arc::new(Writer::spawn(
+        // [GPT-5.6] (sq-kqofk) Open the CDC state before spawning the writer so the append log can
+        // be consumed into its commit hook. A corrupt log remains a clean startup failure.
+        #[cfg(feature = "change-stream")]
+        let change_stream = match &config.change_stream_dir {
+            Some(dir) => {
+                Some(Arc::new(ChangeStreamState::open(dir).map_err(|e| {
+                    format!("change-stream log open failed: {e}")
+                })?))
+            }
+            None => None,
+        };
+        let writer = spawn_server_writer(
             ring.clone(),
             applier,
             writer_config(&config),
-        ));
+            #[cfg(feature = "change-stream")]
+            change_stream.as_deref(),
+        );
         // [OPUS-4.8] sq-gos8: open the structured access-audit sink if one is configured. A
         // failure to open (e.g. an unwritable audit-file path) is surfaced as a clean startup
         // error rather than silently dropping the trail — the operator asked for an audit log.
@@ -2655,20 +2758,6 @@ impl AppState {
                 crate::access_audit::make_sink(target)
                     .map_err(|e| format!("access-audit sink open failed: {e}"))?,
             ),
-            None => None,
-        };
-        // [OPUS-4.8] sq-2999l: open (creating + recovering) the durable CDC change-stream log when a
-        // directory is configured. `ChangeLog::open` re-reads any existing segments and resumes at
-        // the next seq, so restarting on the same dir continues the stream gaplessly. A corrupt log
-        // (bad digest / out-of-order seq / unknown segment version) is surfaced as a clean startup
-        // error (fail-closed) rather than silently serving a wrong feed — the operator asked for a
-        // durable change stream.
-        #[cfg(feature = "change-stream")]
-        let change_log = match &config.change_stream_dir {
-            Some(dir) => Some(Arc::new(std::sync::Mutex::new(
-                sparq_serve::ChangeLog::open(dir)
-                    .map_err(|e| format!("change-stream log open failed: {e}"))?,
-            ))),
             None => None,
         };
         // [FABLE-5] sq-lsp7k.10: seed the named-template store from the optional persistence
@@ -2698,7 +2787,7 @@ impl AppState {
             #[cfg(feature = "access-audit")]
             access_audit_sink,
             #[cfg(feature = "change-stream")]
-            change_log,
+            change_stream,
             // [FABLE-5] sq-fy8ci: no restore in flight at boot (restore-on-start runs on the
             // seed graph in main.rs BEFORE this state exists, so it never holds the permit).
             #[cfg(feature = "backup")]
@@ -2742,7 +2831,7 @@ impl AppState {
     /// set via `--change-stream` / `SPARQ_CHANGE_STREAM`). When `false`, `GET /streams` is `404`.
     #[cfg(feature = "change-stream")]
     pub(crate) fn change_stream_enabled(&self) -> bool {
-        self.change_log.is_some()
+        self.change_stream.is_some()
     }
 
     /// [OPUS-4.8] (sq-2999l) Polls the durable CDC change-stream for every recorded change record
@@ -2757,11 +2846,8 @@ impl AppState {
         &self,
         from_seq: u64,
     ) -> Result<Option<Vec<sparq_serve::ChangeRecord>>, String> {
-        match &self.change_log {
-            Some(log) => {
-                let guard = log.lock().unwrap_or_else(|p| p.into_inner());
-                guard.poll(from_seq).map(Some).map_err(|e| e.to_string())
-            }
+        match &self.change_stream {
+            Some(stream) => stream.poll(from_seq).map(Some),
             None => Ok(None),
         }
     }
@@ -2771,9 +2857,7 @@ impl AppState {
     /// when the change-stream is not configured.
     #[cfg(feature = "change-stream")]
     pub(crate) fn change_stream_next_seq(&self) -> Option<u64> {
-        self.change_log
-            .as_ref()
-            .map(|log| log.lock().unwrap_or_else(|p| p.into_inner()).next_seq())
+        self.change_stream.as_ref().map(|stream| stream.next_seq())
     }
 
     /// Pins the current generation for a request: lock-free, never blocked
@@ -2859,40 +2943,10 @@ impl AppState {
         // default-graph / dynamically-scoped writes still fall back to the global pod
         // (conservative, never under-invalidating). See [`touched_pods`].
         let touched = touched_pods(sparql);
-        // [OPUS-4.8] sq-2999l: when a durable CDC change-stream is configured, record this commit.
-        // Acquire the log lock FIRST, then — UNDER the lock — capture the predecessor generation and
-        // run the submit, and HOLD the lock across both. Because every recording update takes this
-        // same lock, only the lock-holder is ever inside `submit`, so under the lock no other thread
-        // can publish: the pin captured here is the last published generation (== the log's
-        // `last_generation`), and the post-submit `current()` is exactly THIS commit's published
-        // generation. The recorded `(pin, post)` pair is therefore exactly this commit — gapless +
-        // monotonic, the `ChangeLog` contract. Capturing the pin BEFORE the lock would race a
-        // concurrent commit and break the gapless chain; capturing it after is load-bearing. The
-        // whole dance is on the recording path only, so the default build is byte-identical.
-        #[cfg(feature = "change-stream")]
-        let _record = self.change_log.clone();
-        #[cfg(feature = "change-stream")]
-        let _record_lock_and_pin = _record
-            .as_ref()
-            .map(|log| (log.lock().unwrap_or_else(|p| p.into_inner()), self.current()));
+        // [GPT-5.6] (sq-kqofk) CDC recording now happens inside the writer's commit hook, once per
+        // published generation and before its acknowledgements. Concurrent submitters can join the
+        // same group-commit batch; there is no caller-side change-log lock on this path.
         let result = self.writer().submit(sparql.to_string(), touched);
-        #[cfg(feature = "change-stream")]
-        if let (Ok(_number), Some((mut guard, pin))) = (&result, _record_lock_and_pin) {
-            // The published generation is `current()` — holding the lock guarantees no concurrent
-            // update advanced it past this commit. Record only when it moved forward (a batch-mate
-            // sharing the generation, or a no-op update, records nothing; the log would reject a
-            // non-forward range, so this guard preserves the gapless contract proactively).
-            let post = self.current();
-            if post.number() > pin.number() {
-                // A recording I/O failure must NOT lose the already-committed update (it is durable
-                // + published). Surface it to the OPERATOR's log and continue serving; the next poll
-                // simply will not see this one record (an honest gap the operator can detect).
-                if let Err(e) = guard.record_commit(&pin, &post) {
-                    // [OPUS-4.8] positional format arg (CodeQL rust/unused-variable false-positive).
-                    tracing::warn!(target: "sparq_server", detail = %e, "change-stream record append failed (update committed; record dropped)");
-                }
-            }
-        }
         match result {
             Ok(number) => {
                 // Monotonic max: batch-mates share a generation number and may ack in
@@ -3090,11 +3144,15 @@ impl AppState {
         let ring_config = build_ring_config(&self.config);
         let ring = Arc::new(GenerationRing::with_config(graph, ring_config));
         let applier = ServerApplier::new(self.config.clone());
-        let writer = Arc::new(Writer::spawn(
+        // [GPT-5.6] (sq-kqofk) A restored writer retains the same single CDC hook. The hook's
+        // same-lineage guard reports the documented restore discontinuity instead of diffing it.
+        let writer = spawn_server_writer(
             ring.clone(),
             applier,
             writer_config(&self.config),
-        ));
+            #[cfg(feature = "change-stream")]
+            self.change_stream.as_deref(),
+        );
         // Atomic swap: subsequent loads see the new ring+writer; the old core's writer thread
         // joins once its last in-flight reader/Arc drops (Writer's Drop drains + joins).
         self.core.store(Arc::new(ServingCore { ring, writer }));
@@ -4476,8 +4534,9 @@ async fn streams_endpoint(
     };
     let limit = parse_limit(params.get("limit").map(String::as_str));
 
-    // `LATEST` starts at the log's current tail; the others ignore `next_seq`. Reading it under the
-    // log lock is cheap (no disk scan). Absent (disabled) is the 404 above, so this is `Some`.
+    // [GPT-5.6] (sq-kqofk) `LATEST` starts at the successful-hook tail. The writer-thread hook
+    // advances this atomic only after a durable append, so the lookup needs no submitter/log lock.
+    // Absent (disabled) is the 404 above, so this is `Some`.
     let next_seq = state.change_stream_next_seq().unwrap_or(0);
     let from_seq = iter.from_seq(next_seq);
 
@@ -10189,6 +10248,86 @@ mod apply_update_mvcc_tests {
             gen1,
             gen2
         );
+    }
+}
+
+/// [GPT-5.6] (sq-kqofk) Server-adapter coverage for writer-thread CDC recording. This uses a
+/// deliberately wide group-commit window so concurrent submitters deterministically share one
+/// published generation. Mutation witness: replacing `spawn_with_commit_hook` with `spawn` makes
+/// the log empty, while changing the expected record/generation count makes the test fail.
+#[cfg(all(test, feature = "change-stream"))]
+mod change_stream_commit_hook_tests {
+    use super::{spawn_server_writer, ChangeStreamState, ServerApplier, ServerConfig};
+    use sparq_core::Graph;
+    use sparq_serve::{GenerationRing, PodId, WriterConfig};
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    #[test]
+    fn concurrent_submitters_share_one_recorded_generation() {
+        const N: usize = 8;
+        let dir = std::env::temp_dir().join(format!(
+            "sparq-server-cdc-hook-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let stream = Arc::new(ChangeStreamState::open(&dir).expect("open change stream"));
+        let config = Arc::new(ServerConfig::default());
+        let ring = Arc::new(GenerationRing::new(Graph::default()));
+        let writer = spawn_server_writer(
+            ring,
+            ServerApplier::new(config),
+            WriterConfig {
+                window: Duration::from_millis(100),
+                adaptive_commit: false,
+                ..WriterConfig::default()
+            },
+            Some(stream.as_ref()),
+        );
+
+        let barrier = Arc::new(Barrier::new(N + 1));
+        let mut submitters = Vec::with_capacity(N);
+        for i in 0..N {
+            let writer = writer.clone();
+            let barrier = barrier.clone();
+            submitters.push(std::thread::spawn(move || {
+                barrier.wait();
+                writer
+                    .submit(
+                        format!(
+                            "INSERT DATA {{ <http://ex/s{i}> <http://ex/p> <http://ex/o{i}> }}"
+                        ),
+                        [PodId::new("http://ex/g")],
+                    )
+                    .expect("concurrent update commits")
+            }));
+        }
+        barrier.wait();
+        let generations: Vec<u64> = submitters
+            .into_iter()
+            .map(|thread| thread.join().expect("submitter joins"))
+            .collect();
+
+        assert!(generations.iter().all(|&generation| generation == 1));
+        let records = stream.poll(0).expect("poll recorded generation");
+        assert_eq!(records.len(), 1, "one group commit produces one CDC record");
+        assert_eq!(records[0].generation, 1);
+        assert_eq!(
+            records[0].changes.len(),
+            N,
+            "the record contains every update"
+        );
+        assert_eq!(
+            stream.next_seq(),
+            1,
+            "the hook advances the LATEST tail once"
+        );
+
+        drop(writer);
+        drop(stream);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }
 

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -530,10 +530,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // (env SPARQ_SOLID_AUTHZ=1).
             #[cfg(feature = "solid-authz")]
             "--solid-authz" => config.solid_authz = true,
-            // [OPUS-4.8] sq-2999l (gh-906): OPT-IN durable CDC change-stream at DIR. Enables both
-            // RECORDING every committed update to the segmented, fsync'd append-only log AND the
-            // Neptune-GetRecords-shaped poll endpoint GET /streams over it. Resumes the same stream
-            // gaplessly when DIR already holds segments. Off by default (env SPARQ_CHANGE_STREAM=DIR).
+            // [GPT-5.6] (sq-kqofk, gh-906): OPT-IN durable CDC change-stream at DIR. Records each
+            // published group-commit generation on the writer thread to the segmented, fsync'd log
+            // and serves the Neptune-GetRecords-shaped GET /streams endpoint. Resumes gaplessly
+            // when DIR already holds segments. Off by default (env SPARQ_CHANGE_STREAM=DIR).
             #[cfg(feature = "change-stream")]
             "--change-stream" => {
                 let dir = args.next().ok_or("--change-stream requires a directory path")?;

--- a/crates/sparq-server/tests/streams.rs
+++ b/crates/sparq-server/tests/streams.rs
@@ -403,8 +403,8 @@ async fn recorded_changes_are_durable_on_disk() {
 }
 
 // ---------------------------------------------------------------------------
-// Concurrency: CONCURRENT updates produce a gapless, monotonic stream (the recording lock
-// serialises recording so no commit is dropped and seq never skips).
+// [GPT-5.6] (sq-kqofk) Concurrency: concurrent updates may share a group-committed generation;
+// the writer-thread hook records one gapless, monotonic stream record per published generation.
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -412,8 +412,8 @@ async fn concurrent_updates_record_a_gapless_monotonic_stream() {
     let dir = scratch("concurrent");
     let base = spawn(Some(dir.clone()), None).await;
 
-    // Fire 12 distinct updates concurrently from 4 tasks; each is a single-quad INSERT, so each
-    // produces one commit and one change record.
+    // Fire 12 distinct updates concurrently from 4 tasks. Group commit may place several updates
+    // in one generation, but every inserted quad must appear exactly once in the stream.
     const N: usize = 12;
     let mut handles = Vec::new();
     for i in 0..N {
@@ -432,28 +432,44 @@ async fn concurrent_updates_record_a_gapless_monotonic_stream() {
         h.await.unwrap();
     }
 
-    // Poll the whole stream: exactly N records, seqs 0..N gapless and strictly increasing, each
-    // generation strictly increasing (the gapless + monotonic ChangeLog contract under concurrency).
+    // Poll the whole stream: one record per PUBLISHED generation (not per submitter), gapless seqs,
+    // strictly increasing generations, and exactly N flattened quad changes.
     let cl = client();
     let (status, body) = poll(&cl, &base, &[("limit", "1000")]).await;
     assert_eq!(status, 200);
-    assert_eq!(
-        body["totalRecords"], N,
-        "every concurrent commit recorded: {body}"
+    let commit_count = body["totalRecords"].as_u64().unwrap();
+    assert!(
+        (1..=N as u64).contains(&commit_count),
+        "every published generation is recorded: {body}"
     );
     let records = body["records"].as_array().unwrap();
-    assert_eq!(records.len(), N, "one change per single-quad commit");
-    let mut prev_gen = 0u64;
-    for (i, r) in records.iter().enumerate() {
-        assert_eq!(
-            r["eventId"]["commitNum"], i as u64,
-            "gapless seq at index {i}: {body}"
+    assert_eq!(records.len(), N, "every concurrent insert is recorded once");
+    let mut commit_generations = std::collections::BTreeMap::new();
+    for record in records {
+        let commit = record["eventId"]["commitNum"].as_u64().unwrap();
+        let generation = record["generation"].as_u64().unwrap();
+        assert!(
+            commit < commit_count,
+            "commit seq stays inside the gapless range: {body}"
         );
-        let gen = r["generation"].as_u64().unwrap();
-        assert!(gen > prev_gen, "strictly increasing generation: {body}");
-        prev_gen = gen;
+        if let Some(previous) = commit_generations.insert(commit, generation) {
+            assert_eq!(
+                previous, generation,
+                "one commit seq identifies one generation: {body}"
+            );
+        }
     }
-    assert_eq!(body["nextSequenceNumber"], N as u64);
+    assert_eq!(commit_generations.len() as u64, commit_count);
+    let mut previous_generation = 0;
+    for (expected_seq, (&seq, &generation)) in commit_generations.iter().enumerate() {
+        assert_eq!(seq, expected_seq as u64, "commit seqs are gapless: {body}");
+        assert!(
+            generation > previous_generation,
+            "published generations are strictly increasing: {body}"
+        );
+        previous_generation = generation;
+    }
+    assert_eq!(body["nextSequenceNumber"], commit_count);
 
     let _ = std::fs::remove_dir_all(&dir);
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -801,9 +801,10 @@ silently gapping.
 **`GET /streams` — CDC poll endpoint (`sparq-server` feature `change-stream`, default OFF;
 `sq-2999l`, gh-906).** The HTTP poll surface over that durable log, in the Amazon-Neptune-Streams
 `GetRecords` shape. Configure a log directory (`--change-stream DIR` / `SPARQ_CHANGE_STREAM`,
-`ServerConfig::change_stream_dir`) and the server (1) RECORDS every committed SPARQL Update as one
-ordered change record on the update path, and (2) serves `GET /streams` over it (the route is `404`
-unless the directory is set — the same double-opt-in as `/tpf`). Parameters: `iteratorType`
+`ServerConfig::change_stream_dir`) and the server (1) RECORDS every published group-commit
+generation as one ordered change record on the writer thread (possibly containing several
+concurrent SPARQL Updates; [GPT-5.6] `sq-kqofk`), and (2) serves `GET /streams` over it (the route
+is `404` unless the directory is set — the same double-opt-in as `/tpf`). Parameters: `iteratorType`
 (`TRIM_HORIZON` = replay all, the default; `AT_SEQUENCE_NUMBER` + `at=N`; `AFTER_SEQUENCE_NUMBER` +
 `after=N`, the resume case; `LATEST` = tail only) and `limit` (max commits per page, default 100,
 clamped to 10000). The JSON response flattens each commit's quad-level changes to one stream record
@@ -812,8 +813,9 @@ commitTimestampNanos, data: { stmt: "<n-quads line>" } }` — plus a `nextSequen
 token (pass as `at=`/`after=`), `lastSequenceNumber`, `totalRecords` (commit count) and
 `hasMoreRecords`. A poll is a READ (gated by the read auth). A sequence-anchored `iteratorType` with
 no anchor is a fail-closed `400` (never a silent replay-all). With the feature off the route + the
-recording hook are `#[cfg]`-stripped (byte-identical); recording serialises updates only while the
-stream is on. The `ChangeSink` broker trait stays a separate later opt-in (`sq-l6zks`).
+recording hook are `#[cfg]`-stripped (byte-identical); with it on, recording rides the sequenced
+writer's group commit and does not serialise submitters. The `ChangeSink` broker trait stays a
+separate later opt-in (`sq-l6zks`).
 
 **`GET /queries` + `DELETE /queries/{id}` — running-query registry (`sparq-server` feature
 `query-registry`, default OFF; sq-qsm5z, [SONNET-4.6]).** An opt-in in-memory registry of


### PR DESCRIPTION
> 🤖 SPARQ agent

Adopts `Writer::spawn_with_commit_hook` + `ChangeLog::into_commit_hook` in `sparq-server`, moving durable `/streams` recording onto the sequenced writer thread. This removes the caller-side `Mutex<ChangeLog>` held across `submit`, so concurrent updates can group-commit while each published generation remains durably recorded before acknowledgement. Polling uses a separate read handle, the `LATEST` tail advances only after successful appends, and online-restore writer swaps retain the same guarded hook. The public HTTP-server skill and change-stream docs now describe generation-level recording.

Gate status:
- `cargo clippy -p sparq-server --all-targets -- -D warnings` — passed
- `cargo test -p sparq-server` — passed
- `cargo clippy -p sparq-server --all-targets --features change-stream -- -D warnings` — passed
- `cargo test -p sparq-server --features change-stream` — passed (includes the non-vacuous concurrent group-commit hook test and all `/streams` integrations)
- `cargo clippy -p sparq-server --all-targets --features change-stream,backup -- -D warnings` — passed (additional feature-composition check)
- `git diff --check` — passed

Local whole-workspace `cargo fmt --check` remains red on extensive pre-existing `origin/main` formatting outside this change; no unrelated formatting was staged.