### PR TITLE
test(sparq-py): cover term rendering precedence edges (sq-bif.40) [GPT-5.6]

### DIFF
--- a/crates/sparq-py/tests/term_render_edges.rs
+++ b/crates/sparq-py/tests/term_render_edges.rs
@@ -1,0 +1,37 @@
+// The sparq-py cdylib disables its lib test harness because linking a PyO3
+// extension-module harness fails on macOS. Compile the pure renderer directly so
+// these tests remain ordinary Rust integration tests with no Python dependency.
+#[path = "../src/term_render.rs"]
+mod term_render;
+
+use term_render::render_n3;
+
+// [GPT-5.6] sq-bif.40: pin literal-arm precedence and catch-all edge behavior.
+#[test]
+fn language_takes_precedence_over_datatype() {
+    assert_eq!(
+        render_n3(
+            "literal",
+            "x",
+            Some("en"),
+            Some("http://www.w3.org/2001/XMLSchema#integer"),
+            None,
+        ),
+        "\"x\"@en"
+    );
+}
+
+#[test]
+fn direction_without_language_is_dropped() {
+    assert_eq!(render_n3("literal", "x", None, None, Some("ltr")), "\"x\"");
+}
+
+#[test]
+fn renders_empty_literal() {
+    assert_eq!(render_n3("literal", "", None, None, None), "\"\"");
+}
+
+#[test]
+fn unknown_kind_falls_through_to_literal_rendering() {
+    assert_eq!(render_n3("quad", "v", None, None, None), "\"v\"");
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds pure-Rust sparq-py integration coverage for literal rendering precedence and catch-all edges: language overrides datatype, direction requires language, empty literals render correctly, and unknown kinds use literal rendering. This directly pins the Python repr renderer without PyO3 or a Python runtime.

Gates:
- PASS: cargo test -p sparq-py
- PASS: cargo clippy -p sparq-py --all-targets -- -D warnings
- PASS: cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings
- PASS: mutation spot-check (altered expected output failed the focused test)
- PASS: rustfmt --check crates/sparq-py/tests/term_render_edges.rs

Additional honesty: full-workspace cargo fmt --check reports pre-existing formatting drift outside this bead; it is already tracked in #2345.