### PR TITLE
fix(ci): forgive concurrency-cancel race-loser selects so a sound selection can't RED the gate

### DIFF
--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -224,37 +224,54 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
     over the RAW list (self-run included) so THIS gate run's own fresh `gate`
     check-run can supersede its cancelled predecessor.
 
-    [OPUS-4.8] sq-fmx4u.3 hardening (2026-07-17 fleet jam): for the change-based
-    SELECTION pre-job (is_select) the successor need only be a same-normalized-name
-    SUCCESS ANYWHERE on the SHA, not one that is STRICTLY LATER. Rationale: select
-    is a deterministic pure function of the SHA's diff, so a single same-name
-    success PROVES the selection was computed soundly — the per-instance timestamp
-    ordering of its concurrency-cancel race-loser siblings is irrelevant. Under the
-    draft-tier + review-pipeline label churn (#2537/#2546) a head SHA accretes many
-    cancel rounds whose doomed select instances can out-timestamp the winning run's
+    [OPUS-4.8] sq-fmx4u.3 hardening (2026-07-17 fleet jam): for the PURE
+    change-based SELECTION pre-job (is_pure_select) the successor need only be a
+    same-normalized-name, SAME-TIER SUCCESS ANYWHERE on the SHA, not one that is
+    STRICTLY LATER. Rationale: the pure select is a deterministic function of the
+    SHA's diff (given the tier), so a same-tier same-name success PROVES that
+    selection was computed soundly — the per-instance timestamp ordering of its
+    concurrency-cancel race-loser siblings is irrelevant. Under the draft-tier +
+    review-pipeline label churn (#2537/#2546) a head SHA accretes many cancel
+    rounds whose doomed select instances can out-timestamp the winning run's
     already-concluded select success; the strictly-later rule then left a residual
     cancelled select that RED the gate over a provably-sound selection, escalating
-    ~20 review:pass PRs to needs:user and starving the merge train. SAFETY is
-    unchanged: this widening is scoped to select ONLY (an idempotent pre-job, never
-    a leg that produces test evidence), only cancelled/stale are ever forgiven, and
-    a genuine `failure` select or a cancelled select with NO successful same-name
-    sibling still fails the gate. Non-select legs keep the strictly-later rule (a
-    real leg's earlier stale success must never forgive its later cancellation)."""
+    ~20 review:pass PRs to needs:user and starving the merge train. SAFETY (per
+    the cross-provider review of PR #3417): the widening is DOUBLY scoped —
+    (a) is_pure_select ONLY (name ends with the selection phrase): a COMPOUND job
+    that carries additional gating evidence (fv-select + fv-manifest) keeps the
+    strictly-later rule, and (b) SAME TIER only: a full-tier success never erases
+    a cancelled draft-tier instance (which must stay visible to the
+    draft_selects_unsuperseded hold), and a draft-tier success never erases a
+    cancelled full-tier instance (draft evidence must never stand in for a
+    full-tier selection). Cross-tier supersession remains available ONLY via the
+    original strictly-later rule (the intended un-draft flow). Only
+    cancelled/stale are ever forgiven; a genuine `failure` select or a cancelled
+    select with NO qualifying sibling still fails the gate. Non-select legs keep
+    the strictly-later rule (a real leg's earlier stale success must never
+    forgive its later cancellation)."""
     kept: list[dict] = []
     forgiven: list[dict] = []
     for r in runs:
         if r.get("conclusion") in _SUPERSEDABLE:
-            key = normalized_name(r.get("name", ""))
+            r_name = r.get("name", "")
+            key = normalized_name(r_name)
             mine = _order_key(r)
-            select_leg = is_select(r.get("name", ""))
+            pure_select = is_pure_select(r_name)
+            r_tier = is_draft_tier(r_name)
             if any(
                 o is not r
                 and normalized_name(o.get("name", "")) == key
                 and o.get("conclusion") not in _SUPERSEDABLE
                 and (
-                    # select: ANY same-name success proves a sound selection;
-                    # every other leg: only a STRICTLY-LATER re-run supersedes.
-                    (select_leg and o.get("conclusion") == "success")
+                    # pure select: any SAME-TIER same-name success proves a
+                    # sound selection; everything else (non-select legs,
+                    # compound select+evidence jobs, cross-tier pairs): only a
+                    # STRICTLY-LATER re-run supersedes.
+                    (
+                        pure_select
+                        and o.get("conclusion") == "success"
+                        and is_draft_tier(o.get("name", "")) == r_tier
+                    )
                     or _order_key(o) > mine
                 )
                 for o in runs
@@ -331,6 +348,21 @@ def is_select(name: str) -> bool:
     PRE-selection semantics (skipped is unconditionally satisfied), never a
     false RED; the wiring inspection test pins the name so it does not drift."""
     return bool(SELECT_RE.search(name.lower()))
+
+
+def is_pure_select(name: str) -> bool:
+    """[OPUS-4.8] sq-fmx4u.3: eligibility for forgive_superseded's same-name
+    same-tier any-success rule — STRICTER than is_select. Only the PURE reusable
+    change-based-selection pre-job qualifies, matched by the tier-normalized name
+    ENDING with the selection phrase; a COMPOUND job whose name merely CONTAINS
+    the phrase but carries additional gating evidence (e.g. `fv-select
+    (change-based test selection) + fv-manifest (proof inventory)`) is excluded
+    and keeps the strictly-later supersession rule. is_select stays broad for
+    selection-HEALTH detection (a cancelled compound select still REDs
+    select_ok); this predicate only gates the forgiveness widening."""
+    return normalized_name(name).lower().rstrip().endswith(
+        "(change-based test selection)"
+    )
 
 
 def is_self(run: dict, self_run_id: str) -> bool:
@@ -462,9 +494,11 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
     # Selection pre-job health — searched over ALL runs (not just gating) so a
     # hypothetical advisory-renamed select could still never green-light a skip.
     # NB superseded-cancelled select INSTANCES are already dropped upstream by
-    # forgive_superseded (including the deterministic-select same-name-success
-    # race-loser rule, sq-fmx4u.3 hardening), so any cancelled select that
-    # SURVIVES to here has NO successful same-name sibling and rightly REDs.
+    # forgive_superseded (including the deterministic-select same-name SAME-TIER
+    # success race-loser rule for the PURE select pre-job, sq-fmx4u.3
+    # hardening), so any cancelled select that SURVIVES to here has NO
+    # qualifying sibling (no strictly-later successor, and — for a pure select —
+    # no same-tier same-name success either) and rightly REDs.
     select_runs = [r for r in runs if is_select(r.get("name", ""))]
     select_ok = all(r.get("conclusion") == "success" for r in select_runs)
     skipped_ct = sum(1 for r in gating if r.get("conclusion") == "skipped")

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -222,18 +222,41 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
     forgiven (a genuine failure/timed_out always gates, no matter what runs
     later), and a cancellation with NO successor still fails the gate. Call this
     over the RAW list (self-run included) so THIS gate run's own fresh `gate`
-    check-run can supersede its cancelled predecessor."""
+    check-run can supersede its cancelled predecessor.
+
+    [OPUS-4.8] sq-fmx4u.3 hardening (2026-07-17 fleet jam): for the change-based
+    SELECTION pre-job (is_select) the successor need only be a same-normalized-name
+    SUCCESS ANYWHERE on the SHA, not one that is STRICTLY LATER. Rationale: select
+    is a deterministic pure function of the SHA's diff, so a single same-name
+    success PROVES the selection was computed soundly — the per-instance timestamp
+    ordering of its concurrency-cancel race-loser siblings is irrelevant. Under the
+    draft-tier + review-pipeline label churn (#2537/#2546) a head SHA accretes many
+    cancel rounds whose doomed select instances can out-timestamp the winning run's
+    already-concluded select success; the strictly-later rule then left a residual
+    cancelled select that RED the gate over a provably-sound selection, escalating
+    ~20 review:pass PRs to needs:user and starving the merge train. SAFETY is
+    unchanged: this widening is scoped to select ONLY (an idempotent pre-job, never
+    a leg that produces test evidence), only cancelled/stale are ever forgiven, and
+    a genuine `failure` select or a cancelled select with NO successful same-name
+    sibling still fails the gate. Non-select legs keep the strictly-later rule (a
+    real leg's earlier stale success must never forgive its later cancellation)."""
     kept: list[dict] = []
     forgiven: list[dict] = []
     for r in runs:
         if r.get("conclusion") in _SUPERSEDABLE:
             key = normalized_name(r.get("name", ""))
             mine = _order_key(r)
+            select_leg = is_select(r.get("name", ""))
             if any(
                 o is not r
                 and normalized_name(o.get("name", "")) == key
-                and _order_key(o) > mine
                 and o.get("conclusion") not in _SUPERSEDABLE
+                and (
+                    # select: ANY same-name success proves a sound selection;
+                    # every other leg: only a STRICTLY-LATER re-run supersedes.
+                    (select_leg and o.get("conclusion") == "success")
+                    or _order_key(o) > mine
+                )
                 for o in runs
             ):
                 forgiven.append(r)
@@ -438,6 +461,10 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
     excluded = total - len(gating)
     # Selection pre-job health — searched over ALL runs (not just gating) so a
     # hypothetical advisory-renamed select could still never green-light a skip.
+    # NB superseded-cancelled select INSTANCES are already dropped upstream by
+    # forgive_superseded (including the deterministic-select same-name-success
+    # race-loser rule, sq-fmx4u.3 hardening), so any cancelled select that
+    # SURVIVES to here has NO successful same-name sibling and rightly REDs.
     select_runs = [r for r in runs if is_select(r.get("name", ""))]
     select_ok = all(r.get("conclusion") == "success" for r in select_runs)
     skipped_ct = sum(1 for r in gating if r.get("conclusion") == "skipped")

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -354,6 +354,43 @@ class TestSelectionSemantics(unittest.TestCase):
         code, _ = run(tiny_cfg(), [runs])
         self.assertEqual(code, 1)
 
+    def test_cancelled_select_forgiven_by_same_name_success(self):
+        # [OPUS-4.8] sq-fmx4u.3 hardening: the 2026-07-17 fleet jam. Under the
+        # draft-tier + review-pipeline label churn a head SHA accretes many
+        # concurrency-cancel rounds; a doomed select INSTANCE (cancelled) can
+        # out-timestamp the winning run's already-concluded select SUCCESS, so
+        # forgive_superseded's strictly-later rule leaves a residual cancelled
+        # select. A same-normalized-name SUCCESS on the SHA proves the selection
+        # was computed soundly (select is a deterministic pure pre-job over the
+        # diff), so the gate must NOT RED over a provably-sound selection.
+        runs = [R(SELECT_NAME, conclusion="success", started="2026-01-01T00:00:10Z", rid=2),
+                R(SELECT_NAME, conclusion="cancelled", started="2026-01-01T00:00:20Z", rid=3),
+                R("W3C conformance", conclusion="skipped"),
+                GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0, "a cancelled select superseded by a same-name success must not RED")
+        self.assertIn("PASSED", out)
+
+    def test_cancelled_select_with_no_success_still_reds(self):
+        # The forgiveness is narrow: a cancelled select with NO successful
+        # same-name sibling is still an unobservable selection and REDs.
+        runs = [R(SELECT_NAME, conclusion="cancelled"),
+                R("x", conclusion="skipped"), GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+        self.assertIn("selection pre-job", out)
+
+    def test_failure_select_reds_even_with_a_success_sibling(self):
+        # Only cancelled/stale race losers are forgiven — a genuine `failure`
+        # select still REDs regardless of any success sibling (a real selection
+        # failure is never masked by a concurrency winner).
+        runs = [R(SELECT_NAME, conclusion="success"),
+                R(SELECT_NAME, conclusion="failure"),
+                R("x", conclusion="skipped"), GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+        self.assertIn("selection pre-job", out)
+
     def test_select_name_detection_contract(self):
         # The name-detection contract with .github/workflows/ci-select.yml (also
         # pinned cross-file by scripts/tests/test_ci_select_wiring.py).

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -391,6 +391,60 @@ class TestSelectionSemantics(unittest.TestCase):
         self.assertEqual(code, 1)
         self.assertIn("selection pre-job", out)
 
+    def test_cancelled_draft_select_not_forgiven_by_full_success(self):
+        # [OPUS-4.8] cross-provider review of PR #3417, finding 1: the any-success
+        # rule is SAME-TIER only. A full-tier select success must NOT erase a
+        # later cancelled DRAFT-tier instance — that instance must stay visible
+        # (fail-closed: the draft_selects_unsuperseded hold accounts for draft
+        # instances per-instance; erasing one by a cross-tier name collision
+        # would under-count the hold). Strictly-later cross-tier supersession is
+        # a different, still-supported path (the un-draft flow).
+        runs = [R(SELECT_NAME, conclusion="success", started="2026-01-01T00:00:10Z", rid=2),
+                R(SELECT_NAME + ", draft-tier", conclusion="cancelled",
+                  started="2026-01-01T00:00:20Z", rid=3),
+                R("x", conclusion="skipped"), GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, "a cross-tier success must not forgive a cancelled draft select")
+        self.assertIn("selection pre-job", out)
+
+    def test_cancelled_full_select_not_forgiven_by_draft_success(self):
+        # [OPUS-4.8] finding 1, other direction: a DRAFT-tier select success must
+        # never stand in for a cancelled FULL-tier selection (draft-assembled
+        # evidence never satisfies a full-tier verdict, design #2537).
+        runs = [R(SELECT_NAME + ", draft-tier", conclusion="success",
+                  started="2026-01-01T00:00:10Z", rid=2),
+                R(SELECT_NAME, conclusion="cancelled",
+                  started="2026-01-01T00:00:20Z", rid=3),
+                R("x", conclusion="skipped"), GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, "a draft-tier success must not forgive a cancelled full-tier select")
+        self.assertIn("selection pre-job", out)
+
+    def test_cancelled_compound_select_keeps_strictly_later_rule(self):
+        # [OPUS-4.8] cross-provider review of PR #3417, finding 2: the compound
+        # fv-select + fv-manifest job CONTAINS the selection phrase but carries
+        # independent gating evidence (the proof-inventory manifest), so it is
+        # NOT a pure select and must keep the strictly-later supersession rule:
+        # an EARLIER success never forgives its later cancellation.
+        compound = "fv-select (change-based test selection) + fv-manifest (proof inventory)"
+        runs = [R(compound, conclusion="success", started="2026-01-01T00:00:10Z", rid=2),
+                R(compound, conclusion="cancelled", started="2026-01-01T00:00:20Z", rid=3),
+                R("x", conclusion="skipped"), GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, "an earlier success must not forgive a later cancelled compound select+evidence job")
+        self.assertIn("selection pre-job", out)
+
+    def test_pure_select_detection_contract(self):
+        # is_pure_select gates ONLY the forgiveness widening: pure reusable
+        # selector names (tier-marked or not) qualify; the compound
+        # select+manifest job and non-select legs do not.
+        self.assertTrue(g.is_pure_select(SELECT_NAME))
+        self.assertTrue(g.is_pure_select(SELECT_NAME + ", draft-tier"))
+        self.assertFalse(g.is_pure_select(
+            "fv-select (change-based test selection) + fv-manifest (proof inventory)"))
+        self.assertFalse(g.is_pure_select("build + test"))
+        self.assertFalse(g.is_pure_select("gate"))
+
     def test_select_name_detection_contract(self):
         # The name-detection contract with .github/workflows/ci-select.yml (also
         # pinned cross-file by scripts/tests/test_ci_select_wiring.py).


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI-infra fix for the live merge-train jam (2026-07-17).

## Root cause (verified, not assumed)

~20 open `review:pass` PRs were stuck at `needs:user`, BLOCKED, nothing merging for ~90 min. The required `ci-summary / gate` check-run was **FAILURE** on each with the message:

> ci-summary: FAILED — the change-based test-selection pre-job did not succeed, so the *N* skipped gating check(s) on this commit cannot be attributed to a sound selection (fail-closed, sq-fmx4u.3 / design §4.3).

This is **not** golden leg-name drift and **not** a main regression. The mechanism:

- Draft-tier CI (#2537) + the review-pipeline label-event churn (#2546) make a single head SHA accrete **many** concurrency-cancel rounds. On the representative PRs the SHA carried 16 `select` instances (11 `SUCCESS`, 5 `CANCELLED`) and the check-run count grew 57 → 206 across gate polls, never settling.
- `forgive_superseded()` drops a cancelled/stale run only when a **strictly-later** same-normalized-name non-supersedable successor exists. But a doomed select instance from a *later* cancel round can out-timestamp the winning run's *already-concluded* select `SUCCESS`, so a residual cancelled select survived to `render_verdict`.
- `render_verdict` computes `select_ok = all(conclusion == "success" for select instances)` → `False` → **fail-closed** over a provably-sound selection.
- The later select re-runs (which succeeded) never spawned a fresh `gate` run, so the **stale FAILURE gate remained the required context** → branch protection blocked the PR indefinitely.

Confirmed `main` is healthy: `scripts/tests/test_feature_matrix_assemble.py` passes 38/38 on `origin/main` (golden matches), and `test_ci_summary_gate.py` passed 56/56 pre-fix — this is a supersession-accounting bug exposed by the churn, not a content regression. (One unrelated PR, #2512, has a genuine per-PR golden omission — it renamed its own `sparq-reason-dl` leg without updating `feature-matrix-legnames.golden.txt`; that is that PR author's fix, out of scope here.)

## Fix (scoped, gate-preserving)

`forgive_superseded()` now forgives a cancelled/stale **select** instance when **any** same-normalized-name select `SUCCESS` exists on the SHA (not only a strictly-later one). Select is a deterministic pure function of the SHA's diff, so a single same-SHA success proves the selection was computed soundly.

Safety is unchanged:
- Widening is scoped to **select only** — an idempotent pre-job, never a leg that produces test evidence.
- **Non-select legs keep the strictly-later rule** (a real leg's earlier stale success must never forgive its later cancellation). Verified by a mutation check.
- A genuine `failure` select, or a cancelled select with **no** successful same-name sibling, still REDs the gate.
- No workflow YAML changed; the required `ci-summary / gate` context and every leg's gating are byte-identical.

## Tests

- `scripts/tests/test_ci_summary_gate.py` **59/59** (3 new: race-loser forgiven; no-success-sibling still REDs; failure-with-a-success-sibling still REDs).
- `scripts/tests/test_ci_select_wiring.py` **50/50**.
- Direct replay of the real #2505-shaped run set → gate renders **PASS** ("selection pre-job succeeded").

## Operational note (not in this diff)

Already-blocked PRs carry a **stale FAILURE `gate`** from before this fix; they need a fresh `gate` run to pick up the corrected logic (a re-run / rebase / new head). Please route this PR through verify→arm — **I have not armed it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)