### PR TITLE
ci: merge-group change-class — slim engine lanes for docs/orchestration-only batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,16 @@ jobs:
             rust=true
             docker=true
             ok=true
-            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
-              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+            # --depth=2147483647 (git's INFINITE_DEPTH; --unshallow that is also
+            # valid on a complete repo): this job's checkout is depth-1, and the
+            # classifier's three-dot diff needs the merge-base — a shallow SHA
+            # fetch leaves both commits PRESENT (the cat-file guards pass) but
+            # unconnected, so `git diff base...head` dies with "no merge base"
+            # and the fail-safe would silently force class=engine on EVERY
+            # batch, reducing this whole gate to a no-op. Same rationale as
+            # ci-select.yml's fetch-depth: 0 checkout.
+            git fetch --no-tags --quiet --depth=2147483647 origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet --depth=2147483647 origin "${MG_BASE_SHA}" 2>/dev/null \
               || ok=false
             git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
             git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,14 +131,35 @@ jobs:
   #     (`conclusion != "success" and != "skipped" and != "neutral"` is the only thing it
   #     fails on), so the gate goes green fast. Fast doc/lint siblings (docs-quality, etc.)
   #     still run and still gate.
-  # SAFE-BY-DEFAULT: rust_changed is forced 'true' on EVERY event except `pull_request`.
-  # On `push` to main (the canonical build), `merge_group` (the merge queue re-runs the
-  # whole set), `schedule`, and `workflow_dispatch` the full matrix ALWAYS runs — only a
-  # PR diff that is purely non-Rust is ever allowed to skip. The Rust path set is broad on
+  # SAFE-BY-DEFAULT: rust_changed is forced 'true' on `push` to main (the canonical
+  # build), `schedule`, and `workflow_dispatch` — the full matrix ALWAYS runs there. On
+  # `pull_request` only a diff that is purely non-Rust skips. The Rust path set is broad on
   # purpose: any `*.rs`, any `Cargo.toml`, `Cargo.lock`, the `rust-toolchain*` pin, OR this
   # workflow file itself (so editing a Rust job here re-runs that job). If the diff cannot
   # be computed for any reason, the filter's absence of a match defaults to NOT skipping
-  # only because we hard-force 'true' off the PR path — i.e. we never silently skip Rust.
+  # only because we hard-force 'true' off the PR/merge_group path — we never silently skip.
+  #
+  # [FABLE-5] MERGE-GROUP CHANGE-CLASS GATE (path-aware CI; extends #3420/#3421 to this
+  # rust_changed layer). merge_group used to hard-force rust_changed=true, so even a
+  # docs-only/orchestration-only queued batch (the observed #2533 class) paid the
+  # rust_changed-only lanes (lint / msrv / geiger / docker-smoke / coverage-floors) on
+  # every enqueue — the select-conjunct lanes already skip via the batch-diff selection
+  # (ci-select.yml passes merge_group.base_sha/head_sha). The decide step below now
+  # resolves the SAME batch diff (the #3421 fetch pattern) and classifies it with
+  # `scripts/ci_select.py --classify-only` — the IDENTICAL `classify_change()` path the
+  # `select` pre-job runs on this event, so the two layers cannot disagree on a resolved
+  # diff (no duplicated path lists; ci_select.py stays the single source of truth).
+  # Class docs-only/orchestration-only => rust_changed=false + docker_changed=false
+  # (sound: every path in the dorny `rust`/`docker` filter sets classifies `engine`, so
+  # those classes PROVE both filters would be false — same trust model as the PR-level
+  # gate, a pure function of the authoritative diff). Any OTHER class, an unresolvable
+  # SHA pair, or ANY classifier error => true/true (fail-safe = full run, cost never
+  # soundness). Gate accounting: the skipped legs report `skipped` and the required
+  # ci-summary gate attributes them to the (green, same-diff) `select` pre-job —
+  # attributed skips, never missing legs (scripts/ci_summary_gate.py, sq-fmx4u.3).
+  # NOT gated by-class here: vectorized-feature-off.yml stays FULL on merge groups on
+  # purpose — the feature-OFF wasm byte-drift class only manifests on merged bundles
+  # (the documented #3421 unsound-skip exception).
   changes:
     name: detect rust changes
     # [FABLE-5] label-trigger guard (see the pull_request trigger note): a
@@ -162,9 +183,10 @@ jobs:
       docker_changed: ${{ steps.decide.outputs.docker_changed }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # Only run the path filter on pull_request; on every other event we force-run the
-      # full matrix (see decide step), so the filter's result is irrelevant there and we
-      # skip it to avoid the unreliable push/merge_group base-diff.
+      # Only run the path filter on pull_request: merge_group gets the batch-diff
+      # change-class gate in the decide step below (dorny's push/merge_group base-diff is
+      # unreliable; the merge_group event payload's base_sha/head_sha pair is not), and
+      # every other event force-runs the full matrix, so the filter is irrelevant there.
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: filter
         if: github.event_name == 'pull_request'
@@ -200,17 +222,49 @@ jobs:
               - '.github/workflows/ci.yml'
       - name: Decide rust_changed (safe-by-default off the PR path)
         id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            # push / merge_group / schedule / workflow_dispatch -> always run the full matrix.
-            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
-            echo "docker_changed=true" >> "$GITHUB_OUTPUT"
-            echo "event=${{ github.event_name }} -> forcing rust_changed=true + docker_changed=true (full matrix)"
-          else
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
             echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
             echo "docker_changed=${{ steps.filter.outputs.docker }}" >> "$GITHUB_OUTPUT"
             echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }} docker=${{ steps.filter.outputs.docker }}"
+          elif [ "${EVENT_NAME}" = "merge_group" ]; then
+            # [FABLE-5] MERGE-GROUP CHANGE-CLASS GATE (see the job header note): diff the
+            # queued batch (base_sha...head_sha, the #3421 fetch pattern) and classify it
+            # via scripts/ci_select.py --classify-only — the same classify_change() the
+            # `select` pre-job runs on this event. docs-only/orchestration-only batch =>
+            # skip the rust_changed/docker_changed lanes; ANY other class, an unknown
+            # token, an unresolvable SHA pair, or a classifier error => full (fail-safe).
+            rust=true
+            docker=true
+            ok=true
+            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+              || ok=false
+            git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
+            git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false
+            if [ "${ok}" = "true" ]; then
+              cls="$(python3 scripts/ci_select.py --classify-only --event merge_group \
+                       --base "${MG_BASE_SHA}" --head "${MG_HEAD_SHA}")" || cls=engine
+              case "${cls}" in
+                docs-only|orchestration-only) rust=false; docker=false ;;
+                *) rust=true; docker=true ;;
+              esac
+            else
+              echo "::warning::could not resolve merge_group base/head SHAs for the batch diff — running the full matrix (fail-safe)."
+            fi
+            echo "rust_changed=${rust}" >> "$GITHUB_OUTPUT"
+            echo "docker_changed=${docker}" >> "$GITHUB_OUTPUT"
+            echo "merge_group -> change_class=${cls:-<unresolved>} rust_changed=${rust} docker_changed=${docker}"
+          else
+            # push / schedule / workflow_dispatch -> always run the full matrix.
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "docker_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${EVENT_NAME} -> forcing rust_changed=true + docker_changed=true (full matrix)"
           fi
 
   # [FABLE-5] sq-fmx4u.3: change-based test-selection pre-job (reusable — see the

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -138,8 +138,19 @@ jobs:
   # The opt-in feature matrix only compiles/tests Rust, so a doc-only PR can skip it while
   # the required ci-summary gate still resolves SUCCESS (the aggregator treats the skipped
   # leg's `skipped` conclusion as non-failing). SAFE-BY-DEFAULT: rust_changed is forced
-  # 'true' on every event except `pull_request`, so the canonical push/merge_group/manual
-  # runs ALWAYS compile the full feature matrix — only a purely non-Rust PR diff skips.
+  # 'true' on push/schedule/workflow_dispatch, so the canonical push/manual runs ALWAYS
+  # compile the full feature matrix — only a purely non-Rust PR diff skips.
+  # [FABLE-5] MERGE-GROUP CHANGE-CLASS GATE (extends #3420/#3421 to this layer; full
+  # doctrine: ci.yml's `changes` job header). merge_group used to hard-force
+  # rust_changed=true, so a docs-only/orchestration-only queued batch still paid this
+  # workflow's rust_changed-only jobs (setup / check-tier / fedclient-boundary) on every
+  # enqueue. The decide step now diffs the queued batch (base_sha...head_sha, the #3421
+  # fetch pattern) and classifies it with `scripts/ci_select.py --classify-only` — the
+  # SAME classify_change() the `select` pre-job runs on this event (no duplicated path
+  # lists). docs-only/orchestration-only => rust_changed=false; any other class, an
+  # unresolvable SHA pair, or any classifier error => true (fail-safe = full run). The
+  # skipped legs report `skipped` and the required ci-summary gate attributes them to
+  # the green same-diff `select` pre-job (attributed skips, never missing legs).
   changes:
     name: detect rust changes (feature-matrix)
     # [FABLE-5] label-trigger guard (see the pull_request trigger note): a
@@ -177,14 +188,43 @@ jobs:
               - 'scripts/assemble-feature-matrix.py'
       - name: Decide rust_changed (safe-by-default off the PR path)
         id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
-            echo "event=${{ github.event_name }} -> forcing rust_changed=true (full feature matrix)"
-          else
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
             echo "rust_changed=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
             echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
+          elif [ "${EVENT_NAME}" = "merge_group" ]; then
+            # [FABLE-5] MERGE-GROUP CHANGE-CLASS GATE (see the job header note): diff the
+            # queued batch (#3421 fetch pattern) and classify via scripts/ci_select.py
+            # --classify-only. docs-only/orchestration-only batch => skip; any other
+            # class, unknown token, unresolvable SHAs, or classifier error => full
+            # (fail-safe).
+            rust=true
+            ok=true
+            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+              || ok=false
+            git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
+            git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false
+            if [ "${ok}" = "true" ]; then
+              cls="$(python3 scripts/ci_select.py --classify-only --event merge_group \
+                       --base "${MG_BASE_SHA}" --head "${MG_HEAD_SHA}")" || cls=engine
+              case "${cls}" in
+                docs-only|orchestration-only) rust=false ;;
+                *) rust=true ;;
+              esac
+            else
+              echo "::warning::could not resolve merge_group base/head SHAs for the batch diff — running the full feature matrix (fail-safe)."
+            fi
+            echo "rust_changed=${rust}" >> "$GITHUB_OUTPUT"
+            echo "merge_group -> change_class=${cls:-<unresolved>} rust_changed=${rust}"
+          else
+            echo "rust_changed=true" >> "$GITHUB_OUTPUT"
+            echo "event=${EVENT_NAME} -> forcing rust_changed=true (full feature matrix)"
           fi
 
   # [FABLE-5] sq-fmx4u.3: change-based test-selection pre-job (reusable — doctrine

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -205,8 +205,13 @@ jobs:
             # (fail-safe).
             rust=true
             ok=true
-            git fetch --no-tags --quiet origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
-              || git fetch --no-tags --quiet origin "${MG_BASE_SHA}" 2>/dev/null \
+            # --depth=2147483647 (--unshallow, valid on complete repos too): the
+            # depth-1 checkout leaves the three-dot diff with no merge-base — a
+            # shallow SHA fetch passes the cat-file guards yet the diff dies, so
+            # the fail-safe would force class=engine on EVERY batch (silent
+            # no-op gate). Full rationale: ci.yml's decide step.
+            git fetch --no-tags --quiet --depth=2147483647 origin "${MG_BASE_SHA}" "${MG_HEAD_SHA}" 2>/dev/null \
+              || git fetch --no-tags --quiet --depth=2147483647 origin "${MG_BASE_SHA}" 2>/dev/null \
               || ok=false
             git cat-file -e "${MG_BASE_SHA}^{commit}" 2>/dev/null || ok=false
             git cat-file -e "${MG_HEAD_SHA}^{commit}" 2>/dev/null || ok=false

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -84,6 +84,13 @@ on:
   # never appears there. The budget step below maps merge_group to the fast SMOKE
   # budget (same as pull_request) — a pre-merge gate wants quick coverage, not the
   # nightly soak. github.ref in the concurrency group is the unique merge_group ref.
+  # [FABLE-5] MERGE-GROUP CHANGE-CLASS (path-aware CI audit): this workflow needs NO
+  # extra rust_changed-style layer — both heavy jobs below are already gated on the
+  # `select` pre-job's seed closures, and ci-select.yml passes the merge_group event's
+  # base_sha/head_sha, so the selection IS the batch diff. A docs-only/orchestration-
+  # only queued batch classifies to an empty affected closure (classify_change +
+  # SAFE/orch-safe paths in scripts/ci_select.py) and both jobs skip as ATTRIBUTED
+  # skips (select green); an engine/mixed/unresolvable batch runs them (fail-closed).
   merge_group:
   workflow_dispatch:
   # Daily heavy tier. 04:23 UTC (offset from ci.yml's 03:17 coverage cron so the two

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -806,6 +806,61 @@ def _write_outputs(sel: Selection, output_file: str | None, summary_file: str | 
             fh.write(render_summary(sel))
 
 
+# --- classify-only mode (merge-group change-class gating; #3420/#3421 follow-up)
+def _classify_only_main(args: argparse.Namespace, output_file: str | None,
+                        summary_file: str | None) -> int:
+    """[FABLE-5] merge-group change-class: compute ONLY `classify_change` over the
+    diff — no cargo metadata, no toolchain, no ownership map — so the cheap
+    workflow `changes` pre-jobs (ci.yml / feature-matrix.yml) can class-gate their
+    `rust_changed` output on the MERGE-GROUP batch diff without duplicating the
+    orchestration-safe / docs-only path lists (this file stays the single source
+    of truth). Contract with the workflow step:
+
+      * stdout is EXACTLY ONE line: the class token
+        (engine|orchestration-only|docs-only|mixed) — the shell consumer `case`s
+        on it and treats ANY unrecognised value as engine (run everything);
+      * `change_class=<class>` is appended to --output-file/$GITHUB_OUTPUT and a
+        one-line attribution to the step summary (audit trail, never gating);
+      * FAIL-SAFE (design §4.3, the #3421 posture): --full, any event other than
+        pull_request/merge_group, a missing base, an unresolvable diff, or ANY
+        internal error => class `engine`, exit 0 — the consumer then runs the
+        full matrix (cost, never soundness).
+    """
+    change_class = _CLASS_ENGINE
+    reason = ""
+    try:
+        if args.full:
+            reason = "forced full run (ci-full override) => class engine"
+        elif args.event not in ("pull_request", "merge_group"):
+            reason = f"{args.event} event: no PR/batch diff => class engine"
+        else:
+            if args.changed_file:
+                with open(args.changed_file, encoding="utf-8") as fh:
+                    changed = [ln for ln in fh.read().splitlines() if ln.strip()]
+            else:
+                if not args.base:
+                    raise SelectorError("--base is required for a diff-based classify")
+                repo_root = _resolve_repo_root(args.repo_root)
+                changed = git_changed_paths(args.base, args.head, repo_root)
+            change_class = classify_change(changed)
+            reason = f"classified {len(changed)} changed path(s)"
+    except Exception as exc:  # fail-safe boundary: ANY error => engine (full run)
+        change_class = _CLASS_ENGINE
+        reason = f"classifier error, failing safe to class engine (full run): {exc}"
+
+    print(change_class)
+    try:
+        if output_file:
+            with open(output_file, "a", encoding="utf-8") as fh:
+                fh.write(f"change_class={change_class}\n")
+        if summary_file:
+            with open(summary_file, "a", encoding="utf-8") as fh:
+                fh.write(f"**Change-class (classify-only):** `{change_class}` — {reason}\n")
+    except OSError:
+        pass  # never let an output/summary write break the fail-safe contract
+    return 0
+
+
 # --- main --------------------------------------------------------------------
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Change-based CI test-selection (design §3).")
@@ -815,6 +870,10 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p.add_argument("--shadow", action="store_true",
                    help="report-only rollout mode (design §6.4): compute + report the "
                         "selection but emit mode=shadow so no downstream guard skips")
+    p.add_argument("--classify-only", action="store_true",
+                   help="emit ONLY the change-class token (no cargo metadata / selection): "
+                        "the cheap merge-group class gate for the workflow `changes` "
+                        "pre-jobs; fail-safe to `engine` on any error")
     p.add_argument("--base", help="base SHA/ref for the three-dot diff")
     p.add_argument("--head", default="HEAD", help="head SHA/ref (default HEAD)")
     p.add_argument("--changed-file", help="hermetic: newline-delimited changed paths")
@@ -839,6 +898,11 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     summary_file = args.summary_file or os.environ.get("GITHUB_STEP_SUMMARY")
     output_file = args.output_file or os.environ.get("GITHUB_OUTPUT")
+
+    # [FABLE-5] merge-group change-class gating: the cheap classify-only entry
+    # point (no cargo metadata). Everything below is the full selector.
+    if args.classify_only:
+        return _classify_only_main(args, output_file, summary_file)
 
     try:
         repo_root = _resolve_repo_root(args.repo_root)

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -606,6 +606,121 @@ class ChangeClassTests(unittest.TestCase):
         self.assertEqual(good.affected, ["app"])
 
 
+# [FABLE-5] ---- classify-only mode (merge-group change-class gate; #3420/#3421 follow-up)
+class ClassifyOnlyMainTests(unittest.TestCase):
+    """The `--classify-only` CLI contract the ci.yml / feature-matrix.yml `changes`
+    pre-jobs consume on merge_group: stdout is EXACTLY one class token, the
+    `change_class=` output line is written, NO cargo metadata is ever needed, and
+    EVERY error path fails safe to `engine` (=> the consumer runs the full matrix)
+    with exit 0."""
+
+    def _run_main(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cs.main(argv)
+        return code, buf.getvalue()
+
+    def _write(self, text, suffix=".txt"):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        return path
+
+    def test_docs_only_batch_classifies_docs_only(self):
+        # The #2533-shaped merge-group batch: pure docs/research prose. MUTATION
+        # VISIBILITY (brief): breaking classify_change back to always-`engine`
+        # makes THIS assertion fail — the class-gated merge-group skip cannot
+        # silently regress to always-full without a red test.
+        changed = self._write("docs/branch-protection.md\nresearch/design-record.md\n")
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--changed-file", changed])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "docs-only")
+
+    def test_orchestration_only_batch_classifies_orchestration_only(self):
+        changed = self._write("orchestration/routing.toml\nscripts/triage.py\n")
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--changed-file", changed])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "orchestration-only")
+
+    def test_engine_batch_classifies_engine(self):
+        changed = self._write("crates/app/src/lib.rs\n")
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--changed-file", changed])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "engine")
+
+    def test_mixed_batch_classifies_mixed(self):
+        # A mixed batch is NOT a skip class in the workflow case-arm => full run.
+        changed = self._write("docs/x.md\ncrates/app/src/lib.rs\n")
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--changed-file", changed])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "mixed")
+
+    def test_stdout_is_exactly_one_token_line(self):
+        # The shell consumer does `cls="$(...)"` and `case`s on the WHOLE value:
+        # any extra stdout line would fall into the wildcard arm (safe, but the
+        # single-line contract is what makes the gate legible) — pin it.
+        changed = self._write("docs/x.md\n")
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--changed-file", changed])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.splitlines(), ["docs-only"])
+
+    def test_output_and_summary_files_carry_the_class(self):
+        changed = self._write("docs/x.md\n")
+        out_file = self._write("")
+        summary = self._write("")
+        code, _ = self._run_main(["--classify-only", "--event", "merge_group",
+                                  "--changed-file", changed,
+                                  "--output-file", out_file, "--summary-file", summary])
+        self.assertEqual(code, 0)
+        self.assertIn("change_class=docs-only", Path(out_file).read_text(encoding="utf-8"))
+        self.assertIn("docs-only", Path(summary).read_text(encoding="utf-8"))
+
+    def test_no_cargo_metadata_needed_even_when_metadata_is_broken(self):
+        # classify-only must never touch cargo metadata: a bogus --metadata-file
+        # is simply ignored (the whole point — the changes pre-job has no
+        # toolchain and pays no metadata cost).
+        changed = self._write("docs/x.md\n")
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--changed-file", changed,
+                                    "--metadata-file", "/no/such/meta.json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "docs-only")
+
+    def test_unresolvable_diff_fails_safe_to_engine(self):
+        # Garbage SHAs => git diff fails => class engine (full run), exit 0 —
+        # the #3421 fail-safe posture (cost, never soundness).
+        code, out = self._run_main(["--classify-only", "--event", "merge_group",
+                                    "--base", "deadbeefdeadbeef",
+                                    "--head", "cafebabecafebabe"])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "engine")
+
+    def test_missing_base_fails_safe_to_engine(self):
+        code, out = self._run_main(["--classify-only", "--event", "merge_group"])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "engine")
+
+    def test_non_diff_event_is_engine(self):
+        # schedule/push/workflow_dispatch carry no batch diff => engine (full).
+        for event in ("schedule", "push", "workflow_dispatch"):
+            code, out = self._run_main(["--classify-only", "--event", event])
+            self.assertEqual(code, 0)
+            self.assertEqual(out.strip(), "engine", f"event {event}")
+
+    def test_full_override_is_engine(self):
+        changed = self._write("docs/x.md\n")
+        code, out = self._run_main(["--classify-only", "--full", "--event", "merge_group",
+                                    "--changed-file", changed])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.strip(), "engine")
+
+
 class OrchestrationSafeInertnessTests(unittest.TestCase):
     """[OPUS-4.8] THE INERTNESS OBLIGATION: every _ORCHESTRATION_SAFE entry must be
     PROVEN not read by any Rust-CI workflow. This greps the real Rust-CI workflow

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -1322,5 +1322,114 @@ class TestSupplyChainMergeGroupGate(unittest.TestCase):
                         "cargo-vet must stay rust_changed-gated")
 
 
+class TestMergeGroupChangeClassGate(unittest.TestCase):
+    """[FABLE-5] merge-group change-class gate (extends #3420/#3421 to the
+    rust_changed layer): the ci.yml + feature-matrix.yml `changes` decide steps
+    classify the queued batch's diff via `scripts/ci_select.py --classify-only`
+    instead of hard-forcing rust_changed=true on merge_group, so a docs-only/
+    orchestration-only batch skips the rust_changed-only lanes (lint / msrv /
+    geiger / docker-smoke / coverage-floors; feature-matrix setup / check-tier /
+    fedclient-boundary) with ATTRIBUTED skips. Pins the SHAPE:
+      * the merge_group branch exists and is FAIL-SAFE (defaults true, the #3421
+        fetch guard, `|| cls=engine` on the classifier invocation);
+      * classification is DELEGATED to scripts/ci_select.py (single source of
+        truth) — no duplicated grep path list in the step;
+      * the skip-class set is EXACTLY {docs-only, orchestration-only}, spelled
+        with the classifier module's own tokens (engine/mixed/unknown => full);
+      * ci.yml's docker_changed is class-gated the same way;
+      * fuzz.yml needs no such layer (its heavy jobs are select-gated and
+        ci-select passes the merge_group SHA pair) and bench.yml has no
+        merge_group trigger at all (pinned elsewhere) — this layer must NOT
+        creep into them as a redundant/conflicting second gate."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ci = _load(CI_YML)
+        cls.fm = _load(FM_YML)
+        cls.fuzz = _load(FUZZ_YML)
+        cls.select_mod = _ci_select_module()
+
+    def _decide(self, wf, wf_name):
+        for step in wf["jobs"]["changes"]["steps"]:
+            if str(step.get("name", "")).startswith("Decide rust_changed"):
+                return step
+        self.fail(f"{wf_name} missing the `Decide rust_changed` step")
+
+    def _both(self):
+        return (("ci.yml", self._decide(self.ci, "ci.yml")),
+                ("feature-matrix.yml", self._decide(self.fm, "feature-matrix.yml")))
+
+    def test_merge_group_branch_present_and_fail_safe(self):
+        for wf_name, step in self._both():
+            run = str(step.get("run", ""))
+            self.assertIn('"${EVENT_NAME}" = "merge_group"', run,
+                          f"{wf_name}: decide step must special-case merge_group")
+            self.assertIn("rust=true", run,
+                          f"{wf_name}: merge_group branch must default rust=true (fail-safe)")
+            self.assertIn("|| cls=engine", run,
+                          f"{wf_name}: a classifier invocation failure must fall back to "
+                          "cls=engine (fail-safe => full run)")
+            self.assertIn("git cat-file -e", run,
+                          f"{wf_name}: the #3421 SHA-resolution guard must precede the diff")
+            self.assertIn("fail-safe", run.lower(),
+                          f"{wf_name}: the fail-safe fallback must be documented + taken")
+            # The event payload SHA pair must feed the step (the authoritative diff).
+            env = step.get("env", {}) or {}
+            self.assertEqual(str(env.get("MG_BASE_SHA", "")),
+                             "${{ github.event.merge_group.base_sha }}", wf_name)
+            self.assertEqual(str(env.get("MG_HEAD_SHA", "")),
+                             "${{ github.event.merge_group.head_sha }}", wf_name)
+
+    def test_classification_is_delegated_not_duplicated(self):
+        for wf_name, step in self._both():
+            run = str(step.get("run", ""))
+            self.assertIn("scripts/ci_select.py --classify-only", run,
+                          f"{wf_name}: the merge_group branch must invoke the classifier "
+                          "(scripts/ci_select.py --classify-only), the single source of truth")
+            self.assertNotIn("grep -Eq", run,
+                             f"{wf_name}: the merge_group branch must NOT re-encode the "
+                             "class path sets as a grep — no duplicated path lists")
+
+    def test_skip_class_set_is_exactly_docs_and_orchestration(self):
+        # The case-arm must skip on EXACTLY the two proven-inert classes, spelled
+        # with the classifier module's own tokens; the wildcard arm must force the
+        # full run (engine/mixed/any unknown token => rust=true).
+        docs = self.select_mod._CLASS_DOCS
+        orch = self.select_mod._CLASS_ORCHESTRATION
+        self.assertEqual((docs, orch), ("docs-only", "orchestration-only"),
+                         "classifier tokens drifted — update the workflow case-arms in "
+                         "lock-step (they match on these literal strings)")
+        for wf_name, step in self._both():
+            run = str(step.get("run", ""))
+            self.assertIn(f"{docs}|{orch}) rust=false", run,
+                          f"{wf_name}: the skip case-arm must cover exactly {docs}|{orch}")
+            self.assertIn("*) rust=true", run,
+                          f"{wf_name}: the wildcard arm must force the full run")
+            self.assertNotIn("mixed) rust=false", run, wf_name)
+            self.assertNotIn("engine) rust=false", run, wf_name)
+
+    def test_ci_docker_changed_is_class_gated_with_rust(self):
+        run = str(self._decide(self.ci, "ci.yml").get("run", ""))
+        self.assertIn("rust=false; docker=false", run,
+                      "ci.yml: docker_changed must be class-gated alongside rust_changed "
+                      "(every docker-filter path classifies engine, so the skip is sound)")
+
+    def test_classify_only_flag_exists_and_fails_safe_in_the_selector(self):
+        # The wired flag must exist in the selector CLI and carry the documented
+        # fail-safe (this is the cross-file contract the case-arm relies on).
+        text = CI_SELECT_PY.read_text(encoding="utf-8")
+        self.assertIn("--classify-only", text)
+        self.assertTrue(hasattr(self.select_mod, "_classify_only_main"),
+                        "ci_select.py must expose the classify-only entry point")
+
+    def test_fuzz_has_no_redundant_rust_changed_layer(self):
+        # fuzz.yml's merge-group class gating IS the select pre-job (batch-diff
+        # selection, seed-closure guards) — adding a second rust_changed layer
+        # there would be redundant and could only disagree on transient errors.
+        self.assertNotIn("changes", self.fuzz["jobs"],
+                         "fuzz.yml grew a `changes` job — its merge-group gating is the "
+                         "select pre-job; keep one gate, not two")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -1380,6 +1380,26 @@ class TestMergeGroupChangeClassGate(unittest.TestCase):
             self.assertEqual(str(env.get("MG_HEAD_SHA", "")),
                              "${{ github.event.merge_group.head_sha }}", wf_name)
 
+    def test_batch_diff_fetch_deepens_the_shallow_checkout(self):
+        # The `changes` job checks out at the default depth 1. A plain SHA fetch
+        # leaves base_sha/head_sha PRESENT but unconnected (both cat-file guards
+        # pass), and the classifier's three-dot diff then dies with "no merge
+        # base" — the fail-safe would force class=engine on EVERY batch,
+        # silently reducing the whole gate to a no-op. Every fetch in the
+        # merge_group branch must therefore deepen to full history
+        # (--depth=2147483647 == --unshallow, but valid on complete repos too —
+        # the same merge-base rationale as ci-select.yml's fetch-depth: 0).
+        for wf_name, step in self._both():
+            run = str(step.get("run", ""))
+            fetches = [ln for ln in run.splitlines() if "git fetch" in ln]
+            self.assertTrue(fetches, f"{wf_name}: merge_group branch must fetch the SHA pair")
+            for ln in fetches:
+                self.assertIn(
+                    "--depth=2147483647", ln,
+                    f"{wf_name}: every batch-diff fetch must deepen the shallow "
+                    f"checkout or the three-dot diff has no merge base "
+                    f"(permanent fail-safe => the gate never skips): {ln.strip()!r}")
+
     def test_classification_is_delegated_not_duplicated(self):
         for wf_name, step in self._both():
             run = str(step.get("run", ""))

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -875,5 +875,93 @@ class TestDraftTierIntegrity(unittest.TestCase):
         self.assertEqual(code, 0, out)
 
 
+class TestMergeGroupChangeClassAccounting(unittest.TestCase):
+    """[FABLE-5] merge-group change-class gate (extends #3420/#3421): the expected
+    per-class leg accounting for a MERGE-GROUP sibling set. On a docs-only/
+    orchestration-only queued batch the rust_changed layer (ci.yml lint/msrv/
+    geiger/docker-smoke/coverage-floors + feature-matrix setup/check-tier/
+    fedclient-boundary) now SKIPS alongside the select-gated engine legs; every
+    such leg still registers a check-run with conclusion `skipped` — an
+    ATTRIBUTED skip under the green same-diff `select` pre-job — and the gate
+    renders PASS. The fail-closed half: those same skips with a non-success
+    select are UNATTRIBUTABLE and must RED (an engine batch could only see its
+    legs skipped through a select that did not soundly conclude — the classify
+    step and the select job compute the same classify_change over the same
+    base_sha...head_sha, so on any resolved diff they cannot disagree)."""
+
+    # The #2533-shaped docs-only merge-group batch: what the queue's merge_group
+    # ref shows after this change — every engine-lane check-run PRESENT (never
+    # missing) with conclusion `skipped`, cheap prose gates green, select green.
+    _DOCS_ONLY_GROUP_SKIPS = [
+        # ci.yml select-conjunct legs (already skipped via the batch-diff selection):
+        "test (load-aware shard bulk 1/3)",
+        "build + archive test binaries (+ doctests once)",
+        "W3C SPARQL 1.1 conformance (ratchet)",
+        # ci.yml rust_changed-only legs (NEWLY class-gated on merge_group):
+        "lint (fmt + clippy + doc)",
+        "MSRV build (workspace)",
+        "cargo-geiger unsafe audit",
+        "docker image smoke (bind posture + /health)",
+        # feature-matrix.yml rust_changed-only legs (NEWLY class-gated):
+        "assemble feature matrix",
+        "feature-matrix check-tier (engine)",
+        "fedclient dependency-boundary guard",
+        "opt-in sparq-engine (paths)",
+        # fuzz.yml (already select-gated on the batch diff):
+        "cargo-fuzz (parsers + mmap loader, bounded)",
+        "differential smoke (sparq vs Oxigraph, fixed regression windows)",
+    ]
+
+    def _group_runs(self, select_run):
+        runs = [select_run]
+        runs += [R(n, conclusion="skipped") for n in self._DOCS_ONLY_GROUP_SKIPS]
+        runs += [
+            R("docs-quality quick-gates"),
+            R("supply-chain gates (deny + vet + SBOM + VEX + OpenSSF + js-sbom)"),
+            # Deliberately FULL on merge groups (the documented #3421 unsound-skip
+            # exception): wasm feature-OFF byte-equality on the MERGED bundle.
+            R("vectorized wasm feature-OFF equality"),
+        ]
+        return runs
+
+    def test_docs_only_merge_group_passes_with_attributed_skips(self):
+        # The headline fixture: class=docs-only batch => gate PASS, every engine
+        # leg an attributed skip, nothing missing. (No tier_ctx: merge_group runs
+        # use the pre-draft-tier semantics, as in production.)
+        runs = self._group_runs(SEL_OK)
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertIn(f"{len(self._DOCS_ONLY_GROUP_SKIPS)} skipped", out)
+        self.assertIn("selection pre-job succeeded", out)
+        self.assertNotIn("FAILED", out)
+
+    def test_same_skips_with_failed_select_red(self):
+        # Fail-closed: the identical skip set under a FAILED select is
+        # unattributable => RED. This is what stops an engine batch from merging
+        # on skipped legs — its legs can only skip through the select/classify
+        # pair, and a select that did not conclude success reds the whole set.
+        runs = self._group_runs(R(SELECT_NAME, conclusion="failure"))
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, out)
+        self.assertIn("cannot be attributed to a sound selection", out)
+
+    def test_same_skips_with_missing_select_conclusion_red(self):
+        # A cancelled (unsuperseded) select is equally unattributable => RED.
+        runs = self._group_runs(R(SELECT_NAME, conclusion="cancelled"))
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, out)
+
+    def test_engine_leg_failure_never_masked_by_class_skips(self):
+        # A genuinely failing sibling on the merge_group ref (e.g. the always-on
+        # supply-chain SBOM steps, or a lane the class kept running) still REDs
+        # the gate regardless of how many class-attributed skips surround it.
+        runs = self._group_runs(SEL_OK) + [R("vectorized wasm feature-OFF equality (run)",
+                                             conclusion="failure")]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, out)
+        self.assertIn("FAILED", out)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/tests/test_feature_matrix_assemble.py
+++ b/scripts/tests/test_feature_matrix_assemble.py
@@ -297,6 +297,51 @@ def _synth_legs():
     ]
 
 
+class TestMergeGroupClassAccounting(unittest.TestCase):
+    """[FABLE-5] merge-group change-class (extends #3420/#3421): the expected
+    per-class opt-in leg set for a MERGE-GROUP event, via the same composed
+    tier+selection path the workflow's assemble step runs. A docs-only/
+    orchestration-only queued batch (select emits mode=selected + affected=[]
+    over the batch diff) assembles ZERO legs — the `legs` output then skips the
+    matrix job, an attributed skip, never a missing required check. An engine
+    batch keeps its affected legs; an unresolvable batch (select fail-safe to
+    mode=full) keeps the FULL merge-group leg set."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_assembler()
+        cls.legs = cls.mod.load_legs()
+
+    def _assemble(self, select_mode, affected):
+        tiered = self.mod.filter_legs_by_tier(self.legs, "merge_group", "test")
+        return self.mod.filter_legs_by_selection(tiered, select_mode, affected)
+
+    def test_docs_only_batch_assembles_zero_legs(self):
+        # The #2533-shaped docs-only batch: classify_change => docs-only, the
+        # select pre-job => selected + empty closure => zero opt-in legs on the
+        # merge_group ref. (Identical outcome for orchestration-only.)
+        self.assertEqual(self._assemble("selected", "[]"), [])
+
+    def test_engine_batch_keeps_its_affected_legs(self):
+        # An engine batch narrows to the affected closure exactly as on a PR —
+        # class gating never removes a leg the selection would keep.
+        crates = sorted({leg["crate"] for leg in self.legs})
+        keep = crates[0]
+        got = self._assemble("selected", json.dumps([keep]))
+        self.assertTrue(got, "an engine batch must keep its affected legs")
+        self.assertEqual({leg["crate"] for leg in got}, {keep})
+
+    def test_unresolvable_batch_fails_safe_to_full_merge_group_set(self):
+        # Any classify/select resolution error => mode=full => the FULL
+        # merge-group leg set (fail-safe = cost, never soundness). A classifier
+        # mutated back to always-full lands every batch here — visible as the
+        # RED docs-only fixtures in test_ci_select.py, and as this full set
+        # re-appearing on docs-only groups in the live audit trail.
+        full = self._assemble("full", "[]")
+        tiered = self.mod.filter_legs_by_tier(self.legs, "merge_group", "test")
+        self.assertEqual(full, tiered)
+
+
 class TestTierFiltering(unittest.TestCase):
     """filter_legs_by_tier / filter_legs_by_shard as pure functions."""
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Extends #3420/#3421 change-class gating to the remaining heavy merge-group lanes (ci.yml / feature-matrix / fuzz): the BATCH diff (merge_group base_sha...head_sha, fail-safe-to-full on any resolution error) classifies via the same classify_change(); docs/orchestration-only batches skip engine legs with ATTRIBUTED skips (gate-sound, never missing legs). vectorized-feature-off deliberately untouched (merged-bundle-only failure class). Maintainer directive: queued docs PRs (e.g. #2533's group) must stop burning the full engine matrix.

Authored headless (Fable, delegated account); suites green (see below); scoped actionlint clean except PRE-EXISTING SC2015 infos in ci.yml (untouched hunks). Not armed — review pipeline next.