### PR TITLE
fix(routing): terra provider_model placeholder broke codex fleet workers on sparq

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -47,7 +47,9 @@ credential_format = "claude-oauth-token"
 [models.terra]
 provider = "openai"
 harness = "codex"
-provider_model = "TBD"                 # terra = the codex CLI's DEFAULT model (GPT-5.6 codex); the TBD
+provider_model = ""                    # EMPTY = omit --model (codex CLI default). The literal "TBD" placeholder
+                                       # reached `codex exec --model TBD` in every terra fleet worker -> API 400 /
+                                       # no-tool-call fallback (2026-07-18). Never ship a placeholder id here.
                                        # sentinel is load-bearing: dispatch/worker pass NO --model flag
 credential_format = "codex-auth-json"
 


### PR DESCRIPTION
> 🤖 SPARQ agent

sparq-side twin of jeswr/agent-account-registry#80: `orchestration/routing.toml` shipped `provider_model = "TBD"` for terra; the registry worker resolve passed the literal through and every sparq-target codex worker ran `codex exec --model TBD` → API 400 / degraded no-tool-call fallback ('model produced no repository changes'). Empty string = the registry's normalized omit-the-flag contract (codex CLI default). Orchestration-only change-class.