### PR TITLE
fix(solid-server): repair failing js test on main

### DIFF
--- a/packages/solid-server/test/server.test.mjs
+++ b/packages/solid-server/test/server.test.mjs
@@ -2,7 +2,9 @@
 import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import { spawn } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
@@ -74,6 +76,10 @@ test('startSolidServer boots a loopback listener', { timeout: 30_000 }, async ()
 });
 
 test('npx boots, keeps one pod, round-trips Turtle, and enforces WAC', { timeout: 60_000 }, async () => {
+  // Private npm cache: test files run concurrently, and this file and smoke.test.mjs
+  // both `npx --package <packageDir>` — the same npx cache key. Sharing ~/.npm/_npx
+  // makes the two npm installs race on the same symlink (EEXIST on cold CI caches).
+  const npmCache = await mkdtemp(join(tmpdir(), 'solid-server-npx-'));
   const child = spawn(
     'npx',
     [
@@ -92,6 +98,7 @@ test('npx boots, keeps one pod, round-trips Turtle, and enforces WAC', { timeout
       cwd: repoRoot,
       detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, npm_config_cache: npmCache },
     },
   );
 
@@ -138,5 +145,6 @@ test('npx boots, keeps one pod, round-trips Turtle, and enforces WAC', { timeout
     assert.equal(denied.status, 403);
   } finally {
     await stopChild(child);
+    await rm(npmCache, { recursive: true, force: true });
   }
 });

--- a/packages/solid-server/test/smoke.test.mjs
+++ b/packages/solid-server/test/smoke.test.mjs
@@ -19,7 +19,9 @@
 import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import { spawn } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
@@ -85,6 +87,9 @@ test(
     const ownerWebid = 'https://id.example/alice#me';
     const baseUrl = 'http://127.0.0.1';
 
+    // Private npm cache: this file and server.test.mjs run concurrently and share the
+    // npx cache key for <packageDir>; a shared ~/.npm/_npx races on the install symlink.
+    const npmCache = await mkdtemp(join(tmpdir(), 'solid-server-npx-'));
     const child = spawn(
       'npx',
       [
@@ -103,6 +108,7 @@ test(
         cwd: repoRoot,
         detached: process.platform !== 'win32',
         stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, npm_config_cache: npmCache },
       },
     );
 
@@ -231,6 +237,7 @@ _:p solid:inserts { <${base}/doc> dc:title "Smoke-doc" . } .
       );
     } finally {
       await stopChild(child);
+      await rm(npmCache, { recursive: true, force: true });
     }
   },
 );


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes the js CI failure on main (@jeswr/solid-server test suite). Authored headless on a delegated worker account (Fable); host re-ran the suite green before publish. Not armed — review pipeline next.

node --test runs test files concurrently, and both server.test.mjs and
smoke.test.mjs boot the server via `npx --yes --package <packageDir>` — the
identical package spec hashes to the same npx cache key. On a cold cache
(every CI runner; js.yml's setup-node configures no npm cache) the two npm
installs race to create the same symlink in ~/.npm/_npx/<hash>/node_modules/
@jeswr/solid-server, and the loser exits with EEXIST before printing the
readiness line, failing waitForStartup (js.yml run 29618574335; the next
main run passed on the same package tree, confirming a timing race, not a
deterministic break — no solid-server commit is at fault).

Fix the root cause instead of the symptom: give each spawned npx child its
own throwaway npm cache (mkdtemp + npm_config_cache, removed in finally),
so the two concurrent installs can never collide. The tests still exercise
the real npx boot path end to end; no assertion is weakened or skipped.