### PR TITLE
test(sparq-wrapper): pin default-lane empty traversal contracts (sq-bif.39) [GPT-5.6]

### DIFF
--- a/crates/sparq-wrapper/tests/default_lane_edges.rs
+++ b/crates/sparq-wrapper/tests/default_lane_edges.rs
@@ -1,0 +1,60 @@
+// [GPT-5.6] sq-bif.39: default-lane empty-traversal contract witnesses.
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_wrapper::Store;
+
+fn iri(local: &str) -> NamedNode {
+    NamedNode::new(format!("http://example.org/{local}")).unwrap()
+}
+
+fn one_triple_graph() -> Graph {
+    Graph::load_str(
+        "@prefix ex: <http://example.org/> . ex:s ex:p ex:o .",
+        "turtle",
+    )
+    .unwrap()
+}
+
+#[test]
+fn outgoing_traversal_with_absent_predicate_is_empty() {
+    let graph = one_triple_graph();
+    let store = Store::borrowed(&graph);
+
+    assert_eq!(store.node(iri("s")).out(&iri("absent")).count(), 0);
+}
+
+#[test]
+fn absent_focus_has_no_incoming_or_outgoing_traversal() {
+    let graph = one_triple_graph();
+    let store = Store::borrowed(&graph);
+    let absent = store.node(iri("absent"));
+
+    assert_eq!(absent.out(&iri("p")).count(), 0);
+    assert_eq!(absent.r#in(&iri("p")).count(), 0);
+}
+
+#[test]
+fn values_yields_absent_focus_exactly_once() {
+    let graph = one_triple_graph();
+    let store = Store::borrowed(&graph);
+    let absent = iri("absent");
+
+    assert_eq!(
+        store.node(absent.clone()).values().collect::<Vec<_>>(),
+        vec![Term::from(absent)]
+    );
+}
+
+#[test]
+fn subject_only_focus_has_outgoing_but_no_incoming_match() {
+    let graph = one_triple_graph();
+    let store = Store::borrowed(&graph);
+    let subject = store.node(iri("s"));
+
+    assert_eq!(subject.r#in(&iri("p")).count(), 0);
+    assert_eq!(
+        subject.out(&iri("p")).values().collect::<Vec<_>>(),
+        vec![Term::from(iri("o"))]
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds default-lane integration tests for absent-predicate and absent-focus traversal, Node::values() once-semantics for an absent focus, and incoming/outgoing direction asymmetry. This is tests-only in sparq-wrapper: no source, manifest, dependency, or feature changes.

Required gates are green:
- cargo clippy -p sparq-wrapper --all-targets -- -D warnings
- cargo test -p sparq-wrapper
- cargo clippy -p sparq-wrapper --no-default-features --all-targets -- -D warnings
- cargo test -p sparq-wrapper --no-default-features
- cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings
- rustfmt --check crates/sparq-wrapper/tests/default_lane_edges.rs

Mutation spot-check: changing the absent-predicate expected count from 0 to 1 failed at the intended assertion; the correct expectation was restored and re-tested. The repository-wide cargo fmt check still reports the pre-existing deferred workspace reformat documented in rustfmt.toml; it made no changes and the new file-specific format check passes.