### PR TITLE
fix(http3): bound per-connection request concurrency (sq-4rkcc) [FABLE-5]

### DIFF
--- a/crates/sparq-http3/README.md
+++ b/crates/sparq-http3/README.md
@@ -12,7 +12,7 @@ so a default workspace build does not pull those dependencies.
 Enable `server` to convert an aws-lc-rs-backed rustls server configuration and dispatch
 HTTP/3 requests into a cloned `axum::Router`. The bridge injects the QUIC peer address as
 `ConnectInfo<SocketAddr>` and streams request and response bodies. Its compatibility entry point is
-safe by default: `serve_h3` applies global and per-IP concurrent-connection caps, while
+safe by default: `serve_h3` bounds global, per-IP, and per-connection-request concurrency;
 `serve_h3_with_limits` accepts custom `H3ConnectionLimits`. Internal IPs are exempt from the per-IP
 default but remain covered by the global cap. The generated Quinn configuration also uses a bounded
 connection receive window. After a QUIC endpoint binds, `alt_svc_layer` adds the exact

--- a/crates/sparq-http3/src/server.rs
+++ b/crates/sparq-http3/src/server.rs
@@ -27,6 +27,9 @@ const DEFAULT_MAX_CONNECTIONS: usize = 10_000;
 /// Default ceiling for concurrent HTTP/3 connections from one non-internal IP address.
 const DEFAULT_MAX_CONNECTIONS_PER_IP: usize = 512;
 
+/// Default ceiling for concurrently served requests on one HTTP/3 connection.
+const DEFAULT_MAX_REQUESTS_PER_CONNECTION: usize = 256;
+
 /// Connection-level QUIC receive window used by [`quic_server_config`].
 const RECEIVE_WINDOW_BYTES: u32 = 16 * 1024 * 1024;
 
@@ -53,6 +56,15 @@ pub struct H3ConnectionLimits {
     /// reverse proxy, container bridge, or conformance runner is not treated as a single public
     /// client.
     pub exempt_internal_ips: bool,
+    /// Maximum concurrently served requests on one HTTP/3 connection.
+    ///
+    /// Each connection acquires a permit from a per-connection semaphore before accepting the
+    /// next request stream, and the permit is held for the request task's whole lifetime, so a
+    /// single connection cannot fan out unbounded concurrent request tasks (stream-exhaustion
+    /// hardening). Acceptance of further request streams back-pressures until an in-flight
+    /// request completes; already-accepted requests keep progressing.
+    // [FABLE-5] sq-4rkcc: request-level bound mirroring the connection-level semaphore.
+    pub max_requests_per_connection: usize,
 }
 
 impl Default for H3ConnectionLimits {
@@ -61,6 +73,7 @@ impl Default for H3ConnectionLimits {
             max_connections: DEFAULT_MAX_CONNECTIONS,
             max_connections_per_ip: Some(DEFAULT_MAX_CONNECTIONS_PER_IP),
             exempt_internal_ips: true,
+            max_requests_per_connection: DEFAULT_MAX_REQUESTS_PER_CONNECTION,
         }
     }
 }
@@ -121,8 +134,9 @@ pub fn quic_server_config(
 /// inserted as `ConnectInfo<SocketAddr>`. Connection- and request-local protocol failures
 /// close only the affected connection or stream; the endpoint keeps accepting other peers.
 /// The default global and per-IP connection limits bound accepted connection work; internal IPs are
-/// exempt from the per-IP limit but remain subject to the global limit. On shutdown, all endpoint
-/// connections are closed and the function waits for them to drain.
+/// exempt from the per-IP limit but remain subject to the global limit, and each connection's
+/// concurrent request tasks are bounded by the default per-connection request limit. On shutdown,
+/// all endpoint connections are closed and the function waits for them to drain.
 pub async fn serve_h3(
     endpoint: quinn::Endpoint,
     router: Router,
@@ -136,7 +150,11 @@ pub async fn serve_h3(
 /// A global semaphore permit is reserved before polling `endpoint.accept()`, so connections beyond
 /// the global cap remain in Quinn's bounded incoming queue rather than creating tasks. After accept,
 /// a non-exempt peer at its per-IP cap is refused before a task is spawned. Both slots are held for
-/// the full handshake and connection lifetime and released on every exit path.
+/// the full handshake and connection lifetime and released on every exit path. Within each
+/// connection, a request-level semaphore permit is acquired before accepting the next request
+/// stream and moved into the request task, so at most
+/// [`max_requests_per_connection`](H3ConnectionLimits::max_requests_per_connection) request tasks
+/// run concurrently per connection.
 pub async fn serve_h3_with_limits(
     endpoint: quinn::Endpoint,
     router: Router,
@@ -145,6 +163,10 @@ pub async fn serve_h3_with_limits(
 ) -> io::Result<()> {
     tokio::pin!(shutdown);
     let limiter = ConnectionLimiter::new(limits);
+    // [FABLE-5] sq-4rkcc: clamp like ConnectionLimiter::new so zero cannot disable requests.
+    let max_requests_per_connection = limits
+        .max_requests_per_connection
+        .clamp(1, Semaphore::MAX_PERMITS);
 
     loop {
         let permit = tokio::select! {
@@ -180,7 +202,9 @@ pub async fn serve_h3_with_limits(
                         return;
                     };
                     let peer_addr = connection.remote_address();
-                    let _ = serve_connection(connection, router, peer_addr).await;
+                    let _ =
+                        serve_connection(connection, router, peer_addr, max_requests_per_connection)
+                            .await;
                 });
             }
         }
@@ -285,24 +309,43 @@ fn is_internal_ip(ip: IpAddr) -> bool {
     }
 }
 
+/// Serves one HTTP/3 connection, bounding its concurrent request tasks.
+///
+/// Mirroring the connection-level limiter, an owned permit from a per-connection semaphore is
+/// acquired before polling `connection.accept()` and moved into the spawned request task, where
+/// it is held for the task's whole lifetime and released only when the task completes. When
+/// `max_concurrent_requests` request tasks are in flight, acceptance of further request streams
+/// back-pressures on the permit; in-flight requests keep progressing because each is driven by
+/// its own task, so a freed permit always unblocks the accept loop (no deadlock).
+// [FABLE-5] sq-4rkcc: cap the previously unbounded per-request tokio::spawn fan-out.
 async fn serve_connection(
     connection: quinn::Connection,
     router: Router,
     peer_addr: SocketAddr,
+    max_concurrent_requests: usize,
 ) -> Result<(), h3::error::ConnectionError> {
     let mut connection = h3::server::Connection::new(h3_quinn::Connection::new(connection)).await?;
+    let request_slots = Arc::new(Semaphore::new(max_concurrent_requests));
 
-    while let Some(resolver) = connection.accept().await? {
+    loop {
+        let permit = request_slots
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("the private per-connection request semaphore is never closed");
+        let Some(resolver) = connection.accept().await? else {
+            return Ok(());
+        };
         let router = router.clone();
         tokio::spawn(async move {
+            // Hold the request slot until this task finishes, releasing it on every exit path.
+            let _permit = permit;
             let Ok((request, stream)) = resolver.resolve_request().await else {
                 return;
             };
             let _ = dispatch_request(request, stream, router, peer_addr).await;
         });
     }
-
-    Ok(())
 }
 
 async fn dispatch_request<S>(

--- a/crates/sparq-http3/tests/h3_round_trip.rs
+++ b/crates/sparq-http3/tests/h3_round_trip.rs
@@ -198,6 +198,7 @@ async fn h3_dispatches_body_status_and_peer_connect_info() -> TestResult {
 
 async fn limited_server(
     limits: H3ConnectionLimits,
+    router: Router,
 ) -> TestResult<(
     SocketAddr,
     CertificateDer<'static>,
@@ -210,14 +211,9 @@ async fn limited_server(
     let endpoint = quinn::Endpoint::server(quic_server_config(tls)?, "127.0.0.1:0".parse()?)?;
     let server_addr = endpoint.local_addr()?;
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
-    let server = tokio::spawn(serve_h3_with_limits(
-        endpoint,
-        Router::new(),
-        limits,
-        async move {
-            let _ = shutdown_rx.await;
-        },
-    ));
+    let server = tokio::spawn(serve_h3_with_limits(endpoint, router, limits, async move {
+        let _ = shutdown_rx.await;
+    }));
     Ok((server_addr, cert, shutdown_tx, server))
 }
 
@@ -240,8 +236,9 @@ async fn global_connection_cap_queues_excess_connections_until_release() -> Test
         max_connections: 1,
         max_connections_per_ip: None,
         exempt_internal_ips: true,
+        ..H3ConnectionLimits::default()
     };
-    let (server_addr, cert, shutdown_tx, server) = limited_server(limits).await?;
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits, Router::new()).await?;
     let endpoint = client_endpoint(cert)?;
 
     let first = endpoint.connect(server_addr, "localhost")?.await?;
@@ -266,8 +263,9 @@ async fn per_ip_connection_cap_refuses_excess_connections() -> TestResult {
         max_connections: 4,
         max_connections_per_ip: Some(1),
         exempt_internal_ips: false,
+        ..H3ConnectionLimits::default()
     };
-    let (server_addr, cert, shutdown_tx, server) = limited_server(limits).await?;
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits, Router::new()).await?;
     let endpoint = client_endpoint(cert)?;
 
     let first = endpoint.connect(server_addr, "localhost")?.await?;
@@ -282,14 +280,89 @@ async fn per_ip_connection_cap_refuses_excess_connections() -> TestResult {
     stop_limited_server(endpoint, shutdown_tx, server).await
 }
 
+// [FABLE-5] sq-4rkcc: the load-bearing DoS-hardening invariant — with the per-connection request
+// limit at 1, a second request on the SAME connection must not reach the router while the first
+// request task still holds the sole permit; it may start only after that task completes. A raised
+// or removed limit, a permit dropped at the end of the accept-loop iteration, or a permit dropped
+// inside the task before dispatch all let the second request enter concurrently and turn the
+// negative-window assertion red.
+#[tokio::test]
+async fn per_connection_request_cap_backpressures_the_excess_request() -> TestResult {
+    let (entered_tx, mut entered_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let handler_release = release.clone();
+    let gated = move || {
+        let entered_tx = entered_tx.clone();
+        let release = handler_release.clone();
+        async move {
+            let _ = entered_tx.send(());
+            release
+                .acquire()
+                .await
+                .expect("the test release semaphore is never closed")
+                .forget();
+            StatusCode::OK
+        }
+    };
+    let limits = H3ConnectionLimits {
+        max_requests_per_connection: 1,
+        ..H3ConnectionLimits::default()
+    };
+    let router = Router::new().route("/gated", get(gated));
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits, router).await?;
+
+    let client_endpoint = client_endpoint(cert)?;
+    let connection = client_endpoint.connect(server_addr, "localhost")?.await?;
+    let (mut driver, sender) = h3::client::new(h3_quinn::Connection::new(connection)).await?;
+    let driver = tokio::spawn(async move {
+        let _ = poll_fn(|context| driver.poll_close(context)).await;
+    });
+
+    let url = format!("https://localhost:{}/gated", server_addr.port());
+    let mut first_sender = sender.clone();
+    let first_url = url.clone();
+    let first =
+        tokio::spawn(async move { request(&mut first_sender, Method::GET, first_url, None).await });
+    tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+        .await?
+        .ok_or("the first request never entered the handler")?;
+
+    let mut second_sender = sender.clone();
+    let second = tokio::spawn(async move { request(&mut second_sender, Method::GET, url, None).await });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(250), entered_rx.recv())
+            .await
+            .is_err(),
+        "the second request must not enter the handler while the sole request permit is held"
+    );
+
+    // Completing the first request task releases its permit and unblocks the accept loop.
+    release.add_permits(1);
+    tokio::time::timeout(Duration::from_secs(5), entered_rx.recv())
+        .await?
+        .ok_or("the second request never entered the handler after the permit was released")?;
+    release.add_permits(1);
+
+    let (status, _) = tokio::time::timeout(Duration::from_secs(5), first).await???;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _) = tokio::time::timeout(Duration::from_secs(5), second).await???;
+    assert_eq!(status, StatusCode::OK);
+
+    drop(sender);
+    client_endpoint.close(quinn::VarInt::from_u32(0), b"test complete");
+    tokio::time::timeout(Duration::from_secs(5), driver).await??;
+    stop_limited_server(client_endpoint, shutdown_tx, server).await
+}
+
 #[tokio::test]
 async fn internal_ip_exemption_leaves_only_the_global_cap() -> TestResult {
     let limits = H3ConnectionLimits {
         max_connections: 2,
         max_connections_per_ip: Some(1),
         exempt_internal_ips: true,
+        ..H3ConnectionLimits::default()
     };
-    let (server_addr, cert, shutdown_tx, server) = limited_server(limits).await?;
+    let (server_addr, cert, shutdown_tx, server) = limited_server(limits, Router::new()).await?;
     let endpoint = client_endpoint(cert)?;
 
     let first = endpoint.connect(server_addr, "localhost")?.await?;

--- a/skills/http3-server/SKILL.md
+++ b/skills/http3-server/SKILL.md
@@ -58,9 +58,10 @@ sparq_http3::serve_h3(endpoint, router.clone(), async move {
 # Ok::<(), std::io::Error>(())
 ```
 
-The compatibility entry point is safe by default: it limits total concurrent connections and
-connections from one public IP. Internal addresses are exempt from the per-IP cap to avoid treating
-a proxy, container bridge, or conformance runner as one client, but the global cap still applies.
+The compatibility entry point is safe by default: it limits total concurrent connections,
+connections from one public IP, and concurrent requests on each connection. Internal addresses are
+exempt from the per-IP cap to avoid treating a proxy, container bridge, or conformance runner as
+one client, but the global cap still applies.
 Existing callers need no changes. To tune the caps, use the additive variant:
 
 ```rust
@@ -68,13 +69,20 @@ let limits = sparq_http3::H3ConnectionLimits {
     max_connections: 2_000,
     max_connections_per_ip: Some(128),
     exempt_internal_ips: true,
+    max_requests_per_connection: 64,
 };
 sparq_http3::serve_h3_with_limits(endpoint, router.clone(), limits, shutdown_signal).await?;
 # Ok::<(), std::io::Error>(())
 ```
 
 Set `max_connections_per_ip` to `None` only when the global cap is sufficient for the deployment.
-Zero numeric caps are clamped to one rather than disabling the listener. The bridge clones the
+Zero numeric caps are clamped to one rather than disabling the listener.
+`max_requests_per_connection` is a stream-exhaustion bound ([FABLE-5] sq-4rkcc): each connection
+acquires a semaphore permit before accepting its next request stream, and the permit is held by
+the request task until it completes, so one connection cannot fan out unbounded concurrent
+request tasks. At the cap, acceptance of further request streams on that connection back-pressures
+until an in-flight request finishes; already-running requests keep progressing, and other
+connections are unaffected. The bridge clones the
 router per connection and request, streams request and response bodies, and inserts the Quinn peer
 address as `axum::extract::ConnectInfo<SocketAddr>`.
 That extension is load-bearing for request policies keyed by the remote socket address.


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — DoS-hardening: request-level concurrency bound in sparq-http3.

## What

`serve_connection()` spawned one **unbounded** `tokio::spawn` per accepted request stream, so a single HTTP/3 connection could fan out arbitrarily many concurrent request tasks (the stream-exhaustion surface flagged by the review of #2201). Connections were already bounded (`serve_h3_with_limits` + `H3ConnectionLimits` + a global semaphore + per-IP counts); this PR mirrors that exact pattern one level down, at the request level. Bead `sq-4rkcc`.

- `H3ConnectionLimits` gains a `pub max_requests_per_connection` field (default **256**; clamped to ≥1 like the other caps, so zero cannot disable the listener). `Default`/`serve_h3` construction keeps working; no external in-repo caller constructs the struct literally (verified: `sparq-server`/`sparq-lws-core` use `serve_h3` only).
- `serve_connection()` creates **one `Arc<Semaphore>` per connection**, sized to the (clamped) limit.

## Permit lifetime (the crux)

- **Acquire-before-accept:** an owned permit (`Semaphore::acquire_owned` on the `Arc`, so it is `'static`) is acquired on the accept loop **before** polling `connection.accept()` — mirroring the connection-level `limiter.acquire()`-before-`endpoint.accept()` shape — so acceptance of further request streams back-pressures while N tasks are in flight.
- **Moved into the task:** the `OwnedSemaphorePermit` is moved into the spawned task's async block (`let _permit = permit;`) and dropped only when the task completes, on every exit path (including the failed-`resolve_request` early return). It is *not* dropped at the end of the loop iteration.
- **No deadlock:** in-flight request streams are driven by their own tasks (h3 `RequestStream`s poll their quinn streams directly; QUIC flow control lives in quinn's own driver), so they progress while the accept loop is parked on the semaphore, and a finishing task always frees a permit. The new test exercises exactly this: the first request **completes while the accept loop is blocked**, which is what unblocks the second.

## Scope

Concurrency-bounding only — no change to request/response semantics, response bodies, or the HTTP/1.1/2 paths. Contained behind the existing default-off `server` feature; no new feature, no new dependency.

## Test (non-vacuous, mutation-checked)

`per_connection_request_cap_backpressures_the_excess_request`: with the limit at 1, two concurrent requests on ONE connection against a handler that signals entry and blocks on a test-controlled release. Asserts the second request does **not** reach the router while the first holds the sole permit (250 ms negative window), then enters only after the first completes; both finish 200. Verified red under two mutations: (a) permit dropped at end of the loop iteration instead of moved into the task, (b) semaphore sized `limit + 8`.

## Gates (all green locally)

- feature ON (`--features server`): `cargo build -p sparq-http3`, `cargo clippy -p sparq-http3 --all-targets -- -D warnings`, `cargo test -p sparq-http3` (8/8)
- feature OFF (default): build + clippy `--all-targets -D warnings` + test
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-http3 --all-features --no-deps` clean
- `scripts/check-readme-template.py --enforce`: 0 deviations (README held at its 30-line internal-stub cap)
- `typos` clean; branch merged against fresh `origin/main` before opening

## Docs

Public-API change (new pub field) → `skills/http3-server/SKILL.md` updated in this PR (limits example + back-pressure semantics), plus the crate README one-liner.

CI leg `opt-in sparq-http3 (server)` already exists in the feature-matrix golden, so the new test runs on CI without a golden change.