### PR TITLE
feat(ci): draft-tier CI — reduced matrix on draft PR heads, full-tier supersession at ready_for_review

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,8 +49,13 @@ on:
   # `dashboard-labels` and `bench` job `if:`s (the `select` pre-job must stay
   # unconditional — the ci-summary gate REDs on any non-success selection
   # check-run), and label events get a per-run concurrency group below.
+  # [FABLE-5] Draft-tier CI: + ready_for_review, so the un-draft moment runs the
+  # deterministic perf ratchet the draft head skipped (the `bench` job is skipped
+  # entirely on draft PR heads — see its `if:` guard + docs/branch-protection.md
+  # §Draft-tier CI). This is independent of the label guard above and AND-composes
+  # with it on the `bench` job.
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
   # [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) merge_group REMOVED. The deterministic
   # byte-count ratchet is a pure function of the code: it already ran + hard-gated on the
   # PR head (--deterministic-only above), it re-runs on push-to-main below, and the
@@ -88,14 +93,23 @@ on:
 permissions:
   contents: read
 
-# Do NOT cancel an in-progress benchmark run (it would corrupt the stored series).
+# Do NOT cancel an in-progress benchmark run on main/schedule (it would corrupt the
+# stored series). push/schedule therefore keep cancel-in-progress false (see below).
 # [FABLE-5] label-trigger guard: labeled/unlabeled pull_request events get a PER-RUN
-# group. Even with cancel-in-progress:false, a group holds at most ONE PENDING run —
-# a label-flip run queued into the shared group would replace (cancel) a pending real
-# run on the same head SHA. Isolated, a guarded flip is a cheap select-only no-op.
+# group (the run_id suffix) so a label flip is ISOLATED — it can neither cancel nor
+# replace the in-flight/pending real run in the shared per-ref group on the same head
+# SHA (a group holds at most ONE PENDING run; without isolation a flip would evict a
+# pending real run even under cancel-in-progress:false). All other events resolve to
+# the constant `-shared` suffix.
+# [FABLE-5] Draft-tier CI: pull_request runs ARE cancelled when superseded — they
+# never write history (the ratchet/history steps are push-to-main-gated below), so a
+# stale PR bench run burning a runner slot buys nothing. This AND the label guard
+# compose: a label flip sits ALONE in its per-run group, so cancel-in-progress=true
+# there is a no-op on the real run; a PR synchronize sits in `-shared` and correctly
+# supersedes its predecessor; push/schedule stay in `-shared` and are never cancelled.
 concurrency:
   group: bench-${{ github.ref }}-${{ (github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action)) && github.run_id || 'shared' }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # [SONNET-4.6] sq-mel85 (design §5.2, phase 2b): the change-based test-selection
@@ -165,6 +179,13 @@ jobs:
     # ONLY narrow on pull_request / merge_group. That is what keeps the auto-ratchet
     # floor + benchmark-data history (both depend on every main commit being benchmarked)
     # continuous — see the push-gated history/ratchet steps below.
+    # [FABLE-5] Draft-tier CI: benchmarks are SKIPPED ENTIRELY on draft PR heads
+    # (first conjunct — fail-open off the PR path: push/schedule/dispatch satisfy
+    # `github.event_name != 'pull_request'` => the selection disjunction decides as
+    # before). This also removes the per-PR benchmark comparison comment
+    # (comment-always) + alert comment on draft heads — both are steps of THIS job.
+    # The ready_for_review full-tier run executes the deterministic ratchet before
+    # the PR can reach the merge queue; docs/branch-protection.md §Draft-tier CI.
     needs: select
     # [FABLE-5] label-trigger guard (full rationale: ci.yml's pull_request note): the
     # first AND-term skips this job on any labeled/unlabeled event whose label is not
@@ -179,6 +200,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
        contains(fromJSON('["ci-full","bench-full"]'), github.event.label.name)) &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true) &&
       (needs.select.outputs.mode != 'selected' ||
        contains(needs.select.outputs.affected, '"sparq-engine"') ||
        contains(needs.select.outputs.affected, '"sparq-cli"') ||

--- a/.github/workflows/ci-select.yml
+++ b/.github/workflows/ci-select.yml
@@ -69,7 +69,19 @@ permissions:
 
 jobs:
   select:
-    name: select (change-based test selection)
+    # [FABLE-5] Draft-tier CI (docs/branch-protection.md §Draft-tier CI): the job
+    # name APPENDS the ", draft-tier" marker when the calling run was triggered by
+    # a DRAFT pull_request (a reusable workflow sees the caller's event payload;
+    # every non-PR event evaluates the marker empty). The tier thus travels in the
+    # check-run NAME — the same name-as-contract mechanism as the advisory rule —
+    # and scripts/ci_summary_gate.py partitions draft-assembled from full-
+    # assembled selection runs on a head SHA with it: a FULL-tier gate refuses to
+    # conclude success while a draft-tier-marked select has no full-tier
+    # successor, so a draft-tier leg set can never admit a non-draft PR to the
+    # merge queue. The stable phrase "change-based test selection" (the SELECT_RE
+    # detection contract) is a prefix of BOTH spellings, and neither contains the
+    # words "advisory"/"informational".
+    name: select (change-based test selection${{ github.event.pull_request.draft == true && ', draft-tier' || '' }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -107,8 +119,15 @@ jobs:
           # events there is no pull_request payload, so this evaluates false and the
           # override is inert (non-PR events already resolve to full by construction).
           CI_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci-full') }}
+          # [FABLE-5] Draft-tier CI: surfaced in the step summary so a human reading
+          # the run sees which tier this selection was assembled for (the machine
+          # contract is the job NAME marker above).
+          IS_DRAFT_PR: ${{ github.event.pull_request.draft == true }}
         run: |
           set -euo pipefail
+          if [ "${IS_DRAFT_PR:-}" = "true" ]; then
+            echo "**Tier: draft** — draft-tier CI (reduced sibling set; the full matrix re-runs at ready_for_review and its fresh gate supersedes this head's draft-tier results)." >> "$GITHUB_STEP_SUMMARY"
+          fi
           args=(--event "$EVENT")
           case "$EVENT" in
             pull_request|merge_group) args+=(--base "$BASE" --head "$HEAD") ;;

--- a/.github/workflows/ci-select.yml
+++ b/.github/workflows/ci-select.yml
@@ -76,8 +76,11 @@ jobs:
     # check-run NAME — the same name-as-contract mechanism as the advisory rule —
     # and scripts/ci_summary_gate.py partitions draft-assembled from full-
     # assembled selection runs on a head SHA with it: a FULL-tier gate refuses to
-    # conclude success while a draft-tier-marked select has no full-tier
-    # successor, so a draft-tier leg set can never admit a non-draft PR to the
+    # conclude success while any draft-tier-marked select INSTANCE lacks its own
+    # later full-tier successor (per-instance because ci.yml, bench.yml,
+    # feature-matrix.yml and fuzz.yml all expose this IDENTICAL check-run name —
+    # one workflow's full-tier select must never release the hold for the
+    # others), so a draft-tier leg set can never admit a non-draft PR to the
     # merge queue. The stable phrase "change-based test selection" (the SELECT_RE
     # detection contract) is a prefix of BOTH spellings, and neither contains the
     # words "advisory"/"informational".

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -91,6 +91,22 @@
 # (verified in bead sq-fmx4u.4). The `ci-full` PR label + the nightly cron full run
 # are the permanent backstops; CI_SELECT_MODE=shadow is the report-only rollback.
 #
+# DRAFT-TIER CI (docs/branch-protection.md §Draft-tier CI). [FABLE-5] Draft PR
+# heads run a REDUCED sibling set (coverage / bench / CodeQL / heavy shards /
+# wasm-equality skipped; the crate legs stay change-scoped by ci-select) so the
+# review-fix churn of many concurrent draft worker PRs stops saturating the runner
+# pool. THE INVARIANT — a draft-tier gate result must NEVER admit a PR to the merge
+# queue — is enforced in scripts/ci_summary_gate.py: this run knows its own tier
+# from the trigger payload (PR_DRAFT below), a draft-tier run re-checks the PR's
+# CURRENT draft state via the API before any SUCCESS (un-drafted => FAILURE, "stale
+# draft-tier run, full run pending"), and a full-tier pull_request run refuses to
+# conclude over a draft-tier-assembled selection (the ci-select job name carries a
+# ", draft-tier" marker). `ready_for_review` below re-runs this gate (and every
+# tiered sibling workflow) at the un-draft moment, so a fresh FULL-tier `gate`
+# check-run supersedes the draft-tier one on the same head SHA — branch protection
+# and the merge queue read the LATEST run of the required check name. merge_group
+# behaviour is untouched (always full tier, on a fresh ref).
+#
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
 # scripts/ci_summary_gate.py (extracted from the previous inline bash so the
 # semantics are UNIT-TESTED — scripts/tests/test_ci_summary_gate.py, run as a HARD
@@ -99,7 +115,11 @@
 name: ci-summary
 
 on:
+  # [FABLE-5] Draft-tier CI: the default types PLUS ready_for_review — without it
+  # the un-draft moment would run NOTHING and the head would keep its draft-tier
+  # gate result (the exact stale-green the integrity invariant forbids).
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   # [OPUS-4.8] Merge queue: GitHub runs the required check(s) on a temporary
   # `merge_group` ref before merging. ci-summary is the SINGLE required check, so it
   # MUST run here to produce the `ci-summary / gate` check on that ref — and every
@@ -113,12 +133,15 @@ on:
 # Read-only: the gate READS check-runs + commit statuses for the head commit, plus
 # the repo's queued workflow-run count (`actions: read` — the sq-90cv4 saturation
 # signal; a permissions failure there degrades to the progress-only signal, it never
-# fails the gate by itself).
+# fails the gate by itself), plus the PR's live draft state (`pull-requests: read`
+# — the draft-tier conclusion-time re-check; a failure there fail-closes to RED,
+# never to a pass).
 permissions:
   checks: read
   statuses: read
   contents: read
   actions: read
+  pull-requests: read
 
 # One in-flight gate per PR (or per branch on push). Cancel a superseded run so a
 # new push doesn't leave a stale, slowly-timing-out gate behind.
@@ -167,4 +190,13 @@ jobs:
           # ours alone, so the exclusion is exact and collision-proof (anchored to
           # "/runs/<id>(/|$)" in the script). [OPUS-4.8]
           SELF_RUN_ID: ${{ github.run_id }}
+          # [FABLE-5] Draft-tier CI: the tier THIS run evaluates is decided by its
+          # own trigger payload — pull_request + draft == true => draft tier. The
+          # script re-checks the PR's LIVE draft state (PR_NUMBER) at conclusion
+          # time and refuses a draft-tier success on a now-ready PR ("stale
+          # draft-tier run, full run pending"). All three are empty off the PR
+          # path (push/merge_group), which the script reads as full tier.
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: python3 scripts/ci_summary_gate.py

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -96,15 +96,25 @@
 # wasm-equality skipped; the crate legs stay change-scoped by ci-select) so the
 # review-fix churn of many concurrent draft worker PRs stops saturating the runner
 # pool. THE INVARIANT — a draft-tier gate result must NEVER admit a PR to the merge
-# queue — is enforced in scripts/ci_summary_gate.py: this run knows its own tier
-# from the trigger payload (PR_DRAFT below), a draft-tier run re-checks the PR's
-# CURRENT draft state via the API before any SUCCESS (un-drafted => FAILURE, "stale
-# draft-tier run, full run pending"), and a full-tier pull_request run refuses to
-# conclude over a draft-tier-assembled selection (the ci-select job name carries a
-# ", draft-tier" marker). `ready_for_review` below re-runs this gate (and every
-# tiered sibling workflow) at the un-draft moment, so a fresh FULL-tier `gate`
-# check-run supersedes the draft-tier one on the same head SHA — branch protection
-# and the merge queue read the LATEST run of the required check name. merge_group
+# queue — is STRUCTURAL: the gate job's own check-run NAME is tiered. On a draft
+# pull_request payload the job below is named `gate, draft-tier`, NOT `gate`, so a
+# draft-tier run never produces the required `gate` context at all and the
+# ruleset's required_status_checks entry ({context: "gate"}) is unsatisfiable by
+# draft-tier results. From the un-draft moment until the full-tier run's fresh
+# `gate` concludes, the required context is simply ABSENT — which branch protection
+# treats as blocking — so there is no supersession window to race: GitHub event
+# latency, a dropped ready_for_review event, or an Actions outage all leave the PR
+# blocked, never admitted (`gh pr ready && gh pr merge --auto` arms and waits).
+# scripts/ci_summary_gate.py adds defense-in-depth on top: each run knows its own
+# tier from the trigger payload (PR_DRAFT below); a draft-tier run re-checks the
+# PR's CURRENT draft state via the API before any SUCCESS (un-drafted => FAILURE,
+# "stale draft-tier run, full run pending"); a full-tier pull_request run refuses
+# to conclude while ANY draft-tier-marked ci-select INSTANCE lacks its own later
+# full-tier successor (per-instance — ci/bench/feature-matrix/fuzz all expose the
+# identical select check-run name); and stale `gate, draft-tier` check-runs are
+# excluded from every sibling set as tier artifacts. `ready_for_review` below
+# re-runs this gate (and every tiered sibling workflow) at the un-draft moment,
+# producing the first (and only) `gate` check-run on the head SHA. merge_group
 # behaviour is untouched (always full tier, on a fresh ref).
 #
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
@@ -151,7 +161,14 @@ concurrency:
 
 jobs:
   gate:
-    name: gate
+    # [FABLE-5] Draft-tier CI: the check-run name is TIERED (the same marker
+    # expression ci-select.yml uses). A draft pull_request payload renders
+    # `gate, draft-tier`; every other event/state (non-draft PR, merge_group,
+    # push) renders EXACTLY `gate` — the branch-protection ruleset's required
+    # context, which a draft-tier run therefore can never satisfy (the
+    # structural half of the integrity invariant above). Pinned by
+    # scripts/tests/test_ci_select_wiring.py::TestRequiredCheckAnchor.
+    name: gate${{ github.event.pull_request.draft == true && ', draft-tier' || '' }}
     runs-on: ubuntu-latest
     # > the loop's ABSOLUTE budget: ~37 min base (unchanged from the pre-sq-90cv4
     # cap) + up to ~30 min of saturation extension + API overhead. The loop caps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,15 @@ on:
   # commit's select runs are all green. Label events also get a PER-RUN concurrency
   # group (below), so a flip can never concurrency-cancel an in-flight run on the
   # same head SHA — those same-SHA cancellations were the actual gate poison.
+  # [FABLE-5] Draft-tier CI: + ready_for_review, so the un-draft moment re-runs the
+  # whole matrix at FULL tier on the same head SHA (coverage + heavy shards run
+  # again) and the fresh check-runs supersede the draft-tier ones — see
+  # docs/branch-protection.md §Draft-tier CI. The label-trigger guard above and the
+  # draft-tier guards below are independent and AND-compose on each affected job:
+  # a non-`ci-full` label flip stays a no-op regardless of draft state, and a draft
+  # head stays tier-reduced regardless of label events.
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
   # [OPUS-4.8] Merge queue: re-run the identical PR check-set on the queue's
   # merge_group ref so the required ci-summary gate finds the same siblings it finds
   # on a PR. The per-commit `coverage` job (if: event_name != 'schedule') runs here;
@@ -559,6 +566,10 @@ jobs:
           # env is the shard-kind discriminator the run script reads (it is empty on the
           # bulk shards). Passed via env — no inline `${{ }}` in the shell body.
           SHARD_FILTER: ${{ matrix.filter }}
+          # [FABLE-5] Draft-tier CI: "true" only on a DRAFT pull_request head — the
+          # heavy recall shards are ALSO demoted there (see the draft-tier guard
+          # below); every other event/state evaluates "false" and changes nothing.
+          IS_DRAFT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
         run: |
           set -euo pipefail
           # [OPUS-4.8] sq-6vshe.6 (research/ci-structural-speedup.md §7, round 2):
@@ -585,6 +596,21 @@ jobs:
             echo "heavy shard '${{ matrix.name }}' DEMOTED off merge_group (sq-6vshe.6):"
             echo "  deterministic single-crate recall gate — no cross-PR interaction;"
             echo "  full form runs at PR level + push-to-main. Reporting success."
+            exit 0
+          fi
+          # [FABLE-5] Draft-tier CI: ALSO demote the heavy recall shards on DRAFT
+          # pull_request heads (docs/branch-protection.md §Draft-tier CI). Safe for
+          # the same reason as the merge_group demotion above — deterministic
+          # single-crate gates — plus the draft-tier invariant: un-drafting fires
+          # ready_for_review, which re-runs this job at FULL tier on the same head
+          # SHA, and a draft-tier gate result can never admit a PR to the merge
+          # queue (scripts/ci_summary_gate.py refuses it). Bulk shards are NEVER
+          # demoted (SHARD_FILTER is empty there); non-draft PRs and push-to-main
+          # keep the full form.
+          if [ "$IS_DRAFT_PR" = "true" ] && [ -n "$SHARD_FILTER" ]; then
+            echo "heavy shard '${{ matrix.name }}' DEMOTED on this DRAFT head (draft-tier CI):"
+            echo "  the full form re-runs at ready_for_review + push-to-main; a draft-tier"
+            echo "  gate result can never admit a PR to the merge queue. Reporting success."
             exit 0
           fi
           # [FABLE-5] sq-fmx4u.3 (design §5.2): single-crate shard skip guard.
@@ -2559,9 +2585,16 @@ jobs:
     # aggregator counts as satisfied). This references only github/needs contexts —
     # no `matrix.*` — so it is safe as a job-level `if:` on this matrix job. The
     # nightly full coverage backstop is `coverage-nightly` (schedule), unaffected.
+    # [FABLE-5] Draft-tier CI: coverage is SKIPPED on draft PR heads entirely (the
+    # instrumented rebuild is one of the heaviest lanes; the ready_for_review
+    # full-tier run + the merge_group run both re-measure it before any merge, and
+    # a draft-tier gate can never admit a PR — docs/branch-protection.md
+    # §Draft-tier CI). The guard is fail-open off the PR path: any non-pull_request
+    # event (push/merge_group) satisfies the first disjunct => RUN.
     needs: [changes, coverage-floors, select]
     if: >-
       github.event_name != 'schedule' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true) &&
       needs.changes.outputs.rust_changed == 'true' &&
       (needs.select.outputs.mode != 'selected' || needs.select.outputs.affected != '[]')
     runs-on: ubuntu-latest
@@ -2711,9 +2744,12 @@ jobs:
     # INDIVIDUAL tests, so the two >400s lib-target monster tests land on DIFFERENT runners
     # (a per-binary split would not balance).
     name: coverage engine run (partition ${{ matrix.part }}/3)
+    # [FABLE-5] Draft-tier CI: skipped on draft PR heads, same rationale + guard
+    # shape as coverage-measure above (fail-open off the PR path).
     needs: [changes, coverage-floors, select]
     if: >-
       github.event_name != 'schedule' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true) &&
       needs.changes.outputs.rust_changed == 'true' &&
       (needs.select.outputs.mode != 'selected' || needs.select.outputs.affected != '[]')
     runs-on: ubuntu-latest
@@ -2881,16 +2917,26 @@ jobs:
     # [FABLE-5] sq-piapk: the sparq-engine cross-runner split (run + merge) folds into this
     # single verdict alongside the non-engine shard matrix, so the ci-summary `gate` still
     # sees ONE coverage check. A skipped engine job (doc-only PR) counts as satisfied.
+    # [FABLE-5] Draft-tier CI: on a draft PR head the measure/engine jobs above are
+    # skipped, so this aggregate is skipped too (reporting `skipped`, which the
+    # gate treats as satisfied under a green selection) rather than emitting a
+    # vacuous green `coverage` success over zero measurements.
     needs: [coverage-floors, coverage-measure, coverage-engine-run, coverage-engine-merge]
     # [FABLE-5] label-trigger guard: always() bypasses the skipped-needs propagation,
     # so this verdict job must carry the guard explicitly or it would still run (as a
     # trivially-green no-op) on every non-`ci-full` label flip. Skipped is equally
     # satisfied by the gate (the commit's select runs stay green) and saves the slot.
+    # [FABLE-5] Draft-tier CI: AND-composed with the label guard (both survive) — the
+    # measure/engine jobs above are skipped on a draft PR head, so this aggregate is
+    # skipped too (`skipped` ≠ vacuous green) rather than reporting over zero
+    # measurements. A non-`ci-full` label flip stays a no-op regardless of draft
+    # state; a draft head stays coverage-skipped regardless of label events.
     if: >-
       always() && github.event_name != 'schedule' &&
       (github.event_name != 'pull_request' ||
        !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
-       github.event.label.name == 'ci-full')
+       github.event.label.name == 'ci-full') &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true)
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate coverage floor + shard results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,8 +37,12 @@ name: codeql
 on:
   push:
     branches: [main]
+  # [FABLE-5] Draft-tier CI: default types + ready_for_review, so the un-draft
+  # moment runs the analysis the draft head skipped (the `analyze` job below is
+  # guarded off draft PR heads) BEFORE the PR can reach the merge queue.
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   # [OPUS-4.8] Merge queue: CodeQL surfaces a check on PRs, so it must also run on the
   # queue's merge_group ref or the required ci-summary would wait for a sibling that
   # never appears on that ref and time out. (Bare `merge_group` — it fires on every
@@ -60,6 +64,16 @@ concurrency:
 jobs:
   analyze:
     name: CodeQL analysis (rust)
+    # [FABLE-5] Draft-tier CI: SKIPPED on draft PR heads (this analysis is one of
+    # the slowest per-push lanes and the fleet's draft review-fix churn re-ran it
+    # on every push). VERIFIED before changing: CodeQL is NOT schedule/main-only —
+    # it runs per-PR — but the pre-merge guarantee is preserved because the
+    # ready_for_review full-tier run analyses the same head SHA (types above) and
+    # the merge_group + push-to-main + weekly-schedule runs are untouched; the
+    # branch-protection `code_scanning` alert rule therefore still sees a CodeQL
+    # analysis of the head before any merge. Fail-open off the PR path: any
+    # non-pull_request event satisfies the first disjunct => RUN.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -36,6 +36,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "Dockerfile"
       - ".dockerignore"

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -103,6 +103,9 @@ name: docs-quality
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
   # [OPUS-4.8] Merge queue: docs-quality surfaces checks on PRs (some gating, some
   # advisory/informational which ci-summary excludes), so it must also run on the
   # queue's merge_group ref or the required ci-summary would wait for siblings that

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -99,8 +99,13 @@ on:
   # cheap success (a skipped select would poison the gate — ci_summary_gate.py
   # requires every selection check-run to conclude `success`). Label events also get
   # a per-run concurrency group below so a flip never cancels an in-flight run.
+  # [FABLE-5] Draft-tier CI: + ready_for_review, so the un-draft moment re-assembles
+  # the opt-in leg set at FULL tier (the select job name drops its ", draft-tier"
+  # marker) and the required gate stops honouring the draft-tier-assembled set —
+  # see docs/branch-protection.md §Draft-tier CI. Independent of the label guard
+  # above: a non-`ci-full` label flip stays a no-op regardless of draft state.
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
   # Merge queue: mirror the PR check-set onto the merge_group ref so the required
   # ci-summary gate finds the same legs it finds on a PR (matches ci.yml/ci-summary.yml).
   merge_group:

--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -46,6 +46,9 @@ name: flow-on-gates
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
   # Required checks must also run on the merge-queue ref so ci-summary finds the
   # identical sibling set there (mirrors ci-summary.yml's merge_group handling).
   merge_group:

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -62,7 +62,9 @@ name: formal-verification
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
   # Merge queue: re-run the identical check-set on the queue's merge_group ref so the
   # required ci-summary gate finds the same siblings there (base_sha/head_sha of the
   # queue entry give the union-diff — same pairing ci-select.yml uses).

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -76,7 +76,9 @@ on:
   # budget (the budget step reads the label). Label events also get a per-run
   # concurrency group below so a flip never cancels an in-flight run.
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
   # [OPUS-4.8] Merge queue: fuzz surfaces a check on PRs, so it must also run on the
   # queue's merge_group ref or the required ci-summary would wait for a sibling that
   # never appears there. The budget step below maps merge_group to the fast SMOKE

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -44,6 +44,9 @@ name: gui
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     # [OPUS-4.8] The `site build + typecheck` job here consumes `site/` (its static export +
     # the bundle-wasm-esm script) and `js/` (the @jeswr/sparq source it bundles), and resolves
     # workspace deps from the root lockfile — so changes to ANY of those can break it. They were

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -26,6 +26,9 @@ name: js
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     # The surfaces that can affect the js build/test: the js package itself, the npm
     # workspace members + root lockfile/manifest it installs from (the #953 root install),
     # every sparq-*-wasm crate the build compiles (sparq-wasm + reason/rsp/shacl/text-wasm),
@@ -45,6 +48,14 @@ on:
 # build/test job only reads the repo; grant nothing more. Jobs needing writes opt in per-job.
 permissions:
   contents: read
+
+# [FABLE-5] Draft-tier CI: per-PR concurrency so a superseded push's heavy
+# wasm-pack build stops burning a runner slot (same pattern as docs-quality/gui/
+# site-*). No merge_group trigger exists here, so this can never cancel a
+# merge_group run.
+concurrency:
+  group: js-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   js:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,6 +28,9 @@ name: Python bindings
 # `push: branches:[main]` trigger is KEPT for post-merge cover on every main push.
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     # Every input the jobs read: the crate (Rust binding source + Cargo.toml + tests +
     # pyproject), the workspace manifests/lock the maturin build resolves from, the
     # sparq-arrow crate the `arrow` feature compiles in, the hash-pinned build/arrow

--- a/.github/workflows/site-e2e-foundation.yml
+++ b/.github/workflows/site-e2e-foundation.yml
@@ -18,6 +18,9 @@ name: site-e2e-foundation (advisory)
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "site/**"
       - "package.json"

--- a/.github/workflows/site-e2e-hero.yml
+++ b/.github/workflows/site-e2e-hero.yml
@@ -19,6 +19,9 @@ name: site-e2e-hero
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "site/**"
       - "package.json"

--- a/.github/workflows/site-e2e.yml
+++ b/.github/workflows/site-e2e.yml
@@ -34,6 +34,9 @@ on:
   # is no unfiltered main-push catch-all either (unlike js.yml). That is the exact
   # gui.yml/#1081 blind-spot class, so the root workspace inputs are listed too.
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "site/**"
       - "package.json"

--- a/.github/workflows/site-visual.yml
+++ b/.github/workflows/site-visual.yml
@@ -23,6 +23,9 @@ name: site-visual
 
 on:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "site/**"
       - "package.json"

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -29,6 +29,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
   # [OPUS-4.8] Merge queue: supply-chain (cargo-deny etc.) surfaces a check on PRs, so
   # it must also run on the queue's merge_group ref or the required ci-summary would
   # wait for a sibling that never appears there and time out.

--- a/.github/workflows/vectorized-feature-off.yml
+++ b/.github/workflows/vectorized-feature-off.yml
@@ -56,7 +56,12 @@ name: vectorized-feature-off
 on:
   push:
     branches: [main]
+  # [FABLE-5] Draft-tier CI: default types + ready_for_review (the un-draft moment
+  # must re-run the wasm-equality leg a draft head may have scoped out) +
+  # labeled/unlabeled (the `ci-full` label toggle must re-evaluate the draft-tier
+  # scope decision in the artifact-exact-equality decide step below).
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
   merge_group:
 
 permissions:
@@ -239,14 +244,63 @@ jobs:
               - 'bench/feature-off-declarations/**'
       - name: Decide rust_changed (safe-by-default off the PR path)
         id: changes
+        # [FABLE-5] Draft-tier CI (docs/branch-protection.md §Draft-tier CI): on a
+        # DRAFT PR head this heavy wasm double-build runs ONLY when the diff can
+        # affect the feature-OFF sparq-wasm bundle bytes. Path prefixes cannot
+        # decide that (a sparq-core edit changes the bundle), so the step invokes
+        # the SAME selector the select pre-jobs use (scripts/ci_select.py — stdlib
+        # + the preinstalled cargo; checkout above is fetch-depth 0, so the
+        # base...head merge-base resolves) and keeps the leg iff `sparq-wasm` is in
+        # the affected reverse-dependency closure. FAIL-CLOSED on every edge: a
+        # non-draft PR, the ci-full label, mode != selected (incl. every selector
+        # error — ci_select.py exits 0 with mode=full on ANY internal failure), or
+        # an unparsable output all leave rust_changed as the paths-filter verdict
+        # (RUN). Done in-step rather than a `needs: select` job so the non-draft
+        # long pole keeps its early start (sq-6vshe.20). The un-draft moment
+        # re-runs this leg at full tier (ready_for_review in `types` above); a
+        # draft-tier gate result can never admit a PR to the merge queue
+        # (scripts/ci_summary_gate.py).
+        env:
+          IS_DRAFT_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true }}
+          CI_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci-full') }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CARGO_NET_RETRY: "10"
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo "rust_changed=true" >> "$GITHUB_OUTPUT"
             echo "event=${{ github.event_name }} -> forcing rust_changed=true (full gate)"
           else
-            echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
-            echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
+            rust_changed="${{ steps.filter.outputs.rust }}"
+            if [ "$rust_changed" = "true" ] && [ "$IS_DRAFT_PR" = "true" ] && [ "$CI_FULL_LABEL" != "true" ]; then
+              # Draft-tier scope: keep the leg iff sparq-wasm is in the affected
+              # closure. Any failure of this block leaves rust_changed=true (RUN).
+              sel_out="$(mktemp)"
+              if python3 scripts/ci_select.py --event pull_request \
+                   --base "$BASE_SHA" --head "$HEAD_SHA" \
+                   --output-file "$sel_out" --summary-file /dev/null >/dev/null 2>&1; then
+                mode="$(sed -n 's/^mode=//p' "$sel_out" | tail -n1)"
+                affected="$(sed -n 's/^affected=//p' "$sel_out" | tail -n1)"
+                if [ "$mode" = "selected" ]; then
+                  case "$affected" in
+                    *'"sparq-wasm"'*)
+                      echo "draft-tier scope: sparq-wasm IS in the affected closure -> leg runs" ;;
+                    *)
+                      rust_changed="false"
+                      echo "draft-tier scope: sparq-wasm NOT in the affected closure -> leg" \
+                           "skipped on this DRAFT head (full form re-runs at ready_for_review" \
+                           "+ merge_group; the gate refuses draft-tier admission)" ;;
+                  esac
+                else
+                  echo "draft-tier scope: selector mode='${mode:-<empty>}' (not 'selected') -> fail-closed, leg runs"
+                fi
+              else
+                echo "draft-tier scope: selector invocation failed -> fail-closed, leg runs"
+              fi
+            fi
+            echo "rust_changed=$rust_changed" >> "$GITHUB_OUTPUT"
+            echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}, final rust_changed=$rust_changed (draft=${IS_DRAFT_PR})"
           fi
 
       # ---- the heavy leg (unchanged, behind the rust_changed step-if) ----

--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -55,6 +55,9 @@ on:
     - cron: "23 4 * * *"
   workflow_dispatch:
   pull_request:
+    # [FABLE-5] Draft-tier CI: + ready_for_review so the un-draft moment re-runs
+    # this gate-feeding lane (docs/branch-protection.md §Draft-tier CI).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "crates/sparq-zk/**"
       - "crates/sparq-zk-compose/**"

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -105,6 +105,85 @@ From the binding/packaging workflows (when those surfaces are exercised):
 > to the required-checks list, THAT name would now need removing — but per the "select only
 > `ci-summary / gate`" rule above, it was never added.)
 
+## Draft-tier CI (reduced matrix on draft PR heads)
+
+<!-- [FABLE-5] Draft-tier CI design record (2026-07-17). Motivation: the autonomous
+     fleet keeps many draft worker PRs cycling review-fix rounds; every push ran the
+     FULL matrix, saturating the org runner pool (gates timing out as false failures,
+     the merge queue starving, the load-aware heavy shards deferring). -->
+
+CI is **tiered by the PR's draft state**. A **draft** `pull_request` head runs a
+REDUCED sibling set; a **non-draft** head, `merge_group`, `push`-to-main, and every
+scheduled/dispatch run keep the FULL matrix, byte-identical to before.
+
+**What a draft head runs:**
+
+- the **change-scoped crate legs** — the existing `ci-select` change-based selection
+  (affected reverse-dependency closure) already intersects every wide lane and the
+  opt-in feature-matrix legs with the diff, on both tiers;
+- the **cheap global gates** — clippy/fmt, MSRV, docs-quality (typos / privacy /
+  ci-scripts), supply-chain, conformance ratchets for affected crates, pr-title;
+- the **`ci-summary / gate` aggregator**, which evaluates exactly the reduced set it
+  discovers (it is discovery-based, so no expected-leg list needs maintaining).
+
+**What a draft head skips** (each re-runs at full tier before any merge is possible):
+
+| Skipped on drafts | Where | Kept when |
+|---|---|---|
+| coverage ratchet (measure + engine split + aggregate) | `ci.yml` | never on drafts (merge_group + ready_for_review re-measure) |
+| benchmarks (deterministic ratchet + PR comparison/alert comments) | `bench.yml` | never on drafts |
+| CodeQL analysis | `codeql.yml` | never on drafts (merge_group + push-main + weekly schedule + the ready_for_review run keep the `code_scanning` rule fed) |
+| heavy recall shards (`heavy-diskann`/`heavy-hnsw`) | `ci.yml` `test` | never on drafts (same demotion mechanism as their merge_group demotion) |
+| wasm bundle build | `ci.yml` `wasm` | kept iff a wasm-bundle crate is in the affected closure (the existing lane-seed guard — unchanged on both tiers) |
+| `artifact-exact-equality` (wasm feature-OFF byte identity) | `vectorized-feature-off.yml` | kept iff `sparq-wasm` is in the affected closure (in-step `ci_select.py` verdict; ci-full label / selector error / full mode ⇒ run) |
+
+**The integrity invariant — a draft-tier gate result must NEVER admit a PR to the
+merge queue.** Enforcement (all in `scripts/ci_summary_gate.py`, unit-tested in
+`scripts/tests/test_ci_summary_gate.py`):
+
+1. **Supersession by re-run.** Every gate-feeding workflow's `pull_request` trigger
+   now includes **`ready_for_review`** (the default types are only
+   opened/synchronize/reopened — without this the un-draft moment would run
+   *nothing* and the head would keep its draft-tier results). Un-drafting therefore
+   fires a FULL-tier run on the **same head SHA**, whose fresh `gate` check-run
+   supersedes the draft-tier one — branch protection and the merge queue read the
+   LATEST run of the required check name.
+2. **The gate knows its tier.** Each `ci-summary` run derives its tier from its own
+   trigger payload (`PR_DRAFT`), and the reusable `ci-select` job's check-run **name
+   carries a `", draft-tier"` marker** on draft-assembled runs (name-as-contract,
+   like the advisory rule).
+3. **A full-tier gate refuses a draft-tier leg set.** A full-tier `pull_request`
+   gate that finds a draft-tier-marked select with no later full-tier successor
+   treats the set as *still settling* (the ready_for_review re-runs are seconds
+   away) and, at budget exhaustion, concludes **FAILURE — "stale draft-tier run,
+   full run pending"** rather than passing over draft legs.
+4. **A draft-tier gate re-checks the PR at conclusion time.** Before emitting
+   SUCCESS it re-reads the PR's **current** draft state from the API
+   (`pull-requests: read`); if the PR was un-drafted meanwhile it concludes
+   FAILURE with the same stale-draft-tier message, and an unreadable state
+   fail-closes to FAILURE (a draft PR cannot merge anyway).
+5. **Superseded-cancellation forgiveness.** The ready_for_review re-run's per-PR
+   concurrency groups cancel the in-flight draft-tier runs, leaving
+   `cancelled` check-runs on the same SHA; the gate excuses a cancelled/stale
+   check-run **only** when a later run of the same (tier-normalized) name exists —
+   a genuine `failure`/`timed_out` is never forgiven, and a cancellation with no
+   successor still REDs.
+
+Even in the worst race (a draft-tier gate that concluded green in the same instant
+the PR was un-drafted and enqueued), the merge queue re-runs the full check set on
+its own `merge_group` ref — which is always full-tier — before anything merges; the
+lanes deliberately absent from `merge_group` (bench's deterministic ratchet, the
+heavy recall shards) are exactly the ones the ready_for_review full-tier PR run
+re-executes, and rules 3–4 make that gate the one the queue sees.
+
+**Operational notes.** `pull_request`-event CI runs are cancel-superseded per PR
+(`concurrency` groups; `bench.yml` now cancels superseded **PR** runs only — its
+push/schedule runs still never cancel, protecting the benchmark history — and
+`js.yml` gained the standard per-PR group). `merge_group` runs are never cancelled
+by these groups. **No required-check name changed** — the ruleset still requires
+exactly `ci-summary / gate`. Toggling draft state does not change what ultimately
+gates a merge; it only defers the heavy lanes to the un-draft moment.
+
 ## Required reviews
 
 > **Solo-maintainer reality (read this first).** sparq is a **single-maintainer,

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -138,51 +138,94 @@ scheduled/dispatch run keep the FULL matrix, byte-identical to before.
 | `artifact-exact-equality` (wasm feature-OFF byte identity) | `vectorized-feature-off.yml` | kept iff `sparq-wasm` is in the affected closure (in-step `ci_select.py` verdict; ci-full label / selector error / full mode ⇒ run) |
 
 **The integrity invariant — a draft-tier gate result must NEVER admit a PR to the
-merge queue.** Enforcement (all in `scripts/ci_summary_gate.py`, unit-tested in
-`scripts/tests/test_ci_summary_gate.py`):
+merge queue.** The load-bearing mechanism is rule 1 (structural); rules 2–6 are
+belts (all in `scripts/ci_summary_gate.py`, unit-tested in
+`scripts/tests/test_ci_summary_gate.py`; the name/trigger wiring pinned by
+`scripts/tests/test_ci_select_wiring.py`):
 
-1. **Supersession by re-run.** Every gate-feeding workflow's `pull_request` trigger
+1. **A draft-tier run never produces the required context at all.** The
+   `ci-summary` gate job's own check-run name is **tiered**: a draft
+   `pull_request` payload renders **`gate, draft-tier`**; every other event/state
+   renders exactly `gate` — the sole context named by the ruleset's
+   `required_status_checks` rule. A draft-built head therefore carries **no
+   `gate` check-run at all**, and branch protection blocks on the *missing*
+   required check from the un-draft moment until the full-tier run's fresh
+   `gate` concludes. There is no supersession window to race: `gh pr ready &&
+   gh pr merge --auto` (the fleet's standard flow) arms and waits; GitHub event
+   latency, a *dropped* `ready_for_review` event, or an Actions outage all
+   leave the required context ABSENT — blocked — never satisfied by a
+   draft-tier result. Stale `gate, draft-tier` check-runs are tier artifacts:
+   the gate script excludes them from every sibling set (a completed draft-tier
+   verdict, green or red, is superseded by the live full-tier evaluation).
+2. **Supersession by re-run.** Every gate-feeding workflow's `pull_request` trigger
    now includes **`ready_for_review`** (the default types are only
    opened/synchronize/reopened — without this the un-draft moment would run
    *nothing* and the head would keep its draft-tier results). Un-drafting therefore
-   fires a FULL-tier run on the **same head SHA**, whose fresh `gate` check-run
-   supersedes the draft-tier one — branch protection and the merge queue read the
-   LATEST run of the required check name.
-2. **The gate knows its tier.** Each `ci-summary` run derives its tier from its own
+   fires a FULL-tier run on the **same head SHA**, which produces the first (and
+   only) `gate` check-run for that head.
+3. **The gate knows its tier.** Each `ci-summary` run derives its tier from its own
    trigger payload (`PR_DRAFT`), and the reusable `ci-select` job's check-run **name
    carries a `", draft-tier"` marker** on draft-assembled runs (name-as-contract,
    like the advisory rule).
-3. **A full-tier gate refuses a draft-tier leg set.** A full-tier `pull_request`
-   gate that finds a draft-tier-marked select with no later full-tier successor
-   treats the set as *still settling* (the ready_for_review re-runs are seconds
-   away) and, at budget exhaustion, concludes **FAILURE — "stale draft-tier run,
-   full run pending"** rather than passing over draft legs.
-4. **A draft-tier gate re-checks the PR at conclusion time.** Before emitting
+4. **A full-tier gate refuses a draft-tier leg set — per INSTANCE.** `ci.yml`,
+   `bench.yml`, `feature-matrix.yml` and `fuzz.yml` all call the same reusable
+   `ci-select` job, so a head SHA carries up to **four** draft-marked selects
+   under the IDENTICAL check-run name. A full-tier `pull_request` gate requires
+   each draft-marked instance to have its **own, distinct, strictly-later**
+   full-tier successor (greedy start-order matching) — the first workflow's
+   full-tier select can never release the hold for the other three, whose
+   full-tier runs may not have registered any check-runs yet. While any
+   instance lacks a successor the set is *still settling* (the
+   ready_for_review re-runs are expected); at budget exhaustion the verdict is
+   **FAILURE — "stale draft-tier run, full run pending"**, never a pass over
+   draft legs.
+5. **A draft-tier gate re-checks the PR at conclusion time.** Before emitting
    SUCCESS it re-reads the PR's **current** draft state from the API
    (`pull-requests: read`); if the PR was un-drafted meanwhile it concludes
    FAILURE with the same stale-draft-tier message, and an unreadable state
    fail-closes to FAILURE (a draft PR cannot merge anyway).
-5. **Superseded-cancellation forgiveness.** The ready_for_review re-run's per-PR
+6. **Superseded-cancellation forgiveness.** The ready_for_review re-run's per-PR
    concurrency groups cancel the in-flight draft-tier runs, leaving
    `cancelled` check-runs on the same SHA; the gate excuses a cancelled/stale
    check-run **only** when a later run of the same (tier-normalized) name exists —
    a genuine `failure`/`timed_out` is never forgiven, and a cancellation with no
    successor still REDs.
 
-Even in the worst race (a draft-tier gate that concluded green in the same instant
-the PR was un-drafted and enqueued), the merge queue re-runs the full check set on
-its own `merge_group` ref — which is always full-tier — before anything merges; the
-lanes deliberately absent from `merge_group` (bench's deterministic ratchet, the
-heavy recall shards) are exactly the ones the ready_for_review full-tier PR run
-re-executes, and rules 3–4 make that gate the one the queue sees.
+**Why the queue can never latch a draft-tier result.** Rule 1 is structural: the
+queue and branch protection admit a PR only on a successful check-run of the
+exact context `gate`, and no draft-tier run ever emits one. This matters more
+than it may look, because the `merge_group` run deliberately omits two lanes
+(`bench.yml`'s deterministic byte ratchet and the heavy recall shards,
+sq-6vshe.6) on the premise that their full form already ran on the PR head —
+a premise a draft-built head would otherwise break. Rules 2–6 alone would NOT
+close that: a concluded draft-tier `gate` success would remain the *latest* run
+of the required context from the un-draft moment until the ready_for_review
+`ci-summary` run registers its check-run (seconds of event latency; indefinitely
+if the event is dropped), and `gh pr ready && gh pr merge --auto` could enqueue
+inside that window. With the tiered check name the window does not exist —
+so the ready_for_review full-tier PR run (which includes both merge_group-absent
+lanes) must conclude before the queue can admit the head.
+
+The ruleset additionally carries a `code_scanning` rule (CodeQL). A draft-built
+head carries no PR CodeQL analysis (`analyze` skips on drafts), so that rule
+would *independently* block such a head — but it is an **out-of-repo,
+owner-mutable setting** and evadable in corner cases (a non-draft PR sharing the
+same head SHA supplies an analysis for the commit; the rule may be relaxed
+during a CodeQL outage), so it is recorded here as **defense-in-depth only**,
+never the load-bearing mechanism. Do not weaken rule 1 on the strength of it.
 
 **Operational notes.** `pull_request`-event CI runs are cancel-superseded per PR
 (`concurrency` groups; `bench.yml` now cancels superseded **PR** runs only — its
 push/schedule runs still never cancel, protecting the benchmark history — and
 `js.yml` gained the standard per-PR group). `merge_group` runs are never cancelled
 by these groups. **No required-check name changed** — the ruleset still requires
-exactly `ci-summary / gate`. Toggling draft state does not change what ultimately
-gates a merge; it only defers the heavy lanes to the un-draft moment.
+exactly `ci-summary / gate`, and every full-tier run still emits exactly that
+context; a draft-tier run emits the additional, deliberately **non-required**
+context `gate, draft-tier` instead (tooling reading a draft head's checks sees
+the tier verdict there, while the required `gate` context stays absent until
+un-draft — a draft PR cannot merge regardless). Toggling draft state does not
+change what ultimately gates a merge; it only defers the heavy lanes to the
+un-draft moment.
 
 ## Required reviews
 

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -48,11 +48,41 @@
 # MAX_CONSEC_FETCH_FAILURES consecutive failures fail the gate. No data => no
 # verdict, so this cannot create a false pass.
 #
+# DRAFT-TIER INTEGRITY (bead: draft-tier CI). [FABLE-5] Draft PR heads run a REDUCED
+# leg set (coverage / bench / CodeQL / heavy shards / wasm-equality skipped — see
+# docs/branch-protection.md §Draft-tier CI); the ci-select job NAME carries the
+# ", draft-tier" marker on draft-assembled runs. THE INVARIANT: a draft-tier gate
+# result must NEVER admit a PR to the merge queue. Enforced three ways, all here:
+#   * SUPERSEDED-RUN FORGIVENESS — un-drafting fires ready_for_review on the SAME
+#     head SHA; per-PR concurrency then CANCELS the in-flight draft-tier runs,
+#     leaving conclusion=cancelled check-runs on the SHA the fresh full-tier gate
+#     polls. A cancelled/stale check-run is excused iff a LATER check-run with the
+#     same tier-normalized name exists (any state but cancelled/stale — this gate's
+#     own fresh `gate` run supersedes its cancelled predecessor). A cancelled run
+#     with NO successor still fails the gate; failure/timed_out are NEVER forgiven.
+#     This matches branch protection's own semantics (it reads the LATEST run of a
+#     required check name).
+#   * STALE DRAFT-TIER LEG SET — a FULL-tier pull_request gate run refuses to
+#     conclude success while any draft-tier-marked select check-run lacks a later
+#     full-tier (unmarked) same-normalized-name successor: the leg set on the SHA
+#     was assembled draft-tier and the full re-run has not registered. The loop
+#     treats that as STILL-SETTLING (the ready_for_review re-runs are seconds away);
+#     budget exhaustion in that state is a RED ("stale draft-tier run, full run
+#     pending"), never a pass over draft legs.
+#   * CONCLUSION-TIME DRAFT RE-CHECK — a DRAFT-tier gate run re-reads the PR's
+#     CURRENT draft state from the API immediately before emitting a SUCCESS
+#     verdict; if the PR is no longer a draft the gate concludes FAILURE ("stale
+#     draft-tier run, full run pending") so the queue can never latch onto a
+#     draft-tier green. API failure after retries fail-closes to RED (a draft PR
+#     cannot merge anyway, so a false RED here is cheap; a false PASS is the
+#     invariant violation).
+#
 # Exit-0 paths, exhaustively: (1) render_verdict over a stable-empty set;
 # (2) render_verdict over an all-terminal set with zero non-passing GATING checks
 # AND every change-based-selection pre-job check green (sq-fmx4u.3: `skipped` is
 # satisfied only under a successful selection; a present-but-not-success select
-# REDs outright). There is no other `return 0`.
+# REDs outright) AND the draft-tier integrity checks above pass. There is no other
+# `return 0`.
 #
 # Hermetic tests: scripts/tests/test_ci_summary_gate.py (stdlib-only unittest; no
 # network — fetchers are injected). Run: python3 scripts/tests/test_ci_summary_gate.py
@@ -69,6 +99,16 @@ from dataclasses import dataclass, field
 
 ADVISORY_RE = re.compile(r"\b(advisory|informational)\b")
 _PASSING = ("success", "skipped", "neutral")
+# [FABLE-5] draft-tier CI: the marker ci-select.yml appends to the select job name
+# on a draft-assembled run ("select (change-based test selection, draft-tier)").
+# The tier travels in the check-run NAME — the same name-as-contract mechanism the
+# advisory rule uses — so the gate can partition draft-assembled from full-assembled
+# selection check-runs on a head SHA without any extra API surface.
+DRAFT_TIER_MARKER = ", draft-tier"
+# Conclusions a LATER same-normalized-name check-run may excuse (superseded-run
+# forgiveness). Deliberately ONLY the supersession artifacts — a genuine failure /
+# timed_out is never forgiven by a later attempt.
+_SUPERSEDABLE = ("cancelled", "stale")
 # [FABLE-5] sq-fmx4u.3: the change-based test-selection pre-job (the reusable
 # .github/workflows/ci-select.yml job, called from ci.yml + feature-matrix.yml).
 # Its check-run name embeds this phrase; scripts/tests/test_ci_select_wiring.py
@@ -97,6 +137,97 @@ class Config:
 
 class FetchError(RuntimeError):
     """A poll's API fetch failed (transient or otherwise)."""
+
+
+@dataclass
+class TierContext:
+    """[FABLE-5] Draft-tier CI: which tier THIS gate run is evaluating, and how to
+    re-read the PR's live draft state at conclusion time. run_tier is computed from
+    the trigger payload (pull_request + draft == true => "draft"; every other
+    event/state => "full"). fetch_pr_draft() -> bool (current draft state), raising
+    FetchError on API failure; None when the run has no PR (push/merge_group)."""
+
+    run_tier: str = "full"  # "draft" | "full"
+    event_name: str = ""
+    fetch_pr_draft: object = None
+    draft_check_retries: int = 3
+
+
+def normalized_name(name: str) -> str:
+    """A check-run name with the draft-tier marker stripped — the identity under
+    which a draft-assembled select and its full-tier successor are the SAME leg."""
+    return name.replace(DRAFT_TIER_MARKER, "")
+
+
+def is_draft_tier(name: str) -> bool:
+    """Was this check-run produced by a draft-tier-assembled run (name marker)?"""
+    return DRAFT_TIER_MARKER in name
+
+
+def _order_key(run: dict) -> tuple:
+    """Later-run ordering: started_at (ISO-8601 Zulu strings compare correctly as
+    text) tie-broken by the check-run id (monotonically allocated)."""
+    return (run.get("started_at") or "", run.get("id") or 0)
+
+
+def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
+    """[FABLE-5] Draft-tier CI: drop cancelled/stale check-runs that a LATER
+    check-run with the same tier-normalized name supersedes (any status, any
+    conclusion EXCEPT cancelled/stale — an in-flight successor counts: the gate
+    then waits on it). Returns (kept, forgiven).
+
+    WHY: un-drafting fires ready_for_review on the SAME head SHA; the per-PR
+    concurrency groups cancel the in-flight draft-tier runs, leaving
+    conclusion=cancelled check-runs on the SHA that would otherwise permanently
+    RED the fresh full-tier gate. Branch protection itself honours only the
+    LATEST run of a check name, so excusing a superseded cancellation aligns the
+    gate with the enforcement layer. SAFETY: only cancelled/stale are ever
+    forgiven (a genuine failure/timed_out always gates, no matter what runs
+    later), and a cancellation with NO successor still fails the gate. Call this
+    over the RAW list (self-run included) so THIS gate run's own fresh `gate`
+    check-run can supersede its cancelled predecessor."""
+    kept: list[dict] = []
+    forgiven: list[dict] = []
+    for r in runs:
+        if r.get("conclusion") in _SUPERSEDABLE:
+            key = normalized_name(r.get("name", ""))
+            mine = _order_key(r)
+            if any(
+                o is not r
+                and normalized_name(o.get("name", "")) == key
+                and _order_key(o) > mine
+                and o.get("conclusion") not in _SUPERSEDABLE
+                for o in runs
+            ):
+                forgiven.append(r)
+                continue
+        kept.append(r)
+    return kept, forgiven
+
+
+def draft_selects_unsuperseded(runs: list[dict]) -> list[str]:
+    """[FABLE-5] Draft-tier CI: names of draft-tier-marked selection check-runs
+    that have NO later full-tier (unmarked) successor of the same normalized name.
+    Non-empty on a full-tier pull_request gate run == the leg set on this SHA is
+    (still) draft-tier-assembled: the gate must wait for the ready_for_review
+    full re-run to register, and must never conclude success over it."""
+    selects = [r for r in runs if is_select(r.get("name", ""))]
+    out: list[str] = []
+    for r in selects:
+        name = r.get("name", "")
+        if not is_draft_tier(name):
+            continue
+        key = normalized_name(name)
+        mine = _order_key(r)
+        superseded = any(
+            not is_draft_tier(o.get("name", ""))
+            and normalized_name(o.get("name", "")) == key
+            and _order_key(o) > mine
+            for o in selects
+        )
+        if not superseded:
+            out.append(name)
+    return sorted(set(out))
 
 
 def is_advisory(name: str) -> bool:
@@ -131,9 +262,66 @@ def _emit(line: str, summary_path: str = "") -> None:
             fh.write(line + "\n")
 
 
-def render_verdict(runs: list[dict], summary_path: str = "") -> int:
+def _draft_recheck(tier_ctx: TierContext | None, summary_path: str = "") -> int:
+    """[FABLE-5] Draft-tier conclusion-time re-check, applied on EVERY would-be-
+    SUCCESS path (including the stable-empty set): a DRAFT-tier run confirms the
+    PR is STILL a draft immediately before emitting success. Un-drafted => the
+    ready_for_review full-tier run supersedes this one, so conclude FAILURE
+    ("stale draft-tier run, full run pending") — the merge queue must never latch
+    a draft-tier green. An unreadable draft state (API failure after bounded
+    retries, or no fetcher wired) fail-closes to FAILURE: a draft PR cannot merge
+    regardless, so a false RED here is cheap and a false PASS is the invariant
+    violation. Returns 0 (ok to pass) or 1 (fail). Full-tier runs: always 0."""
+    if not tier_ctx or tier_ctx.run_tier != "draft":
+        return 0
+    still_draft = None
+    last_err: Exception | None = None
+    if tier_ctx.fetch_pr_draft is not None:
+        for _ in range(max(1, tier_ctx.draft_check_retries)):
+            try:
+                still_draft = tier_ctx.fetch_pr_draft()
+                break
+            except FetchError as exc:  # transient API blip: bounded retry
+                last_err = exc
+    if still_draft is None:
+        _emit(
+            "### ci-summary: FAILED — draft-tier run could not confirm the PR's "
+            f"current draft state at conclusion time (last error: {last_err}). "
+            "Fail-closed: a draft-tier result must never admit a PR to the merge "
+            "queue, so an unverifiable draft state REDs (re-run once the API "
+            "recovers; a draft PR cannot merge regardless).",
+            summary_path,
+        )
+        print("::error::ci-summary failed — draft state unverifiable on a draft-tier run.")
+        return 1
+    if still_draft is False:
+        _emit(
+            "### ci-summary: FAILED — stale draft-tier run, full run pending. This "
+            "gate run evaluated the REDUCED draft-tier leg set, but the PR is no "
+            "longer a draft: the ready_for_review full-tier run on this head SHA "
+            "supersedes this check (docs/branch-protection.md §Draft-tier CI).",
+            summary_path,
+        )
+        print("::error::ci-summary failed — stale draft-tier run on a now-ready PR.")
+        return 1
+    return 0
+
+
+def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierContext | None = None) -> int:
     """Shared by the clean-converge, graceful-timeout, and post-extension paths, so
     every path applies IDENTICAL gating semantics. Returns the process exit code.
+
+    DRAFT-TIER INTEGRITY ([FABLE-5], see the header): with a TierContext,
+      * a FULL-tier pull_request verdict REDs while any draft-tier-marked select
+        lacks a later full-tier successor (stale draft-tier leg set — the
+        ready_for_review full run has not registered on this SHA);
+      * a DRAFT-tier verdict that would otherwise be SUCCESS first re-reads the
+        PR's CURRENT draft state from the API: no-longer-draft => FAILURE ("stale
+        draft-tier run, full run pending"), and an unreadable state fail-closes
+        to FAILURE after bounded retries. A draft-tier verdict that is already a
+        FAILURE skips the re-check (a RED can never be latched by the queue).
+    Without a TierContext (tests / push / merge_group) the semantics are exactly
+    the pre-draft-tier ones.
 
     SELECTION SEMANTICS ([FABLE-5] sq-fmx4u.3, design §5.3): a `skipped`
     conclusion is satisfied ONLY when the change-based selection pre-job
@@ -149,8 +337,27 @@ def render_verdict(runs: list[dict], summary_path: str = "") -> int:
         behaviour, never a new failure mode.
     A job that FAILED still fails the gate regardless of selection — selection
     can only ever decide whether a SKIP is satisfied, never mask a failure."""
+    # [FABLE-5] Draft-tier belt: a full-tier pull_request gate must never conclude
+    # over a leg set whose selection was assembled draft-tier (checked FIRST — it
+    # invalidates the whole set, including an otherwise-green one).
+    if tier_ctx and tier_ctx.run_tier == "full" and tier_ctx.event_name == "pull_request":
+        stale = draft_selects_unsuperseded(runs)
+        if stale:
+            _emit(
+                "### ci-summary: FAILED — stale draft-tier run, full run pending. The "
+                "selection on this head SHA is draft-tier-assembled "
+                f"({', '.join(stale)}) with no full-tier successor: the ready_for_review "
+                "full-tier re-run never registered/completed here. A draft-tier leg set "
+                "must never admit a non-draft PR to the merge queue "
+                "(docs/branch-protection.md §Draft-tier CI).",
+                summary_path,
+            )
+            print("::error::ci-summary failed — stale draft-tier leg set on a non-draft head.")
+            return 1
     total = len(runs)
     if total == 0:
+        if _draft_recheck(tier_ctx, summary_path) != 0:
+            return 1
         _emit("ci-summary: no sibling checks to aggregate (stable empty set) — passing.", summary_path)
         return 0
     gating = [r for r in runs if not is_advisory(r.get("name", ""))]
@@ -190,9 +397,17 @@ def render_verdict(runs: list[dict], summary_path: str = "") -> int:
             _emit(f"- ✗ {r.get('name')}: {r.get('conclusion') or 'incomplete'}", summary_path)
         print("::error::ci-summary failed — see the non-passing gating checks above.")
         return 1
+    if _draft_recheck(tier_ctx, summary_path) != 0:
+        return 1
     _emit(
         f"### ci-summary: PASSED — all {len(gating)} gating check(s) green (or skipped/neutral); "
-        f"{excluded} advisory check(s) excluded; set stable.",
+        f"{excluded} advisory check(s) excluded; set stable."
+        + (
+            " DRAFT-TIER verdict (reduced leg set; PR draft state re-confirmed): the "
+            "full matrix re-runs at ready_for_review and its fresh gate supersedes this one."
+            if tier_ctx and tier_ctx.run_tier == "draft"
+            else ""
+        ),
         summary_path,
     )
     if select_runs:
@@ -204,11 +419,14 @@ def render_verdict(runs: list[dict], summary_path: str = "") -> int:
     return 0
 
 
-def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep) -> int:
-    """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url}
-    dicts (raises FetchError on API failure); `fetch_queue_depth()` -> int queued
-    workflow-run count for the repo, or None when unknown (API failure — the gate
-    then falls back to the progress signal alone). Returns the exit code."""
+def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
+             tier_ctx: TierContext | None = None) -> int:
+    """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url,
+    started_at,id} dicts (raises FetchError on API failure); `fetch_queue_depth()`
+    -> int queued workflow-run count for the repo, or None when unknown (API
+    failure — the gate then falls back to the progress signal alone). tier_ctx
+    carries the draft-tier integrity context (None => pre-draft-tier semantics).
+    Returns the exit code."""
     prev_names: list[str] | None = None
     stable = 0
     runs: list[dict] = []
@@ -238,25 +456,43 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep) ->
             continue
         consec_fetch_failures = 0
 
-        runs = [r for r in raw if not is_self(r, cfg.self_run_id)]
+        # [FABLE-5] Draft-tier CI: forgive cancelled/stale check-runs a later
+        # same-normalized-name run supersedes — over the RAW list (self included)
+        # so this run's own fresh `gate` check-run supersedes a cancelled
+        # predecessor left on the SHA by the ready_for_review concurrency cancel.
+        kept, forgiven = forgive_superseded(raw)
+        runs = [r for r in kept if not is_self(r, cfg.self_run_id)]
         total = len(runs)
         pending = sum(1 for r in runs if r.get("status") != "completed")
+        # [FABLE-5] Draft-tier CI: on a FULL-tier pull_request run, a draft-tier-
+        # assembled selection with no full-tier successor means the ready_for_review
+        # re-run has not registered yet — treat the set as STILL-SETTLING (hold the
+        # settle window open) instead of concluding over draft-tier legs. Budget
+        # exhaustion in this state REDs via render_verdict's stale-draft-tier belt.
+        awaiting_full = bool(
+            tier_ctx
+            and tier_ctx.run_tier == "full"
+            and tier_ctx.event_name == "pull_request"
+            and draft_selects_unsuperseded(runs)
+        )
         completed_hist.append(total - pending)
         # Settle is a POST-TERMINAL window re-armed ONLY by pending work (sq-ipkku):
         # already-terminal injections must not starve convergence.
-        stable = 0 if pending else stable + 1
+        stable = 0 if (pending or awaiting_full) else stable + 1
         names = sorted({r.get("name", "") for r in runs})
         changed = " (name set changed)" if prev_names is not None and names != prev_names else ""
         prev_names = names
+        extra = f", {len(forgiven)} superseded-cancelled forgiven" if forgiven else ""
+        extra += ", awaiting the full-tier re-run (draft-tier selection present)" if awaiting_full else ""
         print(
             f"attempt {attempt}: {total} check-run(s), {pending} running, "
-            f"all-terminal stable for {stable}/{cfg.settle_polls} poll(s){changed}",
+            f"all-terminal stable for {stable}/{cfg.settle_polls} poll(s){changed}{extra}",
             flush=True,
         )
 
         # Clean convergence: everything terminal, held for the settle, past the floor.
         if attempt >= cfg.min_polls and pending == 0 and stable >= cfg.settle_polls:
-            return render_verdict(runs, cfg.summary_path)
+            return render_verdict(runs, cfg.summary_path, tier_ctx)
 
         # ADAPTIVE SATURATION BUDGET (sq-90cv4): at/after the base budget with work
         # still pending, extend ONLY while the evidence says throughput-starvation
@@ -316,7 +552,7 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep) ->
             "(the set kept being injected into without a full quiet settle) — rendering "
             "the verdict on the final all-terminal set."
         )
-        return render_verdict(runs, cfg.summary_path)
+        return render_verdict(runs, cfg.summary_path, tier_ctx)
     print(
         f"::error::ci-summary timed out — {pending} sibling check-run(s) never finished "
         f"within the ABSOLUTE budget (base + saturation extension, sq-90cv4). The runner "
@@ -350,14 +586,44 @@ def _gh_json_lines(args: list[str]) -> list[dict]:
 
 def make_fetch_runs(repo: str, sha: str):
     def fetch() -> list[dict]:
+        # started_at + id feed the superseded-run ordering (draft-tier CI): a
+        # cancelled/stale check-run is forgiven only for a strictly LATER
+        # same-normalized-name successor.
         return _gh_json_lines(
             [
                 f"repos/{repo}/commits/{sha}/check-runs",
                 "--paginate",
                 "--jq",
-                ".check_runs[] | {name, status, conclusion, details_url, html_url}",
+                ".check_runs[] | {name, status, conclusion, details_url, html_url, started_at, id}",
             ]
         )
+
+    return fetch
+
+
+def make_fetch_pr_draft(repo: str, pr_number: str):
+    """[FABLE-5] Draft-tier CI: the conclusion-time PR draft-state reader. Returns
+    a () -> bool fetcher (True == still a draft) that raises FetchError on any
+    API/parse failure — the caller (render_verdict via _draft_recheck) bounded-
+    retries and fail-closes to RED, never to a pass."""
+
+    def fetch() -> bool:
+        try:
+            proc = subprocess.run(
+                ["gh", "api", f"repos/{repo}/pulls/{pr_number}", "--jq", ".draft"],
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            raise FetchError(f"subprocess raised: {exc}") from exc
+        if proc.returncode != 0:
+            raise FetchError(proc.stderr.strip()[:300] or f"gh api exited {proc.returncode}")
+        val = proc.stdout.strip().lower()
+        if val == "true":
+            return True
+        if val == "false":
+            return False
+        raise FetchError(f"unexpected .draft value {val!r}")
 
     return fetch
 
@@ -397,8 +663,24 @@ def main() -> int:
     if not repo or not sha or not self_run_id:
         print("::error::ci-summary: REPO, SHA and SELF_RUN_ID must all be set.")
         return 1
+    # [FABLE-5] Draft-tier CI: the tier THIS run evaluates is decided by its own
+    # trigger payload — a pull_request event with draft == true is a DRAFT-tier
+    # gate (ci-summary.yml exports the payload's draft flag + PR number). Every
+    # other event/state (push / merge_group / non-draft PR / missing payload) is
+    # FULL tier, which keeps push/merge_group semantics byte-identical.
+    event_name = os.environ.get("EVENT_NAME", "")
+    pr_draft = os.environ.get("PR_DRAFT", "").strip().lower()
+    pr_number = os.environ.get("PR_NUMBER", "").strip()
+    run_tier = "draft" if (event_name == "pull_request" and pr_draft == "true") else "full"
+    tier_ctx = TierContext(
+        run_tier=run_tier,
+        event_name=event_name,
+        fetch_pr_draft=make_fetch_pr_draft(repo, pr_number) if pr_number else None,
+    )
+    print(f"ci-summary: evaluating tier={run_tier} (event={event_name or '<unset>'}).")
     cfg = Config(self_run_id=self_run_id)
-    return run_gate(cfg, make_fetch_runs(repo, sha), make_fetch_queue_depth(repo))
+    return run_gate(cfg, make_fetch_runs(repo, sha), make_fetch_queue_depth(repo),
+                    tier_ctx=tier_ctx)
 
 
 if __name__ == "__main__":

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -51,8 +51,19 @@
 # DRAFT-TIER INTEGRITY (bead: draft-tier CI). [FABLE-5] Draft PR heads run a REDUCED
 # leg set (coverage / bench / CodeQL / heavy shards / wasm-equality skipped — see
 # docs/branch-protection.md §Draft-tier CI); the ci-select job NAME carries the
-# ", draft-tier" marker on draft-assembled runs. THE INVARIANT: a draft-tier gate
-# result must NEVER admit a PR to the merge queue. Enforced three ways, all here:
+# ", draft-tier" marker on draft-assembled runs, and — the STRUCTURAL mechanism —
+# the ci-summary gate job's OWN check-run name is tiered the same way: a draft
+# payload emits `gate, draft-tier`, never the required `gate` context, so branch
+# protection ({context: "gate"}) is unsatisfiable by any draft-tier run and there
+# is no supersession window at the un-draft moment (the required context is simply
+# ABSENT until the full-tier run concludes). THE INVARIANT: a draft-tier gate
+# result must NEVER admit a PR to the merge queue. This script adds four belts on
+# top of the structural name tiering:
+#   * DRAFT-GATE-ARTIFACT EXCLUSION — a `gate, draft-tier` check-run left on the
+#     SHA by an earlier draft-tier gate run is an aggregator verdict over a
+#     superseded assembly, not a leg: it is excluded from every sibling set (its
+#     FAILURE must not permanently RED the full-tier gate on the same SHA, and its
+#     SUCCESS carries nothing the live evaluation does not re-derive).
 #   * SUPERSEDED-RUN FORGIVENESS — un-drafting fires ready_for_review on the SAME
 #     head SHA; per-PR concurrency then CANCELS the in-flight draft-tier runs,
 #     leaving conclusion=cancelled check-runs on the SHA the fresh full-tier gate
@@ -63,12 +74,15 @@
 #     This matches branch protection's own semantics (it reads the LATEST run of a
 #     required check name).
 #   * STALE DRAFT-TIER LEG SET — a FULL-tier pull_request gate run refuses to
-#     conclude success while any draft-tier-marked select check-run lacks a later
-#     full-tier (unmarked) same-normalized-name successor: the leg set on the SHA
-#     was assembled draft-tier and the full re-run has not registered. The loop
-#     treats that as STILL-SETTLING (the ready_for_review re-runs are seconds away);
-#     budget exhaustion in that state is a RED ("stale draft-tier run, full run
-#     pending"), never a pass over draft legs.
+#     conclude success while any draft-tier-marked select check-run INSTANCE lacks
+#     its OWN, distinct, strictly-later full-tier (unmarked) same-normalized-name
+#     successor. Per-INSTANCE matters: ci.yml, bench.yml, feature-matrix.yml and
+#     fuzz.yml all expose the IDENTICAL select check-run name, so the first
+#     workflow's full-tier select must not release the hold for the other three
+#     (whose full-tier runs may not have registered any check-runs yet). The loop
+#     treats an unmatched instance as STILL-SETTLING (the ready_for_review re-runs
+#     are seconds away); budget exhaustion in that state is a RED ("stale
+#     draft-tier run, full run pending"), never a pass over draft legs.
 #   * CONCLUSION-TIME DRAFT RE-CHECK — a DRAFT-tier gate run re-reads the PR's
 #     CURRENT draft state from the API immediately before emitting a SUCCESS
 #     verdict; if the PR is no longer a draft the gate concludes FAILURE ("stale
@@ -105,6 +119,16 @@ _PASSING = ("success", "skipped", "neutral")
 # advisory rule uses — so the gate can partition draft-assembled from full-assembled
 # selection check-runs on a head SHA without any extra API surface.
 DRAFT_TIER_MARKER = ", draft-tier"
+# [FABLE-5] Draft-tier CI: THIS aggregator's own job name is tiered the same way
+# (ci-summary.yml `gate` job): a draft-payload run emits the check-run
+# `gate, draft-tier` and NEVER the required `gate` context — the structural half
+# of the integrity invariant (branch protection's required_status_checks entry
+# {context: "gate"} cannot be satisfied by a draft-tier run at all). A
+# `gate, draft-tier` check-run left on a SHA by an earlier draft-tier gate run is
+# therefore a tier ARTIFACT, not a leg: is_draft_gate_artifact() excludes it from
+# the sibling set (see run_gate).
+GATE_CHECK_NAME = "gate"
+DRAFT_TIER_GATE_NAME = GATE_CHECK_NAME + DRAFT_TIER_MARKER
 # Conclusions a LATER same-normalized-name check-run may excuse (superseded-run
 # forgiveness). Deliberately ONLY the supersession artifacts — a genuine failure /
 # timed_out is never forgiven by a later attempt.
@@ -164,6 +188,19 @@ def is_draft_tier(name: str) -> bool:
     return DRAFT_TIER_MARKER in name
 
 
+def is_draft_gate_artifact(name: str) -> bool:
+    """Is this check-run a draft-tier gate VERDICT (`gate, draft-tier`)? Such a
+    run is an aggregator artifact of a superseded draft-tier evaluation, never a
+    leg: its FAILURE must not permanently RED the full-tier gate on the same SHA
+    (the live run re-derives the verdict over the real legs), and its SUCCESS
+    carries no information the live evaluation does not recompute. The full-tier
+    `gate` name is deliberately NOT excluded here — a future sibling job
+    literally named `gate` in another workflow must keep gating (the run-id
+    self-exclusion comment in ci-summary.yml), and cancelled `gate` predecessors
+    are handled by forgive_superseded instead."""
+    return name == DRAFT_TIER_GATE_NAME
+
+
 def _order_key(run: dict) -> tuple:
     """Later-run ordering: started_at (ISO-8601 Zulu strings compare correctly as
     text) tie-broken by the check-run id (monotonically allocated)."""
@@ -206,28 +243,55 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
 
 
 def draft_selects_unsuperseded(runs: list[dict]) -> list[str]:
-    """[FABLE-5] Draft-tier CI: names of draft-tier-marked selection check-runs
-    that have NO later full-tier (unmarked) successor of the same normalized name.
-    Non-empty on a full-tier pull_request gate run == the leg set on this SHA is
-    (still) draft-tier-assembled: the gate must wait for the ready_for_review
-    full re-run to register, and must never conclude success over it."""
-    selects = [r for r in runs if is_select(r.get("name", ""))]
-    out: list[str] = []
-    for r in selects:
+    """[FABLE-5] Draft-tier CI: names of draft-tier-marked selection check-run
+    INSTANCES that have no OWN, distinct, strictly-later full-tier (unmarked)
+    successor of the same normalized name — one entry per unsuperseded instance
+    (duplicates preserved so the caller can report counts). Non-empty on a
+    full-tier pull_request gate run == the leg set on this SHA is (still, at
+    least partly) draft-tier-assembled: the gate must wait for the
+    ready_for_review full re-runs to register, and must never conclude success
+    over it.
+
+    PER-INSTANCE, not per-name: ci.yml, bench.yml, feature-matrix.yml and
+    fuzz.yml all call the same reusable ci-select job, so a head SHA carries up
+    to FOUR draft-marked selects under the IDENTICAL check-run name. Matching by
+    name alone would let the FIRST workflow's full-tier select supersede ALL of
+    them, releasing the hold while the other workflows' full-tier runs may not
+    have registered any check-runs yet — their skipped/vacuous draft-tier legs
+    would then satisfy a full-tier verdict (the exact admission the invariant
+    forbids; each full-tier run that registers also registers its pending legs,
+    so demanding one successor per instance holds the gate until every selecting
+    workflow's re-run is visible). Within each normalized-name group the marked
+    and unmarked selects are therefore matched greedily in start order (the
+    earliest marked instance consumes the earliest unused strictly-later
+    unmarked one — a maximum matching for this single-key order structure).
+
+    Deliberately fail-closed: repeated draft-tier rounds on ONE SHA (e.g. a
+    ci-full label toggle while the PR was a draft) accumulate marked instances
+    that each demand a successor; a hold that cannot be satisfied REDs at budget
+    exhaustion ("stale draft-tier run, full run pending") rather than ever
+    passing over draft-assembled legs. Re-running the selecting workflows (or
+    pushing a new head) clears it."""
+    groups: dict[str, tuple[list[dict], list[dict]]] = {}
+    for r in runs:
         name = r.get("name", "")
-        if not is_draft_tier(name):
+        if not is_select(name):
             continue
-        key = normalized_name(name)
-        mine = _order_key(r)
-        superseded = any(
-            not is_draft_tier(o.get("name", ""))
-            and normalized_name(o.get("name", "")) == key
-            and _order_key(o) > mine
-            for o in selects
-        )
-        if not superseded:
-            out.append(name)
-    return sorted(set(out))
+        marked, unmarked = groups.setdefault(normalized_name(name), ([], []))
+        (marked if is_draft_tier(name) else unmarked).append(r)
+    out: list[str] = []
+    for marked, unmarked in groups.values():
+        marked.sort(key=_order_key)
+        unmarked.sort(key=_order_key)
+        fi = 0
+        for m in marked:
+            while fi < len(unmarked) and _order_key(unmarked[fi]) <= _order_key(m):
+                fi += 1
+            if fi < len(unmarked):
+                fi += 1  # this full-tier successor is consumed by instance m
+            else:
+                out.append(m.get("name", ""))
+    return sorted(out)
 
 
 def is_advisory(name: str) -> bool:
@@ -313,8 +377,9 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
 
     DRAFT-TIER INTEGRITY ([FABLE-5], see the header): with a TierContext,
       * a FULL-tier pull_request verdict REDs while any draft-tier-marked select
-        lacks a later full-tier successor (stale draft-tier leg set — the
-        ready_for_review full run has not registered on this SHA);
+        INSTANCE lacks its own later full-tier successor (stale draft-tier leg
+        set — at least one selecting workflow's ready_for_review full run has
+        not registered on this SHA);
       * a DRAFT-tier verdict that would otherwise be SUCCESS first re-reads the
         PR's CURRENT draft state from the API: no-longer-draft => FAILURE ("stale
         draft-tier run, full run pending"), and an unreadable state fail-closes
@@ -343,12 +408,21 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
     if tier_ctx and tier_ctx.run_tier == "full" and tier_ctx.event_name == "pull_request":
         stale = draft_selects_unsuperseded(runs)
         if stale:
+            counts: dict[str, int] = {}
+            for n in stale:
+                counts[n] = counts.get(n, 0) + 1
+            detail = ", ".join(
+                f"{n} ×{c}" if c > 1 else n for n, c in sorted(counts.items())
+            )
             _emit(
                 "### ci-summary: FAILED — stale draft-tier run, full run pending. The "
-                "selection on this head SHA is draft-tier-assembled "
-                f"({', '.join(stale)}) with no full-tier successor: the ready_for_review "
-                "full-tier re-run never registered/completed here. A draft-tier leg set "
-                "must never admit a non-draft PR to the merge queue "
+                "selection on this head SHA is (at least partly) draft-tier-assembled: "
+                f"{len(stale)} draft-marked select instance(s) have no OWN later "
+                f"full-tier successor ({detail}). Each selecting workflow's "
+                "ready_for_review full-tier re-run must register its own successor "
+                "(ci/bench/feature-matrix/fuzz share one select name — one full-tier "
+                "select must never release the hold for the others). A draft-tier leg "
+                "set must never admit a non-draft PR to the merge queue "
                 "(docs/branch-protection.md §Draft-tier CI).",
                 summary_path,
             )
@@ -403,8 +477,10 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
         f"### ci-summary: PASSED — all {len(gating)} gating check(s) green (or skipped/neutral); "
         f"{excluded} advisory check(s) excluded; set stable."
         + (
-            " DRAFT-TIER verdict (reduced leg set; PR draft state re-confirmed): the "
-            "full matrix re-runs at ready_for_review and its fresh gate supersedes this one."
+            " DRAFT-TIER verdict (reduced leg set; PR draft state re-confirmed). This "
+            f"check-run is `{DRAFT_TIER_GATE_NAME}`, never the required `{GATE_CHECK_NAME}` "
+            "context — it cannot satisfy branch protection; the full matrix re-runs at "
+            "ready_for_review and only its full-tier gate can."
             if tier_ctx and tier_ctx.run_tier == "draft"
             else ""
         ),
@@ -460,8 +536,17 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         # same-normalized-name run supersedes — over the RAW list (self included)
         # so this run's own fresh `gate` check-run supersedes a cancelled
         # predecessor left on the SHA by the ready_for_review concurrency cancel.
+        # Then drop (a) this run's own check-run and (b) any `gate, draft-tier`
+        # check-run — a draft-tier gate VERDICT is a tier artifact of a
+        # superseded evaluation, never a leg (a completed draft-tier gate
+        # FAILURE on the SHA must not permanently RED the full-tier gate, and
+        # its SUCCESS never was the required context).
         kept, forgiven = forgive_superseded(raw)
-        runs = [r for r in kept if not is_self(r, cfg.self_run_id)]
+        runs = [
+            r for r in kept
+            if not is_self(r, cfg.self_run_id)
+            and not is_draft_gate_artifact(r.get("name", ""))
+        ]
         total = len(runs)
         pending = sum(1 for r in runs if r.get("status") != "completed")
         # [FABLE-5] Draft-tier CI: on a FULL-tier pull_request run, a draft-tier-

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -704,17 +704,44 @@ class TestRequiredCheckAnchor(unittest.TestCase):
         cls.cs = _load(CISUM_YML)
         cls.gate = _gate_module()
 
+    # [FABLE-5] Draft-tier CI: the exact marker expression ci-select.yml also
+    # uses — empty on every non-draft payload, ", draft-tier" on a draft one.
+    GATE_MARKER_EXPR = "${{ github.event.pull_request.draft == true && ', draft-tier' || '' }}"
+
     def test_gate_job_name_is_exactly_gate(self):
         """The branch-protection ruleset (id 17688455) requires context='gate'.
         If this name drifts the required check silently stops matching and the
-        gate weakens with no error anywhere — so pin it."""
+        gate weakens with no error anywhere — so pin it.
+
+        [FABLE-5] Draft-tier CI (GATE INTEGRITY): the name is now TIERED — the
+        job name is the literal 'gate' plus the draft-tier marker expression, so
+        * every non-draft payload (non-draft PR, merge_group, push) still
+          renders EXACTLY 'gate' (the required context, unchanged), and
+        * a draft pull_request payload renders 'gate, draft-tier' — a
+          deliberately NON-required context, so a draft-tier run can never
+          satisfy branch protection in ANY window (event latency, a dropped
+          ready_for_review event, an Actions outage: the required context is
+          simply absent until the full-tier run concludes)."""
         job = self.cs["jobs"]["gate"]
+        name = job["name"]
         self.assertEqual(
-            job["name"], "gate",
-            "ci-summary gate job name must stay exactly 'gate' — "
-            "the branch-protection ruleset anchors on context='gate' (id 17688455); "
-            "renaming breaks the required check without any CI warning",
+            name, "gate" + self.GATE_MARKER_EXPR,
+            "ci-summary gate job name must be exactly 'gate' + the draft-tier "
+            "marker expression — the ruleset anchors on context='gate' (id "
+            "17688455) for every non-draft payload, and the marker is what "
+            "keeps a draft-tier run from ever emitting that required context",
         )
+        # The non-draft rendering is the required context, byte-exact.
+        self.assertEqual(name.replace(self.GATE_MARKER_EXPR, ""), "gate")
+        # The draft rendering is the gate module's artifact name — the script
+        # excludes it from sibling sets and normalizes it back to 'gate'.
+        draft_rendered = name.replace(self.GATE_MARKER_EXPR,
+                                      self.gate.DRAFT_TIER_MARKER)
+        self.assertEqual(draft_rendered, self.gate.DRAFT_TIER_GATE_NAME)
+        self.assertTrue(self.gate.is_draft_gate_artifact(draft_rendered))
+        self.assertFalse(self.gate.is_draft_gate_artifact("gate"))
+        self.assertTrue(self.gate.is_draft_tier(draft_rendered))
+        self.assertEqual(self.gate.normalized_name(draft_rendered), "gate")
 
     def test_gate_job_has_no_job_level_conditional(self):
         """The gate must run unconditionally on every event (pull_request,
@@ -741,8 +768,10 @@ class TestRequiredCheckAnchor(unittest.TestCase):
     def test_gate_is_not_advisory_or_informational(self):
         """The gate name must never accidentally match the advisory/informational
         exclusion — that would un-gate it (its failure would stop being required).
-        Both the bare job name and the `workflow / job` display form are checked."""
-        for name in ("gate", "ci-summary / gate"):
+        Both the bare job name and the `workflow / job` display form are checked,
+        in both tier renderings."""
+        for name in ("gate", "ci-summary / gate",
+                     "gate, draft-tier", "ci-summary / gate, draft-tier"):
             self.assertFalse(
                 self.gate.is_advisory(name),
                 f"gate check name {name!r} must NOT match the advisory exclusion",
@@ -752,7 +781,8 @@ class TestRequiredCheckAnchor(unittest.TestCase):
         """The gate name must not match SELECT_RE — that would make the gate
         self-detect as a selection pre-job and add a circular verdict dependency
         (skipped gating only valid if 'gate' itself concluded success)."""
-        for name in ("gate", "ci-summary / gate"):
+        for name in ("gate", "ci-summary / gate",
+                     "gate, draft-tier", "ci-summary / gate, draft-tier"):
             self.assertFalse(
                 self.gate.is_select(name),
                 f"gate check name {name!r} must NOT match SELECT_RE",
@@ -1058,6 +1088,43 @@ class TestDraftTierWiring(unittest.TestCase):
                 self.assertIn(keep, types, f"{wf_name}: must keep the default {keep}")
 
     # ---- gate plumbing -------------------------------------------------------
+    def test_gate_check_name_is_tiered_on_draft_payloads(self):
+        """[GATE INTEGRITY] The STRUCTURAL half of the invariant: on a draft
+        payload the ci-summary gate job's own check-run is named
+        `gate, draft-tier`, so a draft-tier run never produces the required
+        `gate` context and branch protection cannot be satisfied by it in any
+        window (event latency / dropped ready_for_review / Actions outage —
+        the required context is simply ABSENT until the full-tier run
+        concludes). Full rendering pinned by TestRequiredCheckAnchor."""
+        name = self.summary["jobs"]["gate"]["name"]
+        self.assertEqual(name, "gate" + self.MARKER_EXPR)
+
+    def test_code_scanning_backstop_fed_and_documented_as_non_load_bearing(self):
+        """The live ruleset also carries a `code_scanning` rule (CodeQL). A
+        draft-built head carries no PR CodeQL analysis (analyze skips on
+        drafts), so that rule independently blocks such a head — but it is an
+        out-of-repo, owner-mutable setting and evadable (a non-draft PR sharing
+        the head SHA supplies an analysis; outage relaxation), so it must be
+        recorded as defense-in-depth ONLY and the feeding triggers must not
+        rot: push-to-main + merge_group + weekly schedule + ready_for_review."""
+        on = _on_block(self.codeql)
+        push = on.get("push") or {}
+        self.assertEqual(push.get("branches"), ["main"],
+                         "codeql.yml must keep its push-to-main analysis run")
+        self.assertIn("merge_group", on)
+        self.assertIn("schedule", on)
+        types = (on.get("pull_request") or {}).get("types", [])
+        self.assertIn("ready_for_review", types,
+                      "the un-draft moment must produce a fresh CodeQL analysis")
+        doc = (REPO_ROOT / "docs" / "branch-protection.md").read_text(encoding="utf-8")
+        self.assertIn("code_scanning", doc,
+                      "docs/branch-protection.md must record the code_scanning "
+                      "rule's role in the draft-tier design")
+        self.assertIn("defense-in-depth only", doc,
+                      "the doc must record code_scanning as defense-in-depth, "
+                      "never the load-bearing draft-tier mechanism")
+        self.assertIn("owner-mutable", doc)
+
     def test_gate_receives_tier_env_and_pr_read(self):
         perms = self.summary.get("permissions", {})
         self.assertEqual(perms.get("pull-requests"), "read",

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -898,5 +898,191 @@ class TestHeavyRecallMergeGroupDemotion(unittest.TestCase):
         )
 
 
+class TestDraftTierWiring(unittest.TestCase):
+    """[FABLE-5] Draft-tier CI (docs/branch-protection.md §Draft-tier CI): draft
+    PR heads run a REDUCED matrix — coverage / bench / CodeQL / heavy shards
+    skipped, the wasm-equality leg kept only when the sparq-wasm closure is
+    affected — and the un-draft moment (ready_for_review) re-runs everything at
+    FULL tier so a fresh gate supersedes the draft-tier results. Pins:
+      * the ci-select job-name draft-tier MARKER (the gate's tier detection
+        contract — scripts/ci_summary_gate.py DRAFT_TIER_MARKER);
+      * every draft skip guard's fail-open shape (`github.event_name !=
+        'pull_request' || ... draft != true`: any non-PR event RUNS — push /
+        merge_group / schedule semantics are byte-identical);
+      * ready_for_review in the pull_request types of every gate-feeding
+        workflow (without it the un-draft moment runs NOTHING and the head keeps
+        its draft-tier results — the exact stale-green the invariant forbids);
+      * the gate job's tier env plumbing (EVENT_NAME / PR_DRAFT / PR_NUMBER +
+        pull-requests: read)."""
+
+    # The fail-open draft guard: any non-pull_request event satisfies the first
+    # disjunct => RUN; only a genuinely-draft PR head can skip.
+    DRAFT_GUARD = "github.event_name != 'pull_request' || github.event.pull_request.draft != true"
+    MARKER_EXPR = "${{ github.event.pull_request.draft == true && ', draft-tier' || '' }}"
+
+    # Every gate-feeding workflow with a pull_request trigger. Advisory-only
+    # workflows (pr-title, deploy-lint, deploy-terraform-lint) are deliberately
+    # absent — the gate excludes their checks by name, so they neither gate nor
+    # feed it. bead-autoclose/flow-on react to `closed` only (not gate-feeding).
+    READY_FOR_REVIEW_WFS = [
+        "ci.yml", "feature-matrix.yml", "bench.yml", "fuzz.yml", "codeql.yml",
+        "ci-summary.yml", "vectorized-feature-off.yml", "docs-quality.yml",
+        "supply-chain.yml", "flow-on-gates.yml", "formal-verification.yml",
+        "js.yml", "gui.yml", "python.yml", "site-e2e.yml",
+        "site-e2e-foundation.yml", "site-e2e-hero.yml", "site-visual.yml",
+        "container-scan.yml", "zk-toolchain.yml",
+    ]
+
+    @classmethod
+    def setUpClass(cls):
+        wfdir = REPO_ROOT / ".github" / "workflows"
+        cls.ci = _load(CI_YML)
+        cls.bench = _load(BENCH_YML)
+        cls.sel = _load(SELECT_YML)
+        cls.codeql = _load(wfdir / "codeql.yml")
+        cls.vfo = _load(wfdir / "vectorized-feature-off.yml")
+        cls.summary = _load(wfdir / "ci-summary.yml")
+        cls.js = _load(wfdir / "js.yml")
+        cls.wfdir = wfdir
+        cls.gate = _gate_module()
+        cls.members = _workspace_members()
+
+    # ---- the tier marker (the gate's detection contract) ---------------------
+    def test_select_job_name_carries_the_draft_tier_marker(self):
+        name = self.sel["jobs"]["select"]["name"]
+        self.assertIn(self.MARKER_EXPR, name,
+                      "ci-select's job name must append the draft-tier marker on "
+                      "draft PR payloads (the gate's tier detection contract)")
+        marker = self.gate.DRAFT_TIER_MARKER
+        self.assertIn(marker, self.MARKER_EXPR,
+                      "the YAML marker literal must be the gate's DRAFT_TIER_MARKER")
+        # Both RENDERED spellings must satisfy the SELECT_RE contract, carry no
+        # advisory token, and normalize to the same identity.
+        full = name.replace(self.MARKER_EXPR, "")
+        draft = name.replace(self.MARKER_EXPR, marker)
+        for rendered in (full, draft, f"select / {full}", f"select / {draft}"):
+            self.assertTrue(self.gate.is_select(rendered), rendered)
+            self.assertFalse(self.gate.is_advisory(rendered), rendered)
+        self.assertTrue(self.gate.is_draft_tier(draft))
+        self.assertFalse(self.gate.is_draft_tier(full))
+        self.assertEqual(self.gate.normalized_name(draft), full)
+
+    # ---- draft skip guards ---------------------------------------------------
+    def test_coverage_jobs_skip_on_draft_heads(self):
+        for job_id in ("coverage-measure", "coverage-engine-run", "coverage"):
+            cond = str(self.ci["jobs"][job_id].get("if", ""))
+            self.assertIn(self.DRAFT_GUARD, cond,
+                          f"ci.yml:{job_id} must skip on draft PR heads with the "
+                          f"fail-open guard (draft-tier CI)")
+        # The final aggregate keeps always() (it must still conclude when a
+        # needed job failed on non-draft runs).
+        self.assertIn("always()", str(self.ci["jobs"]["coverage"].get("if", "")))
+
+    def test_bench_job_skips_on_draft_heads(self):
+        cond = str(self.bench["jobs"]["bench"].get("if", ""))
+        self.assertIn(self.DRAFT_GUARD, cond,
+                      "bench.yml:bench must skip entirely on draft PR heads")
+        self.assertIn(FAIL_CLOSED_DISJUNCT, cond,
+                      "the selection disjunction must survive the draft guard")
+
+    def test_codeql_analyze_skips_on_draft_heads(self):
+        cond = str(self.codeql["jobs"]["analyze"].get("if", ""))
+        self.assertIn(self.DRAFT_GUARD, cond,
+                      "codeql.yml:analyze must skip on draft PR heads")
+        on = _on_block(self.codeql)
+        self.assertIn("merge_group", on,
+                      "CodeQL must keep its merge_group run (pre-merge analysis)")
+        self.assertIn("schedule", on, "CodeQL must keep its weekly schedule")
+
+    def test_heavy_shards_also_demoted_on_draft_heads(self):
+        for step in self.ci["jobs"]["test"]["steps"]:
+            if str(step.get("name", "")).startswith("Test (nextest, shard"):
+                env = step.get("env", {})
+                self.assertIn("IS_DRAFT_PR", env,
+                              "the Test step must receive IS_DRAFT_PR via env")
+                self.assertIn("github.event.pull_request.draft == true",
+                              str(env["IS_DRAFT_PR"]))
+                run = str(step.get("run", ""))
+                self.assertIn('[ "$IS_DRAFT_PR" = "true" ] && [ -n "$SHARD_FILTER" ]',
+                              run,
+                              "draft demotion must require BOTH a draft head AND a "
+                              "heavy shard (bulk shards are never demoted)")
+                # The draft guard must be a SEPARATE guard from the merge_group
+                # one (that one is pinned merge_group-exclusive above).
+                draft_lines = [ln for ln in run.splitlines() if "IS_DRAFT_PR" in ln]
+                for ln in draft_lines:
+                    self.assertNotIn("merge_group", ln)
+                return
+        self.fail("Test step not found")
+
+    def test_vfo_draft_scope_keeps_leg_iff_wasm_closure_affected(self):
+        """artifact-exact-equality on a DRAFT head consults the SAME selector
+        (scripts/ci_select.py) in-step and skips only on a definite
+        mode=selected + sparq-wasm-not-affected verdict — every other path
+        (non-draft, ci-full label, full/shadow/error mode, selector failure)
+        leaves the paths-filter verdict (RUN, fail-closed)."""
+        self.assertIn("sparq-wasm", self.members)
+        steps = None
+        for job_id, job in self.vfo["jobs"].items():
+            for s in job.get("steps", []):
+                if s.get("id") == "changes" and "ci_select.py" in str(s.get("run", "")):
+                    steps = s
+        self.assertIsNotNone(steps, "vfo decide step must invoke scripts/ci_select.py")
+        run = str(steps["run"])
+        env = steps.get("env", {})
+        for key in ("IS_DRAFT_PR", "CI_FULL_LABEL", "BASE_SHA", "HEAD_SHA"):
+            self.assertIn(key, env, f"vfo decide step must receive {key}")
+        self.assertIn('[ "$IS_DRAFT_PR" = "true" ]', run)
+        self.assertIn('[ "$CI_FULL_LABEL" != "true" ]', run,
+                      "the ci-full label must force the full leg on drafts too")
+        self.assertIn('[ "$mode" = "selected" ]', run,
+                      "only a definite mode=selected verdict may skip (fail-closed)")
+        self.assertIn('"sparq-wasm"', run,
+                      "the needle must be the quoted sparq-wasm member name")
+        # The skip assignment must exist exactly once, inside the guarded branch.
+        self.assertEqual(run.count('rust_changed="false"'), 1)
+
+    # ---- ready_for_review coverage -------------------------------------------
+    def test_ready_for_review_wired_on_every_gate_feeding_workflow(self):
+        for wf_name in self.READY_FOR_REVIEW_WFS:
+            wf = _load(self.wfdir / wf_name)
+            pr = _on_block(wf).get("pull_request") or {}
+            self.assertIsInstance(pr, dict,
+                                  f"{wf_name}: pull_request must enumerate types "
+                                  f"(bare form lacks ready_for_review)")
+            types = pr.get("types", [])
+            self.assertIn("ready_for_review", types,
+                          f"{wf_name}: without ready_for_review the un-draft moment "
+                          f"runs nothing and the head keeps draft-tier results")
+            for keep in ("opened", "synchronize", "reopened"):
+                self.assertIn(keep, types, f"{wf_name}: must keep the default {keep}")
+
+    # ---- gate plumbing -------------------------------------------------------
+    def test_gate_receives_tier_env_and_pr_read(self):
+        perms = self.summary.get("permissions", {})
+        self.assertEqual(perms.get("pull-requests"), "read",
+                         "the gate needs pull-requests:read for the conclusion-time "
+                         "draft re-check")
+        step = next(s for s in self.summary["jobs"]["gate"]["steps"]
+                    if "ci_summary_gate.py" in str(s.get("run", "")))
+        env = step.get("env", {})
+        for key in ("EVENT_NAME", "PR_DRAFT", "PR_NUMBER"):
+            self.assertIn(key, env, f"gate step must export {key}")
+        self.assertIn("github.event.pull_request.draft", str(env["PR_DRAFT"]))
+
+    def test_bench_concurrency_cancels_only_pull_request(self):
+        conc = self.bench.get("concurrency", {})
+        self.assertEqual(str(conc.get("cancel-in-progress")),
+                         "${{ github.event_name == 'pull_request' }}",
+                         "bench must cancel superseded PR runs but never a "
+                         "push/schedule run (history integrity)")
+
+    def test_js_has_per_pr_concurrency(self):
+        conc = self.js.get("concurrency", {})
+        self.assertIn("github.event.pull_request.number", str(conc.get("group", "")))
+        self.assertTrue(conc.get("cancel-in-progress"),
+                        "js.yml must cancel superseded PR runs")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -47,9 +47,11 @@ def _load_module():
 g = _load_module()
 
 
-def R(name, status="completed", conclusion="success", url=""):
+def R(name, status="completed", conclusion="success", url="", started="", rid=0):
+    # started/rid feed the draft-tier superseded-run ordering (started_at, id);
+    # pre-draft-tier tests omit them and keep their exact semantics.
     return {"name": name, "status": status, "conclusion": conclusion,
-            "details_url": url, "html_url": ""}
+            "details_url": url, "html_url": "", "started_at": started, "id": rid}
 
 
 GREEN = R("build + test")
@@ -88,9 +90,10 @@ def scripted(polls, repeat_last=True):
     return fetch
 
 
-def run(cfg, polls, depth=0):
+def run(cfg, polls, depth=0, tier_ctx=None):
     """Drive run_gate with scripted polls + a constant queue depth (None = the
-    depth API is unavailable). Returns (exit_code, captured_output)."""
+    depth API is unavailable). Returns (exit_code, captured_output). tier_ctx
+    (default None) exercises the draft-tier integrity semantics."""
     out = io.StringIO()
     fetch = scripted(polls)
 
@@ -98,7 +101,8 @@ def run(cfg, polls, depth=0):
         return depth
 
     with redirect_stdout(out):
-        code = g.run_gate(cfg, fetch, depth_fn, sleep_fn=lambda s: None)
+        code = g.run_gate(cfg, fetch, depth_fn, sleep_fn=lambda s: None,
+                          tier_ctx=tier_ctx)
     return code, out.getvalue()
 
 
@@ -461,6 +465,187 @@ class TestSubprocessRobustness(unittest.TestCase):
             code = g.run_gate(tiny_cfg(), fetch, raising_depth, sleep_fn=lambda s: None)
         self.assertEqual(code, 0)
         self.assertIn("PASSED", out.getvalue())
+
+
+SELECT_FULL = "select / select (change-based test selection)"
+SELECT_DRAFT = "select / select (change-based test selection, draft-tier)"
+
+
+def draft_ctx(fetch_pr_draft, run_tier="draft", event="pull_request", retries=3):
+    return g.TierContext(run_tier=run_tier, event_name=event,
+                         fetch_pr_draft=fetch_pr_draft, draft_check_retries=retries)
+
+
+def counting(value):
+    """fetch_pr_draft stub returning `value` (an Exception instance raises)."""
+    state = {"calls": 0}
+
+    def fetch():
+        state["calls"] += 1
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    fetch.state = state
+    return fetch
+
+
+class TestDraftTierIntegrity(unittest.TestCase):
+    """[FABLE-5] Draft-tier CI: the invariant that a draft-tier gate result can
+    NEVER admit a PR to the merge queue — conclusion-time draft re-check,
+    stale-draft-tier leg-set belt, and superseded-cancellation forgiveness."""
+
+    # ---- conclusion-time draft re-check ------------------------------------
+    def test_draft_tier_success_requires_still_draft(self):
+        fetch = counting(True)
+        code, out = run(tiny_cfg(), [[R(SELECT_DRAFT), GREEN]],
+                        tier_ctx=draft_ctx(fetch))
+        self.assertEqual(code, 0)
+        self.assertIn("DRAFT-TIER verdict", out)
+        self.assertEqual(fetch.state["calls"], 1)
+
+    def test_draft_tier_stale_on_ready_pr_fails(self):
+        """The core invariant: an all-green draft-tier run whose PR was un-drafted
+        before conclusion must RED with the supersession message."""
+        code, out = run(tiny_cfg(), [[R(SELECT_DRAFT), GREEN]],
+                        tier_ctx=draft_ctx(counting(False)))
+        self.assertEqual(code, 1)
+        self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_draft_tier_unverifiable_state_fails_closed_bounded(self):
+        fetch = counting(g.FetchError("api down"))
+        code, out = run(tiny_cfg(), [[GREEN]], tier_ctx=draft_ctx(fetch, retries=3))
+        self.assertEqual(code, 1)
+        self.assertIn("could not confirm", out)
+        self.assertEqual(fetch.state["calls"], 3, "retries must be bounded")
+
+    def test_draft_tier_no_fetcher_fails_closed(self):
+        code, out = run(tiny_cfg(), [[GREEN]], tier_ctx=draft_ctx(None))
+        self.assertEqual(code, 1)
+
+    def test_draft_tier_red_legs_skip_the_api_check(self):
+        """A failing verdict REDs regardless; the draft re-check (an API call)
+        must not even run — a RED can never be latched by the queue."""
+        fetch = counting(True)
+        code, out = run(tiny_cfg(), [[R(SELECT_DRAFT), RED]],
+                        tier_ctx=draft_ctx(fetch))
+        self.assertEqual(code, 1)
+        self.assertEqual(fetch.state["calls"], 0)
+
+    def test_draft_tier_empty_set_still_rechecks(self):
+        """The stable-empty pass path must apply the same conclusion-time
+        re-check — no bypass via an empty sibling set."""
+        code, out = run(tiny_cfg(), [[]], tier_ctx=draft_ctx(counting(False)))
+        self.assertEqual(code, 1)
+        self.assertIn("stale draft-tier run", out)
+
+    def test_full_tier_run_never_calls_the_draft_api(self):
+        fetch = counting(True)
+        code, _ = run(tiny_cfg(), [[GREEN]],
+                      tier_ctx=draft_ctx(fetch, run_tier="full"))
+        self.assertEqual(code, 0)
+        self.assertEqual(fetch.state["calls"], 0)
+
+    # ---- stale draft-tier leg-set belt (full-tier pull_request runs) --------
+    def test_full_tier_holds_then_reds_on_unsuperseded_draft_select(self):
+        """A full-tier pull_request gate over a draft-tier-assembled leg set must
+        WAIT (the ready_for_review re-run is expected), and at budget exhaustion
+        must RED — never conclude success over draft-tier legs."""
+        polls = [[R(SELECT_DRAFT, started="2026-07-17T10:00:00Z", rid=1), GREEN]]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertIn("awaiting the full-tier re-run", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_full_tier_passes_once_full_select_supersedes(self):
+        draft_sel = R(SELECT_DRAFT, started="2026-07-17T10:00:00Z", rid=1)
+        full_sel = R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=2)
+        polls = [
+            [draft_sel, GREEN],                       # full re-run not registered yet
+            [draft_sel, full_sel, GREEN],             # it lands; set goes stable
+            [draft_sel, full_sel, GREEN],
+            [draft_sel, full_sel, GREEN],
+        ]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out)
+
+    def test_full_tier_non_pr_event_ignores_draft_selects(self):
+        """merge_group/push gates never see the belt (fresh ref; no PR payload)."""
+        ctx = g.TierContext(run_tier="full", event_name="merge_group")
+        code, _ = run(tiny_cfg(), [[R(SELECT_DRAFT), GREEN]], tier_ctx=ctx)
+        self.assertEqual(code, 0)
+
+    # ---- superseded-cancellation forgiveness --------------------------------
+    def test_superseded_cancelled_forgiven(self):
+        """A cancelled leg with a LATER same-named non-cancelled run (the
+        ready_for_review concurrency-cancel artifact) must not RED the gate —
+        tier-independent (matches branch protection's latest-run semantics)."""
+        old = R("build + test", conclusion="cancelled",
+                started="2026-07-17T10:00:00Z", rid=1)
+        new = R("build + test", started="2026-07-17T10:05:00Z", rid=2)
+        code, out = run(tiny_cfg(), [[old, new, GREEN2]])
+        self.assertEqual(code, 0)
+        self.assertIn("superseded-cancelled forgiven", out)
+
+    def test_cancelled_without_successor_still_fails(self):
+        code, _ = run(tiny_cfg(), [[R("build + test", conclusion="cancelled",
+                                      started="2026-07-17T10:00:00Z", rid=1)]])
+        self.assertEqual(code, 1)
+
+    def test_genuine_failure_never_forgiven(self):
+        """Only cancelled/stale are supersedable — a real FAILURE gates even with
+        a later same-named success (no retry-away of a red)."""
+        old = R("build + test", conclusion="failure",
+                started="2026-07-17T10:00:00Z", rid=1)
+        new = R("build + test", started="2026-07-17T10:05:00Z", rid=2)
+        code, _ = run(tiny_cfg(), [[old, new]])
+        self.assertEqual(code, 1)
+
+    def test_cancelled_draft_select_forgiven_by_full_successor(self):
+        """The draft-marked select cancelled mid-flight at un-draft has no later
+        run under its OWN name — the tier-NORMALIZED name lets the full-tier
+        select supersede it, so the select-health rule doesn't false-RED."""
+        old = R(SELECT_DRAFT, conclusion="cancelled",
+                started="2026-07-17T10:00:00Z", rid=1)
+        new = R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=2)
+        code, out = run(tiny_cfg(), [[old, new, GREEN]],
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 0)
+
+    def test_cancelled_gate_predecessor_superseded_by_self(self):
+        """The old draft-tier gate run cancelled by the ready_for_review
+        concurrency group leaves a cancelled `gate` check-run on the SHA; THIS
+        run's own (self-excluded) `gate` check-run must count as its superseder."""
+        old_gate = R("gate", conclusion="cancelled",
+                     started="2026-07-17T10:00:00Z", rid=1,
+                     url="https://github.com/o/r/actions/runs/111/job/5")
+        self_gate = R("gate", status="in_progress", conclusion=None,
+                      started="2026-07-17T10:05:00Z", rid=2,
+                      url="https://github.com/o/r/actions/runs/999/job/9")
+        code, out = run(tiny_cfg(), [[old_gate, self_gate, GREEN]])
+        self.assertEqual(code, 0, out)
+
+    # ---- pure helpers -------------------------------------------------------
+    def test_marker_helpers(self):
+        self.assertTrue(g.is_draft_tier(SELECT_DRAFT))
+        self.assertFalse(g.is_draft_tier(SELECT_FULL))
+        self.assertEqual(g.normalized_name(SELECT_DRAFT), SELECT_FULL)
+        self.assertTrue(g.is_select(SELECT_DRAFT),
+                        "the draft-marked select must still satisfy SELECT_RE")
+        self.assertFalse(g.is_advisory(SELECT_DRAFT))
+
+    def test_draft_selects_unsuperseded_requires_strictly_later_full(self):
+        draft_sel = R(SELECT_DRAFT, started="2026-07-17T10:05:00Z", rid=2)
+        earlier_full = R(SELECT_FULL, started="2026-07-17T10:00:00Z", rid=1)
+        self.assertEqual(g.draft_selects_unsuperseded([draft_sel, earlier_full]),
+                         [SELECT_DRAFT],
+                         "an EARLIER full select cannot supersede a draft one")
+        later_full = R(SELECT_FULL, started="2026-07-17T10:06:00Z", rid=3)
+        self.assertEqual(
+            g.draft_selects_unsuperseded([draft_sel, earlier_full, later_full]), [])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -572,6 +572,48 @@ class TestDraftTierIntegrity(unittest.TestCase):
         self.assertEqual(code, 0)
         self.assertIn("PASSED", out)
 
+    def test_full_tier_requires_a_successor_per_draft_select_instance(self):
+        """Cross-workflow collision: ci.yml, bench.yml, feature-matrix.yml and
+        fuzz.yml all expose the IDENTICAL select check-run name, so a draft head
+        carries FOUR draft-marked select instances. The hold must release only
+        when EVERY instance has its own later full-tier successor — the first
+        workflow's full-tier select must never release the other three."""
+        drafts = [R(SELECT_DRAFT, started=f"2026-07-17T10:00:0{i}Z", rid=i)
+                  for i in range(1, 5)]
+        fulls = [R(SELECT_FULL, started=f"2026-07-17T10:05:0{i}Z", rid=10 + i)
+                 for i in range(1, 5)]
+        polls = [
+            drafts + [GREEN],              # no full re-run registered yet: hold
+            drafts + fulls[:1] + [GREEN],  # 1 of 4 registered: STILL hold
+            drafts + fulls[:3] + [GREEN],  # 3 of 4 registered: STILL hold
+            drafts + fulls + [GREEN],      # all four registered: settle + pass
+            drafts + fulls + [GREEN],
+            drafts + fulls + [GREEN],
+        ]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        # The per-instance hold must have been observable while 1..3 full-tier
+        # selects were registered (the collision would have released at 1).
+        self.assertIn("awaiting the full-tier re-run", out)
+
+    def test_first_full_select_must_not_release_all_draft_instances(self):
+        """REGRESSION (critic finding 2): with four draft-marked selects and only
+        ONE later full-tier select ever registering, the gate must hold and then
+        RED at budget exhaustion — never conclude success over the three
+        workflows whose full-tier runs never registered any check-runs."""
+        drafts = [R(SELECT_DRAFT, started=f"2026-07-17T10:00:0{i}Z", rid=i)
+                  for i in range(1, 5)]
+        one_full = R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=99)
+        polls = [drafts + [one_full, GREEN]]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertIn("awaiting the full-tier re-run", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+        self.assertIn("3 draft-marked select instance(s)", out)
+
     def test_full_tier_non_pr_event_ignores_draft_selects(self):
         """merge_group/push gates never see the belt (fresh ref; no PR payload)."""
         ctx = g.TierContext(run_tier="full", event_name="merge_group")
@@ -646,6 +688,77 @@ class TestDraftTierIntegrity(unittest.TestCase):
         later_full = R(SELECT_FULL, started="2026-07-17T10:06:00Z", rid=3)
         self.assertEqual(
             g.draft_selects_unsuperseded([draft_sel, earlier_full, later_full]), [])
+
+    def test_draft_selects_unsuperseded_is_per_instance(self):
+        """One full-tier successor covers exactly ONE draft-marked instance —
+        same-named instances (the four selecting workflows) each need their own,
+        and duplicates are preserved so the caller can report counts."""
+        d1 = R(SELECT_DRAFT, started="2026-07-17T10:00:00Z", rid=1)
+        d2 = R(SELECT_DRAFT, started="2026-07-17T10:00:01Z", rid=2)
+        d3 = R(SELECT_DRAFT, started="2026-07-17T10:00:02Z", rid=3)
+        f1 = R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=11)
+        f2 = R(SELECT_FULL, started="2026-07-17T10:05:01Z", rid=12)
+        f3 = R(SELECT_FULL, started="2026-07-17T10:05:02Z", rid=13)
+        # 3 marked, 1 full => 2 instances remain unsuperseded (duplicates kept).
+        self.assertEqual(g.draft_selects_unsuperseded([d1, d2, d3, f1]),
+                         [SELECT_DRAFT, SELECT_DRAFT])
+        # 3 marked, 3 later fulls => all matched.
+        self.assertEqual(g.draft_selects_unsuperseded([d1, d2, d3, f1, f2, f3]), [])
+        # An EARLIER full can never be a successor, even when otherwise unused.
+        f_early = R(SELECT_FULL, started="2026-07-17T09:59:00Z", rid=10)
+        self.assertEqual(g.draft_selects_unsuperseded([d1, d2, f_early, f1]),
+                         [SELECT_DRAFT])
+        # Interleaved rounds pair in start order: a full between two marked
+        # instances supersedes the earlier one only.
+        d_late = R(SELECT_DRAFT, started="2026-07-17T10:06:00Z", rid=4)
+        self.assertEqual(g.draft_selects_unsuperseded([d1, f1, d_late]),
+                         [SELECT_DRAFT])
+        # started_at ties break on the check-run id (strictly-later still holds).
+        d_tie = R(SELECT_DRAFT, started="2026-07-17T10:05:00Z", rid=20)
+        f_tie = R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=21)
+        self.assertEqual(g.draft_selects_unsuperseded([d_tie, f_tie]), [])
+        self.assertEqual(
+            g.draft_selects_unsuperseded(
+                [d_tie, R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=19)]),
+            [SELECT_DRAFT])
+
+    # ---- draft-tier gate artifacts (the structural name tiering) -------------
+    def test_gate_name_constants(self):
+        """The gate's own tiered check-run name (ci-summary.yml renders
+        `gate, draft-tier` on draft payloads) — pinned against the helpers."""
+        self.assertEqual(g.GATE_CHECK_NAME, "gate")
+        self.assertEqual(g.DRAFT_TIER_GATE_NAME, "gate, draft-tier")
+        self.assertTrue(g.is_draft_gate_artifact("gate, draft-tier"))
+        self.assertFalse(g.is_draft_gate_artifact("gate"),
+                         "the full-tier gate name is NOT an artifact (a future "
+                         "sibling job literally named `gate` must keep gating)")
+        self.assertFalse(g.is_draft_gate_artifact("some gate, draft-tier"))
+        self.assertEqual(g.normalized_name(g.DRAFT_TIER_GATE_NAME), "gate")
+        self.assertTrue(g.is_draft_tier(g.DRAFT_TIER_GATE_NAME))
+        self.assertFalse(g.is_advisory(g.DRAFT_TIER_GATE_NAME))
+        self.assertFalse(g.is_select(g.DRAFT_TIER_GATE_NAME))
+
+    def test_stale_draft_gate_failure_is_excluded_not_a_leg(self):
+        """A COMPLETED draft-tier gate verdict left on the SHA is a tier
+        artifact: its FAILURE must not permanently RED the full-tier gate on
+        the same head (the live run re-derives the verdict over the real
+        legs). Non-vacuous: without the exclusion this red would gate."""
+        art = R(g.DRAFT_TIER_GATE_NAME, conclusion="failure",
+                started="2026-07-17T10:00:00Z", rid=1,
+                url="https://github.com/o/r/actions/runs/111/job/5")
+        code, out = run(tiny_cfg(), [[art, GREEN, GREEN2]])
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+
+    def test_cancelled_draft_gate_artifact_needs_no_successor(self):
+        """A cancelled `gate, draft-tier` (concurrency-cancel at un-draft) is
+        excluded as an artifact even before any successor registers — it must
+        not RED the fresh full-tier gate while the sibling set settles."""
+        art = R(g.DRAFT_TIER_GATE_NAME, conclusion="cancelled",
+                started="2026-07-17T10:00:00Z", rid=1,
+                url="https://github.com/o/r/actions/runs/111/job/5")
+        code, out = run(tiny_cfg(), [[art, GREEN]])
+        self.assertEqual(code, 0, out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous worker acting for @jeswr.

## Design (5 lines)

1. **Draft `pull_request` heads run a reduced set**: the change-scoped crate legs (the existing `ci-select` affected-closure intersection, unchanged), the cheap global gates (clippy/fmt, MSRV, docs-quality/typos/privacy, supply-chain, conformance for affected crates), and the ci-summary aggregator over exactly that reduced discovered set.
2. **Skipped on drafts**: coverage (measure + engine split + aggregate), benchmarks incl. the per-PR comparison/alert comments, CodeQL analysis (verified NOT schedule-only — it keeps merge_group + push-main + weekly + the ready_for_review run), the heavy recall shards (same step-guard mechanism as their merge_group demotion), and `artifact-exact-equality` unless `sparq-wasm` is in the affected closure (in-step `ci_select.py` verdict, fail-closed on every edge incl. the `ci-full` label).
3. **The invariant is STRUCTURAL — a draft-tier run never emits the required context at all**: the ci-summary gate job's own check-run name is tiered (`gate, draft-tier` on a draft payload; exactly `gate` — the sole ruleset-required context — on every other event/state). A draft-built head therefore carries **no `gate` check-run**, and branch protection blocks on the missing required check from the un-draft moment until the ready_for_review FULL-tier run's fresh `gate` concludes: there is no supersession window (event latency / dropped event / Actions outage all leave the context absent, blocked). Every gate-feeding workflow's `pull_request` trigger includes `ready_for_review`; merge_group untouched, always full-tier.
4. **Defense-in-depth belts in `scripts/ci_summary_gate.py`** (hermetic unit tests): stale `gate, draft-tier` check-runs are excluded from every sibling set as tier artifacts; a full-tier PR gate holds then REDs (**"stale draft-tier run, full run pending"**) while any draft-marked ci-select **instance** lacks its own, distinct, strictly-later full-tier successor (per-instance because ci/bench/feature-matrix/fuzz expose the IDENTICAL select name — one workflow's full-tier select never releases the hold for the other three); a draft-tier gate re-reads the PR's CURRENT draft state via the API before any SUCCESS and fail-closes to RED; superseded `cancelled`/`stale` check-runs are forgiven only when a later same-normalized-name run exists (genuine failures never are). The ruleset's separate `code_scanning` rule is documented + wiring-tested as defense-in-depth **only** (out-of-repo, owner-mutable, evadable — never load-bearing).
5. **Pool hygiene**: per-PR `cancel-in-progress` concurrency added where missing (`bench.yml` PR runs only — push/schedule never cancel, protecting the benchmark history; `js.yml`); merge_group runs are never cancelled. Design record: `docs/branch-protection.md` §Draft-tier CI.

## Critic-round fixes (blocking defects, resolved)

- **[GATE INTEGRITY] Supersession-window admission**: previously a concluded draft-tier `gate` SUCCESS remained the LATEST run of the required context between `gh pr ready` and the ready_for_review run registering its check-run — `gh pr ready && gh pr merge --auto` could enqueue on a draft-built head whose merge_group run deliberately omits bench's deterministic ratchet + the heavy recall shards (sq-6vshe.6). **Fixed structurally by tiering the gate's own check-run name** (design line 3): drafts can no longer satisfy `{context:"gate"}` in any window. The factually-incorrect worst-race paragraph in `docs/branch-protection.md` is corrected, and the `code_scanning` dependency is recorded + wiring-tested as non-load-bearing.
- **Cross-workflow select-name collision**: the stale-draft-tier belt matched successors by tier-normalized name only, so the FIRST workflow's full-tier select superseded ALL FOUR draft-marked selects (releasing the hold while ci.yml/bench.yml full-tier runs might have registered nothing). `draft_selects_unsuperseded` now requires a successor **per draft-select instance** (greedy start-order matching, counts reported); the wrong single-pair test is replaced by a 4-instance regression test incl. the 1-of-4 must-RED case.

## Measured congestion (2026-07-17, the motivating problem)

The autonomous fleet keeps **12–17 draft worker PRs** cycling review-fix rounds; every push triggered the FULL matrix (**~100–200 checks**: 22+ opt-in crate legs, wasm build matrix, benchmarks, coverage, CodeQL, heavy shards). Observed **52 concurrent runs + 8 queued** saturating the org runner pool: heads sat yellow **30+ min**, gates timed out as false failures, the merge queue starved, and the load-aware heavy shards deferred indefinitely.

## Self-tests

- `scripts/tests/test_ci_summary_gate.py`: **56/56** (new this round: per-instance supersession incl. the 1-of-4 collision regression + tie-break ordering, draft-gate-artifact exclusion incl. the non-vacuous draft-gate-FAILURE and cancelled-without-successor cases; previous round: draft re-check incl. bounded fail-closed retries + empty-set path, hold-then-RED, cancellation forgiveness, failure-never-forgiven).
- `scripts/tests/test_ci_select_wiring.py`: **50/50** (new this round: gate job name pinned as `gate` + marker expression with both renderings checked against the gate module's constants, code_scanning backstop triggers + doc wording; previous round: marker contract vs `SELECT_RE`/advisory rule, fail-open draft-guard shapes, `ready_for_review` on all 20 gate-feeding workflows, gate tier-env + `pull-requests: read` plumbing, bench/js concurrency shape).
- `test_ci_select.py`, `test_feature_matrix_assemble.py`, `test_feature_matrix_tiers.py`, `test_vectorized_feature_off.py`, `test_gates.py`, `test_ci_selection_alarm.py`: all green.
- actionlint over all touched workflows: finding set identical to origin/main modulo pre-existing ci.yml line shifts (zero new findings); all workflows PyYAML-parse; typos + markdownlint + no-perf-numbers clean on the doc.

Notes: advisory-only workflows (pr-title, deploy-lint, deploy-terraform-lint) deliberately did NOT get `ready_for_review` — the gate excludes their checks by name, and their verdicts are tier-independent. On a **draft** head the aggregator's verdict now appears under the check name `ci-summary / gate, draft-tier` (the required `gate` context is absent by design — a draft PR cannot merge regardless); tooling that polls the required context on drafts should read the tier verdict instead. This PR itself touches `.github/**`, a §4.1 full-run trigger, so its own CI runs the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
