### PR TITLE
ci: path-aware audit — extend change-class to merge_group for container-scan + supply-chain

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,8 +62,68 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # [OPUS-4.8] path-aware CI (maintainer ask): "CodeQL doesn't even need to run if
+  # no Rust files are changed." CodeQL analyses the RUST workspace, so a PR whose
+  # diff touches NO Rust (orchestration/workflow/docs-only — e.g. routing.toml +
+  # triage.py) has nothing for CodeQL to analyse. This cheap pre-job computes
+  # whether the diff touches Rust and the `analyze` job below `if:`s on it, exactly
+  # mirroring ci.yml's `changes` (dorny paths-filter) mechanism.
+  #
+  # SOUNDNESS (identical to the draft-tier skip already in effect):
+  #   * The single REQUIRED context is `ci-summary / gate`; `CodeQL analysis (rust)`
+  #     is NOT individually required (docs/branch-protection.md §Required status
+  #     checks). When it is `skipped`, ci-summary treats a `skipped` conclusion as
+  #     NON-failing, so the gate resolves fast — the SAME behaviour as the existing
+  #     draft-head skip of this very job.
+  #   * The ruleset's `code_scanning` rule (CodeQL) is recorded as DEFENSE-IN-DEPTH
+  #     ONLY (docs/branch-protection.md §Draft-tier CI, last paragraph): a draft head
+  #     already carries no PR CodeQL analysis and the rule tolerates that absence.
+  #     A non-Rust PR is the same posture — there is genuinely no Rust to analyse.
+  #   * SAFE-BY-DEFAULT: rust_changed is forced 'true' on EVERY event except a
+  #     `pull_request` (push-to-main, merge_group, weekly schedule all run CodeQL in
+  #     full), and the Rust path set is broad: any *.rs / **/Cargo.toml / Cargo.lock /
+  #     rust-toolchain* / any build.rs (covered by *.rs? build.rs IS a .rs file) /
+  #     the codeql wiring itself. If the diff cannot be computed, we never silently
+  #     skip: off the PR path we hard-force 'true'.
+  changes:
+    name: detect rust changes (codeql)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust_changed: ${{ steps.decide.outputs.rust_changed }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain*'
+              - '.github/workflows/codeql.yml'
+              - '.github/codeql/**'
+      - name: Decide rust_changed (safe-by-default off the PR path)
+        id: decide
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${{ github.event_name }} -> forcing rust_changed=true (full CodeQL)"
+          else
+            echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
+            echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
+          fi
+
   analyze:
     name: CodeQL analysis (rust)
+    needs: changes
     # [FABLE-5] Draft-tier CI: SKIPPED on draft PR heads (this analysis is one of
     # the slowest per-push lanes and the fleet's draft review-fix churn re-ran it
     # on every push). VERIFIED before changing: CodeQL is NOT schedule/main-only —
@@ -73,7 +133,13 @@ jobs:
     # branch-protection `code_scanning` alert rule therefore still sees a CodeQL
     # analysis of the head before any merge. Fail-open off the PR path: any
     # non-pull_request event satisfies the first disjunct => RUN.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft != true
+    # [OPUS-4.8] path-aware CI: ALSO skipped when the PR diff touches no Rust
+    # (needs.changes.outputs.rust_changed == 'false') — nothing for CodeQL to
+    # analyse. rust_changed is forced 'true' off the PR path (see `changes`), so
+    # merge_group / push-to-main / schedule always analyse in full.
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft != true) &&
+      needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -24,9 +24,19 @@
 # On PRs the lane runs only when something that affects the image changed (Dockerfile, the
 # build sources via Cargo manifests, the allowlist/lint configs, or this workflow) so an
 # unrelated docs/test PR does not pay the image build — but it ALWAYS runs on push-to-main,
-# merge_group, schedule, and manual dispatch. Because ci-summary only aggregates checks that
+# schedule, and manual dispatch. Because ci-summary only aggregates checks that
 # actually register on a given ref, a PR that does not touch these paths simply has no
 # container-scan check to wait on (it is not a missing-required-check hang).
+#
+# [OPUS-4.8] MERGE-GROUP (path-aware CI audit, sq path-aware CI): GitHub ignores `paths` for
+# the merge_group event, so the workflow triggers on every enqueue. Rather than rebuild + scan
+# the full fat-LTO image on every merge (the maintainer's merge-queue-heaviness complaint), the
+# heavy `trivy` job now leads with a `detect container changes` step that diffs the queued
+# batch's base_sha..head_sha against the SAME container path set as the PR filter; the build +
+# scan steps skip (job still concludes SUCCESS — non-failing to ci-summary) when no
+# container-relevant path is in the batch. The `trivy (…)` check-run still ALWAYS appears on the
+# merge_group ref (fast green on the skip path), so the required gate never hangs on an absent
+# sibling. Fail-safe: any diff error runs the full build+scan. See the step comment.
 #
 # Third-party actions are pinned by full commit SHA (supply-chain hardening; Scorecard
 # PinnedDependencies); the trailing `# vX.Y.Z` is what Dependabot follows to bump the pin.
@@ -95,11 +105,79 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # [OPUS-4.8] MERGE-GROUP changed-files gate (path-aware CI audit, sq path-aware CI).
+      # The `pull_request` trigger above already narrows this heavy trivy image build+scan
+      # to container-relevant PRs via native `on.pull_request.paths`. But GitHub IGNORES
+      # `paths`/`paths-ignore` for the `merge_group` event, so a BARE `merge_group:` trigger
+      # would rebuild the full fat-LTO release image + run trivy on EVERY enqueue — even when
+      # the queued batch touches no Dockerfile/base-image/dependency path — dragging the
+      # serialized merge queue (the maintainer's exact merge-queue-heaviness complaint).
+      # Mirroring zk-toolchain.yml's proven `detect zk changes` pattern: the job ALWAYS runs
+      # (so the `trivy (…)` check-run ALWAYS appears on the merge_group ref and ci-summary —
+      # the single required gate — never hangs waiting for an absent sibling), but this cheap
+      # leading step diffs the queued batch's base_sha..head_sha and the heavy build+scan
+      # steps below are gated `if: steps.changes.outputs.container == 'true'`:
+      #   • container paths changed in the batch → full build+scan runs and GATES (posture kept),
+      #   • no container paths changed           → heavy steps skip → FAST GREEN check-run with
+      #     the identical name, matching the paths-gated PR posture.
+      # For every NON-merge_group event the step short-circuits to container=true, so the
+      # paths-filtered pull_request / push / schedule / dispatch behaviour is UNCHANGED
+      # (those events only trigger this workflow when container paths changed in the first
+      # place, except the weekly base-image re-scan, which must run in full). SAFE-BY-DEFAULT:
+      # any fetch/diff error leaves container=true (full scan), so a skip is always a proof.
+      # The path set is the SAME as the `on.pull_request.paths` filter above.
+      - name: Detect container changes (merge_group changed-files gate)
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          # Default: run the full build+scan (fail-safe — see step comment).
+          container=true
+          if [ "${EVENT_NAME}" = "merge_group" ]; then
+            container=false
+            # The default checkout is shallow, so the base may be absent. Best-effort fetch;
+            # on any fetch/diff error we leave container=true via the fallbacks below.
+            ok=true
+            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+              || ok=false
+            git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
+            git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false
+            if [ "${ok}" = "true" ]; then
+              changed="$(git diff --name-only "${MG_BASE_SHA}" "${MG_HEAD_SHA}")"
+              echo "Changed files in queued batch (${MG_BASE_SHA}..${MG_HEAD_SHA}):"
+              printf '%s\n' "${changed}"
+              # Container-relevant paths — the SAME set as the pull_request paths filter:
+              # the Dockerfile + its ignore/lint/vuln-allowlist configs, this workflow,
+              # and the manifests that change what the image resolves + installs
+              # (root Cargo.toml/Cargo.lock + any crate manifest).
+              if printf '%s\n' "${changed}" | grep -Eq \
+                '^(Dockerfile$|\.dockerignore$|\.trivyignore$|\.hadolint\.yaml$|\.github/workflows/container-scan\.yml$|Cargo\.toml$|Cargo\.lock$|crates/[^/]+/Cargo\.toml$)'; then
+                container=true
+              else
+                container=false
+              fi
+            else
+              echo "::warning::could not resolve merge_group base/head SHAs for the diff — running the full image build + scan (fail-safe)."
+              container=true
+            fi
+          fi
+          echo "container=${container}" >> "$GITHUB_OUTPUT"
+          if [ "${container}" = "true" ]; then
+            echo "Container-relevant paths changed (or non-merge_group / fail-safe) — building + scanning the image."
+          else
+            echo "No container-relevant paths in this merge_group batch — fast-passing (image build + scan skipped, check stays green)."
+          fi
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        if: steps.changes.outputs.container == 'true'
       # Build the image LOCALLY (load into the runner's docker) so trivy scans the exact
       # artifact this repo would publish. Cached to GHA — the slow fat-LTO release build is
       # a cache hit on unchanged sources. (Mirrors release.yml's smoke-build step.)
       - name: Build image (load locally)
+        if: steps.changes.outputs.container == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -115,6 +193,7 @@ jobs:
       #                       the SARIF run below for triage, not used as a merge blocker).
       #   trivyignores     => .trivyignore allowlist for triaged/accepted CVEs.
       - name: Trivy image scan (fail on fixable HIGH/CRITICAL)
+        if: steps.changes.outputs.container == 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: sparq-server:scan
@@ -129,7 +208,10 @@ jobs:
       # never fails the job (the gating decision is the table pass above); it includes
       # unfixed findings too so the Security tab shows the full picture for triage.
       - name: Trivy image scan (SARIF for code-scanning)
-        if: always()
+        # always() so a FAILED gating scan still uploads its SARIF — but only when the image
+        # was actually built (container==true); on the merge_group skip path there is no
+        # image to scan and nothing to upload.
+        if: always() && steps.changes.outputs.container == 'true'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: sparq-server:scan
@@ -141,7 +223,7 @@ jobs:
           vuln-type: os,library
           trivyignores: .trivyignore
       - name: Upload Trivy SARIF to code-scanning
-        if: always()
+        if: always() && steps.changes.outputs.container == 'true'
         uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -65,10 +65,20 @@ jobs:
       # ci-summary gate). The daily dependency-monitoring.yml watchdog remains the
       # defence-in-depth for advisories disclosed BETWEEN PRs on an unchanged graph.
       # SAFE-BY-DEFAULT: rust_changed is forced 'true' on every event except
-      # `pull_request`, so the canonical push/merge_group/manual supply-chain runs
+      # `pull_request` and `merge_group`, so the canonical push/manual supply-chain runs
       # ALWAYS execute the full set. The VEX/OpenSSF/js-sbom/SBOM-assertion step-groups
       # are deliberately NOT gated (they validate checked-in evidence a doc/config PR
       # can touch without changing Rust, and ran unconditionally before).
+      #
+      # [OPUS-4.8] MERGE-GROUP (path-aware CI audit, sq path-aware CI): GitHub ignores
+      # `paths`/dorny-filter semantics for merge_group, so this gate previously forced
+      # rust_changed=true on EVERY enqueue — installing cargo-deny/vet/cyclonedx + running
+      # the full workspace deny/vet/SBOM on every merge, even for an orchestration/docs-only
+      # batch (the maintainer's merge-queue-heaviness complaint). The deny/vet/SBOM output is
+      # a pure function of the resolved dependency graph + the Rust source tree; a batch that
+      # touches none of the `rust` path set below cannot change it — so we now diff the queued
+      # batch's base_sha..head_sha against the SAME `rust` path set the PR filter uses and skip
+      # the heavy rust step-groups when nothing matched (fail-safe: any diff error → full run).
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         if: github.event_name == 'pull_request'
@@ -84,14 +94,45 @@ jobs:
               - '.github/workflows/supply-chain.yml'
       - name: Decide rust_changed (safe-by-default off the PR path)
         id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
-            echo "event=${{ github.event_name }} -> forcing rust_changed=true (full supply-chain)"
-          else
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
             echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
             echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
+          elif [ "${EVENT_NAME}" = "merge_group" ]; then
+            # Diff the queued batch; fail-safe to the full run on any resolution error.
+            rust=true
+            ok=true
+            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+              || ok=false
+            git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
+            git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false
+            if [ "${ok}" = "true" ]; then
+              changed="$(git diff --name-only "${MG_BASE_SHA}" "${MG_HEAD_SHA}")"
+              echo "Changed files in queued batch (${MG_BASE_SHA}..${MG_HEAD_SHA}):"
+              printf '%s\n' "${changed}"
+              # SAME `rust` path set as the pull_request dorny filter above (kept in sync by
+              # scripts/tests/test_ci_select_wiring.py::TestSupplyChainMergeGroupGate).
+              if printf '%s\n' "${changed}" | grep -Eq \
+                '(\.rs$|(^|/)Cargo\.toml$|^Cargo\.lock$|(^|/)rust-toolchain([^/]*)$|^deny\.toml$|^supply-chain/|^\.github/workflows/supply-chain\.yml$)'; then
+                rust=true
+              else
+                rust=false
+              fi
+            else
+              echo "::warning::could not resolve merge_group base/head SHAs for the diff — running the full supply-chain gate (fail-safe)."
+              rust=true
+            fi
+            echo "rust_changed=${rust}" >> "$GITHUB_OUTPUT"
+            echo "merge_group -> rust_changed=${rust}"
+          else
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${EVENT_NAME} -> forcing rust_changed=true (full supply-chain)"
           fi
 
       # ---- former job: VEX ↔ deny.toml sync (GS-5) — GATING ----
@@ -168,6 +209,13 @@ jobs:
       # Pinning to >= 0.10.2 makes the version independent of the install-action default so
       # the GATING parse is reproducible. Bump this in lock-step with any new imports.lock
       # schema feature. (bead sq-miwt)
+      # [OPUS-4.8] NOTE: the toolchain + cargo-tool install stay UNCONDITIONAL on purpose —
+      # the SBOM self-tests + `Generate SBOM` step-group below run `cargo cyclonedx`
+      # UNCONDITIONALLY (the always-on SBOM cadence, sq-6vshe.20), so gating the install on
+      # rust_changed would break them on the merge_group/doc-only skip path. The dominant
+      # merge-queue cost this audit removes is the cargo-deny + cargo-vet check step-groups
+      # (already rust_changed-gated below); the SBOM generation is a pure function of
+      # Cargo.lock and its unconditional regeneration is a deliberate design choice.
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Install cargo-deny + cargo-vet + cargo-cyclonedx

--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -250,6 +250,18 @@ readers = ["sparq-acbench"]
 pattern = "research/**"
 safe = true
 
+# [OPUS-4.8] path-aware CI: top-level prose docs (docs/*.md — branch-protection,
+# upstream-proposals, guides). AUDIT-PROVEN inert: no workspace crate include_str!/
+# include_bytes!/reads docs/ (the audit re-verifies every run), and docs/ is all
+# markdown (0 non-.md files). NOTE a *crate-owned* README.md/*.md is NOT covered by
+# this — it stays crate-owned (doctest include_str! risk, design §3.2); this is the
+# repo-level docs/ tree only. The docs-quality lane (markdownlint/links) is a
+# separate workflow and still runs. Lets a docs-only PR skip the bench/fuzz seed
+# lanes too (the wide ci.yml/feature-matrix legs already skip via rust_changed).
+[[map]]
+pattern = "docs/**"
+safe = true
+
 # The marketing/explanatory website (Next.js). Owns its own CI lane (pages.yml);
 # no Rust crate reads site/.
 [[map]]

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -83,6 +83,142 @@ _FULL_TRIGGERS: list[tuple[str, str]] = [
 ]
 
 
+# --- ORCHESTRATION-ONLY carve-out (change-class layer; sq path-aware CI) ------
+# [OPUS-4.8] The broad `.github/` and `scripts/` full-run triggers above are
+# CORRECT-BY-DEFAULT but OVER-BROAD: a PR that changes ONLY orchestration/workflow
+# tooling (PR/issue/bead automation, routing, the merge-queue batchers, agent
+# config) forces the FULL Rust matrix even though NOTHING it touches is read by any
+# Rust build/test/clippy/coverage/bench/fuzz/CodeQL job. The maintainer's ask:
+# stop running the engine CI on those PRs (they dominate the drain).
+#
+# SOUNDNESS (§2 — a skip must be a PROOF of non-interference, not a guess): this is
+# a small, EXPLICIT, AUDITED ALLOWLIST of paths PROVEN inert for the Rust matrix,
+# consulted BEFORE `_trigger_match` so it is the ONLY thing that can rescue a
+# `.github/`/`scripts/` path from the full-run trigger. It is a WHITELIST, never a
+# denylist: a `.github/`/`scripts/` path NOT matched here still hits the trigger and
+# forces full (absence of proof ⇒ run). A matched path is treated exactly like an
+# ownership-map `safe = true` verdict — it contributes NO crate, so if EVERY changed
+# path is orchestration-safe the selection is mode=selected with an empty affected
+# closure and every Rust lane (incl. the bench/fuzz/wasm SEED lanes) skips.
+#
+# THE INERTNESS OBLIGATION (enforced by scripts/tests/test_ci_select.py
+# `OrchestrationSafeInertnessTests`): every entry here must be a path that NO
+# `.github/workflows/*.yml` step feeding a Rust build/test/gate ever reads, and that
+# no crate `include_str!`/`include_bytes!`/`../`-escapes to. The test greps the
+# Rust-CI workflows for a reference to each allowlisted script/dir and FAILS if one
+# is referenced (i.e. is actually Rust-CI-affecting) — so an entry can never silently
+# become unsound when a script is later wired into a gate. A pattern ending in "/" is
+# a directory prefix; otherwise an exact repo-relative path.
+#
+# NOT here (deliberately — these ARE read by the Rust matrix, so they must keep
+# triggering full): every Rust-CI script (ci_select.py, ci_summary_gate.py,
+# coverage*.py/sh, perf-gate.py, assemble-feature-matrix.py, feature-matrix-tiers.py,
+# check-*.py gates, fetch-*.sh conformance fetchers, ci-bench.sh, ci-free-disk.sh,
+# unsafe/mutants gates, sbom/vex tooling, docker-smoke.sh, wasm-deps-guard.sh, the
+# fv/formal lane scripts, and scripts/tests/* that gate the engine); the Rust-CI
+# workflow files themselves (ci.yml, feature-matrix.yml, codeql.yml, supply-chain.yml,
+# bench.yml, fuzz.yml, miri.yml, asan.yml, kani.yml, metamorph.yml,
+# vectorized-feature-off.yml, ci-select.yml, ci-summary.yml, conformance/coverage
+# lanes); `.github/feature-matrix.d/**`; `.github/codeql/**`; `.github/actions/**`.
+_ORCHESTRATION_SAFE: list[str] = [
+    # Orchestration configuration + agent harness (never compiled/tested by cargo).
+    "orchestration/",       # routing.toml + orchestration policy (the #3416 class)
+    ".claude/",             # agent definitions / skills / workflows / settings
+    ".beads/",              # the bead task DB (never read by any build/test)
+    # Orchestration-only workflow files (PR/issue/bead/merge automation — none run
+    # cargo build/test/clippy/coverage/bench/fuzz/CodeQL).
+    ".github/workflows/triage-issue.yml",
+    ".github/workflows/retriage.yml",
+    ".github/workflows/pr-backlog.yml",
+    ".github/workflows/pr-title.yml",
+    ".github/workflows/batch-merge.yml",
+    ".github/workflows/bead-autoclose.yml",
+    ".github/workflows/promote-on-approval.yml",
+    ".github/workflows/differential-update.yml",
+    ".github/workflows/kb-dump.yml",
+    ".github/workflows/pkg-ingest.yml",
+    # NOTE deliberately NOT here: selection-alarm.yml / formal-alarm.yml — they are
+    # monitors for the Rust/formal lanes (borderline), so they keep triggering full
+    # (fail-closed; the value of skipping them is negligible and the audit is cleaner).
+    # Orchestration-only scripts (PR/issue/bead/routing/dispatch automation). Each is
+    # pinned inert by the OrchestrationSafeInertnessTests grep.
+    "scripts/triage.py",
+    "scripts/retriage.py",
+    "scripts/routing-validate.py",
+    "scripts/dispatch-plan.py",
+    "scripts/bd-to-issues.py",
+    "scripts/pr-backlog.py",
+    "scripts/batch-merge.py",
+    "scripts/save-agent-log.sh",
+    "scripts/push-frontier.sh",
+]
+
+
+def _orchestration_safe_match(path: str) -> bool:
+    """[OPUS-4.8] Is `path` on the audited orchestration-only inert allowlist?
+    A "/"-suffixed entry is a directory prefix; else an exact path. Consulted
+    BEFORE _trigger_match so it is the sole rescue from a .github/scripts trigger;
+    it can only ever REMOVE a path from the full set for a proven-inert path (a
+    non-matching path still hits the trigger => full)."""
+    for entry in _ORCHESTRATION_SAFE:
+        if entry.endswith("/"):
+            if path == entry.rstrip("/") or path.startswith(entry):
+                return True
+        elif path == entry:
+            return True
+    return False
+
+
+# Change-class labels emitted for the audit trail (design: the gate renders an
+# explicit "skipped-by-class" attribution). PURELY DESCRIPTIVE of the diff — the
+# skip decision itself is still the sound mode/affected math below.
+_CLASS_ENGINE = "engine"
+_CLASS_ORCHESTRATION = "orchestration-only"
+_CLASS_DOCS = "docs-only"
+_CLASS_MIXED = "mixed"
+
+# Docs-only surfaces: pure prose/markdown that no Rust build/test reads. NOTE a
+# crate-owned README.md/*.md is deliberately NOT docs-only — it can be pulled into a
+# doctest via #[doc = include_str!(...)] (design §3.2), so it is crate-owned and
+# classified engine. AGENTS.md / skills/** feed the sparq-kb PKG tests (ownership
+# map), so they are NOT docs-only either. This set is the repo-level prose that the
+# ownership map already proves SAFE (research/**) plus top-level docs/ markdown.
+_DOCS_ONLY_PREFIXES: list[str] = [
+    "docs/",
+    "research/",
+]
+
+
+def classify_change(changed_paths: list[str]) -> str:
+    """[OPUS-4.8] Pure change-class of a diff (WHAT surfaces changed), for the audit
+    trail. Orthogonal to `mode` (HOW MUCH runs) — this only LABELS; the sound skip
+    math is unchanged. Fail-closed: any path that is neither orchestration-safe nor
+    docs-only makes the class `engine` (or `mixed` if it also has orch/docs paths),
+    so a class is never MORE permissive than the mode. Empty diff => engine (a
+    non-PR/full event carries no diff and runs everything anyway)."""
+    seen_orch = seen_docs = seen_other = False
+    for path in changed_paths:
+        path = path.strip()
+        if not path:
+            continue
+        if _orchestration_safe_match(path):
+            seen_orch = True
+        elif any(path == p.rstrip("/") or path.startswith(p) for p in _DOCS_ONLY_PREFIXES):
+            seen_docs = True
+        else:
+            seen_other = True
+    if seen_other:
+        # Any engine/unclassified path present. Pure-engine vs mixed is informational.
+        return _CLASS_MIXED if (seen_orch or seen_docs) else _CLASS_ENGINE
+    if seen_orch and seen_docs:
+        return _CLASS_MIXED
+    if seen_orch:
+        return _CLASS_ORCHESTRATION
+    if seen_docs:
+        return _CLASS_DOCS
+    return _CLASS_ENGINE
+
+
 # --- phase-2 singleton-lane -> seed crates (design §5.2; beads sq-fmx4u.6, sq-mel85)
 # [OPUS-4.8] A "lane" is a SINGLETON CI job (not a per-crate matrix leg) that
 # always exercises a FIXED set of crates: the fuzz smoke (fuzz.yml), the wasm
@@ -180,9 +316,18 @@ class Selection:
     changed_crates: list[str] = field(default_factory=list)
     file_owners: list[tuple[str, str]] = field(default_factory=list)  # (path, owner-label)
     all_members: list[str] = field(default_factory=list)
+    # [OPUS-4.8] change-class of the diff (engine|orchestration-only|docs-only|mixed):
+    # the audit-trail label for WHY the Rust lanes were (or were not) skipped. Part of
+    # the JSON contract so the gate + tooling can render "skipped-by-class: <class>".
+    change_class: str = "engine"
 
     def to_json_obj(self) -> dict:
-        return {"mode": self.mode, "reason": self.reason, "affected": self.affected}
+        return {
+            "mode": self.mode,
+            "reason": self.reason,
+            "affected": self.affected,
+            "change_class": self.change_class,
+        }
 
 
 # --- metadata model ----------------------------------------------------------
@@ -395,6 +540,7 @@ def select(
     map_entries = map_entries or []
     ws = parse_workspace(meta)
     all_members = sorted(ws.members)
+    change_class = classify_change(changed_paths)
 
     def full(reason: str) -> Selection:
         return Selection(
@@ -402,6 +548,7 @@ def select(
             reason=reason,
             affected=all_members,  # "return ALL crates" (run everything)
             all_members=all_members,
+            change_class=change_class,
         )
 
     changed_crates: set[str] = set()
@@ -410,6 +557,13 @@ def select(
     for path in changed_paths:
         path = path.strip()
         if not path:
+            continue
+        # [OPUS-4.8] ORCHESTRATION-ONLY carve-out (BEFORE the trigger check — the sole
+        # rescue from a .github/scripts full-run trigger, and only for a PROVEN-inert
+        # path). Treated exactly like a SAFE-listed path: contributes no crate, so a
+        # pure-orchestration diff selects an empty closure and every Rust lane skips.
+        if _orchestration_safe_match(path):
+            file_owners.append((path, "ORCH-SAFE"))
             continue
         trig = _trigger_match(path)
         if trig is not None:
@@ -459,7 +613,12 @@ def select(
         # on it; still surface it as changed but with an empty member set.
         reason = "changed in-repo package(s) have no member dependents"
     elif not changed_crates:
-        reason = "all changed paths are SAFE-listed or non-crate; no crate affected"
+        if change_class == _CLASS_ORCHESTRATION:
+            reason = "skipped-by-class: orchestration-only — no Rust matrix affected"
+        elif change_class == _CLASS_DOCS:
+            reason = "skipped-by-class: docs-only — no Rust matrix affected"
+        else:
+            reason = "all changed paths are SAFE-listed or non-crate; no crate affected"
     else:
         skipped = len(ws.members) - len(affected)
         reason = f"{len(affected)} of {len(ws.members)} members affected ({skipped} skippable)"
@@ -471,6 +630,7 @@ def select(
         changed_crates=sorted(changed_crates),
         file_owners=file_owners,
         all_members=all_members,
+        change_class=change_class,
     )
 
 
@@ -584,6 +744,7 @@ def shadow_wrap(sel: Selection) -> Selection:
         changed_crates=sel.changed_crates,
         file_owners=sel.file_owners,
         all_members=sel.all_members,
+        change_class=sel.change_class,
     )
 
 
@@ -599,6 +760,16 @@ def filterset(sel: Selection) -> str:
 # --- step summary + outputs --------------------------------------------------
 def render_summary(sel: Selection) -> str:
     lines = ["### CI test-selection", "", f"**Mode:** `{sel.mode}` — {sel.reason}", ""]
+    # [OPUS-4.8] Explicit change-class attribution line so the audit trail shows WHY
+    # the Rust lanes were skipped (or not). No silent skips.
+    lines.append(f"**Change-class:** `{sel.change_class}`")
+    if sel.change_class in (_CLASS_ORCHESTRATION, _CLASS_DOCS) and sel.mode == "selected":
+        lines.append(
+            f"> skipped-by-class: `{sel.change_class}` — every changed path is proven "
+            "inert for the Rust matrix, so the engine test/clippy/coverage/bench/fuzz/"
+            "opt-in-feature lanes are skipped for this PR."
+        )
+    lines.append("")
     if sel.mode == "shadow":
         lines.append(
             "**SHADOW MODE** — selection is REPORT-ONLY on this run: every job still "
@@ -627,6 +798,9 @@ def _write_outputs(sel: Selection, output_file: str | None, summary_file: str | 
             fh.write(f"mode={sel.mode}\n")
             fh.write("affected=" + json.dumps(sel.affected) + "\n")
             fh.write("filterset=" + filterset(sel) + "\n")
+            # [OPUS-4.8] change-class output for the audit trail (consumers may
+            # surface "skipped-by-class: <class>"); never a gating input.
+            fh.write(f"change_class={sel.change_class}\n")
     if summary_file:
         with open(summary_file, "a", encoding="utf-8") as fh:
             fh.write(render_summary(sel))

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -179,9 +179,11 @@ class SyntheticGraphTests(unittest.TestCase):
         self.assertEqual(sel.changed_crates, ["engine"])
 
     def test_json_contract_keys(self):
+        # [OPUS-4.8] `change_class` added to the JSON contract (audit-trail label; not
+        # a gating input — the downstream guards still read only mode/affected).
         sel = self._select(["crates/app/src/lib.rs"])
         obj = sel.to_json_obj()
-        self.assertEqual(set(obj), {"mode", "reason", "affected"})
+        self.assertEqual(set(obj), {"mode", "reason", "affected", "change_class"})
 
 
 class OwnershipMapTests(unittest.TestCase):
@@ -474,6 +476,8 @@ class WiringHookTests(unittest.TestCase):
         self.assertEqual(lines["mode"], "selected")
         self.assertEqual(json.loads(lines["affected"]), ["app"])
         self.assertEqual(lines["filterset"], "package(app)")
+        # [OPUS-4.8] change-class output present (a crate change => engine).
+        self.assertEqual(lines["change_class"], "engine")
 
     def test_filterset_joins_members_with_plus(self):
         self.assertEqual(
@@ -481,6 +485,180 @@ class WiringHookTests(unittest.TestCase):
             "package(a) + package(b)",
         )
         self.assertEqual(cs.filterset(cs.Selection(mode="full", reason="", affected=[])), "")
+
+
+# [OPUS-4.8] ---- change-class layer (path-aware CI for orchestration PRs) --------
+class ChangeClassTests(unittest.TestCase):
+    """The classifier fixtures the maintainer brief mandates: engine diff => full;
+    an orchestration-only diff (the #3416 file set exactly) => reduced (mode=selected,
+    empty closure); docs-only => reduced; mixed => full; a rename crossing classes =>
+    full. classify_change is a PURE function of the diff and is fail-closed (an
+    unclassified path taints the class to engine/mixed)."""
+
+    def setUp(self):
+        self.meta = _synthetic_meta()
+
+    def _select(self, paths, map_entries=None):
+        return cs.select(paths, self.meta, map_entries)
+
+    # --- classify_change unit behaviour ---
+    def test_classify_engine_on_crate_change(self):
+        self.assertEqual(cs.classify_change(["crates/app/src/lib.rs"]), "engine")
+
+    def test_classify_orchestration_only(self):
+        # The #3416 file set EXACTLY: an orchestration config + an orchestration script.
+        self.assertEqual(
+            cs.classify_change(["orchestration/routing.toml", "scripts/triage.py"]),
+            "orchestration-only",
+        )
+
+    def test_classify_docs_only(self):
+        self.assertEqual(cs.classify_change(["docs/guide.md", "research/x.md"]), "docs-only")
+
+    def test_classify_mixed_orchestration_plus_engine(self):
+        self.assertEqual(
+            cs.classify_change(["scripts/triage.py", "crates/app/src/lib.rs"]), "mixed"
+        )
+
+    def test_classify_mixed_docs_plus_orchestration(self):
+        self.assertEqual(
+            cs.classify_change(["docs/x.md", "scripts/triage.py"]), "mixed"
+        )
+
+    def test_classify_engine_on_ci_gate_script(self):
+        # A Rust-CI gate script is NOT orchestration-safe => engine (fail-closed).
+        self.assertEqual(cs.classify_change(["scripts/coverage-gate.py"]), "engine")
+
+    def test_classify_engine_on_rust_ci_workflow(self):
+        self.assertEqual(cs.classify_change([".github/workflows/ci.yml"]), "engine")
+
+    # --- the selection consequences (the whole point) ---
+    def test_orchestration_only_diff_selects_empty_closure(self):
+        # A pure-orchestration PR: mode=selected with an EMPTY affected set — every
+        # Rust lane (incl. the bench/fuzz/wasm seed lanes) skips.
+        sel = self._select(["orchestration/routing.toml", "scripts/triage.py"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+        self.assertEqual(sel.change_class, "orchestration-only")
+        self.assertIn("skipped-by-class: orchestration-only", sel.reason)
+
+    def test_docs_only_diff_selects_empty_closure(self):
+        m = [{"pattern": "research/**", "safe": True}]
+        sel = self._select(["research/design.md"], m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+        self.assertEqual(sel.change_class, "docs-only")
+
+    def test_orchestration_safe_never_triggers_full(self):
+        # Even paired with a crate change, the orch-safe path must not FORCE full;
+        # the crate change narrows normally (selected), class becomes mixed.
+        sel = self._select(["scripts/triage.py", "crates/app/src/lib.rs"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app"])
+        self.assertEqual(sel.change_class, "mixed")
+
+    def test_mixed_engine_ci_script_still_forces_full(self):
+        # A Rust-CI script (NOT orch-safe) keeps forcing full even alongside orch paths.
+        sel = self._select(["scripts/coverage-gate.py", "scripts/triage.py"])
+        self.assertEqual(sel.mode, "full")
+
+    def test_workflow_file_change_forces_full_and_runs_gate_selftest(self):
+        # A .github/workflows/ Rust-CI workflow edit (ci.yml) is NOT orch-safe: it
+        # forces full, so the gate's own self-test leg + actionlint run (a CI change
+        # must prove the gate still works). Representative Rust-CI workflow.
+        sel = self._select([".github/workflows/ci.yml"])
+        self.assertEqual(sel.mode, "full")
+
+    def test_orchestration_workflow_edit_is_safe(self):
+        # An orchestration-ONLY workflow file (triage-issue.yml) is proven inert.
+        sel = self._select([".github/workflows/triage-issue.yml"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+        self.assertEqual(sel.change_class, "orchestration-only")
+
+    def test_rename_crossing_classes_forces_full(self):
+        # git diff --no-renames reports a move as delete+add of BOTH paths. Moving an
+        # orchestration script INTO a crate dir surfaces both paths: the crate path is
+        # owned (engine) => the diff is mixed and the crate is selected (never a skip
+        # of the destination crate). Moving a crate file OUT to orchestration surfaces
+        # the crate delete (owned) => that crate still runs.
+        sel = self._select(["scripts/triage.py", "crates/app/src/triage.rs"])
+        self.assertEqual(sel.change_class, "mixed")
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("app", sel.affected)
+
+    def test_mutation_break_classifier_reddens_engine_fixture(self):
+        # MUTATION SPOT-CHECK (brief): if the classifier were broken to call EVERYTHING
+        # orchestration-safe, an engine-diff fixture must go RED. We simulate the break
+        # by monkeypatching _orchestration_safe_match to always-True and assert the
+        # engine fixture then wrongly skips — proving the real (False) path is what
+        # keeps the engine diff running.
+        orig = cs._orchestration_safe_match
+        try:
+            cs._orchestration_safe_match = lambda _p: True
+            broken = cs.select(["crates/app/src/lib.rs"], self.meta)
+            # Under the break, the crate change is swallowed as "safe" => empty closure.
+            self.assertEqual(broken.affected, [], "mutation should make the engine diff skip")
+        finally:
+            cs._orchestration_safe_match = orig
+        # And the REAL classifier keeps the engine crate selected (red-on-wrong-answer).
+        good = cs.select(["crates/app/src/lib.rs"], self.meta)
+        self.assertEqual(good.affected, ["app"])
+
+
+class OrchestrationSafeInertnessTests(unittest.TestCase):
+    """[OPUS-4.8] THE INERTNESS OBLIGATION: every _ORCHESTRATION_SAFE entry must be
+    PROVEN not read by any Rust-CI workflow. This greps the real Rust-CI workflow
+    files for a reference to each allowlisted SCRIPT/WORKFLOW and FAILS if one is
+    referenced — so an entry can never silently become unsound when a script is later
+    wired into a gate. Directory prefixes (orchestration/, .claude/, .beads/) are
+    audited by convention (never cargo-compiled) and exempt from the grep."""
+
+    # The workflows that run cargo build/test/clippy/coverage/bench/fuzz/CodeQL and
+    # therefore MUST NOT reference an orchestration-safe script.
+    _RUST_CI_WORKFLOWS = [
+        "ci.yml", "feature-matrix.yml", "codeql.yml", "supply-chain.yml",
+        "bench.yml", "fuzz.yml", "miri.yml", "asan.yml", "kani.yml",
+        "metamorph.yml", "vectorized-feature-off.yml", "ci-select.yml",
+        "ci-summary.yml", "formal-verification.yml", "differential.yml",
+        "shacl-diff-fuzz.yml", "nightly-full-sweep.yml",
+    ]
+
+    def test_no_orch_safe_script_is_referenced_by_a_rust_ci_workflow(self):
+        wf_dir = REPO_ROOT / ".github" / "workflows"
+        corpus = []
+        for name in self._RUST_CI_WORKFLOWS:
+            p = wf_dir / name
+            if p.exists():
+                corpus.append(p.read_text(encoding="utf-8"))
+        blob = "\n".join(corpus)
+        for entry in cs._ORCHESTRATION_SAFE:
+            if entry.endswith("/"):
+                continue  # directory prefixes: never cargo-compiled (audited by convention)
+            if entry.startswith(".github/workflows/"):
+                # An orchestration WORKFLOW file: it must not itself be a Rust-CI wf.
+                self.assertNotIn(
+                    Path(entry).name, self._RUST_CI_WORKFLOWS,
+                    f"{entry} is listed as orchestration-safe but is a Rust-CI workflow",
+                )
+                continue
+            # A script: it must not be referenced anywhere in a Rust-CI workflow.
+            self.assertNotIn(
+                entry, blob,
+                f"orchestration-safe {entry} IS referenced by a Rust-CI workflow — it is "
+                f"NOT inert; remove it from _ORCHESTRATION_SAFE (fail-closed: a referenced "
+                f"script must keep triggering the full matrix).",
+            )
+
+    def test_orch_safe_scripts_exist_on_disk(self):
+        # A stale allowlist entry (script deleted/renamed) should be caught, else it
+        # silently covers nothing. Directory prefixes are checked as dirs.
+        for entry in cs._ORCHESTRATION_SAFE:
+            path = REPO_ROOT / entry.rstrip("/")
+            self.assertTrue(
+                path.exists(),
+                f"orchestration-safe entry {entry} does not exist on disk (stale allowlist)",
+            )
 
 
 class RealMetadataShapeTests(unittest.TestCase):

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -58,6 +58,9 @@ SELECT_YML = REPO_ROOT / ".github" / "workflows" / "ci-select.yml"
 GATE_PY = REPO_ROOT / "scripts" / "ci_summary_gate.py"
 CI_SELECT_PY = REPO_ROOT / "scripts" / "ci_select.py"  # [OPUS-4.8] sq-fmx4u.6
 OWNERSHIP_TOML = REPO_ROOT / "ci" / "path-ownership.toml"  # [OPUS-4.8] sq-fmx4u.6
+# [OPUS-4.8] path-aware CI audit: the merge_group changed-files gates.
+CONTAINER_SCAN_YML = REPO_ROOT / ".github" / "workflows" / "container-scan.yml"
+SUPPLY_CHAIN_YML = REPO_ROOT / ".github" / "workflows" / "supply-chain.yml"
 
 FAIL_CLOSED_DISJUNCT = "needs.select.outputs.mode != 'selected'"
 NEEDLE_RE = re.compile(
@@ -1149,6 +1152,174 @@ class TestDraftTierWiring(unittest.TestCase):
         self.assertIn("github.event.pull_request.number", str(conc.get("group", "")))
         self.assertTrue(conc.get("cancel-in-progress"),
                         "js.yml must cancel superseded PR runs")
+
+
+class TestContainerScanMergeGroupGate(unittest.TestCase):
+    """[OPUS-4.8] path-aware CI audit: container-scan.yml narrows its heavy trivy
+    image build+scan to container-relevant PRs via native `on.pull_request.paths`,
+    but GitHub IGNORES `paths` for the merge_group event, so a bare `merge_group:`
+    trigger rebuilt the full fat-LTO image + ran trivy on EVERY enqueue. The `trivy`
+    job now leads with a `detect container changes` step that diffs the queued batch
+    and skips the build+scan on a container-inert merge group (mirrors zk-toolchain's
+    proven detect pattern). Pins the SHAPE so the gate cannot silently rot or over-reach.
+
+    Invariants pinned:
+      * the trivy job still triggers on merge_group (check-run always appears → no gate hang);
+      * the detect step is FAIL-SAFE (default container=true; only merge_group can flip false);
+      * the heavy build/scan steps are STEP-gated on the detect output (not a job `if:`,
+        so the check-run name is preserved and reports success on the skip path);
+      * the merge_group path set MATCHES the pull_request paths filter (no drift)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = _load(CONTAINER_SCAN_YML)
+        cls.trivy = cls.wf["jobs"]["trivy"]
+        cls.steps = cls.trivy["steps"]
+
+    def _step(self, name_prefix: str) -> dict:
+        for step in self.steps:
+            if str(step.get("name", "")).startswith(name_prefix):
+                return step
+        self.fail(f"container-scan trivy job missing a step named {name_prefix!r}")
+
+    def test_triggers_on_merge_group(self):
+        on = _on_block(self.wf)
+        self.assertIn("merge_group", on,
+                      "container-scan must trigger on merge_group so its check-run appears "
+                      "on the queue ref (ci-summary is the single required gate)")
+
+    def test_detect_step_present_and_fail_safe(self):
+        step = self._step("Detect container changes")
+        run = str(step.get("run", ""))
+        self.assertEqual(step.get("id"), "changes",
+                         "detect step must expose id=changes for the downstream if:s")
+        # Fail-safe default: container=true, and only a merge_group event can flip it false.
+        self.assertRegex(run, r"container=true",
+                         "detect step must default to the full scan (container=true)")
+        self.assertIn('"${EVENT_NAME}" = "merge_group"', run,
+                      "only the merge_group event may narrow the scan (fail-safe elsewhere)")
+        # Any diff error must fall back to the full scan.
+        self.assertIn("fail-safe", run.lower(),
+                      "detect step must document its fail-safe fallback")
+
+    def test_heavy_steps_gated_on_detect_output(self):
+        # The build + both trivy scans + the SARIF upload must all be STEP-gated on the
+        # detect output — never run on a container-inert merge group.
+        for prefix in ("Build image", "Trivy image scan (fail",
+                       "Trivy image scan (SARIF", "Upload Trivy SARIF"):
+            step = self._step(prefix)
+            cond = str(step.get("if", ""))
+            self.assertIn("steps.changes.outputs.container == 'true'", cond,
+                          f"the {prefix!r} step must be gated on the detect output")
+
+    def test_gate_is_step_not_job_level(self):
+        # A job-level `if:` would make the whole job skip and CHANGE the check-run
+        # conclusion accounting on the merge_group ref; the gate must be at STEP level so
+        # the `trivy (…)` check-run always appears and concludes SUCCESS on the skip path.
+        self.assertNotIn("container", str(self.trivy.get("if", "")),
+                         "the container gate must be a STEP guard, not a job-level if:")
+
+    def test_merge_group_path_set_matches_pr_paths_filter(self):
+        """The merge_group detect grep must cover the SAME path set as the
+        pull_request `paths:` filter — otherwise the two tiers would disagree about
+        what counts as container-relevant (drift = an unsound skip or a wasted run)."""
+        on = _on_block(self.wf)
+        pr_paths = set(on["pull_request"]["paths"])
+        run = str(self._step("Detect container changes").get("run", ""))
+        # Each PR path must be represented in the detect grep. Map the glob forms to the
+        # anchored regex fragments the detect step uses.
+        expected_fragments = {
+            "Dockerfile": "Dockerfile$",
+            ".dockerignore": r"\.dockerignore$",
+            ".trivyignore": r"\.trivyignore$",
+            ".hadolint.yaml": r"\.hadolint\.yaml$",
+            ".github/workflows/container-scan.yml": r"container-scan\.yml$",
+            "Cargo.toml": r"Cargo\.toml$",
+            "Cargo.lock": r"Cargo\.lock$",
+            "crates/**/Cargo.toml": r"crates/[^/]+/Cargo\.toml$",
+        }
+        for pr_path in pr_paths:
+            self.assertIn(pr_path, expected_fragments,
+                          f"PR path {pr_path!r} has no mapped detect-grep fragment — "
+                          "update the merge_group detect grep to match (no drift)")
+            self.assertIn(expected_fragments[pr_path], run,
+                          f"the merge_group detect grep must cover PR path {pr_path!r}")
+
+
+class TestSupplyChainMergeGroupGate(unittest.TestCase):
+    """[OPUS-4.8] path-aware CI audit: supply-chain.yml gates its cargo-deny/vet
+    step-groups on rust_changed, which was FORCED true on merge_group (paths don't
+    apply there) — so the full deny+vet ran on every enqueue. The `Decide rust_changed`
+    step now diffs the queued batch's base_sha..head_sha against the SAME `rust` path
+    set the pull_request dorny filter uses; a rust-inert merge group skips the heavy
+    deny+vet steps (SBOM stays always-on by the sq-6vshe.20 design). Pins the SHAPE.
+
+    Invariants pinned:
+      * still triggers on merge_group (check-run appears → no gate hang);
+      * the merge_group branch is FAIL-SAFE (rust=true on any diff error);
+      * every path in the pull_request dorny `rust` filter is covered by the
+        merge_group detect grep (no drift between the two tiers);
+      * the deny/vet gating steps remain rust_changed-gated (unchanged)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = _load(SUPPLY_CHAIN_YML)
+        cls.job = cls.wf["jobs"]["supply-chain-gates"]
+        cls.steps = cls.job["steps"]
+
+    def _decide_run(self) -> str:
+        for step in self.steps:
+            if str(step.get("name", "")).startswith("Decide rust_changed"):
+                return str(step.get("run", ""))
+        self.fail("supply-chain missing the `Decide rust_changed` step")
+
+    def _dorny_rust_filter(self) -> list[str]:
+        for step in self.steps:
+            if str(step.get("uses", "")).startswith("dorny/paths-filter"):
+                filters = yaml.safe_load(step["with"]["filters"])
+                return list(filters["rust"])
+        self.fail("supply-chain missing the dorny rust paths-filter")
+
+    def test_triggers_on_merge_group(self):
+        self.assertIn("merge_group", _on_block(self.wf),
+                      "supply-chain must trigger on merge_group (required gate sibling)")
+
+    def test_merge_group_branch_is_fail_safe(self):
+        run = self._decide_run()
+        self.assertIn('"${EVENT_NAME}" = "merge_group"', run,
+                      "Decide step must special-case merge_group with a batch diff")
+        # Default rust=true inside the merge_group branch (fail-safe on any diff error).
+        self.assertIn("rust=true", run,
+                      "merge_group branch must default rust=true (fail-safe)")
+        self.assertIn("fail-safe", run.lower(),
+                      "merge_group branch must document + take its fail-safe fallback")
+
+    def test_merge_group_grep_covers_every_pr_rust_path(self):
+        run = self._decide_run()
+        # Map each dorny glob to the regex fragment the merge_group grep must contain.
+        glob_to_fragment = {
+            "**/*.rs": r"\.rs$",
+            "**/Cargo.toml": r"Cargo\.toml$",
+            "Cargo.lock": r"^Cargo\.lock$",
+            "rust-toolchain*": r"rust-toolchain",
+            "deny.toml": r"^deny\.toml$",
+            "supply-chain/**": r"^supply-chain/",
+            ".github/workflows/supply-chain.yml": r"supply-chain\.yml$",
+        }
+        for glob in self._dorny_rust_filter():
+            self.assertIn(glob, glob_to_fragment,
+                          f"dorny rust glob {glob!r} has no mapped merge_group grep fragment "
+                          "— update the Decide-step grep to match (no tier drift)")
+            self.assertIn(glob_to_fragment[glob], run,
+                          f"merge_group grep must cover the dorny rust glob {glob!r}")
+
+    def test_deny_and_vet_steps_remain_rust_gated(self):
+        gated = [str(s.get("name", "")) for s in self.steps
+                 if "rust_changed == 'true'" in str(s.get("if", ""))]
+        self.assertTrue(any("cargo-deny check (bans" in n for n in gated),
+                        "cargo-deny bans/sources/licenses must stay rust_changed-gated")
+        self.assertTrue(any("cargo-vet check" in n for n in gated),
+                        "cargo-vet must stay rust_changed-gated")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -314,6 +314,29 @@ class TestSelectionSemantics(unittest.TestCase):
         self.assertIn("2 skipped", out)
         self.assertIn("selection pre-job succeeded", out)
 
+    def test_orchestration_only_pr_gate_passes_with_codeql_and_engine_skipped(self):
+        # [OPUS-4.8] path-aware CI: the concrete orchestration-only PR (#3416 class —
+        # routing.toml + triage.py) sibling set. CodeQL is `skipped` (its new
+        # rust_changed guard), every engine lane + opt-in leg is `skipped` (empty
+        # affected closure), the cheap gates run green, and `select` concludes
+        # SUCCESS (mode=selected attributes the skips). The gate must render PASS —
+        # a fast green for an orchestration PR with the whole Rust matrix skipped.
+        runs = [
+            SEL_OK,
+            R("CodeQL analysis (rust)", conclusion="skipped"),
+            R("test (load-aware shard bulk 1/3)", conclusion="skipped"),
+            R("opt-in sparq-engine (paths)", conclusion="skipped"),
+            R("bench (deterministic ratchet)", conclusion="skipped"),
+            R("differential-smoke", conclusion="skipped"),
+            R("docs-quality quick-gates", conclusion="success"),
+        ]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out)
+        self.assertIn("selection pre-job succeeded", out)
+        # CodeQL's skip is attributed (select green), never a false RED.
+        self.assertNotIn("FAILED", out)
+
     def test_real_failure_still_fails_under_selection(self):
         # Invariant 2: selection must never mask a genuine failure.
         runs = [SEL_OK, RED, R("docs", conclusion="skipped")]

--- a/scripts/tests/test_feature_matrix_assemble.py
+++ b/scripts/tests/test_feature_matrix_assemble.py
@@ -190,7 +190,31 @@ class TestSelectionFiltering(unittest.TestCase):
     def test_selected_with_empty_affected_yields_zero_legs(self):
         # Legitimate: a provably-empty closure => no legs; the workflow's `legs`
         # count output then SKIPS the matrix job (never an empty-matrix error).
+        # [OPUS-4.8] This IS the orchestration-only / docs-only change-class outcome:
+        # ci_select.py returns mode=selected + affected=[] for a diff that touches no
+        # Rust (e.g. routing.toml + triage.py), so the whole opt-in feature matrix is
+        # correctly assembled to ZERO legs (skipped-by-class) without any missing
+        # required check — the gate discovers the reduced set by polling.
         self.assertEqual(self._filter("selected", "[]"), [])
+
+    def test_change_class_adds_no_legs_full_golden_set_preserved(self):
+        # [OPUS-4.8] The change-class layer is a SELECTION refinement (ci_select.py),
+        # not a fragment change: the assembler's FULL leg set (the gate-name golden
+        # contract) must be byte-identical to the committed golden snapshot. If the
+        # change-class work ever accidentally added/renamed a leg, this fails.
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        argv = sys.argv
+        try:
+            sys.argv = ["assemble", "--names"]
+            with redirect_stdout(buf):
+                self.mod.main()
+        finally:
+            sys.argv = argv
+        emitted = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+        golden = [ln for ln in GOLDEN.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        self.assertEqual(sorted(emitted), sorted(golden))
 
     def test_shadow_full_and_unset_modes_keep_all(self):
         for mode in ("shadow", "full", "", None, "SELECTED", "enforce"):


### PR DESCRIPTION
> 🤖 SPARQ agent — path-aware CI audit of EVERY `pull_request`/`merge_group` workflow, building on #3420.

## What this does

Audits **all 24** workflows in the inventory (not just the ones #3420 touched) and brings each into the path-aware scheme where sound. Closes the two remaining **ungoverned heavy-merge-queue legs** the maintainer flagged, plus assesses the merge-group change-class extension across every heavy lane.

**Stacked on #3420** (base = `feat/ci-change-class-orchestration`); this PR is the delta on top of it.

## Per-workflow verdict table

Legend: **(a)** already path-scoped (native `paths:` / internal guard); **(b)** governed by the #3420 select/change-class layer; **(c)** ungoverned heavy → wired here; **(d)** intentionally universal.

### pull_request + merge_group

| Workflow | Verdict | Detail |
|---|---|---|
| **ci** | (b) | Governed by `ci_select.py`/`ci-select.yml` select layer + orchestration-safe carve-out (#3420). Heavy legs skip on orchestration/docs-only. |
| **codeql** | (b) | #3420 added the `detect rust changes` dorny gate on `analyze`; forces `rust_changed=true` on merge_group/push/schedule (fail-closed). |
| **feature-matrix** | (b) | Select-governed; the `setup` assembler filters legs by the selection outputs. |
| **fuzz** | (b) | Select-governed via `_LANE_SEEDS["fuzz"]`/`differential-smoke`; skips on unaffected closure. |
| **formal-verification** | (a/b) | Fully change-coupled by its OWN `fv_select.py` — heavy Kani job `if:`-skips (empty matrix) on unrelated PRs AND diffs the merge_group union. Sound, no action. |
| **supply-chain** | **(c) → WIRED** | deny/vet gated on `rust_changed` but merge_group forced it true → full deny+vet every enqueue. Now diffs the batch against the PR `rust` path set; rust-inert batch skips deny+vet. SBOM stays always-on (sq-6vshe.20). |
| **container-scan** | **(c) → WIRED** | Native PR `paths:`, but merge_group ignores paths → full fat-LTO image build+scan every enqueue. Added a fail-safe `detect container changes` merge_group gate (mirrors zk-toolchain); build+scan skip on container-inert batch. |
| **vectorized-feature-off** | (a) + **follow-up** | PR path skip via internal `dorny`+`ci_select.py` `rust_changed`. The heavy `artifact-exact-equality` (wasm feature-OFF byte-identity) leg is **deliberately left full-on-merge_group** — it is the merged-tree wasm-feature-OFF invariant guard (bench.yml was removed from merge_group precisely because this leg covers it); the cfg-gated feature-OFF wasm-drift class only surfaces on the merged bundle, so narrowing it would be **unsound**. Documented follow-up scope. |
| **zk-toolchain** | (a) | Native PR/push `paths:` (narrowed to `zk/compose/**` per #1599) + a `detect zk changes` merge_group diff already skips the ~60min forge suite on zk-inert batches. Exemplary; my new gates copy its pattern. |
| **docs-quality** | (d) | Cheap prose/markdown gate; must surface siblings on merge_group. Universal, negligible cost. |
| **flow-on-gates** | (d) | Cheap python quick-gates (G1/G2/G6) reading the diff + PR labels; not Rust work. Universal. |
| **ci-summary** | (d) | The gate AGGREGATOR itself — must run on every PR/merge_group/push (the single required context). Universal by definition. |

### pull_request only

| Workflow | Verdict | Detail |
|---|---|---|
| **bead-autoclose** | (d) | `types: [closed]` only; regenerates the bead DB on PR close. Universal, correct. |
| **flow-on** | (d) | `types: [closed]`; reactive flow-on engine. Universal. |
| **pr-title** | (d) | Title validator (opened/edited/reopened/synchronize); cheap, must run on all PRs. Universal. |
| **bench** | (b) | Select-governed via `_LANE_SEEDS["bench"]`; PR runs deterministic-only ratchet; merge_group trigger already REMOVED (sq-6vshe.6). |
| **deploy-lint** | (a) | Native `paths: [deploy/**, workflow]`. Correct. |
| **deploy-terraform-lint** | (a) | Native `paths: [deploy/terraform/**]`. Correct. |
| **docs** | (a) | Native `paths:` incl. every embedded source (quickstart.rs, README.md, SKILL.md anchors, the mdbook link-fixup preprocessor) — self-guarding, no blind spot. Correct. |
| **gui** | (a) | Native `paths: [gui/**, packages/sparq-client/**, site/**, js/**, package-lock.json, workflow]` — lists every input the build reads (the #1081 blind-spot fix). Correct. |
| **js** | (a) | Native `paths:` incl. js/**, packages/**, every `sparq-*-wasm` crate, package.json/lock, workflow. A pure-engine/docs PR matches none. Correct. |
| **python** | (a) | Native `paths:` incl. sparq-py/**, sparq-arrow/**, root Cargo.toml/lock, the hash-pinned requirement sets, workflow. Correct. |
| **site-e2e-foundation** | (a) | Native `paths: [site/**, package.json, package-lock.json, workflow]`. Correct — the root lockfile IS listed (workspace-member resolution). |
| **site-e2e-hero** | (a) | Same site path set. Correct. |
| **site-e2e** | (a) | Same set + a self-guarding comment (root workspace lock resolution, #1081 class). Correct. |
| **site-visual** | (a) | Same site path set. Correct. |

## What I wired

- **container-scan.yml** — `trivy` job leads with a fail-safe `detect container changes` step diffing the merge_group `base_sha..head_sha` against the SAME path set as the PR filter (Dockerfile / .dockerignore / .trivyignore / .hadolint.yaml / workflow / Cargo.toml / Cargo.lock / `crates/*/Cargo.toml`). Build + both trivy scans + SARIF upload gated `if: steps.changes.outputs.container == 'true'`. Job still runs → check-run always appears (fast green on skip) → gate never hangs.
- **supply-chain.yml** — `Decide rust_changed` now handles merge_group by diffing the batch against the PR dorny `rust` set; rust-inert batch → `rust_changed=false` → cargo-deny + cargo-vet step-groups skip. Cargo-tool install kept unconditional because the SBOM self-tests + `Generate SBOM` run `cargo cyclonedx` unconditionally (sq-6vshe.20 always-on cadence); gating install would break them.
- **test_ci_select_wiring.py** — added `TestContainerScanMergeGroupGate` (5) + `TestSupplyChainMergeGroupGate` (4): pin merge_group trigger present, fail-safe default, STEP-not-job gating, and — critically — that the merge_group grep covers **every** path in the PR filter (no tier drift).

## What I deferred (with reasons)

- **vectorized-feature-off `artifact-exact-equality`** — deliberately NOT narrowed on merge_group. It is the merged-tree wasm feature-OFF byte-identity invariant guard; the fully-cfg-gated feature-OFF wasm-drift class (`line!()`/`Location`/inlining drift) passes on the PR branch and only fails on the merged bundle, so it MUST run on any rust change in the merge group. Narrowing it would reintroduce that exact unsound skip.
- **formal-verification / codeql** — already handle merge_group soundly (fv_select diffs the union; codeql forces full on merge). No change needed.

## Merge_group extension status

Extended the change-class to the **merge-group diff** for the two lanes where the required-context/attributed-skip mechanics allow it (container-scan, supply-chain). For lanes where they don't (vectorized-feature-off's merged-tree invariant), the full-on-merge posture is retained by design and documented above.

## Gates

- YAML valid on both touched workflows; **actionlint clean** on both.
- **Gate aggregator intact**: every touched job still surfaces its check-run on both PR and merge_group refs (STEP-level skips, not job-level), so no required context becomes "expected but missing". The single required `ci-summary / gate` is unaffected. My legs are **not new gating legs** — they're skip-refinements of existing ones.
- SHA-pins preserved (no action pins touched). No #2546 trigger-guard regression (label events untouched).
- New tests + the four #3420-adjacent suites all green: `test_ci_select_wiring` (59 tests), `test_ci_select`, `test_ci_summary_gate`, `test_feature_matrix_assemble`.
- Locally reproduced both merge_group grep classifiers: container-relevant / rust-relevant paths MATCH; engine-source / docs / orchestration paths correctly don't (so those batches fast-skip). The full `git fetch`/`git diff` sequence is documented-untested against a live merge_group ref — validate on first CI run (fail-safe defaults to full run on any resolution error).

## Compliance level (honest)

No compliance-posture change — this is a merge-queue throughput refinement. Trivy container scanning and cargo-deny/vet supply-chain gating still run in **full** on every PR that touches the relevant surface, on push-to-main, on the weekly re-scan, and (fail-safe) on any merge_group with an unresolvable diff — so the SBOM/SLSA/container-CVE evidence cadence is preserved; only provably-inert merge-group re-runs are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
