### PR TITLE
fix(ci): label-trigger guard — review-pipeline label flips no longer restart CI or poison the gate

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,6 +41,14 @@ on:
   # EC2 lane (bench-ec2.yml `nightly-full-bench`, cron), which publishes the full at-scale
   # series to the benchmark-data branch the Pages dashboard reads. See the "Run benchmarks"
   # step guard below and bench-ec2.yml.
+  #
+  # [FABLE-5] LABEL-TRIGGER GUARD (full rationale: ci.yml's pull_request note): only
+  # the `ci-full` / `bench-full` toggles start real work off a label event. The
+  # review pipeline's review:*/status:* flips otherwise re-queued this workflow on an
+  # unchanged head SHA on every flip. The guard is AND-composed into the
+  # `dashboard-labels` and `bench` job `if:`s (the `select` pre-job must stay
+  # unconditional — the ci-summary gate REDs on any non-success selection
+  # check-run), and label events get a per-run concurrency group below.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # [FABLE-5] (sq-6vshe.6, MAINTAINER-DIRECTED) merge_group REMOVED. The deterministic
@@ -81,8 +89,12 @@ permissions:
   contents: read
 
 # Do NOT cancel an in-progress benchmark run (it would corrupt the stored series).
+# [FABLE-5] label-trigger guard: labeled/unlabeled pull_request events get a PER-RUN
+# group. Even with cancel-in-progress:false, a group holds at most ONE PENDING run —
+# a label-flip run queued into the shared group would replace (cancel) a pending real
+# run on the same head SHA. Isolated, a guarded flip is a cheap select-only no-op.
 concurrency:
-  group: bench-${{ github.ref }}
+  group: bench-${{ github.ref }}-${{ (github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action)) && github.run_id || 'shared' }}
   cancel-in-progress: false
 
 jobs:
@@ -111,6 +123,12 @@ jobs:
   # dashboard.js, and runs the node smoke test (scripts/dashboard-smoke.js).
   dashboard-labels:
     name: dashboard labels (lint + drift)
+    # [FABLE-5] label-trigger guard (see the bench job note below): a root job with
+    # no needs — guard it directly so a non-ci-full/bench-full label flip skips it.
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      contains(fromJSON('["ci-full","bench-full"]'), github.event.label.name)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -148,12 +166,24 @@ jobs:
     # floor + benchmark-data history (both depend on every main commit being benchmarked)
     # continuous — see the push-gated history/ratchet steps below.
     needs: select
+    # [FABLE-5] label-trigger guard (full rationale: ci.yml's pull_request note): the
+    # first AND-term skips this job on any labeled/unlabeled event whose label is not
+    # ci-full/bench-full — the review pipeline's label flips must not re-queue the
+    # bench suite on an unchanged head SHA (with cancel-in-progress:false a flip can
+    # still CANCEL a PENDING real run via the one-pending-slot-per-group rule).
+    # `bench-full` passes because its whole point is re-running this workflow with
+    # the well-known suites enabled (the toolchain-install step reads the label).
+    # `select` stays unguarded (required green by the gate). The second AND-term is
+    # the unchanged fail-closed selection guard.
     if: >-
-      needs.select.outputs.mode != 'selected' ||
-      contains(needs.select.outputs.affected, '"sparq-engine"') ||
-      contains(needs.select.outputs.affected, '"sparq-cli"') ||
-      contains(needs.select.outputs.affected, '"sparq-bench"') ||
-      contains(needs.select.outputs.affected, '"sparq-wasm"')
+      (github.event_name != 'pull_request' ||
+       !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+       contains(fromJSON('["ci-full","bench-full"]'), github.event.label.name)) &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-engine"') ||
+       contains(needs.select.outputs.affected, '"sparq-cli"') ||
+       contains(needs.select.outputs.affected, '"sparq-bench"') ||
+       contains(needs.select.outputs.affected, '"sparq-wasm"'))
     runs-on: ubuntu-latest
     # [OPUS-4.8] Job-scoped writes (least privilege; the rest of the workflow stays read-only):
     #   contents: write     — auto-ratchet commits bench/perf-baseline.json back to main and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,26 @@ on:
   # label re-evaluates the change-based selection (ci-select.yml maps the label to
   # `--full`). The default types (opened/synchronize/reopened) are listed explicitly
   # so adding the label events does NOT drop `synchronize` (the push-to-PR trigger).
+  # [FABLE-5] LABEL-TRIGGER GUARD: only the `ci-full` toggle may start real work off
+  # these label events. The autonomous review pipeline flips review:*/status:* labels
+  # several times per round on ~20 open PRs, and before this guard EVERY flip
+  # restarted this whole workflow on an unchanged head SHA (measured 2026-07-17: one
+  # PR head accumulated 4 generations / 12 concurrency-cancelled runs with zero
+  # pushes), and the cancelled `select` check-runs left on that SHA then REDdened the
+  # required ci-summary gate ("the selection pre-job must conclude success", e.g.
+  # PR #2530). The guard is a job-level `if:` on the root jobs (`changes`,
+  # `unsafe-register`, and the always()-composed `coverage` verdict job): a
+  # labeled/unlabeled pull_request event whose label is not `ci-full` skips them, and
+  # the whole needs:-graph skips with them — a cheap no-op run instead of a restart.
+  # The `select` pre-job is the DELIBERATE exception: it stays unconditional (no
+  # if/needs — pinned by scripts/tests/test_ci_select_wiring.py) and just runs to a
+  # cheap SUCCESS, because scripts/ci_summary_gate.py REDs outright on any
+  # "change-based test selection" check-run whose conclusion is not `success` — a
+  # SKIPPED select would poison the gate exactly like a cancelled one. Skipped
+  # non-select jobs are safe: the gate counts `skipped` as satisfied while the
+  # commit's select runs are all green. Label events also get a PER-RUN concurrency
+  # group (below), so a flip can never concurrency-cancel an in-flight run on the
+  # same head SHA — those same-SHA cancellations were the actual gate poison.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # [OPUS-4.8] Merge queue: re-run the identical PR check-set on the queue's
@@ -48,7 +68,15 @@ concurrency:
   # them. PR / push / merge_group runs keep the per-ref group + cancel-in-progress so a
   # superseded build still auto-cancels to save CI minutes (unchanged behaviour for them —
   # they resolve to the constant `-shared` suffix).
-  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.run_id || 'shared' }}
+  # [FABLE-5] label-trigger guard: labeled/unlabeled pull_request events ALSO get a
+  # per-run group. A label-flip run entering the shared per-ref group would cancel the
+  # in-flight real run on the SAME head SHA (cancellation happens at run level, before
+  # job `if:` guards evaluate), leaving cancelled check-runs that RED the ci-summary
+  # gate. Isolated, a non-`ci-full` flip is a guarded no-op run and a `ci-full` toggle
+  # runs the full matrix WITHOUT killing the superseded selected run mid-flight (both
+  # conclude green; the gate aggregates the union). Non-label PR/push/merge_group runs
+  # keep the shared group + cancel-in-progress exactly as before.
+  group: ci-${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action))) && github.run_id || 'shared' }}
   cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
 
 env:
@@ -106,6 +134,14 @@ jobs:
   # only because we hard-force 'true' off the PR path — i.e. we never silently skip Rust.
   changes:
     name: detect rust changes
+    # [FABLE-5] label-trigger guard (see the pull_request trigger note): a
+    # labeled/unlabeled event for any label other than `ci-full` must not restart the
+    # matrix on an unchanged head SHA — skipping this root job skips every
+    # needs:-dependent below it. All other events pass the first two disjuncts.
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci-full'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -178,7 +214,10 @@ jobs:
   # (never skip) via the filterset output. UNCONDITIONAL (no needs/if): the
   # ci-summary gate REQUIRES every selection check-run to conclude success before
   # any skipped sibling counts as satisfied, so this job must exist and be green
-  # on every run — including doc-only PRs where `changes` skips the Rust matrix.
+  # on every run — including doc-only PRs where `changes` skips the Rust matrix,
+  # AND the label-trigger-guard no-op runs (a guarded/skipped select would conclude
+  # `skipped` ≠ `success` and RED the gate on the whole head SHA; its cheap success
+  # IS the no-op — do NOT add the guard here).
   # Relationship to `changes` (dorny paths-filter) is layered, both directions
   # preserved: rust_changed==false skips a lane regardless of selection (the
   # existing doc-PR fast path), and selection can only skip WITHIN
@@ -2843,7 +2882,15 @@ jobs:
     # single verdict alongside the non-engine shard matrix, so the ci-summary `gate` still
     # sees ONE coverage check. A skipped engine job (doc-only PR) counts as satisfied.
     needs: [coverage-floors, coverage-measure, coverage-engine-run, coverage-engine-merge]
-    if: ${{ always() && github.event_name != 'schedule' }}
+    # [FABLE-5] label-trigger guard: always() bypasses the skipped-needs propagation,
+    # so this verdict job must carry the guard explicitly or it would still run (as a
+    # trivially-green no-op) on every non-`ci-full` label flip. Skipped is equally
+    # satisfied by the gate (the commit's select runs stay green) and saves the slot.
+    if: >-
+      always() && github.event_name != 'schedule' &&
+      (github.event_name != 'pull_request' ||
+       !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+       github.event.label.name == 'ci-full')
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate coverage floor + shard results
@@ -3245,6 +3292,12 @@ jobs:
     # is too heavy/flaky for a gating lane (hence its `|| true`); the deterministic
     # scan is what we actually ratchet. Python-only ⇒ seconds, no toolchain.
     name: unsafe-register (count ratchet)
+    # [FABLE-5] label-trigger guard (see the pull_request trigger note): a root job
+    # with no needs — guard it directly so a non-`ci-full` label flip skips it too.
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci-full'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -90,6 +90,15 @@ on:
   # label re-evaluates change-based selection for the opt-in leg set as well (the
   # `setup` assembler filters legs by the selection outputs). Default types are
   # listed explicitly so adding the label events does not drop `synchronize`.
+  # [FABLE-5] LABEL-TRIGGER GUARD (full rationale: ci.yml's pull_request note): only
+  # the `ci-full` toggle starts real work off a label event — the review pipeline's
+  # review:*/status:* flips otherwise restarted this workflow on an unchanged head
+  # SHA, and the concurrency-cancelled `select` check-runs REDdened the ci-summary
+  # gate. The guard is the job-level `if:` on the root `changes` job (everything else
+  # needs:-chains from it); the `select` pre-job stays UNCONDITIONAL and runs to a
+  # cheap success (a skipped select would poison the gate — ci_summary_gate.py
+  # requires every selection check-run to conclude `success`). Label events also get
+  # a per-run concurrency group below so a flip never cancels an in-flight run.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # Merge queue: mirror the PR check-set onto the merge_group ref so the required
@@ -100,7 +109,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: feature-matrix-${{ github.workflow }}-${{ github.ref }}
+  # [FABLE-5] label-trigger guard: labeled/unlabeled pull_request events get a
+  # PER-RUN group — a label-flip run entering the shared per-ref group would cancel
+  # the in-flight real run on the SAME head SHA (run-level cancellation precedes job
+  # `if:` evaluation), leaving cancelled check-runs that RED the ci-summary gate.
+  # All other events keep the shared per-ref group + cancel-in-progress as before.
+  group: feature-matrix-${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action)) && github.run_id || 'shared' }}
   cancel-in-progress: true
 
 env:
@@ -123,6 +137,15 @@ jobs:
   # runs ALWAYS compile the full feature matrix — only a purely non-Rust PR diff skips.
   changes:
     name: detect rust changes (feature-matrix)
+    # [FABLE-5] label-trigger guard (see the pull_request trigger note): a
+    # labeled/unlabeled event for any label other than `ci-full` skips this root job,
+    # and with it every needs:-dependent (setup/opt-in legs/check-tier/no-default-
+    # features lanes/fedclient-boundary). The `select` pre-job deliberately stays
+    # unguarded (its success is required by the gate on every trigger).
+    if: >-
+      github.event_name != 'pull_request' ||
+      !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'ci-full'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,6 +63,18 @@ on:
   # maps the label to `--full`, which forces the fuzz smoke to run). The default
   # types (opened/synchronize/reopened) are listed explicitly so adding the label
   # events does NOT drop `synchronize` (the push-to-PR trigger).
+  # [FABLE-5] LABEL-TRIGGER GUARD (full rationale: ci.yml's pull_request note): only
+  # the `ci-full` and `fuzz-full` toggles start real work off a label event — the
+  # review pipeline's review:*/status:* flips otherwise restarted this workflow on an
+  # unchanged head SHA and the cancelled `select` check-runs REDdened the ci-summary
+  # gate. `select` is this workflow's ONLY root, and it must stay UNCONDITIONAL (a
+  # skipped select poisons the gate — ci_summary_gate.py requires every selection
+  # check-run to conclude `success`), so the guard is AND-composed into the `fuzz` +
+  # `differential-smoke` job `if:`s instead: on a non-ci-full/fuzz-full flip the run
+  # is select-only (cheap success + two satisfied skips). `fuzz-full` must pass the
+  # guard because its whole point is re-running this workflow with the randomized
+  # budget (the budget step reads the label). Label events also get a per-run
+  # concurrency group below so a flip never cancels an in-flight run.
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   # [OPUS-4.8] Merge queue: fuzz surfaces a check on PRs, so it must also run on the
@@ -81,7 +93,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: fuzz-${{ github.workflow }}-${{ github.ref }}
+  # [FABLE-5] label-trigger guard: labeled/unlabeled pull_request events get a
+  # PER-RUN group — a label-flip run entering the shared per-ref group would cancel
+  # the in-flight real run on the SAME head SHA (run-level cancellation precedes job
+  # `if:` evaluation), leaving cancelled check-runs that RED the ci-summary gate.
+  # All other events keep the shared per-ref group + cancel-in-progress as before.
+  group: fuzz-${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action)) && github.run_id || 'shared' }}
   cancel-in-progress: true
 
 env:
@@ -133,11 +150,18 @@ jobs:
     # the lane; a skipped job reports conclusion `skipped` (= satisfied) to the
     # ci-summary gate — no per-leg name is individually required (bead sq-fmx4u.4).
     needs: select
+    # [FABLE-5] label-trigger guard: the first AND-term skips this job on any
+    # labeled/unlabeled event whose label is not ci-full/fuzz-full (select, the only
+    # root here, must keep running — see the pull_request trigger note). The second
+    # AND-term is the unchanged fail-closed selection guard.
     if: >-
-      needs.select.outputs.mode != 'selected' ||
-      contains(needs.select.outputs.affected, '"sparq-core"') ||
-      contains(needs.select.outputs.affected, '"sparq-engine"') ||
-      contains(needs.select.outputs.affected, '"sparq-shacl"')
+      (github.event_name != 'pull_request' ||
+       !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+       contains(fromJSON('["ci-full","fuzz-full"]'), github.event.label.name)) &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-core"') ||
+       contains(needs.select.outputs.affected, '"sparq-engine"') ||
+       contains(needs.select.outputs.affected, '"sparq-shacl"'))
     runs-on: ubuntu-latest
     # [FABLE-5] sq-6vshe.6: the demotion auto-bead step (randomized-run finding on
     # push/nightly) files a GitHub issue + appends a P1 bead. Least-privilege, scoped
@@ -404,11 +428,17 @@ jobs:
   differential-smoke:
     name: differential smoke (sparq vs Oxigraph, fixed regression windows)
     needs: select
+    # [FABLE-5] label-trigger guard: same first AND-term as the fuzz job above (skip
+    # on non-ci-full/fuzz-full label flips; select alone runs); second AND-term is
+    # the unchanged fail-closed selection guard.
     if: >-
-      needs.select.outputs.mode != 'selected' ||
-      contains(needs.select.outputs.affected, '"sparq-core"') ||
-      contains(needs.select.outputs.affected, '"sparq-engine"') ||
-      contains(needs.select.outputs.affected, '"sparq-bench"')
+      (github.event_name != 'pull_request' ||
+       !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+       contains(fromJSON('["ci-full","fuzz-full"]'), github.event.label.name)) &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-core"') ||
+       contains(needs.select.outputs.affected, '"sparq-engine"') ||
+       contains(needs.select.outputs.affected, '"sparq-bench"'))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous change; verified locally, PR left **unarmed** for the verify pipeline.

## Problem (measured live 2026-07-17)

`ci.yml`, `feature-matrix.yml`, `fuzz.yml` (and `bench.yml` — same trigger set, see scope note) react to `pull_request` types `[opened, synchronize, reopened, labeled, unlabeled]`. The label types were added (sq-fmx4u.5) so toggling **`ci-full`** re-evaluates change-based selection — but the autonomous review pipeline flips `review:*`/`status:*` labels several times per round on ~20 open PRs, and **every flip restarted all these workflows on an unchanged head SHA**, concurrency-cancelling in-flight runs:

- one PR head accumulated **4 generations / 12 cancelled runs with zero pushes** (duplicate CI load);
- cancelled `select` check-runs left on the same SHA **poison the ci-summary gate**, which REDs with *"the selection pre-job must conclude success"* even when every real leg is green (live example: **#2530**).

## Gate-skipped-semantics finding (drove the implementation choice)

Reading `scripts/ci_summary_gate.py::render_verdict`: a `skipped` conclusion is satisfied **iff every "change-based test selection" check-run on the commit concluded `success`**; anything else on a select run (failure, **cancelled**, **skipped**, neutral, stale) REDs the gate outright. So:

- **ordinary skipped root jobs do NOT poison the gate** → the plain job-level `if:` skip is safe for them (also: the ruleset requires exactly one check, `ci-summary / gate`, so no skipped leg can hang the queue — sq-fmx4u.4);
- **the reusable `select` caller must NOT be guarded** — a skipped select is exactly as poisonous as a cancelled one, and `test_ci_select_wiring.py` pins the select callers `if:`/`needs:`-free. Its cheap **success is the succeed-as-no-op leg**; no echo-step no-op job was needed anywhere.

## What landed where

Guard condition, AND-composed with any existing `if:` (allowlist per workflow):

```
github.event_name != 'pull_request' ||
!contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
<label allowlist>
```

| Workflow | Guarded jobs | Label allowlist |
|---|---|---|
| `ci.yml` | `changes`, `unsafe-register` (roots), `coverage` (its `always()` bypasses skipped-needs propagation, so it needs the guard explicitly) | `ci-full` |
| `feature-matrix.yml` | `changes` (sole guarded root — everything else `needs:`-chains from it) | `ci-full` |
| `fuzz.yml` | `fuzz`, `differential-smoke` (`select` is the only root and must keep running) | `ci-full`, `fuzz-full` |
| `bench.yml` | `dashboard-labels`, `bench` | `ci-full`, `bench-full` |

`fuzz-full`/`bench-full` pass their workflow's guard because those labels exist precisely to re-run it (the budget/toolchain steps read them).

**Concurrency**: labeled/unlabeled PR events additionally get a **per-run concurrency group** in all four workflows. Run-level cancellation precedes job-`if:` evaluation, so without this a guarded no-op run entering the shared per-ref group would still cancel the in-flight real run on the same head SHA (bench.yml: replace a *pending* one via the one-pending-slot rule despite `cancel-in-progress: false`) — those same-SHA cancellations are the actual gate poison. Non-label PR/push/merge_group runs keep their existing groups and cancel behaviour.

**Net effect**: a non-trigger-label flip now produces an isolated run consisting of `select` (success, ~1 min) + skipped roots (+ ci.yml's `coverage` skips) — the gate sees only `success`/`skipped` conclusions with all selects green → satisfied. A `ci-full` toggle still runs the full matrix, now without killing the superseded selected run mid-flight.

**Unchanged**: trigger types, all check-run names, merge_group behaviour, push/schedule/dispatch paths, selection fail-closed semantics.

## Scope note

`bench.yml` was added beyond the three workflows named in the task brief: `test_ci_select_wiring.py` pins it to the identical `[labeled, unlabeled]` trigger set and it has the same select-cancellation poison path (via pending-slot replacement), so leaving it out would have kept the failure class alive.

## Validation

- PyYAML parse OK on all four workflows
- `actionlint` finding set byte-identical to origin/main (pre-existing info-level shellcheck notes only; nothing new)
- `scripts/tests/test_ci_select_wiring.py` **38/38** (incl. the unconditional-select + fail-closed-disjunct + seed-needle pins)
- `scripts/tests/test_ci_summary_gate.py` **33/33**
- Live verifiable on this PR: toggling any scratch label on it should yield a cheap select-only run and a still-green gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)