### PR TITLE
feat(routing): UI/front-end work routes to codex (GPT-5.6) — original-builder ownership rule

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -47,7 +47,8 @@ credential_format = "claude-oauth-token"
 [models.terra]
 provider = "openai"
 harness = "codex"
-provider_model = "TBD"                 # terra is an internal alias; maintainer sets the concrete GPT id
+provider_model = "TBD"                 # terra = the codex CLI's DEFAULT model (GPT-5.6 codex); the TBD
+                                       # sentinel is load-bearing: dispatch/worker pass NO --model flag
 credential_format = "codex-auth-json"
 
 [defaults]
@@ -71,9 +72,16 @@ role = "impl"
 model_chain = ["fable", "sonnet", "terra"]
 agent = "sparq-rust-impl"
 
+# [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
+# `terra`) implemented the original registry dashboard UI (jeswr/agent-account-registry e4098b9)
+# and is responsible for ALL UI/front-end work, so the site chain LEADS with terra; the previous
+# chain follows as fallback. scripts/triage.py derives role:site for UI-surface labels
+# (area:site/area:gui/surface:frontend/dashboard) so surface-labelled work lands here too.
+# Deliberately a ROLE route, not match_labels: the review lane's arm-side security classifier
+# unions ALL match_labels keywords, so UI keywords there would human-arm every UI PR.
 [[route]]
 role = "site"
-model_chain = ["fable", "sonnet", "terra"]
+model_chain = ["terra", "fable", "sonnet"]
 agent = "sparq-site"
 
 [[route]]

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -55,6 +55,8 @@ def _self_test():
     chk("impl -> fable-led", (mc[0], ag, esc), ("fable", "sparq-rust-impl", False))
     # docs -> haiku-led
     chk("docs -> haiku", resolve(["role:docs", "area:x"], doc)[0][0], "haiku")
+    # [FABLE-5] UI ownership: site -> terra-led (GPT-5.6 codex, the original dashboard builder)
+    chk("site -> terra-led", resolve(["role:site", "area:site"], doc)[0], ["terra", "fable", "sonnet"])
     # no role -> defaults (fable-led)
     chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "fable")
     # review role -> opus + escalate

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -27,6 +27,12 @@ ROLE_BY_KIND = {"docs": "docs", "design": "research", "research": "research", "p
 ROLE_BY_TYPE = {"feature": "impl", "bug": "impl", "task": "impl", "chore": "ci",
                 "spike": "research", "epic": "impl"}
 SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
+# [FABLE-5] UI/front-end surfaces route role:site (maintainer decision 2026-07-17: GPT-5.6 codex,
+# the original registry-dashboard builder — agent-account-registry e4098b9 — owns ALL UI work; the
+# role:site chain in orchestration/routing.toml leads with terra/codex). EXACT labels, not
+# substrings: a substring set would false-match (e.g. "gui" in "guide") and UI keywords must NOT
+# enter routing match_labels, which the arm-side security classifier unions into its keyword set.
+UI_SURFACE_LABELS = ("area:site", "area:gui", "surface:frontend", "dashboard")
 _PRIO = re.compile(r"^priority:P([0-4])$")
 
 
@@ -47,6 +53,10 @@ def _role(labels, issue_type):
     for lb in labels:
         if lb.startswith("kind:") and lb[5:] in ROLE_BY_KIND:
             return ROLE_BY_KIND[lb[5:]]
+    # [FABLE-5] UI-surface labels derive role:site (codex-led chain) before the generic type map,
+    # after kind (so kind:docs about the site stays docs) and after an explicit role:* label.
+    if any(lb in UI_SURFACE_LABELS for lb in labels):
+        return "site"
     return ROLE_BY_TYPE.get(issue_type)
 
 
@@ -123,6 +133,12 @@ def _self_test():
     # single-role invariant: a double-labelled issue is stripped to one role
     r = triage(["priority:P2", "role:impl", "role:site", "area:site"], "feature")
     chk("single-role invariant", (len([x for x in (({"role:impl", "role:site"} | r["add"]) - r["remove"]) if x.startswith("role:")]) == 1), True)
+    # [FABLE-5] UI-surface ownership: a UI-surface label derives role:site (the codex/GPT-5.6-led
+    # chain) even when the issue type would derive impl; kind (docs) and security still win.
+    chk("ui surface -> site", triage(["priority:P2", "area:site"], "feature")["role"], "site")
+    chk("gui surface -> site", triage(["priority:P2", "area:gui"], "task")["role"], "site")
+    chk("site docs stay docs", triage(["priority:P3", "kind:docs", "area:site"], "task")["role"], "docs")
+    chk("ui+sec -> soundness", triage(["priority:P1", "area:site", "area:sparq-zk"], "feature")["role"], "soundness")
     # [FABLE-5] no-area guard: a complete priority+role issue with NO area:* is NOT promoted to ready
     # (it would reserve the serializing __global__ partition); it parks needs:area instead.
     r = triage(["priority:P1", "role:impl"], "feature")

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -137,6 +137,8 @@ def _self_test():
     # chain) even when the issue type would derive impl; kind (docs) and security still win.
     chk("ui surface -> site", triage(["priority:P2", "area:site"], "feature")["role"], "site")
     chk("gui surface -> site", triage(["priority:P2", "area:gui"], "task")["role"], "site")
+    chk("explicit impl on ui surface stays impl",
+        triage(["priority:P2", "role:impl", "area:site"], "feature")["role"], "impl")
     chk("site docs stay docs", triage(["priority:P3", "kind:docs", "area:site"], "task")["role"], "docs")
     chk("ui+sec -> soundness", triage(["priority:P1", "area:site", "area:sparq-zk"], "feature")["role"], "soundness")
     # [FABLE-5] no-area guard: a complete priority+role issue with NO area:* is NOT promoted to ready


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements the maintainer's **original-builder ownership rule** (2026-07-17): the agent that implemented the original registry dashboard UI — **GPT-5.6 codex** (provider: openai; commit `e4098b9` in jeswr/agent-account-registry, trailer `Co-Authored-By: GPT-5.6 sol`) — is responsible for **all UI/front-end work across repositories**. This PR builds that into sparq's routing so UI work dispatches to codex first.

## Changes
- **`orchestration/routing.toml`** — the `role = "site"` route's chain now leads with `terra` (the wired openai/codex alias; the live openai account acct01 declares `models: [terra]`), with the previous `[fable, sonnet]` chain as fallback: `["terra", "fable", "sonnet"]`. The `[models.terra]` comment now records that terra resolves to the codex CLI's **default** model (GPT-5.6 codex) and that the `TBD` provider_model sentinel is load-bearing (dispatch/worker pass no `--model` flag — the proven codex-drain contract), so no concrete id was pinned.
- **`scripts/triage.py`** — UI-surface labels (`area:site`, `area:gui`, `surface:frontend`, `dashboard`) now derive `role:site`, after security keywords / explicit `role:*` / `kind:*` (so `kind:docs` about the site stays docs, and a UI+zk issue still forces soundness), before the generic issue-type map — so a feature-typed dashboard/front-end issue reaches the codex-led chain, not `role:impl`.
- **Self-tests extended**: `route-resolve.py` asserts site → `[terra, fable, sonnet]`; `triage.py` asserts the four new derivation cases.

## Why a role route + triage derivation, NOT a `match_labels` rule
The registry's arm-side security classifier (`review-fix.yml`) unions **all** `[[route]].match_labels` keywords from the target routing into its security keyword set — a UI `match_labels` rule would have silently flagged every UI issue as a security surface and routed every UI PR to human arm. The role route + exact-label triage derivation implements the same routing intent with no arm-gate side effect.

## Verification
- `scripts/routing-validate.py` → OK
- `scripts/route-resolve.py --self-test` → PASSED (incl. new `site -> terra-led`)
- `scripts/triage.py --self-test` → PASSED (incl. `ui surface -> site`, `site docs stay docs`, `ui+sec -> soundness`)
- `scripts/dispatch-plan.py --self-test` → PASSED
- Live resolve: `role:site,area:site` → `model_chain=['terra', 'fable', 'sonnet'] agent=sparq-site escalate=False`
- Pre-existing (untouched): `scripts/retriage.py --self-test` fails with `KeyError: 9` on clean main too — filed separately.

Companion standing-rule change in jeswr/agent-account-registry (onboarding doc + its own routing.toml) follows in the registry repo.

Do not merge via agent self-arm; the review pipeline arms as usual.