### PR TITLE
test(sparq-arrow): cover malformed import error paths (sq-bif.18) [GPT-5.6]

### DIFF
--- a/crates/sparq-arrow/src/import.rs
+++ b/crates/sparq-arrow/src/import.rs
@@ -1,7 +1,7 @@
 //! The `arrow`-feature-gated import: Arrow `RecordBatch` → `QueryResult`.
 
 use arrow_array::{Array, RecordBatch, StringArray, StructArray};
-use arrow_schema::Schema;
+use arrow_schema::{DataType, Schema};
 use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Variable};
 use sparq_engine::QueryResult;
 
@@ -48,6 +48,17 @@ pub(crate) fn variables_from_schema(schema: &Schema) -> Result<Vec<Variable>, Ar
         if vars.iter().any(|existing: &Variable| existing == &variable) {
             return Err(ArrowError::invalid(format!(
                 "duplicate SELECT variable '{}' in Arrow schema",
+                field.name()
+            )));
+        }
+        // [GPT-5.6] Report malformed struct arity explicitly before the exact-schema
+        // check so safely constructed malformed batches fail closed without a cell read.
+        if matches!(
+            field.data_type(),
+            DataType::Struct(fields) if fields.len() != RDF_TERM_FIELDS.len()
+        ) {
+            return Err(ArrowError::invalid(format!(
+                "Arrow field '{}' does not have five RDF-term children",
                 field.name()
             )));
         }

--- a/crates/sparq-arrow/tests/import_error_paths.rs
+++ b/crates/sparq-arrow/tests/import_error_paths.rs
@@ -1,0 +1,93 @@
+//! [GPT-5.6] Fail-closed tests for malformed Arrow RDF-term input.
+#![cfg(feature = "arrow")]
+
+use std::sync::Arc;
+
+use arrow_array::{Array, ArrayRef, RecordBatch, StringArray, StructArray};
+use arrow_schema::{DataType, Field, Schema};
+use sparq_arrow::{
+    from_record_batch, FIELD_DATATYPE, FIELD_DIRECTION, FIELD_KIND, FIELD_LANGUAGE, FIELD_VALUE,
+};
+
+fn string_field(name: &'static str, value: Option<&str>) -> (Arc<Field>, ArrayRef) {
+    (
+        Arc::new(Field::new(name, DataType::Utf8, true)),
+        Arc::new(StringArray::from(vec![value])) as ArrayRef,
+    )
+}
+
+fn batch_with_children(children: Vec<(Arc<Field>, ArrayRef)>) -> RecordBatch {
+    let column = Arc::new(StructArray::from(children)) as ArrayRef;
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "term",
+        column.data_type().clone(),
+        true,
+    )]));
+    RecordBatch::try_new(schema, vec![column]).unwrap()
+}
+
+/// [GPT-5.6] Mutation witness: accepting four children or changing the pinned error
+/// text makes this assertion fail.
+#[test]
+fn four_child_term_struct_is_rejected() {
+    let batch = batch_with_children(vec![
+        string_field(FIELD_KIND, Some("literal")),
+        string_field(FIELD_VALUE, Some("value")),
+        string_field(FIELD_DATATYPE, None),
+        string_field(FIELD_LANGUAGE, Some("en")),
+    ]);
+
+    let error = from_record_batch(&batch).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("does not have five RDF-term children"),
+        "{error}"
+    );
+}
+
+/// A bound struct slot must carry the required term kind instead of silently becoming
+/// an unbound or guessed value.
+#[test]
+fn bound_term_with_null_kind_is_rejected() {
+    let batch = batch_with_children(vec![
+        string_field(FIELD_KIND, None),
+        string_field(FIELD_VALUE, Some("value")),
+        string_field(
+            FIELD_DATATYPE,
+            Some("http://www.w3.org/2001/XMLSchema#string"),
+        ),
+        string_field(FIELD_LANGUAGE, None),
+        string_field(FIELD_DIRECTION, None),
+    ]);
+
+    let error = from_record_batch(&batch).unwrap_err();
+    assert!(
+        error.to_string().contains("bound term has null 'kind'"),
+        "{error}"
+    );
+}
+
+/// Literal metadata is exclusive: a datatype and language tag may not describe the
+/// same RDF literal.
+#[test]
+fn literal_with_datatype_and_language_is_rejected() {
+    let batch = batch_with_children(vec![
+        string_field(FIELD_KIND, Some("literal")),
+        string_field(FIELD_VALUE, Some("value")),
+        string_field(
+            FIELD_DATATYPE,
+            Some("http://www.w3.org/2001/XMLSchema#string"),
+        ),
+        string_field(FIELD_LANGUAGE, Some("en")),
+        string_field(FIELD_DIRECTION, None),
+    ]);
+
+    let error = from_record_batch(&batch).unwrap_err();
+    assert!(
+        error.to_string().contains(
+            "literal requires either a datatype or a language tag; direction requires language"
+        ),
+        "{error}"
+    );
+}

--- a/crates/sparq-arrow/tests/parquet_error_paths.rs
+++ b/crates/sparq-arrow/tests/parquet_error_paths.rs
@@ -1,0 +1,43 @@
+//! [GPT-5.6] Fail-closed tests for corrupted and truncated Parquet input.
+#![cfg(feature = "parquet")]
+
+use oxrdf::{Literal, Term, Variable};
+use sparq_arrow::{
+    from_parquet_bytes, parquet_row_count_from_bytes, parquet_variables_from_bytes,
+    to_parquet_bytes,
+};
+use sparq_engine::QueryResult;
+
+fn assert_all_readers_reject(bytes: &[u8]) {
+    let import_error = from_parquet_bytes(bytes).unwrap_err();
+    let variables_error = parquet_variables_from_bytes(bytes).unwrap_err();
+    let row_count_error = parquet_row_count_from_bytes(bytes).unwrap_err();
+
+    for error in [&import_error, &variables_error, &row_count_error] {
+        assert!(
+            error.to_string().contains("Parquet import failed"),
+            "{error}"
+        );
+    }
+}
+
+/// [GPT-5.6] Mutation witness: any reader accepting arbitrary bytes, or changing the
+/// pinned error class, makes this assertion fail.
+#[test]
+fn garbage_bytes_are_rejected_by_all_parquet_readers() {
+    assert_all_readers_reject(b"not parquet");
+}
+
+#[test]
+fn truncated_valid_parquet_is_rejected_by_all_parquet_readers() {
+    let result = QueryResult {
+        vars: vec![Variable::new("term").unwrap()],
+        rows: vec![vec![Some(Term::Literal(Literal::new_simple_literal(
+            "value",
+        )))]],
+    };
+    let bytes = to_parquet_bytes(&result).unwrap();
+    assert!(bytes.len() > 8);
+
+    assert_all_readers_reject(&bytes[..8]);
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds feature-gated regression coverage for malformed RecordBatch input and corrupted/truncated Parquet bytes. A small schema-arity validation returns the specified fail-closed error for four-child RDF-term structs without unsafe test construction; the existing datatype-plus-language rejection is pinned unchanged.

Gates passed:

- `cargo fmt --package sparq-arrow --check`
- `cargo test -p sparq-arrow`
- `cargo test -p sparq-arrow --features arrow`
- `cargo test -p sparq-arrow --features parquet`
- `cargo test -p sparq-arrow --features arrow --test import_error_paths`
- `cargo test -p sparq-arrow --features parquet --test parquet_error_paths`
- `cargo clippy -p sparq-arrow --all-targets -- -D warnings`
- `cargo clippy -p sparq-arrow --all-targets --features arrow -- -D warnings`
- `cargo clippy -p sparq-arrow --all-targets --features parquet -- -D warnings`

Note: repository-wide `cargo fmt --check` remains red on unrelated origin/main formatting drift already tracked by #2303; the touched package is clean.