### PR TITLE
fix(vectors): truncate passages at word boundaries (sq-lsp7k) [GPT-5.6]

### DIFF
--- a/crates/sparq-vectors/src/grounding.rs
+++ b/crates/sparq-vectors/src/grounding.rs
@@ -77,7 +77,7 @@
 use crate::encode::{numeric_value, route, temporal_value, Encoder};
 use crate::store::VectorStore;
 use crate::units::{normalise, QuantityKind, QUDT_UNIT_NS};
-use crate::verbalize::{verbalize, EntityTextConfig};
+use crate::verbalize::{truncate_at_word_boundary, verbalize, EntityTextConfig};
 use rustc_hash::{FxHashMap, FxHashSet};
 use sparq_core::dict::{self, Id, TermParts};
 use sparq_core::Graph;
@@ -368,14 +368,11 @@ fn local_name(iri: &str) -> String {
     }
 }
 
-/// Truncate `s` at a char boundary to at most `max` chars (the same budget discipline as
-/// [`verbalize`]).
+/// Truncate `s` at a word or sentence boundary to at most `max` chars (the same budget discipline
+/// as [`verbalize`]).
 fn truncate_chars(s: &str, max: usize) -> String {
-    if s.chars().count() <= max {
-        s.to_string()
-    } else {
-        s.chars().take(max).collect()
-    }
+    // [GPT-5.6] Share the exact boundary policy with entity verbalization.
+    truncate_at_word_boundary(s, max)
 }
 
 // ---- subgraph modality ------------------------------------------------------------------------

--- a/crates/sparq-vectors/src/verbalize.rs
+++ b/crates/sparq-vectors/src/verbalize.rs
@@ -174,8 +174,8 @@ pub struct EntityTextConfig {
     /// Joins the groups' rendered pieces. Default: `". "`.
     pub separator: String,
     /// Character budget for the whole text. Pieces are appended in group order while
-    /// they fit; the piece that overflows is truncated at a char boundary and ends the
-    /// text (so the leading label survives even a tiny budget). Default: 2048 —
+    /// they fit; the piece that overflows is truncated at a word or sentence boundary
+    /// and ends the text. Default: 2048 —
     /// passage-sized, comfortably within every embedding model's window.
     pub max_chars: usize,
     /// Texts per [`Embedder::embed`] call in [`embed_entities`]. Default: 256.
@@ -254,7 +254,7 @@ fn verbalize_id(graph: &Graph, id: Id, cfg: &EntityTextConfig) -> Option<String>
         return None;
     }
     // Assemble under the char budget: whole pieces while they fit; the overflowing
-    // piece is truncated at a char boundary and ends the text.
+    // piece is truncated at a word or sentence boundary and ends the text.
     let mut out = String::new();
     for piece in pieces {
         let lead = if out.is_empty() { 0 } else { cfg.separator.chars().count() };
@@ -263,13 +263,20 @@ fn verbalize_id(graph: &Graph, id: Id, cfg: &EntityTextConfig) -> Option<String>
         if remaining == 0 {
             break;
         }
-        if !out.is_empty() {
-            out.push_str(&cfg.separator);
-        }
         if piece.chars().count() <= remaining {
+            if !out.is_empty() {
+                out.push_str(&cfg.separator);
+            }
             out.push_str(&piece);
         } else {
-            out.extend(piece.chars().take(remaining));
+            let truncated = truncate_at_word_boundary(&piece, remaining);
+            if truncated.is_empty() {
+                break;
+            }
+            if !out.is_empty() {
+                out.push_str(&cfg.separator);
+            }
+            out.push_str(&truncated);
             break;
         }
     }
@@ -278,6 +285,47 @@ fn verbalize_id(graph: &Graph, id: Id, cfg: &EntityTextConfig) -> Option<String>
     } else {
         Some(out)
     }
+}
+
+/// [GPT-5.6] Returns `s` unchanged when it fits; otherwise cuts at the last word or sentence
+/// boundary within `max_chars`. The returned string never exceeds the character budget and never
+/// ends partway through a whitespace-delimited token.
+pub(crate) fn truncate_at_word_boundary(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let mut chars = s.chars();
+    let prefix: String = chars.by_ref().take(max_chars).collect();
+    let next = chars.next();
+    let last = prefix.chars().next_back();
+
+    // A cut immediately before whitespace/punctuation, or immediately after sentence
+    // punctuation, already lands on a boundary at exactly the requested budget.
+    if next.is_some_and(is_boundary) || last.is_some_and(is_sentence_delimiter) {
+        return prefix.trim_end().to_string();
+    }
+
+    for (index, ch) in prefix.char_indices().rev() {
+        if ch.is_whitespace() {
+            return prefix[..index].trim_end().to_string();
+        }
+        if is_sentence_delimiter(ch) {
+            return prefix[..index + ch.len_utf8()].trim_end().to_string();
+        }
+    }
+    String::new()
+}
+
+fn is_boundary(ch: char) -> bool {
+    ch.is_whitespace() || is_sentence_delimiter(ch)
+}
+
+fn is_sentence_delimiter(ch: char) -> bool {
+    matches!(ch, '.' | '!' | '?')
 }
 
 /// The rendered value of one group for one entity: the first predicate (in group
@@ -487,4 +535,18 @@ pub fn embed_entities(
         }
     }
     Ok(verbalized.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_at_word_boundary;
+
+    #[test]
+    fn verbalize_truncation_uses_a_word_boundary_within_budget() {
+        // [GPT-5.6] A raw eight-character cut would produce "alpha be".
+        let truncated = truncate_at_word_boundary("alpha beta gamma", 8);
+        assert_eq!(truncated, "alpha");
+        assert!(truncated.chars().count() <= 8);
+        assert_eq!(truncate_at_word_boundary("alpha beta", 10), "alpha beta");
+    }
 }

--- a/crates/sparq-vectors/tests/verbalize.rs
+++ b/crates/sparq-vectors/tests/verbalize.rs
@@ -5,8 +5,8 @@
 use oxrdf::{NamedNode, Term};
 use sparq_core::Graph;
 use sparq_vectors::{
-    embed_entities, verbalize, Embedder, EntityTextConfig, HashEmbedder, ObjectKind,
-    PropertyGroup, VectorStore,
+    embed_entities, label_predicates, nearest_term_exact, verbalize, Embedder, EntityTextConfig,
+    HashEmbedder, ObjectKind, PropertyGroup, VectorStore,
 };
 
 const TTL: &str = r#"
@@ -138,9 +138,81 @@ fn char_budget_truncates_but_keeps_the_label() {
     };
     assert_eq!(verbalize(&g, &ex("bolt"), &cfg).unwrap(), "Usain Bolt. a athlete");
 
-    // Mid-piece overflow: the overflowing piece is truncated at a char boundary.
+    // Mid-piece overflow: back off rather than cutting the second word.
     cfg.max_chars = 8;
-    assert_eq!(verbalize(&g, &ex("bolt"), &cfg).unwrap(), "Usain Bo");
+    assert_eq!(verbalize(&g, &ex("bolt"), &cfg).unwrap(), "Usain");
+}
+
+#[test]
+fn verbalize_precision_at_k_fixture_is_not_worse_than_labels_only() {
+    // [GPT-5.6] Fixture-scale demonstration only: HashEmbedder is lexical and this is not a
+    // benchmark or a general retrieval-quality claim. The richer passages disambiguate two equal
+    // labels using their type and description.
+    const RANKING_TTL: &str = r#"
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix ex:     <http://example.org/> .
+
+ex:query rdfs:label "Mercury" ;
+    a ex:Planet ;
+    schema:description "orbiting planet astronomy" .
+ex:a-ambiguous rdfs:label "Mercury" ;
+    a ex:ChemicalElement ;
+    schema:description "liquid metal chemistry" .
+ex:z-correct rdfs:label "Mercury" ;
+    a ex:Planet ;
+    schema:description "orbiting planet astronomy" .
+"#;
+
+    let graph = Graph::load_str(RANKING_TTL, "turtle").unwrap();
+    let query = ex("query");
+    let correct = ex("z-correct");
+    let ambiguous = ex("a-ambiguous");
+    let ambiguous_id = graph.id_of(&ambiguous).unwrap();
+    let correct_id = graph.id_of(&correct).unwrap();
+    assert!(
+        ambiguous_id < correct_id,
+        "the labels-only cosine tie must prefer the ambiguous fixture id ({ambiguous_id} < {correct_id})"
+    );
+
+    let embedder = HashEmbedder::new(64);
+    let suffix = std::process::id();
+    let full_path =
+        std::env::temp_dir().join(format!("sparq-vectors-full-precision-{suffix}.spqv"));
+    let labels_path =
+        std::env::temp_dir().join(format!("sparq-vectors-label-precision-{suffix}.spqv"));
+
+    let mut full_store = VectorStore::create(&full_path, embedder.dim()).unwrap();
+    embed_entities(
+        &graph,
+        &mut full_store,
+        &embedder,
+        &EntityTextConfig::default(),
+    )
+    .unwrap();
+    full_store.finalize().unwrap();
+
+    let labels_cfg = EntityTextConfig::labels_only(label_predicates(), 256);
+    let mut labels_store = VectorStore::create(&labels_path, embedder.dim()).unwrap();
+    embed_entities(&graph, &mut labels_store, &embedder, &labels_cfg).unwrap();
+    labels_store.finalize().unwrap();
+
+    let full_hits = nearest_term_exact(&full_store, &graph, &query, 1);
+    let labels_hits = nearest_term_exact(&labels_store, &graph, &query, 1);
+    let precision_at_one =
+        |hits: &[(Term, f32)]| usize::from(hits.first().map(|h| &h.0) == Some(&correct));
+    let full_precision = precision_at_one(&full_hits);
+    let labels_precision = precision_at_one(&labels_hits);
+
+    assert_eq!(full_hits.first().map(|h| &h.0), Some(&correct));
+    assert_eq!(labels_hits.first().map(|h| &h.0), Some(&ambiguous));
+    assert!(
+        full_precision >= labels_precision,
+        "fixture precision@1: verbalize={full_precision}, labels_only={labels_precision}"
+    );
+
+    let _ = std::fs::remove_file(full_path);
+    let _ = std::fs::remove_file(labels_path);
 }
 
 #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent

Truncate overflowing verbalized and grounded passages at a shared word/sentence boundary without exceeding `max_chars`, while leaving fitting passages unchanged and preserving separator accounting.

Adds a direct non-vacuous boundary unit test and a fixture-scale HashEmbedder precision@1 comparison showing full label+type+description verbalization ranks the correct neighbor at least as precisely as labels-only. This is a deterministic fixture demonstration, not a benchmark claim.

Required gates passed:
- `cargo test -p sparq-vectors verbalize`
- `cargo test -p sparq-vectors grounding`
- both filters with `--features structure`
- `cargo clippy -p sparq-vectors --all-targets -- -D warnings`
- the same clippy gate with `--features structure`
- `git diff --check`

The unrelated workspace-wide rustfmt drift is pre-existing and tracked in #2362.