### PR TITLE
feat(js): RDF/JS ResultStream queryBindings over the cursor API (sq-7lk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [GPT-5.6] **Breaking (`@jeswr/sparq`)** — `SparqStore.queryBindings(sparql, context?)` now
+  returns `Promise<ResultStream<Bindings>>` instead of `Bindings[]`; await it and consume
+  `data` / `end` / `error` events (or use `query()` for synchronous materialisation). Unsupported
+  `context.sources` overrides, including an empty array, now reject instead of being ignored.
+
 ## [0.1.0] - 2026-06-13
 
 First release: an experimental, from-scratch RDF triplestore and SPARQL engine in Rust

--- a/js/README.md
+++ b/js/README.md
@@ -24,9 +24,11 @@ browser. (The wasm bundle bytes are tracked per-commit on the perf dashboard,
   `CREATE`/`ADD`/`COPY`/`MOVE`), applied in place through the engine's delta
   overlay — O(batch), no index rebuild — plus quad-level `applyDelta` /
   `addQuads` / `removeQuads`.
-- Streaming results: `queryBindingsStream()` yields one solution at a time
-  (`for…of` or `for await…of`) from ~64 KiB wasm-boundary chunks — no giant
-  JSON blob, no giant array; `queryJsonChunks()` exposes the raw chunks.
+- RDF/JS Query streaming: `await queryBindings()` returns a Query-spec
+  `ResultStream<Bindings>` with `data` / `end` / `error` events and pull
+  backpressure (`read()`, plus `pause()` / `resume()`). The lower-level
+  `queryBindingsStream()` generator and `queryJsonChunks()` expose the same
+  ~64 KiB cursor path directly — no giant JSON blob or result array.
 - Compressed ingest: `fromCompressed()` decodes `.nt.zst` (including
   multi-frame zstd from sparq's `CompressedSink`) via pure-JS `fzstd`, and
   `.gz` via the platform.
@@ -97,12 +99,18 @@ const store = await SparqStore.fromString(`
   ex:bob   ex:name "Bob"@en .
 `, 'turtle'); // or 'ntriples' | 'nquads' | 'trig'
 
-// SELECT → RDF/JS bindings
-for (const row of store.queryBindings(
+// SELECT → RDF/JS ResultStream<Bindings>
+const bindings = await store.queryBindings(
   'PREFIX ex: <http://ex/> SELECT ?s ?name WHERE { ?s ex:name ?name }',
-)) {
+);
+bindings.on('data', (row) => {
   console.log(row.get('s').value, '→', row.get('name').value);
-}
+});
+bindings.on('end', () => console.log('done'));
+bindings.on('error', console.error);
+
+// Synchronous materialisation remains available through query():
+const rows = store.query('SELECT ?s WHERE { ?s ?p ?o }'); // Bindings[]
 
 // ASK → boolean
 store.queryBoolean('PREFIX ex: <http://ex/> ASK { ex:alice ex:knows ex:bob }'); // true
@@ -136,7 +144,7 @@ for (const binding of store.querySolutions('SELECT ?s WHERE { ?s ?p ?o } LIMIT 1
 // Raw SPARQL 1.1 JSON results, skipping JS-side term materialisation
 const json = JSON.parse(store.queryJson('SELECT * WHERE { ?s ?p ?o } LIMIT 10'));
 
-// Stream large results one solution at a time (no whole-result JSON/array):
+// Lower-level cursor generator (also no whole-result JSON/array):
 for await (const row of store.queryBindingsStream('SELECT ?s ?o WHERE { ?s ?p ?o }')) {
   console.log(row.get('s').value);
 }
@@ -148,7 +156,7 @@ store.applyDelta(insertQuads, deleteQuads); // deletes applied first, then inser
 
 // Named graphs: load as a DATASET (N-Quads / TriG / fromQuads keep their graphs)
 const ds = await SparqStore.fromString(nquads, 'nquads', { dataset: true });
-ds.queryBindings('SELECT ?g ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+const namedRows = ds.query('SELECT ?g ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
 ds.update('INSERT DATA { GRAPH <http://ex/g> { <http://ex/s> <http://ex/p> "o" } }');
 ds.match(null, null, null, DF.namedNode('http://ex/g')); // graph-aware lookup
 

--- a/js/bench/oxigraph-result-shape.mjs
+++ b/js/bench/oxigraph-result-shape.mjs
@@ -1,5 +1,5 @@
 // [OPUS-4.8] #1123 — measures the cost of the OXIGRAPH-shaped SELECT result accessor
-// (`querySolutions` → `Map<string, Term>[]`) relative to the existing RDF/JS `queryBindings`
+// (`querySolutions` → `Map<string, Term>[]`) relative to the materialised `query` SELECT path
 // (`Bindings[]`) and the raw `queryJson` path, to answer the maintainer's explicit question:
 // "are there performance (or other) detriments to aligning the result type with Oxigraph's?"
 //
@@ -8,11 +8,11 @@
 // hard-coded perf numbers in markdown). Run: `node bench/oxigraph-result-shape.mjs`.
 //
 // What it shows (and why the alignment is safe):
-//   * The dominant cost in BOTH `queryBindings` and `querySolutions` is the engine's SPARQL-JSON
+//   * The dominant cost in BOTH `query` and `querySolutions` is the engine's SPARQL-JSON
 //     serialize + JS-side parse + term materialisation — IDENTICAL regardless of the row shape
 //     (`queryJson` isolates that floor).
-//   * `querySolutions` is a thin O(rows) re-view of `queryBindings` (one extra `Map` per row),
-//     so it is strictly ADDITIVE and opt-in — it does NOT slow the existing `queryBindings`.
+//   * `querySolutions` is a thin O(rows) re-view of the same cursor rows (one extra `Map` per
+//     row), so it is strictly additive and opt-in.
 //   * An Oxigraph-shaped `Map<string, Term>` is if anything CHEAPER to build than an immutable
 //     RDF/JS `Bindings` (no `Variable` wrappers, no immutable-Bindings machinery), so aligning
 //     the result type carries no material runtime detriment.
@@ -37,17 +37,17 @@ function best(fn, repeat = 7) {
   return b;
 }
 
-const rows = store.queryBindings(Q).length;
+const rows = store.query(Q).length;
 const tJson = best(() => store.queryJson(Q).length);
-const tBindings = best(() => store.queryBindings(Q).length);
+const tQuery = best(() => store.query(Q).length);
 const tSolutions = best(() => store.querySolutions(Q).length);
 
 console.log(`SELECT result-shape bench — ${rows.toLocaleString()} rows\n`);
 console.log(`  queryJson      (raw SPARQL-JSON string)  ${tJson.toFixed(1).padStart(8)} ms   ← serialize/parse floor`);
-console.log(`  queryBindings  (RDF/JS Bindings[])       ${tBindings.toFixed(1).padStart(8)} ms`);
+console.log(`  query          (RDF/JS Bindings[])       ${tQuery.toFixed(1).padStart(8)} ms`);
 console.log(`  querySolutions (Oxigraph Map<str,Term>[])${tSolutions.toFixed(1).padStart(8)} ms`);
 console.log(
-  `\n  Oxigraph-Map view overhead vs Bindings: ${(((tSolutions - tBindings) / tBindings) * 100).toFixed(1)}% ` +
+  `\n  Oxigraph-Map view overhead vs Bindings: ${(((tSolutions - tQuery) / tQuery) * 100).toFixed(1)}% ` +
     `(one extra Map/row; the shared parse+materialise floor dominates both).`,
 );
 

--- a/js/bench/vs-oxigraph.mjs
+++ b/js/bench/vs-oxigraph.mjs
@@ -56,7 +56,7 @@ console.log(`dataset: ${N.toLocaleString()} triples (${(nt.length / 1e6).toFixed
   const store = await SparqStore.fromString(nt, 'ntriples');
   console.log(`  ${'load N-Triples'.padEnd(28)} ${(performance.now() - t0).toFixed(1).padStart(8)} ms  (${store.size} triples)`);
   for (const [label, q] of Object.entries(QUERIES)) {
-    bench(label, () => store.queryBindings(q).length);
+    bench(label, () => store.query(q).length);
   }
   bench('count (no materialise)', () => store.count(QUERIES['full scan (count rows)']));
   console.log(`  heapBytes ≈ ${(store.heapBytes() / 1e6).toFixed(1)} MB\n`);

--- a/js/package.json
+++ b/js/package.json
@@ -43,7 +43,7 @@
     "build": "npm run build:wasm && npm run build:ts",
     "typecheck": "tsc --noEmit",
     "typecheck:conformance": "tsc --noEmit -p tsconfig.conformance.json",
-    "test": "node --test \"test/*.test.mjs\"",
+    "test": "node --test",
     "bench": "node bench/vs-oxigraph.mjs",
     "check:package": "node guardrails/check-package.mjs",
     "prepack:skills": "rm -rf skills AGENTS.md && cp -R ../skills skills && cp ../AGENTS.md AGENTS.md",

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -16,6 +16,7 @@ export { Dataset, datasetFactory } from './dataset.js';
 // `Source`/`Sink`/`Store` adapter over a `SparqStore` (also reachable via `store.asSource()`).
 export { SparqSource, QuadStream } from './source.js';
 export { Bindings } from './bindings.js';
+export type { SparqResultStream } from './result-stream.js';
 export { DataFactory, NamedNode, BlankNode, Literal, Variable, DefaultGraph, Quad } from './terms.js';
 export {
   termFromSparqlJson,

--- a/js/src/result-stream.ts
+++ b/js/src/result-stream.ts
@@ -1,0 +1,256 @@
+/**
+ * [GPT-5] sq-7lk — a browser-safe RDF/JS query `ResultStream` over a pull iterator.
+ *
+ * The RDF/JS type extends Node's `EventEmitter`, but importing `node:events` at runtime would
+ * break the package's browser build. This class implements the interoperable event subset used
+ * by the Query and Stream specifications (`on` / `once` / `removeListener` / `off` / `emit`),
+ * plus Node-style `pause` / `resume` controls for backpressure.
+ */
+import type * as RDF from '@rdfjs/types';
+
+type EventName = string | symbol;
+type StreamListener = ((...args: unknown[]) => void) & { listener?: StreamListener };
+
+/** RDF/JS `ResultStream` with the pull backpressure controls this implementation exposes. */
+export interface SparqResultStream<T> extends RDF.ResultStream<T> {
+  pause(): this;
+  resume(): this;
+  destroy(error?: Error): this;
+}
+
+export class ResultStream<T> {
+  readonly #source: () => Iterator<T>;
+  readonly #listeners = new Map<EventName, StreamListener[]>();
+  #iterator: Iterator<T> | undefined;
+  #maxListeners = 10;
+  #flowing = false;
+  #pumpScheduled = false;
+  #completionScheduled = false;
+  #terminal = false;
+
+  constructor(source: () => Iterator<T>) {
+    this.#source = source;
+  }
+
+  /** Pulls one result, or `null` after exhaustion/error as required by RDF/JS. */
+  read(): T | null {
+    if (this.#terminal) return null;
+    try {
+      const next = this.#next();
+      if (next.done) {
+        this.#scheduleEnd();
+        return null;
+      }
+      return next.value;
+    } catch (error) {
+      this.#scheduleError(error);
+      return null;
+    }
+  }
+
+  on(event: EventName, listener: StreamListener): this {
+    let listeners = this.#listeners.get(event);
+    if (!listeners) this.#listeners.set(event, (listeners = []));
+    listeners.push(listener);
+    // Like a Node readable, adding a data listener enters flowing mode. Pulling starts in a
+    // later microtask so chained end/error listeners are installed before the first result.
+    if (event === 'data') this.resume();
+    return this;
+  }
+
+  addListener(event: EventName, listener: StreamListener): this {
+    return this.on(event, listener);
+  }
+
+  once(event: EventName, listener: StreamListener): this {
+    const wrapper: StreamListener = (...args) => {
+      this.removeListener(event, wrapper);
+      listener(...args);
+    };
+    wrapper.listener = listener;
+    return this.on(event, wrapper);
+  }
+
+  removeListener(event: EventName, listener: StreamListener): this {
+    const listeners = this.#listeners.get(event);
+    if (!listeners) return this;
+    for (let i = listeners.length - 1; i >= 0; i--) {
+      const current = listeners[i]!;
+      if (current === listener || current.listener === listener) {
+        listeners.splice(i, 1);
+        break;
+      }
+    }
+    if (listeners.length === 0) this.#listeners.delete(event);
+    return this;
+  }
+
+  off(event: EventName, listener: StreamListener): this {
+    return this.removeListener(event, listener);
+  }
+
+  prependListener(event: EventName, listener: StreamListener): this {
+    let listeners = this.#listeners.get(event);
+    if (!listeners) this.#listeners.set(event, (listeners = []));
+    listeners.unshift(listener);
+    if (event === 'data') this.resume();
+    return this;
+  }
+
+  prependOnceListener(event: EventName, listener: StreamListener): this {
+    const wrapper: StreamListener = (...args) => {
+      this.removeListener(event, wrapper);
+      listener(...args);
+    };
+    wrapper.listener = listener;
+    return this.prependListener(event, wrapper);
+  }
+
+  removeAllListeners(event?: EventName): this {
+    if (event === undefined) this.#listeners.clear();
+    else this.#listeners.delete(event);
+    return this;
+  }
+
+  listeners(event: EventName): StreamListener[] {
+    return (this.#listeners.get(event) ?? []).map((listener) => listener.listener ?? listener);
+  }
+
+  rawListeners(event: EventName): StreamListener[] {
+    return [...(this.#listeners.get(event) ?? [])];
+  }
+
+  listenerCount(event: EventName, listener?: StreamListener): number {
+    const listeners = this.#listeners.get(event) ?? [];
+    if (!listener) return listeners.length;
+    return listeners.filter((current) => current === listener || current.listener === listener).length;
+  }
+
+  eventNames(): EventName[] {
+    return [...this.#listeners.keys()];
+  }
+
+  setMaxListeners(count: number): this {
+    if (!Number.isInteger(count) || count < 0) throw new RangeError('max listeners must be a non-negative integer');
+    this.#maxListeners = count;
+    return this;
+  }
+
+  getMaxListeners(): number {
+    return this.#maxListeners;
+  }
+
+  emit(event: EventName, ...args: unknown[]): boolean {
+    const listeners = this.#listeners.get(event);
+    if (!listeners || listeners.length === 0) {
+      if (event === 'error') {
+        const error = args[0];
+        throw error instanceof Error ? error : new Error(`Unhandled ResultStream error: ${String(error)}`);
+      }
+      return false;
+    }
+    // Snapshot like EventEmitter: listener changes during an emission affect later events only.
+    for (const listener of [...listeners]) listener(...args);
+    return true;
+  }
+
+  /** Stops cursor advancement after the currently emitted result. */
+  pause(): this {
+    this.#flowing = false;
+    return this;
+  }
+
+  /** Continues emitting one result per microtask until paused or exhausted. */
+  resume(): this {
+    if (!this.#terminal) {
+      this.#flowing = true;
+      this.#schedulePump();
+    }
+    return this;
+  }
+
+  /** Closes an abandoned cursor immediately, then emits `end` (or the supplied `error`). */
+  destroy(error?: Error): this {
+    if (this.#terminal) return this;
+    try {
+      this.#iterator?.return?.();
+    } catch (closeError) {
+      this.#fail(closeError);
+      return this;
+    }
+    if (error) this.#fail(error);
+    else this.#end();
+    return this;
+  }
+
+  #next(): IteratorResult<T> {
+    this.#iterator ??= this.#source();
+    return this.#iterator.next();
+  }
+
+  #schedulePump(): void {
+    if (!this.#flowing || this.#terminal || this.#pumpScheduled) return;
+    this.#pumpScheduled = true;
+    queueMicrotask(() => {
+      this.#pumpScheduled = false;
+      if (!this.#flowing || this.#terminal) return;
+
+      let next: IteratorResult<T>;
+      try {
+        next = this.#next();
+      } catch (error) {
+        this.#fail(error);
+        return;
+      }
+
+      if (next.done) {
+        this.#end();
+        return;
+      }
+
+      this.emit('data', next.value);
+      this.#schedulePump();
+    });
+  }
+
+  #scheduleEnd(): void {
+    if (this.#terminal || this.#completionScheduled) return;
+    this.#completionScheduled = true;
+    queueMicrotask(() => {
+      this.#completionScheduled = false;
+      this.#end();
+    });
+  }
+
+  #scheduleError(error: unknown): void {
+    if (this.#terminal || this.#completionScheduled) return;
+    this.#completionScheduled = true;
+    queueMicrotask(() => {
+      this.#completionScheduled = false;
+      this.#fail(error);
+    });
+  }
+
+  #end(): void {
+    if (this.#terminal) return;
+    this.#terminal = true;
+    this.#flowing = false;
+    this.emit('end');
+  }
+
+  #fail(error: unknown): void {
+    if (this.#terminal) return;
+    this.#terminal = true;
+    this.#flowing = false;
+    this.emit('error', error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+/**
+ * The implementation deliberately remains browser-safe instead of subclassing Node's
+ * `EventEmitter`; this bridge exposes its spec-complete runtime subset as the nominal RDF/JS
+ * `ResultStream` type (the same pattern used by the package's quad stream adapter).
+ */
+export function asResultStream<T>(stream: ResultStream<T>): SparqResultStream<T> {
+  return stream as unknown as SparqResultStream<T>;
+}

--- a/js/src/store.ts
+++ b/js/src/store.ts
@@ -14,10 +14,10 @@ import {
   SparqlJsonRowsParser,
   termFromSparqlJson,
   termToNT,
-  type SparqlJsonResults,
   type SparqlJsonTerm,
 } from './sparql.js';
 import { SparqSource } from './source.js';
+import { asResultStream, ResultStream, type SparqResultStream } from './result-stream.js';
 import { DataFactory, Quad, Variable } from './terms.js';
 import { init, WasmStore } from './wasm.js';
 
@@ -152,7 +152,7 @@ function position(term: MatchTerm, variable: string): { sparql: string; fixed: R
   return { sparql: termToNT(term), fixed: term };
 }
 
-export class SparqStore {
+export class SparqStore implements RDF.StringSparqlQueryable<RDF.BindingsResultSupport> {
   #inner: WasmStore;
 
   private constructor(inner: WasmStore) {
@@ -284,14 +284,36 @@ export class SparqStore {
   query(sparql: string): Bindings[] | boolean {
     const form = detectQueryForm(sparql)?.form;
     if (form === 'ASK') return this.queryBoolean(sparql);
-    return this.queryBindings(sparql);
+    return [...this.queryBindingsStream(sparql)];
   }
 
-  /** Runs a SELECT query, returning one RDF/JS `Bindings` per solution. */
-  queryBindings(sparql: string): Bindings[] {
-    const json = JSON.parse(this.#inner.query(sparql)) as SparqlJsonResults;
-    const rows = json.results?.bindings ?? [];
-    return rows.map(bindingsFromRow);
+  /**
+   * [GPT-5] sq-7lk — RDF/JS `StringSparqlQueryable.queryBindings`: resolves to a lazy
+   * `ResultStream<Bindings>` backed by {@link queryBindingsStream}'s wasm cursor. Adding a
+   * `data` listener starts flowing; `pause()` / `resume()` provide backpressure, `read()` pulls
+   * one row manually, and terminal failures are delivered through `error` without a following
+   * `end`. `destroy()` deterministically frees a paused/abandoned cursor. Use {@link query} when
+   * a synchronous materialised array is more convenient. The optional RDF/JS context accepts
+   * the default SPARQL 1.1 query format; base IRIs, query timestamps, and format extensions are
+   * rejected because the wasm cursor cannot apply them.
+   */
+  async queryBindings(
+    sparql: string,
+    context?: RDF.QueryStringContext,
+  ): Promise<SparqResultStream<Bindings>> {
+    if (context?.baseIRI !== undefined || context?.queryTimestamp !== undefined) {
+      throw new Error('queryBindings context.baseIRI and context.queryTimestamp are not supported');
+    }
+    const format = context?.queryFormat;
+    if (
+      format &&
+      (format.language.toLowerCase() !== 'sparql' ||
+        format.version !== '1.1' ||
+        (format.extensions?.length ?? 0) > 0)
+    ) {
+      throw new Error('queryBindings context.queryFormat must be unextended SPARQL 1.1');
+    }
+    return asResultStream(new ResultStream(() => this.queryBindingsStream(sparql)));
   }
 
   /**
@@ -300,13 +322,13 @@ export class SparqStore {
    * `Term` values — exactly what Oxigraph's `Store.query` yields for a SELECT, so Oxigraph code
    * (`for (const binding of store.querySolutions(q)) binding.get("s").value`) ports unchanged.
    *
-   * It is a thin O(n) re-view of {@link queryBindings}'s RDF/JS `Bindings` (one `Map` allocation
-   * per solution, no extra wasm round-trip), so the engine's SPARQL-JSON path — not a second
-   * code path — stays the single source of truth. Prefer {@link queryBindings} for an RDF/JS
-   * pipeline (richer immutable `Bindings`); use this for drop-in Oxigraph migration.
+   * It is a thin O(n) re-view of {@link queryBindingsStream}'s RDF/JS `Bindings` (one `Map`
+   * allocation per solution, no extra wasm round-trip), so the cursor path — not a second query
+   * implementation — stays the single source of truth. Prefer {@link queryBindings} for an
+   * RDF/JS event-stream pipeline; use this for synchronous Oxigraph migration.
    */
   querySolutions(sparql: string): Map<string, RDF.Term>[] {
-    return this.queryBindings(sparql).map((b) => b.toMap());
+    return [...this.queryBindingsStream(sparql)].map((b) => b.toMap());
   }
 
   /**

--- a/js/src/store.ts
+++ b/js/src/store.ts
@@ -293,14 +293,18 @@ export class SparqStore implements RDF.StringSparqlQueryable<RDF.BindingsResultS
    * `data` listener starts flowing; `pause()` / `resume()` provide backpressure, `read()` pulls
    * one row manually, and terminal failures are delivered through `error` without a following
    * `end`. `destroy()` deterministically frees a paused/abandoned cursor. Use {@link query} when
-   * a synchronous materialised array is more convenient. The optional RDF/JS context accepts
-   * the default SPARQL 1.1 query format; base IRIs, query timestamps, and format extensions are
-   * rejected because the wasm cursor cannot apply them.
+   * a synchronous materialised array is more convenient. The optional RDF/JS context accepts the
+   * default SPARQL 1.1 query format; sources, base IRIs, query timestamps, and format extensions
+   * are rejected because the wasm cursor cannot apply them.
    */
   async queryBindings(
     sparql: string,
     context?: RDF.QueryStringContext,
   ): Promise<SparqResultStream<Bindings>> {
+    // [GPT-5.6] #3429: reject on presence so an explicitly empty source override is not ignored.
+    if (context?.sources !== undefined) {
+      throw new Error('queryBindings context.sources is not supported');
+    }
     if (context?.baseIRI !== undefined || context?.queryTimestamp !== undefined) {
       throw new Error('queryBindings context.baseIRI and context.queryTimestamp are not supported');
     }

--- a/js/test/dataset.test.mjs
+++ b/js/test/dataset.test.mjs
@@ -67,7 +67,7 @@ test('Dataset.fromQuads round-trips RDF/JS quads', async () => {
 
 test('Dataset.store exposes the full SPARQL surface', async () => {
   const ds = await Dataset.fromString(TTL, 'turtle');
-  const rows = ds.store.queryBindings('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s ex:name ?n }');
+  const rows = ds.store.query('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s ex:name ?n }');
   assert.equal(rows.length, 2);
   ds.free();
 });

--- a/js/test/oxigraph-result.test.mjs
+++ b/js/test/oxigraph-result.test.mjs
@@ -52,7 +52,7 @@ test('querySolutionsStream yields Oxigraph-shaped Maps lazily', async () => {
 
 test('Bindings.toMap bridges RDF/JS Bindings to the Oxigraph Map shape', async () => {
   const store = await SparqStore.fromString(TTL, 'turtle');
-  const [b] = store.queryBindings('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s ex:name ?n } LIMIT 1');
+  const [b] = store.query('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s ex:name ?n } LIMIT 1');
   // RDF/JS Bindings: .get accepts a string already; iteration yields [Variable, Term]
   const [[variable]] = [...b];
   assert.equal(variable.termType, 'Variable', 'Bindings iteration keeps RDF/JS Variable keys');
@@ -64,10 +64,10 @@ test('Bindings.toMap bridges RDF/JS Bindings to the Oxigraph Map shape', async (
   store.free();
 });
 
-test('Bindings.toMap and querySolutions agree term-for-term with queryBindings', async () => {
+test('Bindings.toMap and querySolutions agree term-for-term with materialised query()', async () => {
   const store = await SparqStore.fromString(TTL, 'turtle');
   const q = 'PREFIX ex: <http://ex/> SELECT ?s ?n WHERE { ?s ex:name ?n } ORDER BY ?n';
-  const bindings = store.queryBindings(q);
+  const bindings = store.query(q);
   const sols = store.querySolutions(q);
   assert.equal(bindings.length, sols.length);
   for (let i = 0; i < bindings.length; i++) {

--- a/js/test/store.test.mjs
+++ b/js/test/store.test.mjs
@@ -41,7 +41,7 @@ test('fromString parses JSON-LD (folded), queryable like Turtle', async () => {
   });
   const store = await SparqStore.fromString(jsonld, 'jsonld');
   assert.equal(store.size, 2);
-  const rows = store.queryBindings('PREFIX ex: <http://ex/> SELECT ?n WHERE { ex:alice ex:name ?n }');
+  const rows = store.query('PREFIX ex: <http://ex/> SELECT ?n WHERE { ex:alice ex:name ?n }');
   assert.equal(rows.length, 1);
   assert.equal(rows[0].get('n').value, 'Alice');
 });
@@ -52,14 +52,14 @@ test('fromString JSON-LD with dataset:true preserves @graph as a named graph', a
     '@graph': [{ '@id': 'http://ex/s', 'http://ex/p': { '@id': 'http://ex/o' } }],
   });
   const store = await SparqStore.fromString(jsonld, 'jsonld', { dataset: true });
-  const rows = store.queryBindings('SELECT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
+  const rows = store.query('SELECT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
   assert.equal(rows.length, 1);
   assert.equal(rows[0].get('g').value, 'http://ex/g1');
 });
 
 test('SELECT returns RDF/JS bindings with spec-compliant terms', async () => {
   const store = await load();
-  const rows = store.queryBindings(
+  const rows = store.query(
     'PREFIX ex: <http://ex/> SELECT ?s ?n ?a WHERE { ?s ex:name ?n . ?s ex:age ?a } ORDER BY ?a',
   );
   assert.equal(rows.length, 2);
@@ -88,7 +88,7 @@ test('SELECT returns RDF/JS bindings with spec-compliant terms', async () => {
 
 test('bindings are Map-like per the RDF/JS query spec', async () => {
   const store = await load();
-  const [row] = store.queryBindings(
+  const [row] = store.query(
     'PREFIX ex: <http://ex/> SELECT ?s ?n WHERE { ?s ex:name ?n . ?s ex:knows ?x }',
   );
   assert.equal(row.type, 'bindings');
@@ -146,7 +146,7 @@ test('full-text-style matching via plain SPARQL string functions', async () => {
   // plain SPARQL — which the wasm engine evaluates directly. This pins the
   // plain-SPARQL substring path that browser callers get.
   const store = await load();
-  const rows = store.queryBindings(
+  const rows = store.query(
     'SELECT ?s WHERE { ?s ?p ?o FILTER(isLiteral(?o) && CONTAINS(LCASE(STR(?o)), "ali")) }',
   );
   assert.equal(rows.length, 1);
@@ -266,11 +266,11 @@ test('dataset stores preserve named graphs (GRAPH / FROM / FROM NAMED)', async (
   const store = await loadDataset();
   assert.equal(store.size, 1); // size reports the default graph
 
-  const g1 = store.queryBindings('SELECT ?o WHERE { GRAPH <http://ex/g1> { ?s <http://ex/p> ?o } }');
+  const g1 = store.query('SELECT ?o WHERE { GRAPH <http://ex/g1> { ?s <http://ex/p> ?o } }');
   assert.equal(g1.length, 1);
   assert.equal(g1[0].get('o').value, 'in-g1');
 
-  const all = store.queryBindings('SELECT ?g ?o WHERE { GRAPH ?g { ?s ?p ?o } }');
+  const all = store.query('SELECT ?g ?o WHERE { GRAPH ?g { ?s ?p ?o } }');
   assert.equal(all.length, 3);
   assert.deepEqual([...new Set(all.map(r => r.get('g').value))].sort(), ['http://ex/g1', 'http://ex/g2']);
 
@@ -278,10 +278,10 @@ test('dataset stores preserve named graphs (GRAPH / FROM / FROM NAMED)', async (
   assert.equal(store.queryBoolean('ASK { GRAPH <http://ex/g2> { ?s ?p "in-g1" } }'), false);
 
   // FROM merges the named graph into the active default graph
-  const from = store.queryBindings('SELECT ?o FROM <http://ex/g1> WHERE { ?s <http://ex/p> ?o }');
+  const from = store.query('SELECT ?o FROM <http://ex/g1> WHERE { ?s <http://ex/p> ?o }');
   assert.deepEqual(from.map(r => r.get('o').value), ['in-g1']);
   // FROM NAMED scopes which graphs GRAPH ?g ranges over
-  const fromNamed = store.queryBindings(
+  const fromNamed = store.query(
     'SELECT ?o FROM NAMED <http://ex/g2> WHERE { GRAPH ?g { ?s ?p ?o } }',
   );
   assert.deepEqual(fromNamed.map(r => r.get('o').value), ['in-g2']);
@@ -429,7 +429,7 @@ test('update() applies in place: handle stays valid, named graphs preserved', as
 
 test('engine errors surface as JS exceptions', async () => {
   const store = await load();
-  assert.throws(() => store.queryBindings('SELECT ?s WHERE { broken'), /error|expected/i);
+  assert.throws(() => store.query('SELECT ?s WHERE { broken'), /error|expected/i);
   assert.throws(() => store.query('CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'), /SELECT/);
 });
 
@@ -536,7 +536,7 @@ test('empty() builds a mutable store; named-graph updates round-trip', async () 
   assert.equal(store.size, 1);
   // Named-graph INSERT then GRAPH ?g query returns the inserted row (no dataset flag needed).
   store.update('INSERT DATA { GRAPH <http://ex/g> { <http://ex/s> <http://ex/p> <http://ex/o> } }');
-  const rows = store.queryBindings('SELECT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
+  const rows = store.query('SELECT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
   assert.equal(rows.length, 1);
   assert.equal(rows[0].get('g').value, 'http://ex/g');
 });
@@ -558,7 +558,7 @@ test('fromString with baseIri resolves relative IRIs', async () => {
     baseIri: 'http://ex/dir/',
   });
   assert.equal(store.size, 1);
-  const rows = store.queryBindings('SELECT ?s ?o WHERE { ?s ?p ?o }');
+  const rows = store.query('SELECT ?s ?o WHERE { ?s ?p ?o }');
   assert.equal(rows[0].get('s').value, 'http://ex/dir/a');
   assert.equal(rows[0].get('o').value, 'http://ex/up/o');
 });
@@ -566,7 +566,7 @@ test('fromString with baseIri resolves relative IRIs', async () => {
 test('fromStringSync with baseIri resolves relative IRIs', async () => {
   await SparqStore.empty(); // ensure wasm init
   const store = SparqStore.fromStringSync('<a> <p> <o> .', 'turtle', { baseIri: 'http://ex/' });
-  const rows = store.queryBindings('SELECT ?s WHERE { ?s ?p ?o }');
+  const rows = store.query('SELECT ?s WHERE { ?s ?p ?o }');
   assert.equal(rows[0].get('s').value, 'http://ex/a');
 });
 

--- a/js/test/stream.test.mjs
+++ b/js/test/stream.test.mjs
@@ -16,6 +16,15 @@ function bigNT(n) {
 const N = 4000;
 const load = () => SparqStore.fromString(bigNT(N), 'ntriples');
 
+function collectResultStream(stream) {
+  return new Promise((resolve, reject) => {
+    const rows = [];
+    stream.on('data', (row) => rows.push(row));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(rows));
+  });
+}
+
 test('queryJsonChunks concatenates byte-identically to queryJson, in >1 chunk', async () => {
   const store = await load();
   const sparql = 'SELECT ?s ?p ?o WHERE { ?s ?p ?o }';
@@ -25,10 +34,10 @@ test('queryJsonChunks concatenates byte-identically to queryJson, in >1 chunk', 
   assert.equal(chunks.join(''), store.queryJson(sparql));
 });
 
-test('queryBindingsStream yields the same solutions as queryBindings', async () => {
+test('queryBindingsStream yields repeatable cursor results', async () => {
   const store = await load();
   const sparql = 'SELECT ?s ?name ?i WHERE { ?s <http://ex/name> ?name ; <http://ex/index> ?i } ORDER BY ?s';
-  const materialised = store.queryBindings(sparql);
+  const materialised = [...store.queryBindingsStream(sparql)];
   assert.equal(materialised.length, N);
 
   let i = 0;
@@ -37,6 +46,190 @@ test('queryBindingsStream yields the same solutions as queryBindings', async () 
     i++;
   }
   assert.equal(i, N);
+});
+
+test('queryBindings returns an RDF/JS ResultStream with the same bindings as the cursor', async () => {
+  const store = await load();
+  const sparql =
+    'SELECT ?s ?name ?i WHERE { ?s <http://ex/name> ?name ; <http://ex/index> ?i } ORDER BY ?s LIMIT 50';
+  const cursorRows = [...store.queryBindingsStream(sparql)];
+
+  const streamPromise = store.queryBindings(sparql);
+  assert.ok(streamPromise instanceof Promise);
+  const stream = await streamPromise;
+  assert.equal(typeof stream.read, 'function');
+
+  const eventRows = await collectResultStream(stream);
+  assert.equal(eventRows.length, cursorRows.length);
+  for (let i = 0; i < cursorRows.length; i++) {
+    assert.ok(eventRows[i].equals(cursorRows[i]), `row ${i} differs`);
+  }
+  store.free();
+});
+
+test('queryBindings ResultStream pauses without over-pulling and ends exactly once', async () => {
+  const store = await load();
+  const stream = await store.queryBindings(
+    'SELECT ?s WHERE { ?s <http://ex/index> ?i } ORDER BY ?s LIMIT 6',
+  );
+  const rows = [];
+  let endCount = 0;
+
+  await new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('end', () => {
+      endCount++;
+      resolve();
+    });
+    stream.on('data', (row) => {
+      rows.push(row);
+      if (rows.length !== 1) return;
+      stream.pause();
+      setTimeout(() => {
+        try {
+          assert.equal(rows.length, 1, 'cursor advanced while the ResultStream was paused');
+          stream.resume();
+        } catch (error) {
+          reject(error);
+        }
+      }, 0);
+    });
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(rows.length, 6);
+  assert.equal(endCount, 1);
+  store.free();
+});
+
+test('queryBindings ResultStream propagates cursor errors without emitting end', async () => {
+  const store = await load();
+  const stream = await store.queryBindings('SELECT ?s WHERE { broken');
+  let ended = false;
+
+  const error = await new Promise((resolve, reject) => {
+    stream.on('end', () => {
+      ended = true;
+      reject(new Error('invalid query emitted end instead of error'));
+    });
+    stream.on('error', resolve);
+    stream.on('data', () => reject(new Error('invalid query emitted data')));
+  });
+
+  await Promise.resolve();
+  assert.ok(error instanceof Error);
+  assert.match(error.message, /error|expected/i);
+  assert.equal(ended, false);
+  store.free();
+});
+
+test('queryBindings ResultStream follows EventEmitter error and duplicate-listener semantics', async () => {
+  const store = await load();
+  const stream = await store.queryBindings('SELECT ?s WHERE { ?s ?p ?o } LIMIT 1');
+  const expected = new Error('unhandled');
+  assert.throws(() => stream.emit('error', expected), (error) => error === expected);
+
+  let calls = 0;
+  const listener = () => calls++;
+  stream.on('custom', listener).on('custom', listener);
+  assert.equal(stream.listenerCount('custom'), 2);
+  assert.equal(stream.emit('custom'), true);
+  assert.equal(calls, 2);
+  stream.removeListener('custom', listener);
+  assert.equal(stream.listenerCount('custom'), 1);
+  stream.removeAllListeners('custom');
+  assert.deepEqual(stream.eventNames(), []);
+  stream.destroy();
+  store.free();
+});
+
+test('queryBindings ResultStream destroy() closes an abandoned wasm cursor', async () => {
+  const store = await load();
+  const original = store.queryBindingsStream.bind(store);
+  let cursorClosed = false;
+  store.queryBindingsStream = function* (sparql) {
+    try {
+      yield* original(sparql);
+    } finally {
+      cursorClosed = true;
+    }
+  };
+
+  const stream = await store.queryBindings('SELECT ?s ?p ?o WHERE { ?s ?p ?o }');
+  let seen = 0;
+  await new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('end', resolve);
+    stream.on('data', () => {
+      seen++;
+      stream.pause();
+      stream.destroy();
+    });
+  });
+
+  assert.equal(seen, 1);
+  assert.equal(cursorClosed, true);
+  assert.equal(store.count('SELECT ?s WHERE { ?s <http://ex/index> ?o }'), N);
+  store.free();
+});
+
+test('queryBindings accepts only the supported default RDF/JS query context', async () => {
+  const store = await load();
+  const stream = await store.queryBindings('SELECT ?s WHERE { ?s ?p ?o } LIMIT 1', {
+    queryFormat: { language: 'sparql', version: '1.1' },
+  });
+  stream.destroy();
+
+  await assert.rejects(
+    store.queryBindings('SELECT ?s WHERE { ?s ?p ?o }', { baseIRI: 'http://ex/' }),
+    /not supported/,
+  );
+  await assert.rejects(
+    store.queryBindings('SELECT ?s WHERE { ?s ?p ?o }', {
+      queryFormat: { language: 'sparql', version: '1.2' },
+    }),
+    /SPARQL 1\.1/,
+  );
+  store.free();
+});
+
+test('queryBindings ResultStream read() pulls rows and signals empty/end once', async () => {
+  const store = await load();
+  const sparql = 'SELECT ?s WHERE { ?s <http://ex/index> ?i } ORDER BY ?s LIMIT 3';
+  const cursorRows = [...store.queryBindingsStream(sparql)];
+  const stream = await store.queryBindings(sparql);
+  let endCount = 0;
+  const ended = new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('end', () => {
+      endCount++;
+      resolve();
+    });
+  });
+
+  const pulled = [];
+  for (let row = stream.read(); row !== null; row = stream.read()) pulled.push(row);
+  await ended;
+
+  assert.equal(pulled.length, cursorRows.length);
+  assert.ok(pulled.every((row, i) => row.equals(cursorRows[i])));
+  assert.equal(stream.read(), null);
+  assert.equal(endCount, 1);
+
+  const empty = await store.queryBindings('SELECT ?s WHERE { ?s <http://ex/missing> ?o }');
+  let emptyData = 0;
+  let emptyEnds = 0;
+  await new Promise((resolve, reject) => {
+    empty.on('error', reject);
+    empty.on('end', () => {
+      emptyEnds++;
+      resolve();
+    });
+    empty.on('data', () => emptyData++);
+  });
+  assert.equal(emptyData, 0);
+  assert.equal(emptyEnds, 1);
+  store.free();
 });
 
 test('queryBindingsStream works with for await…of and OPTIONAL rows', async () => {

--- a/js/test/stream.test.mjs
+++ b/js/test/stream.test.mjs
@@ -185,6 +185,10 @@ test('queryBindings accepts only the supported default RDF/JS query context', as
     /not supported/,
   );
   await assert.rejects(
+    store.queryBindings('SELECT ?s WHERE { ?s ?p ?o }', { sources: [] }),
+    /context\.sources.*not supported/,
+  );
+  await assert.rejects(
     store.queryBindings('SELECT ?s WHERE { ?s ?p ?o }', {
       queryFormat: { language: 'sparql', version: '1.2' },
     }),

--- a/skills/javascript-wasm/SKILL.md
+++ b/skills/javascript-wasm/SKILL.md
@@ -14,19 +14,24 @@ Use `SparqStore` (the high-level wrapper) by default — it covers SELECT/ASK (`
 ```js
 import { SparqStore, DataFactory as DF } from '@jeswr/sparq';
 
-// init() runs lazily on first construction; nothing else to await.
+// init() runs lazily on first construction.
 const store = await SparqStore.fromString(`
   @prefix ex: <http://ex/> .
   ex:alice ex:name "Alice" ; ex:knows ex:bob .
   ex:bob   ex:name "Bob"@en .
 `, 'turtle'); // 'turtle' (default) | 'ntriples' | 'nquads' | 'trig' | 'jsonld'
 
-// SELECT -> RDF/JS Bindings[]
-for (const row of store.queryBindings(
+// SELECT -> asynchronous RDF/JS ResultStream<Bindings>
+const bindings = await store.queryBindings(
   'PREFIX ex: <http://ex/> SELECT ?s ?name WHERE { ?s ex:name ?name }',
-)) {
-  console.log(row.get('s').value, '->', row.get('name').value);
-}
+);
+await new Promise((resolve, reject) => {
+  bindings.on('error', reject);
+  bindings.on('end', resolve);
+  bindings.on('data', (row) => {
+    console.log(row.get('s').value, '->', row.get('name').value);
+  });
+});
 
 // ASK -> boolean (native early-exit at first solution)
 store.queryBoolean('PREFIX ex: <http://ex/> ASK { ex:alice ex:knows ex:bob }'); // true
@@ -65,7 +70,7 @@ interface SparqStoreOptions { compressed?: boolean; dataset?: boolean; baseIri?:
 get size(): number                                  // deduped triples in the DEFAULT graph
 heapBytes(): number                                 // rough wasm-side footprint
 query(sparql): Bindings[] | boolean                 // dispatches: SELECT->Bindings[], ASK->boolean
-queryBindings(sparql): Bindings[]                    // SELECT -> one Bindings per solution
+queryBindings(sparql, context?): Promise<ResultStream<Bindings>> // SELECT -> RDF/JS event stream
 querySolutions(sparql): Map<string, Term>[]          // SELECT -> OXIGRAPH-shaped: array of plain Map (drop-in for oxigraph Store.query)
 querySolutionsStream(sparql): Generator<Map<string,Term>> // streaming querySolutions
 queryBoolean(sparql): boolean                        // ASK (native path; rejects non-ASK)
@@ -220,7 +225,14 @@ store.countQuads(null, DF.namedNode('http://ex/name'));      // -> 2 (no materia
 ```js
 const store = await SparqStore.empty();
 store.update('INSERT DATA { GRAPH <http://ex/g> { <http://ex/s> <http://ex/p> <http://ex/o> } }');
-store.queryBindings('SELECT ?g WHERE { GRAPH ?g { ?s ?p ?o } }'); // [{ g: http://ex/g }]
+const graphBindings = await store.queryBindings('SELECT ?g WHERE { GRAPH ?g { ?s ?p ?o } }');
+await new Promise((resolve, reject) => {
+  graphBindings.on('error', reject);
+  graphBindings.on('end', resolve);
+  graphBindings.on('data', (row) => {
+    console.log(row.get('g').value); // http://ex/g
+  });
+});
 ```
 
 **Resolve relative IRIs against a base ([OPUS-4.8] sq-f66jz / #1115).** Pass `{ baseIri }` to `fromString` (or raw `Store.loadWithBase(text, format, base)`) for a document fetched from a URL (or a shapes graph / manifest) that carries relative IRIs and no `@base`. A document-level `@base` still overrides it; line-based formats ignore it; an invalid base throws. Not combinable with `dataset` / `compressed`.
@@ -243,7 +255,14 @@ store.applyDelta(insertQuads, deleteQuads); // deletes applied first, then inser
 
 ```js
 const ds = await SparqStore.fromString(nquads, 'nquads', { dataset: true });
-ds.queryBindings('SELECT ?g ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+const namedBindings = await ds.queryBindings('SELECT ?g ?s WHERE { GRAPH ?g { ?s ?p ?o } }');
+await new Promise((resolve, reject) => {
+  namedBindings.on('error', reject);
+  namedBindings.on('end', resolve);
+  namedBindings.on('data', (row) => {
+    console.log(row.get('g').value, row.get('s').value);
+  });
+});
 ds.update('INSERT DATA { GRAPH <http://ex/g> { <http://ex/s> <http://ex/p> "o" } }');
 ds.match(null, null, null, DF.namedNode('http://ex/g')); // graph-aware
 ```


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes #3397.

Authored by GPT-5.6 sol (codex); the sandbox blocked its final git commit, so the host committed its completed working tree after re-running the js suite green. Draft — cross-provider review next.