### PR TITLE
feat(orchestration): retriage cron + migration gating pre-flight + paginated readiness snapshot

### DIFF
--- a/.github/workflows/retriage.yml
+++ b/.github/workflows/retriage.yml
@@ -1,0 +1,34 @@
+# [FABLE-5] Retriage cron (audit-2026-07-17): `status:untriaged` used to be TERMINAL — triage
+# only fires on opened/edited/reopened, and GitHub's `edited` event does not cover label changes,
+# so an issue missing a priority at open time (or fixed later by label) never became ready. This
+# sweep re-runs the SAME static triage over parked untriaged issues by trusted authors, applying a
+# default priority:P3 only when NO priority label exists (ambiguity still parks for a human).
+name: retriage
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/30 * * * *'
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: retriage
+  cancel-in-progress: false
+
+jobs:
+  retriage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Re-run static triage over status:untriaged issues
+        run: |
+          set -euo pipefail
+          python3 scripts/triage.py --self-test
+          python3 scripts/retriage.py --self-test
+          python3 scripts/retriage.py --repo "$GITHUB_REPOSITORY" --apply

--- a/research/context-economy-worker-fleet.md
+++ b/research/context-economy-worker-fleet.md
@@ -149,9 +149,10 @@ container has **no `gh` binary** and the brief forbids GitHub APIs, so *if* agen
 execute in fresh-HOME non-interactive `claude -p`, every cargo/git/test Bash call pays
 an Opus round-trip to conclude "not applicable". At 30–100 Bash calls per
 implementation run that is ~100–400k Opus input tokens of pure overhead per worker
-(estimate) — which would dwarf everything else in this record. **Whether the hook fires
-headless is UNVERIFIED** (folder-trust/hook-approval gating may skip it); §5 pilot E is
-the verify-first canary. The fix is trivial either way (command-hook prefilter on the
+(estimate) — which would dwarf everything else in this record. **RESOLVED 2026-07-17:
+the §5 pilot E canary found the hook does NOT fire in fresh-HOME headless runs with the
+committed settings — but only via a fragile config interaction; see the pilot E RESULT
+in §5.** The fix is trivial either way (command-hook prefilter on the
 arming pattern, or a worker-mode settings override in the container). The `SessionStart`
 bd hook provably no-ops in-container (`bd` not installed; script exits 0).
 
@@ -428,6 +429,29 @@ except P0: stub repo + a counting command hook + the committed agent hook;
 agent hook present in settings. If agent hooks fire headless: fix immediately (no
 threshold — it is pure overhead); re-run one baseline batch afterwards so pilots A–D
 measure against the fixed floor.
+
+**Pilot E RESULT (2026-07-17, audit fix wave).** Ran fresh-HOME headless `claude -p`
+probes (worker-shaped: isolated `$HOME` + copied credential, cwd at a checkout root,
+`--allowedTools Bash`, haiku main model). Findings:
+1. With the **committed sparq `settings.json` as-is**, the `sparq-perf-reviewer` agent
+   hook does **NOT** fire on Bash calls (two independent probes: no Opus/no second
+   model in `modelUsage`, no `hook_started` events for PreToolUse, seconds-scale total
+   duration) — workers are NOT currently paying the per-Bash Opus overhead feared in
+   §1.5. The `SessionStart` bd hook DOES fire.
+2. **Do not conclude agent hooks are inert headless**: in a synthetic project with a
+   minimal `PreToolUse` config, BOTH the command hook and a test agent hook fired in
+   the same fresh-HOME headless mode (the hook agent showed up as a second model in
+   `modelUsage`), and stripping the `SessionStart` entry from a copy of the sparq
+   config also un-suppressed its PreToolUse hooks. The suppression is a
+   config-interaction effect, not a headless guarantee — a future settings.json edit
+   could silently start billing Opus per Bash call.
+3. When the agent hook did fire in probes, its `model: "opus"` pin was **not honored**
+   (the hook agent ran on a haiku snapshot id) — the worst-case Opus overhead estimate
+   in §1.5 may overstate the price even in the firing configuration.
+Action: the matcher fix (command-hook prefilter on the `gh pr merge --auto` arming
+pattern, or a worker-mode settings override) is still the right hardening so the
+outcome stops depending on an undocumented interaction; tracked as a sparq-side
+follow-up issue (dedupe marker: audit-2026-07-17).
 
 **Sequencing**: P0 → E → A → {B, D in parallel, separate accounts} → C. Every pilot's
 results land in `bench/` (the sanctioned home for measured numbers) with a one-line

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -69,10 +69,25 @@ def role_for(issue):
 # [OPUS-4.8] Only PIPELINE-RELEVANT labels cross into GitHub. bd carries ~200 free-form tags
 # (from:*, effort:*, tier:*, roadmap, one-off topic tags) that triage/readiness/dispatch NEVER read.
 # Passing them through would (a) force creating ~200 junk repo labels and (b) risk a LABEL-LESS issue:
-# `gh issue create` fails on the first unknown label and the fallback drops ALL labels, so triage
-# cannot derive priority → the issue is stuck untriaged. Keep only what the pipeline consumes.
+# `gh issue create` fails on the first unknown label → issues are only created against a PRE-CREATED
+# full label set (ensure_labels), failing LOUDLY instead of silently dropping labels. Keep only what
+# the pipeline consumes.
 _KEEP_PREFIX = ("area:", "needs:", "trust:", "kind:")
 _SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
+_BLOCKED_ON = re.compile(r"^blocked[-:]on[-:](.+)$")
+_BLOCKED = re.compile(r"^blocked:(.+)$")
+
+
+def _map_label(lb):
+    """Migration gating pass (audit-2026-07-17): bd `blocked:*` / `blocked-on-*` tags become
+    `needs:*` gates — the readiness engine only gates on the needs:/trust: prefixes, so an unmapped
+    `blocked:ec2` bead would migrate DISPATCHABLE and burn worker attempts on an un-runnable task.
+    `blocked-by-epic:*` is DROPPED: parent-child edges already model epic linkage, and mapping it to
+    needs:* would reintroduce the sub-epic-leaf-invisibility bug the migration deliberately fixes."""
+    if lb.startswith("blocked-by-epic:"):
+        return None
+    m = _BLOCKED_ON.match(lb) or _BLOCKED.match(lb)
+    return f"needs:{m.group(1)}" if m else lb
 
 
 def _pipeline_relevant(lb):
@@ -81,13 +96,42 @@ def _pipeline_relevant(lb):
     return lb.startswith(_KEEP_PREFIX) or any(k in lb for k in _SEC_KEYWORDS)
 
 
+# External/audit gating (audit-2026-07-17): human/credential/externally gated beads (the sq-qhy4
+# external-cryptographer-audit class, token-placement, maintainer-decision beads) must migrate as
+# needs:user — NOT as plain dispatchable issues. needs:user is the ONLY durable parking state: the
+# dispatcher's deferred-retry re-fires any needs-free status:deferred issue, so without this gate
+# sq-qhy4 (P0, no area → the __global__ partition) would be dispatched FIRST, fail, and loop —
+# serializing the frontier behind an issue no worker can implement.
+_EXTERNAL_IDS = {"sq-qhy4", "sq-v286.8"}
+_EXTERNAL_TITLE = re.compile(
+    r"\bexternal\b.*\baudit\b|accredited|cryptographer|\bneeds:user\b|"
+    r"maintainer[- ](sign-?off|review|greenlit|gated)|code-signing|notariz|"
+    r"token (placement|upload|provisioning)", re.I)
+_EXTERNAL_DESC = re.compile(r"agent[- ]out[- ]of[- ]scope|out[- ]of[- ]scope by definition", re.I)
+
+
+def externally_gated(bead):
+    """True when a bead is gated on a human/credential/external dependency (curated id list +
+    title patterns + an explicit description marker). Deliberately errs toward over-gating:
+    needs:user is maintainer-visible and trivially reversible, while a mis-dispatched external
+    gate burns worker attempts and can reserve the global partition."""
+    if str(bead.get("id", "")) in _EXTERNAL_IDS:
+        return True
+    if _EXTERNAL_TITLE.search(bead.get("title") or ""):
+        return True
+    return bool(_EXTERNAL_DESC.search((bead.get("description") or "")[:400]))
+
+
 def issue_labels(bead):
     labels = [lb["name"] if isinstance(lb, dict) else lb for lb in bead.get("labels", [])]
-    out = {lb for lb in labels if _pipeline_relevant(lb)}   # whitelist — drop free-form bd tags
+    mapped = (_map_label(lb) for lb in labels)              # blocked:* -> needs:* gating pass
+    out = {lb for lb in mapped if lb and _pipeline_relevant(lb)}   # whitelist — drop free-form tags
     p = bead.get("priority")
     if isinstance(p, int) and 0 <= p <= 4:
         out.add(f"priority:P{p}")
     out.add(f"role:{role_for(bead)}")
+    if externally_gated(bead):
+        out.add("needs:user")
     # [OPUS-4.8] an epic is a tracking/umbrella issue, never a dispatchable work item — mark it
     # `kind:epic` so the readiness engine excludes it (else a worker would try to "implement" the
     # epic itself, producing a garbage PR). 57 of the 893 open beads are epics, 41 at P1 — they would
@@ -140,14 +184,33 @@ def _body(bead, bid):
     return f"{desc}\n\n<!-- bd-id:{bid} -->\n"
 
 
+def ensure_labels(repo, labels):
+    """Idempotently create EVERY label the migration will use, BEFORE any issue create. Fails
+    LOUDLY on any real failure: `gh issue create` errors on the first unknown label, and the old
+    fallback dropped ALL labels — a silent label-less issue is permanently status:untriaged and
+    loses its package partition. No --force: existing labels keep their curated colors."""
+    failed = []
+    for l in sorted(labels):
+        r = _run(["gh", "label", "create", l, "-R", repo, "--color", "ededed",
+                  "--description", "bd migration label"], check=False)
+        if r.returncode != 0 and "already exists" not in (r.stderr or ""):
+            failed.append(l)
+    if failed:
+        raise SystemExit(f"refusing --apply: {len(failed)} label(s) could not be created "
+                         f"(fail-loud, no silent label drop): {failed[:10]}")
+
+
 def _create_issue(repo, bid, bead):
-    base = ["gh", "issue", "create", "-R", repo, "--title", f"{bid}: {bead['title']}", "--body", _body(bead, bid)]
-    args = list(base)
+    args = ["gh", "issue", "create", "-R", repo, "--title", f"{bid}: {bead['title']}", "--body", _body(bead, bid)]
     for l in issue_labels(bead):
         args += ["--label", l]
     r = _run(args, check=False)
-    if r.returncode != 0:            # a label may not exist in a scratch repo → create without labels
-        r = _run(base)
+    if r.returncode != 0:
+        # FAIL LOUDLY (audit-2026-07-17): the old fallback retried with NO labels at all, silently
+        # producing untriaged, partition-less issues. Labels are pre-created by ensure_labels, so a
+        # failure here is a real problem the operator must see. The run is crash-resumable.
+        raise SystemExit(f"issue create failed for {bid} (labels are pre-created; refusing the "
+                         f"silent label-drop fallback): {(r.stderr or '').strip()[:300]}")
     return int(re.search(r"/issues/(\d+)", r.stdout).group(1))
 
 
@@ -164,6 +227,8 @@ def apply_migration(repo, open_ids, blockers, parents, limit=None, checkpoint="/
     adds Blocked-by:/Parent: markers. Re-running creates nothing new."""
     id_map = fetch_bd_map(repo)
     ids = list(open_ids)[: limit] if limit else list(open_ids)
+    # Pre-flight: the FULL label set exists before the first create (fail-loud, item 10).
+    ensure_labels(repo, {l for bid in ids for l in issue_labels(open_ids[bid])})
     created = 0
     for bid in ids:                                  # pass 1
         if bid in id_map:
@@ -205,6 +270,28 @@ def _self_test():
     # epic gets kind:epic
     chk("epic tagged", "kind:epic" in issue_labels(
         {"priority": 1, "issue_type": "epic", "labels": ["area:x"]}), True)
+    # blocked:* -> needs:* gating pass (audit-2026-07-17)
+    chk("blocked:ec2 maps to needs:ec2", _map_label("blocked:ec2"), "needs:ec2")
+    chk("blocked-on-zk maps to needs:zk", _map_label("blocked-on-zk"), "needs:zk")
+    chk("blocked-by-epic is dropped", _map_label("blocked-by-epic:sq-3kd2g"), None)
+    chk("plain label passes through", _map_label("area:sparq-core"), "area:sparq-core")
+    got = set(issue_labels({"priority": 1, "issue_type": "task",
+                            "labels": ["blocked:ec2", "blocked-by-epic:sq-x", "area:bench"]}))
+    chk("mapped gate survives whitelist", ("needs:ec2" in got, "blocked:ec2" in got,
+                                           any("epic" in lb for lb in got)), (True, False, False))
+    # external/audit gating: the sq-qhy4 class must land needs:user (durably parked)
+    qhy4 = {"id": "sq-qhy4", "priority": 0, "issue_type": "task",
+            "title": "[cert][cryptoreview] External accredited-cryptographer audit of the ZK "
+                     "verifier + Noir circuits", "labels": []}
+    chk("sq-qhy4 class gated needs:user", "needs:user" in issue_labels(qhy4), True)
+    chk("curated id gated", externally_gated({"id": "sq-v286.8", "title": "x"}), True)
+    chk("needs:user title gated", externally_gated(
+        {"id": "sq-z", "title": "needs:user — flip GitHub Pages source"}), True)
+    chk("agent-out-of-scope desc gated", externally_gated(
+        {"id": "sq-z", "title": "plain", "description": "Agent-out-of-scope by definition."}), True)
+    chk("plain feature not gated", externally_gated(
+        {"id": "sq-a", "title": "feat(core): add a parser fast-path",
+         "description": "speed up ingest"}), False)
     print("bd-to-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 
@@ -241,9 +328,16 @@ def main():
     roles = Counter(role_for(b) for b in open_ids.values())
     pkgs = Counter(lb[5:] for b in open_ids.values()
                    for lb in issue_labels(b) if lb.startswith("area:"))
+    gated = sum(1 for b in open_ids.values() if "needs:user" in issue_labels(b))
+    no_area = sum(1 for b in open_ids.values()
+                  if str(b.get("issue_type", "")).lower() != "epic"
+                  and not any(lb.startswith("area:") for lb in issue_labels(b)))
     print(f"beads (all): {len(issues)}  |  to migrate (open/in_progress): {len(open_ids)}")
     print(f"blocker (blocks) edges among migrated: {sum(len(v) for v in blockers.values())}")
     print(f"parent-child links among migrated:    {sum(len(v) for v in parents.values())}")
+    print(f"gated needs:user (external/audit/blocked:*): {gated}")
+    print(f"WARNING non-epic beads with NO area label (each reserves the serializing __global__ "
+          f"partition): {no_area}")
     print(f"priority: {dict(sorted(prio.items()))}")
     print(f"roles:    {dict(roles.most_common())}")
     print(f"top packages: {dict(pkgs.most_common(8))}")

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -15,9 +15,10 @@ of a quarantine label. An issue is READY iff, in priority order, ALL hold:
     earlier-selected ready issue. A no-package / cross-cutting issue reserves a **global partition**
     that serializes it against ALL other work (shared lockfiles/CI/workspace configs).
 
-Truncation fails closed (an incomplete snapshot is refused). Native GitHub dependencies + cursor
-pagination are a follow-up (see FIXME); today blockers come from validated `Blocked-by: #NN` markers.
-Pure `compute_ready()` is unit-tested; the CLI wraps it over `gh issue list`.
+The snapshot uses real cursor pagination (`gh api --paginate`) with an explicit fail-closed
+ceiling; native GitHub dependencies remain a follow-up — today blockers come from validated
+`Blocked-by: #NN` markers. Pure `compute_ready()` is unit-tested; the CLI wraps it over the
+paginated fetch.
 """
 import argparse
 import json
@@ -154,19 +155,36 @@ def _self_test():
     check("packages multi", packages_of({"area:a", "area:b"}), {"a", "b"})
     check("packages none->global", packages_of({"role:impl"}), {GLOBAL})
     check("untriaged is busy", is_busy({"status:untriaged"}), True)
+    # paginated-snapshot flattening: multi-page merge, PR rows dropped, junk tolerated
+    check("flatten pages drops PRs", _flatten_pages(
+        [[{"number": 1}, {"number": 2, "pull_request": {}}], [{"number": 3}], "junk", [None]]),
+        [{"number": 1}, {"number": 3}])
     print("ready-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 
 
-def _fetch(repo, limit=1000):
+def _flatten_pages(pages):
+    """Flatten `gh api --paginate --slurp` output (a list of pages) into issues, dropping PRs
+    (REST /issues includes them, marked by the `pull_request` key). Pure — unit-tested."""
+    return [i for page in pages for i in (page if isinstance(page, list) else [])
+            if isinstance(i, dict) and "pull_request" not in i]
+
+
+def _fetch(repo, ceiling=10000):
+    """Open-issue snapshot via REAL cursor pagination (`gh api --paginate` follows Link headers),
+    replacing the old single-page `--limit 1000` fetch that FAILED CLOSED at exactly 1000 open
+    issues — the full bd migration (~900 beads on top of organic issues) crosses that. The explicit
+    ceiling still fails closed on a runaway snapshot."""
     out = subprocess.run(
-        ["gh", "issue", "list", "-R", repo, "--state", "open", "--limit", str(limit),
-         "--json", "number,labels,body,state"],
+        ["gh", "api", "--paginate", "--slurp",
+         f"repos/{repo}/issues?state=open&per_page=100"],
         capture_output=True, text=True, check=True).stdout
-    raw = json.loads(out)
-    if len(raw) >= limit:  # FIXME: replace with cursor pagination + native deps (GraphQL)
-        raise SystemExit(f"refusing: fetched {len(raw)} >= limit {limit} — snapshot may be truncated "
-                         "(fail-closed). Implement pagination before raising the limit.")
+    pages = json.loads(out or "[]")
+    raw = _flatten_pages(pages)
+    if len(raw) >= ceiling:
+        raise SystemExit(f"refusing: fetched {len(raw)} >= ceiling {ceiling} — snapshot looks "
+                         "runaway (fail-closed). Raise the ceiling deliberately if the backlog "
+                         "is really that large.")
     open_numbers = {i["number"] for i in raw}
     issues = []
     for i in raw:

--- a/scripts/retriage.py
+++ b/scripts/retriage.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# [FABLE-5] Issue-native orchestration: the designed RETRIAGE cron pass (audit-2026-07-17).
+"""retriage.py — re-run static triage over parked `status:untriaged` issues, fail-closed.
+
+`triage-issue.yml` only fires on opened/edited/reopened, and GitHub's `edited` activity does NOT
+cover label changes — so an issue that lands `status:untriaged` (e.g. opened without a priority)
+was TERMINAL: even a human later adding `priority:P2` never re-ran triage. This sweep closes the
+loop the triage.py docstring already promised ("status:untriaged for the retriage cron"):
+
+  * only OPEN issues carrying `status:untriaged` are considered;
+  * `trust:untrusted` is excluded (owned by promote-on-approval) and `kind:epic` is excluded
+    (untriaged-by-design tracking umbrellas);
+  * the author trust-gate is re-verified exactly like triage-issue.yml (the orchestrator App bot,
+    or admin/maintain/write collaborators) — untrusted authors are never triaged here;
+  * scripts/triage.py (the same static pass) recomputes the label delta; if the issue has NO
+    priority label at all, a default `priority:P3` is applied so the loop CONVERGES instead of
+    parking forever (an AMBIGUOUS priority still parks — that needs a human);
+  * retriage only PROMOTES (untriaged -> ready). It never re-parks or edits gated issues, so a
+    needs:* / ambiguous issue is simply left untouched.
+
+Pure `plan_retriage()` is unit-tested (--self-test); the CLI wraps it over `gh`. Default is a
+dry-run print; the cron passes --apply.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import triage  # noqa: E402  (same-directory static-triage module)
+
+DEFAULT_PRIORITY = "priority:P3"
+TRUSTED_BOT = "sparq-orchestrator[bot]"
+SKIP_LABELS = {"trust:untrusted", "kind:epic"}
+
+
+def plan_retriage(issues, trusted):
+    """[(number, add:sortedlist, remove:sortedlist)] for open status:untriaged issues whose author
+    passes `trusted(login)`. Only PROMOTING deltas are returned (ready==True); everything else is
+    left untouched for a human / the future LLM pass."""
+    actions = []
+    for it in issues:
+        labels = {lb["name"] if isinstance(lb, dict) else lb for lb in it.get("labels", [])}
+        if "status:untriaged" not in labels or labels & SKIP_LABELS:
+            continue
+        if not trusted(str(it.get("author", ""))):
+            continue
+        add_default = not any(triage._PRIO.match(lb) for lb in labels)
+        effective = labels | ({DEFAULT_PRIORITY} if add_default else set())
+        result = triage.triage(effective, "task")
+        if not result["ready"]:
+            continue  # ambiguous priority / needs:* / no role — parked for a human, no churn
+        add = set(result["add"]) | ({DEFAULT_PRIORITY} if add_default else set())
+        remove = set(result["remove"])
+        actions.append((it.get("number"), sorted(add - labels), sorted(remove & labels)))
+    return actions
+
+
+def _gh(args):
+    return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+
+
+def _trusted_factory(repo):
+    cache = {}
+
+    def trusted(login):
+        if not login:
+            return False
+        if login == TRUSTED_BOT:
+            return True
+        if login not in cache:
+            r = _gh(["api", f"repos/{repo}/collaborators/{login}/permission",
+                     "--jq", ".permission"])
+            cache[login] = (r.stdout or "").strip() if r.returncode == 0 else "none"
+        return cache[login] in {"admin", "maintain", "write"}
+
+    return trusted
+
+
+def _fetch_untriaged(repo):
+    r = _gh(["issue", "list", "-R", repo, "--state", "open", "--label", "status:untriaged",
+             "--limit", "500", "--json", "number,labels,author"])
+    if r.returncode != 0:
+        raise SystemExit("retriage: could not list status:untriaged issues")
+    issues = []
+    for it in json.loads(r.stdout or "[]"):
+        issues.append({"number": it.get("number"), "labels": it.get("labels") or [],
+                       "author": ((it.get("author") or {}).get("login") or "")})
+    return issues
+
+
+def _self_test():
+    ok = True
+
+    def chk(n, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {'ok  ' if good else 'FAIL'} {n}: {got} (want {want})")
+
+    def iss(n, labels, author="jeswr"):
+        return {"number": n, "labels": labels, "author": author}
+
+    trusted = lambda login: login in {"jeswr", TRUSTED_BOT}  # noqa: E731
+    fixture = [
+        # 1: human later added a priority by LABEL (the exact terminal case) -> promotes
+        iss(1, ["status:untriaged", "role:impl", "priority:P2", "area:sparq-core"]),
+        # 2: no priority at all -> default P3 -> promotes
+        iss(2, ["status:untriaged", "kind:docs", "area:site"]),
+        # 3: AMBIGUOUS priority -> needs a human, untouched
+        iss(3, ["status:untriaged", "role:impl", "priority:P1", "priority:P2"]),
+        # 4: epic umbrella -> untriaged-by-design, skipped
+        iss(4, ["status:untriaged", "kind:epic", "priority:P1", "role:impl"]),
+        # 5: quarantined -> owned by promote-on-approval, skipped
+        iss(5, ["status:untriaged", "trust:untrusted", "priority:P1"]),
+        # 6: untrusted author -> never triaged here
+        iss(6, ["status:untriaged", "priority:P1", "role:impl"], author="rando"),
+        # 7: needs:user gate -> triage refuses ready, untouched
+        iss(7, ["status:untriaged", "priority:P1", "role:impl", "needs:user"]),
+        # 8: not untriaged at all -> out of scope
+        iss(8, ["status:ready", "priority:P1", "role:impl"]),
+        # 9: orchestrator-bot author is trusted
+        iss(9, ["status:untriaged", "priority:P2", "kind:test"], author=TRUSTED_BOT),
+    ]
+    actions = {n: (a, r) for n, a, r in plan_retriage(fixture, trusted)}
+    chk("promoted set", sorted(actions), [1, 2, 9])
+    chk("label-added priority promotes", actions[1],
+        (["status:ready"], ["status:untriaged"]))
+    chk("default P3 applied", "priority:P3" in actions[2][0], True)
+    chk("default promotion readies", ("status:ready" in actions[2][0],
+                                      "status:untriaged" in actions[2][1]), (True, True))
+    chk("role derived for default case", any(x.startswith("role:") for x in actions[2][0]), True)
+    chk("bot author promoted", actions[9][0][0].startswith(("priority", "role", "status")), True)
+    chk("ambiguous priority untouched", 3 in actions, False)
+    chk("epic skipped", 4 in actions, False)
+    chk("quarantine skipped", 5 in actions, False)
+    chk("untrusted author skipped", 6 in actions, False)
+    chk("needs:user untouched", 7 in actions, False)
+    print("retriage self-test", "PASSED" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default="sparq-org/sparq")
+    ap.add_argument("--apply", action="store_true", help="apply the label deltas (cron mode)")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return _self_test()
+    actions = plan_retriage(_fetch_untriaged(args.repo), _trusted_factory(args.repo))
+    for number, add, remove in actions:
+        print(f"#{number}: +{','.join(add) or '-'} -{','.join(remove) or '-'}")
+        if args.apply:
+            for lb in add:
+                _gh(["issue", "edit", str(number), "-R", args.repo, "--add-label", lb])
+            for lb in remove:
+                _gh(["issue", "edit", str(number), "-R", args.repo, "--remove-label", lb])
+    print(f"retriage: {len(actions)} issue(s) {'promoted' if args.apply else 'promotable (dry-run)'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 SPARQ agent — audit fix wave (registry+sparq), sparq-side PR. UNARMED: do not auto-merge; the orchestrator's verify pipeline owns arming.

## What / why (audit-2026-07-17 confirmed-HIGH findings)

1. **Retriage path** (`.github/workflows/retriage.yml` + `scripts/retriage.py`): `status:untriaged` was **terminal** — `triage-issue.yml` only fires on `opened/edited/reopened`, and GitHub's `edited` event does not cover label changes, so ~11 trusted issues (e.g. #2384) sat parked even after a human added a priority label. The `*/30` cron re-runs the same static triage over open `status:untriaged` issues by trusted authors (same trust gate as triage-issue.yml). A default `priority:P3` is applied **only** when no priority label exists at all, so the loop converges; ambiguous priority still parks for a human. `kind:epic` (untriaged-by-design) and `trust:untrusted` (owned by promote-on-approval) are excluded. Retriage only promotes — it never re-parks or touches gated issues.

2. **Migration pre-flight** (`scripts/bd-to-issues.py`), before the full-893 `--apply`:
   - `blocked:*` / `blocked-on-*` bd tags map to `needs:*` gates (readiness only gates on `needs:`/`trust:` prefixes — an unmapped `blocked:ec2` bead would migrate dispatchable). `blocked-by-epic:*` is dropped (parent-child edges model epic linkage; mapping it would reintroduce sub-epic-leaf invisibility).
   - External/audit beads (the `sq-qhy4` external-cryptographer-audit class, token-placement, maintainer-decision beads) migrate as `needs:user` — the only durable parking state now that deferred-retry re-fires needs-free deferred issues. Dry-run over the real export: `sq-qhy4` (the only P0, global-partition) now lands gated; 15 beads gated total.
   - The **full label set is pre-created** (`ensure_labels`, no `--force` so curated colors survive) and `_create_issue` **fails loudly** instead of the silent retry-with-no-labels fallback (which produced permanently-untriaged, partition-less issues — 225/893 beads carried at least one nonexistent label).
   - Plan summary now prints the gated count and a loud warning for non-epic no-area beads (549) that would reserve the serializing `__global__` partition.

3. **1000-issue ceiling lifted** (`scripts/ready-issues.py`): `_fetch` now uses real cursor pagination (`gh api --paginate`, PRs dropped via the `pull_request` marker) with an explicit runaway ceiling (10000), replacing the hard `SystemExit` at exactly 1000 open issues that migration + organic growth would trip. `dispatch-plan.py` reuses this fetch, and the registry-side PLAN/groom snapshots get the matching lift in the registry change set.

4. **Canary E note** (`research/context-economy-worker-fleet.md` §1.5/§5): measured — with the committed `settings.json`, the PreToolUse `sparq-perf-reviewer` (Opus) agent hook does **not** fire in fresh-HOME headless `claude -p` worker runs (no second model in `modelUsage`, no PreToolUse hook events). But agent hooks **do** run headless in a minimal config, and stripping the `SessionStart` entry from a copy of the sparq config un-suppressed PreToolUse — the current safety is a fragile config interaction, so the matcher hardening stays a follow-up.

## Self-tests

- `python3 scripts/retriage.py --self-test` — 11 checks incl. the exact terminal case (priority added later by label), default-P3 convergence, ambiguity/epic/quarantine/untrusted/needs:user exclusions.
- `python3 scripts/bd-to-issues.py --self-test` — blocked-mapping, whitelist interaction, sq-qhy4-class gating, curated ids, non-gated control.
- `python3 scripts/ready-issues.py --self-test` — page-flattening/PR-drop check added.
- `actionlint` + YAML parse clean on `retriage.yml`; dry-run of the full-893 plan verified against the live bd export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)