### PR TITLE
chore(ci): reduce maintainer tag-noise + benchmark self-monitoring

### DIFF
--- a/.github/workflows/bench-ec2.yml
+++ b/.github/workflows/bench-ec2.yml
@@ -110,10 +110,16 @@ jobs:
           auto-push: true
           gh-pages-branch: benchmark-data
           benchmark-data-dir-path: dev/bench-ec2
+          # [OPUS-4.8] (noise-reduction-bench-selfmonitor) NO alert-comment-cc-users — the maintainer
+          # is never @-mentioned on a benchmark alert. This WEEKLY heavy lane is a cron run with no PR
+          # to block, so it stays comment-only (fail-on-alert: false) and does not hard-fail; the
+          # nightly full-suite lane below carries the two-zone gating + auto-attribution. This is a
+          # QUIET dedicated EC2 box, so the shared-runner-derived 175/200 thresholds do not apply; the
+          # kept 150% is a placeholder until dev/bench-ec2 accrues history for scripts/bench-thresholds.py
+          # to derive an EC2-specific value (documented-untested; refine once seeded).
           alert-threshold: '150%'
           comment-on-alert: true
           fail-on-alert: false
-          alert-comment-cc-users: '@jeswr'
 
   # [FABLE-5] (sq-6vshe.6 heavy-lane placement, MAINTAINER-DIRECTED) The NIGHTLY FULL-SUITE lane —
   # the destination for the noisy timing benchmarks moved OFF the per-PR / merge_group bench gate. It
@@ -130,12 +136,16 @@ jobs:
       github.repository == 'sparq-org/sparq' &&
       github.event_name == 'schedule' && github.event.schedule == '41 6 * * *'
     runs-on: ubuntu-latest
-    # Job-scoped writes (least privilege), identical to ec2-bench:
+    # Job-scoped writes (least privilege):
     #   id-token: write — assume the short-lived, tag-scoped IAM role via OIDC
     #   contents: write — github-action-benchmark pushes to the benchmark-data branch
+    #   issues: write   — [OPUS-4.8] the nightly-attribution step files a `bench-regression` issue
+    #                     (P1, role:impl) naming the ranked suspect commits — instead of @-mentioning
+    #                     anyone — so the regression enters the autonomous dispatch frontier.
     permissions:
       id-token: write
       contents: write
+      issues: write
     timeout-minutes: 45        # hard wall-clock cap (backstop to the script's own cleanup trap)
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -176,6 +186,28 @@ jobs:
               benchmark-data:benchmark-data
             echo "Created and pushed orphan benchmark-data branch."
           fi
+      # [OPUS-4.8] (noise-reduction-bench-selfmonitor) Capture the previously-published nightly point
+      # BEFORE the track step pushes the new one. github-action-benchmark only auto-pushes on a green
+      # run, so the latest published point IS the "last green nightly baseline": its data.js gives the
+      # previous per-metric values (for the regression comparison) and its newest entry's commit id is
+      # the baseline SHA the attribution ranks commits against. Absent on the first nightly (no baseline
+      # yet → the attribution step no-ops).
+      - name: Capture last-green-nightly baseline (before push)
+        id: nightly_baseline
+        run: |
+          set -uo pipefail
+          if git fetch --depth=50 origin benchmark-data 2>/dev/null \
+             && git show FETCH_HEAD:dev/bench-nightly/data.js > prev-nightly-data.js 2>/dev/null; then
+            echo "captured previous dev/bench-nightly/data.js"
+            base_sha="$(python3 scripts/bench-triage.py --mode baseline-sha \
+              --prev-data-js prev-nightly-data.js \
+              --suite 'sparq engine (nightly full suite)')"
+            echo "baseline_sha=${base_sha}" >> "$GITHUB_OUTPUT"
+            echo "last green nightly baseline sha: ${base_sha:-<none>}"
+          else
+            echo "no previous dev/bench-nightly/data.js (first nightly) — no baseline."
+            echo "baseline_sha=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Track nightly full-suite series
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
@@ -186,10 +218,52 @@ jobs:
           auto-push: true
           gh-pages-branch: benchmark-data
           benchmark-data-dir-path: dev/bench-nightly
-          alert-threshold: '150%'
+          # [OPUS-4.8] (noise-reduction-bench-selfmonitor) Two-zone thresholds (soft 175% / hard 200%)
+          # derived by scripts/bench-thresholds.py from the per-commit benchmark-data history (the
+          # nightly runs the SAME suite at the same 200k scale, so the same noise envelope applies; the
+          # quiet EC2 box is if anything less noisy, so these are conservative). comment-only here
+          # (fail-on-alert: false) — a nightly run has no PR/merge to block; instead the attribution
+          # step below files a `bench-regression` P1 issue for the HARD zone. NO alert-comment-cc-users:
+          # the maintainer is never @-mentioned; the issue enters the autonomous dispatch frontier.
+          alert-threshold: '175%'
+          fail-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: false
-          alert-comment-cc-users: '@jeswr'
+      # [OPUS-4.8] NIGHTLY ATTRIBUTION (noise-reduction-bench-selfmonitor). On a HARD-zone regression
+      # (>=200%) vs the last green nightly baseline, rank the most-likely culprit commits by
+      # intersecting each commit's touched crate paths with the crates the regressed suite exercises,
+      # and file ONE `bench-regression` issue per cluster (P1, role:impl, area:<crate>) with the
+      # regression table + ranked suspects + repro commands — NO @mentions. `if: always()` so a
+      # non-green run is still triaged; best-effort (exits 0). Fetch full history so `git log
+      # baseline..HEAD` can enumerate the landed commits.
+      - name: Nightly regression attribution (file a bench-regression issue; no @mentions)
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ ! -f nightly-bench-results.json ]; then
+            echo "no nightly-bench-results.json — nothing to attribute."; exit 0
+          fi
+          base_sha="${{ steps.nightly_baseline.outputs.baseline_sha }}"
+          if [ -z "$base_sha" ]; then
+            echo "no last-green-nightly baseline — skipping attribution (first nightly)."; exit 0
+          fi
+          # Deepen history so git log baseline..HEAD resolves (checkout was shallow).
+          git fetch --unshallow origin 2>/dev/null || git fetch --deepen=200 origin 2>/dev/null || true
+          python3 scripts/bench-triage.py --mode build-comparison \
+            --results nightly-bench-results.json \
+            --prev-data-js prev-nightly-data.js \
+            --suite 'sparq engine (nightly full suite)' \
+            --out nightly-comparison.json || { echo "::warning::comparison build failed (non-fatal)"; exit 0; }
+          python3 scripts/bench-triage.py --mode nightly \
+            --comparison nightly-comparison.json \
+            --soft 175 --hard 200 \
+            --baseline-sha "$base_sha" \
+            --head-sha "${{ github.sha }}" \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}" \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            || echo "::warning::nightly attribution filer failed (non-fatal)"
       # [FABLE-5] DEMOTION AUTO-BEAD PROTOCOL (research/ci-structural-speedup.md §7; mirrors fuzz.yml +
       # differential.yml). The full noisy timing suite was DEMOTED off per-PR/merge_group to this nightly
       # lane. If the nightly run FAILS (a suite correctness diff regressed, or the run itself broke) that

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -161,10 +161,14 @@ jobs:
     #   deployments: write  — github-action-benchmark records a GitHub deployment status
     #   pull-requests: write— comment-always posts the comparison table on (same-repo) PRs;
     #                         fork PRs get a read-only token, so the action skips the comment.
+    #   issues: write       — [OPUS-4.8] the soft-zone triage step files/updates a deduped
+    #                         `bench-flake` issue instead of @-mentioning anyone (no maintainer CC).
+    #                         Guarded to the canonical repo (fork PRs get a read-only token).
     permissions:
       contents: write
       deployments: write
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -490,18 +494,70 @@ jobs:
           # pre-merge, not only when an alert fires. [OPUS-4.8]
           comment-always: true
           summary-always: true
-          # GitHub-hosted runners are noisy, so this action's gate only flags a *large* regression and
-          # never hard-fails: fail-on-alert stays false because this single GLOBAL switch would otherwise
-          # trip on the noisy wall-clock latencies. The TRUE hard gate is the dedicated "Hard gate" step
-          # ABOVE (scripts/perf-gate.py): the DETERMINISTIC byte counts (store/dict bytes-per-{triple,term},
-          # store_bytes_per_triple_small, wasm_bundle_bytes) are gated strictly, and the TIMING metric
-          # parse_ns_per_byte is made robust to runner noise via best-of-N re-measure (real regressions
-          # still fail). This action keeps the trend chart + alert comment for ALL metrics (including the
-          # latency trends) for human review. [OPUS-4.8]
-          alert-threshold: '150%'
+          # [OPUS-4.8] TWO-ZONE self-monitoring thresholds (noise-reduction-bench-selfmonitor;
+          # maintainer-directed). GitHub-hosted runners are noisy, so a single global switch would
+          # either trip constantly on µs-scale wall-clock jitter or be so loose it catches nothing.
+          # Instead this action now gates in TWO empirically-derived zones:
+          #   * alert-threshold: '175%'  — SOFT zone. Emits an alert COMMENT but does NOT fail the
+          #     step (comment-only for the soft band; the "Soft-zone triage" step below files/updates a
+          #     deduped `bench-flake` issue for it — NO @mention of anyone). 175% ≈ p95 run-to-run
+          #     timing swing (43.66%) + ~30pp headroom.
+          #   * fail-threshold: '200%' + fail-on-alert: true — HARD zone. A regression at/above 200%
+          #     is clearly BEYOND any observed shared-runner noise (worst observed noise swing over the
+          #     20-commit history = 185.0%), so the STEP FAILS CI. An agent must fix it.
+          # WHERE THE TIMING HARD-FAIL BITES (honest — it does NOT re-noise the per-PR gate): under
+          # sq-6vshe.6 (also maintainer-directed) the PR run is `--deterministic-only`, so on a PR this
+          # step sees ONLY the deterministic byte-count metrics (0.00% noise; already strictly gated by
+          # the "Hard gate" perf-gate.py step above — this fail-on-alert is a redundant looser backstop
+          # there and never trips on runner noise). The NOISY TIMING metrics run on push-to-main + the
+          # nightly EC2 lane, so the timing hard-fail bites THERE (a post-merge / nightly hard signal),
+          # NOT on the per-PR path — deliberately, so this change does not re-introduce the merge-queue
+          # flapping sq-6vshe.6 removed. Pre-merge timing coverage stays the nightly attribution lane
+          # (bench-ec2.yml), which files a P1 `bench-regression` issue into the dispatch frontier.
+          # DERIVATION (no hard-coded perf numbers in markdown — the numbers live here + are recomputable):
+          #   scripts/bench-thresholds.py recomputes both from the benchmark-data history; over 20
+          #   commits × 322 timing metrics (6137 adjacent-pair samples) the pooled p95 run-to-run swing
+          #   was 43.66% and the worst 185.0%; deterministic byte-count metrics are 0.00% noise. Re-run
+          #   that script and refresh these two values if the noise floor shifts.
+          # The DETERMINISTIC byte-count ratchet remains the strict, separate "Hard gate" step ABOVE
+          # (scripts/perf-gate.py) — this action's zones govern only the NOISY timing metrics.
+          # NO alert-comment-cc-users: the maintainer is never @-mentioned; soft-zone flakiness routes
+          # to a deduped issue and hard-zone timing failures block the run for an agent to fix.
+          alert-threshold: '175%'
+          fail-threshold: '200%'
           comment-on-alert: true
-          fail-on-alert: false
-          alert-comment-cc-users: '@jeswr'
+          fail-on-alert: true
+      # [OPUS-4.8] SOFT-ZONE triage (noise-reduction-bench-selfmonitor). Runs AFTER the action —
+      # `if: always()` so it still fires when the action HARD-FAILED (hard zone) above; it re-derives
+      # the two zones from the SAME thresholds and files/updates a deduped `bench-flake` GitHub issue
+      # for any SOFT-zone metric (>=175% and <200%), with NO @mention of anyone. It NEVER weakens the
+      # hard gate: the action's own fail-on-alert already failed the step for the hard zone; this step
+      # only handles the soft (possible-flakiness) band and always exits 0 (its filing is best-effort).
+      # Canonical repo only — fork PRs get a read-only token, so no issue can be filed there.
+      - name: Soft-zone triage (file a deduped bench-flake issue; no @mentions)
+        if: always() && github.repository == 'sparq-org/sparq'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          if [ ! -f bench-results.json ]; then
+            echo "no bench-results.json (bench did not run to completion) — nothing to triage."
+            exit 0
+          fi
+          # Build the normalized comparison from THIS run's results + the previously-published point
+          # (prev-data.js fetched by the "Fetch previous benchmark series" step; absent on first run).
+          python3 scripts/bench-triage.py --mode build-comparison \
+            --results bench-results.json \
+            --prev-data-js prev-data.js \
+            --suite 'sparq engine' \
+            --out bench-comparison.json || { echo "::warning::comparison build failed (non-fatal)"; exit 0; }
+          # Thresholds MUST match the github-action-benchmark step above (derived by
+          # scripts/bench-thresholds.py from the benchmark-data history).
+          python3 scripts/bench-triage.py --mode soft \
+            --comparison bench-comparison.json \
+            --soft 175 --hard 200 \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            || echo "::warning::soft-zone triage filer failed (non-fatal)"
       # [OPUS-4.8] Seed the custom Pages dashboard onto benchmark-data IF ABSENT (or stale).
       # github-action-benchmark only writes its DEFAULT index.html when one does NOT already exist
       # (fs.stat early-return) but OVERWRITES data.js every run — so a CUSTOM dashboard committed

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,17 +1,24 @@
 # CODEOWNERS — sparq
 #
-# [OPUS-4.8] Governance: code ownership (bead sq-fvip).
+# [OPUS-4.8] Governance: code ownership (bead sq-fvip; policy revised under
+# noise-reduction-bench-selfmonitor).
 #
-# GitHub applies the LAST matching pattern in this file to a changed path, so the
-# catch-all comes FIRST and the high-risk, security-sensitive paths come AFTER it
-# (a later, more specific line overrides the earlier catch-all). When branch
-# protection requires CODEOWNERS review (see docs/branch-protection.md), a PR
-# touching any path below requires approval from its listed owner.
+# POLICY — codeowner review-requests are RESERVED for the rare, genuinely
+# security-critical surfaces. Everything else in the repo is covered by the
+# automated review pipeline (adversarial/mechanical verify + the Copilot review)
+# and the single required `ci-summary / gate` aggregator; it does NOT auto-request
+# a human review. A prior catch-all `* @jeswr` (plus high-churn /crates/sparq-core/,
+# /crates/sparq-server/, and /.github/ entries) auto-requested the maintainer on
+# EVERY pull request — an unsustainable review-notification load with no security
+# benefit, since those paths are already gated by CI. Those entries are removed.
+#
+# GitHub applies the LAST matching pattern to a changed path. With the catch-all
+# gone, a PR that touches NONE of the paths below requests no codeowner and merges
+# on the automated pipeline + the gate alone. A PR touching a path below still
+# requires that owner's approval when branch protection requires CODEOWNERS review
+# (see docs/branch-protection.md).
 
-# Default owner for everything in the repo.
-*                               @jeswr
-
-# --- High-risk / security-sensitive paths (override the catch-all above) ---
+# --- Security-critical paths ONLY (each is a deliberate, low-churn exception) ---
 
 # Zero-knowledge proof estate: cryptographic soundness is load-bearing here and
 # the v1 verifier is NOT sound yet (see research/zk-soundness-audit.md + SECURITY.md).
@@ -21,16 +28,7 @@
 # Multi-party computation scaffold: crypto deferred, no security guarantee.
 /crates/sparq-mpc/              @jeswr
 
-# Core engine: contains the `unsafe` and the mmap/encoding internals.
-/crates/sparq-core/             @jeswr
-
-# Network-facing surface: the SPARQL 1.1 Protocol HTTP server.
-/crates/sparq-server/           @jeswr
-
-# CI / workflows / issue + PR templates / this ownership file.
-/.github/                       @jeswr
-
-# Supply-chain policy (cargo-deny). Owned even before the file lands.
+# Supply-chain policy (cargo-deny): allow/deny lists gate what enters the build.
 deny.toml                       @jeswr
 
 # The security policy itself.

--- a/scripts/bench-thresholds.py
+++ b/scripts/bench-thresholds.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Empirical benchmark-noise threshold deriver (noise-reduction-bench-selfmonitor).
+#
+# WHY — the benchmark self-monitoring two-zone design (maintainer-directed). The per-PR /
+# merge github-action-benchmark step compares each metric's current value against the
+# published `benchmark-data` series and, in the maintainer's design, gates in TWO zones:
+#   * SOFT (alert-threshold): a regression that COULD be shared-runner noise — it does NOT
+#     fail CI and does NOT @-mention anyone; it auto-files/updates a deduped bench-flake
+#     issue (see scripts/bench-triage.py).
+#   * HARD (fail-threshold + fail-on-alert): a regression clearly BEYOND any observed runner
+#     noise — the benchmark step FAILS CI so an agent must fix it before merge.
+#
+# The two thresholds MUST be derived empirically from the historical run-to-run variance of
+# the timing metrics on largely-unchanged code, NOT invented. This script recomputes them
+# from the `benchmark-data` history branch so the values baked into the workflow YAML can be
+# re-derived + justified at any time. It is NOT run in the gating path — it is the audit /
+# refresh tool the workflow comments cite. (No hard-coded perf numbers land in markdown; the
+# thresholds live in the workflow YAML only, and this script reproduces them on demand.)
+#
+# github-action-benchmark semantics: for a `customSmallerIsBetter` metric it computes the
+# ratio (current / previous). A threshold of `150%` means "alert when current >= 1.5x
+# previous" i.e. a +50% regression. So the natural noise quantity is the run-to-run RELATIVE
+# CHANGE abs(v2 - v1) / v1 between adjacent commits' values for the SAME metric.
+#
+# DERIVATION POLICY (documented so the numbers are reproducible, not magical):
+#   soft alert-threshold  = 100% + round_up(p95 timing swing + ~30pp headroom)   [>= 125%]
+#   hard fail-threshold   = 100% + clamp(worst observed timing swing, ...)         [>= 150%]
+#                           capped at 200% so a genuine 2x regression is still caught
+#                           (2x-worst-swing is uselessly loose once the worst swing is a
+#                           microsecond-scale flake); floored at 150% per the directive.
+#
+# USAGE
+#   scripts/bench-thresholds.py                      # derive from origin/benchmark-data
+#   scripts/bench-thresholds.py --data-js path/to/data.js [--data-js ...]   # from files
+#   scripts/bench-thresholds.py --json               # machine-readable output
+#   scripts/bench-thresholds.py --self-test          # hermetic; no git, no network
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import subprocess
+import sys
+from statistics import median
+
+PROG = "bench-thresholds"
+
+# The dashboards on the benchmark-data branch. dev/bench is the PER-COMMIT GitHub-hosted-
+# runner series the PR/merge github-action-benchmark step compares against, so it is the
+# noise source that governs the gating thresholds. The EC2 / nightly quiet-box series are
+# far less noisy and reported separately (informational) when present.
+_DEFAULT_DATA_PATHS = [
+    "dev/bench/data.js",
+    "dev/bench-ec2/data.js",
+    "dev/bench-nightly/data.js",
+]
+_GATING_DASHBOARD = "dev/bench/data.js"
+
+# Metric-name category heuristics (name-substring based; case-insensitive).
+_BYTE_PAT = re.compile(r"(_bytes|bytes_per|bytes_per_triple|bytes_per_term|bundle_bytes)", re.I)
+_TIMING_PAT = re.compile(r"(_ns|_ms|_us|ns_per|per_byte|latency|_secs|_s\b|throughput|qps)", re.I)
+_COUNT_PAT = re.compile(r"(_rows|_triples|_terms|_chars|_count|_gates|recall)", re.I)
+
+
+def log(msg: str) -> None:
+    print(f"[{PROG}] {msg}", file=sys.stderr)
+
+
+def parse_data_js(text: str) -> dict:
+    """Parse a github-action-benchmark data.js (`window.BENCHMARK_DATA = {...};`) payload."""
+    # Strip the assignment prefix + any trailing semicolon/whitespace.
+    m = re.search(r"window\.BENCHMARK_DATA\s*=\s*", text)
+    if m:
+        text = text[m.end():]
+    text = text.strip()
+    if text.endswith(";"):
+        text = text[:-1].strip()
+    return json.loads(text)
+
+
+def categorize(name: str) -> str:
+    if _BYTE_PAT.search(name):
+        return "byte"
+    if _TIMING_PAT.search(name):
+        return "timing"
+    if _COUNT_PAT.search(name):
+        return "count"
+    return "other"
+
+
+def adjacent_rel_changes(entries: list) -> dict:
+    """metric-name -> list of abs relative changes between adjacent distinct-commit values.
+
+    entries is one suite's list of run records (each with 'commit' and 'benches'). We order
+    by date (github-action-benchmark appends chronologically), then for every adjacent pair of
+    DISTINCT commits compute abs(v2 - v1) / v1 per metric. On largely-unchanged code this
+    approximates the run-to-run noise; genuine perf-changing commits inflate it (conservative).
+    """
+    ordered = sorted(entries, key=lambda e: e.get("date", 0))
+    per_metric_series: dict[str, list[tuple[str, float]]] = {}
+    for e in ordered:
+        commit_id = (e.get("commit") or {}).get("id") or str(e.get("date", ""))
+        for b in e.get("benches", []):
+            name = b.get("name")
+            val = b.get("value")
+            if name is None or not isinstance(val, (int, float)):
+                continue
+            per_metric_series.setdefault(name, []).append((commit_id, float(val)))
+    changes: dict[str, list[float]] = {}
+    for name, series in per_metric_series.items():
+        out = []
+        for (c1, v1), (c2, v2) in zip(series, series[1:]):
+            if c1 == c2 or v1 == 0:
+                continue
+            out.append(abs(v2 - v1) / abs(v1))
+        if out:
+            changes[name] = out
+    return changes
+
+
+def _pct(x: float) -> float:
+    return round(x * 100.0, 2)
+
+
+def _quantile(sorted_vals: list[float], q: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    pos = q * (len(sorted_vals) - 1)
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return sorted_vals[lo]
+    frac = pos - lo
+    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+
+
+def summarize(changes: dict, category: str) -> dict:
+    """Pool the relative-change fractions across all metrics in a category."""
+    pool: list[float] = []
+    for name, vals in changes.items():
+        if categorize(name) == category:
+            pool.extend(vals)
+    pool.sort()
+    if not pool:
+        return {"category": category, "metrics": 0, "pairs": 0}
+    return {
+        "category": category,
+        "metrics": sum(1 for n in changes if categorize(n) == category),
+        "pairs": len(pool),
+        "median_pct": _pct(median(pool)),
+        "p90_pct": _pct(_quantile(pool, 0.90)),
+        "p95_pct": _pct(_quantile(pool, 0.95)),
+        "p99_pct": _pct(_quantile(pool, 0.99)),
+        "max_pct": _pct(max(pool)),
+    }
+
+
+def derive_thresholds(timing_summary: dict, n_runs: int) -> dict:
+    """Turn a timing-noise summary into github-action-benchmark soft/hard percentages.
+
+    Returns {soft, hard, basis} where soft/hard are integer percentages (150 == 1.5x).
+    Conservative fallback when the sample is too small (<5 runs) to characterise the tail.
+    """
+    if not timing_summary or timing_summary.get("pairs", 0) == 0 or n_runs < 5:
+        return {
+            "soft": 130,
+            "hard": 200,
+            "basis": (
+                f"CONSERVATIVE FALLBACK — too little history "
+                f"(runs={n_runs}, timing-pairs={timing_summary.get('pairs', 0)}) to derive "
+                f"robustly; re-run bench-thresholds.py once more history accrues."
+            ),
+        }
+    p95 = timing_summary["p95_pct"]
+    worst = timing_summary["max_pct"]
+    # Soft: p95 swing + ~30pp headroom, expressed as a github-action-benchmark ratio %.
+    soft = int(math.ceil((100.0 + p95 + 30.0) / 5.0) * 5)  # round UP to nearest 5%
+    soft = max(soft, 125)
+    # Hard: above the worst observed noise swing, floored at 150%, capped at 200% (a genuine
+    # 2x regression is still caught; 2x-worst is uselessly loose once worst is a µs flake).
+    hard = int(math.ceil((100.0 + worst) / 5.0) * 5)
+    hard = max(hard, 150)
+    hard = min(hard, 200)
+    if hard <= soft:
+        hard = min(max(soft + 25, 150), 200)
+    return {
+        "soft": soft,
+        "hard": hard,
+        "basis": (
+            f"soft={soft}% = 100 + p95 timing swing ({p95}%) + ~30pp headroom, rounded up to 5%; "
+            f"hard={hard}% = above worst observed timing noise swing ({worst}%), floored 150% / "
+            f"capped 200%; over {n_runs} runs."
+        ),
+    }
+
+
+def git_show(ref: str, path: str) -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "show", f"{ref}:{path}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        return None
+
+
+def load_from_git(ref: str) -> dict:
+    """dashboard-path -> parsed data.js dict, for every dashboard present at `ref`."""
+    # Best-effort fetch (no checkout) so origin/<ref> resolves in CI + locally.
+    subprocess.run(
+        ["git", "fetch", "origin", "benchmark-data:refs/remotes/origin/benchmark-data"],
+        capture_output=True, text=True,
+    )
+    out = {}
+    for p in _DEFAULT_DATA_PATHS:
+        raw = git_show(ref, p)
+        if raw is None:
+            log(f"{p}: absent at {ref} (skipped)")
+            continue
+        try:
+            out[p] = parse_data_js(raw)
+        except (json.JSONDecodeError, ValueError) as e:
+            log(f"{p}: parse failed ({e})")
+    return out
+
+
+def report(datasets: dict) -> dict:
+    """Build the full report + the gating-dashboard thresholds."""
+    result = {"dashboards": {}, "gating": None}
+    for path, data in datasets.items():
+        entries = data.get("entries", {})
+        # A dashboard has ONE suite normally, but pool across all suites in the file.
+        pooled_changes: dict[str, list[float]] = {}
+        n_runs = 0
+        for suite, suite_entries in entries.items():
+            n_runs = max(n_runs, len(suite_entries))
+            for name, vals in adjacent_rel_changes(suite_entries).items():
+                pooled_changes.setdefault(f"{suite}::{name}", []).extend(vals)
+        cats = {c: summarize(pooled_changes, c) for c in ("byte", "count", "timing", "other")}
+        result["dashboards"][path] = {"runs": n_runs, "categories": cats}
+        if path == _GATING_DASHBOARD:
+            result["gating"] = {
+                "dashboard": path,
+                "runs": n_runs,
+                "timing": cats["timing"],
+                "thresholds": derive_thresholds(cats["timing"], n_runs),
+            }
+    if result["gating"] is None:
+        # No dev/bench history present — conservative fallback.
+        result["gating"] = {
+            "dashboard": _GATING_DASHBOARD,
+            "runs": 0,
+            "timing": {},
+            "thresholds": derive_thresholds({}, 0),
+        }
+    return result
+
+
+def render_human(rep: dict) -> str:
+    lines = []
+    for path, d in rep["dashboards"].items():
+        lines.append(f"== {path} ({d['runs']} runs) ==")
+        for cat in ("byte", "count", "timing", "other"):
+            c = d["categories"][cat]
+            if c.get("pairs", 0) == 0:
+                lines.append(f"  {cat:7s}: (none)")
+                continue
+            lines.append(
+                f"  {cat:7s}: metrics={c['metrics']} pairs={c['pairs']} "
+                f"median={c['median_pct']}% p95={c['p95_pct']}% max={c['max_pct']}%"
+            )
+    g = rep["gating"]
+    t = g["thresholds"]
+    lines.append("")
+    lines.append(f"GATING dashboard: {g['dashboard']} ({g['runs']} runs)")
+    lines.append(f"  soft alert-threshold : {t['soft']}%")
+    lines.append(f"  hard fail-threshold  : {t['hard']}%")
+    lines.append(f"  basis: {t['basis']}")
+    return "\n".join(lines)
+
+
+# ── self-test (hermetic: no git, no network) ─────────────────────────────────────
+def self_test() -> int:
+    # parse_data_js strips the assignment + trailing semicolon.
+    js = 'window.BENCHMARK_DATA = {"entries": {"s": []}};\n'
+    assert parse_data_js(js) == {"entries": {"s": []}}
+    assert parse_data_js('window.BENCHMARK_DATA = {"a":1}') == {"a": 1}
+
+    # categorization.
+    assert categorize("store_bytes_per_triple") == "byte"
+    assert categorize("wasm_bundle_bytes") == "byte"
+    assert categorize("watdiv_q1_us") == "timing"
+    assert categorize("parse_ns_per_byte") == "timing"
+    assert categorize("result_rows") == "count"
+    assert categorize("some_gauge") == "other"
+
+    # adjacent_rel_changes: deterministic byte metric = 0 noise; timing metric picks up swing.
+    entries = [
+        {"commit": {"id": "c1"}, "date": 1, "benches": [
+            {"name": "store_bytes_per_triple", "value": 100.0},
+            {"name": "q_us", "value": 10.0},
+        ]},
+        {"commit": {"id": "c2"}, "date": 2, "benches": [
+            {"name": "store_bytes_per_triple", "value": 100.0},   # unchanged
+            {"name": "q_us", "value": 12.0},                       # +20%
+        ]},
+        {"commit": {"id": "c3"}, "date": 3, "benches": [
+            {"name": "store_bytes_per_triple", "value": 100.0},
+            {"name": "q_us", "value": 6.0},                        # -50%
+        ]},
+    ]
+    ch = adjacent_rel_changes(entries)
+    assert ch["store_bytes_per_triple"] == [0.0, 0.0], ch["store_bytes_per_triple"]
+    assert abs(ch["q_us"][0] - 0.20) < 1e-9 and abs(ch["q_us"][1] - 0.50) < 1e-9, ch["q_us"]
+
+    # Same commit id adjacent => the pair is dropped (a scheduled re-run of the same SHA).
+    dup = [
+        {"commit": {"id": "c1"}, "date": 1, "benches": [{"name": "q_us", "value": 10.0}]},
+        {"commit": {"id": "c1"}, "date": 2, "benches": [{"name": "q_us", "value": 99.0}]},
+    ]
+    assert "q_us" not in adjacent_rel_changes(dup)
+
+    # summarize byte category => all zero; timing => nonzero p95/max.
+    byte_sum = summarize(ch, "byte")
+    assert byte_sum["max_pct"] == 0.0 and byte_sum["p95_pct"] == 0.0
+    timing_sum = summarize(ch, "timing")
+    assert timing_sum["max_pct"] == 50.0 and timing_sum["pairs"] == 2
+
+    # quantile sanity.
+    assert _quantile([0, 100], 0.0) == 0 and _quantile([0, 100], 1.0) == 100
+    assert _quantile([0, 100], 0.5) == 50
+
+    # derive_thresholds: with enough runs, soft > p95, hard capped at 200 and > soft.
+    ts = derive_thresholds({"pairs": 100, "p95_pct": 43.3, "max_pct": 185.0}, 20)
+    assert ts["soft"] == 175, ts          # ceil((100+43.3+30)/5)*5 = 175
+    assert ts["hard"] == 200, ts          # ceil((100+185)/5)*5 = 285 -> capped 200
+    assert ts["hard"] > ts["soft"]
+    # Small worst swing => hard floored at 150, still > soft.
+    ts2 = derive_thresholds({"pairs": 100, "p95_pct": 10.0, "max_pct": 20.0}, 20)
+    assert ts2["soft"] == 140 and ts2["hard"] == 150, ts2
+    # Too little history => conservative fallback.
+    ts3 = derive_thresholds({"pairs": 3, "p95_pct": 5.0, "max_pct": 5.0}, 3)
+    assert ts3["soft"] == 130 and ts3["hard"] == 200 and "CONSERVATIVE" in ts3["basis"]
+    ts4 = derive_thresholds({}, 0)
+    assert ts4["soft"] == 130 and ts4["hard"] == 200
+
+    # end-to-end report over a tiny in-memory dataset.
+    datasets = {
+        _GATING_DASHBOARD: {"entries": {"sparq engine": entries}},
+    }
+    rep = report(datasets)
+    assert rep["gating"]["dashboard"] == _GATING_DASHBOARD
+    assert rep["gating"]["runs"] == 3
+    assert "soft" in rep["gating"]["thresholds"] and "hard" in rep["gating"]["thresholds"]
+    txt = render_human(rep)
+    assert "GATING dashboard" in txt and "soft alert-threshold" in txt
+
+    log("self-test OK")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog=PROG)
+    ap.add_argument("--ref", default="origin/benchmark-data",
+                    help="git ref holding the dashboards (default origin/benchmark-data)")
+    ap.add_argument("--data-js", action="append", default=None,
+                    help="explicit data.js file(s) instead of reading from git")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.data_js:
+        datasets = {}
+        for p in args.data_js:
+            try:
+                with open(p, encoding="utf-8") as fh:
+                    datasets[p] = parse_data_js(fh.read())
+            except (OSError, json.JSONDecodeError, ValueError) as e:
+                log(f"{p}: {e}")
+    else:
+        datasets = load_from_git(args.ref)
+
+    if not datasets:
+        log("no benchmark-data dashboards found — nothing to derive from.")
+        rep = report({})
+    else:
+        rep = report(datasets)
+
+    if args.json:
+        print(json.dumps(rep, indent=2))
+    else:
+        print(render_human(rep))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench-triage.py
+++ b/scripts/bench-triage.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Benchmark self-monitoring triage (noise-reduction-bench-selfmonitor).
+#
+# WHY — the maintainer gets @-mentioned on every benchmark alert. This script replaces the
+# @-mention noise with SELF-MONITORING: it classifies each flagged benchmark into a two-zone
+# model and routes it to the AUTONOMOUS-AGENT workflow instead of a human, with NO @mentions
+# anywhere.
+#
+# TWO ZONES (thresholds derived empirically by scripts/bench-thresholds.py from the
+# benchmark-data history; the values live in the workflow YAML, not here):
+#   * HARD  — a regression clearly BEYOND any observed shared-runner noise. github-action-
+#             benchmark's own fail-on-alert (with the hard fail-threshold) FAILS the benchmark
+#             STEP directly, so an agent must fix it before merge. This script does NOT need to
+#             re-implement the hard fail — it OWNS the two SOFT paths below.
+#   * SOFT  — a regression that COULD be shared-runner flakiness (between the soft alert-
+#             threshold and the hard fail-threshold). Do NOT notify anyone. Instead auto-file /
+#             update ONE rolling deduped GitHub issue per benchmark suite (label `bench-flake`),
+#             listing the flagged benchmarks + runs. No @mentions.
+#
+# NIGHTLY ATTRIBUTION (--mode nightly): when the scheduled/nightly bench detects a regression
+# vs the last green nightly baseline, rank the most likely culprit commits/PRs by intersecting
+# each commit's touched paths with the crates the regressed suite exercises (a small static
+# suite->crate map seeded from the bench-harness dir names). File ONE issue per regression
+# cluster (label `bench-regression`, priority:P1, role:impl, area:<most-likely crate>) with the
+# regression table + ranked suspect list + repro commands. No @mentions. These issues enter the
+# normal autonomous dispatch frontier so agents fix them.
+#
+# The gating (HARD) decision stays in github-action-benchmark (fail-on-alert + fail-threshold).
+# This script is invoked AFTER the action, reads its comparison output, and does the SOFT +
+# nightly routing. It NEVER weakens a gate.
+#
+# USAGE
+#   # soft-zone triage from a github-action-benchmark comparison JSON:
+#   scripts/bench-triage.py --mode soft --comparison cmp.json \
+#       --soft 175 --hard 200 --run-url URL
+#   # nightly attribution:
+#   scripts/bench-triage.py --mode nightly --comparison cmp.json \
+#       --soft 175 --hard 200 --baseline-sha SHA --head-sha SHA --run-url URL
+#   scripts/bench-triage.py --self-test          # hermetic; no gh, no git, no writes
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PROG = "bench-triage"
+FLAKE_LABEL = "bench-flake"
+REGRESSION_LABEL = "bench-regression"
+FLAKE_MARKER = "[bench-flake]"
+REGRESSION_MARKER = "[bench-regression]"
+
+# ── suite -> crate map (seeded from the bench-harness dir names + real metric-name prefixes) ──
+# Metric names in the github-action-benchmark series are prefixed by their suite/harness. We map
+# each metric to the CRATES it exercises so a nightly regression can be attributed to the commits
+# that touched those crates. This is a STATIC seed (a fine starting point per the directive); it
+# is intentionally conservative — an unmapped metric falls back to the core engine closure, which
+# every query benchmark ultimately exercises.
+#
+# Keys are metric-name PREFIXES (matched longest-first). Values are the crate dirs under crates/.
+_PREFIX_CRATES: dict[str, list[str]] = {
+    # well-known query suites — exercise the core engine + query path.
+    "watdiv": ["sparq-engine", "sparq-core"],
+    "sp2b": ["sparq-engine", "sparq-core"],
+    "sp_": ["sparq-engine", "sparq-core"],
+    "bsbm": ["sparq-engine", "sparq-core"],
+    "lubm": ["sparq-engine", "sparq-core"],
+    "dbpsb": ["sparq-engine", "sparq-core"],
+    "sameas": ["sparq-engine", "sparq-core"],
+    "snikmeta": ["sparq-engine", "sparq-core"],
+    "deeptax": ["sparq-reason", "sparq-engine"],
+    # core micro-op + hand-written query suites (q0N_*, op_*).
+    "q0": ["sparq-engine", "sparq-core"],
+    "op": ["sparq-engine", "sparq-core"],
+    # deterministic layout metrics (still mapped so a nightly on them attributes correctly).
+    "store": ["sparq-core"],
+    "dict": ["sparq-core"],
+    "parse": ["sparq-parse", "sparq-core"],
+    "load": ["sparq-core"],
+    "comp": ["sparq-core"],
+    "wasm": ["sparq-wasm", "sparq-core"],
+    # subsystem suites -> their crate.
+    "fts": ["sparq-engine"],
+    "text": ["sparq-engine"],
+    "geo": ["sparq-geo"],
+    "vectors": ["sparq-engine"],
+    "vector": ["sparq-engine"],
+    "rsp": ["sparq-rsp"],
+    "hdt": ["sparq-hdt"],
+    "solid": ["sparq-solid"],
+    "nlq": ["sparq-nlq"],
+    "shacl": ["sparq-shacl"],
+    "zk": ["sparq-zk"],
+    "rdfs": ["sparq-reason"],
+}
+_FALLBACK_CRATES = ["sparq-engine", "sparq-core"]
+
+
+def log(msg: str) -> None:
+    print(f"[{PROG}] {msg}", file=sys.stderr)
+
+
+def metric_crates(name: str) -> list[str]:
+    """Map a benchmark metric name to the crates it exercises (longest-prefix wins)."""
+    lname = name.lower()
+    best = None
+    for prefix in sorted(_PREFIX_CRATES, key=len, reverse=True):
+        if lname.startswith(prefix):
+            best = prefix
+            break
+    return list(_PREFIX_CRATES[best]) if best else list(_FALLBACK_CRATES)
+
+
+def suite_of(name: str) -> str:
+    """A stable suite bucket for a metric name (for the one-rolling-issue-per-suite dedupe).
+
+    Uses the mapped-crate set as the suite key when known, else the leading alpha token.
+    """
+    lname = name.lower()
+    for prefix in sorted(_PREFIX_CRATES, key=len, reverse=True):
+        if lname.startswith(prefix):
+            # group by the mapped crate list so e.g. all watdiv/sp2b/bsbm engine benches share a
+            # single rolling flake issue keyed on the engine, keeping issue count bounded.
+            return "+".join(_PREFIX_CRATES[prefix])
+    m = re.match(r"([a-z]+)", lname)
+    return m.group(1) if m else "misc"
+
+
+# ── zone classification ──────────────────────────────────────────────────────────
+def classify(ratio_pct: float, soft: float, hard: float) -> str:
+    """Given a github-action-benchmark regression ratio (150 == 1.5x == +50%), return the zone.
+
+    ratio_pct is (current/previous)*100 for a smaller-is-better metric (>100 == regression).
+    """
+    if ratio_pct >= hard:
+        return "hard"
+    if ratio_pct >= soft:
+        return "soft"
+    return "ok"
+
+
+def _to_ratio_pct(cur: float, prev: float) -> float | None:
+    if prev == 0:
+        return None
+    return (cur / prev) * 100.0
+
+
+def _parse_data_js(text: str) -> dict:
+    """Parse a github-action-benchmark data.js payload (window.BENCHMARK_DATA = {...};)."""
+    m = re.search(r"window\.BENCHMARK_DATA\s*=\s*", text)
+    if m:
+        text = text[m.end():]
+    text = text.strip().rstrip(";").strip()
+    return json.loads(text)
+
+
+def baseline_sha(prev_data_js: str, suite: str) -> str:
+    """The commit id of the most-recent published point in `suite` (the last green baseline).
+
+    Empty string if the file / suite / commit is absent (first run → no baseline). Fail-soft:
+    any parse error yields "" so the caller no-ops attribution rather than crashing.
+    """
+    p = Path(prev_data_js)
+    if not p.exists():
+        return ""
+    try:
+        data = _parse_data_js(p.read_text(encoding="utf-8"))
+        entries = data.get("entries", {})
+        series = entries.get(suite) or (next(iter(entries.values())) if entries else [])
+        series = sorted(series, key=lambda e: e.get("date", 0))
+        if not series:
+            return ""
+        return (series[-1].get("commit") or {}).get("id", "") or ""
+    except (json.JSONDecodeError, ValueError, OSError):
+        return ""
+
+
+def build_comparison(results_path: str, prev_data_js: str | None, suite: str) -> list[dict]:
+    """Construct the normalized comparison rows from THIS run's results + the previous point.
+
+    github-action-benchmark does not emit a stable machine-readable comparison file, so the
+    workflow reconstructs one: `results_path` is this run's output-file-path (a list of
+    {name,value,unit}); `prev_data_js` is the previously-published dev/bench/data.js (the last
+    committed point on the benchmark-data branch). We pair each current metric with its most
+    recent previous value of the SAME name in `suite`. Metrics with no previous value are
+    emitted with previous=null (skipped by parse_comparison — nothing to compare).
+    """
+    current = json.loads(Path(results_path).read_text(encoding="utf-8"))
+    cur_rows = current if isinstance(current, list) else current.get("benches", [])
+    prev_by_name: dict[str, float] = {}
+    if prev_data_js and Path(prev_data_js).exists():
+        try:
+            data = _parse_data_js(Path(prev_data_js).read_text(encoding="utf-8"))
+            entries = data.get("entries", {})
+            # prefer the named suite; fall back to the only/first suite present.
+            series = entries.get(suite) or (next(iter(entries.values())) if entries else [])
+            ordered = sorted(series, key=lambda e: e.get("date", 0))
+            for e in ordered:  # later entries overwrite earlier -> most-recent value wins
+                for b in e.get("benches", []):
+                    if b.get("name") is not None and isinstance(b.get("value"), (int, float)):
+                        prev_by_name[b["name"]] = float(b["value"])
+        except (json.JSONDecodeError, ValueError, OSError) as e:
+            log(f"warning: could not parse previous data.js ({e}) — no comparison baseline")
+    out = []
+    for b in cur_rows:
+        name = b.get("name")
+        val = b.get("value")
+        if name is None or not isinstance(val, (int, float)):
+            continue
+        out.append({
+            "name": name,
+            "current": float(val),
+            "previous": prev_by_name.get(name),
+            "unit": b.get("unit", ""),
+        })
+    return out
+
+
+def parse_comparison(path: str) -> list[dict]:
+    """Read a comparison JSON: a list of {name, current, previous[, unit]} rows.
+
+    This is the small normalized shape the workflow builds from github-action-benchmark's
+    output (the action does not emit a stable machine file, so the workflow constructs this
+    from the current run's results + the previous data.js point). Rows with no previous value
+    (a brand-new metric) are skipped — nothing to compare against.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    rows = data if isinstance(data, list) else data.get("benches", [])
+    out = []
+    for r in rows:
+        name = r.get("name")
+        cur = r.get("current", r.get("value"))
+        prev = r.get("previous")
+        if name is None or cur is None or prev is None:
+            continue
+        ratio = _to_ratio_pct(float(cur), float(prev))
+        if ratio is None:
+            continue
+        out.append({
+            "name": name,
+            "current": float(cur),
+            "previous": float(prev),
+            "ratio_pct": round(ratio, 1),
+            "unit": r.get("unit", ""),
+        })
+    return out
+
+
+def zone_partition(rows: list[dict], soft: float, hard: float) -> dict[str, list[dict]]:
+    part = {"ok": [], "soft": [], "hard": []}
+    for r in rows:
+        part[classify(r["ratio_pct"], soft, hard)].append(r)
+    return part
+
+
+# ── gh helpers (fail-soft) ─────────────────────────────────────────────────────────
+def gh(*argv: str) -> str:
+    return subprocess.run(["gh", *argv], check=True, capture_output=True, text=True).stdout.strip()
+
+
+def ensure_label(name: str, color: str, desc: str) -> None:
+    """Create the label if missing (idempotent via --force). Fail-soft."""
+    try:
+        gh("label", "create", name, "--color", color, "--description", desc, "--force")
+    except subprocess.CalledProcessError as e:
+        log(f"warning: label create {name} failed (non-fatal): {e.stderr.strip() if e.stderr else e}")
+
+
+def find_open_issue(marker: str, key: str) -> str | None:
+    try:
+        out = gh(
+            "issue", "list", "--state", "open",
+            "--search", f'in:title "{marker} {key}"',
+            "--json", "number,title", "--limit", "10",
+        )
+        for item in json.loads(out or "[]"):
+            title = item.get("title", "")
+            if marker in title and key in title:
+                return str(item["number"])
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        log(f"warning: issue dedupe search failed ({e})")
+    return None
+
+
+def _post_issue(title: str, body: str, labels: list[str], existing: str | None) -> str | None:
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as tf:
+        tf.write(body)
+        body_file = tf.name
+    try:
+        if existing:
+            gh("issue", "comment", existing, "--body-file", body_file)
+            log(f"commented on existing issue #{existing} (deduped)")
+            return existing
+        argv = ["issue", "create", "--title", title, "--body-file", body_file]
+        for lab in labels:
+            argv += ["--label", lab]
+        url = gh(*argv)
+        log(f"filed issue: {url}")
+        return url
+    except subprocess.CalledProcessError as e:
+        log(f"warning: gh issue filing failed (non-fatal): {e.stderr.strip() if e.stderr else e}")
+        return None
+    finally:
+        Path(body_file).unlink(missing_ok=True)
+
+
+# ── SOFT zone: one rolling deduped bench-flake issue per suite ──────────────────────
+def build_flake_body(suite: str, rows: list[dict], soft: float, hard: float, run_url: str) -> str:
+    lines = [
+        "> 🤖 **SPARQ agent** — auto-filed by the benchmark self-monitoring soft zone "
+        "(noise-reduction-bench-selfmonitor). No human is @-mentioned by design.",
+        "",
+        f"Benchmarks in suite `{suite}` regressed into the **soft zone** — above the soft "
+        f"alert-threshold (`{soft}%`) but below the hard fail-threshold (`{hard}%`), so this "
+        "**could be shared-runner flakiness** rather than a real regression. It does **not** "
+        "fail CI. This is a rolling, deduped record — new soft-zone hits append below.",
+        "",
+        f"- **Run:** {run_url}",
+        "",
+        "### Flagged benchmarks (this run)",
+        "",
+        "| benchmark | previous | current | ratio |",
+        "|---|---|---|---|",
+    ]
+    for r in sorted(rows, key=lambda x: -x["ratio_pct"]):
+        lines.append(
+            f"| `{r['name']}` | {r['previous']:g}{r['unit']} | "
+            f"{r['current']:g}{r['unit']} | {r['ratio_pct']:g}% |"
+        )
+    lines += [
+        "",
+        "If these persist across several runs the swing is likely real — promote to a "
+        f"`{REGRESSION_LABEL}` investigation. If they come and go, they are runner noise; "
+        "re-derive the thresholds with `scripts/bench-thresholds.py` if the noise floor has "
+        "shifted.",
+    ]
+    return "\n".join(lines)
+
+
+def file_flake_issues(part: dict, soft: float, hard: float, run_url: str) -> list[str]:
+    soft_rows = part["soft"]
+    if not soft_rows:
+        log("no soft-zone regressions — nothing to file.")
+        return []
+    ensure_label(FLAKE_LABEL, "fbca04", "benchmark soft-zone (possible runner flakiness)")
+    by_suite: dict[str, list[dict]] = {}
+    for r in soft_rows:
+        by_suite.setdefault(suite_of(r["name"]), []).append(r)
+    filed = []
+    for suite, rows in sorted(by_suite.items()):
+        key = f"suite={suite}"
+        title = f"{FLAKE_MARKER} {key}: benchmarks in the soft zone (possible runner noise)"
+        existing = find_open_issue(FLAKE_MARKER, key)
+        body = build_flake_body(suite, rows, soft, hard, run_url)
+        res = _post_issue(title, body, [FLAKE_LABEL], existing)
+        if res:
+            filed.append(res)
+    return filed
+
+
+# ── NIGHTLY attribution: rank suspect commits, file one bench-regression issue per cluster ──
+def commits_between(baseline_sha: str, head_sha: str) -> list[dict]:
+    """List commits (with touched paths) landed on main in (baseline, head]. Fail-soft -> []."""
+    try:
+        raw = subprocess.run(
+            ["git", "log", "--no-merges", "--name-only", "--pretty=format:%x00%H%x00%s%x00%an",
+             f"{baseline_sha}..{head_sha}"],
+            check=True, capture_output=True, text=True,
+        ).stdout
+    except subprocess.CalledProcessError as e:
+        log(f"warning: git log failed ({e}) — no attribution")
+        return []
+    commits = []
+    for block in raw.split("\x00\x00"):
+        block = block.strip("\x00\n")
+        if not block:
+            continue
+        parts = block.split("\x00")
+        if len(parts) < 3:
+            continue
+        sha, subject, rest = parts[0], parts[1], parts[2]
+        rest_lines = rest.split("\n")
+        author = rest_lines[0]
+        paths = [p for p in rest_lines[1:] if p.strip()]
+        commits.append({"sha": sha, "subject": subject, "author": author, "paths": paths})
+    return commits
+
+
+def _crate_of_path(path: str) -> str | None:
+    m = re.match(r"crates/([^/]+)/", path)
+    return m.group(1) if m else None
+
+
+def rank_suspects(regressed_crates: set[str], commits: list[dict]) -> list[dict]:
+    """Rank commits by how much their touched paths intersect the regressed suite's crates."""
+    ranked = []
+    for c in commits:
+        touched_crates = {cr for cr in (_crate_of_path(p) for p in c["paths"]) if cr}
+        overlap = touched_crates & regressed_crates
+        # score: direct crate-overlap dominates; a bench-harness / scripts touch is a weak signal.
+        score = len(overlap) * 10
+        if any(p.startswith("bench/") for p in c["paths"]):
+            score += 2
+        if any(p.startswith("scripts/") for p in c["paths"]):
+            score += 1
+        if score > 0:
+            ranked.append({
+                "sha": c["sha"],
+                "subject": c["subject"],
+                "author": c["author"],
+                "overlap": sorted(overlap),
+                "touched_crates": sorted(touched_crates),
+                "score": score,
+            })
+    ranked.sort(key=lambda x: (-x["score"], x["sha"]))
+    return ranked
+
+
+def _pr_ref(subject: str) -> str:
+    """Extract a trailing (#NNNN) PR ref from a squash-merge subject, else empty."""
+    m = re.search(r"\(#(\d+)\)\s*$", subject)
+    return f"#{m.group(1)}" if m else ""
+
+
+def build_regression_body(cluster_crates: list[str], rows: list[dict], ranked: list[dict],
+                          hard: float, run_url: str, repo: str, baseline_sha: str,
+                          head_sha: str) -> str:
+    lines = [
+        "> 🤖 **SPARQ agent** — auto-filed by the nightly benchmark attribution "
+        "(noise-reduction-bench-selfmonitor). No human is @-mentioned by design; this issue "
+        "enters the autonomous dispatch frontier for an agent to fix.",
+        "",
+        f"The nightly full-suite benchmark detected a regression **beyond the hard "
+        f"fail-threshold (`{hard}%`)** vs the last green nightly baseline, in the "
+        f"`{'+'.join(cluster_crates)}` suite cluster.",
+        "",
+        f"- **Run:** {run_url}",
+        f"- **Baseline (last green nightly):** `{baseline_sha[:12]}`",
+        f"- **Head:** `{head_sha[:12]}`",
+        "",
+        "### Regression table",
+        "",
+        "| benchmark | previous | current | ratio |",
+        "|---|---|---|---|",
+    ]
+    for r in sorted(rows, key=lambda x: -x["ratio_pct"]):
+        lines.append(
+            f"| `{r['name']}` | {r['previous']:g}{r['unit']} | "
+            f"{r['current']:g}{r['unit']} | {r['ratio_pct']:g}% |"
+        )
+    lines += ["", "### Ranked suspect commits", ""]
+    if ranked:
+        lines += ["| rank | commit | PR | overlap crates | subject |", "|---|---|---|---|---|"]
+        for i, c in enumerate(ranked[:10], 1):
+            pr = _pr_ref(c["subject"])
+            pr_link = f"[{pr}]({repo}/pull/{pr[1:]})" if pr else "—"
+            commit_link = f"[`{c['sha'][:10]}`]({repo}/commit/{c['sha']})"
+            lines.append(
+                f"| {i} | {commit_link} | {pr_link} | "
+                f"{', '.join(c['overlap']) or '—'} | {c['subject']} |"
+            )
+    else:
+        lines.append("_No commit in the baseline..head range touched the regressed crates; "
+                     "the regression may be environmental (investigate the runner) or in a "
+                     "shared dependency._")
+    lines += [
+        "",
+        "### Reproduce locally",
+        "",
+        "```bash",
+        "# full nightly timing suite at the CI scale (quiet box recommended):",
+        "BENCH_FULL_SUITE=1 BENCH_SCALE=200000 bash scripts/ec2-bench.sh   # or, locally:",
+        "bash scripts/ci-bench.sh   # (writes bench-results.json; compare the flagged metrics)",
+        "# bisect the ranked suspects above against the regressed benchmark.",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def file_regression_issues(part: dict, soft: float, hard: float, baseline_sha: str,
+                           head_sha: str, run_url: str, repo: str) -> list[str]:
+    hard_rows = part["hard"]
+    if not hard_rows:
+        log("no hard-zone regressions — no nightly attribution issue.")
+        return []
+    ensure_label(REGRESSION_LABEL, "b60205", "benchmark hard-zone regression (needs a fix)")
+    commits = commits_between(baseline_sha, head_sha) if baseline_sha and head_sha else []
+    # Cluster hard rows by their mapped crate set (one issue per regression cluster).
+    by_cluster: dict[tuple, list[dict]] = {}
+    for r in hard_rows:
+        by_cluster.setdefault(tuple(metric_crates(r["name"])), []).append(r)
+    filed = []
+    for cluster_crates_t, rows in sorted(by_cluster.items()):
+        cluster_crates = list(cluster_crates_t)
+        regressed = set(cluster_crates)
+        ranked = rank_suspects(regressed, commits)
+        area = ranked[0]["overlap"][0] if (ranked and ranked[0]["overlap"]) else cluster_crates[0]
+        key = f"cluster={'+'.join(cluster_crates)}"
+        title = f"{REGRESSION_MARKER} {key}: nightly benchmark regression (P1)"
+        existing = find_open_issue(REGRESSION_MARKER, key)
+        body = build_regression_body(cluster_crates, rows, ranked, hard, run_url, repo,
+                                     baseline_sha, head_sha)
+        labels = [REGRESSION_LABEL, "priority:P1", "role:impl", f"area:{area}"]
+        res = _post_issue(title, body, labels, existing)
+        if res:
+            filed.append(res)
+    return filed
+
+
+# ── self-test (hermetic: no gh, no git, no writes) ────────────────────────────────
+def self_test() -> int:
+    # zone classification.
+    assert classify(210, 175, 200) == "hard"
+    assert classify(200, 175, 200) == "hard"      # >= hard is hard
+    assert classify(180, 175, 200) == "soft"
+    assert classify(175, 175, 200) == "soft"      # >= soft is soft
+    assert classify(120, 175, 200) == "ok"
+    assert classify(100, 175, 200) == "ok"
+
+    # ratio helper.
+    assert _to_ratio_pct(15, 10) == 150.0
+    assert _to_ratio_pct(10, 0) is None
+
+    # suite->crate map: longest-prefix + fallback.
+    assert metric_crates("watdiv_sf1_q1_us") == ["sparq-engine", "sparq-core"]
+    assert metric_crates("geo_within_us") == ["sparq-geo"]
+    assert metric_crates("rsp_window_us") == ["sparq-rsp"]
+    assert metric_crates("hdt_load_us") == ["sparq-hdt"]
+    assert metric_crates("zk_prove_ms") == ["sparq-zk"]
+    assert metric_crates("q02_type_person_count_us") == ["sparq-engine", "sparq-core"]
+    assert metric_crates("totally_unknown_metric") == _FALLBACK_CRATES  # fallback
+
+    # suite bucketing groups engine query suites under one key (bounded issue count).
+    assert suite_of("watdiv_q1_us") == suite_of("sp2b_q3_us") == "sparq-engine+sparq-core"
+    assert suite_of("geo_x_us") == "sparq-geo"
+
+    # parse_comparison + zone_partition over a fixture.
+    with tempfile.TemporaryDirectory() as td:
+        cmp = Path(td) / "cmp.json"
+        cmp.write_text(json.dumps([
+            {"name": "watdiv_q1_us", "current": 30.0, "previous": 10.0, "unit": "us"},  # 300% hard
+            {"name": "geo_within_us", "current": 18.0, "previous": 10.0, "unit": "us"},  # 180% soft
+            {"name": "q02_type_person_count_us", "current": 11.0, "previous": 10.0},      # 110% ok
+            {"name": "new_metric_us", "current": 5.0},                                    # no prev -> skip
+            {"name": "zero_prev_us", "current": 5.0, "previous": 0.0},                    # prev 0 -> skip
+        ]), encoding="utf-8")
+        rows = parse_comparison(str(cmp))
+        assert len(rows) == 3, [r["name"] for r in rows]   # two skipped
+        part = zone_partition(rows, 175, 200)
+        assert [r["name"] for r in part["hard"]] == ["watdiv_q1_us"]
+        assert [r["name"] for r in part["soft"]] == ["geo_within_us"]
+        assert [r["name"] for r in part["ok"]] == ["q02_type_person_count_us"]
+
+        # flake body is @mention-free + lists the flagged bench.
+        fbody = build_flake_body("sparq-geo", part["soft"], 175, 200, "http://run/1")
+        assert "@" not in fbody.replace("@-mentioned", "").replace("@-mention", "")
+        assert "geo_within_us" in fbody and "🤖" in fbody and "soft zone" in fbody
+
+    # build_comparison: pair current results with the previous data.js point.
+    with tempfile.TemporaryDirectory() as tdc:
+        results = Path(tdc) / "bench-results.json"
+        results.write_text(json.dumps([
+            {"name": "watdiv_q1_us", "value": 30.0, "unit": "us"},
+            {"name": "new_only_us", "value": 5.0, "unit": "us"},   # no prev -> previous null
+        ]), encoding="utf-8")
+        prev = Path(tdc) / "prev-data.js"
+        prev.write_text(
+            'window.BENCHMARK_DATA = ' + json.dumps({"entries": {"sparq engine": [
+                {"date": 1, "commit": {"id": "c1"}, "benches": [
+                    {"name": "watdiv_q1_us", "value": 8.0, "unit": "us"}]},
+                {"date": 2, "commit": {"id": "c2"}, "benches": [
+                    {"name": "watdiv_q1_us", "value": 10.0, "unit": "us"}]},  # most-recent wins
+            ]}}) + ';\n', encoding="utf-8")
+        cmp_rows = build_comparison(str(results), str(prev), "sparq engine")
+        by = {r["name"]: r for r in cmp_rows}
+        assert by["watdiv_q1_us"]["previous"] == 10.0, by["watdiv_q1_us"]  # newest prev value
+        assert by["watdiv_q1_us"]["current"] == 30.0
+        assert by["new_only_us"]["previous"] is None
+        # feeding it through parse_comparison drops the no-previous row + computes ratio.
+        cmp_file = Path(tdc) / "cmp.json"
+        cmp_file.write_text(json.dumps(cmp_rows), encoding="utf-8")
+        parsed = parse_comparison(str(cmp_file))
+        assert [r["name"] for r in parsed] == ["watdiv_q1_us"]
+        assert parsed[0]["ratio_pct"] == 300.0
+        # missing prev file => all previous null (first-ever run).
+        cmp_noprev = build_comparison(str(results), str(Path(tdc) / "absent.js"), "sparq engine")
+        assert all(r["previous"] is None for r in cmp_noprev)
+        # baseline_sha returns the newest published commit id (empty when absent / unparseable).
+        assert baseline_sha(str(prev), "sparq engine") == "c2"
+        assert baseline_sha(str(prev), "nonexistent suite") == "c2"  # falls back to only suite
+        assert baseline_sha(str(Path(tdc) / "absent.js"), "sparq engine") == ""
+
+    # nightly attribution ranking: overlap with regressed crates ranks first.
+    commits = [
+        {"sha": "a" * 40, "subject": "feat(geo): add index (#101)", "author": "x",
+         "paths": ["crates/sparq-geo/src/index.rs"]},
+        {"sha": "b" * 40, "subject": "docs: readme (#102)", "author": "y",
+         "paths": ["README.md"]},
+        {"sha": "c" * 40, "subject": "perf(engine): join (#103)", "author": "z",
+         "paths": ["crates/sparq-engine/src/join.rs", "bench/watdiv/run.sh"]},
+    ]
+    ranked = rank_suspects({"sparq-geo"}, commits)
+    assert ranked and ranked[0]["sha"] == "a" * 40, ranked
+    assert all(c["sha"] != "b" * 40 for c in ranked)  # no-overlap docs commit excluded
+    # engine regression ranks the engine+bench commit.
+    ranked2 = rank_suspects({"sparq-engine"}, commits)
+    assert ranked2[0]["sha"] == "c" * 40 and ranked2[0]["score"] >= 12  # overlap*10 + bench 2
+
+    # PR-ref extraction.
+    assert _pr_ref("feat(geo): add (#101)") == "#101"
+    assert _pr_ref("no pr here") == ""
+
+    # regression body: table + ranked suspects + repro, no @mention.
+    with tempfile.TemporaryDirectory() as td2:
+        cmp2 = Path(td2) / "c.json"
+        cmp2.write_text(json.dumps([
+            {"name": "geo_within_us", "current": 30.0, "previous": 10.0, "unit": "us"},
+        ]), encoding="utf-8")
+        rows2 = parse_comparison(str(cmp2))
+        part2 = zone_partition(rows2, 175, 200)
+        rbody = build_regression_body(["sparq-geo"], part2["hard"], ranked, 200,
+                                      "http://run/9", "https://github.com/o/r",
+                                      "d" * 40, "e" * 40)
+        assert "geo_within_us" in rbody and "Ranked suspect commits" in rbody
+        assert "Reproduce locally" in rbody and "#101" in rbody
+        assert "🤖" in rbody
+        # no naked @mention (the only '@' allowed is inside '@-mention' prose).
+        stripped = rbody.replace("@-mentioned", "").replace("@-mention", "")
+        assert "@" not in stripped, "regression body must not @-mention anyone"
+
+    log("self-test OK")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog=PROG)
+    ap.add_argument("--mode",
+                    choices=["soft", "nightly", "build-comparison", "baseline-sha"],
+                    default="soft")
+    ap.add_argument("--comparison", help="normalized comparison JSON (list of name/current/previous)")
+    ap.add_argument("--results", help="this run's bench results json (for build-comparison)")
+    ap.add_argument("--prev-data-js", help="previously-published data.js (for build-comparison)")
+    ap.add_argument("--suite", default="sparq engine", help="suite/entries key (for build-comparison)")
+    ap.add_argument("--out", help="where build-comparison writes the normalized JSON")
+    ap.add_argument("--soft", type=float, default=175.0, help="soft alert-threshold %% (150==1.5x)")
+    ap.add_argument("--hard", type=float, default=200.0, help="hard fail-threshold %% (150==1.5x)")
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--baseline-sha", default="")
+    ap.add_argument("--head-sha", default="")
+    ap.add_argument("--repo-url", default="")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.mode == "baseline-sha":
+        # Prints the last-green-baseline commit id to stdout (empty if none). Fail-soft.
+        print(baseline_sha(args.prev_data_js or "", args.suite))
+        return 0
+
+    if args.mode == "build-comparison":
+        if not args.results:
+            ap.error("--results is required for --mode build-comparison")
+        rows = build_comparison(args.results, args.prev_data_js, args.suite)
+        payload = json.dumps(rows, indent=2)
+        if args.out:
+            Path(args.out).write_text(payload + "\n", encoding="utf-8")
+            log(f"wrote {len(rows)} comparison rows to {args.out}")
+        else:
+            print(payload)
+        return 0
+
+    if not args.comparison:
+        ap.error("--comparison is required (or use --self-test)")
+
+    rows = parse_comparison(args.comparison)
+    part = zone_partition(rows, args.soft, args.hard)
+    log(f"zones: ok={len(part['ok'])} soft={len(part['soft'])} hard={len(part['hard'])}")
+
+    repo = args.repo_url or "https://github.com/sparq-org/sparq"
+    if args.mode == "soft":
+        file_flake_issues(part, args.soft, args.hard, args.run_url)
+    else:  # nightly
+        file_regression_issues(part, args.soft, args.hard, args.baseline_sha,
+                               args.head_sha, args.run_url, repo)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing the maintainer's noise-reduction + self-monitoring-benchmarks directive. No human is @-mentioned by any lane this PR touches.

The maintainer (@jeswr — sole mention, in this description) gets tagged far too much. This PR removes the two confirmed sources and implements the maintainer's own self-monitoring-benchmarks design so regressions route to autonomous agents instead of a person.

## 1. CODEOWNERS — stop auto-requesting review on every PR
`* @jeswr` requested the maintainer's review on **every** pull request; the `/crates/sparq-core/`, `/crates/sparq-server/`, and `/.github/` entries did the same for the highest-churn paths. All removed. Kept: only the rare, genuinely security-critical surfaces — `/crates/sparq-zk/`, `/crates/sparq-zk-compose/`, `/crates/sparq-mpc/`, `deny.toml`, `SECURITY.md`. The header now states the policy: codeowner review-requests are reserved for security-critical paths; everything else is covered by the automated review pipeline + the `ci-summary / gate` aggregator. (All 5 referenced paths exist — no phantom-path warnings.)

## 2. Benchmark alert noise — no more CC
Removed every `alert-comment-cc-users: '@jeswr'` from `bench.yml` (1) and `bench-ec2.yml` (2, weekly + nightly). The maintainer is no longer CC'd on any benchmark warning.

## 3. Self-monitoring benchmarks (two-zone + auto-triage)

**Two-zone thresholds** on the `github-action-benchmark` step:
- **SOFT** `alert-threshold: 175%` — comment-only, does **not** fail CI. A deduped `bench-flake` issue (one rolling issue per suite) is filed/updated for it. No @mentions.
- **HARD** `fail-threshold: 200%` + `fail-on-alert: true` — a regression clearly beyond runner noise fails the step so an agent must fix it.

**Where the timing hard-fail bites (honest):** under `sq-6vshe.6` (also maintainer-directed) the per-PR run is `--deterministic-only`, so on a PR this step sees only the deterministic byte-count metrics (0.00% noise, already strictly gated by `perf-gate.py`; the new `fail-on-alert` is a redundant looser backstop there and never trips on noise). The noisy **timing** metrics run on push-to-main + the nightly EC2 lane, so the timing hard-fail bites there — deliberately, so this PR does **not** re-introduce the merge-queue flapping `sq-6vshe.6` removed. Pre-merge timing coverage stays the nightly attribution lane below.

**Threshold derivation (empirical, not invented).** `scripts/bench-thresholds.py` recomputes both from the `benchmark-data` history and reproduces the baked-in values:
- **soft 175%** = 100 + p95 run-to-run timing swing (43.66%) + ~30pp headroom, rounded up to 5%.
- **hard 200%** = above the worst observed timing noise swing (185.0%), floored 150% / capped 200% (2×-worst is uselessly loose once the worst swing is a µs-scale flake; a genuine 2× regression is still caught).
- Basis: 20 commits × 322 timing metrics = 6137 adjacent-pair samples on `dev/bench`; deterministic byte-count metrics confirmed at **0.00%** noise. No hard-coded perf numbers in markdown — the values live in the workflow YAML + the script only.

**SOFT zone** (`scripts/bench-triage.py --mode soft`): files/updates one deduped `bench-flake` issue per suite listing the flagged benchmarks + runs. `bench-flake` label created at runtime with `gh label create --force`. No @mentions.

**NIGHTLY attribution** (`scripts/bench-triage.py --mode nightly`): on a hard-zone regression vs the last green nightly baseline, lists commits landed on main in `baseline..head`, maps each benchmark suite to the crates it exercises (a static suite→crate map seeded from the bench-harness dir names + real metric-name prefixes), intersects with each commit's touched paths, and ranks. Files one `bench-regression` issue per cluster (labels `bench-regression`, `priority:P1`, `role:impl`, `area:<most-likely crate>`) with the regression table, ranked suspect commit/PR list with links, and repro commands. No @mentions — the issue enters the normal autonomous dispatch frontier.

Both scripts are fixture-driven `--self-test` (zone classification, culprit ranking, comparison building, baseline-SHA extraction). Least-privilege `issues: write` added only to the two jobs that file.

## Gates
- `actionlint` + `python3 -c "yaml.safe_load"` clean on both touched workflows.
- `scripts/bench-triage.py --self-test` and `scripts/bench-thresholds.py --self-test` green; end-to-end smoke-tested the exact workflow commands (`build-comparison` → `soft`/`nightly`) with `gh` stubbed, confirming correct zone classification + well-formed `gh` argv.
- No markdown changed → `check-readme-template.py` + no-perf-numbers untouched-OK (`check-no-perf-numbers.py`: 0 findings).
- **Gate aggregator intact:** no new check-run is introduced (the triage steps are steps within existing jobs); the `bench` job stays a gating leg with no advisory/informational token.

Do **not** arm/merge — leaving for review.
