### PR TITLE
feat(backlog): event-driven grooming — 4-hourly cron + dependabot-failure trigger

### DIFF
--- a/.github/workflows/pr-backlog.yml
+++ b/.github/workflows/pr-backlog.yml
@@ -21,8 +21,17 @@ name: pr-backlog
 
 on:
   schedule:
-    # Daily at ~05:00 UTC (a quiet window; cron is best-effort on GitHub's scheduler).
-    - cron: "0 5 * * *"
+    # Every 4 hours — a daily-only groomer lags exactly when repo activity is highest
+    # (maintainer-directed 2026-07-17). The run is a handful of API reads; the event
+    # trigger below covers the latency-sensitive case in between crons.
+    - cron: "0 */4 * * *"
+  # Event trigger: the moment CI CONCLUDES on a dependabot branch, groom immediately —
+  # a failing dependabot PR is closed + re-routed to a `deps:` issue within minutes
+  # instead of waiting for the next cron. workflow_run only fires for workflows on the
+  # default branch, and the job-level guard below restricts it to dependabot heads.
+  workflow_run:
+    workflows: ["ci-summary"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -48,6 +57,13 @@ jobs:
   # this workflow never runs on a PR head commit, it is NOT part of the required-checks gate.
   groom:
     name: groom
+    # On the event trigger, run only for a FAILED ci-summary on a dependabot branch —
+    # the exact case the dependabot policy acts on. Green runs and non-dependabot
+    # branches change nothing the next cron wouldn't handle, so skip the noise.
+    if: >
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       startsWith(github.event.workflow_run.head_branch, 'dependabot/'))
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
> 🤖 SPARQ agent

Maintainer-directed: daily-only backlog grooming lags when the repo is busiest. This adds (1) a `workflow_run` trigger firing the groomer the moment `ci-summary` CONCLUDES in failure on a `dependabot/` head branch — so a failing dependabot PR is closed + re-routed to a tracked `deps:` issue within minutes — and (2) densifies the cron from daily to every 4 hours for the stale-PR sweep. The job-level guard skips green/non-dependabot events; concurrency group unchanged (no overlap, no cancel); still structurally non-gating (never runs on a PR head).