### PR TITLE
fix(orchestration): exclude epics from the dispatch frontier

### DIFF
--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -73,6 +73,12 @@ def issue_labels(bead):
     if isinstance(p, int) and 0 <= p <= 4:
         out.add(f"priority:P{p}")
     out.add(f"role:{role_for(bead)}")
+    # [OPUS-4.8] an epic is a tracking/umbrella issue, never a dispatchable work item — mark it
+    # `kind:epic` so the readiness engine excludes it (else a worker would try to "implement" the
+    # epic itself, producing a garbage PR). 57 of the 893 open beads are epics, 41 at P1 — they would
+    # otherwise be selected FIRST by priority. Enforcement is in ready-issues.py; this is the signal.
+    if str(bead.get("issue_type", "")).lower() == "epic":
+        out.add("kind:epic")
     return sorted(out)
 
 

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -27,6 +27,9 @@ import sys
 
 GATE_LABELS = ("needs:", "trust:untrusted")
 BUSY_STATUS = {"status:in-progress", "status:blocked", "status:deferred", "status:untriaged"}
+# [OPUS-4.8] an epic is a tracking umbrella (its children are the work) — never dispatchable, even
+# with a full ready label-set + zero blockers. Excluded here so a worker never "implements" an epic.
+NON_DISPATCHABLE = "kind:epic"
 GLOBAL = "__global__"  # the cross-cutting partition (serializes against everything)
 _PRIO = re.compile(r"^priority:P([0-4])$")   # only P0..P4 are valid
 _PKG = re.compile(r"^area:(.+)$")
@@ -78,6 +81,8 @@ def compute_ready(issues, in_progress_packages=None):
         L = labels_of(it)
         if "status:ready" not in L:          # positive attestation required
             continue
+        if NON_DISPATCHABLE in L:            # epics are tracking umbrellas, not work items
+            continue
         if is_gated(L) or is_busy(L):
             continue
         p = valid_priority(L)
@@ -120,6 +125,7 @@ def _self_test():
         iss(10, R + ["priority:P1", "area:sparq-fedplan", "status:in-progress"]),# in-progress fedplan
         iss(11, R + ["priority:P4"]),                                            # no package -> global
         iss(12, R + ["priority:P1", "area:sparq-hdt"]),                          # hdt (free)
+        iss(13, R + ["priority:P0", "area:sparq-text", "kind:epic"]),            # epic -> excluded
     ]
     ok = True
 
@@ -131,10 +137,12 @@ def _self_test():
 
     ready = compute_ready(F)
     # eligible: 1,2,3,12 (+11 global). 4 gated, 5 blocked, 6 closed, 7 untrusted, 8 no-ready,
-    # 9 ambiguous-prio, 10 in-progress. Order by prio: #2(P0 core) -> #3(P1 engine) -> #12(P1 hdt)
-    # -> #11(P4 global). core taken by #2 so #1(P2 core) excluded. #11 global: only selectable if
-    # nothing taken -> excluded (core/engine/hdt already taken).
+    # 9 ambiguous-prio, 10 in-progress, 13 epic (kind:epic → excluded despite a P0 ready label-set).
+    # Order by prio: #2(P0 core) -> #3(P1 engine) -> #12(P1 hdt) -> #11(P4 global). core taken by #2
+    # so #1(P2 core) excluded. #11 global: only selectable if nothing taken -> excluded.
     check("ready order", [i["number"] for i in ready], [2, 3, 12])
+    # a P0 epic with an otherwise-perfect ready label-set must NOT dispatch (tracking umbrella):
+    check("epic excluded", 13 in [i["number"] for i in ready], False)
     # a lone global issue with an empty board is selectable:
     check("lone global", [i["number"] for i in compute_ready([iss(11, R + ["priority:P4"])])], [11])
     # global blocks everything else:

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -58,7 +58,11 @@ def triage(labels, issue_type="task", trusted=True):
         # [OPUS-4.8] single-role invariant: strip any OTHER role:* labels so the dispatcher's
         # resolve() never sees an ambiguous role set (a security keyword may override an explicit role).
         remove |= {lb for lb in labels if lb.startswith("role:") and lb != f"role:{role}"}
-    ready = bool(role) and _valid_priority(labels) and "needs:user" not in labels
+    # [OPUS-4.8] an epic is a tracking umbrella, never dispatchable — it must not gain status:ready
+    # (the readiness engine also excludes kind:epic as the hard dispatch gate; this keeps the tracker
+    # honest so an epic never *shows* as ready).
+    ready = (bool(role) and _valid_priority(labels) and "needs:user" not in labels
+             and "kind:epic" not in labels)
     if ready:
         add.add("status:ready")
         remove.add("status:untriaged")
@@ -98,6 +102,8 @@ def _self_test():
     r = triage(["priority:P2", "role:site", "area:site"], "feature")
     chk("explicit role respected", (r["role"], "role:impl" in r["add"], any(x.startswith("role:") for x in r["remove"])),
         ("site", False, False))
+    # [OPUS-4.8] an epic is never dispatchable, even with a full priority+role label-set
+    chk("epic not ready", triage(["priority:P1", "role:impl", "kind:epic"], "epic")["ready"], False)
     # single-role invariant: a double-labelled issue is stripped to one role
     r = triage(["priority:P2", "role:impl", "role:site", "area:site"], "feature")
     chk("single-role invariant", (len([x for x in (({"role:impl", "role:site"} | r["add"]) - r["remove"]) if x.startswith("role:")]) == 1), True)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous orchestration hardening.

## Problem
The bd→issue migration maps `epic → role:impl`. Neither the migration nor the readiness engine excluded epics, so a migrated epic would become `status:ready` + `role:impl` + zero blockers (parent-child edges are not readiness blockers) → **`ready-issues.py::compute_ready()` would select it and a worker would try to "implement" the umbrella epic**, producing a garbage PR.

**Impact:** 57 of the 893 open beads are epics (41 at P1). Priority-ordered dispatch would grab them **first**.

## Fix (3 coherent parts)
- **`bd-to-issues.py`** — an `issue_type == epic` bead now carries a `kind:epic` label (the signal).
- **`ready-issues.py`** — `compute_ready()` excludes `kind:epic` (the hard dispatch gate). Self-test: a P0 epic with an otherwise-perfect ready label-set is excluded.
- **`triage.py`** — an epic is never marked `status:ready` (keeps the tracker honest).

## Verification
All three script self-tests pass:
- `triage.py --self-test` → `epic not ready` ✓
- `ready-issues.py --self-test` → `epic excluded` ✓ (non-vacuous: dropping the guard makes the P0 epic sort first → red)
- `bd-to-issues.py` dry-run: 57/57 epics tagged `kind:epic`, 0 non-epics wrongly tagged.

Prerequisite hardening before the full bd→issue migration.