### PR TITLE
test(sparq-difftest): pin edge contracts (sq-bif.25) [GPT-5.6]

### DIFF
--- a/crates/sparq-difftest/tests/edge_contracts.rs
+++ b/crates/sparq-difftest/tests/edge_contracts.rs
@@ -1,0 +1,60 @@
+//! [GPT-5.6] Integration pins for the differential comparator's boundary contracts (sq-bif.25).
+
+use sparq_difftest::{
+    canonical_double_string, multiset_equal, numeric_equal, parse_results_json, NumericValue,
+    QueryResults, Solution,
+};
+
+#[test]
+fn results_json_errors_and_boolean_contract() {
+    let error = parse_results_json("[]").expect_err("an array root must be rejected");
+    assert!(error.to_string().contains("root is not an object"));
+
+    let error = parse_results_json("{}").expect_err("a SELECT result must declare head.vars");
+    assert!(error.to_string().contains("missing head.vars"));
+
+    assert!(matches!(
+        parse_results_json(r#"{"boolean":true}"#),
+        Ok(QueryResults::Boolean(true))
+    ));
+
+    let error = parse_results_json(r#"{"boolean":"yes"}"#)
+        .expect_err("a non-boolean ASK result must be rejected");
+    assert!(error.to_string().contains("boolean"));
+}
+
+#[test]
+fn empty_select_has_no_variables_or_solutions() {
+    let parsed = parse_results_json(r#"{"head":{"vars":[]},"results":{"bindings":[]}}"#)
+        .expect("an empty SELECT result is valid");
+
+    match parsed {
+        QueryResults::Solutions { vars, solutions } => {
+            assert!(vars.is_empty());
+            assert!(solutions.is_empty());
+        }
+        QueryResults::Boolean(value) => panic!("expected SELECT solutions, got boolean {value}"),
+    }
+}
+
+#[test]
+fn multiset_empty_and_length_mismatch_contract() {
+    assert!(multiset_equal(&[], &[]));
+    assert!(!multiset_equal(&[], &[Solution::new()]));
+}
+
+#[test]
+fn numeric_special_values_signed_zero_and_promotion_contract() {
+    assert_eq!(canonical_double_string(f64::NAN), "NaN");
+    assert_eq!(canonical_double_string(f64::INFINITY), "INF");
+    assert_eq!(canonical_double_string(f64::NEG_INFINITY), "-INF");
+    assert_eq!(canonical_double_string(0.0), "0.0");
+    assert_eq!(canonical_double_string(-0.0), "0.0");
+
+    let nan = NumericValue::Double(f64::NAN);
+    assert!(!numeric_equal(&nan, &nan));
+    assert!(numeric_equal(
+        &NumericValue::Integer(2.into()),
+        &NumericValue::Double(2.0),
+    ));
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds the single bead-scoped integration test file to pin SPARQL Results JSON parse errors and empty results, multiset empty/length behavior, canonical double special and signed-zero tokens, and numeric NaN/promotion equality. This protects the engine-independent differential harness contracts without source, dependency, manifest, or feature changes.

Gates green:
- cargo test -p sparq-difftest --test edge_contracts (4 passed)
- cargo test -p sparq-difftest
- cargo clippy -p sparq-difftest --all-targets -- -D warnings
- cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings
- targeted rustfmt and git diff checks

Mutation spot-check: temporarily changed the -0.0 canonical token expectation from 0.0 to 0; the targeted test failed at that assertion, then passed after restoration.

Honest note: cargo fmt --check -p sparq-difftest also exposes pre-existing formatting drift in existing source files unchanged by this PR; tracked separately in #2341.