### PR TITLE
feat(routing): luna alias + docs-only sonnet/terra rule (structurally enforced)

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -47,7 +47,7 @@ credential_format = "claude-oauth-token"
 [models.terra]
 provider = "openai"
 harness = "codex"
-provider_model = ""                    # EMPTY = omit --model (codex CLI default). The literal "TBD" placeholder
+provider_model = "gpt-5.6-sol"  # maintainer 2026-07-18: GPT-5.6 sol for reviews (terra=review model for anthropic-authored PRs)
                                        # reached `codex exec --model TBD` in every terra fleet worker -> API 400 /
                                        # no-tool-call fallback (2026-07-18). Never ship a placeholder id here.
                                        # sentinel is load-bearing: dispatch/worker pass NO --model flag

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -55,15 +55,21 @@ credential_format = "codex-auth-json"
 [models.sol]
 provider = "openai"
 harness = "codex"
-provider_model = "gpt-5.6-sol"         # THE cross-provider REVIEW model (maintainer 2026-07-18): the
-                                       # registry REVIEW_CHAIN routes reviews of anthropic-authored PRs
-                                       # to `sol`. Distinct alias from `terra` (a different GPT model,
-                                       # which stays the openai IMPL/fix alias); id probed working on
-                                       # the worker account type 2026-07-18.
+provider_model = "gpt-5.6-sol"         # Cross-provider REVIEW model (maintainer 2026-07-18): the registry
+                                       # REVIEW_CHAIN routes reviews of anthropic-authored CONTENT to
+                                       # `sol`. Distinct alias from `terra` (a different GPT model); id
+                                       # probed working on the worker account type 2026-07-18.
+credential_format = "codex-auth-json"
+[models.luna]
+provider = "openai"
+harness = "codex"
+provider_model = "gpt-5.6-luna"        # Second tier of the unified fix ladder opus<luna<fable<sol
+                                       # (maintainer 2026-07-18) + sol's review fallback; id probed
+                                       # working on the worker account type 2026-07-18.
 credential_format = "codex-auth-json"
 
 [defaults]
-model_chain = ["fable", "sonnet", "terra"]
+model_chain = ["fable", "sol", "opus"]
 agent = "sparq-rust-impl"
 
 # ---------------------------------------------------------------------------------------------------
@@ -80,7 +86,7 @@ escalate = true                        # consumed by dispatch: on chain-exhausti
 # cross-provider implementation fallback so an Anthropic outage does not stall implementation.
 [[route]]
 role = "impl"
-model_chain = ["fable", "sonnet", "terra"]
+model_chain = ["fable", "sol", "opus"]
 agent = "sparq-rust-impl"
 
 # [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
@@ -92,7 +98,7 @@ agent = "sparq-rust-impl"
 # unions ALL match_labels keywords, so UI keywords there would human-arm every UI PR.
 [[route]]
 role = "site"
-model_chain = ["terra", "fable", "sonnet"]
+model_chain = ["sol", "fable", "opus"]
 agent = "sparq-site"
 
 # [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
@@ -112,7 +118,7 @@ agent = "sparq-site"
 # escalation) — where role:ci and a security surface overlap, the security lane is correct.
 [[route]]
 role = "ci"
-model_chain = ["fable", "terra"]
+model_chain = ["fable", "sol"]
 agent = "sparq-ci-infra"
 
 [[route]]
@@ -125,9 +131,12 @@ role = "research"
 model_chain = ["fable", "opus"]
 agent = "sparq-researcher"
 
+# docs-only cheap tiers (maintainer 2026-07-18): sonnet AND terra appear in THIS chain and
+# nowhere else — scripts/route-resolve.py validate_routing() REJECTS any table naming either
+# outside role=docs.
 [[route]]
 role = "docs"
-model_chain = ["haiku", "fable"]
+model_chain = ["haiku", "sonnet", "terra", "fable"]
 agent = "sparq-docs"
 
 # Review / soundness: Opus only; escalate to human on unavailability (do NOT fall to a weaker model).

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -47,7 +47,7 @@ credential_format = "claude-oauth-token"
 [models.terra]
 provider = "openai"
 harness = "codex"
-provider_model = "gpt-5.6-sol"  # maintainer 2026-07-18: GPT-5.6 sol for reviews (terra=review model for anthropic-authored PRs)
+provider_model = ""                    # EMPTY = omit --model (codex CLI default). The literal "TBD" placeholder
                                        # reached `codex exec --model TBD` in every terra fleet worker -> API 400 /
                                        # no-tool-call fallback (2026-07-18). Never ship a placeholder id here.
                                        # sentinel is load-bearing: dispatch/worker pass NO --model flag

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -15,8 +15,27 @@ except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
 
+def validate_routing(doc):
+    """Structural invariants a routing table must satisfy before ANY resolution — enforced in
+    resolve() so a violating table fails LOUDLY at PLAN time instead of silently routing.
+    Maintainer rule 2026-07-18: the cheap tiers `sonnet` and `terra` author NOTHING but docs —
+    they may appear only in the model_chain of a route whose role == "docs" (never in defaults,
+    a match_labels security rule, or any other role's chain)."""
+    docs_only = {"sonnet", "terra"}
+    offenders = []
+    if docs_only & set(doc.get("defaults", {}).get("model_chain", [])):
+        offenders.append("defaults")
+    for r in doc.get("route", []):
+        if docs_only & set(r.get("model_chain", [])) and r.get("role") != "docs":
+            offenders.append(r.get("role") or ",".join(r.get("match_labels", [])) or "<unnamed>")
+    if offenders:
+        raise ValueError("routing violates the docs-only rule for sonnet/terra (maintainer "
+                         "2026-07-18) in: " + "; ".join(offenders))
+
+
 def resolve(labels, doc):
     """Return (model_chain, agent, escalate). `labels`: iterable of the issue's labels."""
+    validate_routing(doc)
     labels = set(labels)
 
     def role_of(lbs):
@@ -56,12 +75,12 @@ def _self_test():
     # docs -> haiku-led
     chk("docs -> haiku", resolve(["role:docs", "area:x"], doc)[0][0], "haiku")
     # [FABLE-5] UI ownership: site -> terra-led (GPT-5.6 codex, the original dashboard builder)
-    chk("site -> terra-led", resolve(["role:site", "area:site"], doc)[0], ["terra", "fable", "sonnet"])
+    chk("site -> sol-led (GPT owns UI; terra is docs-only)", resolve(["role:site", "area:site"], doc)[0], ["sol", "fable", "opus"])
     # [FABLE-5] frontier-tier infra authorship (standing rule 2026-07-17): ci -> fable-first,
     # FRONTIER-ONLY chain — no sub-frontier model (sonnet/haiku) anywhere in it, so exhaustion
     # DEFERS at the registry claim step (retried next tick) instead of degrading tier.
     mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
-    chk("ci -> frontier-only fable-first", (mc, ag, esc), (["fable", "terra"], "sparq-ci-infra", False))
+    chk("ci -> frontier-only fable-first", (mc, ag, esc), (["fable", "sol"], "sparq-ci-infra", False))
     chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
     # no role -> defaults (fable-led)
     chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "fable")


### PR DESCRIPTION
> 🤖 SPARQ agent

Follow-up to #3491 (merged before these landed). Maintainer directives 2026-07-18:
- **`[models.luna]`** (`gpt-5.6-luna`, probed): second tier of the unified fix ladder **opus < luna < fable < sol**
- **sonnet AND terra are docs-only** (terra is sonnet-class): removed from defaults/impl/site/ci chains — impl `[fable, sol, opus]`, site `[sol, fable, opus]` (GPT still owns UI), ci `[fable, sol]`, docs `[haiku, sonnet, terra, fable]`
- **Structural enforcement**: `route-resolve.validate_routing()` rejects any table naming sonnet/terra outside `role=docs`, called from `resolve()` so every PLAN consumer fails loudly. Self-test covers the shipped table + a violating table.

Registry-side chain switch (REVIEW_CHAIN content-keyed, unified FIX_CHAIN, legacy-pin translation) is jeswr/agent-account-registry#94.