### PR TITLE
fix(shacl): type string generator picks for rustc 1.88 (sq-qvqk7) [GPT-5.6]

### DIFF
--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -84,6 +84,15 @@ use sparq_shacl::validate;
 mod gen;
 use gen::{Rng, Scenario};
 
+/// [GPT-5.6] (sq-qvqk7) The explicit element type must keep string-literal picks
+/// sized on rustc 1.88 while preserving the selected value.
+#[test]
+fn rng_string_pick_has_sized_elements() {
+    let mut rng = Rng::new(0);
+    let picked: &str = rng.pick::<&str>(&["typed"]);
+    assert_eq!(picked, "typed");
+}
+
 // ---------------------------------------------------------------------------
 // Reference engine: a report-cli adapter (sq-eifd "report-cli" kind).
 // ---------------------------------------------------------------------------

--- a/crates/sparq-shacl/tests/gen.rs
+++ b/crates/sparq-shacl/tests/gen.rs
@@ -662,8 +662,9 @@ fn gen_constraint(rng: &mut Rng, _support: &mut Vec<String>) -> Option<Constrain
     // 12..=14: the sq-0hj7 logical/node extensions (drawn ~1-in-5 of value cases).
     let choice = rng.below(15);
     Some(match choice {
-        0 => Constraint::Datatype(rng.pick(&["integer", "string", "boolean", "decimal"])),
-        1 => Constraint::NodeKind(rng.pick(&["sh:IRI", "sh:Literal", "sh:BlankNode"])),
+        // [GPT-5.6] (sq-qvqk7) Keep rustc 1.88 from inferring unsized `str` here.
+        0 => Constraint::Datatype(rng.pick::<&str>(&["integer", "string", "boolean", "decimal"])),
+        1 => Constraint::NodeKind(rng.pick::<&str>(&["sh:IRI", "sh:Literal", "sh:BlankNode"])),
         2 => {
             // sh:class: conforming values get a typed instance minted lazily by
             // `resolve_value` (so each conforming value points at its own typed
@@ -671,7 +672,7 @@ fn gen_constraint(rng: &mut Rng, _support: &mut Vec<String>) -> Option<Constrain
             let cls = format!("{EX}Kind{}", rng.below(100));
             Constraint::Class(cls)
         }
-        3 => Constraint::Pattern(rng.pick(&["^[a-z]+[0-9]+$", "^a.*$", "[0-9]"])),
+        3 => Constraint::Pattern(rng.pick::<&str>(&["^[a-z]+[0-9]+$", "^a.*$", "[0-9]"])),
         4 => {
             let n = 2 + rng.below(3);
             let vals: Vec<String> = (0..n).map(|j| format!("\"opt{j}\"")).collect();
@@ -718,9 +719,10 @@ fn gen_constraint(rng: &mut Rng, _support: &mut Vec<String>) -> Option<Constrain
 /// composites — one level is enough to stress the conformance memo).
 fn gen_leaf_for_node(rng: &mut Rng) -> Constraint {
     match rng.below(7) {
-        0 => Constraint::Datatype(rng.pick(&["integer", "string", "boolean"])),
-        1 => Constraint::NodeKind(rng.pick(&["sh:IRI", "sh:Literal"])),
-        2 => Constraint::Pattern(rng.pick(&["^[a-z]+[0-9]+$", "^a.*$"])),
+        // [GPT-5.6] (sq-qvqk7) Keep rustc 1.88 from inferring unsized `str` here.
+        0 => Constraint::Datatype(rng.pick::<&str>(&["integer", "string", "boolean"])),
+        1 => Constraint::NodeKind(rng.pick::<&str>(&["sh:IRI", "sh:Literal"])),
+        2 => Constraint::Pattern(rng.pick::<&str>(&["^[a-z]+[0-9]+$", "^a.*$"])),
         3 => {
             let n = 2 + rng.below(3);
             let vals: Vec<String> = (0..n).map(|j| format!("\"opt{j}\"")).collect();


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes rustc 1.88 E0277/E0308 failures in the `sparq-shacl` dev-tests by explicitly selecting `&str` as the slice element type at all six ambiguous generator call sites. Adds an exact-value regression test; generator behaviour is unchanged.

Gates (green):
- `cargo +1.88 test --no-run --tests -p sparq-shacl && cargo test -p sparq-shacl`
- `cargo +1.88 test --no-run --tests -p sparq-shacl --all-features && cargo test -p sparq-shacl --all-features`
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings`
- `cargo clippy -p sparq-shacl --all-features --all-targets -- -D warnings`