### PR TITLE
test(sparq-wac-oracle): pin oracle edge contracts (sq-bif.38) [GPT-5.6]

### DIFF
--- a/crates/sparq-wac-oracle/tests/oracle_edges.rs
+++ b/crates/sparq-wac-oracle/tests/oracle_edges.rs
@@ -1,0 +1,52 @@
+// [GPT-5.6] sq-bif.38 — integration-level edge contracts for the dev-only oracle.
+
+use sparq_wac_oracle::escalation_corpus::{canonicalize_child, is_acl_shaped, naive_acl_guard};
+use sparq_wac_oracle::{build_store, fixtures, run_vectors};
+
+#[test]
+fn empty_vector_report_is_a_pass() {
+    let store = build_store(&fixtures()[0]).expect("WAC fixture builds");
+    let report = run_vectors(&store, &[]);
+
+    assert_eq!(report.total, 0);
+    assert!(report.failures.is_empty());
+    assert!(report.passed());
+}
+
+#[test]
+fn acl_shape_detection_pins_boundary_names() {
+    let cases = [
+        ("", false),
+        ("/", false),
+        ("FOO.ACL", true),
+        ("dir/x.acl/", true),
+        (".acl", true),
+    ];
+
+    for (name, expected) in cases {
+        assert_eq!(is_acl_shaped(name), expected, "name: {name:?}");
+    }
+}
+
+#[test]
+fn child_canonicalization_pins_dot_and_trailing_character_rules() {
+    let cases = [
+        ("foo.acl.", "foo.acl"),
+        ("foo.acl ", "foo.acl"),
+        ("foo\u{FF0E}acl", "foo.acl"),
+        ("foo%2Eacl", "foo.acl"),
+        (".foo", ".foo"),
+    ];
+
+    for (raw, expected) in cases {
+        assert_eq!(canonicalize_child(raw), expected, "raw child: {raw:?}");
+    }
+}
+
+#[test]
+fn canonicalization_exposes_encoded_acl_shape_missed_by_naive_guard() {
+    let raw = "foo%2Eacl";
+
+    assert!(!naive_acl_guard(raw));
+    assert!(is_acl_shaped(&canonicalize_child(raw)));
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds the first sparq-wac-oracle integration test file to pin the empty-vector OracleReport floor, ACL-shaped name boundary predicates, child-name canonicalisation edges, and the percent-encoded differential witness. These tests document helper contracts of a dev-only test oracle; they are not a security audit or guarantee of the WAC/ACP decision layer.

Gates:
- `cargo test -p sparq-wac-oracle --test oracle_edges` — PASS (4 tests)
- `cargo test -p sparq-wac-oracle` — PASS (18 unit, 4 integration, 1 doctest)
- `cargo clippy -p sparq-wac-oracle --all-targets -- -D warnings` — PASS
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings` — PASS
- Mutation spot-check: flipped the expected `FOO.ACL` boolean and confirmed the focused test failed; restored expectation and reran green.
- `rustfmt --edition 2021 --check crates/sparq-wac-oracle/tests/oracle_edges.rs` — PASS