### PR TITLE
feat(routing): frontier-tier floor for CI/infrastructure authorship (fable/sol)

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -84,9 +84,24 @@ role = "site"
 model_chain = ["terra", "fable", "sonnet"]
 agent = "sparq-site"
 
+# [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
+# 2026-07-17; same standing-rule pattern as the UI→codex route above, PR #3416): ALL CI/
+# infrastructure work — .github/workflows, gate aggregators, orchestration/ + dispatch scripts,
+# the self-draining pipeline itself — is authored by a FRONTIER-tier model only: fable (Claude
+# Fable) or terra (GPT-5.6 sol / codex). Cheaper tiers (sonnet/haiku) no longer author infra;
+# cross-provider review is unchanged (whichever provider's frontier writes, the other reviews).
+# The chain is deliberately FRONTIER-ONLY rather than floor-pinned: the routing schema has no
+# floor/pin marker (the fix-floor pin lives in the registry's review loop, not here), and
+# chain-exhaustion at the registry's claim step already DEFERS the item (no eligible account →
+# no claim → retried next tick) instead of degrading below the chain. NOT `escalate = true`:
+# that flips a starved item to needs:user (human); this rule wants defer+retry.
+# scripts/triage.py derives role:ci for infra-surface labels (area:ci/area:ci-fragments/
+# area:orchestration/area:workflows/area:release) so surface-labelled infra work lands here.
+# Security overlap: the match_labels overrides above still WIN over this route (opus + human
+# escalation) — where role:ci and a security surface overlap, the security lane is correct.
 [[route]]
 role = "ci"
-model_chain = ["fable", "sonnet", "terra"]   # cross-provider fallback (was Anthropic-only)
+model_chain = ["fable", "terra"]
 agent = "sparq-ci-infra"
 
 [[route]]

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -173,6 +173,16 @@ def _self_test():
     chk("docs -> haiku", row["model_chain"][0], "haiku")
     chk("docs -> sparq-docs", row["agent"], "sparq-docs")
 
+    # --- Fixture: a ci/infra issue → frontier-only chain (standing rule 2026-07-17) --------------
+    # No sub-frontier model (sonnet/haiku) in the plan row's chain: the registry claim step can
+    # only serve a frontier account or DEFER the item to the next tick — degradation to a cheaper
+    # authoring tier is impossible by construction (see routing-validate's frontier-floor check).
+    ci = compute_ready([iss(8, R + ["priority:P1", "role:ci", "area:ci"])])
+    row = plan_dispatch(ci, doc)[0]
+    chk("ci -> frontier-only row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
+        ("ci", ["fable", "terra"], "sparq-ci-infra", False))
+    chk("ci row has no sub-frontier tier", sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
+
     # --- Fixture: package-conflict pair → only the higher-priority one is planned ----------------
     pair = compute_ready([
         iss(4, R + ["priority:P2", "role:impl", "area:sparq-engine"]),   # lower priority

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -57,6 +57,12 @@ def _self_test():
     chk("docs -> haiku", resolve(["role:docs", "area:x"], doc)[0][0], "haiku")
     # [FABLE-5] UI ownership: site -> terra-led (GPT-5.6 codex, the original dashboard builder)
     chk("site -> terra-led", resolve(["role:site", "area:site"], doc)[0], ["terra", "fable", "sonnet"])
+    # [FABLE-5] frontier-tier infra authorship (standing rule 2026-07-17): ci -> fable-first,
+    # FRONTIER-ONLY chain — no sub-frontier model (sonnet/haiku) anywhere in it, so exhaustion
+    # DEFERS at the registry claim step (retried next tick) instead of degrading tier.
+    mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
+    chk("ci -> frontier-only fable-first", (mc, ag, esc), (["fable", "terra"], "sparq-ci-infra", False))
+    chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
     # no role -> defaults (fable-led)
     chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "fable")
     # review role -> opus + escalate

--- a/scripts/routing-validate.py
+++ b/scripts/routing-validate.py
@@ -14,6 +14,10 @@ except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
 CATALOG_REQUIRED = ("provider", "harness", "provider_model", "credential_format")
+# [FABLE-5] STANDING RULE (maintainer 2026-07-17): CI/infrastructure work is authored by a
+# FRONTIER-tier model only (fable / terra). Validation enforces the floor structurally: a role:ci
+# chain containing a sub-frontier tier fails CI, so exhaustion can only ever DEFER, never degrade.
+SUB_FRONTIER = ("sonnet", "haiku")
 
 
 def validate(doc):
@@ -44,6 +48,12 @@ def validate(doc):
         if not r.get("agent"):
             errs.append(f"{where}: missing agent")
         check_chain(where, r.get("model_chain", []))
+        # [FABLE-5] frontier-tier floor for CI/infrastructure authorship (standing rule 2026-07-17)
+        if r.get("role") == "ci":
+            for m in r.get("model_chain", []):
+                if m in SUB_FRONTIER:
+                    errs.append(f"{where}: role:ci chain contains sub-frontier model '{m}' "
+                                "(frontier-tier infra-authorship rule: fable/terra only)")
     return errs
 
 
@@ -52,14 +62,22 @@ def _self_test():
         "models": {"fable": {"provider": "a", "harness": "claude", "provider_model": "x",
                              "credential_format": "y"}},
         "defaults": {"model_chain": ["fable"], "agent": "sparq-rust-impl"},
-        "route": [{"role": "impl", "model_chain": ["fable"], "agent": "sparq-rust-impl"}],
+        "route": [{"role": "impl", "model_chain": ["fable"], "agent": "sparq-rust-impl"},
+                  # a frontier-only ci chain is valid (frontier-tier infra-authorship rule)
+                  {"role": "ci", "model_chain": ["fable"], "agent": "sparq-ci-infra"}],
     }
     bad = {
-        "models": {"fable": {"provider": "a"}},  # missing fields
+        "models": {"fable": {"provider": "a"},  # missing fields
+                   "sonnet": {"provider": "a", "harness": "claude", "provider_model": "x",
+                              "credential_format": "y"}},
         "defaults": {"model_chain": ["ghost"], "agent": ""},  # unknown model + no agent
-        "route": [{"model_chain": [], "agent": "x"}],  # empty chain + no role/labels
+        "route": [{"model_chain": [], "agent": "x"},  # empty chain + no role/labels
+                  # sub-frontier model in a role:ci chain -> frontier-floor violation
+                  {"role": "ci", "model_chain": ["sonnet"], "agent": "sparq-ci-infra"}],
     }
-    ok = not validate(good) and len(validate(bad)) >= 4
+    bad_errs = validate(bad)
+    ok = (not validate(good) and len(bad_errs) >= 5
+          and any("sub-frontier" in e for e in bad_errs))
     print("good doc errors:", validate(good))
     print("bad doc errors :", validate(bad))
     print("routing-validate self-test", "PASSED" if ok else "FAILED")

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -33,6 +33,15 @@ SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
 # substrings: a substring set would false-match (e.g. "gui" in "guide") and UI keywords must NOT
 # enter routing match_labels, which the arm-side security classifier unions into its keyword set.
 UI_SURFACE_LABELS = ("area:site", "area:gui", "surface:frontend", "dashboard")
+# [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
+# 2026-07-17, same pattern as the UI→codex rule above / PR #3416): infra-surface labels derive
+# role:ci so infra work (.github/workflows, gate aggregators, orchestration/ + dispatch scripts)
+# reaches the FRONTIER-ONLY ci chain in orchestration/routing.toml (fable/terra — sonnet/haiku no
+# longer author infra). EXACT labels, not substrings ("ci" as a substring would match nearly every
+# label), and deliberately NOT routing match_labels (the arm-side security classifier unions those
+# keywords — infra keywords there would human-arm every infra PR). Security keywords still win.
+INFRA_SURFACE_LABELS = ("area:ci", "area:ci-fragments", "area:orchestration", "area:workflows",
+                        "area:release")
 _PRIO = re.compile(r"^priority:P([0-4])$")
 
 
@@ -57,6 +66,11 @@ def _role(labels, issue_type):
     # after kind (so kind:docs about the site stays docs) and after an explicit role:* label.
     if any(lb in UI_SURFACE_LABELS for lb in labels):
         return "site"
+    # [FABLE-5] infra-surface labels derive role:ci (the frontier-only fable/terra chain) before
+    # the generic type map — same precedence slot as the UI rule: after security (soundness wins),
+    # after an explicit role:*, after kind (so kind:docs about the CI stays docs).
+    if any(lb in INFRA_SURFACE_LABELS for lb in labels):
+        return "ci"
     return ROLE_BY_TYPE.get(issue_type)
 
 
@@ -141,6 +155,15 @@ def _self_test():
         triage(["priority:P2", "role:impl", "area:site"], "feature")["role"], "impl")
     chk("site docs stay docs", triage(["priority:P3", "kind:docs", "area:site"], "task")["role"], "docs")
     chk("ui+sec -> soundness", triage(["priority:P1", "area:site", "area:sparq-zk"], "feature")["role"], "soundness")
+    # [FABLE-5] frontier-tier infra authorship: an infra-surface label derives role:ci (the
+    # frontier-only fable/terra chain) even when the issue type would derive impl; kind (docs)
+    # and security keywords still win (soundness), matching the UI-rule precedence.
+    chk("infra surface -> ci", triage(["priority:P1", "area:ci"], "feature")["role"], "ci")
+    chk("orchestration surface -> ci",
+        triage(["priority:P2", "area:orchestration"], "task")["role"], "ci")
+    chk("infra docs stay docs", triage(["priority:P3", "kind:docs", "area:ci"], "task")["role"], "docs")
+    chk("infra+sec -> soundness",
+        triage(["priority:P1", "area:ci", "area:sparq-zk"], "feature")["role"], "soundness")
     # [FABLE-5] no-area guard: a complete priority+role issue with NO area:* is NOT promoted to ready
     # (it would reserve the serializing __global__ partition); it parks needs:area instead.
     r = triage(["priority:P1", "role:impl"], "feature")


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing a maintainer standing rule (2026-07-17).

## Standing rule: frontier-tier CI/infrastructure authorship

**Frontier-tier agents — Claude Fable (`fable`) or GPT-5.6 sol (openai; wired alias `terra`) — author ALL CI/infrastructure work**, explicitly including the self-draining pipeline infrastructure itself (dispatch, workers, gate aggregators, `.github/workflows`, orchestration scripts). Cheaper tiers (sonnet/haiku) no longer author infra. Cross-provider review is unchanged: whichever provider's frontier writes, the other reviews.

This follows the same standing-rule pattern as the UI→codex ownership rule (#3416): a role-route chain change + an exact-label triage surface derivation + self-tests, mirrored into the registry.

## Changes

- **`orchestration/routing.toml`** — `role = "ci"` chain `["fable", "sonnet", "terra"]` → `["fable", "terra"]`, with the standing-rule comment.
- **`scripts/triage.py`** — exact infra-surface labels (`area:ci`, `area:ci-fragments`, `area:orchestration`, `area:workflows`, `area:release`) derive `role:ci`, in the same precedence slot as the UI rule: after security keywords (soundness wins), after an explicit `role:*`, after `kind:` (docs about CI stay docs), before the generic type map. Exact labels, not substrings, and deliberately NOT routing `match_labels` (the arm-side security classifier unions those keywords — infra keywords there would human-arm every infra PR).
- **`scripts/routing-validate.py`** — structural frontier-floor check: a `role:ci` chain containing a sub-frontier model (`sonnet`/`haiku`) now fails validation.
- **Self-tests extended** (`route-resolve`, `triage`, `routing-validate`, `dispatch-plan`) — see evidence below.

## Defer vs degrade semantics (why the chain is frontier-only, with no floor marker)

The routing schema has **no floor/pin field** — routes are `{role|match_labels, model_chain, agent, escalate}`. The defer-not-fallback floor pin from the round-budget/decide_budget work (`pinned_fix_floor`) is a *registry review-loop* concept keyed off PR comments, not a routing.toml concept. So the rule is implemented as a **frontier-only chain**, which already yields exactly the required semantics:

- Chain exhaustion at the registry's claim step (`select-and-claim.choose_account` → no eligible account) means **no claim → the item defers with no mutation and is retried next tick** (a failed run leaves `status:deferred`, the deferred-retry trigger). It never degrades below the chain; `cross_provider_fallback = false` in `policy/repos.toml` keeps starved items queued + alerting rather than silently degrading.
- Deliberately **not** `escalate = true`: that contract flips a starved item to `needs:user` (human escalation, used for the opus-only soundness lanes). The rule wants defer+retry, not a human round-trip.
- The new `routing-validate` check makes the floor **structural**: degradation to sonnet/haiku for `role:ci` is impossible by construction, and reintroducing it fails validation.

## Security precedence — unchanged and correct

The `match_labels` security overrides are listed first and still win over every role route (first-match). Security surfaces already route opus (`escalate = true`, human on exhaustion). Where `role:ci` and a security surface overlap, **the security override wins** — that is correct and unchanged, covered by the new `infra+sec -> soundness` triage case.

## Registry ↔ target routing composition

`policy/repos.toml`'s per-repo `routing` pointer selects the **target repo's own `routing.toml` as the sole routing table consulted for that target** — the registry never overrides a target's routing at runtime (it supplies policy: account pool, caps, gate profile, arm). Standing rules propagate by **mirroring** into each target's routing table, which is what this PR does for sparq (registry-side mirror in jeswr/agent-account-registry).

## Self-test evidence (all run locally against the live table)

```
routing.toml OK
routing-validate self-test PASSED   (incl. "route[1]: role:ci chain contains sub-frontier model 'sonnet'" on the bad doc)
route-resolve self-test PASSED      (ci -> frontier-only fable-first: (['fable','terra'], 'sparq-ci-infra', False))
triage self-test PASSED             (infra surface -> ci; infra docs stay docs; infra+sec -> soundness)
dispatch-plan self-test PASSED      (ci -> frontier-only row; no sub-frontier tier in the plan row)
```

Note: only `triage.py --self-test` is wired into a workflow today (the retriage cron); the other self-tests have no CI wiring — pre-existing gap, filed separately as a self-improvement issue rather than growing this PR's scope.
