### PR TITLE
feat(routing): implementation chains lead with sol (credit abundance, cross-provider review auto-flips)

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -82,10 +82,10 @@ agent = "sparq-reviewer"
 escalate = true                        # consumed by dispatch: on chain-exhaustion, label needs:user
 
 # ---------------------------------------------------------------------------------------------------
-# ROLE ROUTES. Fable is the primary code-writer (maintainer doctrine); terra (GPT) is the
-# cross-provider implementation fallback so an Anthropic outage does not stall implementation.
-# Implementation chains lead with sol (maintainer directive 2026-07-18, credit abundance; cross-provider
-# review flips automatically, so sol-authored implementation still receives Anthropic review).
+# ROLE ROUTES. Implementation chains LEAD WITH SOL (maintainer directive 2026-07-18: credit
+# abundance; capability order opus < luna < fable < sol). Fable is the anthropic-side fallback,
+# so an OpenAI outage does not stall implementation. Cross-provider review flips automatically:
+# sol-authored implementation receives Anthropic review, and vice versa.
 [[route]]
 role = "impl"
 model_chain = ["sol", "fable", "opus"]

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -69,7 +69,7 @@ provider_model = "gpt-5.6-luna"        # Second tier of the unified fix ladder o
 credential_format = "codex-auth-json"
 
 [defaults]
-model_chain = ["fable", "sol", "opus"]
+model_chain = ["sol", "fable", "opus"]
 agent = "sparq-rust-impl"
 
 # ---------------------------------------------------------------------------------------------------
@@ -84,9 +84,11 @@ escalate = true                        # consumed by dispatch: on chain-exhausti
 # ---------------------------------------------------------------------------------------------------
 # ROLE ROUTES. Fable is the primary code-writer (maintainer doctrine); terra (GPT) is the
 # cross-provider implementation fallback so an Anthropic outage does not stall implementation.
+# Implementation chains lead with sol (maintainer directive 2026-07-18, credit abundance; cross-provider
+# review flips automatically, so sol-authored implementation still receives Anthropic review).
 [[route]]
 role = "impl"
-model_chain = ["fable", "sol", "opus"]
+model_chain = ["sol", "fable", "opus"]
 agent = "sparq-rust-impl"
 
 # [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
@@ -118,12 +120,12 @@ agent = "sparq-site"
 # escalation) — where role:ci and a security surface overlap, the security lane is correct.
 [[route]]
 role = "ci"
-model_chain = ["fable", "sol"]
+model_chain = ["sol", "fable"]
 agent = "sparq-ci-infra"
 
 [[route]]
 role = "perf"
-model_chain = ["fable", "opus"]
+model_chain = ["sol", "fable", "opus"]
 agent = "sparq-perf-engineer"
 
 [[route]]

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -154,7 +154,7 @@ def _self_test():
     chk("impl -> single row", len(p_impl), 1)
     row = p_impl[0]
     chk("impl row", (row["role"], row["model_chain"][0], row["agent"], row["escalate"]),
-        ("impl", "fable", "sparq-rust-impl", False))
+        ("impl", "sol", "sparq-rust-impl", False))
     chk("impl package", row["package"], "sparq-core")
     chk("impl priority", row["priority"], 1)
 
@@ -180,7 +180,7 @@ def _self_test():
     ci = compute_ready([iss(8, R + ["priority:P1", "role:ci", "area:ci"])])
     row = plan_dispatch(ci, doc)[0]
     chk("ci -> frontier-only row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
-        ("ci", ["fable", "sol"], "sparq-ci-infra", False))
+        ("ci", ["sol", "fable"], "sparq-ci-infra", False))
     chk("ci row has no sub-frontier tier", sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
 
     # --- Fixture: package-conflict pair → only the higher-priority one is planned ----------------

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -69,9 +69,9 @@ def _self_test():
     # impl + a security surface (area:sparq-zk) -> security rule wins over role -> Opus, escalate
     mc, ag, esc = resolve(["role:impl", "area:sparq-zk"], doc)
     chk("impl+zk -> opus/escalate", (mc, ag, esc), (["opus"], "sparq-reviewer", True))
-    # plain impl -> Fable-led chain
+    # plain impl -> sol-led chain (maintainer directive 2026-07-18)
     mc, ag, esc = resolve(["role:impl", "area:sparq-core"], doc)
-    chk("impl -> fable-led", (mc[0], ag, esc), ("fable", "sparq-rust-impl", False))
+    chk("impl -> sol-led", (mc, ag, esc), (["sol", "fable", "opus"], "sparq-rust-impl", False))
     # docs -> haiku-led
     chk("docs -> haiku", resolve(["role:docs", "area:x"], doc)[0][0], "haiku")
     # [FABLE-5] UI ownership: site -> terra-led (GPT-5.6 codex, the original dashboard builder)
@@ -80,10 +80,12 @@ def _self_test():
     # FRONTIER-ONLY chain — no sub-frontier model (sonnet/haiku) anywhere in it, so exhaustion
     # DEFERS at the registry claim step (retried next tick) instead of degrading tier.
     mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
-    chk("ci -> frontier-only fable-first", (mc, ag, esc), (["fable", "sol"], "sparq-ci-infra", False))
+    chk("ci -> frontier-only sol-first", (mc, ag, esc), (["sol", "fable"], "sparq-ci-infra", False))
     chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
-    # no role -> defaults (fable-led)
-    chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "fable")
+    # no role -> defaults (sol-led, 2026-07-18)
+    chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "sol")
+    # perf -> sol-led with the fable/opus fallbacks (new order pinned)
+    chk("perf -> sol-led", resolve(["role:perf", "area:sparq-engine"], doc)[0], ["sol", "fable", "opus"])
     # review role -> opus + escalate
     chk("review -> opus/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))
     print("route-resolve self-test", "PASSED" if ok else "FAILED")


### PR DESCRIPTION
> 🤖 **SPARQ agent** — orchestrator-lane routing change (maintainer-directed).

Maintainer directive 2026-07-18: heavy `sol` usage for implementation — abundant credits; capability order `opus < luna < fable < sol`. Reviews are cross-provider vs the content author and handled pipeline-side, so `sol`-authored implementation work receives Anthropic review automatically.

## Change (`orchestration/routing.toml` only)
| chain | before | after |
| --- | --- | --- |
| role `impl` | `["fable", "sol", "opus"]` | `["sol", "fable", "opus"]` |
| role `ci` | `["fable", "sol"]` | `["sol", "fable"]` |
| role `perf` | `["fable", "opus"]` | `["sol", "fable", "opus"]` |
| `[defaults]` | `["fable", "sol", "opus"]` | `["sol", "fable", "opus"]` |

Plus one sentence in the ROLE-ROUTES header comment recording the rationale.

**Deliberately untouched:** the `zk`/`mpc`/`reasoner`/`crypto`/`auth`/`e2ee` security-label override block (`opus` only + human escalate), role `site` (already `sol`-first), role `research`/`docs`/`review`/`soundness`, and the `[models]` catalog. `sol` and `luna` are already in the catalog.

## Validation
- `python3 scripts/routing-validate.py orchestration/routing.toml` → **`routing.toml OK`** (every chain model is in `[models]`; no empty chains; every route has an agent; the `role:ci` frontier-only rule is satisfied — `["sol", "fable"]` contains no sub-frontier tier).
- TOML parses (`tomllib`).

## Honest note — stale consumer self-tests (not CI-wired)
`route-resolve.py --self-test` (3 assertions) and `dispatch-plan.py --self-test` (1 assertion) hard-code the prior `fable`-first ordering (`impl -> fable-led`, `ci -> ["fable","sol"]`, `no-role -> fable`) and now report FAILED against the new chains. These self-tests are **not** wired into any CI workflow (verified), so this PR's `gate` is unaffected. Refreshing those fixtures to the new maintainer-directed ordering is left for a companion change to keep this PR to the `routing.toml`-only scope; noted on #3423 (the open issue that proposes wiring these self-tests into a PR gate — those fixtures must be refreshed there before/with that wiring, or the new gate would go red).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>