### PR TITLE
ci(merge-queue): demote heavy sparq-vectors recall shards off merge_group (sq-6vshe.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -514,8 +514,40 @@ jobs:
           SELECT_AFFECTED: ${{ needs.select.outputs.affected }}
           SELECT_FILTERSET: ${{ needs.select.outputs.filterset }}
           SHARD_CRATE: ${{ matrix.crate }}
+          # [OPUS-4.8] sq-6vshe.6 (heavy-lane placement, round 2): the two heavy
+          # recall shards are DEMOTED off the merge_group ref (see the demotion guard
+          # below). `matrix.filter` is non-empty ONLY on those two heavy shards, so this
+          # env is the shard-kind discriminator the run script reads (it is empty on the
+          # bulk shards). Passed via env — no inline `${{ }}` in the shell body.
+          SHARD_FILTER: ${{ matrix.filter }}
         run: |
           set -euo pipefail
+          # [OPUS-4.8] sq-6vshe.6 (research/ci-structural-speedup.md §7, round 2):
+          # DEMOTE the two heavy sparq-vectors recall shards (heavy-diskann/heavy-hnsw)
+          # off the merge_group ref. WHY it is SAFE (per-leg cross-PR-interaction
+          # analysis): each heavy shard runs exactly ONE deterministic, self-contained,
+          # single-crate accuracy gate ({diskann,hnsw}_recall_at_10_vs_brute_force_on_50k
+          # in crates/sparq-vectors/tests/, fixed seeds, `approx-ann` feature). Its
+          # outcome is a pure function of sparq-vectors' ANN impl + its pinned
+          # instant-distance dep — NOTHING else in the workspace. A squash-merge group
+          # re-running it on the combined tree reproduces the identical result each PR
+          # already gated, so it carries no cross-PR-interaction signal (unlike the bulk
+          # workspace-unification build+test, which stays). FULL FORM is UNCHANGED: the
+          # heavy shards still run at PR level AND on push-to-main (both force
+          # rust_changed=true and neither hits this guard), so the recall floors gate
+          # every PR + the canonical main build exactly as before. A post-merge
+          # regression is caught by the push-to-main heavy run (this same job on the
+          # `push` event) + the dedicated `heavy-recall-demoted-filer` job below, which
+          # auto-files a P1 bead + GitHub issue if a heavy shard fails on main. This ONLY
+          # affects the merge_group ref, and reports `success` (exit 0) so the ci-summary gate is
+          # satisfied (the poller discovers whatever check-runs exist; an absent-by-design
+          # sub-result never hangs it). Mirrors the selection skip idiom directly below.
+          if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$SHARD_FILTER" ]; then
+            echo "heavy shard '${{ matrix.name }}' DEMOTED off merge_group (sq-6vshe.6):"
+            echo "  deterministic single-crate recall gate — no cross-PR interaction;"
+            echo "  full form runs at PR level + push-to-main. Reporting success."
+            exit 0
+          fi
           # [FABLE-5] sq-fmx4u.3 (design §5.2): single-crate shard skip guard.
           # FAIL-CLOSED: only the exact mode 'selected' AND a non-empty SHARD_CRATE
           # AND a definite non-membership ('"<crate>"' absent from the affected
@@ -582,6 +614,99 @@ jobs:
             ./scripts/ci-free-disk.sh || true
             attempt=$((attempt + 1))
           done
+
+  # [OPUS-4.8] sq-6vshe.6 (research/ci-structural-speedup.md §7, round 2) — the
+  # DEMOTED-LANE SAFETY NET for the two heavy recall shards demoted off merge_group.
+  # The heavy shards' FULL FORM runs at PR level AND on push-to-main (in `test` above).
+  # This tiny job is the "cannot silently rot" backstop mandated by the demotion
+  # protocol (§7): if a heavy recall shard FAILS on the canonical push-to-main build —
+  # the exact regression a merge_group run no longer catches — it auto-files a P1 bead +
+  # a deduped GitHub issue naming the lane + run, via scripts/ci-file-demoted-lane-
+  # failure.py (the generic filer the fuzz demotion already uses). It runs ONLY on
+  # push-to-main failure, and files ONLY when a job named `test (load-aware shard heavy-…)`
+  # is the one that failed (a bulk-shard failure is a normal red main build, not a
+  # demoted-lane finding). It is a SEPARATE job so the write scope stays off the 5-shard
+  # `test` matrix — least-privilege, matching the fuzz/differential filer precedent.
+  heavy-recall-demoted-filer:
+    name: heavy-recall demoted-lane safety-net (push-to-main)
+    needs: [changes, test]
+    # push-to-main only, and only when `test` did not succeed. `always()` so this runs
+    # despite the failed `needs`; the body then confirms a HEAVY shard was the culprit.
+    if: >-
+      always() && github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.test.result != 'success' && needs.test.result != 'skipped'
+    runs-on: ubuntu-latest
+    # Scoped write: append the bead + best-effort push (contents), file/comment the issue
+    # (issues), read this run's job list to detect which shard failed (actions).
+    permissions:
+      contents: write
+      issues: write
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Detect a failed heavy recall shard in this run
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # List THIS workflow-run's jobs and find a FAILED heavy shard by name. The
+          # heavy shards are the only jobs named "test (load-aware shard heavy-…)".
+          failed="$(gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" \
+            --jq '.jobs[] | select(.conclusion == "failure") | select(.name | test("test \\(load-aware shard heavy-")) | .name' \
+            | head -n1 || true)"
+          if [ -z "$failed" ]; then
+            echo "No heavy recall shard failed in this run (only bulk/other legs) — nothing to file."
+            echo "file=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Failed heavy shard detected: $failed"
+            echo "file=true" >> "$GITHUB_OUTPUT"
+            echo "shard_name=$failed" >> "$GITHUB_OUTPUT"
+          fi
+      - name: File the demoted-lane P1 bead + issue
+        if: steps.detect.outputs.file == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SHARD_NAME: ${{ steps.detect.outputs.shard_name }}
+        run: |
+          set -euo pipefail
+          # Self-test the filer first (hermetic; no gh, no writes) so a script regression
+          # is caught here, not silently.
+          python3 scripts/ci-file-demoted-lane-failure.py --self-test
+          python3 scripts/ci-file-demoted-lane-failure.py \
+            --lane "heavy-recall-vectors" \
+            --bead-prefix "hr" \
+            --full-form "sparq-vectors heavy recall shards on push-to-main ($SHARD_NAME)" \
+            --per-pr-form "runs at PR level; demoted off merge_group (sq-6vshe.6)" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+      - name: Commit + push the auto-filed bead (best-effort)
+        if: steps.detect.outputs.file == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          if git diff --quiet -- .beads/issues.jsonl; then
+            echo "no bead appended (dedupe hit) — nothing to push."
+            exit 0
+          fi
+          git config user.name "sparq-ci[bot]"
+          git config user.email "sparq-ci@users.noreply.github.com"
+          git add .beads/issues.jsonl
+          git commit -m "chore(ci): auto-file demoted heavy-recall lane failure (sq-6vshe.6). [OPUS-4.8]"
+          push_rc=0
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main || push_rc=$?
+          if [ "$push_rc" -ne 0 ]; then
+            echo "::warning title=demoted-lane bead push declined::Could not push the auto-filed bead to protected main (git push exit ${push_rc}; likely GH013 ruleset rejection). The GitHub issue filed in the previous step is the durable record; the orchestrator beads it on the next issue sweep."
+          else
+            echo "pushed the demoted-lane bead to main."
+          fi
 
   wasm:
     name: wasm build (sparq-wasm + sparq-reason-wasm + sparq-rsp-wasm + sparq-text-wasm + sparq-shacl-wasm + sparq-solid)

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -759,5 +759,144 @@ class TestRequiredCheckAnchor(unittest.TestCase):
             )
 
 
+class TestHeavyRecallMergeGroupDemotion(unittest.TestCase):
+    """[OPUS-4.8] sq-6vshe.6 (research/ci-structural-speedup.md §7, round 2): the two
+    heavy sparq-vectors recall shards (heavy-diskann/heavy-hnsw) are DEMOTED off the
+    merge_group ref — deterministic single-crate accuracy gates with no cross-PR
+    interaction — while the bulk workspace-unification shards (the real cross-PR value)
+    stay. Pins the guard SHAPE + the demoted-lane safety-net job so the demotion cannot
+    silently rot or over-reach.
+
+    Key safety invariants pinned here:
+      * the demotion is merge_group-ONLY (never PR, never push-to-main — the full form);
+      * it is a STEP guard, not a job `if:` (matrix context is unavailable there);
+      * the check-run NAMES are unchanged (guard reports success, not a missing leg);
+      * a heavy-shard failure on push-to-main auto-files via the demoted-lane filer;
+      * the filer's job-name detection regex matches the real heavy shard names."""
+
+    # The regex the heavy-recall-demoted-filer uses (in ci.yml) to find a FAILED heavy
+    # shard by job name. Kept in sync with the workflow's `--jq ... test("...")`.
+    _HEAVY_JOB_RE = re.compile(r"test \(load-aware shard heavy-")
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ci = _load(CI_YML)
+
+    def _test_run_step(self) -> str:
+        """The `Test (nextest, shard …)` step's run body."""
+        for step in self.ci["jobs"]["test"]["steps"]:
+            if str(step.get("name", "")).startswith("Test (nextest, shard"):
+                return str(step.get("run", ""))
+        self.fail("could not find the `Test (nextest, shard …)` step in the test job")
+
+    def test_heavy_shards_demoted_off_merge_group_only(self):
+        run = self._test_run_step()
+        # The guard: merge_group AND a non-empty SHARD_FILTER (heavy shards only) -> exit 0.
+        self.assertIn('"${{ github.event_name }}" = "merge_group"', run,
+                      "heavy-recall demotion guard must key on the merge_group event")
+        self.assertIn('-n "$SHARD_FILTER"', run,
+                      "demotion guard must fire only on heavy shards (non-empty filter)")
+        # It must be an AND so it never fires on a bulk shard or a non-merge_group event.
+        self.assertRegex(
+            run,
+            r'"\$\{\{ github\.event_name \}\}" = "merge_group" \] && \[ -n "\$SHARD_FILTER"',
+            "demotion must require BOTH merge_group AND a heavy shard (AND, not OR) — "
+            "otherwise it would skip bulk shards or run on PR/push",
+        )
+        # The guard must NOT reference push / pull_request — the full form runs there.
+        # (Assert the guard line itself mentions merge_group exclusively.)
+        guard_lines = [ln for ln in run.splitlines()
+                       if "github.event_name" in ln and "SHARD_FILTER" in ln]
+        self.assertTrue(guard_lines, "expected a single-line combined event+shard guard")
+        for ln in guard_lines:
+            self.assertNotIn("push", ln,
+                             "the demotion guard must not fire on push-to-main (full form)")
+            self.assertNotIn("pull_request", ln,
+                             "the demotion guard must not fire on PRs (full form, blocking)")
+
+    def test_shard_filter_env_maps_to_matrix_filter(self):
+        """The guard reads $SHARD_FILTER; it must be populated from matrix.filter (the
+        heavy-shard discriminator — non-empty only on the two heavy shards)."""
+        for step in self.ci["jobs"]["test"]["steps"]:
+            if str(step.get("name", "")).startswith("Test (nextest, shard"):
+                env = step.get("env", {})
+                self.assertIn("SHARD_FILTER", env,
+                              "the Test step must pass SHARD_FILTER via env")
+                self.assertEqual(env["SHARD_FILTER"], "${{ matrix.filter }}",
+                                 "SHARD_FILTER must come from matrix.filter")
+                return
+        self.fail("Test step not found")
+
+    def test_heavy_shards_still_run_at_pr_and_push(self):
+        """The demotion must NOT remove the heavy shards from the matrix — they must
+        still run (full form) at PR level and on push-to-main. Confirm the matrix
+        entries are untouched and the job triggers on those events."""
+        matrix = self.ci["jobs"]["test"]["strategy"]["matrix"]["include"]
+        heavy = [e for e in matrix if str(e.get("name", "")).startswith("heavy-")]
+        self.assertEqual(
+            {e["name"] for e in heavy}, {"heavy-diskann", "heavy-hnsw"},
+            "both heavy recall shards must remain in the test matrix (demoted at "
+            "runtime on merge_group only, never removed)",
+        )
+        on = _on_block(self.ci)
+        self.assertIn("pull_request", on, "CI must run on pull_request (heavy full form)")
+        self.assertIn("push", on, "CI must run on push (heavy full form on main)")
+
+    def test_demoted_lane_filer_job_wired(self):
+        """The demotion protocol (§7) requires a full-form-failure auto-filer so the
+        demoted lane cannot silently rot. Pin the safety-net job's existence, its
+        push-to-main-only guard, its scoped write perms, and its use of the filer."""
+        job = self.ci["jobs"].get("heavy-recall-demoted-filer")
+        self.assertIsNotNone(job, "missing the heavy-recall demoted-lane safety-net job")
+        cond = str(job.get("if", ""))
+        self.assertIn("github.event_name == 'push'", cond,
+                      "safety-net must run on push-to-main only")
+        self.assertIn("refs/heads/main", cond, "safety-net must be main-only")
+        self.assertIn("needs.test.result", cond,
+                      "safety-net must gate on the test job's result")
+        needs = job.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        self.assertIn("test", needs, "safety-net must need the test job")
+        perms = job.get("permissions", {})
+        self.assertEqual(perms.get("contents"), "write",
+                         "safety-net needs contents:write to append+push the bead")
+        self.assertEqual(perms.get("issues"), "write",
+                         "safety-net needs issues:write to file the GitHub issue")
+        self.assertEqual(perms.get("actions"), "read",
+                         "safety-net needs actions:read to inspect this run's jobs")
+        body = "\n".join(str(s.get("run", "")) for s in job.get("steps", []))
+        self.assertIn("scripts/ci-file-demoted-lane-failure.py", body,
+                      "safety-net must invoke the generic demoted-lane filer")
+        self.assertIn("--self-test", body,
+                      "safety-net must self-test the filer before using it")
+
+    def test_filer_job_name_detection_matches_real_heavy_shard_names(self):
+        """The safety-net detects a failed heavy shard by matching its JOB NAME against
+        `test \\(load-aware shard heavy-`. If a heavy shard is renamed and this regex is
+        not, the filer would silently never fire (silent rot). Pin the regex against the
+        REAL job names GitHub produces (workflow-job name template + matrix.name)."""
+        test_job_name_tmpl = self.ci["jobs"]["test"]["name"]  # "test (load-aware shard ${{ matrix.name }})"
+        matrix = self.ci["jobs"]["test"]["strategy"]["matrix"]["include"]
+        heavy_names = [e["name"] for e in matrix if str(e.get("name", "")).startswith("heavy-")]
+        for mname in heavy_names:
+            real = test_job_name_tmpl.replace("${{ matrix.name }}", mname)
+            self.assertRegex(
+                real, self._HEAVY_JOB_RE,
+                f"the filer's heavy-shard detection regex must match job name {real!r}",
+            )
+        # And it must NOT match a bulk shard or the nightly-coverage 'heavy' substring
+        # job (which carries "heavy" but is not a heavy recall shard).
+        self.assertNotRegex(
+            test_job_name_tmpl.replace("${{ matrix.name }}", "bulk 1/3"),
+            self._HEAVY_JOB_RE,
+            "the filer regex must not match bulk shards",
+        )
+        self.assertNotRegex(
+            "coverage (nightly, full incl. heavy vectors)",
+            self._HEAVY_JOB_RE,
+            "the filer regex must not match the nightly-coverage 'heavy' substring job",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — merge-queue CI slimming (bead sq-6vshe.6, round 2). [OPUS-4.8]
> Measure → classify → demote-where-safe, following the established heavy-lane placement protocol (`research/ci-structural-speedup.md` §7, the same one PR #1895 used for fuzz).
> **Not armed** — high blast-radius (touches the merge-queue critical-path workflow). Requesting review.

## What this does

DEMOTES the two heavy `sparq-vectors` recall shards (`heavy-diskann`, `heavy-hnsw`) off the **merge_group** ref only. They still run in full at PR level (blocking) and on push-to-main. A new tiny `heavy-recall-demoted-filer` job auto-files a P1 bead + GitHub issue if a heavy shard fails on main, so the demoted lane cannot silently rot.

## STEP 1 — Measurement (last 6 completed `merge_group` SHAs on `sparq-org/sparq`)

> These are **measurements from these specific runs on shared GitHub-hosted runners — NON-canonical**, not repo performance facts. High run-to-run variance (shared runners); reported to locate the pole, not to bake numbers.

**Per-workflow wall time on `merge_group` (12 workflows fire; n=6 runs each):**

| Workflow | min | median | max |
|---|---|---|---|
| **ci-summary** (the gate waiter itself) | 20.3m | 25.0m | 25.5m |
| **CI** (the pole) | 19.7m | 24.3m | 24.9m |
| feature-matrix | 1.6m | 6.7m | 7.6m |
| fuzz | 0.3m | 5.6m | 6.7m |
| codeql | 4.9m | 5.1m | 5.2m |
| container-scan | 3.5m | 4.2m | 4.7m |
| vectorized-feature-off | 1.1m | 1.6m | 1.9m |
| docs-quality | 0.9m | 1.1m | 1.6m |
| supply-chain | 0.8m | 0.9m | 1.5m |
| flow-on-gates / zk-toolchain / formal-verification | — | ≤0.3m | ≤0.8m |

**The critical path is 100% inside `CI`.** Per-SHA, the last sibling the gate waits on was `CI` every single cycle; the 2nd-place sibling was ≤7.6m — a ~17m gap. So **nothing outside `CI` is on the critical path.**

**Top `CI` sub-jobs by wall-time (the real pole is inside here):**

| CI job | median | max |
|---|---|---|
| `test (load-aware shard bulk 1/3..3/3)` | ~9-11m | 13.8-16.5m |
| `test (load-aware shard heavy-diskann)` | 7.8m | 12.9m |
| `test (load-aware shard heavy-hnsw)` | 9.1m | 12.6m |
| `build + archive test binaries` | 10.5m | 11.5m |
| `coverage ratchet (shard 1/3..3/3)` | ~8-9m | 8.7-10.1m |
| `clippy (gate) + fmt` | 3.6m | 6.0m |

Critical path = `build-archive` (~10m) → `test bulk` tail (~10-16m), serial. The heavy recall legs and coverage run **in parallel** to that tail. **Queue-wait was ~0 (median 0.0m, p90 0.1m across 222 jobs) — the runner pool was NOT saturated**, so freeing runner slots buys no cycle time right now (only headroom).

Also established: on `merge_group`, `ci.yml`'s `changes` job force-sets `rust_changed=true` and `select` reports `skipped`, so the **full heavy matrix runs unconditionally** — change-based selection does not narrow anything on the queue ref.

## STEP 2 — Per-leg classification

| Leg | Class | Verdict | Reasoning |
|---|---|---|---|
| `build-archive` → `test bulk N/3` | (c) true pole **with** cross-PR value | **KEEP** | This is the combined-tree workspace build + unification test — the exact thing a merge queue exists to verify (feature-unification, cross-PR API breaks). Un-demotable by definition. It IS the cycle wall. |
| `test heavy-diskann` / `test heavy-hnsw` | (b) redundant + deterministic, **no** cross-PR value | **DEMOTE (this PR)** | Each runs ONE deterministic single-crate accuracy gate (`{diskann,hnsw}_recall_at_10_vs_brute_force_on_50k`, fixed seeds `0xC0FFEE`/`0xDECAF`, `approx-ann`). Outcome = pure function of `sparq-vectors` + pinned `instant-distance`; nothing else in the workspace. A squash group reproduces the identical result each PR already gated. |
| `coverage ratchet (shard 1-3)` + `coverage engine run/merge` | (c) pole with cross-PR value, **already sharded** | **KEEP untouched** | Coverage sharding is sq-piapk's domain (already done). It is a genuine gate, off the critical-path tail, and out of scope per the task's do-not-touch list. |
| `codeql` | resolved KEEP | **KEEP** | Already measured + resolved (buildless ~5m); merge-queue is where the security posture gates. Out of scope. |
| `supply-chain`, `feature-matrix`, `fuzz`, `container-scan`, `docs-quality`, `flow-on-gates`, `zk-toolchain`, `formal-verification`, `vectorized-feature-off` | (a) fast/harmless, or already-demoted (fuzz), or has cross-PR value (supply-chain lockfile merges, feature-matrix unification) | **KEEP** | All finish ≥17m before the pole. Demoting any saves ZERO cycle time and (supply-chain / feature-matrix) removes real cross-PR interaction coverage. Not worth the risk. |

## STEP 3 — Implementation (the safe subset = the two heavy recall legs)

- **STEP guard** in the `Test (nextest, shard …)` step (not a job `if:` — matrix context is unavailable there, a known trap): fires only on `merge_group` AND a heavy shard (`$SHARD_FILTER` non-empty), prints a demotion notice, `exit 0`. The check-run **name is unchanged and reports `success`** → zero missing-leg risk for the `ci-summary` poller (it discovers whatever check-runs exist; an absent-by-design sub-result never hangs it — verified the gate poller is name-agnostic and treats success/skipped as non-failing).
- **Full form preserved:** heavy shards still run at PR level (blocking) and on push-to-main (both force `rust_changed=true`, neither hits the guard).
- **Demotion auto-bead wired** (`heavy-recall-demoted-filer`, push-to-main only, scoped `contents/issues: write` + `actions: read`): detects a failed heavy shard by job name via `gh api …/jobs`, then `scripts/ci-file-demoted-lane-failure.py` files a P1 bead + deduped issue (self-tested first). Least-privilege — write scope is on this one tiny job, not the 5-shard `test` matrix (matches the fuzz/differential filer precedent).

## Validation

- YAML valid (`yaml.safe_load`); `actionlint` clean (no new findings).
- `scripts/tests/test_ci_select_wiring.py`: **+5 tests, 38 pass** — pin the guard shape (merge_group-only, AND-not-OR, never push/PR), the `SHARD_FILTER`↔`matrix.filter` map, heavy shards still in the matrix, the filer job wiring (guard/perms/needs/script), and the filer's job-name detection regex against the real heavy-shard names (rename-safety).
- `scripts/ci-file-demoted-lane-failure.py --self-test` passes; `scripts/tests/test_ci_summary_gate.py` (33 tests) still green.
- The `--jq` shard-detection filter verified end-to-end against real `merge_group`/`push` job lists and a synthetic failure set (matches only failed heavy shards; excludes the `coverage (… heavy vectors)` substring job).

## Honest expected impact

- **Cycle time: unchanged** (~20-25m). The heavy legs are parallel to the longer `test bulk` tail and are not the pole; the wall is `build-archive → test bulk`, which is un-demotable core cross-PR verification.
- **Runner-minutes: ~24 min/cycle saved** (2 legs × ~12m) + **2 runner slots freed** per merge_group cycle — real cost + saturation-headroom value (matters as the queue merges up to 8 PRs/cycle and cadence rises), but honestly **not** a drain-rate improvement.
- The genuine cycle-time lever is shrinking `build-archive → test bulk` (engine split sq-6vshe.4 / cache priming sq-6vshe.5), all out of demotion scope.

## Compliance gap closed

None weakened. This strictly narrows redundant merge-queue work while preserving every gate's PR-level + push-to-main coverage and adding a rot-proof auto-filer, per the sq-6vshe.6 demotion protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
