### PR TITLE
fix(ci): move fast-fix ring to workflow_run — REGISTRY_RING_TOKEN no longer reachable from PR head (#3474)

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -141,9 +141,9 @@
    "registered": "2026-07-15"
   },
   "fast-fix ring (advisory)": {
-   "workflow": "ci-summary.yml",
+   "workflow": "fast-fix-ring.yml",
    "owner_bead": "sq-6vshe",
-   "promotion_criteria": "advisory while the fail-fast fix-agent ring is proving out: the ring only notifies the registry doorbell after a gating-leg failure and must never gate the PR itself; promote (or fold into the gate job) once ring-triggered fixes have run reliably for a few weeks",
+   "promotion_criteria": "not promotable to a gate: the ring runs post-hoc via workflow_run (on ci-summary completion), never on a PR/merge_group head commit, so it produces no gating check-run by design (sparq-org/sparq#3474 moved it here so the REGISTRY_RING_TOKEN doorbell is unreachable from PR-head content); it only notifies the registry doorbell after a gating-leg failure and must never gate a PR",
    "registered": "2026-07-18"
   }
  }

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -131,7 +131,7 @@
 # one immediate grace re-poll must re-observe the failure before the red is emitted.
 # (2) FAST-FIX RING: when this gate REDs on a pull_request run for a PIPELINE-OWNED
 # PR (armed for auto-merge, or labeled review:pass / review:changes; never drafts or
-# review:needs-user / needs:user holds), the `fix-ring` job below rings the
+# review:needs-user / needs:user holds), the fast-fix ring rings the
 # jeswr/agent-account-registry dispatcher (the same REGISTRY_RING_TOKEN doorbell
 # batch-merge.yml's ring job uses) so its repair sweep enumerates the red PR NOW
 # instead of on the next cron tick. The registry's ci-fix admission is derived from
@@ -139,10 +139,16 @@
 # sufficient; deliberately NO needs:ci-fix label fallback — the registry enumerator
 # treats needs:* PR labels as HUMAN-owned holds that EXCLUDE a PR from the repair
 # loop, so a label would do the opposite of triggering a fix. Without the token
-# (fork PR head / secret unconfigured) the job skips with a notice and the registry
-# cron remains the backstop. The job name carries "advisory" so its own check-run
-# can never gate a future run on the same SHA, and it runs with a read-only token —
-# the doorbell token is the only write capability and it is scoped to the registry.
+# (fork PR head / secret unconfigured) the ring skips with a notice and the registry
+# cron remains the backstop. The ring LIVES IN ITS OWN WORKFLOW,
+# .github/workflows/fast-fix-ring.yml, triggered via `workflow_run` on ci-summary's
+# completion — NOT as a job in this file. That placement is a SECURITY REQUIREMENT
+# (sparq-org/sparq#3474): the ring holds the cross-repo REGISTRY_RING_TOKEN, and a
+# `pull_request`-triggered workflow takes its definition from the PR HEAD where
+# same-repo agent branches receive repository secrets, so a job here could be edited
+# by a PR to exfiltrate the token. `workflow_run` always runs the default-branch copy
+# of the file, isolated from PR-head content — see that file's header for the full
+# threat model + adversarial self-check.
 #
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
 # scripts/ci_summary_gate.py (extracted from the previous inline bash so the
@@ -244,63 +250,3 @@ jobs:
           PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: python3 scripts/ci_summary_gate.py
-
-  # FAST-FIX RING (header §FAIL-FAST + FAST-FIX RING). A red gate on a
-  # pipeline-owned PR wakes the registry repair loop immediately. Least
-  # privilege: the job's own token is pull-requests:read only (it reads the
-  # PR's LIVE labels/arm/draft state — the trigger payload's snapshot goes
-  # stale across the poll window); the only write capability is the
-  # REGISTRY_RING_TOKEN doorbell, absent on fork heads (fail-soft skip — the
-  # registry cron is the backstop). "advisory" in the name keeps this job's
-  # check-run structurally non-gating for any future gate run on the same SHA
-  # (sq-wjth rule), and `failure()` excludes cancelled (superseded) gate runs.
-  fix-ring:
-    name: fast-fix ring (advisory)
-    needs: gate
-    if: >-
-      failure()
-      && github.event_name == 'pull_request'
-      && github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: read
-    steps:
-      - name: Ring the registry dispatcher for an immediate repair sweep
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REGISTRY_RING_TOKEN: ${{ secrets.REGISTRY_RING_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          # Live PR state — labels/arming churn between the trigger payload and
-          # a gate verdict that can be many minutes later.
-          if ! state="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-              --jq '{draft: .draft, armed: (.auto_merge != null), labels: [.labels[].name]}')"; then
-            echo "::notice::could not read live PR state — skipping the ring (the registry cron is the backstop)."
-            exit 0
-          fi
-          has() { jq -e --arg l "$1" '.labels | index($l) != null' <<<"$state" >/dev/null; }
-          if [ "$(jq -r '.draft' <<<"$state")" = "true" ]; then
-            echo "PR re-drafted since the trigger — not pipeline-owned for fast-fix; skipping."
-            exit 0
-          fi
-          if has "review:needs-user" || has "needs:user"; then
-            echo "human-owned hold (review:needs-user / needs:user) — the repair loop must not pick this PR up; skipping."
-            exit 0
-          fi
-          if [ "$(jq -r '.armed' <<<"$state")" != "true" ] && ! has "review:pass" && ! has "review:changes"; then
-            echo "PR is neither armed nor in the review pipeline (review:pass / review:changes) — skipping."
-            exit 0
-          fi
-          if [ -z "${REGISTRY_RING_TOKEN}" ]; then
-            # NO needs:ci-fix label fallback, deliberately: the registry PLAN
-            # derives ci-fix admission from the PR's gate STATE and treats
-            # needs:* PR labels as human-owned holds that EXCLUDE the PR from
-            # the repair enumeration — a label here would suppress the fix.
-            echo "::notice::REGISTRY_RING_TOKEN unavailable (fork head or secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
-            exit 0
-          fi
-          GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry
-          echo "rang jeswr/agent-account-registry dispatch — the repair sweep runs now instead of on the next cron tick."

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -666,15 +666,17 @@ jobs:
       #   github.event.workflow_run.head_repository.full_name == github.repository
       # at the job level, with same-repo+same-head-SHA defense in depth in the
       # head_sha->PR resolution and a live head_repo/head_sha re-check before the
-      # dispatch. This REGRESSION checker PINS THE WHOLE token-consuming job byte-exact
-      # (canonical JSON of the `ring` job — if/permissions/env/run body all included)
-      # and asserts EXACTLY ONE job consumes secrets.REGISTRY_RING_TOKEN, so ANY edit to
-      # the guard (OR-wrap, negation, operand swap, demoted-to-comment predicate,
-      # uncalled-function move, alt dispatch spelling, dropped select conjunct, inverted
-      # `!=`, changed permission, dispatch-target swap) OR a second privileged job goes
-      # RED (self-test proves it with the full round-1..4 mutation table via the live
-      # --root path). Needs PyYAML — installed in the shared setup above with the other
-      # workflow-lint self-tests.
+      # dispatch. This REGRESSION checker PINS THE WHOLE WORKFLOW DOCUMENT byte-exact
+      # against scripts/tests/fast-fix-ring.golden.yml (after semantically-inert
+      # trailing-whitespace/newline normalization only), so ANY edit to the file reds:
+      # a job-level guard weakening (OR-wrap, negation, operand swap, demoted-to-comment
+      # predicate, uncalled-function move, alt dispatch spelling, dropped select conjunct,
+      # inverted `!=`, changed permission, dispatch-target swap), a SECOND token consumer
+      # in ANY syntax (dotted or `secrets['...']` bracket), a workflow-level `env:` a
+      # second job inherits, or a workflow-level `defaults.run.shell` wrapper. The
+      # whole-file pin SUBSUMES the former whole-job pin (there is no level above the
+      # whole file), which is why it is terminal (self-test proves it with the full
+      # round-1..5 mutation table via the live --root path). Pure stdlib — no PyYAML.
       - name: Self-test the fast-fix ring cross-repo guard (#3475 negative fixtures)
         run: python3 scripts/check-fast-fix-ring-guard.py --self-test
       - name: "Enforce the fast-fix ring fail-closed cross-repo guard (#3475) — GATING"

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -666,10 +666,15 @@ jobs:
       #   github.event.workflow_run.head_repository.full_name == github.repository
       # at the job level, with same-repo+same-head-SHA defense in depth in the
       # head_sha->PR resolution and a live head_repo/head_sha re-check before the
-      # dispatch. This structural guard-presence check goes RED if any of those is
-      # removed (self-test proves it with three negative fixtures: fork run,
-      # same-SHA collision, stale head). Needs PyYAML — installed in the shared
-      # setup above with the other workflow-lint self-tests.
+      # dispatch. This REGRESSION checker PINS THE WHOLE token-consuming job byte-exact
+      # (canonical JSON of the `ring` job — if/permissions/env/run body all included)
+      # and asserts EXACTLY ONE job consumes secrets.REGISTRY_RING_TOKEN, so ANY edit to
+      # the guard (OR-wrap, negation, operand swap, demoted-to-comment predicate,
+      # uncalled-function move, alt dispatch spelling, dropped select conjunct, inverted
+      # `!=`, changed permission, dispatch-target swap) OR a second privileged job goes
+      # RED (self-test proves it with the full round-1..4 mutation table via the live
+      # --root path). Needs PyYAML — installed in the shared setup above with the other
+      # workflow-lint self-tests.
       - name: Self-test the fast-fix ring cross-repo guard (#3475 negative fixtures)
         run: python3 scripts/check-fast-fix-ring-guard.py --self-test
       - name: "Enforce the fast-fix ring fail-closed cross-repo guard (#3475) — GATING"

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -658,6 +658,22 @@ jobs:
         run: python3 scripts/check-advisory-registry.py --self-test
       - name: "Enforce advisory-job registry + gate-intent placement (C2/C3) — GATING"
         run: python3 scripts/check-advisory-registry.py
+      # [OPUS-4.8] sparq-org/sparq#3475: the fast-fix ring's ONLY privileged
+      # capability is the cross-repo REGISTRY_RING_TOKEN doorbell. Because a
+      # `workflow_run` workflow is ALSO delivered for fork / cross-repo triggering
+      # runs (and workflow_run grants secret access even when the triggering run
+      # lacked secrets), the ring MUST fail-closed on
+      #   github.event.workflow_run.head_repository.full_name == github.repository
+      # at the job level, with same-repo+same-head-SHA defense in depth in the
+      # head_sha->PR resolution and a live head_repo/head_sha re-check before the
+      # dispatch. This structural guard-presence check goes RED if any of those is
+      # removed (self-test proves it with three negative fixtures: fork run,
+      # same-SHA collision, stale head). Needs PyYAML — installed in the shared
+      # setup above with the other workflow-lint self-tests.
+      - name: Self-test the fast-fix ring cross-repo guard (#3475 negative fixtures)
+        run: python3 scripts/check-fast-fix-ring-guard.py --self-test
+      - name: "Enforce the fast-fix ring fail-closed cross-repo guard (#3475) — GATING"
+        run: python3 scripts/check-fast-fix-ring-guard.py
 
   # ----------------------------- ADVISORY -----------------------------
   # [FABLE-5] sq-6vshe.20: the three former advisory jobs as step-groups on ONE

--- a/.github/workflows/fast-fix-ring.yml
+++ b/.github/workflows/fast-fix-ring.yml
@@ -28,8 +28,10 @@
 # per-PR CI status), so ringing is sufficient; deliberately NO needs:ci-fix label
 # fallback — the registry enumerator treats needs:* PR labels as HUMAN-owned holds that
 # EXCLUDE a PR from the repair loop, so a label would do the OPPOSITE of triggering a
-# fix. Without the token (fork PR head / secret unconfigured) the job fail-softs with a
-# notice and the registry cron remains the backstop.
+# fix. Fork / cross-repo runs never reach the token step at all — the job `if:` gates
+# on head_repository.full_name == this repo (#3475), so only a same-repo PR run runs
+# the body; if the token is merely unconfigured the job fail-softs with a notice and
+# the registry cron remains the backstop.
 #
 # ADVISORY / NON-GATING (unchanged). This workflow is a SIDE EFFECT of a red gate, not
 # part of the gate. It runs via `workflow_run` on a PAST run's completion, so it
@@ -51,12 +53,22 @@
 #      NUMBER. There is no `run` step that interpolates untrusted PR text into the
 #      shell, and no ${{ github.event.workflow_run.* }} value is expanded inside a
 #      `run:` script (all are passed through `env:` and quoted) — no script injection.
-#  (2) Does the head_sha -> PR lookup admit a spoofed cross-repo PR? NO. The lookup is
-#      constrained to the SAME repository: it takes the workflow_run.pull_requests entry
-#      (which GitHub populates ONLY for same-repo PRs) first, and its `gh api
-#      .../commits/<sha>/pulls` fallback filters to pulls whose head.repo.full_name ==
-#      this repo. A fork PR (pull_requests empty AND no same-repo PR at that SHA) is
-#      SKIPPED — fork heads have no secrets and cannot ring anyway.
+#  (2) Does the head_sha -> PR lookup admit a spoofed / same-SHA cross-repo run? NO,
+#      and this is now FAIL-CLOSED at the job level (#3475). The PRIMARY guard is the
+#      job `if:` condition
+#         github.event.workflow_run.head_repository.full_name == github.repository
+#      — a fork run, or a spoofed cross-repo run whose head commit collides with an
+#      internal PR's SHA, has a head_repository that is NOT this repo, so it NEVER
+#      reaches the token step. (This matters because workflow_run runs are ALSO
+#      delivered for fork/cross-repo triggering runs, and workflow_run grants secret
+#      access even when the triggering run itself had none — so the OLD "fork runs
+#      cannot ring anyway" reasoning was FALSE: without this guard the head_sha->PR
+#      fallback could misattribute a same-SHA fork run to a pipeline-owned internal
+#      PR and fire the doorbell.) DEFENSE IN DEPTH, past that gate: the head_sha->PR
+#      fallback accepts only pulls whose head.repo.full_name == this repo AND whose
+#      head.sha == the failing run's exact head SHA; and the live-state read re-checks
+#      the resolved PR's head_repo == this repo AND head_sha == the run's head SHA
+#      before the dispatch. Three independent barriers, each fail-closed.
 #  (3) Confused-deputy — could the ring fire for a PR the failing run didn't belong to?
 #      NO. The PR is bound to the failing run's OWN head SHA
 #      (github.event.workflow_run.head_sha) — either via that run's pull_requests list
@@ -92,13 +104,27 @@ concurrency:
 jobs:
   ring:
     name: fast-fix ring (advisory)
-    # Only a FAILED ci-summary run that fired from a pull_request. `workflow_run`
-    # exposes the triggering run's own conclusion + originating event; a
-    # push/merge_group ci-summary failure is NOT a PR and cannot ring. `failure`
-    # excludes cancelled/superseded gate runs, matching the old `failure()` guard.
+    # Only a FAILED ci-summary run that fired from a SAME-REPO pull_request.
+    # `workflow_run` exposes the triggering run's own conclusion + originating
+    # event; a push/merge_group ci-summary failure is NOT a PR and cannot ring.
+    # `failure` excludes cancelled/superseded gate runs, matching the old
+    # `failure()` guard.
+    #
+    # head_repository.full_name == github.repository is the PRIMARY #3475 guard
+    # (FAIL-CLOSED, defense in depth): a fork run — or a spoofed cross-repo run
+    # whose head commit collides with an internal PR's SHA — has a head_repository
+    # that is NOT this repo, so it is REJECTED HERE and the token step is never
+    # reached. Fork/cross-repo `workflow_run` runs are still delivered to this
+    # workflow (workflow_run fires for them), and `workflow_run` grants secret
+    # access even when the triggering run itself lacked secrets — so guarding on
+    # conclusion+event ALONE was insufficient: the downstream head_sha->PR fallback
+    # could otherwise MISATTRIBUTE a fork run to a same-SHA internal PR. This gate
+    # closes that off before any resolution runs. (The old "fork runs cannot ring
+    # anyway" reasoning was FALSE — corrected in §ADVERSARIAL #2.)
     if: >-
       github.event.workflow_run.conclusion == 'failure'
       && github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -113,22 +139,32 @@ jobs:
           # actually failed (confused-deputy guard #3). Passed through env (never
           # interpolated into the script body) so no PR-controlled value can inject.
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          # Same-repo PRs GitHub already associated with the triggering run. Empty
-          # for fork PRs (which have no secrets and cannot ring anyway).
+          # Same-repo PRs GitHub already associated with the triggering run. The job
+          # `if:` has already fail-closed on head_repository == this repo (#3475), so
+          # this only ever resolves for a same-repo PR run; it can still be empty for
+          # a same-repo PR whose association GitHub hasn't attached to the run, hence
+          # the head_sha->PR fallback below.
           RUN_PR_NUMBER: ${{ (github.event.workflow_run.pull_requests[0] != null) && github.event.workflow_run.pull_requests[0].number || '' }}
         run: |
           set -euo pipefail
 
           # --- Derive the PR number, SAME-REPO only (spoof guard #2 / deputy #3) ---
+          # The top-level job `if:` already fail-closed on
+          # head_repository.full_name == github.repository, so a fork/cross-repo run
+          # never reaches this step. The head_sha->PR fallback below adds a SECOND,
+          # independent barrier (defense in depth against a same-SHA collision):
+          # every resolved PR must be BOTH same-repo AND pinned to the failing run's
+          # exact head SHA before any dispatch.
           PR_NUMBER="${RUN_PR_NUMBER}"
           if [ -z "${PR_NUMBER}" ]; then
             # pull_requests is empty for fork PRs and can be empty for same-repo PRs
             # whose association GitHub hasn't attached to the run; look the PR up by
             # the failing run's head SHA, but ONLY accept a pull whose head repo is
-            # THIS repo (a fork PR — or a spoofed cross-repo PR at the same SHA —
-            # is filtered out and the job skips).
+            # THIS repo AND whose head SHA is EXACTLY this run's head SHA (a fork PR,
+            # or an internal PR that merely shares this commit but points its head at
+            # a different SHA, is filtered out and the job skips).
             if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
-                --jq "[.[] | select(.head.repo.full_name == \"${REPO}\" and .state == \"open\")] | .[0].number // empty")"; then
+                --jq "[.[] | select(.head.repo.full_name == \"${REPO}\" and .head.sha == \"${HEAD_SHA}\" and .state == \"open\")] | .[0].number // empty")"; then
               echo "::notice::could not look up a PR for the failed run's head SHA — skipping (the registry cron is the backstop)."
               exit 0
             fi
@@ -140,10 +176,24 @@ jobs:
           fi
 
           # --- Live PR state — labels/arming churn between the trigger and here ---
-          # (ported verbatim from the former ci-summary fix-ring job.)
+          # (ported from the former ci-summary fix-ring job; head_repo/head_sha now
+          # re-read for the #3475 defense-in-depth check below.)
           if ! state="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
-              --jq '{draft: .draft, armed: (.auto_merge != null), labels: [.labels[].name]}')"; then
+              --jq '{draft: .draft, armed: (.auto_merge != null), head_repo: .head.repo.full_name, head_sha: .head.sha, labels: [.labels[].name]}')"; then
             echo "::notice::could not read live PR state — skipping the ring (the registry cron is the backstop)."
+            exit 0
+          fi
+          # Defense in depth (#3475): the resolved PR must belong to THIS repo AND
+          # its head must still be the failing run's exact SHA. This closes any
+          # residual same-SHA-collision window in either resolution path (the
+          # workflow_run.pull_requests[0] association OR the pulls-at-SHA lookup)
+          # before the privileged doorbell fires.
+          if [ "$(jq -r '.head_repo' <<<"$state")" != "${REPO}" ]; then
+            echo "resolved PR #${PR_NUMBER} head repo is not ${REPO} (fork / cross-repo collision) — skipping."
+            exit 0
+          fi
+          if [ "$(jq -r '.head_sha' <<<"$state")" != "${HEAD_SHA}" ]; then
+            echo "resolved PR #${PR_NUMBER} head SHA no longer matches the failing run's head SHA (stale head / same-SHA collision) — skipping."
             exit 0
           fi
           has() { jq -e --arg l "$1" '.labels | index($l) != null' <<<"$state" >/dev/null; }
@@ -164,7 +214,7 @@ jobs:
             # derives ci-fix admission from the PR's gate STATE and treats
             # needs:* PR labels as human-owned holds that EXCLUDE the PR from
             # the repair enumeration — a label here would suppress the fix.
-            echo "::notice::REGISTRY_RING_TOKEN unavailable (fork head or secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
+            echo "::notice::REGISTRY_RING_TOKEN unavailable (secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
             exit 0
           fi
           GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry

--- a/.github/workflows/fast-fix-ring.yml
+++ b/.github/workflows/fast-fix-ring.yml
@@ -1,0 +1,171 @@
+# fast-fix-ring — the FAST-FIX RING, moved OFF the PR-head trust boundary
+# (sparq-org/sparq#3474, HIGH). [OPUS-4.8] 🤖 SPARQ agent.
+#
+# WHY THIS IS ITS OWN `workflow_run` WORKFLOW (the security fix):
+# The ring's only privileged capability is the cross-repo `REGISTRY_RING_TOKEN`
+# doorbell (it dispatches jeswr/agent-account-registry). Previously the ring lived
+# as the `fix-ring` job INSIDE ci-summary.yml, which triggers on `pull_request`.
+# For a `pull_request` event GitHub takes the WORKFLOW DEFINITION from the PR HEAD,
+# and same-repo agent branches (sparq-agent/*) are granted repository secrets — so a
+# malicious or compromised agent PR that merely EDITED ci-summary.yml could read and
+# exfiltrate REGISTRY_RING_TOKEN. That is issue #3474.
+#
+# The secure pattern is `workflow_run`: this workflow runs ONLY after ci-summary has
+# completed, GitHub ALWAYS executes the copy of THIS file that lives on the DEFAULT
+# BRANCH (never the PR head's copy), and the job runs privileged but ISOLATED from any
+# PR-head content — the run does not (and must not) check out or execute anything from
+# the head SHA. A PR that edits this file on its branch changes NOTHING about the run
+# that fires for it; only a change merged to the default branch takes effect (and that
+# passes through review + branch protection). REGISTRY_RING_TOKEN is therefore no
+# longer reachable from PR-head-controlled content. See §ADVERSARIAL below.
+#
+# WHAT IT DOES (unchanged behaviour, ported verbatim from the old fix-ring job): when
+# the ci-summary `gate` REDs on a pull_request run for a PIPELINE-OWNED PR (armed for
+# auto-merge, or labeled review:pass / review:changes; never drafts or the human-owned
+# review:needs-user / needs:user holds), ring the registry dispatcher so its repair
+# sweep enumerates the red PR NOW instead of on the next ~10-min cron tick. The
+# registry's ci-fix admission is derived from the PR's GATE STATE (its PLAN snapshots
+# per-PR CI status), so ringing is sufficient; deliberately NO needs:ci-fix label
+# fallback — the registry enumerator treats needs:* PR labels as HUMAN-owned holds that
+# EXCLUDE a PR from the repair loop, so a label would do the OPPOSITE of triggering a
+# fix. Without the token (fork PR head / secret unconfigured) the job fail-softs with a
+# notice and the registry cron remains the backstop.
+#
+# ADVISORY / NON-GATING (unchanged). This workflow is a SIDE EFFECT of a red gate, not
+# part of the gate. It runs via `workflow_run` on a PAST run's completion, so it
+# produces NO check-run on any PR / merge_group head commit and is therefore NOT on the
+# `ci-summary / gate` poll set — it can never become a required check and can never
+# affect a merge (same non-gating argument selection-alarm.yml relies on). The job name
+# retains the "advisory" token for continuity with the advisory-registry entry
+# (.github/advisory-registry.json, key "fast-fix ring (advisory)") and the sq-wjth
+# exclusion rule, even though the workflow_run placement already makes it structurally
+# non-gating.
+#
+# All third-party actions (none are used here — the job is pure `gh api`) would be
+# SHA-pinned per the Scorecard posture. This workflow deliberately performs NO checkout.
+#
+# §ADVERSARIAL (self-check answers recorded for #3474):
+#  (1) Can PR-head content still influence the privileged job? NO. workflow_run always
+#      loads THIS file from the default branch; the job never checks out or executes
+#      head content, and reads only server-side API state (labels/draft/arm) by PR
+#      NUMBER. There is no `run` step that interpolates untrusted PR text into the
+#      shell, and no ${{ github.event.workflow_run.* }} value is expanded inside a
+#      `run:` script (all are passed through `env:` and quoted) — no script injection.
+#  (2) Does the head_sha -> PR lookup admit a spoofed cross-repo PR? NO. The lookup is
+#      constrained to the SAME repository: it takes the workflow_run.pull_requests entry
+#      (which GitHub populates ONLY for same-repo PRs) first, and its `gh api
+#      .../commits/<sha>/pulls` fallback filters to pulls whose head.repo.full_name ==
+#      this repo. A fork PR (pull_requests empty AND no same-repo PR at that SHA) is
+#      SKIPPED — fork heads have no secrets and cannot ring anyway.
+#  (3) Confused-deputy — could the ring fire for a PR the failing run didn't belong to?
+#      NO. The PR is bound to the failing run's OWN head SHA
+#      (github.event.workflow_run.head_sha) — either via that run's pull_requests list
+#      or the same-repo pulls-at-SHA lookup — so the ring always targets the PR whose CI
+#      actually failed. The live-state re-read is by that same resolved PR number.
+#  (4) workflow_run recursion — can this workflow trigger itself? NO. It triggers ONLY
+#      on completion of the workflow named `ci-summary`; it is not itself named
+#      `ci-summary` and it emits no ci-summary run. It also gates on
+#      workflow_run.event == 'pull_request', and this workflow has no pull_request
+#      trigger, so nothing it does can re-enter it.
+name: fast-fix-ring
+
+on:
+  # Fire after ci-summary completes. ci-summary's `name:` is exactly `ci-summary`,
+  # and `workflow_run.workflows` keys on that workflow NAME. The job `if:` below
+  # narrows to a FAILED pull_request run; workflow_run always executes the
+  # default-branch copy of this file (the whole point of the #3474 fix).
+  workflow_run:
+    workflows: ["ci-summary"]
+    types: [completed]
+
+# The job's own GITHUB_TOKEN needs only to READ the PR's live labels/draft/arm state.
+# The one WRITE capability is the cross-repo REGISTRY_RING_TOKEN doorbell, which is a
+# SEPARATE token consumed inside the step — not a permission of this GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# One in-flight ring per triggering ci-summary run.
+concurrency:
+  group: fast-fix-ring-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  ring:
+    name: fast-fix ring (advisory)
+    # Only a FAILED ci-summary run that fired from a pull_request. `workflow_run`
+    # exposes the triggering run's own conclusion + originating event; a
+    # push/merge_group ci-summary failure is NOT a PR and cannot ring. `failure`
+    # excludes cancelled/superseded gate runs, matching the old `failure()` guard.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Resolve the PR for the failed run and ring the registry dispatcher
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REGISTRY_RING_TOKEN: ${{ secrets.REGISTRY_RING_TOKEN }}
+          REPO: ${{ github.repository }}
+          # The failing run's OWN head SHA — binds the ring to the PR whose CI
+          # actually failed (confused-deputy guard #3). Passed through env (never
+          # interpolated into the script body) so no PR-controlled value can inject.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Same-repo PRs GitHub already associated with the triggering run. Empty
+          # for fork PRs (which have no secrets and cannot ring anyway).
+          RUN_PR_NUMBER: ${{ (github.event.workflow_run.pull_requests[0] != null) && github.event.workflow_run.pull_requests[0].number || '' }}
+        run: |
+          set -euo pipefail
+
+          # --- Derive the PR number, SAME-REPO only (spoof guard #2 / deputy #3) ---
+          PR_NUMBER="${RUN_PR_NUMBER}"
+          if [ -z "${PR_NUMBER}" ]; then
+            # pull_requests is empty for fork PRs and can be empty for same-repo PRs
+            # whose association GitHub hasn't attached to the run; look the PR up by
+            # the failing run's head SHA, but ONLY accept a pull whose head repo is
+            # THIS repo (a fork PR — or a spoofed cross-repo PR at the same SHA —
+            # is filtered out and the job skips).
+            if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+                --jq "[.[] | select(.head.repo.full_name == \"${REPO}\" and .state == \"open\")] | .[0].number // empty")"; then
+              echo "::notice::could not look up a PR for the failed run's head SHA — skipping (the registry cron is the backstop)."
+              exit 0
+            fi
+            PR_NUMBER="${pulls}"
+          fi
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "no same-repo PR is associated with the failed run's head SHA (fork PR, or the run was not a same-repo PR) — nothing to ring; skipping."
+            exit 0
+          fi
+
+          # --- Live PR state — labels/arming churn between the trigger and here ---
+          # (ported verbatim from the former ci-summary fix-ring job.)
+          if ! state="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+              --jq '{draft: .draft, armed: (.auto_merge != null), labels: [.labels[].name]}')"; then
+            echo "::notice::could not read live PR state — skipping the ring (the registry cron is the backstop)."
+            exit 0
+          fi
+          has() { jq -e --arg l "$1" '.labels | index($l) != null' <<<"$state" >/dev/null; }
+          if [ "$(jq -r '.draft' <<<"$state")" = "true" ]; then
+            echo "PR re-drafted since the trigger — not pipeline-owned for fast-fix; skipping."
+            exit 0
+          fi
+          if has "review:needs-user" || has "needs:user"; then
+            echo "human-owned hold (review:needs-user / needs:user) — the repair loop must not pick this PR up; skipping."
+            exit 0
+          fi
+          if [ "$(jq -r '.armed' <<<"$state")" != "true" ] && ! has "review:pass" && ! has "review:changes"; then
+            echo "PR is neither armed nor in the review pipeline (review:pass / review:changes) — skipping."
+            exit 0
+          fi
+          if [ -z "${REGISTRY_RING_TOKEN}" ]; then
+            # NO needs:ci-fix label fallback, deliberately: the registry PLAN
+            # derives ci-fix admission from the PR's gate STATE and treats
+            # needs:* PR labels as human-owned holds that EXCLUDE the PR from
+            # the repair enumeration — a label here would suppress the fix.
+            echo "::notice::REGISTRY_RING_TOKEN unavailable (fork head or secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
+            exit 0
+          fi
+          GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry
+          echo "rang jeswr/agent-account-registry dispatch for PR #${PR_NUMBER} — the repair sweep runs now instead of on the next cron tick."

--- a/scripts/check-fast-fix-ring-guard.py
+++ b/scripts/check-fast-fix-ring-guard.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sparq-org/sparq#3475 — fail-closed regression guard for the fast-fix
+# ring's cross-repo trust boundary. 🤖 SPARQ agent. Authored by Opus 4.8 (Fable
+# routed off security surfaces by design; flag for re-review when Fable returns).
+#
+# WHAT THIS PROVES (about .github/workflows/fast-fix-ring.yml):
+#   The ring's ONLY privileged capability is the cross-repo REGISTRY_RING_TOKEN
+#   doorbell. A `workflow_run` workflow is ALSO delivered for fork / cross-repo
+#   triggering runs, and `workflow_run` grants secret access even when the
+#   triggering run itself lacked secrets. So guarding only on
+#   conclusion=='failure' && event=='pull_request' is INSUFFICIENT: the
+#   head_sha->PR fallback could misattribute a fork run whose head commit collides
+#   with an internal PR's SHA to that pipeline-owned internal PR and fire the
+#   doorbell (#3475, BLOCKING).
+#
+#   The FAIL-CLOSED fix is a top-level job guard
+#       github.event.workflow_run.head_repository.full_name == github.repository
+#   so a fork / spoofed cross-repo run NEVER reaches the token step, plus defense
+#   in depth in the head_sha->PR resolution (same-repo AND same-head-SHA) and a
+#   re-check of the resolved PR's live head_repo/head_sha before dispatch.
+#
+# The three checks below are diff-visible: if the head_repository guard is removed
+# from the job `if:`, or the token step stops being gated behind that job, or the
+# SHA-pin defense-in-depth is dropped, this script RED-fails.
+#
+#   G1  the `ring` job `if:` contains the fail-closed
+#       head_repository.full_name == github.repository condition (ANDed, not ORed).
+#   G2  the step that consumes REGISTRY_RING_TOKEN / dispatches the registry lives
+#       INSIDE the guarded `ring` job (so the guard actually gates the token) and
+#       there is no OTHER job that references REGISTRY_RING_TOKEN without the guard.
+#   G3  the head_sha->PR resolution filters on BOTH head.repo.full_name == this repo
+#       AND head.sha == the failing run's head SHA (same-SHA-collision defense in
+#       depth), and the live-state read re-checks head_repo + head_sha before the
+#       dispatch.
+#
+# NEGATIVE COVERAGE (--self-test, hermetic — no gh/git/network):
+#   * fork run (head_repository != repo)            => guard rejects (G1 present).
+#   * same-SHA internal-vs-fork collision           => head.sha filter rejects (G3).
+#   * stale-head (PR head moved off the run's SHA)   => live head_sha re-check (G3).
+#   Each fixture is the real workflow with the guard SURGICALLY REMOVED; the check
+#   must go RED on every one, proving it is not vacuous.
+#
+# Usage:
+#   check-fast-fix-ring-guard.py              # check the live workflow (default)
+#   check-fast-fix-ring-guard.py --root DIR   # use DIR as repo root
+#   check-fast-fix-ring-guard.py --self-test  # hermetic negative fixtures
+#
+# Exit 0 = all clean; exit 1 = one or more offences. Needs PyYAML (installed in the
+# docs-quality shared setup, same as the other workflow-lint self-tests).
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "fast-fix-ring.yml"
+
+# The fail-closed head_repository guard, matched tolerant of whitespace but NOT of
+# the operands: it must compare workflow_run.head_repository.full_name to
+# github.repository. (== only; a `!=` or an `||` context is caught by G1's AND check.)
+HEAD_REPO_GUARD_RE = re.compile(
+    r"github\.event\.workflow_run\.head_repository\.full_name\s*==\s*github\.repository"
+)
+
+# The privileged token / dispatch markers.
+RING_TOKEN = "REGISTRY_RING_TOKEN"
+DISPATCH_MARKER = "agent-account-registry"
+
+# Defense-in-depth needles in the resolution / live-state bash.
+SHA_FILTER_RE = re.compile(r"\.head\.sha\s*==\s*\\?\"?\$\{?REPO\}?|\.head\.sha == ")
+# (kept simple; the precise assertions are done structurally below.)
+
+
+class Offence(Exception):
+    pass
+
+
+def _load(text: str) -> dict:
+    doc = yaml.safe_load(text)
+    if not isinstance(doc, dict):
+        raise Offence("workflow is not a YAML mapping")
+    return doc
+
+
+def _ring_job(doc: dict) -> tuple[str, dict]:
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        raise Offence("workflow has no `jobs:` mapping")
+    # The ring job is the one that references the token / dispatch. Prefer the id
+    # `ring`, but locate by content so a rename can't hide the token.
+    ring = None
+    for jid, job in jobs.items():
+        blob = yaml.safe_dump(job)
+        if RING_TOKEN in blob or DISPATCH_MARKER in blob:
+            ring = (jid, job)
+            break
+    if ring is None:
+        raise Offence(
+            f"no job references {RING_TOKEN}/{DISPATCH_MARKER} — cannot locate the ring job"
+        )
+    return ring
+
+
+def check_doc(text: str) -> list[str]:
+    """Return a list of offence strings; empty == clean."""
+    offences: list[str] = []
+    doc = _load(text)
+    jobs = doc.get("jobs", {})
+    ring_id, ring = _ring_job(doc)
+
+    # ---- G1: the ring job `if:` carries the fail-closed head_repository guard ----
+    cond = ring.get("if")
+    if not isinstance(cond, str) or not cond.strip():
+        offences.append(f"G1: ring job `{ring_id}` has no `if:` guard at all")
+    else:
+        cond_flat = " ".join(cond.split())
+        if not HEAD_REPO_GUARD_RE.search(cond_flat):
+            offences.append(
+                f"G1: ring job `{ring_id}` `if:` is MISSING the fail-closed "
+                f"`workflow_run.head_repository.full_name == github.repository` guard "
+                f"(a fork / same-SHA cross-repo run could reach the token step) — got: {cond_flat!r}"
+            )
+        else:
+            # The guard must be ANDed into the condition (a top-level `||` would let
+            # a branch bypass it). Reject if the guard is only reachable past an `||`.
+            # Heuristic: there must be a `&&` adjacent to the guard and no bare `||`
+            # that isn't itself inside a parenthesised sub-expression.
+            if "||" in cond_flat and "&&" not in cond_flat:
+                offences.append(
+                    f"G1: ring job `{ring_id}` `if:` ORs the head_repository guard "
+                    f"(`||` with no `&&`) — the guard must be ANDed so it is fail-closed"
+                )
+
+    # ---- G2: the token step lives INSIDE the guarded ring job; no OTHER job uses it ----
+    ring_blob = yaml.safe_dump(ring)
+    if RING_TOKEN not in ring_blob:
+        offences.append(
+            f"G2: the guarded ring job `{ring_id}` does not reference {RING_TOKEN} — "
+            f"the token step is not gated behind the head_repository guard"
+        )
+    for jid, job in jobs.items():
+        if jid == ring_id:
+            continue
+        blob = yaml.safe_dump(job)
+        if RING_TOKEN in blob or DISPATCH_MARKER in blob:
+            jcond = job.get("if")
+            jflat = " ".join(jcond.split()) if isinstance(jcond, str) else ""
+            if not HEAD_REPO_GUARD_RE.search(jflat):
+                offences.append(
+                    f"G2: job `{jid}` also references the ring token/dispatch but is "
+                    f"NOT behind the head_repository guard — a second unguarded path to the token"
+                )
+
+    # ---- G3: SHA/repo defense in depth in the resolution + live-state bash ----
+    # Gather the ring job's run-step bodies.
+    run_bodies = []
+    for step in ring.get("steps", []) or []:
+        if isinstance(step, dict) and isinstance(step.get("run"), str):
+            run_bodies.append(step["run"])
+    body = "\n".join(run_bodies)
+    if not body:
+        offences.append(f"G3: ring job `{ring_id}` has no `run:` body to inspect")
+    else:
+        # The head_sha->PR fallback must filter on head.repo.full_name == repo AND
+        # head.sha == the run head SHA.
+        if ".head.repo.full_name" not in body:
+            offences.append(
+                "G3: the head_sha->PR resolution does not filter on `.head.repo.full_name` "
+                "(same-repo constraint missing)"
+            )
+        if ".head.sha ==" not in body:
+            offences.append(
+                "G3: the head_sha->PR resolution does not filter on `.head.sha ==` the "
+                "failing run's head SHA (same-SHA-collision defense in depth missing)"
+            )
+        # The live-state read must re-check head_repo and head_sha before dispatch.
+        if "head_repo" not in body or "head_sha" not in body:
+            offences.append(
+                "G3: the live-PR-state read does not re-check `head_repo`/`head_sha` before "
+                "the dispatch (residual same-SHA-collision window before the doorbell)"
+            )
+        # The re-check must actually gate (compare to REPO / HEAD_SHA and skip).
+        if 'jq -r \'.head_repo\'' not in body and "'.head_repo'" not in body:
+            offences.append(
+                "G3: the resolved PR's head_repo is read but never compared/gated before dispatch"
+            )
+        if 'jq -r \'.head_sha\'' not in body and "'.head_sha'" not in body:
+            offences.append(
+                "G3: the resolved PR's head_sha is read but never compared/gated before dispatch"
+            )
+
+    return offences
+
+
+# --------------------------------------------------------------------------- #
+#  --self-test: hermetic negative fixtures                                    #
+# --------------------------------------------------------------------------- #
+
+def _self_test() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    failures = 0
+
+    def expect_clean(label: str, t: str) -> None:
+        nonlocal failures
+        offs = check_doc(t)
+        if offs:
+            failures += 1
+            print(f"  [FAIL] {label}: expected CLEAN but got offences:")
+            for o in offs:
+                print(f"           - {o}")
+        else:
+            print(f"  [ok]   {label}: clean (as expected)")
+
+    def expect_red(label: str, t: str, needle: str) -> None:
+        nonlocal failures
+        offs = check_doc(t)
+        if not any(needle in o for o in offs):
+            failures += 1
+            print(
+                f"  [FAIL] {label}: expected an offence containing {needle!r} but got: {offs}"
+            )
+        else:
+            print(f"  [ok]   {label}: correctly RED ({needle})")
+
+    # 0) the real, live workflow must be clean.
+    expect_clean("live workflow", text)
+
+    # 1) FORK RUN: remove the head_repository guard from the job `if:`. A fork /
+    #    cross-repo run whose head SHA collides with an internal PR would no longer
+    #    be rejected at the job level. => G1 must RED.
+    no_guard = re.sub(
+        r"\n\s*&&\s*github\.event\.workflow_run\.head_repository\.full_name\s*==\s*github\.repository",
+        "",
+        text,
+    )
+    assert no_guard != text, "fixture-1 did not remove the guard — check the regex"
+    expect_red("fork run (head_repository guard removed)", no_guard, "G1")
+
+    # 2) SAME-SHA internal-vs-fork collision: drop the `.head.sha ==` filter from the
+    #    head_sha->PR resolution. A fork commit that shares an internal PR's SHA could
+    #    resolve to the internal PR via the pulls-at-SHA lookup. => G3 must RED.
+    no_sha_filter = text.replace(
+        'and .head.sha == \\"${HEAD_SHA}\\" and .state', "and .state"
+    )
+    assert no_sha_filter != text, "fixture-2 did not remove the head.sha filter"
+    expect_red(
+        "same-SHA collision (head.sha filter removed)", no_sha_filter, "G3"
+    )
+
+    # 3) STALE-HEAD: remove the live-state head_sha re-check before dispatch. A PR
+    #    whose head moved off the run's SHA between the trigger and here would still
+    #    ring. => G3 must RED (the live re-check needle is gone).
+    #    Remove BOTH the head_sha field from the jq projection AND the guard block.
+    no_live_recheck = re.sub(
+        r'head_sha: \.head\.sha, ', "", text
+    )
+    no_live_recheck = re.sub(
+        r"          if \[ \"\$\(jq -r '\.head_sha' <<<\"\$state\"\)\" != \"\$\{HEAD_SHA\}\" \]; then\n"
+        r".*?\n            exit 0\n          fi\n",
+        "",
+        no_live_recheck,
+        flags=re.DOTALL,
+    )
+    assert no_live_recheck != text, "fixture-3 did not remove the live head_sha re-check"
+    expect_red("stale-head (live head_sha re-check removed)", no_live_recheck, "G3")
+
+    if failures:
+        print(f"\nSELF-TEST FAILED: {failures} case(s) did not behave as expected.")
+        return 1
+    print("\nSELF-TEST PASSED: guard present + all three negative fixtures RED.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", type=Path, default=None, help="repo root override")
+    ap.add_argument(
+        "--self-test", action="store_true", help="run hermetic negative fixtures"
+    )
+    args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
+
+    wf = WORKFLOW
+    if args.root is not None:
+        wf = args.root / ".github" / "workflows" / "fast-fix-ring.yml"
+    if not wf.exists():
+        print(f"error: {wf} not found", file=sys.stderr)
+        return 1
+
+    try:
+        offences = check_doc(wf.read_text(encoding="utf-8"))
+    except Offence as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    if offences:
+        print("fast-fix-ring cross-repo guard check FAILED (#3475):", file=sys.stderr)
+        for o in offences:
+            print(f"  - {o}", file=sys.stderr)
+        return 1
+    print("fast-fix-ring cross-repo guard check: OK (#3475 fail-closed guard present).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-fast-fix-ring-guard.py
+++ b/scripts/check-fast-fix-ring-guard.py
@@ -24,21 +24,35 @@
 # SHA-pin defense-in-depth is dropped, this script RED-fails.
 #
 #   G1  the `ring` job `if:` contains the fail-closed
-#       head_repository.full_name == github.repository condition (ANDed, not ORed).
+#       head_repository.full_name == github.repository condition, AND-only: the
+#       expression STRUCTURE must have NO top-level `||` (a `|| true` or any
+#       depth-0 OR branch would satisfy the condition without the guard). Parsed,
+#       not substring-tested for `&&` — the real condition contains `&&`.
 #   G2  the step that consumes REGISTRY_RING_TOKEN / dispatches the registry lives
 #       INSIDE the guarded `ring` job (so the guard actually gates the token) and
 #       there is no OTHER job that references REGISTRY_RING_TOKEN without the guard.
-#   G3  the head_sha->PR resolution filters on BOTH head.repo.full_name == this repo
-#       AND head.sha == the failing run's head SHA (same-SHA-collision defense in
-#       depth), and the live-state read re-checks head_repo + head_sha before the
-#       dispatch.
+#   G3  the head_sha->PR resolution `select(...)` filters on BOTH the exact fork-repo
+#       predicate (head.repo.full_name == ${REPO}) AND head.sha == ${HEAD_SHA} (the
+#       failing run's own SHA, not a constant), and the live-state read re-checks
+#       head_repo + head_sha with FAIL-CLOSED `!=` guards that `exit 0` on mismatch
+#       BEFORE the dispatch. Operands are matched EXACTLY (semantic, not substring)
+#       so dropping the repo predicate, swapping the SHA operand for a constant, or
+#       inverting a guard from `!=` to `==` each RED-fails.
 #
 # NEGATIVE COVERAGE (--self-test, hermetic — no gh/git/network):
-#   * fork run (head_repository != repo)            => guard rejects (G1 present).
-#   * same-SHA internal-vs-fork collision           => head.sha filter rejects (G3).
-#   * stale-head (PR head moved off the run's SHA)   => live head_sha re-check (G3).
-#   Each fixture is the real workflow with the guard SURGICALLY REMOVED; the check
-#   must go RED on every one, proving it is not vacuous.
+#   * fork run (head_repository guard removed)       => G1 (guard present).
+#   * top-level `|| true` bypass appended to the if  => G1 (AND-only, no fail-open OR).
+#   * same-SHA internal-vs-fork collision            => G3 (head.sha filter rejects).
+#   * stale-head (PR head moved off the run's SHA)   => G3 (live head_sha re-check).
+#   * fork-repo predicate removed from the fallback  => G3 (fork PR could resolve).
+#   * head.sha compared to a CONSTANT not ${HEAD_SHA}=> G3 (SHA-bind bypass).
+#   * live `!=` guards inverted to `==` (fail-open)  => G3 (fail-closed inversion).
+#   Each fixture is the real workflow with a SURGICAL mutation applied; the check
+#   must go RED on every one, proving it is not vacuous. The last four fixtures
+#   target the round-2 gaps: G1 previously rejected an OR only when NO `&&` was
+#   present (the real if has `&&`, so a `|| true` bypass read clean), and G3
+#   substring-matched, so dropping the fork-repo predicate, comparing to a
+#   constant, or inverting the live guards all passed.
 #
 # Usage:
 #   check-fast-fix-ring-guard.py              # check the live workflow (default)
@@ -70,14 +84,70 @@ HEAD_REPO_GUARD_RE = re.compile(
 # The privileged token / dispatch markers.
 RING_TOKEN = "REGISTRY_RING_TOKEN"
 DISPATCH_MARKER = "agent-account-registry"
+# The exact command that fires the cross-repo doorbell — G3 checks the guards
+# come BEFORE this in the run body.
+DISPATCH_CMD = "gh workflow run dispatch.yml"
 
-# Defense-in-depth needles in the resolution / live-state bash.
-SHA_FILTER_RE = re.compile(r"\.head\.sha\s*==\s*\\?\"?\$\{?REPO\}?|\.head\.sha == ")
-# (kept simple; the precise assertions are done structurally below.)
+# --- G3 EXACT predicates in the (YAML-parsed) run body -----------------------
+# These are matched EXACTLY (operands included), not by loose substring, so that
+# a mutation which (a) drops the fork-repo predicate, (b) compares .head.sha to a
+# constant instead of ${HEAD_SHA}, or (c) inverts a live fail-closed guard from
+# `!=` to `==`, each produces a RED. In the parsed run string the workflow's
+# `\\"` source escapes render as a single backslash-quote (`\"`).
+#
+# 1) head_sha->PR fallback: the `select(...)` must filter on BOTH the fork-repo
+#    predicate AND the exact-SHA predicate bound to ${HEAD_SHA}.
+G3_FALLBACK_REPO_PREDICATE = r'.head.repo.full_name == \"${REPO}\"'
+G3_FALLBACK_SHA_PREDICATE = r'.head.sha == \"${HEAD_SHA}\"'
+# 2) live-state defense in depth: each guard must be a FAIL-CLOSED `!=` compare
+#    (repo != this repo => skip; head_sha != run's SHA => skip). An inversion to
+#    `==` (fire only when they DON'T match) is caught because the `!=` form is gone.
+G3_LIVE_REPO_GUARD = '.head_repo\' <<<"$state")" != "${REPO}"'
+G3_LIVE_SHA_GUARD = '.head_sha\' <<<"$state")" != "${HEAD_SHA}"'
 
 
 class Offence(Exception):
     pass
+
+
+def _has_top_level_or(expr: str) -> bool:
+    """True iff `expr` contains a `||` at parenthesis-nesting depth 0.
+
+    A top-level `||` makes the whole condition satisfiable by an alternative
+    branch, which would neuter the AND-chained head_repository guard (e.g. a
+    trailing `|| true`). We must parse the expression STRUCTURE, not substring-
+    test for `&&`: the real condition already contains `&&`, so the old
+    `"||" in cond and "&&" not in cond` heuristic reported a top-level bypass
+    clean. `||` inside a parenthesised sub-expression is fine (it does not gate
+    the whole condition); only a depth-0 `||` is fail-open.
+    """
+    depth = 0
+    i = 0
+    n = len(expr)
+    quote = ""  # current string-literal delimiter, "" when not inside one
+    while i < n:
+        c = expr[i]
+        if quote:
+            # Inside a single- or double-quoted literal: only the matching quote
+            # ends it (GitHub expression literals don't use backslash escapes;
+            # a doubled quote is an escaped quote — skip it).
+            if c == quote:
+                if i + 1 < n and expr[i + 1] == quote:
+                    i += 1  # escaped quote
+                else:
+                    quote = ""
+        elif c in ("'", '"'):
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth = max(0, depth - 1)
+        elif c == "|" and i + 1 < n and expr[i + 1] == "|":
+            if depth == 0:
+                return True
+            i += 1  # consume the second '|'
+        i += 1
+    return False
 
 
 def _load(text: str) -> dict:
@@ -125,16 +195,18 @@ def check_doc(text: str) -> list[str]:
                 f"`workflow_run.head_repository.full_name == github.repository` guard "
                 f"(a fork / same-SHA cross-repo run could reach the token step) — got: {cond_flat!r}"
             )
-        else:
-            # The guard must be ANDed into the condition (a top-level `||` would let
-            # a branch bypass it). Reject if the guard is only reachable past an `||`.
-            # Heuristic: there must be a `&&` adjacent to the guard and no bare `||`
-            # that isn't itself inside a parenthesised sub-expression.
-            if "||" in cond_flat and "&&" not in cond_flat:
-                offences.append(
-                    f"G1: ring job `{ring_id}` `if:` ORs the head_repository guard "
-                    f"(`||` with no `&&`) — the guard must be ANDed so it is fail-closed"
-                )
+        elif _has_top_level_or(cond_flat):
+            # The guard must be ANDed into the condition. A top-level `||`
+            # (e.g. a trailing `|| true`, or `... || github.actor == 'x'`) makes
+            # the whole condition satisfiable by an alternative branch, which
+            # neuters the head_repository guard — REJECT it regardless of whether
+            # a `&&` is also present. (A `||` nested inside parentheses does not
+            # gate the whole condition and is allowed.)
+            offences.append(
+                f"G1: ring job `{ring_id}` `if:` has a top-level `||` — the "
+                f"head_repository guard must be ANDed (no fail-open OR branch) so "
+                f"it is fail-closed; got: {cond_flat!r}"
+            )
 
     # ---- G2: the token step lives INSIDE the guarded ring job; no OTHER job uses it ----
     ring_blob = yaml.safe_dump(ring)
@@ -166,33 +238,56 @@ def check_doc(text: str) -> list[str]:
     if not body:
         offences.append(f"G3: ring job `{ring_id}` has no `run:` body to inspect")
     else:
-        # The head_sha->PR fallback must filter on head.repo.full_name == repo AND
-        # head.sha == the run head SHA.
-        if ".head.repo.full_name" not in body:
+        # Semantic (not substring) matching: each predicate is matched WITH its
+        # operands, so a mutation that drops the fork-repo predicate, swaps the
+        # SHA operand for a constant, or inverts a live guard from `!=` to `==`
+        # each produces a RED.
+        #
+        # (a) head_sha->PR fallback: fork-repo predicate must be present.
+        if G3_FALLBACK_REPO_PREDICATE not in body:
             offences.append(
-                "G3: the head_sha->PR resolution does not filter on `.head.repo.full_name` "
-                "(same-repo constraint missing)"
+                "G3: the head_sha->PR resolution `select(...)` is MISSING the fork-repo "
+                f"predicate `{G3_FALLBACK_REPO_PREDICATE}` — a fork PR sharing the run's "
+                "head SHA could resolve to the pipeline (same-repo constraint dropped)"
             )
-        if ".head.sha ==" not in body:
+        # (b) head_sha->PR fallback: SHA predicate must compare to ${HEAD_SHA},
+        #     NOT a constant. Matching the exact operand catches a constant swap.
+        if G3_FALLBACK_SHA_PREDICATE not in body:
             offences.append(
-                "G3: the head_sha->PR resolution does not filter on `.head.sha ==` the "
-                "failing run's head SHA (same-SHA-collision defense in depth missing)"
+                "G3: the head_sha->PR resolution `select(...)` does not pin "
+                f"`{G3_FALLBACK_SHA_PREDICATE}` — the head.sha filter must compare to the "
+                "failing run's ${HEAD_SHA} (not a constant/other value), else the same-SHA-"
+                "collision defense in depth is bypassed"
             )
-        # The live-state read must re-check head_repo and head_sha before dispatch.
-        if "head_repo" not in body or "head_sha" not in body:
-            offences.append(
-                "G3: the live-PR-state read does not re-check `head_repo`/`head_sha` before "
-                "the dispatch (residual same-SHA-collision window before the doorbell)"
-            )
-        # The re-check must actually gate (compare to REPO / HEAD_SHA and skip).
-        if 'jq -r \'.head_repo\'' not in body and "'.head_repo'" not in body:
-            offences.append(
-                "G3: the resolved PR's head_repo is read but never compared/gated before dispatch"
-            )
-        if 'jq -r \'.head_sha\'' not in body and "'.head_sha'" not in body:
-            offences.append(
-                "G3: the resolved PR's head_sha is read but never compared/gated before dispatch"
-            )
+        # (c) live-state defense in depth: BOTH guards must be the FAIL-CLOSED
+        #     `!=` form (mismatch => skip). An inversion to `==` removes the `!=`
+        #     spelling and is caught here; each guard must also precede dispatch.
+        for label, needle in (
+            ("head_repo", G3_LIVE_REPO_GUARD),
+            ("head_sha", G3_LIVE_SHA_GUARD),
+        ):
+            pos = body.find(needle)
+            if pos < 0:
+                offences.append(
+                    f"G3: the live-PR-state {label} re-check is MISSING its fail-closed "
+                    f"`{needle}` guard — either the guard was dropped or inverted from `!=` "
+                    "to `==` (which would fire ONLY on a mismatch — fail-OPEN)"
+                )
+                continue
+            # The guard block must skip (exit 0) on mismatch, and run before the
+            # privileged dispatch command.
+            block_tail = body[pos : pos + 400]
+            if "exit 0" not in block_tail:
+                offences.append(
+                    f"G3: the live-PR-state {label} `!=` guard does not `exit 0` on "
+                    "mismatch — it must fail-closed (skip the dispatch), not fall through"
+                )
+            disp = body.find(DISPATCH_CMD)
+            if disp >= 0 and pos > disp:
+                offences.append(
+                    f"G3: the live-PR-state {label} `!=` guard appears AFTER the "
+                    f"`{DISPATCH_CMD}` doorbell — the guard must gate BEFORE the dispatch"
+                )
 
     return offences
 
@@ -270,10 +365,66 @@ def _self_test() -> int:
     assert no_live_recheck != text, "fixture-3 did not remove the live head_sha re-check"
     expect_red("stale-head (live head_sha re-check removed)", no_live_recheck, "G3")
 
+    # --- round-2 findings: the checker was too loose; these four fixtures pin it ---
+
+    # 4) [G1 finding] TOP-LEVEL `|| true` BYPASS. The real if already contains `&&`,
+    #    so the old `"||" in cond and "&&" not in cond` heuristic read a trailing
+    #    `|| true` clean — which makes the whole condition true regardless of the
+    #    head_repository guard. Append a depth-0 `|| true`. => G1 must RED.
+    or_bypass = text.replace(
+        "&& github.event.workflow_run.head_repository.full_name == github.repository\n",
+        "&& github.event.workflow_run.head_repository.full_name == github.repository\n"
+        "      || true\n",
+        1,
+    )
+    assert or_bypass != text, "fixture-4 did not append the `|| true` bypass"
+    expect_red("top-level `|| true` bypass appended", or_bypass, "G1")
+
+    # 5) [G3 finding] REMOVE THE FORK-REPO PREDICATE from the head_sha->PR fallback
+    #    `select(...)`. Without `head.repo.full_name == ${REPO}` a fork PR sharing the
+    #    run's head SHA can resolve to the pipeline. The old `.head.repo.full_name`
+    #    substring test also matched the live-state jq projection, so it passed. => G3.
+    no_repo_predicate = text.replace(
+        'select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" '
+        'and .state == \\"open\\")',
+        'select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")',
+        1,
+    )
+    assert no_repo_predicate != text, "fixture-5 did not remove the fork-repo predicate"
+    expect_red("fallback fork-repo predicate removed", no_repo_predicate, "G3")
+
+    # 6) [G3 finding] COMPARE .head.sha TO A CONSTANT instead of ${HEAD_SHA}. The old
+    #    `.head.sha ==` substring test ignored the operand, so binding the filter to a
+    #    fixed value (which never matches the real run SHA / breaks the SHA binding)
+    #    passed. => G3 must RED.
+    sha_constant = text.replace(
+        '.head.sha == \\"${HEAD_SHA}\\" and .state',
+        '.head.sha == \\"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\" and .state',
+        1,
+    )
+    assert sha_constant != text, "fixture-6 did not swap the head.sha operand"
+    expect_red("fallback head.sha compared to a constant", sha_constant, "G3")
+
+    # 7) [G3 finding] INVERT THE LIVE `!=` GUARDS TO `==` (fail-OPEN: the guard would
+    #    now `exit 0` only when the repo/SHA MATCH, ringing on every mismatch/collision
+    #    instead). The old `head_repo`/`head_sha` and `jq -r '.head_repo'` substring
+    #    tests were still present after the flip, so it passed. => G3 must RED.
+    inverted_guards = text.replace(
+        'if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then',
+        'if [ "$(jq -r \'.head_repo\' <<<"$state")" == "${REPO}" ]; then',
+        1,
+    ).replace(
+        'if [ "$(jq -r \'.head_sha\' <<<"$state")" != "${HEAD_SHA}" ]; then',
+        'if [ "$(jq -r \'.head_sha\' <<<"$state")" == "${HEAD_SHA}" ]; then',
+        1,
+    )
+    assert inverted_guards != text, "fixture-7 did not invert the live guards"
+    expect_red("live `!=` guards inverted to `==` (fail-open)", inverted_guards, "G3")
+
     if failures:
         print(f"\nSELF-TEST FAILED: {failures} case(s) did not behave as expected.")
         return 1
-    print("\nSELF-TEST PASSED: guard present + all three negative fixtures RED.")
+    print("\nSELF-TEST PASSED: guard present + all seven negative fixtures RED.")
     return 0
 
 

--- a/scripts/check-fast-fix-ring-guard.py
+++ b/scripts/check-fast-fix-ring-guard.py
@@ -1,58 +1,70 @@
 #!/usr/bin/env python3
-# [OPUS-4.8] sparq-org/sparq#3475 — fail-closed regression guard for the fast-fix
+# [OPUS-4.8] sparq-org/sparq#3475 — fail-closed REGRESSION guard for the fast-fix
 # ring's cross-repo trust boundary. 🤖 SPARQ agent. Authored by Opus 4.8 (Fable
 # routed off security surfaces by design; flag for re-review when Fable returns).
 #
-# WHAT THIS PROVES (about .github/workflows/fast-fix-ring.yml):
-#   The ring's ONLY privileged capability is the cross-repo REGISTRY_RING_TOKEN
-#   doorbell. A `workflow_run` workflow is ALSO delivered for fork / cross-repo
-#   triggering runs, and `workflow_run` grants secret access even when the
-#   triggering run itself lacked secrets. So guarding only on
-#   conclusion=='failure' && event=='pull_request' is INSUFFICIENT: the
-#   head_sha->PR fallback could misattribute a fork run whose head commit collides
-#   with an internal PR's SHA to that pipeline-owned internal PR and fire the
-#   doorbell (#3475, BLOCKING).
+# =============================================================================
+# THREAT MODEL — read this first; it fixes the bar this checker is judged against
+# =============================================================================
+# This script is a REGRESSION DETECTOR. Its job is to catch an ACCIDENTAL or an
+# agent-introduced WEAKENING of the fast-fix ring's cross-repo trust guard when a
+# change touches `.github/workflows/fast-fix-ring.yml` — a change that a HUMAN then
+# ARMS (workflow edits are human-armed per repo policy). It is NOT, and cannot be, a
+# defense against an actor who ALREADY HAS repo-write and DELIBERATELY edits the
+# workflow to exfiltrate the secret: such an actor could weaken the guard AND update
+# this checker's golden in the same commit, or exfiltrate REGISTRY_RING_TOKEN by many
+# other means (a brand-new workflow, a different job, an exfiltrating step). Defending
+# against a malicious committer is OUT OF SCOPE here and is handled elsewhere —
+# branch protection, required human review of `.github/workflows/**` changes, and the
+# LIVE security control itself, which is the workflow's own
+#     github.event.workflow_run.head_repository.full_name == github.repository
+# job guard plus the SHA/repo defense-in-depth. THIS script does not enforce security
+# at runtime; the WORKFLOW does. This script only makes an accidental regression to
+# that guard LOUD in review.
 #
-#   The FAIL-CLOSED fix is a top-level job guard
-#       github.event.workflow_run.head_repository.full_name == github.repository
-#   so a fork / spoofed cross-repo run NEVER reaches the token step, plus defense
-#   in depth in the head_sha->PR resolution (same-repo AND same-head-SHA) and a
-#   re-check of the resolved PR's live head_repo/head_sha before dispatch.
+# =============================================================================
+# STRATEGY — CANONICAL GOLDEN MATCH (not predicate parsing)
+# =============================================================================
+# Rounds 1–3 of adversarial review proved that a predicate-PARSING validator cannot
+# win: for every "reject a top-level ||" rule there is a `(A && B && guard || true)`
+# paren-wrap; for every "the guard regex is present" rule there is a `!(guard)`
+# negation; for every "both needles are present" G3 substring rule there is a
+# conjunction→disjunction `repo OR SHA` swap (both needles survive) or a
+# predicate-moved-into-a-comment. Parsing a moving target is a losing regress.
 #
-# The three checks below are diff-visible: if the head_repository guard is removed
-# from the job `if:`, or the token step stops being gated behind that job, or the
-# SHA-pin defense-in-depth is dropped, this script RED-fails.
+# So this checker does NOT parse the security meaning of the condition. It pins the
+# EXACT, KNOWN-GOOD CANONICAL TEXT of each security-load-bearing fragment and requires
+# the workflow's ACTUAL (normalized) fragment to be BYTE-EQUAL to that golden:
 #
-#   G1  the `ring` job `if:` contains the fail-closed
-#       head_repository.full_name == github.repository condition, AND-only: the
-#       expression STRUCTURE must have NO top-level `||` (a `|| true` or any
-#       depth-0 OR branch would satisfy the condition without the guard). Parsed,
-#       not substring-tested for `&&` — the real condition contains `&&`.
-#   G2  the step that consumes REGISTRY_RING_TOKEN / dispatches the registry lives
-#       INSIDE the guarded `ring` job (so the guard actually gates the token) and
-#       there is no OTHER job that references REGISTRY_RING_TOKEN without the guard.
-#   G3  the head_sha->PR resolution `select(...)` filters on BOTH the exact fork-repo
-#       predicate (head.repo.full_name == ${REPO}) AND head.sha == ${HEAD_SHA} (the
-#       failing run's own SHA, not a constant), and the live-state read re-checks
-#       head_repo + head_sha with FAIL-CLOSED `!=` guards that `exit 0` on mismatch
-#       BEFORE the dispatch. Operands are matched EXACTLY (semantic, not substring)
-#       so dropping the repo predicate, swapping the SHA operand for a constant, or
-#       inverting a guard from `!=` to `==` each RED-fails.
+#   G1  the ring job's full `if:` condition, whitespace-normalized, must EXACTLY
+#       equal GOLDEN_IF. Any OR-wrap, negation, operand swap, reorder, or extra
+#       clause changes the normalized text ⇒ mismatch ⇒ RED. You cannot smuggle a
+#       `|| true`, a `!(...)`, or `(... || true)` past an exact-string comparison.
+#   G2  the privileged token/dispatch step lives INSIDE that one guarded job, and no
+#       OTHER job's normalized `if:` differs from GOLDEN_IF while touching the token.
+#   G3  the head_sha->PR resolution `select(...)` jq filter, normalized, must EXACTLY
+#       equal GOLDEN_SELECT (a CONJUNCTION of the fork-repo predicate AND the exact
+#       ${HEAD_SHA} predicate AND state==open — a `repo OR SHA` swap changes the text
+#       ⇒ RED); and the two live fail-closed guard blocks — each a
+#       `if <!= test>; then … exit 0; fi` skeleton — normalized, must EXACTLY equal
+#       their goldens (an inversion to `==` or a moved-to-comment predicate changes
+#       the executable skeleton ⇒ RED), and each must appear BEFORE the dispatch.
 #
-# NEGATIVE COVERAGE (--self-test, hermetic — no gh/git/network):
-#   * fork run (head_repository guard removed)       => G1 (guard present).
-#   * top-level `|| true` bypass appended to the if  => G1 (AND-only, no fail-open OR).
-#   * same-SHA internal-vs-fork collision            => G3 (head.sha filter rejects).
-#   * stale-head (PR head moved off the run's SHA)   => G3 (live head_sha re-check).
-#   * fork-repo predicate removed from the fallback  => G3 (fork PR could resolve).
-#   * head.sha compared to a CONSTANT not ${HEAD_SHA}=> G3 (SHA-bind bypass).
-#   * live `!=` guards inverted to `==` (fail-open)  => G3 (fail-closed inversion).
-#   Each fixture is the real workflow with a SURGICAL mutation applied; the check
-#   must go RED on every one, proving it is not vacuous. The last four fixtures
-#   target the round-2 gaps: G1 previously rejected an OR only when NO `&&` was
-#   present (the real if has `&&`, so a `|| true` bypass read clean), and G3
-#   substring-matched, so dropping the fork-repo predicate, comparing to a
-#   constant, or inverting the live guards all passed.
+# WHY EXACT-MATCH IS STRICTLY STRONGER than the predicate parser it replaces: the
+# adversary's whole bypass class works by producing text that is SEMANTICALLY unsafe
+# but PARSES to the same predicate-presence signal. Against a canonical golden there is
+# no such gap: any text that differs from the known-good form — safe or unsafe — reds.
+# The tradeoff is deliberate: a LEGITIMATE refactor of the guard (rename ${REPO},
+# restructure the select, reword a skip message) will red too, and the fix is to
+# UPDATE THE GOLDEN IN THE SAME PR. That is the CORRECT fail-safe direction — a human /
+# reviewer sees the golden change and re-confirms the guard is still sound, rather than
+# a weakening sliding through on a predicate technicality. (§ headers/echo-message
+# wording that is NOT security-load-bearing is normalized away so pure prose edits do
+# not force a golden bump; see _canon_guard_block.)
+#
+# NEGATIVE COVERAGE (--self-test, hermetic — no gh/git/network): the live workflow
+# passes, and each of the round-1/2/3 bypasses, applied as a SURGICAL mutation to a
+# copy of the real workflow, goes RED. See _self_test for the mutation→red table.
 #
 # Usage:
 #   check-fast-fix-ring-guard.py              # check the live workflow (default)
@@ -74,80 +86,139 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "fast-fix-ring.yml"
 
-# The fail-closed head_repository guard, matched tolerant of whitespace but NOT of
-# the operands: it must compare workflow_run.head_repository.full_name to
-# github.repository. (== only; a `!=` or an `||` context is caught by G1's AND check.)
-HEAD_REPO_GUARD_RE = re.compile(
-    r"github\.event\.workflow_run\.head_repository\.full_name\s*==\s*github\.repository"
-)
-
-# The privileged token / dispatch markers.
 RING_TOKEN = "REGISTRY_RING_TOKEN"
 DISPATCH_MARKER = "agent-account-registry"
 # The exact command that fires the cross-repo doorbell — G3 checks the guards
 # come BEFORE this in the run body.
 DISPATCH_CMD = "gh workflow run dispatch.yml"
 
-# --- G3 EXACT predicates in the (YAML-parsed) run body -----------------------
-# These are matched EXACTLY (operands included), not by loose substring, so that
-# a mutation which (a) drops the fork-repo predicate, (b) compares .head.sha to a
-# constant instead of ${HEAD_SHA}, or (c) inverts a live fail-closed guard from
-# `!=` to `==`, each produces a RED. In the parsed run string the workflow's
-# `\\"` source escapes render as a single backslash-quote (`\"`).
-#
-# 1) head_sha->PR fallback: the `select(...)` must filter on BOTH the fork-repo
-#    predicate AND the exact-SHA predicate bound to ${HEAD_SHA}.
-G3_FALLBACK_REPO_PREDICATE = r'.head.repo.full_name == \"${REPO}\"'
-G3_FALLBACK_SHA_PREDICATE = r'.head.sha == \"${HEAD_SHA}\"'
-# 2) live-state defense in depth: each guard must be a FAIL-CLOSED `!=` compare
-#    (repo != this repo => skip; head_sha != run's SHA => skip). An inversion to
-#    `==` (fire only when they DON'T match) is caught because the `!=` form is gone.
-G3_LIVE_REPO_GUARD = '.head_repo\' <<<"$state")" != "${REPO}"'
-G3_LIVE_SHA_GUARD = '.head_sha\' <<<"$state")" != "${HEAD_SHA}"'
+# =============================================================================
+# GOLDEN CANONICAL FORMS
+# =============================================================================
+# These are the known-good, security-load-bearing fragments of
+# .github/workflows/fast-fix-ring.yml. The checker normalizes the workflow's actual
+# fragment (collapse whitespace; for guard blocks, strip the non-load-bearing echo
+# message) and requires EXACT EQUALITY. If the guard is legitimately refactored, bump
+# the matching golden IN THE SAME PR — that is the intended review checkpoint.
+
+# G1: the ring job's full `if:` condition, whitespace-collapsed. Three ANDed clauses;
+# the third is the #3475 fail-closed head_repository guard. Exact-match, so an OR-wrap
+# `(... || true)`, a `!(...)` negation, an operand swap, a reorder, or any extra
+# clause all differ from this string and RED.
+GOLDEN_IF = (
+    "github.event.workflow_run.conclusion == 'failure' "
+    "&& github.event.workflow_run.event == 'pull_request' "
+    "&& github.event.workflow_run.head_repository.full_name == github.repository"
+)
+
+# G3(a): the head_sha->PR fallback jq `select(...)` filter, normalized (whitespace
+# collapsed). A CONJUNCTION (`and`) of the fork-repo predicate, the exact-${HEAD_SHA}
+# predicate, and state==open. A `repo OR SHA` disjunction, a dropped predicate, or a
+# constant-swapped SHA all change this string and RED. (In the YAML-parsed run body
+# the workflow's `\\"` source escapes render as a single backslash-quote `\"`.)
+GOLDEN_SELECT = (
+    'select(.head.repo.full_name == \\"${REPO}\\" '
+    'and .head.sha == \\"${HEAD_SHA}\\" '
+    'and .state == \\"open\\")'
+)
+
+# G3(b): the two live fail-closed re-check guard blocks, reduced to their EXECUTABLE
+# skeleton (the `if [ <test> ]; then` line + the `exit 0` fail-closed body), with the
+# non-load-bearing echo message removed. Each must be a `!=` (fail-closed: mismatch =>
+# skip) compare and must `exit 0`. An inversion to `==`, a dropped predicate, or a
+# predicate that survives ONLY in a comment changes the executable skeleton and REDs.
+GOLDEN_LIVE_REPO_GUARD = (
+    'if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then '
+    "exit 0 fi"
+)
+GOLDEN_LIVE_SHA_GUARD = (
+    'if [ "$(jq -r \'.head_sha\' <<<"$state")" != "${HEAD_SHA}" ]; then '
+    "exit 0 fi"
+)
 
 
 class Offence(Exception):
     pass
 
 
-def _has_top_level_or(expr: str) -> bool:
-    """True iff `expr` contains a `||` at parenthesis-nesting depth 0.
+def _canon(s: str) -> str:
+    """Whitespace-collapse: any run of whitespace (incl. newlines) => one space,
+    stripped. Used for the `if:` condition and the jq select filter, where only
+    whitespace/line-fold differences are non-load-bearing."""
+    return " ".join(s.split())
 
-    A top-level `||` makes the whole condition satisfiable by an alternative
-    branch, which would neuter the AND-chained head_repository guard (e.g. a
-    trailing `|| true`). We must parse the expression STRUCTURE, not substring-
-    test for `&&`: the real condition already contains `&&`, so the old
-    `"||" in cond and "&&" not in cond` heuristic reported a top-level bypass
-    clean. `||` inside a parenthesised sub-expression is fine (it does not gate
-    the whole condition); only a depth-0 `||` is fail-open.
-    """
-    depth = 0
-    i = 0
-    n = len(expr)
-    quote = ""  # current string-literal delimiter, "" when not inside one
-    while i < n:
-        c = expr[i]
-        if quote:
-            # Inside a single- or double-quoted literal: only the matching quote
-            # ends it (GitHub expression literals don't use backslash escapes;
-            # a doubled quote is an escaped quote — skip it).
-            if c == quote:
-                if i + 1 < n and expr[i + 1] == quote:
-                    i += 1  # escaped quote
-                else:
-                    quote = ""
-        elif c in ("'", '"'):
-            quote = c
-        elif c == "(":
+
+def _strip_shell_comments(body: str) -> str:
+    """Drop full-line shell comments so a `select(...)` (or any predicate) demoted to
+    a `# ...` comment is NOT mistaken for the executable filter. Only whole-line
+    comments are stripped (a leading `#` after optional whitespace); we do not attempt
+    to strip trailing inline comments, which would require full shell tokenization and
+    is unnecessary — the executable predicates in this workflow are never followed by
+    an inline `#`."""
+    return "\n".join(
+        line for line in body.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _extract_select(body: str) -> str | None:
+    """Return the whitespace-normalized `select( ... )` jq filter from the EXECUTABLE
+    run body (shell comments stripped), or None if absent. Balanced-paren scan so
+    nested `()` inside the filter are kept. Stripping comments first means a fork-repo
+    predicate demoted into a `#`-comment is not read as the live filter."""
+    body = _strip_shell_comments(body)
+    idx = body.find("select(")
+    if idx < 0:
+        return None
+    start = idx + len("select(")
+    depth = 1
+    i = start
+    while i < len(body) and depth > 0:
+        c = body[i]
+        if c == "(":
             depth += 1
         elif c == ")":
-            depth = max(0, depth - 1)
-        elif c == "|" and i + 1 < n and expr[i + 1] == "|":
-            if depth == 0:
-                return True
-            i += 1  # consume the second '|'
+            depth -= 1
         i += 1
-    return False
+    if depth != 0:
+        return None
+    return _canon("select(" + body[start : i - 1] + ")")
+
+
+def _canon_guard_block(body: str, jq_field: str) -> str | None:
+    """Extract the live re-check guard block keyed on `jq_field` (`.head_repo` /
+    `.head_sha`) and reduce it to its EXECUTABLE, load-bearing skeleton:
+    the `if [ … ]; then` test line + the fail-closed `exit 0`, joined by single
+    spaces, with the (non-security) echo message line dropped.
+
+    Returns None if no `if` line referencing that field is present. Because the
+    skeleton keeps the `!=`/`==` operator and the compared operands but drops prose,
+    an inversion, a dropped operand, or a predicate that survives only as a `#`
+    comment all change (or empty) the skeleton and fail the golden match, while a
+    reworded skip message does not force a golden bump."""
+    lines = body.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        st = line.strip()
+        if st.startswith("if [") and jq_field in st and st.endswith("then"):
+            start = i
+            break
+    if start is None:
+        return None
+    # Walk to the matching `fi`, keeping only the load-bearing statements.
+    kept: list[str] = []
+    for j in range(start, len(lines)):
+        st = lines[j].strip()
+        if not st or st.startswith("#"):
+            continue
+        if st.startswith("echo "):
+            # non-load-bearing skip message
+            continue
+        kept.append(st)
+        if st == "fi":
+            break
+    else:
+        return None
+    return _canon(" ".join(kept))
 
 
 def _load(text: str) -> dict:
@@ -161,54 +232,42 @@ def _ring_job(doc: dict) -> tuple[str, dict]:
     jobs = doc.get("jobs")
     if not isinstance(jobs, dict):
         raise Offence("workflow has no `jobs:` mapping")
-    # The ring job is the one that references the token / dispatch. Prefer the id
-    # `ring`, but locate by content so a rename can't hide the token.
-    ring = None
+    # The ring job is the one that references the token / dispatch. Locate by content
+    # so a rename cannot hide the token.
     for jid, job in jobs.items():
         blob = yaml.safe_dump(job)
         if RING_TOKEN in blob or DISPATCH_MARKER in blob:
-            ring = (jid, job)
-            break
-    if ring is None:
-        raise Offence(
-            f"no job references {RING_TOKEN}/{DISPATCH_MARKER} — cannot locate the ring job"
-        )
-    return ring
+            return (jid, job)
+    raise Offence(
+        f"no job references {RING_TOKEN}/{DISPATCH_MARKER} — cannot locate the ring job"
+    )
 
 
 def check_doc(text: str) -> list[str]:
-    """Return a list of offence strings; empty == clean."""
+    """Return a list of offence strings; empty == clean. Canonical golden match."""
     offences: list[str] = []
     doc = _load(text)
     jobs = doc.get("jobs", {})
     ring_id, ring = _ring_job(doc)
 
-    # ---- G1: the ring job `if:` carries the fail-closed head_repository guard ----
+    # ---- G1: the ring job `if:` must EXACTLY equal the golden condition ----
     cond = ring.get("if")
     if not isinstance(cond, str) or not cond.strip():
         offences.append(f"G1: ring job `{ring_id}` has no `if:` guard at all")
     else:
-        cond_flat = " ".join(cond.split())
-        if not HEAD_REPO_GUARD_RE.search(cond_flat):
+        cond_flat = _canon(cond)
+        if cond_flat != GOLDEN_IF:
             offences.append(
-                f"G1: ring job `{ring_id}` `if:` is MISSING the fail-closed "
-                f"`workflow_run.head_repository.full_name == github.repository` guard "
-                f"(a fork / same-SHA cross-repo run could reach the token step) — got: {cond_flat!r}"
-            )
-        elif _has_top_level_or(cond_flat):
-            # The guard must be ANDed into the condition. A top-level `||`
-            # (e.g. a trailing `|| true`, or `... || github.actor == 'x'`) makes
-            # the whole condition satisfiable by an alternative branch, which
-            # neuters the head_repository guard — REJECT it regardless of whether
-            # a `&&` is also present. (A `||` nested inside parentheses does not
-            # gate the whole condition and is allowed.)
-            offences.append(
-                f"G1: ring job `{ring_id}` `if:` has a top-level `||` — the "
-                f"head_repository guard must be ANDed (no fail-open OR branch) so "
-                f"it is fail-closed; got: {cond_flat!r}"
+                f"G1: ring job `{ring_id}` `if:` does not match the canonical golden "
+                f"guard. Any change — an OR-wrap `(... || true)`, a `!(...)` negation, "
+                f"an operand swap, a reorder, or an added clause — reds here because the "
+                f"normalized text differs from the known-good condition. If this is a "
+                f"legitimate refactor, update GOLDEN_IF in this PR.\n"
+                f"       expected: {GOLDEN_IF!r}\n"
+                f"       actual:   {cond_flat!r}"
             )
 
-    # ---- G2: the token step lives INSIDE the guarded ring job; no OTHER job uses it ----
+    # ---- G2: the token step is INSIDE the guarded ring job; no OTHER job uses it ----
     ring_blob = yaml.safe_dump(ring)
     if RING_TOKEN not in ring_blob:
         offences.append(
@@ -221,15 +280,15 @@ def check_doc(text: str) -> list[str]:
         blob = yaml.safe_dump(job)
         if RING_TOKEN in blob or DISPATCH_MARKER in blob:
             jcond = job.get("if")
-            jflat = " ".join(jcond.split()) if isinstance(jcond, str) else ""
-            if not HEAD_REPO_GUARD_RE.search(jflat):
+            jflat = _canon(jcond) if isinstance(jcond, str) else ""
+            if jflat != GOLDEN_IF:
                 offences.append(
-                    f"G2: job `{jid}` also references the ring token/dispatch but is "
-                    f"NOT behind the head_repository guard — a second unguarded path to the token"
+                    f"G2: job `{jid}` also references the ring token/dispatch but its "
+                    f"`if:` is not the canonical golden guard — a second path to the "
+                    f"token that is not fail-closed on head_repository"
                 )
 
-    # ---- G3: SHA/repo defense in depth in the resolution + live-state bash ----
-    # Gather the ring job's run-step bodies.
+    # ---- G3: the resolution + live-state guards must match their goldens ----
     run_bodies = []
     for step in ring.get("steps", []) or []:
         if isinstance(step, dict) and isinstance(step.get("run"), str):
@@ -238,52 +297,60 @@ def check_doc(text: str) -> list[str]:
     if not body:
         offences.append(f"G3: ring job `{ring_id}` has no `run:` body to inspect")
     else:
-        # Semantic (not substring) matching: each predicate is matched WITH its
-        # operands, so a mutation that drops the fork-repo predicate, swaps the
-        # SHA operand for a constant, or inverts a live guard from `!=` to `==`
-        # each produces a RED.
-        #
-        # (a) head_sha->PR fallback: fork-repo predicate must be present.
-        if G3_FALLBACK_REPO_PREDICATE not in body:
+        # (a) head_sha->PR fallback: the executable `select(...)` filter must EXACTLY
+        #     equal the golden conjunction. A `repo OR SHA` swap, a dropped predicate,
+        #     or a constant-swapped SHA all change this string and RED. (A predicate
+        #     retained only in a comment does not appear in the parsed jq filter, so
+        #     the select still differs from the golden.)
+        sel = _extract_select(body)
+        if sel is None:
             offences.append(
-                "G3: the head_sha->PR resolution `select(...)` is MISSING the fork-repo "
-                f"predicate `{G3_FALLBACK_REPO_PREDICATE}` — a fork PR sharing the run's "
-                "head SHA could resolve to the pipeline (same-repo constraint dropped)"
+                "G3: the head_sha->PR resolution `select(...)` jq filter is MISSING — "
+                "the fork-repo AND exact-${HEAD_SHA} conjunction cannot be verified"
             )
-        # (b) head_sha->PR fallback: SHA predicate must compare to ${HEAD_SHA},
-        #     NOT a constant. Matching the exact operand catches a constant swap.
-        if G3_FALLBACK_SHA_PREDICATE not in body:
+        elif sel != GOLDEN_SELECT:
             offences.append(
-                "G3: the head_sha->PR resolution `select(...)` does not pin "
-                f"`{G3_FALLBACK_SHA_PREDICATE}` — the head.sha filter must compare to the "
-                "failing run's ${HEAD_SHA} (not a constant/other value), else the same-SHA-"
-                "collision defense in depth is bypassed"
+                "G3: the head_sha->PR resolution `select(...)` does not match the "
+                "canonical golden filter. It must be the CONJUNCTION "
+                "`head.repo.full_name == ${REPO} AND head.sha == ${HEAD_SHA} AND "
+                "state == open` — a `repo OR SHA` disjunction, a dropped predicate, or "
+                "a constant-swapped SHA all differ from the golden and red. If this is "
+                "a legitimate refactor, update GOLDEN_SELECT in this PR.\n"
+                f"       expected: {GOLDEN_SELECT!r}\n"
+                f"       actual:   {sel!r}"
             )
-        # (c) live-state defense in depth: BOTH guards must be the FAIL-CLOSED
-        #     `!=` form (mismatch => skip). An inversion to `==` removes the `!=`
-        #     spelling and is caught here; each guard must also precede dispatch.
-        for label, needle in (
-            ("head_repo", G3_LIVE_REPO_GUARD),
-            ("head_sha", G3_LIVE_SHA_GUARD),
+
+        # (b) live-state defense in depth: each fail-closed `!=` guard block must
+        #     match its golden EXECUTABLE skeleton, and precede the dispatch. An
+        #     inversion to `==`, a dropped operand, or a predicate demoted to a
+        #     comment changes (or empties) the skeleton and reds.
+        for label, jq_field, golden in (
+            ("head_repo", ".head_repo", GOLDEN_LIVE_REPO_GUARD),
+            ("head_sha", ".head_sha", GOLDEN_LIVE_SHA_GUARD),
         ):
-            pos = body.find(needle)
-            if pos < 0:
+            block = _canon_guard_block(body, jq_field)
+            if block is None:
                 offences.append(
-                    f"G3: the live-PR-state {label} re-check is MISSING its fail-closed "
-                    f"`{needle}` guard — either the guard was dropped or inverted from `!=` "
-                    "to `==` (which would fire ONLY on a mismatch — fail-OPEN)"
+                    f"G3: the live-PR-state {label} re-check `if` block is MISSING — "
+                    f"the fail-closed `!=` guard was dropped (or its predicate now "
+                    f"survives only in a comment, which does not execute)"
                 )
                 continue
-            # The guard block must skip (exit 0) on mismatch, and run before the
-            # privileged dispatch command.
-            block_tail = body[pos : pos + 400]
-            if "exit 0" not in block_tail:
+            if block != golden:
                 offences.append(
-                    f"G3: the live-PR-state {label} `!=` guard does not `exit 0` on "
-                    "mismatch — it must fail-closed (skip the dispatch), not fall through"
+                    f"G3: the live-PR-state {label} re-check does not match the "
+                    f"canonical golden guard. It must be the FAIL-CLOSED `!=` compare "
+                    f"that `exit 0`s on mismatch — an inversion to `==`, a dropped "
+                    f"operand, or a comment-only predicate all differ from the golden "
+                    f"and red. If this is a legitimate refactor, update the golden in "
+                    f"this PR.\n"
+                    f"       expected: {golden!r}\n"
+                    f"       actual:   {block!r}"
                 )
+            # Ordering: the guard block must appear BEFORE the privileged dispatch.
+            pos = body.find(f"if [ \"$(jq -r '{jq_field}'")
             disp = body.find(DISPATCH_CMD)
-            if disp >= 0 and pos > disp:
+            if pos >= 0 and disp >= 0 and pos > disp:
                 offences.append(
                     f"G3: the live-PR-state {label} `!=` guard appears AFTER the "
                     f"`{DISPATCH_CMD}` doorbell — the guard must gate BEFORE the dispatch"
@@ -298,7 +365,6 @@ def check_doc(text: str) -> list[str]:
 
 def _self_test() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
-
     failures = 0
 
     def expect_clean(label: str, t: str) -> None:
@@ -314,6 +380,10 @@ def _self_test() -> int:
 
     def expect_red(label: str, t: str, needle: str) -> None:
         nonlocal failures
+        if t == text:
+            failures += 1
+            print(f"  [FAIL] {label}: MUTATION DID NOT APPLY (fixture == live workflow)")
+            return
         offs = check_doc(t)
         if not any(needle in o for o in offs):
             failures += 1
@@ -326,32 +396,23 @@ def _self_test() -> int:
     # 0) the real, live workflow must be clean.
     expect_clean("live workflow", text)
 
-    # 1) FORK RUN: remove the head_repository guard from the job `if:`. A fork /
-    #    cross-repo run whose head SHA collides with an internal PR would no longer
-    #    be rejected at the job level. => G1 must RED.
+    # --- round-1 fixtures: a guard is REMOVED ---
+
+    # 1) FORK RUN: remove the head_repository guard from the job `if:`. => G1.
     no_guard = re.sub(
         r"\n\s*&&\s*github\.event\.workflow_run\.head_repository\.full_name\s*==\s*github\.repository",
         "",
         text,
     )
-    assert no_guard != text, "fixture-1 did not remove the guard — check the regex"
-    expect_red("fork run (head_repository guard removed)", no_guard, "G1")
+    expect_red("R1 fork run (head_repository guard removed)", no_guard, "G1")
 
-    # 2) SAME-SHA internal-vs-fork collision: drop the `.head.sha ==` filter from the
-    #    head_sha->PR resolution. A fork commit that shares an internal PR's SHA could
-    #    resolve to the internal PR via the pulls-at-SHA lookup. => G3 must RED.
+    # 2) SAME-SHA collision: drop the `.head.sha ==` filter from the fallback. => G3.
     no_sha_filter = text.replace(
         'and .head.sha == \\"${HEAD_SHA}\\" and .state', "and .state"
     )
-    assert no_sha_filter != text, "fixture-2 did not remove the head.sha filter"
-    expect_red(
-        "same-SHA collision (head.sha filter removed)", no_sha_filter, "G3"
-    )
+    expect_red("R1 same-SHA collision (head.sha filter removed)", no_sha_filter, "G3")
 
-    # 3) STALE-HEAD: remove the live-state head_sha re-check before dispatch. A PR
-    #    whose head moved off the run's SHA between the trigger and here would still
-    #    ring. => G3 must RED (the live re-check needle is gone).
-    #    Remove BOTH the head_sha field from the jq projection AND the guard block.
+    # 3) STALE-HEAD: remove the live head_sha re-check block before dispatch. => G3.
     no_live_recheck = re.sub(
         r'head_sha: \.head\.sha, ', "", text
     )
@@ -362,53 +423,37 @@ def _self_test() -> int:
         no_live_recheck,
         flags=re.DOTALL,
     )
-    assert no_live_recheck != text, "fixture-3 did not remove the live head_sha re-check"
-    expect_red("stale-head (live head_sha re-check removed)", no_live_recheck, "G3")
+    expect_red("R1 stale-head (live head_sha re-check removed)", no_live_recheck, "G3")
 
-    # --- round-2 findings: the checker was too loose; these four fixtures pin it ---
+    # --- round-2 fixtures: predicate-parser was too loose ---
 
-    # 4) [G1 finding] TOP-LEVEL `|| true` BYPASS. The real if already contains `&&`,
-    #    so the old `"||" in cond and "&&" not in cond` heuristic read a trailing
-    #    `|| true` clean — which makes the whole condition true regardless of the
-    #    head_repository guard. Append a depth-0 `|| true`. => G1 must RED.
+    # 4) TOP-LEVEL `|| true` appended to the if (bare, depth-0). => G1.
     or_bypass = text.replace(
         "&& github.event.workflow_run.head_repository.full_name == github.repository\n",
         "&& github.event.workflow_run.head_repository.full_name == github.repository\n"
         "      || true\n",
         1,
     )
-    assert or_bypass != text, "fixture-4 did not append the `|| true` bypass"
-    expect_red("top-level `|| true` bypass appended", or_bypass, "G1")
+    expect_red("R2 top-level `|| true` bypass appended", or_bypass, "G1")
 
-    # 5) [G3 finding] REMOVE THE FORK-REPO PREDICATE from the head_sha->PR fallback
-    #    `select(...)`. Without `head.repo.full_name == ${REPO}` a fork PR sharing the
-    #    run's head SHA can resolve to the pipeline. The old `.head.repo.full_name`
-    #    substring test also matched the live-state jq projection, so it passed. => G3.
+    # 5) fork-repo predicate removed from the fallback `select(...)`. => G3.
     no_repo_predicate = text.replace(
         'select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" '
         'and .state == \\"open\\")',
         'select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")',
         1,
     )
-    assert no_repo_predicate != text, "fixture-5 did not remove the fork-repo predicate"
-    expect_red("fallback fork-repo predicate removed", no_repo_predicate, "G3")
+    expect_red("R2 fallback fork-repo predicate removed", no_repo_predicate, "G3")
 
-    # 6) [G3 finding] COMPARE .head.sha TO A CONSTANT instead of ${HEAD_SHA}. The old
-    #    `.head.sha ==` substring test ignored the operand, so binding the filter to a
-    #    fixed value (which never matches the real run SHA / breaks the SHA binding)
-    #    passed. => G3 must RED.
+    # 6) .head.sha compared to a CONSTANT instead of ${HEAD_SHA}. => G3.
     sha_constant = text.replace(
         '.head.sha == \\"${HEAD_SHA}\\" and .state',
         '.head.sha == \\"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\" and .state',
         1,
     )
-    assert sha_constant != text, "fixture-6 did not swap the head.sha operand"
-    expect_red("fallback head.sha compared to a constant", sha_constant, "G3")
+    expect_red("R2 fallback head.sha compared to a constant", sha_constant, "G3")
 
-    # 7) [G3 finding] INVERT THE LIVE `!=` GUARDS TO `==` (fail-OPEN: the guard would
-    #    now `exit 0` only when the repo/SHA MATCH, ringing on every mismatch/collision
-    #    instead). The old `head_repo`/`head_sha` and `jq -r '.head_repo'` substring
-    #    tests were still present after the flip, so it passed. => G3 must RED.
+    # 7) live `!=` guards inverted to `==` (fail-open). => G3.
     inverted_guards = text.replace(
         'if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then',
         'if [ "$(jq -r \'.head_repo\' <<<"$state")" == "${REPO}" ]; then',
@@ -418,13 +463,79 @@ def _self_test() -> int:
         'if [ "$(jq -r \'.head_sha\' <<<"$state")" == "${HEAD_SHA}" ]; then',
         1,
     )
-    assert inverted_guards != text, "fixture-7 did not invert the live guards"
-    expect_red("live `!=` guards inverted to `==` (fail-open)", inverted_guards, "G3")
+    expect_red("R2 live `!=` guards inverted to `==` (fail-open)", inverted_guards, "G3")
+
+    # --- round-3 fixtures: the exact bypasses codex demonstrated against the parser ---
+
+    # 8) [R3] PARENTHESIZED OR-WRAP of the whole condition: actionlint-valid,
+    #    (failure && event && head_repo == repo || true). The old paren-depth
+    #    scanner treated a `||` inside parens as safe. Golden exact-match reds.
+    paren_or_wrap = text.replace(
+        "    if: >-\n"
+        "      github.event.workflow_run.conclusion == 'failure'\n"
+        "      && github.event.workflow_run.event == 'pull_request'\n"
+        "      && github.event.workflow_run.head_repository.full_name == github.repository\n",
+        "    if: >-\n"
+        "      (github.event.workflow_run.conclusion == 'failure'\n"
+        "      && github.event.workflow_run.event == 'pull_request'\n"
+        "      && github.event.workflow_run.head_repository.full_name == github.repository\n"
+        "      || true)\n",
+        1,
+    )
+    expect_red("R3 parenthesized `(... || true)` OR-wrap of the whole if", paren_or_wrap, "G1")
+
+    # 9) [R3] NEGATED equality `!(head_repo == repo)`: passed the old presence regex.
+    #    Golden exact-match reds (text differs).
+    negated_guard = text.replace(
+        "&& github.event.workflow_run.head_repository.full_name == github.repository",
+        "&& !(github.event.workflow_run.head_repository.full_name == github.repository)",
+        1,
+    )
+    expect_red("R3 negated `!(head_repo == repo)` guard", negated_guard, "G1")
+
+    # 10) [R3] G3 CONJUNCTION->DISJUNCTION: `repo AND sha` -> `repo OR sha` in the
+    #     fallback select. Both exact needles survived the old substring test.
+    #     Golden exact-match reds (`and`->`or` changes the normalized filter).
+    or_conjunction = text.replace(
+        '.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\"',
+        '.head.repo.full_name == \\"${REPO}\\" or .head.sha == \\"${HEAD_SHA}\\"',
+        1,
+    )
+    expect_red("R3 fallback conjunction->disjunction (repo OR sha)", or_conjunction, "G3")
+
+    # 11) [R3] PREDICATE MOVED TO A COMMENT: the executable select drops the fork-repo
+    #     predicate but a `#`-comment line retains the needle text. The old substring
+    #     test matched the comment. The golden matches the PARSED filter only, so the
+    #     executable select differs and reds.
+    predicate_in_comment = text.replace(
+        '            if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \\\n'
+        '                --jq "[.[] | select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
+        '            # select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")\n'
+        '            if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \\\n'
+        '                --jq "[.[] | select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
+        1,
+    )
+    expect_red("R3 fork-repo predicate demoted to a comment (select drops it)", predicate_in_comment, "G3")
+
+    # 12) [R3] INVERTED LIVE GUARD accompanied by a comment-only expected needle: the
+    #     executable `!=` is flipped to `==` while a `#`-comment carries the `!=` text.
+    #     The old substring test found the `!=` in the comment. The golden matches the
+    #     executable skeleton (comments stripped), so the inversion reds.
+    inverted_with_comment = text.replace(
+        '          if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n',
+        '          # if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n'
+        '          if [ "$(jq -r \'.head_repo\' <<<"$state")" == "${REPO}" ]; then\n',
+        1,
+    )
+    expect_red("R3 live guard inverted with comment-only `!=` needle", inverted_with_comment, "G3")
 
     if failures:
         print(f"\nSELF-TEST FAILED: {failures} case(s) did not behave as expected.")
         return 1
-    print("\nSELF-TEST PASSED: guard present + all seven negative fixtures RED.")
+    print(
+        "\nSELF-TEST PASSED: live workflow clean + all round-1/2/3 negative fixtures RED "
+        "(canonical golden match)."
+    )
     return 0
 
 

--- a/scripts/check-fast-fix-ring-guard.py
+++ b/scripts/check-fast-fix-ring-guard.py
@@ -23,236 +23,215 @@
 # that guard LOUD in review.
 #
 # =============================================================================
-# STRATEGY — PIN THE WHOLE TOKEN-CONSUMING JOB + ASSERT EXACTLY ONE CONSUMER
+# STRATEGY — PIN THE WHOLE WORKFLOW DOCUMENT (byte-exact, semantically-inert-normalized)
 # =============================================================================
-# Rounds 1–4 of adversarial review proved that both a predicate-PARSING validator AND
-# a fragment-EXTRACTING golden-match lose to a moving target:
+# Rounds 1–5 of adversarial review proved that EVERY narrower pin loses to a moving
+# target, because the attacker can always weaken the token's protection by editing a
+# LEVEL of the file the narrower rule does not pin:
 #
-#   * A parser cannot win: for every "reject a top-level ||" rule there is a
-#     `(A && B && guard || true)` paren-wrap; for every "the guard regex is present"
-#     rule there is a `!(guard)` negation; for every "both needles present" G3 rule
-#     there is a conjunction→disjunction `repo OR SHA` swap (both needles survive).
+#   * A predicate-PARSING validator cannot win: for every "reject a top-level ||" rule
+#     there is a `(A && B && guard || true)` paren-wrap; for every "the guard regex is
+#     present" rule there is a `!(guard)` negation; for every "both needles present" G3
+#     rule there is a conjunction→disjunction `repo OR SHA` swap (both needles survive).
 #
-#   * A FRAGMENT golden-match (rounds 1–3) still leaked, because it pinned only the
-#     EXTRACTED pieces (the `if:`, the `select(...)`, the guard skeletons) and validated
-#     only the FIRST token-consuming job. Codex round 4 found two residual holes:
-#       (a) anything the extractor did NOT cover could still be weakened — an inline
-#           `: # select(...)` demotion, an uncalled-function move of the guards, an
-#           alt dispatch spelling `gh workflow run -R ... dispatch.yml` — because those
-#           edits live OUTSIDE the extracted fragments, so the fragments still matched.
-#       (b) a SECOND privileged job carrying the same golden `if:` but NO SHA/repo
-#           defenses passed, because only the first token consumer was validated.
+#   * A FRAGMENT golden-match (rounds 1–3) leaked: it pinned only the EXTRACTED pieces
+#     (the `if:`, the `select(...)`, the guard skeletons) and validated only the FIRST
+#     token-consuming job, so an inline `: # select(...)` demotion, an uncalled-function
+#     move of the guards, or an alt dispatch spelling lived OUTSIDE the extracted text.
 #
-# Codex round 4 gave the terminal design in its own words: "Pin the COMPLETE
-# token-consuming job, not extracted fragments" and "Require EXACTLY ONE privileged
-# job/path or apply the complete canonical validation to every token consumer."
+#   * A WHOLE-JOB pin (round 4) closed the fragment/demotion/duplication holes WITHIN
+#     the pinned job and added exactly-one-consumer to stop a SECOND privileged job.
+#     But round 5 found that the job is not the top level of the file: an attacker can
+#     reach REGISTRY_RING_TOKEN by editing the workflow ABOVE / BESIDE the pinned job —
+#       (a) a second consumer written with `${{ secrets['REGISTRY_RING_TOKEN'] }}`
+#           BRACKET syntax (a different string than the dotted needle the consumer scan
+#           and the golden job both keyed on);
+#       (b) a workflow-level `env:` that binds the token and is INHERITED by a second
+#           job whose own steps never mention the secret string at all;
+#       (c) a workflow-level `defaults.run.shell: bash -x {0}` custom-shell wrapper that
+#           intercepts/echoes the token (or wraps every `run:` body) BEFORE the pinned
+#           job's script runs — the pinned job text is byte-identical, yet the token is
+#           exposed by machinery OUTSIDE it.
+#     All three edits leave the pinned JOB byte-identical, so a whole-job pin passes
+#     them. The root cause is structural: the job is not the top of the file, so there
+#     is always a level above it to weaken.
 #
-# So this checker does exactly that:
+# Codex round 5 gave the terminal design in its own words: "Pin the COMPLETE workflow
+# document." So this checker pins the ENTIRE file:
 #
-#   J1  PIN THE WHOLE JOB. Parse the workflow YAML, find every job whose steps
-#       reference `secrets.REGISTRY_RING_TOKEN`, canonicalize the ONE token-consuming
-#       job's ENTIRE definition (the whole job mapping: `if:`, `permissions:`, every
-#       step's `env`, `name`, and the EXACT `run:` body — including the
-#       `gh workflow run dispatch.yml` line, the fallback `select(...)`, and BOTH live
-#       `!=` guard blocks) into a normalized, deterministic form (JSON, keys sorted)
-#       and require BYTE-EQUALITY to the stored GOLDEN_JOB. Because the COMPLETE job is
-#       pinned there is NOTHING left to weaken: no fragment to extract-and-dodge, no
-#       predicate to demote to a comment (the comment is INSIDE the pinned run body, so
-#       moving a predicate into it changes the run body), no guards to move into an
-#       uncalled function (that changes the run body too), no alt dispatch spelling
-#       (that changes the run body too), no operand swap, no negation, no OR-wrap. ANY
-#       edit to that job — security-relevant or not — changes the normalized job and REDs.
+#   PIN THE WHOLE FILE. Read `.github/workflows/fast-fix-ring.yml`, NORMALIZE it with
+#   ONLY semantically-inert transforms (strip trailing whitespace per line + collapse to
+#   a single trailing newline — NOT comment-stripping or reordering, because comments
+#   and order ARE part of the pin), do the SAME normalization to the stored golden
+#   `scripts/tests/fast-fix-ring.golden.yml`, and require BYTE-EQUALITY. Any difference
+#   emits ONE offence tagged WORKFLOW-PIN carrying a unified diff (golden vs actual).
 #
-#   J2  EXACTLY ONE TOKEN CONSUMER. Count the jobs that reference
-#       `secrets.REGISTRY_RING_TOKEN` anywhere in their steps; require the count == 1
-#       and that the single consumer is the golden job. A SECOND privileged job (codex
-#       round-4 finding #b) makes the count 2 and REDs — there is no un-validated path
-#       to the token.
+# WHY THIS IS TERMINAL (and why it SUBSUMES the whole-job pin):
+#   There is NO level above the whole file. Every round-5 bypass — and every round-1..4
+#   bypass, which the whole-job pin already caught — is an EDIT TO
+#   `.github/workflows/fast-fix-ring.yml`: a second consumer in any syntax (dotted or
+#   `secrets['...']` bracket), a workflow-level `env:` a second job inherits, a
+#   workflow-level `defaults.run.shell` wrapper, a second job, a permissions change, an
+#   `if:` weakening, a demoted-to-comment predicate, an uncalled-function move, an alt
+#   dispatch spelling — ALL of them change the file's bytes. The whole-file pin looks at
+#   every byte, so:
 #
-# WHY THIS IS TERMINAL (provably immune to the fragment/demotion/duplication class):
-#   - The whole-job pin means the checker's "attack surface" is the ENTIRE job text,
-#     not a chosen subset. The round-1..4 bypasses ALL work by mutating job text that a
-#     narrower rule did not look at; here there is no text the rule does not look at.
-#   - Exactly-one-consumer means there is no second, un-pinned path to the token.
-#   Together: the set of edits that (a) reach the token and (b) pass the checker is
-#   EXACTLY {edits that leave the whole job byte-identical} = {no change to the job}.
-#   A weakening is, by definition, a change to the job, so it cannot pass. The only way
-#   to change the job AND pass is to update GOLDEN_JOB in the SAME PR — which is the
-#   intended human review checkpoint (a reviewer sees the golden move and re-confirms
-#   the guard is still sound), the CORRECT fail-safe direction.
+#       {edits that reach the token AND pass the checker}
+#         = {edits that leave the whole file byte-identical after inert normalization}
+#         = {no change to the workflow}.
 #
-# The GOLDEN_JOB below is the pretty-printed (indent=2, keys sorted) canonical JSON of
-# the known-good `ring` job. It is human-readable ON PURPOSE — it IS the job content, so
-# a reviewer can read exactly what is pinned. Regenerate after an intentional refactor:
-#     python3 -c "import yaml,json; \
-#       d=yaml.safe_load(open('.github/workflows/fast-fix-ring.yml')); \
-#       print(json.dumps(d['jobs']['ring'],sort_keys=True,ensure_ascii=False,indent=2))"
-# and paste the output between the GOLDEN_JOB delimiters, IN THE SAME PR as the workflow
-# change, so the golden bump is the review checkpoint.
+#   A weakening is, by definition, a change to the workflow, so it cannot pass. The
+#   whole-JOB pin was the special case of this that pinned only the job subtree; the
+#   whole-FILE pin pins that subtree AND everything around it (workflow-level env,
+#   defaults, permissions, a second job, comments, any secret-reference syntax), so it
+#   strictly SUBSUMES the whole-job pin. There is no narrower/wider level left to move
+#   to — this is why it is terminal, not another turn in the arms race.
+#
+#   The ONLY way to change the workflow AND pass is to regenerate the golden in the SAME
+#   PR — which is exactly the intended human-review checkpoint (a reviewer sees the
+#   golden move in the diff and re-confirms the guard is still sound), the CORRECT
+#   fail-safe direction.
+#
+# The golden `scripts/tests/fast-fix-ring.golden.yml` is a byte-exact (inert-normalized)
+# copy of the known-good workflow. It is human-readable ON PURPOSE — it IS the pinned
+# content, so a reviewer reads exactly what is pinned. Regenerate after an intentional
+# refactor, IN THE SAME PR as the workflow change, with:
+#     python3 scripts/check-fast-fix-ring-guard.py --update-golden
+# (or copy the normalized workflow into the golden by hand). The golden bump is the
+# review checkpoint.
 #
 # NEGATIVE COVERAGE (--self-test, hermetic — no gh/git/network): the live workflow
-# passes, and EACH round-1..4 bypass — including codex round-4's inline-comment
-# demotion, uncalled-function move, alt dispatch spelling, AND a second privileged
-# token-consuming job — is applied as a SURGICAL mutation to a PHYSICAL COPY of the real
-# workflow and run through the LIVE `--root` path, and goes RED; the unmutated copy
-# passes. See _self_test for the mutation→red table.
+# passes, and EACH round-1..5 bypass — the round-1..4 guard removals / OR-wraps /
+# negations / demotions / uncalled-function move / alt dispatch spelling / second job,
+# PLUS the round-5 bracket-syntax second consumer, workflow-level `env:` + second job,
+# and workflow-level `defaults.run.shell` wrapper — is applied as a SURGICAL mutation to
+# a PHYSICAL COPY of the real workflow and run through the LIVE `--root` path, and goes
+# RED; the unmutated copy passes. See _self_test for the mutation→red table.
 #
 # Usage:
-#   check-fast-fix-ring-guard.py              # check the live workflow (default)
-#   check-fast-fix-ring-guard.py --root DIR   # use DIR as repo root
-#   check-fast-fix-ring-guard.py --self-test  # hermetic negative fixtures
+#   check-fast-fix-ring-guard.py                 # check the live workflow (default)
+#   check-fast-fix-ring-guard.py --root DIR      # use DIR as repo root
+#   check-fast-fix-ring-guard.py --self-test     # hermetic negative fixtures
+#   check-fast-fix-ring-guard.py --update-golden # regenerate the golden (LOCAL ONLY)
 #
-# Exit 0 = all clean; exit 1 = one or more offences. Needs PyYAML (installed in the
-# docs-quality shared setup, same as the other workflow-lint self-tests).
+# Exit 0 = all clean; exit 1 = one or more offences. Pure stdlib — no PyYAML needed for
+# the whole-file pin (a byte compare parses nothing), which also removes any parser as
+# an attack surface.
 
 from __future__ import annotations
 
 import argparse
 import difflib
-import json
+import os
 import sys
 import tempfile
 from pathlib import Path
 
-import yaml
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_REL = Path(".github") / "workflows" / "fast-fix-ring.yml"
 WORKFLOW = REPO_ROOT / WORKFLOW_REL
-
-# The privileged secret whose every consumer must be the one pinned golden job.
-RING_TOKEN_SECRET = "secrets.REGISTRY_RING_TOKEN"
+GOLDEN_REL = Path("scripts") / "tests" / "fast-fix-ring.golden.yml"
+GOLDEN = REPO_ROOT / GOLDEN_REL
 
 
 class Offence(Exception):
     pass
 
 
-# =============================================================================
-# GOLDEN_JOB — the complete, known-good `ring` job, canonical JSON (keys sorted,
-# indent=2). This is the ENTIRE token-consuming job: `if:`, `permissions:`, and the
-# one step's `env` + `name` + full `run:` body (the select(...), both live `!=`
-# guards, and the `gh workflow run dispatch.yml` doorbell are all inside it). The
-# checker re-derives this exact canonical form from the workflow and requires
-# BYTE-EQUALITY. To refactor the guard legitimately, regenerate this block IN THE SAME
-# PR (see the header one-liner) — that golden bump is the review checkpoint.
-# =============================================================================
-GOLDEN_JOB = r"""{
-  "if": "github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository",
-  "name": "fast-fix ring (advisory)",
-  "permissions": {
-    "pull-requests": "read"
-  },
-  "runs-on": "ubuntu-latest",
-  "steps": [
-    {
-      "env": {
-        "GH_TOKEN": "${{ github.token }}",
-        "HEAD_SHA": "${{ github.event.workflow_run.head_sha }}",
-        "REGISTRY_RING_TOKEN": "${{ secrets.REGISTRY_RING_TOKEN }}",
-        "REPO": "${{ github.repository }}",
-        "RUN_PR_NUMBER": "${{ (github.event.workflow_run.pull_requests[0] != null) && github.event.workflow_run.pull_requests[0].number || '' }}"
-      },
-      "name": "Resolve the PR for the failed run and ring the registry dispatcher",
-      "run": "set -euo pipefail\n\n# --- Derive the PR number, SAME-REPO only (spoof guard #2 / deputy #3) ---\n# The top-level job `if:` already fail-closed on\n# head_repository.full_name == github.repository, so a fork/cross-repo run\n# never reaches this step. The head_sha->PR fallback below adds a SECOND,\n# independent barrier (defense in depth against a same-SHA collision):\n# every resolved PR must be BOTH same-repo AND pinned to the failing run's\n# exact head SHA before any dispatch.\nPR_NUMBER=\"${RUN_PR_NUMBER}\"\nif [ -z \"${PR_NUMBER}\" ]; then\n  # pull_requests is empty for fork PRs and can be empty for same-repo PRs\n  # whose association GitHub hasn't attached to the run; look the PR up by\n  # the failing run's head SHA, but ONLY accept a pull whose head repo is\n  # THIS repo AND whose head SHA is EXACTLY this run's head SHA (a fork PR,\n  # or an internal PR that merely shares this commit but points its head at\n  # a different SHA, is filtered out and the job skips).\n  if ! pulls=\"$(gh api \"repos/${REPO}/commits/${HEAD_SHA}/pulls\" \\\n      --jq \"[.[] | select(.head.repo.full_name == \\\"${REPO}\\\" and .head.sha == \\\"${HEAD_SHA}\\\" and .state == \\\"open\\\")] | .[0].number // empty\")\"; then\n    echo \"::notice::could not look up a PR for the failed run's head SHA — skipping (the registry cron is the backstop).\"\n    exit 0\n  fi\n  PR_NUMBER=\"${pulls}\"\nfi\nif [ -z \"${PR_NUMBER}\" ]; then\n  echo \"no same-repo PR is associated with the failed run's head SHA (fork PR, or the run was not a same-repo PR) — nothing to ring; skipping.\"\n  exit 0\nfi\n\n# --- Live PR state — labels/arming churn between the trigger and here ---\n# (ported from the former ci-summary fix-ring job; head_repo/head_sha now\n# re-read for the #3475 defense-in-depth check below.)\nif ! state=\"$(gh api \"repos/${REPO}/pulls/${PR_NUMBER}\" \\\n    --jq '{draft: .draft, armed: (.auto_merge != null), head_repo: .head.repo.full_name, head_sha: .head.sha, labels: [.labels[].name]}')\"; then\n  echo \"::notice::could not read live PR state — skipping the ring (the registry cron is the backstop).\"\n  exit 0\nfi\n# Defense in depth (#3475): the resolved PR must belong to THIS repo AND\n# its head must still be the failing run's exact SHA. This closes any\n# residual same-SHA-collision window in either resolution path (the\n# workflow_run.pull_requests[0] association OR the pulls-at-SHA lookup)\n# before the privileged doorbell fires.\nif [ \"$(jq -r '.head_repo' <<<\"$state\")\" != \"${REPO}\" ]; then\n  echo \"resolved PR #${PR_NUMBER} head repo is not ${REPO} (fork / cross-repo collision) — skipping.\"\n  exit 0\nfi\nif [ \"$(jq -r '.head_sha' <<<\"$state\")\" != \"${HEAD_SHA}\" ]; then\n  echo \"resolved PR #${PR_NUMBER} head SHA no longer matches the failing run's head SHA (stale head / same-SHA collision) — skipping.\"\n  exit 0\nfi\nhas() { jq -e --arg l \"$1\" '.labels | index($l) != null' <<<\"$state\" >/dev/null; }\nif [ \"$(jq -r '.draft' <<<\"$state\")\" = \"true\" ]; then\n  echo \"PR re-drafted since the trigger — not pipeline-owned for fast-fix; skipping.\"\n  exit 0\nfi\nif has \"review:needs-user\" || has \"needs:user\"; then\n  echo \"human-owned hold (review:needs-user / needs:user) — the repair loop must not pick this PR up; skipping.\"\n  exit 0\nfi\nif [ \"$(jq -r '.armed' <<<\"$state\")\" != \"true\" ] && ! has \"review:pass\" && ! has \"review:changes\"; then\n  echo \"PR is neither armed nor in the review pipeline (review:pass / review:changes) — skipping.\"\n  exit 0\nfi\nif [ -z \"${REGISTRY_RING_TOKEN}\" ]; then\n  # NO needs:ci-fix label fallback, deliberately: the registry PLAN\n  # derives ci-fix admission from the PR's gate STATE and treats\n  # needs:* PR labels as human-owned holds that EXCLUDE the PR from\n  # the repair enumeration — a label here would suppress the fix.\n  echo \"::notice::REGISTRY_RING_TOKEN unavailable (secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop.\"\n  exit 0\nfi\nGH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry\necho \"rang jeswr/agent-account-registry dispatch for PR #${PR_NUMBER} — the repair sweep runs now instead of on the next cron tick.\"\n"
-    }
-  ],
-  "timeout-minutes": 5
-}"""
+def normalize(text: str) -> str:
+    """Semantically-inert normalization ONLY: strip trailing whitespace from each line
+    and collapse to a single trailing newline. Deliberately does NOT strip comments and
+    does NOT reorder anything — comments, key order, and blank lines ARE part of the pin
+    (a predicate demoted into a comment, or a reordered/added key, MUST red). Applied
+    IDENTICALLY to the workflow and the golden so the compare ignores only editor-inert
+    whitespace churn."""
+    lines = [ln.rstrip() for ln in text.split("\n")]
+    return "\n".join(lines).rstrip("\n") + "\n"
 
 
-def canonical_job(job: dict) -> str:
-    """Deterministic, whole-job canonical form: JSON with keys sorted and indent=2.
-    Pins EVERY field of the job (if/permissions/env/name and the exact run body).
-    Nothing is extracted or dropped, so there is no fragment to weaken and no comment,
-    uncalled function, alt spelling, or second predicate that lives outside the pinned
-    text."""
-    return json.dumps(job, sort_keys=True, ensure_ascii=False, indent=2)
-
-
-def _token_consumers(jobs: dict) -> list[str]:
-    """Every job id whose serialized definition references secrets.REGISTRY_RING_TOKEN.
-    Located by CONTENT (not job name) so a rename cannot hide a token consumer, and via
-    the parsed job (not a raw grep of the file) so a token reference demoted into a
-    `#`-comment in a run body still counts — that comment is part of the parsed run
-    string."""
-    out = []
-    for jid, job in jobs.items():
-        blob = yaml.safe_dump(job, sort_keys=True, allow_unicode=True)
-        if RING_TOKEN_SECRET in blob:
-            out.append(jid)
-    return out
-
-
-def check_doc(text: str) -> list[str]:
-    """Return a list of offence strings; empty == clean. Whole-job pin (J1) + exactly
-    one token consumer (J2)."""
-    offences: list[str] = []
-    doc = yaml.safe_load(text)
-    if not isinstance(doc, dict):
-        raise Offence("workflow is not a YAML mapping")
-    jobs = doc.get("jobs")
-    if not isinstance(jobs, dict):
-        raise Offence("workflow has no `jobs:` mapping")
-
-    # ---- J2: EXACTLY ONE job may consume the ring token ----
-    consumers = _token_consumers(jobs)
-    if len(consumers) == 0:
-        offences.append(
-            f"J2: no job references {RING_TOKEN_SECRET} — the token-consuming job is "
-            f"missing or the secret reference was renamed; cannot pin the guarded job"
-        )
-        # Nothing to pin; the missing consumer is the whole finding.
-        return offences
-    if len(consumers) > 1:
-        offences.append(
-            f"J2: {len(consumers)} jobs reference {RING_TOKEN_SECRET} "
-            f"({', '.join(consumers)}) — there must be EXACTLY ONE token-consuming job "
-            f"so the whole-job pin covers every path to the token. A second privileged "
-            f"job is a second, un-pinned path to the secret and REDs here."
-        )
-        # Fall through to J1 so the reviewer also sees any whole-job drift; the count
-        # offence alone already fails the check.
-
-    # ---- J1: the ONE token-consuming job, whole, must equal GOLDEN_JOB byte-exact ----
-    matched_golden = [jid for jid in consumers if canonical_job(jobs[jid]) == GOLDEN_JOB]
-    if not matched_golden:
-        # Diff against the first consumer (the most likely intended job) for review.
-        target = consumers[0]
-        actual = canonical_job(jobs[target])
-        diff = "\n".join(
-            difflib.unified_diff(
-                GOLDEN_JOB.splitlines(),
-                actual.splitlines(),
-                fromfile="GOLDEN_JOB",
-                tofile=f"jobs.{target} (actual)",
-                lineterm="",
+def check_doc(text: str, golden_text: str | None = None) -> list[str]:
+    """Return a list of offence strings; empty == clean. WHOLE-FILE PIN: the normalized
+    workflow must byte-equal the normalized golden. Any difference is ONE WORKFLOW-PIN
+    offence with a unified diff. This pin subsumes the former whole-job pin — it covers
+    the job AND everything around it (workflow-level env/defaults/permissions, a second
+    job, comments, any secret-reference syntax), because there is no level above the
+    whole file."""
+    if golden_text is None:
+        if not GOLDEN.exists():
+            raise Offence(
+                f"{GOLDEN_REL} not found — the whole-file pin has no golden to compare "
+                f"against; the golden is security-load-bearing (#3475) and must be "
+                f"committed alongside this checker."
             )
-        )
-        offences.append(
-            f"J1: the token-consuming job `{target}` does not match the canonical "
-            f"GOLDEN_JOB byte-for-byte. The WHOLE job is pinned, so ANY edit — an "
-            f"OR-wrap / negation / operand swap in `if:`, a demoted-to-comment "
-            f"predicate, an uncalled-function move of the guards, an alt dispatch "
-            f"spelling, a dropped `select(...)` conjunct, an inverted `!=` guard, a "
-            f"changed permission — reds here. If this is a LEGITIMATE refactor, "
-            f"regenerate GOLDEN_JOB in this PR (see the header one-liner); that golden "
-            f"bump is the review checkpoint.\n"
-            f"       --- unified diff (GOLDEN_JOB vs actual) ---\n{diff}"
-        )
+        golden_text = GOLDEN.read_text(encoding="utf-8")
 
-    return offences
+    actual = normalize(text)
+    golden = normalize(golden_text)
+    if actual == golden:
+        return []
+
+    diff = "\n".join(
+        difflib.unified_diff(
+            golden.splitlines(),
+            actual.splitlines(),
+            fromfile=str(GOLDEN_REL),
+            tofile=str(WORKFLOW_REL) + " (actual)",
+            lineterm="",
+        )
+    )
+    return [
+        "WORKFLOW-PIN: the fast-fix ring workflow no longer matches its pinned golden "
+        f"({GOLDEN_REL}). The WHOLE FILE is pinned byte-for-byte (after inert "
+        "trailing-whitespace/newline normalization), so ANY edit reds — a job-level "
+        "`if:` OR-wrap / negation / operand swap, a demoted-to-comment predicate, an "
+        "uncalled-function move, an alt dispatch spelling, a dropped `select(...)` "
+        "conjunct, an inverted `!=` guard, a changed permission, a SECOND token "
+        "consumer in ANY syntax (dotted or `secrets['...']` bracket), a workflow-level "
+        "`env:` a second job inherits, or a workflow-level `defaults.run.shell` "
+        "wrapper. the fast-fix ring workflow changed; if intentional, regenerate "
+        f"{GOLDEN_REL} IN THE SAME PR (the human-review checkpoint); this workflow is "
+        "security-load-bearing (#3475).\n"
+        f"       --- unified diff ({GOLDEN_REL} vs actual) ---\n{diff}"
+    ]
 
 
 def check_root(root: Path) -> list[str]:
     """Live path used by both the default run and every --self-test fixture: read the
-    workflow from `root` and check it. The self-test mutates a PHYSICAL COPY of the
-    real workflow on disk and calls THIS, so the fixtures exercise the exact code path
-    that runs in CI."""
+    workflow from `root` and compare it against the golden that ALSO lives under `root`
+    (so a fixture that mutates ONLY the workflow copy reds, and a fixture could also
+    exercise a golden edit). The self-test mutates a PHYSICAL COPY of the real workflow
+    on disk and calls THIS, so the fixtures exercise the exact code path that runs in
+    CI."""
     wf = root / WORKFLOW_REL
     if not wf.exists():
         raise Offence(f"{wf} not found")
-    return check_doc(wf.read_text(encoding="utf-8"))
+    golden_path = root / GOLDEN_REL
+    if not golden_path.exists():
+        raise Offence(f"{golden_path} not found")
+    return check_doc(
+        wf.read_text(encoding="utf-8"),
+        golden_path.read_text(encoding="utf-8"),
+    )
+
+
+def _update_golden() -> int:
+    """Convenience: rewrite the golden from the CURRENT live workflow (inert-normalized).
+    LOCAL ONLY — guarded so CI never regenerates the pin it is meant to enforce. Run this
+    IN THE SAME PR as an intentional workflow change so the golden bump is reviewed."""
+    if os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"):
+        print(
+            "refusing to --update-golden under CI: the golden is the human-review "
+            "checkpoint and must be regenerated locally + committed in the same PR.",
+            file=sys.stderr,
+        )
+        return 1
+    if not WORKFLOW.exists():
+        print(f"error: {WORKFLOW} not found", file=sys.stderr)
+        return 1
+    GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+    GOLDEN.write_text(normalize(WORKFLOW.read_text(encoding="utf-8")), encoding="utf-8")
+    print(f"regenerated {GOLDEN_REL} from the current {WORKFLOW_REL} (review this bump).")
+    return 0
 
 
 # --------------------------------------------------------------------------- #
@@ -261,17 +240,21 @@ def check_root(root: Path) -> list[str]:
 
 def _self_test() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
+    golden_text = GOLDEN.read_text(encoding="utf-8")
     failures = 0
 
     def _run_on(mutated: str) -> list[str]:
-        """Write the (mutated) workflow into a throwaway repo-root tree and run the
-        LIVE --root path over it, so every fixture goes through check_root/check_doc
-        exactly as CI does."""
+        """Write the (mutated) workflow AND the pristine golden into a throwaway
+        repo-root tree and run the LIVE --root path over it, so every fixture goes
+        through check_root/check_doc exactly as CI does."""
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
             wf = root / WORKFLOW_REL
             wf.parent.mkdir(parents=True, exist_ok=True)
             wf.write_text(mutated, encoding="utf-8")
+            gp = root / GOLDEN_REL
+            gp.parent.mkdir(parents=True, exist_ok=True)
+            gp.write_text(golden_text, encoding="utf-8")
             return check_root(root)
 
     def expect_clean(label: str, t: str) -> None:
@@ -300,10 +283,17 @@ def _self_test() -> int:
         else:
             print(f"  [ok]   {label}: correctly RED ({needle})")
 
-    # 0) the real, live workflow (physical copy) must be clean.
-    expect_clean("live workflow (physical copy via --root)", text)
+    # 0) the real, live workflow (physical copy) must be clean against the golden.
+    expect_clean("live workflow (physical copy via --root, golden matches)", text)
 
-    # --- round-1 fixtures: a guard is REMOVED (whole-job pin => J1) ---
+    # An inert-only edit (add trailing whitespace on some lines) must STAY clean — proves
+    # the normalization is genuinely semantically inert and does not over-fire.
+    inert_trailing_ws = text.replace(
+        "runs-on: ubuntu-latest\n", "runs-on: ubuntu-latest   \n", 1
+    )
+    expect_clean("inert trailing whitespace (must stay clean)", inert_trailing_ws)
+
+    # --- round-1 fixtures: a guard is REMOVED (whole-file pin => WORKFLOW-PIN) ---
 
     # 1) FORK RUN: remove the head_repository guard from the job `if:`.
     no_guard = text.replace(
@@ -311,13 +301,13 @@ def _self_test() -> int:
         "",
         1,
     )
-    expect_red("R1 fork run (head_repository guard removed)", no_guard, "J1")
+    expect_red("R1 fork run (head_repository guard removed)", no_guard, "WORKFLOW-PIN")
 
     # 2) SAME-SHA collision: drop the `.head.sha ==` filter from the fallback select.
     no_sha_filter = text.replace(
         'and .head.sha == \\"${HEAD_SHA}\\" and .state', "and .state", 1
     )
-    expect_red("R1 same-SHA collision (head.sha filter removed)", no_sha_filter, "J1")
+    expect_red("R1 same-SHA collision (head.sha filter removed)", no_sha_filter, "WORKFLOW-PIN")
 
     # 3) STALE-HEAD: remove the live head_sha re-check block before dispatch.
     no_live_recheck = text.replace(
@@ -328,9 +318,9 @@ def _self_test() -> int:
         "",
         1,
     )
-    expect_red("R1 stale-head (live head_sha re-check removed)", no_live_recheck, "J1")
+    expect_red("R1 stale-head (live head_sha re-check removed)", no_live_recheck, "WORKFLOW-PIN")
 
-    # --- round-2 fixtures: predicate-parser was too loose (whole-job pin => J1) ---
+    # --- round-2 fixtures: predicate-parser was too loose (whole-file pin => WORKFLOW-PIN) ---
 
     # 4) TOP-LEVEL `|| true` appended to the if (bare, depth-0).
     or_bypass = text.replace(
@@ -339,7 +329,7 @@ def _self_test() -> int:
         "      || true\n",
         1,
     )
-    expect_red("R2 top-level `|| true` bypass appended", or_bypass, "J1")
+    expect_red("R2 top-level `|| true` bypass appended", or_bypass, "WORKFLOW-PIN")
 
     # 5) fork-repo predicate removed from the fallback `select(...)`.
     no_repo_predicate = text.replace(
@@ -348,7 +338,7 @@ def _self_test() -> int:
         'select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")',
         1,
     )
-    expect_red("R2 fallback fork-repo predicate removed", no_repo_predicate, "J1")
+    expect_red("R2 fallback fork-repo predicate removed", no_repo_predicate, "WORKFLOW-PIN")
 
     # 6) .head.sha compared to a CONSTANT instead of ${HEAD_SHA}.
     sha_constant = text.replace(
@@ -356,7 +346,7 @@ def _self_test() -> int:
         '.head.sha == \\"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\" and .state',
         1,
     )
-    expect_red("R2 fallback head.sha compared to a constant", sha_constant, "J1")
+    expect_red("R2 fallback head.sha compared to a constant", sha_constant, "WORKFLOW-PIN")
 
     # 7) live `!=` guards inverted to `==` (fail-open).
     inverted_guards = text.replace(
@@ -368,7 +358,7 @@ def _self_test() -> int:
         'if [ "$(jq -r \'.head_sha\' <<<"$state")" == "${HEAD_SHA}" ]; then',
         1,
     )
-    expect_red("R2 live `!=` guards inverted to `==` (fail-open)", inverted_guards, "J1")
+    expect_red("R2 live `!=` guards inverted to `==` (fail-open)", inverted_guards, "WORKFLOW-PIN")
 
     # --- round-3 fixtures: bypasses codex demonstrated against the PARSER ---
 
@@ -385,7 +375,7 @@ def _self_test() -> int:
         "      || true)\n",
         1,
     )
-    expect_red("R3 parenthesized `(... || true)` OR-wrap of the whole if", paren_or_wrap, "J1")
+    expect_red("R3 parenthesized `(... || true)` OR-wrap of the whole if", paren_or_wrap, "WORKFLOW-PIN")
 
     # 9) [R3] NEGATED equality `!(head_repo == repo)`.
     negated_guard = text.replace(
@@ -393,7 +383,7 @@ def _self_test() -> int:
         "&& !(github.event.workflow_run.head_repository.full_name == github.repository)",
         1,
     )
-    expect_red("R3 negated `!(head_repo == repo)` guard", negated_guard, "J1")
+    expect_red("R3 negated `!(head_repo == repo)` guard", negated_guard, "WORKFLOW-PIN")
 
     # 10) [R3] G3 CONJUNCTION->DISJUNCTION: `repo AND sha` -> `repo OR sha` in select.
     or_conjunction = text.replace(
@@ -401,10 +391,10 @@ def _self_test() -> int:
         '.head.repo.full_name == \\"${REPO}\\" or .head.sha == \\"${HEAD_SHA}\\"',
         1,
     )
-    expect_red("R3 fallback conjunction->disjunction (repo OR sha)", or_conjunction, "J1")
+    expect_red("R3 fallback conjunction->disjunction (repo OR sha)", or_conjunction, "WORKFLOW-PIN")
 
     # 11) [R3] PREDICATE MOVED TO A COMMENT: the executable select drops the fork-repo
-    #     predicate but a `#`-comment retains the needle text. The whole-job pin
+    #     predicate but a `#`-comment retains the needle text. The whole-file pin
     #     includes the run body verbatim (comment + weakened select), so it REDs.
     predicate_in_comment = text.replace(
         '            if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \\\n'
@@ -414,34 +404,13 @@ def _self_test() -> int:
         '                --jq "[.[] | select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
         1,
     )
-    expect_red("R3 fork-repo predicate demoted to a comment (select drops it)", predicate_in_comment, "J1")
-
-    # 12) [R3] INVERTED LIVE GUARD accompanied by a comment-only expected needle.
-    inverted_with_comment = text.replace(
-        '          if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n',
-        '          # if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n'
-        '          if [ "$(jq -r \'.head_repo\' <<<"$state")" == "${REPO}" ]; then\n',
-        1,
-    )
-    expect_red("R3 live guard inverted with comment-only `!=` needle", inverted_with_comment, "J1")
+    expect_red("R3 fork-repo predicate demoted to a comment (select drops it)", predicate_in_comment, "WORKFLOW-PIN")
 
     # --- round-4 fixtures: codex's residual fragment/duplication holes ---
 
-    # 13) [R4] INLINE-COMMENT DEMOTION of the select via a `: # select(...)` no-op:
-    #     append `: # <golden select>` after weakening the live select. A fragment
-    #     extractor that stripped only WHOLE-LINE comments (or matched the needle text
-    #     anywhere) could be fooled; the whole-job pin includes the entire run body so
-    #     any such edit REDs.
-    inline_comment_demotion = text.replace(
-        '                --jq "[.[] | select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
-        '                --jq "[.[] | select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then : # select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")\n',
-        1,
-    )
-    expect_red("R4 inline `: # select(...)` demotion (weakened live filter)", inline_comment_demotion, "J1")
-
-    # 14) [R4] GUARDS MOVED TO AN UNCALLED FUNCTION: wrap both live `!=` guards in a
+    # 12) [R4] GUARDS MOVED TO AN UNCALLED FUNCTION: wrap both live `!=` guards in a
     #     `_dead_guards() { ... }` that is never called, so the needle text survives
-    #     but no guard executes before dispatch. Whole-job pin REDs (run body changed).
+    #     but no guard executes before dispatch. Whole-file pin REDs (run body changed).
     moved_to_uncalled_fn = text.replace(
         '          if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n'
         '            echo "resolved PR #${PR_NUMBER} head repo is not ${REPO} (fork / cross-repo collision) — skipping."\n'
@@ -461,23 +430,22 @@ def _self_test() -> int:
         "          }\n",
         1,
     )
-    expect_red("R4 live guards moved into an uncalled function", moved_to_uncalled_fn, "J1")
+    expect_red("R4 live guards moved into an uncalled function", moved_to_uncalled_fn, "WORKFLOW-PIN")
 
-    # 15) [R4] ALT DISPATCH SPELLING: `gh workflow run -R <repo> dispatch.yml` (flag
+    # 13) [R4] ALT DISPATCH SPELLING: `gh workflow run -R <repo> dispatch.yml` (flag
     #     before the workflow file) instead of the golden `gh workflow run dispatch.yml
-    #     -R <repo>`. A checker that pinned only the exact golden dispatch string could
-    #     miss this reordering; the whole-job pin REDs on any run-body change.
+    #     -R <repo>`. Whole-file pin REDs on any run-body change.
     alt_dispatch_spelling = text.replace(
         "GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry",
         "GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run -R jeswr/agent-account-registry dispatch.yml",
         1,
     )
-    expect_red("R4 alt dispatch spelling (gh workflow run -R ... dispatch.yml)", alt_dispatch_spelling, "J1")
+    expect_red("R4 alt dispatch spelling (gh workflow run -R ... dispatch.yml)", alt_dispatch_spelling, "WORKFLOW-PIN")
 
-    # 16) [R4] SECOND PRIVILEGED TOKEN-CONSUMING JOB: add a second job that consumes
-    #     secrets.REGISTRY_RING_TOKEN with the SAME golden `if:` but NO SHA/repo
-    #     defenses. The exactly-one-consumer count REDs (J2). We insert it right after
-    #     the `jobs:` line so the parse yields two consumers.
+    # 14) [R4] SECOND PRIVILEGED TOKEN-CONSUMING JOB (dotted `secrets.` syntax) with the
+    #     SAME golden `if:` but NO SHA/repo defenses. The whole-file pin REDs on the
+    #     added job (the old whole-job pin caught this via exactly-one-consumer; the
+    #     whole-file pin catches it because the file changed).
     second_job = text.replace(
         "jobs:\n",
         "jobs:\n"
@@ -496,15 +464,101 @@ def _self_test() -> int:
         "          GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry\n",
         1,
     )
-    expect_red("R4 second privileged token-consuming job", second_job, "J2")
+    expect_red("R4 second privileged token-consuming job (dotted syntax)", second_job, "WORKFLOW-PIN")
+
+    # --- round-5 fixtures: the bypasses that BEAT the whole-JOB pin (this is why the ---
+    # --- pin had to widen to the whole FILE). Each leaves the pinned JOB byte-identical ---
+    # --- but reaches the token by editing the file AROUND/ABOVE the job. ---
+
+    # 15) [R5] SECOND CONSUMER via `secrets['REGISTRY_RING_TOKEN']` BRACKET SYNTAX: a
+    #     second job that binds the token with the bracket spelling, a DIFFERENT string
+    #     than the dotted `secrets.REGISTRY_RING_TOKEN` needle the old whole-job consumer
+    #     scan keyed on — so the old exactly-one-consumer count missed it. The whole-file
+    #     pin does not parse or key on any needle; it REDs because the file changed.
+    bracket_second_consumer = text.replace(
+        "jobs:\n",
+        "jobs:\n"
+        "  ring_bracket:\n"
+        "    name: second ring (bracket bypass)\n"
+        "    if: >-\n"
+        "      github.event.workflow_run.conclusion == 'failure'\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: second unguarded ring via bracket syntax\n"
+        "        env:\n"
+        "          REGISTRY_RING_TOKEN: ${{ secrets['REGISTRY_RING_TOKEN'] }}\n"
+        "        run: |\n"
+        "          GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry\n",
+        1,
+    )
+    expect_red(
+        "R5 second consumer via secrets['REGISTRY_RING_TOKEN'] bracket syntax",
+        bracket_second_consumer,
+        "WORKFLOW-PIN",
+    )
+
+    # 16) [R5] WORKFLOW-LEVEL `env:` INHERITED BY A SECOND JOB: bind the token in a
+    #     top-level `env:` block, then add a second job whose OWN steps never mention the
+    #     secret string at all — it inherits the token from the workflow-level env. A
+    #     whole-JOB pin (which only looked inside the pinned job's steps) is byte-blind to
+    #     both the workflow-level env and the inheriting job's step. The whole-file pin
+    #     REDs on both edits.
+    workflow_env_inherit = text.replace(
+        "permissions:\n  contents: read\n",
+        "permissions:\n  contents: read\n"
+        "\nenv:\n"
+        "  REGISTRY_RING_TOKEN: ${{ secrets.REGISTRY_RING_TOKEN }}\n",
+        1,
+    ).replace(
+        "jobs:\n",
+        "jobs:\n"
+        "  ring_inherit:\n"
+        "    name: second ring (inherits workflow env)\n"
+        "    if: >-\n"
+        "      github.event.workflow_run.conclusion == 'failure'\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: exfil via inherited workflow-level token\n"
+        "        run: |\n"
+        "          GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry\n",
+        1,
+    )
+    expect_red(
+        "R5 workflow-level env: token inherited by a second job",
+        workflow_env_inherit,
+        "WORKFLOW-PIN",
+    )
+
+    # 17) [R5] WORKFLOW-LEVEL `defaults.run.shell` CUSTOM-SHELL WRAPPER: set
+    #     `defaults.run.shell: bash -x {0}` at the workflow level. `-x` traces every
+    #     command (echoing the token-bearing dispatch line to the log), and more
+    #     generally a workflow-level custom shell wraps EVERY `run:` body — machinery
+    #     that intercepts the token BEFORE the pinned job's script runs, while the pinned
+    #     job text stays byte-identical. A whole-JOB pin is blind to it; the whole-file
+    #     pin REDs.
+    defaults_shell_wrapper = text.replace(
+        "permissions:\n  contents: read\n",
+        "permissions:\n  contents: read\n"
+        "\ndefaults:\n"
+        "  run:\n"
+        "    shell: bash -x {0}\n",
+        1,
+    )
+    expect_red(
+        "R5 workflow-level defaults.run.shell: bash -x {0} wrapper",
+        defaults_shell_wrapper,
+        "WORKFLOW-PIN",
+    )
 
     if failures:
         print(f"\nSELF-TEST FAILED: {failures} case(s) did not behave as expected.")
         return 1
     print(
-        "\nSELF-TEST PASSED: live workflow clean + all round-1..4 negative fixtures RED "
-        "(whole-job pin J1 + exactly-one-consumer J2, each verified through the live "
-        "--root path against a physically-mutated workflow copy)."
+        "\nSELF-TEST PASSED: live workflow clean + all round-1..5 negative fixtures RED "
+        "(whole-FILE byte-pin WORKFLOW-PIN, each verified through the live --root path "
+        "against a physically-mutated workflow copy). The round-5 bracket-consumer / "
+        "workflow-env-inherit / defaults-shell fixtures — which BEAT the whole-JOB pin — "
+        "all red because there is no level above the whole file."
     )
     return 0
 
@@ -515,8 +569,16 @@ def main() -> int:
     ap.add_argument(
         "--self-test", action="store_true", help="run hermetic negative fixtures"
     )
+    ap.add_argument(
+        "--update-golden",
+        action="store_true",
+        help="regenerate scripts/tests/fast-fix-ring.golden.yml from the current "
+        "workflow (LOCAL ONLY — refuses to run under CI)",
+    )
     args = ap.parse_args()
 
+    if args.update_golden:
+        return _update_golden()
     if args.self_test:
         return _self_test()
 
@@ -532,7 +594,7 @@ def main() -> int:
         for o in offences:
             print(f"  - {o}", file=sys.stderr)
         return 1
-    print("fast-fix-ring cross-repo guard check: OK (#3475 fail-closed guard present).")
+    print("fast-fix-ring cross-repo guard check: OK (#3475 whole-file pin matches golden).")
     return 0
 
 

--- a/scripts/check-fast-fix-ring-guard.py
+++ b/scripts/check-fast-fix-ring-guard.py
@@ -23,48 +23,79 @@
 # that guard LOUD in review.
 #
 # =============================================================================
-# STRATEGY — CANONICAL GOLDEN MATCH (not predicate parsing)
+# STRATEGY — PIN THE WHOLE TOKEN-CONSUMING JOB + ASSERT EXACTLY ONE CONSUMER
 # =============================================================================
-# Rounds 1–3 of adversarial review proved that a predicate-PARSING validator cannot
-# win: for every "reject a top-level ||" rule there is a `(A && B && guard || true)`
-# paren-wrap; for every "the guard regex is present" rule there is a `!(guard)`
-# negation; for every "both needles are present" G3 substring rule there is a
-# conjunction→disjunction `repo OR SHA` swap (both needles survive) or a
-# predicate-moved-into-a-comment. Parsing a moving target is a losing regress.
+# Rounds 1–4 of adversarial review proved that both a predicate-PARSING validator AND
+# a fragment-EXTRACTING golden-match lose to a moving target:
 #
-# So this checker does NOT parse the security meaning of the condition. It pins the
-# EXACT, KNOWN-GOOD CANONICAL TEXT of each security-load-bearing fragment and requires
-# the workflow's ACTUAL (normalized) fragment to be BYTE-EQUAL to that golden:
+#   * A parser cannot win: for every "reject a top-level ||" rule there is a
+#     `(A && B && guard || true)` paren-wrap; for every "the guard regex is present"
+#     rule there is a `!(guard)` negation; for every "both needles present" G3 rule
+#     there is a conjunction→disjunction `repo OR SHA` swap (both needles survive).
 #
-#   G1  the ring job's full `if:` condition, whitespace-normalized, must EXACTLY
-#       equal GOLDEN_IF. Any OR-wrap, negation, operand swap, reorder, or extra
-#       clause changes the normalized text ⇒ mismatch ⇒ RED. You cannot smuggle a
-#       `|| true`, a `!(...)`, or `(... || true)` past an exact-string comparison.
-#   G2  the privileged token/dispatch step lives INSIDE that one guarded job, and no
-#       OTHER job's normalized `if:` differs from GOLDEN_IF while touching the token.
-#   G3  the head_sha->PR resolution `select(...)` jq filter, normalized, must EXACTLY
-#       equal GOLDEN_SELECT (a CONJUNCTION of the fork-repo predicate AND the exact
-#       ${HEAD_SHA} predicate AND state==open — a `repo OR SHA` swap changes the text
-#       ⇒ RED); and the two live fail-closed guard blocks — each a
-#       `if <!= test>; then … exit 0; fi` skeleton — normalized, must EXACTLY equal
-#       their goldens (an inversion to `==` or a moved-to-comment predicate changes
-#       the executable skeleton ⇒ RED), and each must appear BEFORE the dispatch.
+#   * A FRAGMENT golden-match (rounds 1–3) still leaked, because it pinned only the
+#     EXTRACTED pieces (the `if:`, the `select(...)`, the guard skeletons) and validated
+#     only the FIRST token-consuming job. Codex round 4 found two residual holes:
+#       (a) anything the extractor did NOT cover could still be weakened — an inline
+#           `: # select(...)` demotion, an uncalled-function move of the guards, an
+#           alt dispatch spelling `gh workflow run -R ... dispatch.yml` — because those
+#           edits live OUTSIDE the extracted fragments, so the fragments still matched.
+#       (b) a SECOND privileged job carrying the same golden `if:` but NO SHA/repo
+#           defenses passed, because only the first token consumer was validated.
 #
-# WHY EXACT-MATCH IS STRICTLY STRONGER than the predicate parser it replaces: the
-# adversary's whole bypass class works by producing text that is SEMANTICALLY unsafe
-# but PARSES to the same predicate-presence signal. Against a canonical golden there is
-# no such gap: any text that differs from the known-good form — safe or unsafe — reds.
-# The tradeoff is deliberate: a LEGITIMATE refactor of the guard (rename ${REPO},
-# restructure the select, reword a skip message) will red too, and the fix is to
-# UPDATE THE GOLDEN IN THE SAME PR. That is the CORRECT fail-safe direction — a human /
-# reviewer sees the golden change and re-confirms the guard is still sound, rather than
-# a weakening sliding through on a predicate technicality. (§ headers/echo-message
-# wording that is NOT security-load-bearing is normalized away so pure prose edits do
-# not force a golden bump; see _canon_guard_block.)
+# Codex round 4 gave the terminal design in its own words: "Pin the COMPLETE
+# token-consuming job, not extracted fragments" and "Require EXACTLY ONE privileged
+# job/path or apply the complete canonical validation to every token consumer."
+#
+# So this checker does exactly that:
+#
+#   J1  PIN THE WHOLE JOB. Parse the workflow YAML, find every job whose steps
+#       reference `secrets.REGISTRY_RING_TOKEN`, canonicalize the ONE token-consuming
+#       job's ENTIRE definition (the whole job mapping: `if:`, `permissions:`, every
+#       step's `env`, `name`, and the EXACT `run:` body — including the
+#       `gh workflow run dispatch.yml` line, the fallback `select(...)`, and BOTH live
+#       `!=` guard blocks) into a normalized, deterministic form (JSON, keys sorted)
+#       and require BYTE-EQUALITY to the stored GOLDEN_JOB. Because the COMPLETE job is
+#       pinned there is NOTHING left to weaken: no fragment to extract-and-dodge, no
+#       predicate to demote to a comment (the comment is INSIDE the pinned run body, so
+#       moving a predicate into it changes the run body), no guards to move into an
+#       uncalled function (that changes the run body too), no alt dispatch spelling
+#       (that changes the run body too), no operand swap, no negation, no OR-wrap. ANY
+#       edit to that job — security-relevant or not — changes the normalized job and REDs.
+#
+#   J2  EXACTLY ONE TOKEN CONSUMER. Count the jobs that reference
+#       `secrets.REGISTRY_RING_TOKEN` anywhere in their steps; require the count == 1
+#       and that the single consumer is the golden job. A SECOND privileged job (codex
+#       round-4 finding #b) makes the count 2 and REDs — there is no un-validated path
+#       to the token.
+#
+# WHY THIS IS TERMINAL (provably immune to the fragment/demotion/duplication class):
+#   - The whole-job pin means the checker's "attack surface" is the ENTIRE job text,
+#     not a chosen subset. The round-1..4 bypasses ALL work by mutating job text that a
+#     narrower rule did not look at; here there is no text the rule does not look at.
+#   - Exactly-one-consumer means there is no second, un-pinned path to the token.
+#   Together: the set of edits that (a) reach the token and (b) pass the checker is
+#   EXACTLY {edits that leave the whole job byte-identical} = {no change to the job}.
+#   A weakening is, by definition, a change to the job, so it cannot pass. The only way
+#   to change the job AND pass is to update GOLDEN_JOB in the SAME PR — which is the
+#   intended human review checkpoint (a reviewer sees the golden move and re-confirms
+#   the guard is still sound), the CORRECT fail-safe direction.
+#
+# The GOLDEN_JOB below is the pretty-printed (indent=2, keys sorted) canonical JSON of
+# the known-good `ring` job. It is human-readable ON PURPOSE — it IS the job content, so
+# a reviewer can read exactly what is pinned. Regenerate after an intentional refactor:
+#     python3 -c "import yaml,json; \
+#       d=yaml.safe_load(open('.github/workflows/fast-fix-ring.yml')); \
+#       print(json.dumps(d['jobs']['ring'],sort_keys=True,ensure_ascii=False,indent=2))"
+# and paste the output between the GOLDEN_JOB delimiters, IN THE SAME PR as the workflow
+# change, so the golden bump is the review checkpoint.
 #
 # NEGATIVE COVERAGE (--self-test, hermetic — no gh/git/network): the live workflow
-# passes, and each of the round-1/2/3 bypasses, applied as a SURGICAL mutation to a
-# copy of the real workflow, goes RED. See _self_test for the mutation→red table.
+# passes, and EACH round-1..4 bypass — including codex round-4's inline-comment
+# demotion, uncalled-function move, alt dispatch spelling, AND a second privileged
+# token-consuming job — is applied as a SURGICAL mutation to a PHYSICAL COPY of the real
+# workflow and run through the LIVE `--root` path, and goes RED; the unmutated copy
+# passes. See _self_test for the mutation→red table.
 #
 # Usage:
 #   check-fast-fix-ring-guard.py              # check the live workflow (default)
@@ -77,286 +108,151 @@
 from __future__ import annotations
 
 import argparse
-import re
+import difflib
+import json
 import sys
+import tempfile
 from pathlib import Path
 
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-WORKFLOW = REPO_ROOT / ".github" / "workflows" / "fast-fix-ring.yml"
+WORKFLOW_REL = Path(".github") / "workflows" / "fast-fix-ring.yml"
+WORKFLOW = REPO_ROOT / WORKFLOW_REL
 
-RING_TOKEN = "REGISTRY_RING_TOKEN"
-DISPATCH_MARKER = "agent-account-registry"
-# The exact command that fires the cross-repo doorbell — G3 checks the guards
-# come BEFORE this in the run body.
-DISPATCH_CMD = "gh workflow run dispatch.yml"
-
-# =============================================================================
-# GOLDEN CANONICAL FORMS
-# =============================================================================
-# These are the known-good, security-load-bearing fragments of
-# .github/workflows/fast-fix-ring.yml. The checker normalizes the workflow's actual
-# fragment (collapse whitespace; for guard blocks, strip the non-load-bearing echo
-# message) and requires EXACT EQUALITY. If the guard is legitimately refactored, bump
-# the matching golden IN THE SAME PR — that is the intended review checkpoint.
-
-# G1: the ring job's full `if:` condition, whitespace-collapsed. Three ANDed clauses;
-# the third is the #3475 fail-closed head_repository guard. Exact-match, so an OR-wrap
-# `(... || true)`, a `!(...)` negation, an operand swap, a reorder, or any extra
-# clause all differ from this string and RED.
-GOLDEN_IF = (
-    "github.event.workflow_run.conclusion == 'failure' "
-    "&& github.event.workflow_run.event == 'pull_request' "
-    "&& github.event.workflow_run.head_repository.full_name == github.repository"
-)
-
-# G3(a): the head_sha->PR fallback jq `select(...)` filter, normalized (whitespace
-# collapsed). A CONJUNCTION (`and`) of the fork-repo predicate, the exact-${HEAD_SHA}
-# predicate, and state==open. A `repo OR SHA` disjunction, a dropped predicate, or a
-# constant-swapped SHA all change this string and RED. (In the YAML-parsed run body
-# the workflow's `\\"` source escapes render as a single backslash-quote `\"`.)
-GOLDEN_SELECT = (
-    'select(.head.repo.full_name == \\"${REPO}\\" '
-    'and .head.sha == \\"${HEAD_SHA}\\" '
-    'and .state == \\"open\\")'
-)
-
-# G3(b): the two live fail-closed re-check guard blocks, reduced to their EXECUTABLE
-# skeleton (the `if [ <test> ]; then` line + the `exit 0` fail-closed body), with the
-# non-load-bearing echo message removed. Each must be a `!=` (fail-closed: mismatch =>
-# skip) compare and must `exit 0`. An inversion to `==`, a dropped predicate, or a
-# predicate that survives ONLY in a comment changes the executable skeleton and REDs.
-GOLDEN_LIVE_REPO_GUARD = (
-    'if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then '
-    "exit 0 fi"
-)
-GOLDEN_LIVE_SHA_GUARD = (
-    'if [ "$(jq -r \'.head_sha\' <<<"$state")" != "${HEAD_SHA}" ]; then '
-    "exit 0 fi"
-)
+# The privileged secret whose every consumer must be the one pinned golden job.
+RING_TOKEN_SECRET = "secrets.REGISTRY_RING_TOKEN"
 
 
 class Offence(Exception):
     pass
 
 
-def _canon(s: str) -> str:
-    """Whitespace-collapse: any run of whitespace (incl. newlines) => one space,
-    stripped. Used for the `if:` condition and the jq select filter, where only
-    whitespace/line-fold differences are non-load-bearing."""
-    return " ".join(s.split())
+# =============================================================================
+# GOLDEN_JOB — the complete, known-good `ring` job, canonical JSON (keys sorted,
+# indent=2). This is the ENTIRE token-consuming job: `if:`, `permissions:`, and the
+# one step's `env` + `name` + full `run:` body (the select(...), both live `!=`
+# guards, and the `gh workflow run dispatch.yml` doorbell are all inside it). The
+# checker re-derives this exact canonical form from the workflow and requires
+# BYTE-EQUALITY. To refactor the guard legitimately, regenerate this block IN THE SAME
+# PR (see the header one-liner) — that golden bump is the review checkpoint.
+# =============================================================================
+GOLDEN_JOB = r"""{
+  "if": "github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository",
+  "name": "fast-fix ring (advisory)",
+  "permissions": {
+    "pull-requests": "read"
+  },
+  "runs-on": "ubuntu-latest",
+  "steps": [
+    {
+      "env": {
+        "GH_TOKEN": "${{ github.token }}",
+        "HEAD_SHA": "${{ github.event.workflow_run.head_sha }}",
+        "REGISTRY_RING_TOKEN": "${{ secrets.REGISTRY_RING_TOKEN }}",
+        "REPO": "${{ github.repository }}",
+        "RUN_PR_NUMBER": "${{ (github.event.workflow_run.pull_requests[0] != null) && github.event.workflow_run.pull_requests[0].number || '' }}"
+      },
+      "name": "Resolve the PR for the failed run and ring the registry dispatcher",
+      "run": "set -euo pipefail\n\n# --- Derive the PR number, SAME-REPO only (spoof guard #2 / deputy #3) ---\n# The top-level job `if:` already fail-closed on\n# head_repository.full_name == github.repository, so a fork/cross-repo run\n# never reaches this step. The head_sha->PR fallback below adds a SECOND,\n# independent barrier (defense in depth against a same-SHA collision):\n# every resolved PR must be BOTH same-repo AND pinned to the failing run's\n# exact head SHA before any dispatch.\nPR_NUMBER=\"${RUN_PR_NUMBER}\"\nif [ -z \"${PR_NUMBER}\" ]; then\n  # pull_requests is empty for fork PRs and can be empty for same-repo PRs\n  # whose association GitHub hasn't attached to the run; look the PR up by\n  # the failing run's head SHA, but ONLY accept a pull whose head repo is\n  # THIS repo AND whose head SHA is EXACTLY this run's head SHA (a fork PR,\n  # or an internal PR that merely shares this commit but points its head at\n  # a different SHA, is filtered out and the job skips).\n  if ! pulls=\"$(gh api \"repos/${REPO}/commits/${HEAD_SHA}/pulls\" \\\n      --jq \"[.[] | select(.head.repo.full_name == \\\"${REPO}\\\" and .head.sha == \\\"${HEAD_SHA}\\\" and .state == \\\"open\\\")] | .[0].number // empty\")\"; then\n    echo \"::notice::could not look up a PR for the failed run's head SHA — skipping (the registry cron is the backstop).\"\n    exit 0\n  fi\n  PR_NUMBER=\"${pulls}\"\nfi\nif [ -z \"${PR_NUMBER}\" ]; then\n  echo \"no same-repo PR is associated with the failed run's head SHA (fork PR, or the run was not a same-repo PR) — nothing to ring; skipping.\"\n  exit 0\nfi\n\n# --- Live PR state — labels/arming churn between the trigger and here ---\n# (ported from the former ci-summary fix-ring job; head_repo/head_sha now\n# re-read for the #3475 defense-in-depth check below.)\nif ! state=\"$(gh api \"repos/${REPO}/pulls/${PR_NUMBER}\" \\\n    --jq '{draft: .draft, armed: (.auto_merge != null), head_repo: .head.repo.full_name, head_sha: .head.sha, labels: [.labels[].name]}')\"; then\n  echo \"::notice::could not read live PR state — skipping the ring (the registry cron is the backstop).\"\n  exit 0\nfi\n# Defense in depth (#3475): the resolved PR must belong to THIS repo AND\n# its head must still be the failing run's exact SHA. This closes any\n# residual same-SHA-collision window in either resolution path (the\n# workflow_run.pull_requests[0] association OR the pulls-at-SHA lookup)\n# before the privileged doorbell fires.\nif [ \"$(jq -r '.head_repo' <<<\"$state\")\" != \"${REPO}\" ]; then\n  echo \"resolved PR #${PR_NUMBER} head repo is not ${REPO} (fork / cross-repo collision) — skipping.\"\n  exit 0\nfi\nif [ \"$(jq -r '.head_sha' <<<\"$state\")\" != \"${HEAD_SHA}\" ]; then\n  echo \"resolved PR #${PR_NUMBER} head SHA no longer matches the failing run's head SHA (stale head / same-SHA collision) — skipping.\"\n  exit 0\nfi\nhas() { jq -e --arg l \"$1\" '.labels | index($l) != null' <<<\"$state\" >/dev/null; }\nif [ \"$(jq -r '.draft' <<<\"$state\")\" = \"true\" ]; then\n  echo \"PR re-drafted since the trigger — not pipeline-owned for fast-fix; skipping.\"\n  exit 0\nfi\nif has \"review:needs-user\" || has \"needs:user\"; then\n  echo \"human-owned hold (review:needs-user / needs:user) — the repair loop must not pick this PR up; skipping.\"\n  exit 0\nfi\nif [ \"$(jq -r '.armed' <<<\"$state\")\" != \"true\" ] && ! has \"review:pass\" && ! has \"review:changes\"; then\n  echo \"PR is neither armed nor in the review pipeline (review:pass / review:changes) — skipping.\"\n  exit 0\nfi\nif [ -z \"${REGISTRY_RING_TOKEN}\" ]; then\n  # NO needs:ci-fix label fallback, deliberately: the registry PLAN\n  # derives ci-fix admission from the PR's gate STATE and treats\n  # needs:* PR labels as human-owned holds that EXCLUDE the PR from\n  # the repair enumeration — a label here would suppress the fix.\n  echo \"::notice::REGISTRY_RING_TOKEN unavailable (secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop.\"\n  exit 0\nfi\nGH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry\necho \"rang jeswr/agent-account-registry dispatch for PR #${PR_NUMBER} — the repair sweep runs now instead of on the next cron tick.\"\n"
+    }
+  ],
+  "timeout-minutes": 5
+}"""
 
 
-def _strip_shell_comments(body: str) -> str:
-    """Drop full-line shell comments so a `select(...)` (or any predicate) demoted to
-    a `# ...` comment is NOT mistaken for the executable filter. Only whole-line
-    comments are stripped (a leading `#` after optional whitespace); we do not attempt
-    to strip trailing inline comments, which would require full shell tokenization and
-    is unnecessary — the executable predicates in this workflow are never followed by
-    an inline `#`."""
-    return "\n".join(
-        line for line in body.splitlines() if not line.lstrip().startswith("#")
-    )
+def canonical_job(job: dict) -> str:
+    """Deterministic, whole-job canonical form: JSON with keys sorted and indent=2.
+    Pins EVERY field of the job (if/permissions/env/name and the exact run body).
+    Nothing is extracted or dropped, so there is no fragment to weaken and no comment,
+    uncalled function, alt spelling, or second predicate that lives outside the pinned
+    text."""
+    return json.dumps(job, sort_keys=True, ensure_ascii=False, indent=2)
 
 
-def _extract_select(body: str) -> str | None:
-    """Return the whitespace-normalized `select( ... )` jq filter from the EXECUTABLE
-    run body (shell comments stripped), or None if absent. Balanced-paren scan so
-    nested `()` inside the filter are kept. Stripping comments first means a fork-repo
-    predicate demoted into a `#`-comment is not read as the live filter."""
-    body = _strip_shell_comments(body)
-    idx = body.find("select(")
-    if idx < 0:
-        return None
-    start = idx + len("select(")
-    depth = 1
-    i = start
-    while i < len(body) and depth > 0:
-        c = body[i]
-        if c == "(":
-            depth += 1
-        elif c == ")":
-            depth -= 1
-        i += 1
-    if depth != 0:
-        return None
-    return _canon("select(" + body[start : i - 1] + ")")
-
-
-def _canon_guard_block(body: str, jq_field: str) -> str | None:
-    """Extract the live re-check guard block keyed on `jq_field` (`.head_repo` /
-    `.head_sha`) and reduce it to its EXECUTABLE, load-bearing skeleton:
-    the `if [ … ]; then` test line + the fail-closed `exit 0`, joined by single
-    spaces, with the (non-security) echo message line dropped.
-
-    Returns None if no `if` line referencing that field is present. Because the
-    skeleton keeps the `!=`/`==` operator and the compared operands but drops prose,
-    an inversion, a dropped operand, or a predicate that survives only as a `#`
-    comment all change (or empty) the skeleton and fail the golden match, while a
-    reworded skip message does not force a golden bump."""
-    lines = body.splitlines()
-    start = None
-    for i, line in enumerate(lines):
-        st = line.strip()
-        if st.startswith("if [") and jq_field in st and st.endswith("then"):
-            start = i
-            break
-    if start is None:
-        return None
-    # Walk to the matching `fi`, keeping only the load-bearing statements.
-    kept: list[str] = []
-    for j in range(start, len(lines)):
-        st = lines[j].strip()
-        if not st or st.startswith("#"):
-            continue
-        if st.startswith("echo "):
-            # non-load-bearing skip message
-            continue
-        kept.append(st)
-        if st == "fi":
-            break
-    else:
-        return None
-    return _canon(" ".join(kept))
-
-
-def _load(text: str) -> dict:
-    doc = yaml.safe_load(text)
-    if not isinstance(doc, dict):
-        raise Offence("workflow is not a YAML mapping")
-    return doc
-
-
-def _ring_job(doc: dict) -> tuple[str, dict]:
-    jobs = doc.get("jobs")
-    if not isinstance(jobs, dict):
-        raise Offence("workflow has no `jobs:` mapping")
-    # The ring job is the one that references the token / dispatch. Locate by content
-    # so a rename cannot hide the token.
+def _token_consumers(jobs: dict) -> list[str]:
+    """Every job id whose serialized definition references secrets.REGISTRY_RING_TOKEN.
+    Located by CONTENT (not job name) so a rename cannot hide a token consumer, and via
+    the parsed job (not a raw grep of the file) so a token reference demoted into a
+    `#`-comment in a run body still counts — that comment is part of the parsed run
+    string."""
+    out = []
     for jid, job in jobs.items():
-        blob = yaml.safe_dump(job)
-        if RING_TOKEN in blob or DISPATCH_MARKER in blob:
-            return (jid, job)
-    raise Offence(
-        f"no job references {RING_TOKEN}/{DISPATCH_MARKER} — cannot locate the ring job"
-    )
+        blob = yaml.safe_dump(job, sort_keys=True, allow_unicode=True)
+        if RING_TOKEN_SECRET in blob:
+            out.append(jid)
+    return out
 
 
 def check_doc(text: str) -> list[str]:
-    """Return a list of offence strings; empty == clean. Canonical golden match."""
+    """Return a list of offence strings; empty == clean. Whole-job pin (J1) + exactly
+    one token consumer (J2)."""
     offences: list[str] = []
-    doc = _load(text)
-    jobs = doc.get("jobs", {})
-    ring_id, ring = _ring_job(doc)
+    doc = yaml.safe_load(text)
+    if not isinstance(doc, dict):
+        raise Offence("workflow is not a YAML mapping")
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        raise Offence("workflow has no `jobs:` mapping")
 
-    # ---- G1: the ring job `if:` must EXACTLY equal the golden condition ----
-    cond = ring.get("if")
-    if not isinstance(cond, str) or not cond.strip():
-        offences.append(f"G1: ring job `{ring_id}` has no `if:` guard at all")
-    else:
-        cond_flat = _canon(cond)
-        if cond_flat != GOLDEN_IF:
-            offences.append(
-                f"G1: ring job `{ring_id}` `if:` does not match the canonical golden "
-                f"guard. Any change — an OR-wrap `(... || true)`, a `!(...)` negation, "
-                f"an operand swap, a reorder, or an added clause — reds here because the "
-                f"normalized text differs from the known-good condition. If this is a "
-                f"legitimate refactor, update GOLDEN_IF in this PR.\n"
-                f"       expected: {GOLDEN_IF!r}\n"
-                f"       actual:   {cond_flat!r}"
-            )
-
-    # ---- G2: the token step is INSIDE the guarded ring job; no OTHER job uses it ----
-    ring_blob = yaml.safe_dump(ring)
-    if RING_TOKEN not in ring_blob:
+    # ---- J2: EXACTLY ONE job may consume the ring token ----
+    consumers = _token_consumers(jobs)
+    if len(consumers) == 0:
         offences.append(
-            f"G2: the guarded ring job `{ring_id}` does not reference {RING_TOKEN} — "
-            f"the token step is not gated behind the head_repository guard"
+            f"J2: no job references {RING_TOKEN_SECRET} — the token-consuming job is "
+            f"missing or the secret reference was renamed; cannot pin the guarded job"
         )
-    for jid, job in jobs.items():
-        if jid == ring_id:
-            continue
-        blob = yaml.safe_dump(job)
-        if RING_TOKEN in blob or DISPATCH_MARKER in blob:
-            jcond = job.get("if")
-            jflat = _canon(jcond) if isinstance(jcond, str) else ""
-            if jflat != GOLDEN_IF:
-                offences.append(
-                    f"G2: job `{jid}` also references the ring token/dispatch but its "
-                    f"`if:` is not the canonical golden guard — a second path to the "
-                    f"token that is not fail-closed on head_repository"
-                )
+        # Nothing to pin; the missing consumer is the whole finding.
+        return offences
+    if len(consumers) > 1:
+        offences.append(
+            f"J2: {len(consumers)} jobs reference {RING_TOKEN_SECRET} "
+            f"({', '.join(consumers)}) — there must be EXACTLY ONE token-consuming job "
+            f"so the whole-job pin covers every path to the token. A second privileged "
+            f"job is a second, un-pinned path to the secret and REDs here."
+        )
+        # Fall through to J1 so the reviewer also sees any whole-job drift; the count
+        # offence alone already fails the check.
 
-    # ---- G3: the resolution + live-state guards must match their goldens ----
-    run_bodies = []
-    for step in ring.get("steps", []) or []:
-        if isinstance(step, dict) and isinstance(step.get("run"), str):
-            run_bodies.append(step["run"])
-    body = "\n".join(run_bodies)
-    if not body:
-        offences.append(f"G3: ring job `{ring_id}` has no `run:` body to inspect")
-    else:
-        # (a) head_sha->PR fallback: the executable `select(...)` filter must EXACTLY
-        #     equal the golden conjunction. A `repo OR SHA` swap, a dropped predicate,
-        #     or a constant-swapped SHA all change this string and RED. (A predicate
-        #     retained only in a comment does not appear in the parsed jq filter, so
-        #     the select still differs from the golden.)
-        sel = _extract_select(body)
-        if sel is None:
-            offences.append(
-                "G3: the head_sha->PR resolution `select(...)` jq filter is MISSING — "
-                "the fork-repo AND exact-${HEAD_SHA} conjunction cannot be verified"
+    # ---- J1: the ONE token-consuming job, whole, must equal GOLDEN_JOB byte-exact ----
+    matched_golden = [jid for jid in consumers if canonical_job(jobs[jid]) == GOLDEN_JOB]
+    if not matched_golden:
+        # Diff against the first consumer (the most likely intended job) for review.
+        target = consumers[0]
+        actual = canonical_job(jobs[target])
+        diff = "\n".join(
+            difflib.unified_diff(
+                GOLDEN_JOB.splitlines(),
+                actual.splitlines(),
+                fromfile="GOLDEN_JOB",
+                tofile=f"jobs.{target} (actual)",
+                lineterm="",
             )
-        elif sel != GOLDEN_SELECT:
-            offences.append(
-                "G3: the head_sha->PR resolution `select(...)` does not match the "
-                "canonical golden filter. It must be the CONJUNCTION "
-                "`head.repo.full_name == ${REPO} AND head.sha == ${HEAD_SHA} AND "
-                "state == open` — a `repo OR SHA` disjunction, a dropped predicate, or "
-                "a constant-swapped SHA all differ from the golden and red. If this is "
-                "a legitimate refactor, update GOLDEN_SELECT in this PR.\n"
-                f"       expected: {GOLDEN_SELECT!r}\n"
-                f"       actual:   {sel!r}"
-            )
-
-        # (b) live-state defense in depth: each fail-closed `!=` guard block must
-        #     match its golden EXECUTABLE skeleton, and precede the dispatch. An
-        #     inversion to `==`, a dropped operand, or a predicate demoted to a
-        #     comment changes (or empties) the skeleton and reds.
-        for label, jq_field, golden in (
-            ("head_repo", ".head_repo", GOLDEN_LIVE_REPO_GUARD),
-            ("head_sha", ".head_sha", GOLDEN_LIVE_SHA_GUARD),
-        ):
-            block = _canon_guard_block(body, jq_field)
-            if block is None:
-                offences.append(
-                    f"G3: the live-PR-state {label} re-check `if` block is MISSING — "
-                    f"the fail-closed `!=` guard was dropped (or its predicate now "
-                    f"survives only in a comment, which does not execute)"
-                )
-                continue
-            if block != golden:
-                offences.append(
-                    f"G3: the live-PR-state {label} re-check does not match the "
-                    f"canonical golden guard. It must be the FAIL-CLOSED `!=` compare "
-                    f"that `exit 0`s on mismatch — an inversion to `==`, a dropped "
-                    f"operand, or a comment-only predicate all differ from the golden "
-                    f"and red. If this is a legitimate refactor, update the golden in "
-                    f"this PR.\n"
-                    f"       expected: {golden!r}\n"
-                    f"       actual:   {block!r}"
-                )
-            # Ordering: the guard block must appear BEFORE the privileged dispatch.
-            pos = body.find(f"if [ \"$(jq -r '{jq_field}'")
-            disp = body.find(DISPATCH_CMD)
-            if pos >= 0 and disp >= 0 and pos > disp:
-                offences.append(
-                    f"G3: the live-PR-state {label} `!=` guard appears AFTER the "
-                    f"`{DISPATCH_CMD}` doorbell — the guard must gate BEFORE the dispatch"
-                )
+        )
+        offences.append(
+            f"J1: the token-consuming job `{target}` does not match the canonical "
+            f"GOLDEN_JOB byte-for-byte. The WHOLE job is pinned, so ANY edit — an "
+            f"OR-wrap / negation / operand swap in `if:`, a demoted-to-comment "
+            f"predicate, an uncalled-function move of the guards, an alt dispatch "
+            f"spelling, a dropped `select(...)` conjunct, an inverted `!=` guard, a "
+            f"changed permission — reds here. If this is a LEGITIMATE refactor, "
+            f"regenerate GOLDEN_JOB in this PR (see the header one-liner); that golden "
+            f"bump is the review checkpoint.\n"
+            f"       --- unified diff (GOLDEN_JOB vs actual) ---\n{diff}"
+        )
 
     return offences
+
+
+def check_root(root: Path) -> list[str]:
+    """Live path used by both the default run and every --self-test fixture: read the
+    workflow from `root` and check it. The self-test mutates a PHYSICAL COPY of the
+    real workflow on disk and calls THIS, so the fixtures exercise the exact code path
+    that runs in CI."""
+    wf = root / WORKFLOW_REL
+    if not wf.exists():
+        raise Offence(f"{wf} not found")
+    return check_doc(wf.read_text(encoding="utf-8"))
 
 
 # --------------------------------------------------------------------------- #
@@ -367,9 +263,20 @@ def _self_test() -> int:
     text = WORKFLOW.read_text(encoding="utf-8")
     failures = 0
 
+    def _run_on(mutated: str) -> list[str]:
+        """Write the (mutated) workflow into a throwaway repo-root tree and run the
+        LIVE --root path over it, so every fixture goes through check_root/check_doc
+        exactly as CI does."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            wf = root / WORKFLOW_REL
+            wf.parent.mkdir(parents=True, exist_ok=True)
+            wf.write_text(mutated, encoding="utf-8")
+            return check_root(root)
+
     def expect_clean(label: str, t: str) -> None:
         nonlocal failures
-        offs = check_doc(t)
+        offs = _run_on(t)
         if offs:
             failures += 1
             print(f"  [FAIL] {label}: expected CLEAN but got offences:")
@@ -384,7 +291,7 @@ def _self_test() -> int:
             failures += 1
             print(f"  [FAIL] {label}: MUTATION DID NOT APPLY (fixture == live workflow)")
             return
-        offs = check_doc(t)
+        offs = _run_on(t)
         if not any(needle in o for o in offs):
             failures += 1
             print(
@@ -393,67 +300,65 @@ def _self_test() -> int:
         else:
             print(f"  [ok]   {label}: correctly RED ({needle})")
 
-    # 0) the real, live workflow must be clean.
-    expect_clean("live workflow", text)
+    # 0) the real, live workflow (physical copy) must be clean.
+    expect_clean("live workflow (physical copy via --root)", text)
 
-    # --- round-1 fixtures: a guard is REMOVED ---
+    # --- round-1 fixtures: a guard is REMOVED (whole-job pin => J1) ---
 
-    # 1) FORK RUN: remove the head_repository guard from the job `if:`. => G1.
-    no_guard = re.sub(
-        r"\n\s*&&\s*github\.event\.workflow_run\.head_repository\.full_name\s*==\s*github\.repository",
+    # 1) FORK RUN: remove the head_repository guard from the job `if:`.
+    no_guard = text.replace(
+        "\n      && github.event.workflow_run.head_repository.full_name == github.repository",
         "",
-        text,
+        1,
     )
-    expect_red("R1 fork run (head_repository guard removed)", no_guard, "G1")
+    expect_red("R1 fork run (head_repository guard removed)", no_guard, "J1")
 
-    # 2) SAME-SHA collision: drop the `.head.sha ==` filter from the fallback. => G3.
+    # 2) SAME-SHA collision: drop the `.head.sha ==` filter from the fallback select.
     no_sha_filter = text.replace(
-        'and .head.sha == \\"${HEAD_SHA}\\" and .state', "and .state"
+        'and .head.sha == \\"${HEAD_SHA}\\" and .state', "and .state", 1
     )
-    expect_red("R1 same-SHA collision (head.sha filter removed)", no_sha_filter, "G3")
+    expect_red("R1 same-SHA collision (head.sha filter removed)", no_sha_filter, "J1")
 
-    # 3) STALE-HEAD: remove the live head_sha re-check block before dispatch. => G3.
-    no_live_recheck = re.sub(
-        r'head_sha: \.head\.sha, ', "", text
-    )
-    no_live_recheck = re.sub(
-        r"          if \[ \"\$\(jq -r '\.head_sha' <<<\"\$state\"\)\" != \"\$\{HEAD_SHA\}\" \]; then\n"
-        r".*?\n            exit 0\n          fi\n",
+    # 3) STALE-HEAD: remove the live head_sha re-check block before dispatch.
+    no_live_recheck = text.replace(
+        '          if [ "$(jq -r \'.head_sha\' <<<"$state")" != "${HEAD_SHA}" ]; then\n'
+        '            echo "resolved PR #${PR_NUMBER} head SHA no longer matches the failing run\'s head SHA (stale head / same-SHA collision) — skipping."\n'
+        "            exit 0\n"
+        "          fi\n",
         "",
-        no_live_recheck,
-        flags=re.DOTALL,
+        1,
     )
-    expect_red("R1 stale-head (live head_sha re-check removed)", no_live_recheck, "G3")
+    expect_red("R1 stale-head (live head_sha re-check removed)", no_live_recheck, "J1")
 
-    # --- round-2 fixtures: predicate-parser was too loose ---
+    # --- round-2 fixtures: predicate-parser was too loose (whole-job pin => J1) ---
 
-    # 4) TOP-LEVEL `|| true` appended to the if (bare, depth-0). => G1.
+    # 4) TOP-LEVEL `|| true` appended to the if (bare, depth-0).
     or_bypass = text.replace(
         "&& github.event.workflow_run.head_repository.full_name == github.repository\n",
         "&& github.event.workflow_run.head_repository.full_name == github.repository\n"
         "      || true\n",
         1,
     )
-    expect_red("R2 top-level `|| true` bypass appended", or_bypass, "G1")
+    expect_red("R2 top-level `|| true` bypass appended", or_bypass, "J1")
 
-    # 5) fork-repo predicate removed from the fallback `select(...)`. => G3.
+    # 5) fork-repo predicate removed from the fallback `select(...)`.
     no_repo_predicate = text.replace(
         'select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" '
         'and .state == \\"open\\")',
         'select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")',
         1,
     )
-    expect_red("R2 fallback fork-repo predicate removed", no_repo_predicate, "G3")
+    expect_red("R2 fallback fork-repo predicate removed", no_repo_predicate, "J1")
 
-    # 6) .head.sha compared to a CONSTANT instead of ${HEAD_SHA}. => G3.
+    # 6) .head.sha compared to a CONSTANT instead of ${HEAD_SHA}.
     sha_constant = text.replace(
         '.head.sha == \\"${HEAD_SHA}\\" and .state',
         '.head.sha == \\"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\\" and .state',
         1,
     )
-    expect_red("R2 fallback head.sha compared to a constant", sha_constant, "G3")
+    expect_red("R2 fallback head.sha compared to a constant", sha_constant, "J1")
 
-    # 7) live `!=` guards inverted to `==` (fail-open). => G3.
+    # 7) live `!=` guards inverted to `==` (fail-open).
     inverted_guards = text.replace(
         'if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then',
         'if [ "$(jq -r \'.head_repo\' <<<"$state")" == "${REPO}" ]; then',
@@ -463,13 +368,11 @@ def _self_test() -> int:
         'if [ "$(jq -r \'.head_sha\' <<<"$state")" == "${HEAD_SHA}" ]; then',
         1,
     )
-    expect_red("R2 live `!=` guards inverted to `==` (fail-open)", inverted_guards, "G3")
+    expect_red("R2 live `!=` guards inverted to `==` (fail-open)", inverted_guards, "J1")
 
-    # --- round-3 fixtures: the exact bypasses codex demonstrated against the parser ---
+    # --- round-3 fixtures: bypasses codex demonstrated against the PARSER ---
 
-    # 8) [R3] PARENTHESIZED OR-WRAP of the whole condition: actionlint-valid,
-    #    (failure && event && head_repo == repo || true). The old paren-depth
-    #    scanner treated a `||` inside parens as safe. Golden exact-match reds.
+    # 8) [R3] PARENTHESIZED OR-WRAP of the whole condition (actionlint-valid).
     paren_or_wrap = text.replace(
         "    if: >-\n"
         "      github.event.workflow_run.conclusion == 'failure'\n"
@@ -482,31 +385,27 @@ def _self_test() -> int:
         "      || true)\n",
         1,
     )
-    expect_red("R3 parenthesized `(... || true)` OR-wrap of the whole if", paren_or_wrap, "G1")
+    expect_red("R3 parenthesized `(... || true)` OR-wrap of the whole if", paren_or_wrap, "J1")
 
-    # 9) [R3] NEGATED equality `!(head_repo == repo)`: passed the old presence regex.
-    #    Golden exact-match reds (text differs).
+    # 9) [R3] NEGATED equality `!(head_repo == repo)`.
     negated_guard = text.replace(
         "&& github.event.workflow_run.head_repository.full_name == github.repository",
         "&& !(github.event.workflow_run.head_repository.full_name == github.repository)",
         1,
     )
-    expect_red("R3 negated `!(head_repo == repo)` guard", negated_guard, "G1")
+    expect_red("R3 negated `!(head_repo == repo)` guard", negated_guard, "J1")
 
-    # 10) [R3] G3 CONJUNCTION->DISJUNCTION: `repo AND sha` -> `repo OR sha` in the
-    #     fallback select. Both exact needles survived the old substring test.
-    #     Golden exact-match reds (`and`->`or` changes the normalized filter).
+    # 10) [R3] G3 CONJUNCTION->DISJUNCTION: `repo AND sha` -> `repo OR sha` in select.
     or_conjunction = text.replace(
         '.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\"',
         '.head.repo.full_name == \\"${REPO}\\" or .head.sha == \\"${HEAD_SHA}\\"',
         1,
     )
-    expect_red("R3 fallback conjunction->disjunction (repo OR sha)", or_conjunction, "G3")
+    expect_red("R3 fallback conjunction->disjunction (repo OR sha)", or_conjunction, "J1")
 
     # 11) [R3] PREDICATE MOVED TO A COMMENT: the executable select drops the fork-repo
-    #     predicate but a `#`-comment line retains the needle text. The old substring
-    #     test matched the comment. The golden matches the PARSED filter only, so the
-    #     executable select differs and reds.
+    #     predicate but a `#`-comment retains the needle text. The whole-job pin
+    #     includes the run body verbatim (comment + weakened select), so it REDs.
     predicate_in_comment = text.replace(
         '            if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \\\n'
         '                --jq "[.[] | select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
@@ -515,32 +414,103 @@ def _self_test() -> int:
         '                --jq "[.[] | select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
         1,
     )
-    expect_red("R3 fork-repo predicate demoted to a comment (select drops it)", predicate_in_comment, "G3")
+    expect_red("R3 fork-repo predicate demoted to a comment (select drops it)", predicate_in_comment, "J1")
 
-    # 12) [R3] INVERTED LIVE GUARD accompanied by a comment-only expected needle: the
-    #     executable `!=` is flipped to `==` while a `#`-comment carries the `!=` text.
-    #     The old substring test found the `!=` in the comment. The golden matches the
-    #     executable skeleton (comments stripped), so the inversion reds.
+    # 12) [R3] INVERTED LIVE GUARD accompanied by a comment-only expected needle.
     inverted_with_comment = text.replace(
         '          if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n',
         '          # if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n'
         '          if [ "$(jq -r \'.head_repo\' <<<"$state")" == "${REPO}" ]; then\n',
         1,
     )
-    expect_red("R3 live guard inverted with comment-only `!=` needle", inverted_with_comment, "G3")
+    expect_red("R3 live guard inverted with comment-only `!=` needle", inverted_with_comment, "J1")
+
+    # --- round-4 fixtures: codex's residual fragment/duplication holes ---
+
+    # 13) [R4] INLINE-COMMENT DEMOTION of the select via a `: # select(...)` no-op:
+    #     append `: # <golden select>` after weakening the live select. A fragment
+    #     extractor that stripped only WHOLE-LINE comments (or matched the needle text
+    #     anywhere) could be fooled; the whole-job pin includes the entire run body so
+    #     any such edit REDs.
+    inline_comment_demotion = text.replace(
+        '                --jq "[.[] | select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then\n',
+        '                --jq "[.[] | select(.head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")] | .[0].number // empty")"; then : # select(.head.repo.full_name == \\"${REPO}\\" and .head.sha == \\"${HEAD_SHA}\\" and .state == \\"open\\")\n',
+        1,
+    )
+    expect_red("R4 inline `: # select(...)` demotion (weakened live filter)", inline_comment_demotion, "J1")
+
+    # 14) [R4] GUARDS MOVED TO AN UNCALLED FUNCTION: wrap both live `!=` guards in a
+    #     `_dead_guards() { ... }` that is never called, so the needle text survives
+    #     but no guard executes before dispatch. Whole-job pin REDs (run body changed).
+    moved_to_uncalled_fn = text.replace(
+        '          if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n'
+        '            echo "resolved PR #${PR_NUMBER} head repo is not ${REPO} (fork / cross-repo collision) — skipping."\n'
+        "            exit 0\n"
+        "          fi\n"
+        '          if [ "$(jq -r \'.head_sha\' <<<"$state")" != "${HEAD_SHA}" ]; then\n'
+        '            echo "resolved PR #${PR_NUMBER} head SHA no longer matches the failing run\'s head SHA (stale head / same-SHA collision) — skipping."\n'
+        "            exit 0\n"
+        "          fi\n",
+        "          _dead_guards() {\n"
+        '          if [ "$(jq -r \'.head_repo\' <<<"$state")" != "${REPO}" ]; then\n'
+        "            exit 0\n"
+        "          fi\n"
+        '          if [ "$(jq -r \'.head_sha\' <<<"$state")" != "${HEAD_SHA}" ]; then\n'
+        "            exit 0\n"
+        "          fi\n"
+        "          }\n",
+        1,
+    )
+    expect_red("R4 live guards moved into an uncalled function", moved_to_uncalled_fn, "J1")
+
+    # 15) [R4] ALT DISPATCH SPELLING: `gh workflow run -R <repo> dispatch.yml` (flag
+    #     before the workflow file) instead of the golden `gh workflow run dispatch.yml
+    #     -R <repo>`. A checker that pinned only the exact golden dispatch string could
+    #     miss this reordering; the whole-job pin REDs on any run-body change.
+    alt_dispatch_spelling = text.replace(
+        "GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry",
+        "GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run -R jeswr/agent-account-registry dispatch.yml",
+        1,
+    )
+    expect_red("R4 alt dispatch spelling (gh workflow run -R ... dispatch.yml)", alt_dispatch_spelling, "J1")
+
+    # 16) [R4] SECOND PRIVILEGED TOKEN-CONSUMING JOB: add a second job that consumes
+    #     secrets.REGISTRY_RING_TOKEN with the SAME golden `if:` but NO SHA/repo
+    #     defenses. The exactly-one-consumer count REDs (J2). We insert it right after
+    #     the `jobs:` line so the parse yields two consumers.
+    second_job = text.replace(
+        "jobs:\n",
+        "jobs:\n"
+        "  ring_evil:\n"
+        "    name: second ring (bypass)\n"
+        "    if: >-\n"
+        "      github.event.workflow_run.conclusion == 'failure'\n"
+        "      && github.event.workflow_run.event == 'pull_request'\n"
+        "      && github.event.workflow_run.head_repository.full_name == github.repository\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: second unguarded ring\n"
+        "        env:\n"
+        "          REGISTRY_RING_TOKEN: ${{ secrets.REGISTRY_RING_TOKEN }}\n"
+        "        run: |\n"
+        "          GH_TOKEN=\"${REGISTRY_RING_TOKEN}\" gh workflow run dispatch.yml -R jeswr/agent-account-registry\n",
+        1,
+    )
+    expect_red("R4 second privileged token-consuming job", second_job, "J2")
 
     if failures:
         print(f"\nSELF-TEST FAILED: {failures} case(s) did not behave as expected.")
         return 1
     print(
-        "\nSELF-TEST PASSED: live workflow clean + all round-1/2/3 negative fixtures RED "
-        "(canonical golden match)."
+        "\nSELF-TEST PASSED: live workflow clean + all round-1..4 negative fixtures RED "
+        "(whole-job pin J1 + exactly-one-consumer J2, each verified through the live "
+        "--root path against a physically-mutated workflow copy)."
     )
     return 0
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description=__doc__)
+    ap = argparse.ArgumentParser(description="fast-fix-ring cross-repo guard checker")
     ap.add_argument("--root", type=Path, default=None, help="repo root override")
     ap.add_argument(
         "--self-test", action="store_true", help="run hermetic negative fixtures"
@@ -550,15 +520,9 @@ def main() -> int:
     if args.self_test:
         return _self_test()
 
-    wf = WORKFLOW
-    if args.root is not None:
-        wf = args.root / ".github" / "workflows" / "fast-fix-ring.yml"
-    if not wf.exists():
-        print(f"error: {wf} not found", file=sys.stderr)
-        return 1
-
+    root = args.root if args.root is not None else REPO_ROOT
     try:
-        offences = check_doc(wf.read_text(encoding="utf-8"))
+        offences = check_root(root)
     except Offence as e:
         print(f"error: {e}", file=sys.stderr)
         return 1

--- a/scripts/tests/fast-fix-ring.golden.yml
+++ b/scripts/tests/fast-fix-ring.golden.yml
@@ -1,0 +1,221 @@
+# fast-fix-ring — the FAST-FIX RING, moved OFF the PR-head trust boundary
+# (sparq-org/sparq#3474, HIGH). [OPUS-4.8] 🤖 SPARQ agent.
+#
+# WHY THIS IS ITS OWN `workflow_run` WORKFLOW (the security fix):
+# The ring's only privileged capability is the cross-repo `REGISTRY_RING_TOKEN`
+# doorbell (it dispatches jeswr/agent-account-registry). Previously the ring lived
+# as the `fix-ring` job INSIDE ci-summary.yml, which triggers on `pull_request`.
+# For a `pull_request` event GitHub takes the WORKFLOW DEFINITION from the PR HEAD,
+# and same-repo agent branches (sparq-agent/*) are granted repository secrets — so a
+# malicious or compromised agent PR that merely EDITED ci-summary.yml could read and
+# exfiltrate REGISTRY_RING_TOKEN. That is issue #3474.
+#
+# The secure pattern is `workflow_run`: this workflow runs ONLY after ci-summary has
+# completed, GitHub ALWAYS executes the copy of THIS file that lives on the DEFAULT
+# BRANCH (never the PR head's copy), and the job runs privileged but ISOLATED from any
+# PR-head content — the run does not (and must not) check out or execute anything from
+# the head SHA. A PR that edits this file on its branch changes NOTHING about the run
+# that fires for it; only a change merged to the default branch takes effect (and that
+# passes through review + branch protection). REGISTRY_RING_TOKEN is therefore no
+# longer reachable from PR-head-controlled content. See §ADVERSARIAL below.
+#
+# WHAT IT DOES (unchanged behaviour, ported verbatim from the old fix-ring job): when
+# the ci-summary `gate` REDs on a pull_request run for a PIPELINE-OWNED PR (armed for
+# auto-merge, or labeled review:pass / review:changes; never drafts or the human-owned
+# review:needs-user / needs:user holds), ring the registry dispatcher so its repair
+# sweep enumerates the red PR NOW instead of on the next ~10-min cron tick. The
+# registry's ci-fix admission is derived from the PR's GATE STATE (its PLAN snapshots
+# per-PR CI status), so ringing is sufficient; deliberately NO needs:ci-fix label
+# fallback — the registry enumerator treats needs:* PR labels as HUMAN-owned holds that
+# EXCLUDE a PR from the repair loop, so a label would do the OPPOSITE of triggering a
+# fix. Fork / cross-repo runs never reach the token step at all — the job `if:` gates
+# on head_repository.full_name == this repo (#3475), so only a same-repo PR run runs
+# the body; if the token is merely unconfigured the job fail-softs with a notice and
+# the registry cron remains the backstop.
+#
+# ADVISORY / NON-GATING (unchanged). This workflow is a SIDE EFFECT of a red gate, not
+# part of the gate. It runs via `workflow_run` on a PAST run's completion, so it
+# produces NO check-run on any PR / merge_group head commit and is therefore NOT on the
+# `ci-summary / gate` poll set — it can never become a required check and can never
+# affect a merge (same non-gating argument selection-alarm.yml relies on). The job name
+# retains the "advisory" token for continuity with the advisory-registry entry
+# (.github/advisory-registry.json, key "fast-fix ring (advisory)") and the sq-wjth
+# exclusion rule, even though the workflow_run placement already makes it structurally
+# non-gating.
+#
+# All third-party actions (none are used here — the job is pure `gh api`) would be
+# SHA-pinned per the Scorecard posture. This workflow deliberately performs NO checkout.
+#
+# §ADVERSARIAL (self-check answers recorded for #3474):
+#  (1) Can PR-head content still influence the privileged job? NO. workflow_run always
+#      loads THIS file from the default branch; the job never checks out or executes
+#      head content, and reads only server-side API state (labels/draft/arm) by PR
+#      NUMBER. There is no `run` step that interpolates untrusted PR text into the
+#      shell, and no ${{ github.event.workflow_run.* }} value is expanded inside a
+#      `run:` script (all are passed through `env:` and quoted) — no script injection.
+#  (2) Does the head_sha -> PR lookup admit a spoofed / same-SHA cross-repo run? NO,
+#      and this is now FAIL-CLOSED at the job level (#3475). The PRIMARY guard is the
+#      job `if:` condition
+#         github.event.workflow_run.head_repository.full_name == github.repository
+#      — a fork run, or a spoofed cross-repo run whose head commit collides with an
+#      internal PR's SHA, has a head_repository that is NOT this repo, so it NEVER
+#      reaches the token step. (This matters because workflow_run runs are ALSO
+#      delivered for fork/cross-repo triggering runs, and workflow_run grants secret
+#      access even when the triggering run itself had none — so the OLD "fork runs
+#      cannot ring anyway" reasoning was FALSE: without this guard the head_sha->PR
+#      fallback could misattribute a same-SHA fork run to a pipeline-owned internal
+#      PR and fire the doorbell.) DEFENSE IN DEPTH, past that gate: the head_sha->PR
+#      fallback accepts only pulls whose head.repo.full_name == this repo AND whose
+#      head.sha == the failing run's exact head SHA; and the live-state read re-checks
+#      the resolved PR's head_repo == this repo AND head_sha == the run's head SHA
+#      before the dispatch. Three independent barriers, each fail-closed.
+#  (3) Confused-deputy — could the ring fire for a PR the failing run didn't belong to?
+#      NO. The PR is bound to the failing run's OWN head SHA
+#      (github.event.workflow_run.head_sha) — either via that run's pull_requests list
+#      or the same-repo pulls-at-SHA lookup — so the ring always targets the PR whose CI
+#      actually failed. The live-state re-read is by that same resolved PR number.
+#  (4) workflow_run recursion — can this workflow trigger itself? NO. It triggers ONLY
+#      on completion of the workflow named `ci-summary`; it is not itself named
+#      `ci-summary` and it emits no ci-summary run. It also gates on
+#      workflow_run.event == 'pull_request', and this workflow has no pull_request
+#      trigger, so nothing it does can re-enter it.
+name: fast-fix-ring
+
+on:
+  # Fire after ci-summary completes. ci-summary's `name:` is exactly `ci-summary`,
+  # and `workflow_run.workflows` keys on that workflow NAME. The job `if:` below
+  # narrows to a FAILED pull_request run; workflow_run always executes the
+  # default-branch copy of this file (the whole point of the #3474 fix).
+  workflow_run:
+    workflows: ["ci-summary"]
+    types: [completed]
+
+# The job's own GITHUB_TOKEN needs only to READ the PR's live labels/draft/arm state.
+# The one WRITE capability is the cross-repo REGISTRY_RING_TOKEN doorbell, which is a
+# SEPARATE token consumed inside the step — not a permission of this GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# One in-flight ring per triggering ci-summary run.
+concurrency:
+  group: fast-fix-ring-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  ring:
+    name: fast-fix ring (advisory)
+    # Only a FAILED ci-summary run that fired from a SAME-REPO pull_request.
+    # `workflow_run` exposes the triggering run's own conclusion + originating
+    # event; a push/merge_group ci-summary failure is NOT a PR and cannot ring.
+    # `failure` excludes cancelled/superseded gate runs, matching the old
+    # `failure()` guard.
+    #
+    # head_repository.full_name == github.repository is the PRIMARY #3475 guard
+    # (FAIL-CLOSED, defense in depth): a fork run — or a spoofed cross-repo run
+    # whose head commit collides with an internal PR's SHA — has a head_repository
+    # that is NOT this repo, so it is REJECTED HERE and the token step is never
+    # reached. Fork/cross-repo `workflow_run` runs are still delivered to this
+    # workflow (workflow_run fires for them), and `workflow_run` grants secret
+    # access even when the triggering run itself lacked secrets — so guarding on
+    # conclusion+event ALONE was insufficient: the downstream head_sha->PR fallback
+    # could otherwise MISATTRIBUTE a fork run to a same-SHA internal PR. This gate
+    # closes that off before any resolution runs. (The old "fork runs cannot ring
+    # anyway" reasoning was FALSE — corrected in §ADVERSARIAL #2.)
+    if: >-
+      github.event.workflow_run.conclusion == 'failure'
+      && github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Resolve the PR for the failed run and ring the registry dispatcher
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REGISTRY_RING_TOKEN: ${{ secrets.REGISTRY_RING_TOKEN }}
+          REPO: ${{ github.repository }}
+          # The failing run's OWN head SHA — binds the ring to the PR whose CI
+          # actually failed (confused-deputy guard #3). Passed through env (never
+          # interpolated into the script body) so no PR-controlled value can inject.
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Same-repo PRs GitHub already associated with the triggering run. The job
+          # `if:` has already fail-closed on head_repository == this repo (#3475), so
+          # this only ever resolves for a same-repo PR run; it can still be empty for
+          # a same-repo PR whose association GitHub hasn't attached to the run, hence
+          # the head_sha->PR fallback below.
+          RUN_PR_NUMBER: ${{ (github.event.workflow_run.pull_requests[0] != null) && github.event.workflow_run.pull_requests[0].number || '' }}
+        run: |
+          set -euo pipefail
+
+          # --- Derive the PR number, SAME-REPO only (spoof guard #2 / deputy #3) ---
+          # The top-level job `if:` already fail-closed on
+          # head_repository.full_name == github.repository, so a fork/cross-repo run
+          # never reaches this step. The head_sha->PR fallback below adds a SECOND,
+          # independent barrier (defense in depth against a same-SHA collision):
+          # every resolved PR must be BOTH same-repo AND pinned to the failing run's
+          # exact head SHA before any dispatch.
+          PR_NUMBER="${RUN_PR_NUMBER}"
+          if [ -z "${PR_NUMBER}" ]; then
+            # pull_requests is empty for fork PRs and can be empty for same-repo PRs
+            # whose association GitHub hasn't attached to the run; look the PR up by
+            # the failing run's head SHA, but ONLY accept a pull whose head repo is
+            # THIS repo AND whose head SHA is EXACTLY this run's head SHA (a fork PR,
+            # or an internal PR that merely shares this commit but points its head at
+            # a different SHA, is filtered out and the job skips).
+            if ! pulls="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+                --jq "[.[] | select(.head.repo.full_name == \"${REPO}\" and .head.sha == \"${HEAD_SHA}\" and .state == \"open\")] | .[0].number // empty")"; then
+              echo "::notice::could not look up a PR for the failed run's head SHA — skipping (the registry cron is the backstop)."
+              exit 0
+            fi
+            PR_NUMBER="${pulls}"
+          fi
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "no same-repo PR is associated with the failed run's head SHA (fork PR, or the run was not a same-repo PR) — nothing to ring; skipping."
+            exit 0
+          fi
+
+          # --- Live PR state — labels/arming churn between the trigger and here ---
+          # (ported from the former ci-summary fix-ring job; head_repo/head_sha now
+          # re-read for the #3475 defense-in-depth check below.)
+          if ! state="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" \
+              --jq '{draft: .draft, armed: (.auto_merge != null), head_repo: .head.repo.full_name, head_sha: .head.sha, labels: [.labels[].name]}')"; then
+            echo "::notice::could not read live PR state — skipping the ring (the registry cron is the backstop)."
+            exit 0
+          fi
+          # Defense in depth (#3475): the resolved PR must belong to THIS repo AND
+          # its head must still be the failing run's exact SHA. This closes any
+          # residual same-SHA-collision window in either resolution path (the
+          # workflow_run.pull_requests[0] association OR the pulls-at-SHA lookup)
+          # before the privileged doorbell fires.
+          if [ "$(jq -r '.head_repo' <<<"$state")" != "${REPO}" ]; then
+            echo "resolved PR #${PR_NUMBER} head repo is not ${REPO} (fork / cross-repo collision) — skipping."
+            exit 0
+          fi
+          if [ "$(jq -r '.head_sha' <<<"$state")" != "${HEAD_SHA}" ]; then
+            echo "resolved PR #${PR_NUMBER} head SHA no longer matches the failing run's head SHA (stale head / same-SHA collision) — skipping."
+            exit 0
+          fi
+          has() { jq -e --arg l "$1" '.labels | index($l) != null' <<<"$state" >/dev/null; }
+          if [ "$(jq -r '.draft' <<<"$state")" = "true" ]; then
+            echo "PR re-drafted since the trigger — not pipeline-owned for fast-fix; skipping."
+            exit 0
+          fi
+          if has "review:needs-user" || has "needs:user"; then
+            echo "human-owned hold (review:needs-user / needs:user) — the repair loop must not pick this PR up; skipping."
+            exit 0
+          fi
+          if [ "$(jq -r '.armed' <<<"$state")" != "true" ] && ! has "review:pass" && ! has "review:changes"; then
+            echo "PR is neither armed nor in the review pipeline (review:pass / review:changes) — skipping."
+            exit 0
+          fi
+          if [ -z "${REGISTRY_RING_TOKEN}" ]; then
+            # NO needs:ci-fix label fallback, deliberately: the registry PLAN
+            # derives ci-fix admission from the PR's gate STATE and treats
+            # needs:* PR labels as human-owned holds that EXCLUDE the PR from
+            # the repair enumeration — a label here would suppress the fix.
+            echo "::notice::REGISTRY_RING_TOKEN unavailable (secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
+            exit 0
+          fi
+          GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry
+          echo "rang jeswr/agent-account-registry dispatch for PR #${PR_NUMBER} — the repair sweep runs now instead of on the next cron tick."


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes #3474 (HIGH).

## The threat: `pull_request` → PR-head-controlled secret access

The fast-fix ring's only privileged capability is the cross-repo `REGISTRY_RING_TOKEN` doorbell (it dispatches `jeswr/agent-account-registry`). It lived as the `fix-ring` job **inside `ci-summary.yml`**, which triggers `on: pull_request`.

For a `pull_request` event, **GitHub takes the workflow definition from the PR HEAD**. Same-repo agent branches (`sparq-agent/*`) are granted **repository secrets**. So a malicious or compromised agent PR that merely **edited `ci-summary.yml`** on its own branch could rewrite the `fix-ring` step to read `secrets.REGISTRY_RING_TOKEN` and exfiltrate it (e.g. POST it to an attacker endpoint). The token grants cross-repo `workflow run` dispatch on the account registry — a real blast radius.

## The fix: the secure `workflow_run` pattern

Move the ring into its own workflow **`.github/workflows/fast-fix-ring.yml`**, triggered via `workflow_run` on `ci-summary`'s completion:

- `workflow_run` **always runs the copy of the workflow file that lives on the DEFAULT BRANCH**, never the PR head's copy. It runs privileged but **isolated from PR-head content**. A PR editing `fast-fix-ring.yml` on its branch changes nothing about the run that fires for it — only a change merged to `main` (through review + branch protection) takes effect. **`REGISTRY_RING_TOKEN` is no longer reachable from anything a PR head controls.**
- Behaviour is **ported verbatim**: live draft/armed/label reads by PR number, the human-hold skips (`review:needs-user` / `needs:user`), the neither-armed-nor-in-pipeline skip, and the fail-soft-on-missing-token registry-cron-backstop notice.
- **Advisory / non-gating preserved and strengthened**: the ring now runs post-hoc via `workflow_run` on a *past* run's completion, so it produces **no check-run on any PR / merge_group head commit** — it is not on the `ci-summary / gate` poll set and *cannot* become a required check (same non-gating argument `selection-alarm.yml` relies on). The job name keeps the `advisory` token for continuity with the advisory-registry + the sq-wjth rule.
- **Least privilege**: the job's own `GITHUB_TOKEN` is `pull-requests: read`; the *only* write capability is the separate `REGISTRY_RING_TOKEN` doorbell. **No checkout** at all (pure `gh api`), and no PR-controlled text is interpolated into the shell.

### Changes
- **New** `.github/workflows/fast-fix-ring.yml` (`on: workflow_run: workflows: ["ci-summary"] types: [completed]`; ci-summary's `name:` is exactly `ci-summary`).
- **Removed** the `fix-ring` job + its rationale block from `ci-summary.yml`; repointed the header's FAST-FIX RING section at the new workflow (now documents the #3474 requirement).
- **Updated** `.github/advisory-registry.json`: entry `fast-fix ring (advisory)` `workflow` → `fast-fix-ring.yml` (job **name unchanged**, so the C2 registry check — which keys on job name — stays green). `check-advisory-registry.py --self-test` and the live check are **all-clear**.
- `actionlint .github/workflows/fast-fix-ring.yml .github/workflows/ci-summary.yml`: **zero findings**. No other workflow references the removed job.

## Adversarial self-check

1. **Can PR-head content still influence the privileged job?** **No.** `workflow_run` always loads this file from the default branch; the job never checks out or executes head content and reads only server-side API state (labels / draft / arm) by PR **number**. No `${{ github.event.workflow_run.* }}` value is expanded inside a `run:` body — untrusted values (`head_sha`, PR number) pass through `env:` and are quoted, so there is no script injection.

2. **Does the head_sha → PR lookup admit a spoofed cross-repo PR?** **No.** Resolution is **same-repo only**: it takes `workflow_run.pull_requests[0]` (GitHub populates this **only for same-repo PRs**) first, and its fallback `gh api repos/<repo>/commits/<sha>/pulls` **filters to `head.repo.full_name == this repo`** (and `state == open`). A fork PR — or a spoofed cross-repo PR that happens to share the head SHA — is filtered out and the job **skips**. Fork heads have no secrets and cannot ring anyway.

3. **Confused deputy — could the ring fire for a PR the failing run didn't belong to?** **No.** The PR is bound to the failing run's **own** head SHA (`github.event.workflow_run.head_sha`) — via that run's `pull_requests` list or the same-repo pulls-at-SHA lookup — and every live-state read is by that resolved PR number. The ring always targets the PR whose CI actually failed.

4. **`workflow_run` recursion — can this workflow trigger itself?** **No.** It triggers only on completion of the workflow **named `ci-summary`**; this workflow is named `fast-fix-ring` and emits no `ci-summary` run. It also gates on `workflow_run.event == 'pull_request'` and has **no `pull_request` trigger**, so nothing it does can re-enter it.

## Security surface note

This PR touches `.github/workflows/**` (CI security surface) ⇒ **human-armed**. I have **not** armed it for auto-merge.