### PR TITLE
ci: gate fail-fast on first gating-leg failure + immediate fix-agent doorbell

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -1,144 +1,150 @@
 {
-  "_doc": "Advisory-job registry (sq-qcnn.32). [SONNET-4.6] Every job whose NAME matches the ci-summary exclusion pattern \\b(advisory|informational)\\b must have an entry here with {owner_bead, promotion_criteria, registered}. A job that intentionally runs a gate-classified script (scripts/*gate*.py) must also carry gate_script_waiver. Maintained by check-advisory-registry.py (C2/C3). See scripts/check-advisory-registry.py for the enforcement rule.",
-  "jobs": {
-    "secret-literal grep (advisory)": {
-      "workflow": "deploy-terraform-lint.yml",
-      "owner_bead": "sq-sos84",
-      "promotion_criteria": "advisory while the multi-cloud Terraform deploy templates are new; promote by moving the R4 secret-literal grep into a gating deploy-lint job once the deploy surface is proven stable on main",
-      "registered": "2026-07-15"
-    },
-    "terraform validate (advisory)": {
-      "workflow": "deploy-terraform-lint.yml",
-      "owner_bead": "sq-sos84",
-      "promotion_criteria": "advisory while terraform validate runs credential-free across provider-version drift; promote by removing the (advisory) token once validate is proven stable on main across the pinned terraform_version",
-      "registered": "2026-07-15"
-    },
-    "asan (mmap corruption corpus, informational)": {
-      "workflow": "asan.yml",
-      "owner_bead": "sq-hybl",
-      "promotion_criteria": "MS-G3 memsafety gap (epic sq-toze) addressed and lane proven stable on main with sufficient green runs",
-      "registered": "2026-07-06"
-    },
-    "new-bench-registry-dashboard (G3, advisory)": {
-      "workflow": "flow-on-gates.yml",
-      "owner_bead": "sq-ncvq.6",
-      "promotion_criteria": "G3 heuristic proven on real PR traffic with zero false-positives; promote by removing (advisory) token and --advisory flag",
-      "registered": "2026-07-06"
-    },
-    "docs-quality quick-advisory (advisory)": {
-      "workflow": "docs-quality.yml",
-      "owner_bead": "sq-5fd1",
-      "promotion_criteria": "per-step (sq-6vshe.20 consolidation of the former markdownlint-advisory / vale / external-links jobs): a step promotes by MOVING into the quick-gates job — markdownlint-advisory once the whole-repo backlog (bench/, .claude/) is fully clean; vale once the prose-style backlog on README/skills/docs/crates is clean and the vale ruleset has settled; external-links never promotes (network-flaky by nature — dead external links must never block a merge)",
-      "registered": "2026-07-11"
-    },
-    "mutation ratchet (cargo-mutants, advisory)": {
-      "workflow": "ci.yml",
-      "owner_bead": "sq-qcnn.11",
-      "promotion_criteria": "sq-qcnn.27: all seeded ceilings pass --check AND sq-qcnn.29 nightly-fix (concurrency-cancel + sharding) is merged and seeded",
-      "registered": "2026-07-06",
-      "gate_script_waiver": "scripts/mutants-gate.py is the mutation ratchet checker itself, run advisory while the per-crate baseline is seeding (sq-qcnn.11); exits non-fatally until sq-qcnn.27 promotes it to gating"
-    },
-    "unsafe report (cargo-geiger, informational)": {
-      "workflow": "ci.yml",
-      "owner_bead": "sq-4plh",
-      "promotion_criteria": "not promotable; cargo-geiger is too heavy/flaky for per-PR gating; the HARD gate is unsafe-register (sq-toze.6 / cert gap GX-5)",
-      "registered": "2026-07-06"
-    },
-    "resolve nightly run config (advisory)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "a11y full sweep (chromium, advisory)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "visual full-surface sweep (container-pinned, advisory)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "cross-browser P1 journeys firefox+webkit (advisory)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "tauri-driver GUI smoke Linux (advisory)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "tauri-driver GUI smoke ${{ matrix.os }} (advisory, documented-untested)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "route consolidated failures (advisory)": {
-      "workflow": "nightly-full-sweep.yml",
-      "owner_bead": "sq-ymr2e.11",
-      "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
-      "registered": "2026-07-06"
-    },
-    "GUI build + clippy (${{ matrix.label }}, advisory)": {
-      "workflow": "gui.yml",
-      "owner_bead": "sq-pnnl",
-      "promotion_criteria": "sq-var9: macOS + Windows tauri-build matrix proven stable across main; remove advisory token",
-      "registered": "2026-07-06"
-    },
-    "GUI tauri-driver e2e (Linux, advisory)": {
-      "workflow": "gui.yml",
-      "owner_bead": "sq-ymr2e.6",
-      "promotion_criteria": "advisory forever; real WebKitWebDriver + xvfb is environment-coupled by nature (E2E-GATING-POLICY.md §2)",
-      "registered": "2026-07-06"
-    },
-    "GUI tauri-driver flake probe (Linux, advisory)": {
-      "workflow": "gui.yml",
-      "owner_bead": "sq-ymr2e.6",
-      "promotion_criteria": "never promotable; workflow_dispatch flake probe only — not a PR check",
-      "registered": "2026-07-06"
-    },
-    "kani ${{ matrix.suite.name }} (bounded proofs, informational)": {
-      "workflow": "kani.yml",
-      "owner_bead": "sq-hkud",
-      "promotion_criteria": "bounded proofs are informational until a credentialed formal-methods review validates coverage (sq-hkud + epic sq-toze MS-G4)",
-      "registered": "2026-07-06"
-    },
-    "conventional-commits (advisory)": {
-      "workflow": "pr-title.yml",
-      "owner_bead": "sq-v286.5",
-      "promotion_criteria": "heuristic proven on real PR traffic with zero false-positives; remove advisory token (sq-v286.5 follow-up bead)",
-      "registered": "2026-07-06"
-    },
-    "home hero-runner journeys (advisory)": {
-      "workflow": "site-e2e-hero.yml",
-      "owner_bead": "sq-ymr2e.3",
-      "promotion_criteria": "sq-ymr2e.12 probation bar: 50 consecutive green runs spanning at least 10 distinct PRs or two weeks, zero quarantine events (E2E-GATING-POLICY.md §3)",
-      "registered": "2026-07-06"
-    },
-    "visual key layouts (container-pinned, advisory)": {
-      "workflow": "site-visual.yml",
-      "owner_bead": "sq-ymr2e.10",
-      "promotion_criteria": "promotes last (E2E-GATING-POLICY.md §5): after all functional E2E lanes are stable on the sq-ymr2e.12 probation bar",
-      "registered": "2026-07-06"
-    },
-    "determinism gate + foundation smoke (advisory)": {
-      "workflow": "site-e2e-foundation.yml",
-      "owner_bead": "sq-ymr2e.1",
-      "promotion_criteria": "sq-ymr2e.12 probation bar: 50 consecutive green runs spanning at least 10 distinct PRs or two weeks, zero quarantine events (E2E-GATING-POLICY.md §3)",
-      "registered": "2026-07-06"
-    },
-    "Helm lint, render, and schema validation (advisory)": {
-      "workflow": "deploy-lint.yml",
-      "owner_bead": "sq-0d744",
-      "promotion_criteria": "advisory: the helm-validate job runs on push/PR (path-filtered to deploy/**), NOT merge_group, and installs network-fetched helm+kubeconform, so it must not gate the merge queue (a missing merge_group check otherwise fails ci-summary). Promote by running it on merge_group + removing the (advisory) token once proven non-flaky on main",
-      "registered": "2026-07-15"
-    }
+ "_doc": "Advisory-job registry (sq-qcnn.32). [SONNET-4.6] Every job whose NAME matches the ci-summary exclusion pattern \\b(advisory|informational)\\b must have an entry here with {owner_bead, promotion_criteria, registered}. A job that intentionally runs a gate-classified script (scripts/*gate*.py) must also carry gate_script_waiver. Maintained by check-advisory-registry.py (C2/C3). See scripts/check-advisory-registry.py for the enforcement rule.",
+ "jobs": {
+  "secret-literal grep (advisory)": {
+   "workflow": "deploy-terraform-lint.yml",
+   "owner_bead": "sq-sos84",
+   "promotion_criteria": "advisory while the multi-cloud Terraform deploy templates are new; promote by moving the R4 secret-literal grep into a gating deploy-lint job once the deploy surface is proven stable on main",
+   "registered": "2026-07-15"
+  },
+  "terraform validate (advisory)": {
+   "workflow": "deploy-terraform-lint.yml",
+   "owner_bead": "sq-sos84",
+   "promotion_criteria": "advisory while terraform validate runs credential-free across provider-version drift; promote by removing the (advisory) token once validate is proven stable on main across the pinned terraform_version",
+   "registered": "2026-07-15"
+  },
+  "asan (mmap corruption corpus, informational)": {
+   "workflow": "asan.yml",
+   "owner_bead": "sq-hybl",
+   "promotion_criteria": "MS-G3 memsafety gap (epic sq-toze) addressed and lane proven stable on main with sufficient green runs",
+   "registered": "2026-07-06"
+  },
+  "new-bench-registry-dashboard (G3, advisory)": {
+   "workflow": "flow-on-gates.yml",
+   "owner_bead": "sq-ncvq.6",
+   "promotion_criteria": "G3 heuristic proven on real PR traffic with zero false-positives; promote by removing (advisory) token and --advisory flag",
+   "registered": "2026-07-06"
+  },
+  "docs-quality quick-advisory (advisory)": {
+   "workflow": "docs-quality.yml",
+   "owner_bead": "sq-5fd1",
+   "promotion_criteria": "per-step (sq-6vshe.20 consolidation of the former markdownlint-advisory / vale / external-links jobs): a step promotes by MOVING into the quick-gates job \u2014 markdownlint-advisory once the whole-repo backlog (bench/, .claude/) is fully clean; vale once the prose-style backlog on README/skills/docs/crates is clean and the vale ruleset has settled; external-links never promotes (network-flaky by nature \u2014 dead external links must never block a merge)",
+   "registered": "2026-07-11"
+  },
+  "mutation ratchet (cargo-mutants, advisory)": {
+   "workflow": "ci.yml",
+   "owner_bead": "sq-qcnn.11",
+   "promotion_criteria": "sq-qcnn.27: all seeded ceilings pass --check AND sq-qcnn.29 nightly-fix (concurrency-cancel + sharding) is merged and seeded",
+   "registered": "2026-07-06",
+   "gate_script_waiver": "scripts/mutants-gate.py is the mutation ratchet checker itself, run advisory while the per-crate baseline is seeding (sq-qcnn.11); exits non-fatally until sq-qcnn.27 promotes it to gating"
+  },
+  "unsafe report (cargo-geiger, informational)": {
+   "workflow": "ci.yml",
+   "owner_bead": "sq-4plh",
+   "promotion_criteria": "not promotable; cargo-geiger is too heavy/flaky for per-PR gating; the HARD gate is unsafe-register (sq-toze.6 / cert gap GX-5)",
+   "registered": "2026-07-06"
+  },
+  "resolve nightly run config (advisory)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "a11y full sweep (chromium, advisory)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "visual full-surface sweep (container-pinned, advisory)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "cross-browser P1 journeys firefox+webkit (advisory)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "tauri-driver GUI smoke Linux (advisory)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "tauri-driver GUI smoke ${{ matrix.os }} (advisory, documented-untested)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "route consolidated failures (advisory)": {
+   "workflow": "nightly-full-sweep.yml",
+   "owner_bead": "sq-ymr2e.11",
+   "promotion_criteria": "never promotable; nightly workflows never gate the merge queue by design (sq-ymr2e.11)",
+   "registered": "2026-07-06"
+  },
+  "GUI build + clippy (${{ matrix.label }}, advisory)": {
+   "workflow": "gui.yml",
+   "owner_bead": "sq-pnnl",
+   "promotion_criteria": "sq-var9: macOS + Windows tauri-build matrix proven stable across main; remove advisory token",
+   "registered": "2026-07-06"
+  },
+  "GUI tauri-driver e2e (Linux, advisory)": {
+   "workflow": "gui.yml",
+   "owner_bead": "sq-ymr2e.6",
+   "promotion_criteria": "advisory forever; real WebKitWebDriver + xvfb is environment-coupled by nature (E2E-GATING-POLICY.md \u00a72)",
+   "registered": "2026-07-06"
+  },
+  "GUI tauri-driver flake probe (Linux, advisory)": {
+   "workflow": "gui.yml",
+   "owner_bead": "sq-ymr2e.6",
+   "promotion_criteria": "never promotable; workflow_dispatch flake probe only \u2014 not a PR check",
+   "registered": "2026-07-06"
+  },
+  "kani ${{ matrix.suite.name }} (bounded proofs, informational)": {
+   "workflow": "kani.yml",
+   "owner_bead": "sq-hkud",
+   "promotion_criteria": "bounded proofs are informational until a credentialed formal-methods review validates coverage (sq-hkud + epic sq-toze MS-G4)",
+   "registered": "2026-07-06"
+  },
+  "conventional-commits (advisory)": {
+   "workflow": "pr-title.yml",
+   "owner_bead": "sq-v286.5",
+   "promotion_criteria": "heuristic proven on real PR traffic with zero false-positives; remove advisory token (sq-v286.5 follow-up bead)",
+   "registered": "2026-07-06"
+  },
+  "home hero-runner journeys (advisory)": {
+   "workflow": "site-e2e-hero.yml",
+   "owner_bead": "sq-ymr2e.3",
+   "promotion_criteria": "sq-ymr2e.12 probation bar: 50 consecutive green runs spanning at least 10 distinct PRs or two weeks, zero quarantine events (E2E-GATING-POLICY.md \u00a73)",
+   "registered": "2026-07-06"
+  },
+  "visual key layouts (container-pinned, advisory)": {
+   "workflow": "site-visual.yml",
+   "owner_bead": "sq-ymr2e.10",
+   "promotion_criteria": "promotes last (E2E-GATING-POLICY.md \u00a75): after all functional E2E lanes are stable on the sq-ymr2e.12 probation bar",
+   "registered": "2026-07-06"
+  },
+  "determinism gate + foundation smoke (advisory)": {
+   "workflow": "site-e2e-foundation.yml",
+   "owner_bead": "sq-ymr2e.1",
+   "promotion_criteria": "sq-ymr2e.12 probation bar: 50 consecutive green runs spanning at least 10 distinct PRs or two weeks, zero quarantine events (E2E-GATING-POLICY.md \u00a73)",
+   "registered": "2026-07-06"
+  },
+  "Helm lint, render, and schema validation (advisory)": {
+   "workflow": "deploy-lint.yml",
+   "owner_bead": "sq-0d744",
+   "promotion_criteria": "advisory: the helm-validate job runs on push/PR (path-filtered to deploy/**), NOT merge_group, and installs network-fetched helm+kubeconform, so it must not gate the merge queue (a missing merge_group check otherwise fails ci-summary). Promote by running it on merge_group + removing the (advisory) token once proven non-flaky on main",
+   "registered": "2026-07-15"
+  },
+  "fast-fix ring (advisory)": {
+   "workflow": "ci-summary.yml",
+   "owner_bead": "sq-6vshe",
+   "promotion_criteria": "advisory while the fail-fast fix-agent ring is proving out: the ring only notifies the registry doorbell after a gating-leg failure and must never gate the PR itself; promote (or fold into the gate job) once ring-triggered fixes have run reliably for a few weeks",
+   "registered": "2026-07-18"
   }
+ }
 }

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -117,6 +117,33 @@
 # producing the first (and only) `gate` check-run on the head SHA. merge_group
 # behaviour is untouched (always full tier, on a fresh ref).
 #
+# FAIL-FAST + FAST-FIX RING (2026-07-17 maintainer directive). [FABLE-5]
+# (1) FAIL-FAST: while polling, the moment any GATING leg has CONCLUDED failure the
+# gate REDs immediately instead of waiting for every other leg — a genuine `failure`
+# is never forgiven by any later state (only cancelled/stale are supersedable), so
+# every eventual render REDs anyway; the wait was pure latency on the verdict. A red
+# PR learns its fate in roughly the time of its fastest failing leg (~2-4 min for
+# clippy/fmt/test-compile classes) instead of the full sibling wall-clock (~30-40
+# min). Soundness guards live in scripts/ci_summary_gate.py §FAIL-FAST: the mid-poll
+# scan runs over the SAME forgiveness-filtered set the final render judges (a
+# cancelled-then-rerun leg or race-loser select can never fire it), advisory legs
+# never fire it, a red leg with a same-name rerun already in flight stands down, and
+# one immediate grace re-poll must re-observe the failure before the red is emitted.
+# (2) FAST-FIX RING: when this gate REDs on a pull_request run for a PIPELINE-OWNED
+# PR (armed for auto-merge, or labeled review:pass / review:changes; never drafts or
+# review:needs-user / needs:user holds), the `fix-ring` job below rings the
+# jeswr/agent-account-registry dispatcher (the same REGISTRY_RING_TOKEN doorbell
+# batch-merge.yml's ring job uses) so its repair sweep enumerates the red PR NOW
+# instead of on the next cron tick. The registry's ci-fix admission is derived from
+# the PR's GATE STATE (its PLAN snapshots per-PR CI status), so ringing is
+# sufficient; deliberately NO needs:ci-fix label fallback — the registry enumerator
+# treats needs:* PR labels as HUMAN-owned holds that EXCLUDE a PR from the repair
+# loop, so a label would do the opposite of triggering a fix. Without the token
+# (fork PR head / secret unconfigured) the job skips with a notice and the registry
+# cron remains the backstop. The job name carries "advisory" so its own check-run
+# can never gate a future run on the same SHA, and it runs with a read-only token —
+# the doorbell token is the only write capability and it is scoped to the registry.
+#
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
 # scripts/ci_summary_gate.py (extracted from the previous inline bash so the
 # semantics are UNIT-TESTED — scripts/tests/test_ci_summary_gate.py, run as a HARD
@@ -217,3 +244,63 @@ jobs:
           PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: python3 scripts/ci_summary_gate.py
+
+  # FAST-FIX RING (header §FAIL-FAST + FAST-FIX RING). A red gate on a
+  # pipeline-owned PR wakes the registry repair loop immediately. Least
+  # privilege: the job's own token is pull-requests:read only (it reads the
+  # PR's LIVE labels/arm/draft state — the trigger payload's snapshot goes
+  # stale across the poll window); the only write capability is the
+  # REGISTRY_RING_TOKEN doorbell, absent on fork heads (fail-soft skip — the
+  # registry cron is the backstop). "advisory" in the name keeps this job's
+  # check-run structurally non-gating for any future gate run on the same SHA
+  # (sq-wjth rule), and `failure()` excludes cancelled (superseded) gate runs.
+  fix-ring:
+    name: fast-fix ring (advisory)
+    needs: gate
+    if: >-
+      failure()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Ring the registry dispatcher for an immediate repair sweep
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REGISTRY_RING_TOKEN: ${{ secrets.REGISTRY_RING_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          # Live PR state — labels/arming churn between the trigger payload and
+          # a gate verdict that can be many minutes later.
+          if ! state="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+              --jq '{draft: .draft, armed: (.auto_merge != null), labels: [.labels[].name]}')"; then
+            echo "::notice::could not read live PR state — skipping the ring (the registry cron is the backstop)."
+            exit 0
+          fi
+          has() { jq -e --arg l "$1" '.labels | index($l) != null' <<<"$state" >/dev/null; }
+          if [ "$(jq -r '.draft' <<<"$state")" = "true" ]; then
+            echo "PR re-drafted since the trigger — not pipeline-owned for fast-fix; skipping."
+            exit 0
+          fi
+          if has "review:needs-user" || has "needs:user"; then
+            echo "human-owned hold (review:needs-user / needs:user) — the repair loop must not pick this PR up; skipping."
+            exit 0
+          fi
+          if [ "$(jq -r '.armed' <<<"$state")" != "true" ] && ! has "review:pass" && ! has "review:changes"; then
+            echo "PR is neither armed nor in the review pipeline (review:pass / review:changes) — skipping."
+            exit 0
+          fi
+          if [ -z "${REGISTRY_RING_TOKEN}" ]; then
+            # NO needs:ci-fix label fallback, deliberately: the registry PLAN
+            # derives ci-fix admission from the PR's gate STATE and treats
+            # needs:* PR labels as human-owned holds that EXCLUDE the PR from
+            # the repair enumeration — a label here would suppress the fix.
+            echo "::notice::REGISTRY_RING_TOKEN unavailable (fork head or secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
+            exit 0
+          fi
+          GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry
+          echo "rang jeswr/agent-account-registry dispatch — the repair sweep runs now instead of on the next cron tick."

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -48,6 +48,31 @@
 # MAX_CONSEC_FETCH_FAILURES consecutive failures fail the gate. No data => no
 # verdict, so this cannot create a false pass.
 #
+# FAIL-FAST ON A CONCLUDED GATING FAILURE (2026-07-17 maintainer directive).
+# [FABLE-5] Mid-poll, if any GATING leg has CONCLUDED failure, the gate REDs NOW
+# instead of waiting for every other sibling to finish: a genuine `failure` is
+# never forgiven by any later state (forgive_superseded excuses only
+# cancelled/stale), so every future render over any superset of this sibling set
+# REDs anyway — the remaining wait is pure latency on the red verdict (and on the
+# fast-fix trigger it fires, ci-summary.yml `fix-ring`). Soundness guards, each
+# reusing the FINAL render's own classification (failfast_failures):
+#   * the candidate set is the SAME post-forgive_superseded / post-self-exclusion
+#     / post-draft-gate-artifact set the final render sees — a cancelled-then-
+#     rerun leg or a concurrency race-loser select can never fire it (cancelled
+#     is not failure, and forgiven runs are dropped upstream);
+#   * advisory/informational legs never fire it (the same is_advisory predicate
+#     render_verdict excludes by);
+#   * a red leg with a same-tier-normalized-name run still IN PROGRESS (a rerun
+#     already underway on the SHA) stands down — the gate keeps waiting on the
+#     rerun exactly as before;
+#   * the verdict fires only after ONE immediate grace re-poll re-observes the
+#     identical concluded-failure set (name+id), dodging API read races; and
+#   * it fires only while siblings are still outstanding (pending, or the
+#     awaiting-full draft-tier hold) — an all-terminal set renders through the
+#     normal settle path, byte-identical to before.
+# Fail-fast is an exit-1-only path: it can never conclude success, so every
+# exit-0 invariant below is untouched.
+#
 # DRAFT-TIER INTEGRITY (bead: draft-tier CI). [FABLE-5] Draft PR heads run a REDUCED
 # leg set (coverage / bench / CodeQL / heavy shards / wasm-equality skipped — see
 # docs/branch-protection.md §Draft-tier CI); the ci-select job NAME carries the
@@ -91,7 +116,8 @@
 #     cannot merge anyway, so a false RED here is cheap; a false PASS is the
 #     invariant violation).
 #
-# Exit-0 paths, exhaustively: (1) render_verdict over a stable-empty set;
+# Exit-0 paths, exhaustively (fail-fast adds NO exit-0 path — it only ever
+# returns 1): (1) render_verdict over a stable-empty set;
 # (2) render_verdict over an all-terminal set with zero non-passing GATING checks
 # AND every change-based-selection pre-job check green (sq-fmx4u.3: `skipped` is
 # satisfied only under a successful selection; a present-but-not-success select
@@ -556,6 +582,39 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
     return 0
 
 
+def failfast_failures(runs: list[dict]) -> list[dict]:
+    """[FABLE-5] Fail-fast (2026-07-17 directive, header §FAIL-FAST): the GATING
+    legs whose CONCLUDED failure already decides the verdict. `runs` must be the
+    poll loop's post-forgive_superseded, post-self-exclusion, post-draft-gate-
+    artifact sibling set — i.e. EXACTLY the set render_verdict would judge — so
+    this helper inherits the final render's supersession/forgiveness
+    classification instead of reimplementing it (a forgiven race-loser is
+    already gone; a surviving cancelled/stale run is not `failure` and never
+    fires this). A leg qualifies iff it is completed with conclusion=failure,
+    is not advisory (the same is_advisory predicate the verdict excludes by),
+    and no same-tier-normalized-name run on the SHA is still in flight (a rerun
+    already underway must be allowed to finish — the gate keeps waiting on it,
+    exactly as the settle loop always has). `timed_out`/`cancelled`/`stale`
+    conclusions deliberately do NOT qualify: only an unambiguous `failure`
+    fails fast; everything else waits for the full render."""
+    inflight = {
+        normalized_name(r.get("name", ""))
+        for r in runs
+        if r.get("status") != "completed"
+    }
+    out: list[dict] = []
+    for r in runs:
+        if r.get("status") != "completed" or r.get("conclusion") != "failure":
+            continue
+        name = r.get("name", "")
+        if is_advisory(name):
+            continue
+        if normalized_name(name) in inflight:
+            continue
+        out.append(r)
+    return out
+
+
 def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
              tier_ctx: TierContext | None = None) -> int:
     """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url,
@@ -571,6 +630,10 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     completed_hist: list[int] = []
     consec_fetch_failures = 0
     extension_started = False
+    # Fail-fast grace state: the (name, id) key set of concluded gating failures
+    # observed on the PREVIOUS poll — the red fires only when a fresh re-poll
+    # re-observes the identical set (header §FAIL-FAST).
+    ff_suspect: tuple | None = None
 
     attempt = 0
     while attempt < cfg.max_total_polls:
@@ -635,6 +698,43 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             f"all-terminal stable for {stable}/{cfg.settle_polls} poll(s){changed}{extra}",
             flush=True,
         )
+
+        # [FABLE-5] FAIL-FAST (header §FAIL-FAST): a concluded gating failure in
+        # the (already forgiveness-filtered) sibling set decides the verdict now
+        # — a genuine `failure` is never forgiven, so every later render REDs
+        # anyway; waiting out the remaining legs only delays the red and the
+        # fast-fix trigger behind it. Applies only while siblings are still
+        # outstanding (pending / awaiting_full): an all-terminal set renders via
+        # the normal settle path below, byte-identical to before. The first
+        # observation arms a grace re-poll (immediate, no sleep — dodges an API
+        # read race); the red fires when a fresh fetch re-observes the same set.
+        if pending or awaiting_full:
+            ff = failfast_failures(runs)
+            if ff:
+                key = tuple(sorted((r.get("name", ""), r.get("id") or 0) for r in ff))
+                if key == ff_suspect:
+                    _emit(
+                        f"### ci-summary: FAILED (fail-fast) — {len(ff)} gating "
+                        f"check(s) concluded failure while {pending} sibling(s) "
+                        f"were still running; no later state can turn this verdict "
+                        f"green (a genuine failure is never forgiven), so the gate "
+                        f"REDs now instead of waiting out the remaining legs.",
+                        cfg.summary_path,
+                    )
+                    for r in ff:
+                        _emit(f"- ✗ {r.get('name')}: failure", cfg.summary_path)
+                    print(
+                        "::error::ci-summary failed fast — a gating check concluded "
+                        "failure; the remaining siblings were not waited on."
+                    )
+                    return 1
+                ff_suspect = key
+                print(
+                    f"  fail-fast: {len(ff)} concluded gating failure(s) observed — "
+                    f"immediate grace re-poll to confirm before concluding."
+                )
+                continue  # no sleep: the grace re-poll is deliberately immediate
+            ff_suspect = None
 
         # Clean convergence: everything terminal, held for the settle, past the floor.
         if attempt >= cfg.min_polls and pending == 0 and stable >= cfg.settle_polls:

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -183,6 +183,121 @@ class TestSettleAndGracefulTimeout(unittest.TestCase):
         self.assertIn("FAILED", out)
 
 
+class TestFailFast(unittest.TestCase):
+    """[FABLE-5] Fail-fast on a concluded gating failure (2026-07-17 maintainer
+    directive): the gate REDs the moment a gating leg's failure is confirmed by
+    the grace re-poll, instead of waiting out every other sibling — WITHOUT ever
+    firing on a superseded/forgiven run, an in-flight rerun's predecessor, or an
+    advisory leg. Each guard's mutation is caught: dropping fail-fast breaks the
+    immediacy assertions; dropping a guard turns a must-pass scenario red."""
+
+    def test_gating_failure_with_others_pending_reds_immediately(self):
+        # (i) One concluded gating failure + siblings still pending => FAILURE at
+        # the grace-confirm poll (attempt 2), not after the pending legs settle.
+        # Mutation coverage: without fail-fast these polls run to the base budget
+        # and red as a "genuine hang" — the fail-fast marker + the poll-count
+        # assertions below then fail.
+        code, out = run(tiny_cfg(), [[RED, PENDING]])
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED (fail-fast)", out)
+        self.assertIn("clippy", out)
+        self.assertIn("attempt 2", out)
+        self.assertNotIn("attempt 3", out, "the red must land at the grace-confirm poll")
+        self.assertNotIn("genuine hang", out)
+
+    def test_failed_leg_with_inflight_same_name_rerun_does_not_fail_fast(self):
+        # (ii) A red leg whose same-name rerun is already IN PROGRESS must NOT
+        # fail-fast — the gate waits on the rerun (which wins: the check-runs
+        # listing returns the latest attempt, so the old failure drops out).
+        # Mutation coverage: without the in-flight guard the identical failure
+        # is observed on polls 1+2 and the gate REDs before the rerun lands.
+        failed = R("clippy", conclusion="failure", started="2026-07-17T10:00:00Z", rid=1)
+        rerun = R("clippy", status="in_progress", conclusion=None,
+                  started="2026-07-17T10:05:00Z", rid=2)
+        rerun_green = R("clippy", started="2026-07-17T10:05:00Z", rid=2)
+        polls = [
+            [failed, rerun, PENDING],
+            [failed, rerun, PENDING],
+            [rerun_green, R("coverage")],
+        ]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertNotIn("fail-fast", out)
+
+    def test_cancelled_race_loser_select_mid_poll_does_not_fail_fast(self):
+        # (iii) A concurrency-cancel race-loser select observed MID-POLL (siblings
+        # still pending) must not fail-fast the gate: forgive_superseded drops it
+        # upstream of the fail-fast scan (same-tier same-name success, the
+        # sq-fmx4u.3 pure-select rule), and a cancelled conclusion is not
+        # `failure` in any case. The eventual verdict is the real (green) one.
+        sel_win = R(SELECT_NAME, conclusion="success",
+                    started="2026-07-17T10:00:10Z", rid=2)
+        sel_lost = R(SELECT_NAME, conclusion="cancelled",
+                     started="2026-07-17T10:00:20Z", rid=3)
+        polls = [
+            [sel_win, sel_lost, PENDING],
+            [sel_win, sel_lost, R("coverage")],
+        ]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertNotIn("fail-fast", out)
+
+    def test_cancelled_leg_awaiting_rerun_does_not_fail_fast(self):
+        # (iii-b) spec guard (a): a cancelled-then-rerun leg mid-poll — cancelled
+        # is never a fail-fast trigger, the successor supersedes it, gate greens.
+        old = R("build + test", conclusion="cancelled",
+                started="2026-07-17T10:00:00Z", rid=1)
+        new_running = R("build + test", status="in_progress", conclusion=None,
+                        started="2026-07-17T10:05:00Z", rid=2)
+        new_green = R("build + test", started="2026-07-17T10:05:00Z", rid=2)
+        polls = [[old, PENDING], [old, new_running, PENDING], [old, new_green, R("coverage")]]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0, out)
+        self.assertNotIn("fail-fast", out)
+
+    def test_advisory_failure_mid_poll_does_not_fail_fast(self):
+        # (iv) An advisory leg's failure while siblings are pending must neither
+        # fail-fast nor gate at all (sq-wjth) — the verdict stays green.
+        adv = R("vale (prose, advisory)", conclusion="failure")
+        polls = [[adv, PENDING], [adv, R("coverage")]]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertNotIn("fail-fast", out)
+
+    def test_grace_repoll_dodges_a_transient_failure_read(self):
+        # The grace re-poll: a failure observed ONCE that a fresh fetch does not
+        # re-observe (an API read race) must not red the gate.
+        polls = [
+            [RED, PENDING],                 # racy read: clippy "failure"
+            [GREEN2, PENDING],              # fresh fetch: clippy is green
+            [GREEN2, R("coverage")],
+        ]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertIn("grace re-poll", out)
+        self.assertNotIn("FAILED (fail-fast)", out)
+
+    def test_all_terminal_failure_keeps_the_normal_render_path(self):
+        # pending == 0 => fail-fast stands down and the classic settle + full
+        # render_verdict path (with its richer message) is byte-identical.
+        code, out = run(tiny_cfg(), [[GREEN, RED]])
+        self.assertEqual(code, 1)
+        self.assertIn("non-passing gating check(s)", out)
+        self.assertNotIn("fail-fast", out)
+
+    def test_fail_fast_never_turns_a_verdict_green(self):
+        # Exit-0 invariant: fail-fast is an exit-1-only path — a green set with
+        # pending work must still settle normally and pass.
+        polls = [[GREEN, PENDING], [GREEN, R("coverage")]]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0)
+        self.assertNotIn("fail-fast", out)
+
+
 class TestAdaptiveSaturationBudget(unittest.TestCase):
     """sq-90cv4: saturation extends, hangs RED, real verdicts are untouched."""
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Maintainer directive: (1) the gate poll now concludes FAILURE on the FIRST genuine gating-leg failure (mid-poll supersession/forgiveness applied — race-loser selects and in-progress reruns never fail-fast; advisory legs excluded; one grace re-poll vs API races) — red PRs learn their fate in ~2-4 min instead of 30-40; (2) on gate failure for a pipeline-owned PR (armed/review:pass/review:changes, never human-parked), ci-summary fires the registry doorbell so the repair loop dispatches a fix agent immediately instead of on the next cron tick.

test_ci_summary_gate green incl. the 4 new fail-fast cases (mutation-checked); scoped actionlint clean except pre-existing SC2015 infos. Authored headless (Fable, delegated). Not armed — review pipeline next.