### PR TITLE
fix(dispatch-plan): self-test ci-chain fixture tracks the docs-only routing change

### DIFF
--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -180,7 +180,7 @@ def _self_test():
     ci = compute_ready([iss(8, R + ["priority:P1", "role:ci", "area:ci"])])
     row = plan_dispatch(ci, doc)[0]
     chk("ci -> frontier-only row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
-        ("ci", ["fable", "terra"], "sparq-ci-infra", False))
+        ("ci", ["fable", "sol"], "sparq-ci-infra", False))
     chk("ci row has no sub-frontier tier", sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
 
     # --- Fixture: package-conflict pair → only the higher-priority one is planned ----------------


### PR DESCRIPTION
> 🤖 SPARQ agent

**Dispatch is down fleet-wide** since #3492 merged: the registry PLAN runs sparq's `dispatch-plan.py --self-test` against live routing, and its ci-chain fixture still pinned `[fable, terra]` while routing now says `[fable, sol]` — every tick hard-fails (the #51 plan-alert correctly paged; this is the fix it paged for). One-line fixture update; self-test PASSES. Same dual-definition drift class as registry #99 — the fixture should ultimately derive from the table.