### PR TITLE
feat(forms): add headless field validation (sq-lsp7k.1.3) [GPT-5.6]

### DIFF
--- a/crates/sparq-forms/README.md
+++ b/crates/sparq-forms/README.md
@@ -60,7 +60,11 @@ assert_eq!(field.widget.editor.as_deref(),
   `FormDescription` (`dash:DetailsEditor`), depth-limited and cycle-safe.
 - **Constraints carried per field** — counts, datatypes, classes, node kinds,
   `sh:in` enumerations, pattern/length/range bounds, `sh:or` unions — the
-  renderer's live-validation hints (F3) and the widget-scoring inputs.
+  widget-scoring inputs.
+- **Opt-in live validation** — `derive_form_validated(data, shapes, model,
+  focus, opts, registry)` runs the base SHACL validator and adds each
+  focus-node property violation to the matching editable field's `validation`
+  vector without changing the data graph or the plain derivation APIs.
 - **Pure edit diff** — `FormDiff::between(&before, &after)` reports added and
   removed RDF terms, while `to_sparql_update` renders them as one SPARQL 1.1
   `DELETE`/`INSERT` request. It intentionally excludes read-only, inverse,
@@ -75,8 +79,8 @@ assert_eq!(field.widget.editor.as_deref(),
   vocabulary and scoring contract this crate implements (documented
   deviations are marked *(sparq)* in the `widgets` module docs).
 - `sparq-shacl` — the shapes model + validation engine this crate consumes.
-- Roadmap: F2 GUI renderer (sq-lsp7k.1.2), F3 live validation + DASH
-  suggestions (sq-lsp7k.1.3), F5 RDF 1.2 / computed fields (sq-lsp7k.1.5),
+- Roadmap: F2 GUI renderer (sq-lsp7k.1.2), DASH suggestions (sq-lsp7k.1.4),
+  F5 RDF 1.2 / computed fields (sq-lsp7k.1.5),
   F6 sparq-mcp agent tools (sq-lsp7k.1.6).
 
 ## License

--- a/crates/sparq-forms/src/derive.rs
+++ b/crates/sparq-forms/src/derive.rs
@@ -385,9 +385,7 @@ fn build_field(
     let label = field_label(shapes, prop, path);
     FormField {
         property_shape: Some(TermRef::from_term(&prop.node)),
-        path: path
-            .to_sparql_property_path()
-            .unwrap_or_else(|| path.to_turtle()),
+        path: render_path(path),
         inverse: matches!(path, Path::Inverse(_)),
         label,
         description: literal_object(shapes, &prop.node, &sh("description")).or_else(|| {
@@ -400,6 +398,7 @@ fn build_field(
         widget,
         values,
         constraints,
+        validation: Vec::new(),
     }
 }
 
@@ -470,6 +469,7 @@ fn other_fields(
                     })
                     .collect(),
                 constraints,
+                validation: Vec::new(),
             }
         })
         .collect()
@@ -568,6 +568,11 @@ fn field_label(shapes: &GraphView, prop: &Shape, path: &Path) -> String {
             return local_name(n.as_str()).to_string();
         }
     }
+    render_path(path)
+}
+
+/// [GPT-5.6] Canonical field/result key for a parsed SHACL property path.
+pub(crate) fn render_path(path: &Path) -> String {
     path.to_sparql_property_path()
         .unwrap_or_else(|| path.to_turtle())
 }
@@ -582,7 +587,7 @@ fn predicate_term(path: &Path) -> Option<Term> {
 }
 
 /// Deterministic literal pick: no-language first, then by tag, then by value.
-fn pick_literal(terms: Vec<Term>) -> Option<String> {
+pub(crate) fn pick_literal(terms: Vec<Term>) -> Option<String> {
     let mut lits: Vec<(bool, String, String)> = terms
         .into_iter()
         .filter_map(|t| match t {

--- a/crates/sparq-forms/src/description.rs
+++ b/crates/sparq-forms/src/description.rs
@@ -227,6 +227,20 @@ pub struct FormValue {
     pub nested: Option<Box<FormDescription>>,
 }
 
+/// [GPT-5.6] One SHACL validation result attached to its declared form field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ValidationHint {
+    /// Constraint-component IRI (for example, `sh:PatternConstraintComponent`).
+    pub source_component: String,
+    /// Shape-provided `sh:message`, or the validator's generated fallback.
+    pub message: String,
+    /// Offending value node, when the constraint reports one.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub value: Option<TermRef>,
+    /// Result severity IRI (`sh:Violation`, `sh:Warning`, `sh:Info`, or custom).
+    pub severity: String,
+}
+
 /// One field of the form (per property shape, or per off-shape predicate).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FormField {
@@ -259,6 +273,9 @@ pub struct FormField {
     pub widget: WidgetChoice,
     pub values: Vec<FormValue>,
     pub constraints: Constraints,
+    /// [GPT-5.6] Live SHACL results for this declared, editable field.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub validation: Vec<ValidationHint>,
 }
 
 /// The whole derived form: what a renderer needs to draw (and an agent needs

--- a/crates/sparq-forms/src/lib.rs
+++ b/crates/sparq-forms/src/lib.rs
@@ -11,7 +11,7 @@ pub mod widgets;
 
 pub use description::{
     Constraints, FormDescription, FormField, FormGroup, FormValue, GroupKind, Mode, ShapeChoice,
-    ShapeVia, TermRef, WidgetChoice,
+    ShapeVia, TermRef, ValidationHint, WidgetChoice,
 };
 pub use diff::{to_sparql_update, FieldValueDiff, FormDiff};
 pub use widgets::{Resolution, Scorer, Suitability, WidgetContext, WidgetRegistry, DASH};
@@ -85,6 +85,58 @@ pub fn derive_form_with_model(
         opts,
         registry,
     )
+}
+
+/// [GPT-5.6] Derives a form and attaches live SHACL results for `focus` to
+/// matching declared, editable fields without mutating `data`.
+///
+/// Validation is additive and opt-in: [`derive_form`] and
+/// [`derive_form_with_model`] continue to return fields with empty validation
+/// vectors. Property-level results are matched using the same rendered SHACL
+/// path stored in [`FormField::path`]; node-level and unmatched results are not
+/// attached.
+pub fn derive_form_validated(
+    data: &Graph,
+    shapes: &Graph,
+    model: &ShapesModel,
+    focus: &Term,
+    opts: &FormOptions,
+    registry: &WidgetRegistry,
+) -> FormDescription {
+    let mut form = derive_form_with_model(data, shapes, model, focus, opts, registry);
+    let report = sparq_shacl::validate_with_model(data, model);
+
+    for result in report.results {
+        if result.focus_node != *focus {
+            continue;
+        }
+        let Some(path) = result.path.as_ref() else {
+            continue;
+        };
+        let rendered_path = derive::render_path(path);
+        let Some(field) = form
+            .groups
+            .iter_mut()
+            .flat_map(|group| &mut group.fields)
+            .find(|field| {
+                field.editable
+                    && field.property_shape.is_some()
+                    && field.path == rendered_path
+            })
+        else {
+            continue;
+        };
+        let message =
+            derive::pick_literal(result.messages).unwrap_or(result.default_message);
+        field.validation.push(ValidationHint {
+            source_component: result.source_component,
+            message,
+            value: result.value.as_ref().map(TermRef::from_term),
+            severity: result.severity,
+        });
+    }
+
+    form
 }
 
 /// The node shapes applicable to `focus` — the renderer's shape switcher:

--- a/crates/sparq-forms/tests/validation.rs
+++ b/crates/sparq-forms/tests/validation.rs
@@ -1,0 +1,141 @@
+//! [GPT-5.6] Live-validation coverage for `derive_form_validated` (sq-lsp7k.1.3).
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_forms::{derive_form, derive_form_validated, FormOptions, Mode, WidgetRegistry};
+use sparq_shacl::ShapesModel;
+
+const PREFIXES: &str = r#"
+  @prefix sh: <http://www.w3.org/ns/shacl#> .
+  @prefix ex: <http://example.org/> .
+"#;
+
+fn graph(turtle: &str) -> Graph {
+    Graph::load_str(&format!("{PREFIXES}{turtle}"), "turtle").unwrap()
+}
+
+fn focus() -> Term {
+    Term::from(NamedNode::new_unchecked("http://example.org/alice"))
+}
+
+fn field<'a>(form: &'a sparq_forms::FormDescription, label: &str) -> &'a sparq_forms::FormField {
+    form.groups
+        .iter()
+        .flat_map(|group| &group.fields)
+        .find(|field| field.label == label)
+        .unwrap_or_else(|| panic!("missing field {label}"))
+}
+
+#[test]
+fn validation_attaches_one_hint_to_the_violating_declared_field() {
+    let shapes = graph(
+        r#"
+        ex:PersonShape a sh:NodeShape ;
+          sh:targetNode ex:alice ;
+          sh:class ex:Employee ;
+          sh:property [ sh:path ex:code ; sh:name "Code" ;
+                        sh:pattern "^AB" ;
+                        sh:message "Le code doit commencer par AB"@fr,
+                                   "Code must start with AB" ] ;
+          sh:property [ sh:path ex:name ; sh:name "Name" ; sh:minLength 2 ] .
+        "#,
+    );
+    let data = graph(
+        r#"
+        ex:alice a ex:Person ;
+          ex:code "wrong" ;
+          ex:name "Alice" ;
+          ex:extra "off shape" .
+        "#,
+    );
+    let model = ShapesModel::parse(&shapes);
+    let opts = FormOptions::default();
+    let registry = WidgetRegistry::dash();
+
+    let plain = derive_form(&data, &shapes, &focus(), &opts);
+    let validated = derive_form_validated(&data, &shapes, &model, &focus(), &opts, &registry);
+
+    let code = field(&validated, "Code");
+    assert_eq!(code.validation.len(), 1);
+    let hint = &code.validation[0];
+    assert_eq!(
+        hint.source_component,
+        "http://www.w3.org/ns/shacl#PatternConstraintComponent"
+    );
+    assert_eq!(hint.message, "Code must start with AB");
+    assert_eq!(hint.severity, "http://www.w3.org/ns/shacl#Violation");
+    assert_eq!(
+        hint.value.as_ref().map(|value| value.value.as_str()),
+        Some("wrong")
+    );
+
+    assert!(field(&validated, "Name").validation.is_empty());
+    assert!(field(&validated, "extra").validation.is_empty());
+
+    // Removing the additive hints must recover the exact plain description:
+    // validation cannot perturb widgets, constraints, values, or layout.
+    let mut without_hints = validated;
+    for form_field in without_hints
+        .groups
+        .iter_mut()
+        .flat_map(|group| &mut group.fields)
+    {
+        form_field.validation.clear();
+    }
+    assert_eq!(without_hints, plain);
+}
+
+#[test]
+fn validation_does_not_attach_to_read_only_fields() {
+    let shapes = graph(
+        r#"
+        ex:PersonShape a sh:NodeShape ; sh:targetNode ex:alice ;
+          sh:property [ sh:path ex:code ; sh:name "Code" ; sh:pattern "^AB" ] .
+        "#,
+    );
+    let data = graph(r#"ex:alice ex:code "wrong" ."#);
+    let model = ShapesModel::parse(&shapes);
+    let opts = FormOptions {
+        mode: Mode::View,
+        ..FormOptions::default()
+    };
+
+    let validated = derive_form_validated(
+        &data,
+        &shapes,
+        &model,
+        &focus(),
+        &opts,
+        &WidgetRegistry::dash(),
+    );
+
+    let code = field(&validated, "Code");
+    assert!(!code.editable);
+    assert!(code.validation.is_empty());
+}
+
+#[test]
+fn validation_uses_the_generated_message_when_the_shape_has_none() {
+    let shapes = graph(
+        r#"
+        ex:PersonShape a sh:NodeShape ; sh:targetNode ex:alice ;
+          sh:property [ sh:path ex:code ; sh:name "Code" ; sh:pattern "^AB" ] .
+        "#,
+    );
+    let data = graph(r#"ex:alice ex:code "wrong" ."#);
+    let model = ShapesModel::parse(&shapes);
+
+    let validated = derive_form_validated(
+        &data,
+        &shapes,
+        &model,
+        &focus(),
+        &FormOptions::default(),
+        &WidgetRegistry::dash(),
+    );
+
+    assert_eq!(
+        field(&validated, "Code").validation[0].message,
+        "Value does not match pattern \"^AB\""
+    );
+}

--- a/skills/shacl-forms/SKILL.md
+++ b/skills/shacl-forms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shacl-forms
-description: "Derive a DASH-compatible, renderer-agnostic form description from SHACL shapes with the opt-in sparq-forms crate: (data graph, shapes graph, focus node, view|edit mode) -> serde-JSON FormDescription — applicable-shape switcher, property-group/field layout (sh:name/sh:description/sh:order/sh:group, sh:inversePath incoming references, sh:deactivated, implicit read-only Other group), DASH widget auto-selection via the documented 0-100 scoring registry (TextField/TextArea/BooleanSelect/Date+DateTimePicker/EnumSelect/InstancesSelect/URIEditor/RichText/SubClass/DetailsEditor and the viewers) with dash:editor/dash:viewer overrides, required/multi cardinality typing, per-field constraints, and nested sh:node sub-forms. Use when an agent or GUI needs a shape-directed data-entry/edit/view form for a focus node (headless: no GUI deps, builds for wasm32)."
+description: "Derive a DASH-compatible, renderer-agnostic form description from SHACL shapes with the opt-in sparq-forms crate: (data graph, shapes graph, focus node, view|edit mode) -> serde-JSON FormDescription — applicable-shape switcher, property-group/field layout (sh:name/sh:description/sh:order/sh:group, sh:inversePath incoming references, sh:deactivated, implicit read-only Other group), DASH widget auto-selection via the documented 0-100 scoring registry (TextField/TextArea/BooleanSelect/Date+DateTimePicker/EnumSelect/InstancesSelect/URIEditor/RichText/SubClass/DetailsEditor and the viewers) with dash:editor/dash:viewer overrides, required/multi cardinality typing, per-field constraints and opt-in live SHACL validation hints, and nested sh:node sub-forms. Use when an agent or GUI needs a shape-directed data-entry/edit/view form for a focus node (headless: no GUI deps, builds for wasm32)."
 license: MIT
 metadata:
   version: "0.1.0"
@@ -66,7 +66,13 @@ What the description carries (all serde `Serialize + Deserialize`):
 - **`required` / `multi`** — `sh:minCount >= 1` / `sh:maxCount != 1` (the
   add/remove affordance signal).
 - **`constraints`** — per-field counts/datatypes/classes/nodeKind/`sh:in`/
-  pattern/length/range/`sh:or` for live validation hints.
+  pattern/length/range/`sh:or` for renderer-side guidance.
+- **`validation`** — with `derive_form_validated(data, shapes, model, focus,
+  opts, registry)`, SHACL results for the focus node are attached to the
+  matching declared, editable field by property path. Each `ValidationHint`
+  carries the source-component IRI, selected shape message (or generated
+  fallback), optional offending value, and severity. Plain `derive_form` and
+  `derive_form_with_model` leave this vector empty.
 - **`values[].nested`** — `sh:node` values recurse into nested sub-forms
   (`dash:DetailsEditor`), `max_depth`-limited and cycle-safe.
 
@@ -76,10 +82,10 @@ Amortise shape parsing across focus nodes with `derive_form_with_model`
 switcher with `applicable_shapes`. Blank-node labels in the output are
 renamed deterministically (`b0`, `b1`, …) — do not treat them as graph handles.
 
-Scope: derivation plus pure edit-to-UPDATE building. Applying the request,
-validate-before-commit guards, draft graphs, in-form validation + DASH
-suggestions, `dash:propertyRole`, and the GUI renderer are follow-on beads
-(sq-lsp7k.1.2/.1.3/.1.4/.1.5/.1.6); `sparq-shacl` (see
+Scope: derivation, opt-in live validation hints, plus pure edit-to-UPDATE
+building. Applying the request, validate-before-commit guards, draft graphs,
+DASH suggestions, `dash:propertyRole`, and the GUI renderer are follow-on
+beads (sq-lsp7k.1.2/.1.4/.1.5/.1.6); `sparq-shacl` (see
 [`shacl-validation`](../shacl-validation/SKILL.md)) already validates the same
 graphs.
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Adds the opt-in `derive_form_validated` entry point and per-field `ValidationHint` data so renderers can surface current SHACL results without mutating the graph. Results are focus/path matched only onto declared editable fields; plain derivation remains unchanged, including existing golden JSON. The public usage docs were updated with the new additive API.

Gates passed:
- `cargo test -p sparq-forms validation` — 3 focused tests passed
- `cargo clippy -p sparq-forms --all-targets -- -D warnings`
- `cargo test -p sparq-forms` — 49 tests plus 1 doctest passed