### PR TITLE
test(sparq-cli): pin CLI error exit-code contracts (sq-bif.36) [GPT-5.6]

### DIFF
--- a/crates/sparq-cli/tests/error_paths_cli.rs
+++ b/crates/sparq-cli/tests/error_paths_cli.rs
@@ -1,0 +1,114 @@
+//! [GPT-5.6] Exit-code contracts for previously uncovered CLI usage and I/O failures.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_sparq-cli"))
+        .args(args)
+        .output()
+        .expect("spawning sparq-cli")
+}
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join(format!("error-paths-cli-{tag}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn write_nt(dir: &Path) -> PathBuf {
+    let path = dir.join("data.nt");
+    std::fs::write(&path, "<http://ex/s> <http://ex/p> <http://ex/o> .\n")
+        .expect("write N-Triples fixture");
+    path
+}
+
+fn s(path: &Path) -> &str {
+    path.to_str().expect("UTF-8 fixture path")
+}
+
+fn assert_contract(args: &[&str], expected_exit: i32, stderr_substring: &str) {
+    let output = run(args);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        output.status.code(),
+        Some(expected_exit),
+        "argv {args:?}; stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(stderr_substring),
+        "argv {args:?}; expected stderr to contain {stderr_substring:?}; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn build_nonexistent_input_exits_1() {
+    let dir = scratch("build-nonexistent-input");
+    let output_dir = dir.join("store");
+    assert_contract(
+        &["build", "/no/such/file.nt", "ntriples", s(&output_dir)],
+        1,
+        "open /no/such/file.nt",
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn query_format_without_value_exits_2() {
+    let dir = scratch("query-format-without-value");
+    let data = write_nt(&dir);
+    assert_contract(
+        &["query", s(&data), "ntriples", "ASK {}", "--format"],
+        2,
+        "--format needs a value",
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn recompress_nonexistent_source_exits_1() {
+    let dir = scratch("recompress-nonexistent-source");
+    let output_dir = dir.join("store");
+    assert_contract(
+        &["recompress", "/no/such/src", s(&output_dir)],
+        1,
+        "open error",
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn compact_without_directory_exits_2() {
+    assert_contract(&["compact"], 2, "usage: sparq-cli compact");
+}
+
+#[test]
+fn compact_nonexistent_directory_exits_1() {
+    assert_contract(&["compact", "/no/such/dir"], 1, "open error");
+}
+
+#[test]
+fn save_too_few_arguments_exits_2() {
+    let dir = scratch("save-too-few-arguments");
+    let data = write_nt(&dir);
+    assert_contract(&["save", s(&data), "ntriples"], 2, "usage: sparq-cli save");
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn query_mmap_without_arguments_exits_2() {
+    assert_contract(&["query-mmap"], 2, "usage: sparq-cli query-mmap");
+}
+
+#[test]
+fn reason_too_few_arguments_exits_2() {
+    let dir = scratch("reason-too-few-arguments");
+    let data = write_nt(&dir);
+    assert_contract(
+        &["reason", s(&data), "ntriples"],
+        2,
+        "usage: sparq-cli reason",
+    );
+    let _ = std::fs::remove_dir_all(dir);
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds focused subprocess coverage for the uncovered build, query --format, recompress, compact, save, query-mmap, and reason error paths. This pins the implemented usage-vs-runtime contract (exit 2 vs exit 1) while asserting only CLI-owned stderr substrings.

Gates:
- cargo clippy -p sparq-cli --all-targets -- -D warnings — PASS
- cargo test -p sparq-cli — PASS
- cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings — PASS
- mutation spot-check (build expected exit 1 changed to 2) — failed as intended, then restored
- rustfmt --edition 2021 --check crates/sparq-cli/tests/error_paths_cli.rs — PASS