### PR TITLE
test(sparq-algos): pin graph-shape edge cases (sq-bif.29) [GPT-5.6]

### DIFF
--- a/crates/sparq-algos/tests/edge_graph_shapes.rs
+++ b/crates/sparq-algos/tests/edge_graph_shapes.rs
@@ -1,0 +1,59 @@
+// [GPT-5.6] sq-bif.29: pin the default-feature graph-shape seams through the public API.
+
+use sparq_algos::{
+    degree_centrality, degree_centrality_normalized, label_propagation, num_communities, pagerank,
+    top_k, weakly_connected_components, Direction, LabelPropConfig, NodeGraph, PageRankConfig,
+};
+use sparq_core::Graph;
+
+fn build(nt: &str) -> NodeGraph {
+    let graph = Graph::load_str(nt, "nt").expect("parse N-Triples fixture");
+    NodeGraph::build(&graph)
+}
+
+#[test]
+fn empty_graph_algorithms_return_empty_results() {
+    let graph = build("");
+
+    assert_eq!(
+        pagerank(&graph, PageRankConfig::default()),
+        Vec::<f64>::new()
+    );
+    assert_eq!(
+        degree_centrality(&graph, Direction::Total),
+        Vec::<usize>::new()
+    );
+    assert_eq!(weakly_connected_components(&graph), Vec::<usize>::new());
+    assert_eq!(
+        label_propagation(&graph, LabelPropConfig::default()),
+        Vec::<usize>::new()
+    );
+    assert_eq!(num_communities(&[]), 0);
+}
+
+#[test]
+fn single_directed_edge_has_expected_two_node_degrees() {
+    let graph = build("<http://e/a> <http://p/k> <http://e/b> .\n");
+
+    assert_eq!(degree_centrality(&graph, Direction::Total), vec![1, 1]);
+    assert_eq!(
+        degree_centrality_normalized(&graph, Direction::In),
+        vec![0.0, 1.0]
+    );
+}
+
+#[test]
+fn top_k_breaks_score_ties_by_ascending_index() {
+    assert_eq!(top_k(&[5, 5, 1, 5], 2), vec![(0, 5), (1, 5)]);
+}
+
+#[test]
+fn disconnected_edges_count_as_two_components() {
+    let graph = build(
+        "<http://e/a> <http://p/k> <http://e/b> .\n\
+         <http://e/c> <http://p/k> <http://e/d> .\n",
+    );
+
+    let components = weakly_connected_components(&graph);
+    assert_eq!(num_communities(&components), 2);
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds default-feature integration coverage for empty graph algorithm outputs, canonical two-node degree values, deterministic `top_k` tie-breaking, and disconnected weak-component counting. This pins the public graph-shape floors without source, dependency, manifest, or feature changes.

Gates: `cargo clippy -p sparq-algos --all-targets -- -D warnings` ✅; `cargo test -p sparq-algos` ✅; `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` ✅. Mutation spot-check (`2` components changed to `1`) failed as required, then the correct value was restored and the full crate suite passed. The new file passes `rustfmt --check`; workspace-wide formatting has unrelated pre-existing drift tracked in #2345.