### PR TITLE
fix(triage): trust the orchestrator App's own issues (stop self-quarantine)

### DIFF
--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -27,9 +27,16 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Trust-gate the author (repo permission)
+      - name: Trust-gate the author (repo permission, or the orchestrator App itself)
         id: trust
         run: |
+          # The orchestrator GitHub App is our own automation identity, but an App is never a
+          # collaborator, so the permission probe returns none and its issues (worker follow-ups)
+          # were wrongly quarantined. Trust exactly that one bot login — no blanket [bot] trust.
+          if [ "$AUTHOR" = "sparq-orchestrator[bot]" ]; then
+            echo "trusted=1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           perm=$(gh api "repos/$REPO/collaborators/$AUTHOR/permission" --jq .permission 2>/dev/null || echo none)
           case "$perm" in
             admin|maintain|write) echo "trusted=1" >> "$GITHUB_OUTPUT" ;;


### PR DESCRIPTION
> 🤖 SPARQ agent

The trust gate probes the author's collaborator permission; a GitHub App is never a collaborator, so every issue the orchestrator App itself opens (worker follow-up issues, e.g. #2435) was wrongly quarantined `trust:untrusted`. This trusts exactly the `sparq-orchestrator[bot]` login — deliberately not any-`[bot]` — before falling back to the permission probe. Third-party quarantine behavior is unchanged.

Also un-quarantining the 6 existing wrongly-labelled issues operationally (#2435–#2437, #2440, #2442, #2443).