### PR TITLE
feat(forms): DASH presentation flags — hidden/readOnly/defaultValue (sq-lsp7k.1.5) [FABLE]

### DIFF
--- a/crates/sparq-forms/README.md
+++ b/crates/sparq-forms/README.md
@@ -61,6 +61,10 @@ assert_eq!(field.widget.editor.as_deref(),
 - **Constraints carried per field** — counts, datatypes, classes, node kinds,
   `sh:in` enumerations, pattern/length/range bounds, `sh:or` unions — the
   widget-scoring inputs.
+- **Presentation flags** — `dash:hidden` (field derives but a renderer omits
+  it), `dash:readOnly` (forces `editable: false` even in edit mode), and
+  `sh:defaultValue` (verbatim seed term to pre-fill an empty field); all three
+  are additive JSON keys, omitted when the property shape does not declare them.
 - **Opt-in live validation** — `derive_form_validated(data, shapes, model,
   focus, opts, registry)` runs the base SHACL validator and adds each
   focus-node property violation to the matching editable field's `validation`

--- a/crates/sparq-forms/src/derive.rs
+++ b/crates/sparq-forms/src/derive.rs
@@ -127,6 +127,11 @@ fn normalize_form(form: &mut FormDescription, names: &mut std::collections::Hash
                 normalize_ref(n, names);
             }
             normalize_constraints(&mut f.constraints, names);
+            // sh:defaultValue may (degenerately) be a blank node — keep the
+            // deterministic-label contract. [FABLE] sq-lsp7k.1.5
+            if let Some(dv) = &mut f.default_value {
+                normalize_ref(dv, names);
+            }
             for v in &mut f.values {
                 normalize_ref(&mut v.term, names);
                 if let Some(nested) = &mut v.nested {
@@ -382,6 +387,14 @@ fn build_field(
         })
         .collect();
 
+    // ---- dash presentation flags (additive; absent statements leave the ----
+    // ---- description exactly as before). [FABLE] sq-lsp7k.1.5           ----
+    let hidden = bool_object(shapes, &prop.node, &dash("hidden"));
+    let read_only = bool_object(shapes, &prop.node, &dash("readOnly"));
+    let default_value = shapes
+        .object(&prop.node, &sh("defaultValue"))
+        .map(|t| TermRef::from_term(&t));
+
     let label = field_label(shapes, prop, path);
     FormField {
         property_shape: Some(TermRef::from_term(&prop.node)),
@@ -394,7 +407,10 @@ fn build_field(
         order: order_of(shapes, &prop.node),
         required: constraints.min_count.is_some_and(|c| c >= 1),
         multi: constraints.max_count != Some(1),
-        editable: opts.mode == Mode::Edit,
+        // dash:readOnly true forces read-only even in edit mode. [FABLE]
+        editable: opts.mode == Mode::Edit && !read_only,
+        hidden,
+        default_value,
         widget,
         values,
         constraints,
@@ -453,6 +469,8 @@ fn other_fields(
                 required: false,
                 multi: true,
                 editable: false, // off-shape triples are ALWAYS read-only
+                hidden: false,      // presentation flags live on property shapes
+                default_value: None, // [FABLE] sq-lsp7k.1.5
                 widget: WidgetChoice {
                     editor: None,
                     viewer: viewer_res.selected.clone(),
@@ -605,6 +623,12 @@ pub(crate) fn pick_literal(terms: Vec<Term>) -> Option<String> {
 
 fn literal_object(g: &GraphView, node: &Term, pred: &str) -> Option<String> {
     pick_literal(g.objects(node, pred))
+}
+
+/// `true` iff the node declares `<pred> true` (lexical `true`, matching the
+/// `dash:singleLine` handling in `constraints_of`). [FABLE-5] sq-lsp7k.1.5
+fn bool_object(g: &GraphView, node: &Term, pred: &str) -> bool {
+    literal_object(g, node, pred).is_some_and(|v| v == "true")
 }
 
 fn iri_object(g: &GraphView, node: &Term, pred: &str) -> Option<String> {

--- a/crates/sparq-forms/src/description.rs
+++ b/crates/sparq-forms/src/description.rs
@@ -268,8 +268,20 @@ pub struct FormField {
     pub required: bool,
     /// `sh:maxCount != 1`: the renderer shows add/remove affordances.
     pub multi: bool,
-    /// `false` for view mode and for off-shape (read-only) fields.
+    /// `false` for view mode, for off-shape (read-only) fields, and for
+    /// property shapes declaring `dash:readOnly true` (read-only even in
+    /// edit mode). [FABLE-5]
     pub editable: bool,
+    /// `dash:hidden true` on the property shape: the field still participates
+    /// in the data model (values, constraints, diffing) but a renderer should
+    /// not display it. [FABLE-5] sq-lsp7k.1.5
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub hidden: bool,
+    /// `sh:defaultValue` on the property shape, carried verbatim: the seed
+    /// value a renderer pre-fills when the field currently has no values.
+    /// [FABLE-5] sq-lsp7k.1.5
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub default_value: Option<TermRef>,
     pub widget: WidgetChoice,
     pub values: Vec<FormValue>,
     pub constraints: Constraints,

--- a/crates/sparq-forms/tests/derive.rs
+++ b/crates/sparq-forms/tests/derive.rs
@@ -291,6 +291,79 @@ fn form_options_default_values() {
     assert_eq!(opts.max_depth, 3);
 }
 
+// ---- dash presentation flags: hidden / readOnly / defaultValue -------------
+// [FABLE] sq-lsp7k.1.5
+
+const FLAGGABLE_SHAPES: &str = r#"
+  ex:PersonShape a sh:NodeShape ; sh:targetClass ex:Person ;
+    sh:property ex:nameProp ; sh:property ex:secretProp ; sh:property ex:codeProp .
+  ex:nameProp sh:path ex:name ; sh:name "Name" ; sh:order 1 .
+  ex:secretProp sh:path ex:secret ; sh:name "Secret" ; sh:order 2 .
+  ex:codeProp sh:path ex:code ; sh:name "Code" ; sh:order 3 .
+"#;
+
+const PRESENTATION_FLAGS: &str = r#"
+  ex:secretProp dash:hidden true .
+  ex:codeProp dash:readOnly true ; sh:defaultValue ex:draft .
+  ex:nameProp sh:defaultValue "Anon" .
+"#;
+
+#[test]
+fn dash_hidden_readonly_and_default_value_surface_on_fields() {
+    let shapes = g(&format!("{FLAGGABLE_SHAPES}{PRESENTATION_FLAGS}"));
+    let form = derive_form(&g(ALICE), &shapes, &iri("alice"), &FormOptions::default());
+    assert_eq!(form.mode, Mode::Edit);
+    let fields = &form.groups[0].fields;
+    let by = |label: &str| fields.iter().find(|f| f.label == label).unwrap();
+
+    // dash:hidden true → flagged; the field still derives (the RENDERER omits it).
+    let secret = by("Secret");
+    assert!(secret.hidden);
+    assert!(secret.editable, "dash:hidden does not imply read-only");
+
+    // dash:readOnly true → editable=false even though the form is in Edit mode.
+    let code = by("Code");
+    assert!(!code.editable, "dash:readOnly true forces read-only in Mode::Edit");
+    assert!(!code.hidden);
+
+    // sh:defaultValue terms carried verbatim (literal and IRI kinds).
+    let name = by("Name");
+    assert!(!name.hidden && name.editable);
+    let dv = name.default_value.as_ref().expect("literal default");
+    assert_eq!((dv.kind.as_str(), dv.value.as_str()), ("literal", "Anon"));
+    let dv = code.default_value.as_ref().expect("IRI default");
+    assert_eq!(
+        (dv.kind.as_str(), dv.value.as_str()),
+        ("iri", "http://example.org/draft")
+    );
+    assert!(secret.default_value.is_none());
+}
+
+#[test]
+fn presentation_flags_are_additive_stripping_them_recovers_plain() {
+    let data = g(ALICE);
+    let opts = FormOptions::default();
+    let plain = derive_form(&data, &g(FLAGGABLE_SHAPES), &iri("alice"), &opts);
+
+    // Shapes WITHOUT the statements serialize with none of the new keys
+    // (goldens separately pin the flag-free JSON byte-for-byte).
+    let json = serde_json::to_string(&plain).unwrap();
+    assert!(!json.contains("\"hidden\"") && !json.contains("\"default_value\""));
+
+    // Resetting the additive flags must recover the exact plain description:
+    // presentation flags cannot perturb widgets, constraints, values, or layout.
+    let flagged_shapes = g(&format!("{FLAGGABLE_SHAPES}{PRESENTATION_FLAGS}"));
+    let mut stripped = derive_form(&data, &flagged_shapes, &iri("alice"), &opts);
+    for field in stripped.groups.iter_mut().flat_map(|group| &mut group.fields) {
+        field.hidden = false;
+        field.default_value = None;
+        if field.label == "Code" {
+            field.editable = true; // undo dash:readOnly
+        }
+    }
+    assert_eq!(stripped, plain);
+}
+
 #[test]
 fn role_is_echoed_and_focus_without_shapes_is_all_other() {
     let opts = FormOptions {

--- a/skills/shacl-forms/SKILL.md
+++ b/skills/shacl-forms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shacl-forms
-description: "Derive a DASH-compatible, renderer-agnostic form description from SHACL shapes with the opt-in sparq-forms crate: (data graph, shapes graph, focus node, view|edit mode) -> serde-JSON FormDescription — applicable-shape switcher, property-group/field layout (sh:name/sh:description/sh:order/sh:group, sh:inversePath incoming references, sh:deactivated, implicit read-only Other group), DASH widget auto-selection via the documented 0-100 scoring registry (TextField/TextArea/BooleanSelect/Date+DateTimePicker/EnumSelect/InstancesSelect/URIEditor/RichText/SubClass/DetailsEditor and the viewers) with dash:editor/dash:viewer overrides, required/multi cardinality typing, per-field constraints and opt-in live SHACL validation hints, and nested sh:node sub-forms. Use when an agent or GUI needs a shape-directed data-entry/edit/view form for a focus node (headless: no GUI deps, builds for wasm32)."
+description: "Derive a DASH-compatible, renderer-agnostic form description from SHACL shapes with the opt-in sparq-forms crate: (data graph, shapes graph, focus node, view|edit mode) -> serde-JSON FormDescription — applicable-shape switcher, property-group/field layout (sh:name/sh:description/sh:order/sh:group, sh:inversePath incoming references, sh:deactivated, implicit read-only Other group), DASH widget auto-selection via the documented 0-100 scoring registry (TextField/TextArea/BooleanSelect/Date+DateTimePicker/EnumSelect/InstancesSelect/URIEditor/RichText/SubClass/DetailsEditor and the viewers) with dash:editor/dash:viewer overrides, required/multi cardinality typing, dash:hidden/dash:readOnly/sh:defaultValue presentation flags, per-field constraints and opt-in live SHACL validation hints, and nested sh:node sub-forms. Use when an agent or GUI needs a shape-directed data-entry/edit/view form for a focus node (headless: no GUI deps, builds for wasm32)."
 license: MIT
 metadata:
   version: "0.1.0"
@@ -67,6 +67,12 @@ What the description carries (all serde `Serialize + Deserialize`):
   add/remove affordance signal).
 - **`constraints`** — per-field counts/datatypes/classes/nodeKind/`sh:in`/
   pattern/length/range/`sh:or` for renderer-side guidance.
+- **`hidden` / `editable` / `default_value`** — `dash:hidden true` flags a
+  field the renderer should omit (it still derives, with values and
+  constraints), `dash:readOnly true` forces `editable: false` even in edit
+  mode, and `sh:defaultValue` is carried verbatim as the seed term a renderer
+  pre-fills when a field has no values. All additive: omitted from the JSON
+  when the property shape does not declare them.
 - **`validation`** — with `derive_form_validated(data, shapes, model, focus,
   opts, registry)`, SHACL results for the focus node are attached to the
   matching declared, editable field by property path. Each `ValidationHint`


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable, salvaged + Opus-verified)

Adds dash:hidden / dash:readOnly / sh:defaultValue presentation flags to sparq-forms FormField (workbench forms F5, sq-lsp7k.1.5).

- **Additive**: hidden (bool, skip-if-false) + default_value (Option<TermRef>, skip-if-none) new on FormField; read_only reuses the existing editable field. A form derived from shapes WITHOUT these statements serializes byte-identically to today.
- **Behaviour**: dash:readOnly true forces editable=false even in Mode::Edit; dash:hidden true sets hidden=true (renderer omits, field still derives); sh:defaultValue surfaces verbatim.
- **Gates**: clippy -p sparq-forms --all-targets -D warnings + cargo test -p sparq-forms --all-targets GREEN. Non-vacuous test asserts all three behaviours + hidden≠readOnly + literal-vs-IRI defaults. README + SKILL.md updated.

Fable implemented this; the impl agent stalled at the final gate under CPU contention, so the orchestrator re-ran the gates (green) and Opus-reviewed the diff before opening. Unarmed.