### PR TITLE
feat(sparq-rsp): add batch stream pushes and edge tests (sq-bif.20) [GPT-5.6]

### DIFF
--- a/crates/sparq-rsp/src/stream.rs
+++ b/crates/sparq-rsp/src/stream.rs
@@ -53,6 +53,14 @@ impl TripleStream {
         self
     }
 
+    /// [GPT-5.6] Appends already-wrapped elements in iterator order.
+    pub fn push_batch<I: IntoIterator<Item = TimestampedTriple>>(&mut self, items: I) -> &mut Self {
+        for item in items {
+            self.push_item(item);
+        }
+        self
+    }
+
     /// Number of buffered elements.
     pub fn len(&self) -> usize {
         self.items.len()

--- a/crates/sparq-rsp/tests/stream_edge_paths.rs
+++ b/crates/sparq-rsp/tests/stream_edge_paths.rs
@@ -1,0 +1,82 @@
+// [GPT-5.6] sq-bif.20: Direct regressions for stream batching and error/late-arrival edges.
+
+use oxrdf::{NamedNode, Term};
+use sparq_rsp::{ContinuousQuery, TimestampedTriple, TripleStream, WindowSpec, WindowedStream};
+
+fn triple(object: &str) -> [Term; 3] {
+    [
+        NamedNode::new_unchecked("http://example.com/subject").into(),
+        NamedNode::new_unchecked("http://example.com/predicate").into(),
+        NamedNode::new_unchecked(format!("http://example.com/{object}")).into(),
+    ]
+}
+
+fn item(object: &str, ts: u64) -> TimestampedTriple {
+    TimestampedTriple {
+        triple: triple(object),
+        ts,
+    }
+}
+
+#[test]
+fn push_batch_preserves_item_order_and_content() {
+    let first = item("first", 9);
+    let second = item("second", 3);
+    let third = item("third", 7);
+    let mut stream = TripleStream::new();
+
+    stream.push_batch([first.clone(), second.clone(), third.clone()]);
+
+    assert_eq!(
+        stream.items(),
+        [first.clone(), second.clone(), third.clone()]
+    );
+    assert_eq!(stream.into_items(), vec![first, second, third]);
+}
+
+#[test]
+fn push_item_then_into_items_preserves_single_item() {
+    let expected = item("only", 42);
+    let mut stream = TripleStream::new();
+
+    stream.push_item(expected.clone());
+
+    assert_eq!(stream.into_items(), vec![expected]);
+}
+
+#[test]
+fn continuous_query_register_reports_nonempty_malformed_query_error() {
+    let result = ContinuousQuery::register("SELECT INVALID WHERE {", WindowSpec::time(10, 10));
+    let Err(error) = result else {
+        panic!("malformed SPARQL must fail during registration");
+    };
+
+    assert!(
+        !error.trim().is_empty(),
+        "registration error must explain the failure"
+    );
+}
+
+#[test]
+fn zero_delay_drops_arrival_older_than_the_first_open_window() {
+    let mut stream = WindowedStream::empty(WindowSpec::time(10, 10));
+
+    stream.push(triple("at-ten"), 10);
+    stream.push(triple("late-five"), 5);
+    stream.push(triple("at-fifteen"), 15);
+    let closed = stream.flush();
+
+    // The module-level docs in src/window.rs specify that initial-watermark windows are
+    // skipped and an arrival whose last covering window has closed is counted as late.
+    assert_eq!(stream.late_dropped(), 1);
+    assert_eq!(closed.len(), 1);
+    assert_eq!((closed[0].start, closed[0].end), (10, 20));
+    assert_eq!(
+        closed[0]
+            .triples
+            .iter()
+            .map(|item| item.ts)
+            .collect::<Vec<_>>(),
+        [10, 15]
+    );
+}

--- a/skills/streaming-rsp/SKILL.md
+++ b/skills/streaming-rsp/SKILL.md
@@ -111,6 +111,7 @@ ContinuousMultiQuery::register(rspql_text: &str) -> Result<ContinuousMultiQuery,
   .window_iris() -> Vec<&NamedNode>   .output_stream() -> Option<&NamedNode>   .r2s() -> R2S
 
 // --- Low-level S2R only (no query): WindowedStream<[Term;3]>, Window { start, end, triples } ---
+TripleStream::new().push(triple, ts).push_item(item).push_batch(items)  // batch preserves iterator order
 WindowedStream::empty(spec) / ::new(stream: TripleStream, spec)
   .push(triple, ts)  .take_closed() -> Vec<Window>  .flush() -> Vec<Window>  .late_dropped()
 ```


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds chainable `TripleStream::push_batch` as pure composition over `push_item`, documents it in the streaming RSP skill, and directly tests batch ordering/content, single-item identity, malformed registration errors, and documented zero-delay late-arrival behavior. This provides a bulk initialization seam without changing window/report semantics.

Gates: `cargo test -p sparq-rsp`; `cargo clippy -p sparq-rsp --all-targets -- -D warnings`; `cargo test -p sparq-rsp --all-features`; `cargo clippy -p sparq-rsp --all-targets --all-features -- -D warnings`; `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings`; focused expected-value mutation failed as required; terminology, rustfmt (touched Rust files), and diff checks passed.