### PR TITLE
fix(ci): zero-leg skeleton check must not trigger the reporter await

### DIFF
--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -476,24 +476,36 @@ def is_fm_report(name: str) -> bool:
     return name == FM_REPORT_NAME
 
 
+def fm_run_id_of(run: dict) -> str:
+    """The feature-matrix Actions run id a group check-run belongs to, parsed from
+    its `/actions/runs/<id>` url (details_url, else html_url). "" when the url has no
+    parseable run id (a group check that carries no locating url). Used to bucket
+    group checks by the run they belong to so presence and correlation are decided
+    relative to the LATEST run — including the zero-leg skeleton, which is itself a
+    check-run of that run and so carries its run id."""
+    url = run.get("details_url") or run.get("html_url") or ""
+    m = RUNS_URL_RE.search(url)
+    return m.group(1) if m else ""
+
+
 def fm_group_run_id(runs: list[dict]) -> str:
     """[FABLE-5] PR #3511 finding 2: the CURRENT feature-matrix run id, extracted as
     the MAXIMUM `/actions/runs/<id>` seen across the `opt-in group (…)` check-runs'
-    details_url. GitHub Actions run ids are monotonically ascending, so the max is the
-    LATEST feature-matrix run on this head — the one whose reporter verdict the gate
-    must await. (On a same-SHA rerun — ready_for_review / label — the commit carries
-    group check-runs from BOTH the stale and the fresh run; the fresh run's id is the
-    larger.) Returns "" if no group check carries a parseable run id (then the
-    correlation degrades to the pre-finding-2 any-report behaviour — never a false
-    RED, and the stale-report race is only reachable on a same-SHA rerun anyway)."""
+    details_url — name-only (is_fm_group), so the zero-leg skeleton (a check-run of
+    the current run) is INCLUDED. GitHub Actions run ids are monotonically ascending,
+    so the max is the LATEST feature-matrix run on this head — the one whose reporter
+    verdict the gate must await (or, when that run is zero-leg, the one that proves no
+    reporter is expected; see fm_report_status). On a same-SHA rerun (ready_for_review
+    / label) the commit carries group check-runs from BOTH the stale and the fresh run;
+    the fresh run's id is the larger. Returns "" if no group check carries a parseable
+    run id (then correlation degrades to the pre-finding-2 any-report behaviour — never
+    a false RED, and the stale-report race is only reachable on a same-SHA rerun)."""
     best = ""
     for r in runs:
         if not is_fm_group(r.get("name", "")):
             continue
-        url = r.get("details_url") or r.get("html_url") or ""
-        m = RUNS_URL_RE.search(url)
-        if m:
-            rid = m.group(1)
+        rid = fm_run_id_of(r)
+        if rid:
             # Numeric max (ids are ints of possibly-different width); compare as ints.
             if best == "" or int(rid) > int(best):
                 best = rid
@@ -505,10 +517,15 @@ def fm_report_status(runs: list[dict]) -> str:
     reporter-await status over the (already forgiveness-filtered, self-excluded)
     sibling set. Returns one of:
 
-      * "n/a"     — no `opt-in group (…)` check-run on this head, so the
-                    feature-matrix produced no legs for it and NO reporter is
-                    expected (a doc-only PR, a fully change-selected-out matrix,
-                    or a merge_group that skipped the lane). No requirement.
+      * "n/a"     — the LATEST feature-matrix run on this head produced NO legs, so
+                    NO reporter is expected. Two shapes: (1) no `opt-in group (…)`
+                    check-run at all — a doc-only PR, a fully change-selected-out
+                    matrix, or a merge_group that skipped the lane; (2) the latest
+                    run posted ONLY the zero-leg skeleton (unexpanded placeholder,
+                    server-set skipped) — no real leg ran, so the reporter correctly
+                    posts nothing. Presence is LATEST-RUN-RELATIVE (finding, r3): an
+                    OLDER real group run's leftover check on a same-SHA rerun does
+                    NOT resurrect the requirement when the current run is zero-leg.
       * "ok"      — legs ran AND a terminal-SUCCESS `feature-matrix report`
                     check-run FOR THE CURRENT GROUP RUN is present: the reporter
                     posted its green verdict.
@@ -543,15 +560,42 @@ def fm_report_status(runs: list[dict]) -> str:
     read-only token) will hold here to timeout and RED; that is acceptable — a fork
     PR is not auto-merged into the queue and fail-closed is the safe posture the
     finding demands."""
-    group_present = any(is_real_fm_group(r) for r in runs)
-    if not group_present:
-        return "n/a"
+    # PRESENCE is decided relative to the LATEST feature-matrix run (finding, r3).
+    # A same-SHA rerun (ready_for_review / label) leaves an OLDER real group run's
+    # check-runs on the commit alongside a NEWER zero-leg skeleton run; keying
+    # presence off ANY real group (the old run's) while keying the run id off the
+    # newer skeleton deadlocked the gate — it awaited a reporter the zero-leg run
+    # correctly never posts. So: bucket the group checks by the run they belong to
+    # and judge the presence + reporter requirement of the LATEST run only.
+    group_checks = [r for r in runs if is_fm_group(r.get("name", ""))]
+    if not group_checks:
+        return "n/a"  # no feature-matrix legs on this head at all
+    real_groups = [r for r in group_checks if is_real_fm_group(r)]
+    if not real_groups:
+        return "n/a"  # only zero-leg skeleton(s) anywhere — no real leg ever ran
+    current_run_id = fm_group_run_id(runs)  # max run id across ALL group checks
+    # Can we bucket by run id? Only if a latest run id resolved AND every REAL group
+    # carries a parseable run id — otherwise a real leg of an UNKNOWN (possibly newer)
+    # run may exist, so we cannot safely declare the latest run zero-leg. In that
+    # fail-CLOSED case we keep the reporter requirement (real legs ran somewhere) and
+    # let current_run_id (possibly "") drive the graceful any-report degradation below.
+    real_unparseable = any(not fm_run_id_of(r) for r in real_groups)
+    if current_run_id and not real_unparseable:
+        latest_run_checks = [r for r in group_checks
+                             if fm_run_id_of(r) == current_run_id]
+        if not any(is_real_fm_group(r) for r in latest_run_checks):
+            # The LATEST run posted only the zero-leg skeleton — no leg ran, no
+            # reporter is expected. (A stale OLDER real run's leftover check does not
+            # matter; its own reporter, if any, is not what this head awaits.)
+            return "n/a"
+        # else: the latest run DID run real legs (a forged placeholder name with a
+        # server-set NON-skipped conclusion still counts as real — security, r2) —
+        # require its reporter, correlated to current_run_id.
     reports = [r for r in runs if is_fm_report(r.get("name", ""))]
     if not reports:
         return "pending"  # legs ran; reporter verdict not on the head SHA yet
     # CORRELATION: bind the verdict to the CURRENT group run. Prefer the report(s)
     # whose external_id equals the current group run id; ignore stale reports.
-    current_run_id = fm_group_run_id(runs)
     any_report_has_extid = any((r.get("external_id") or "") for r in reports)
     if current_run_id and any_report_has_extid:
         matched = [r for r in reports if (r.get("external_id") or "") == current_run_id]

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -444,9 +444,28 @@ def is_fm_group(name: str) -> bool:
     `opt-in group (${{ matrix.group }})`, conclusion=skipped. That is proof legs
     did NOT run; counting it as group presence made every docs/config-only PR
     await a reporter verdict the reporter correctly never posts (zero-leg no-op)
-    and time out RED after the full gate budget. A REAL group check has an
-    expanded name (no `${{`)."""
-    return name.startswith(FM_GROUP_PREFIX) and "${{" not in name
+    and time out RED after the full gate budget.
+
+    SECURITY (sol on #3525): the exclusion must NOT be name-only — matrix.group
+    names come from the PR-controlled assembler, so a real successful group named
+    to contain `${{` could masquerade as the skeleton and drop the reporter
+    requirement (fail-open). The skeleton is identified by BOTH marks: the
+    unexpanded placeholder in the name AND conclusion == skipped (server-set).
+    is_real_fm_group(run) implements that; this name-only helper is for callers
+    that have no conclusion in hand (run-id extraction, where a forged name only
+    ADDS a candidate id — never removes the requirement)."""
+    return name.startswith(FM_GROUP_PREFIX)
+
+
+def is_real_fm_group(run: dict) -> bool:
+    """A group check that PROVES legs ran: group-prefixed name, excluding only the
+    zero-leg skeleton (unexpanded `${{` placeholder AND server-set skipped)."""
+    name = run.get("name", "")
+    if not name.startswith(FM_GROUP_PREFIX):
+        return False
+    if "${{" in name and (run.get("conclusion") or "") == "skipped":
+        return False
+    return True
 
 
 def is_fm_report(name: str) -> bool:
@@ -524,7 +543,7 @@ def fm_report_status(runs: list[dict]) -> str:
     read-only token) will hold here to timeout and RED; that is acceptable — a fork
     PR is not auto-merged into the queue and fail-closed is the safe posture the
     finding demands."""
-    group_present = any(is_fm_group(r.get("name", "")) for r in runs)
+    group_present = any(is_real_fm_group(r) for r in runs)
     if not group_present:
         return "n/a"
     reports = [r for r in runs if is_fm_report(r.get("name", ""))]

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -436,8 +436,17 @@ def is_fm_group(name: str) -> bool:
     their own conclusions directly on the head SHA (no privileged token), so their
     PRESENCE is the robust, reporter-timing-independent proof that legs were
     selected and the trusted `feature-matrix report` reporter must post its
-    verdict for this head."""
-    return name.startswith(FM_GROUP_PREFIX)
+    verdict for this head.
+
+    ZERO-LEG SKELETON (production incident, PR #3524 2026-07-19): when the setup
+    job selects ZERO legs the skipped matrix job still posts ONE skeleton
+    check-run named with the UNEXPANDED placeholder — literally
+    `opt-in group (${{ matrix.group }})`, conclusion=skipped. That is proof legs
+    did NOT run; counting it as group presence made every docs/config-only PR
+    await a reporter verdict the reporter correctly never posts (zero-leg no-op)
+    and time out RED after the full gate budget. A REAL group check has an
+    expanded name (no `${{`)."""
+    return name.startswith(FM_GROUP_PREFIX) and "${{" not in name
 
 
 def is_fm_report(name: str) -> bool:

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1107,8 +1107,19 @@ class TestFeatureMatrixReporterAwait(unittest.TestCase):
             {"name": "opt-in group (${{ matrix.group }})", "status": "completed",
              "conclusion": "skipped", "details_url": ""},
         ]
-        self.assertFalse(g.is_fm_group(runs[0]["name"]))
+        self.assertFalse(g.is_real_fm_group(runs[0]))
         self.assertEqual(g.fm_report_status(runs), "n/a")
+
+    def test_forged_placeholder_name_with_success_still_requires_reporter(self):
+        """SECURITY (sol on #3525): a REAL successful group whose PR-controlled name
+        embeds `${{` must NOT masquerade as the skeleton — the exclusion requires
+        the server-set skipped conclusion too."""
+        runs = [
+            {"name": "opt-in group (g01 ${{ attacker)", "status": "completed",
+             "conclusion": "success", "details_url": ""},
+        ]
+        self.assertTrue(g.is_real_fm_group(runs[0]))
+        self.assertEqual(g.fm_report_status(runs), "pending")
 
     def test_real_group_name_still_counts(self):
         runs = [

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1098,6 +1098,26 @@ class TestFeatureMatrixReporterAwait(unittest.TestCase):
     past the gate — absence keeps the gate polling and FAILS CLOSED at timeout."""
 
     # ---- pure predicates ----------------------------------------------------
+    def test_zero_leg_skeleton_placeholder_is_not_group_presence(self):
+        """The unexpanded `${{ matrix.group }}` skeleton (zero-leg run, skipped) must
+        NOT trigger the reporter requirement — production incident PR #3524: every
+        docs/config-only PR timed out RED awaiting a verdict the reporter correctly
+        never posts on a zero-leg run."""
+        runs = [
+            {"name": "opt-in group (${{ matrix.group }})", "status": "completed",
+             "conclusion": "skipped", "details_url": ""},
+        ]
+        self.assertFalse(g.is_fm_group(runs[0]["name"]))
+        self.assertEqual(g.fm_report_status(runs), "n/a")
+
+    def test_real_group_name_still_counts(self):
+        runs = [
+            {"name": "opt-in group (g01 sparq-engine)", "status": "completed",
+             "conclusion": "success", "details_url": "https://github.com/o/r/actions/runs/123/job/9"},
+        ]
+        self.assertTrue(g.is_fm_group(runs[0]["name"]))
+        self.assertEqual(g.fm_report_status(runs), "pending")
+
     def test_predicate_contract(self):
         self.assertTrue(g.is_fm_group("opt-in group (sparq-engine 1/2)"))
         self.assertFalse(g.is_fm_group("opt-in sparq-engine (paths)"),

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1337,5 +1337,93 @@ class TestFeatureMatrixReporterCorrelation(unittest.TestCase):
         self.assertIn("PASSED", out)
 
 
+# --- Fix round 3 (fable): latest-run-relative presence -------------------------
+# Same-SHA zero-leg rerun (ready_for_review / label) leaves an OLDER real group run's
+# check-runs on the commit alongside a NEWER zero-leg skeleton run. Keying presence
+# off ANY real group (the old run's) while keying the run id off the newer skeleton
+# deadlocked the gate: current_run_id = the skeleton's id, no report ever carries it
+# (zero-leg posts none), matched=[] => "pending" => timeout RED. FIX: presence AND the
+# reporter requirement are decided relative to the LATEST feature-matrix run.
+def _skel(run_id="", conclusion="skipped"):
+    """The zero-leg skeleton check-run (unexpanded placeholder + server-set skipped),
+    optionally carrying its own run id url (it is a check-run of that run)."""
+    url = f"https://github.com/o/r/actions/runs/{run_id}/job/1" if run_id else ""
+    return R("opt-in group (${{ matrix.group }})", conclusion=conclusion, url=url)
+
+
+class TestLatestRunRelativePresence(unittest.TestCase):
+    """[FABLE-5] fix round 3: a same-SHA zero-leg rerun must CONCLUDE (n/a), not
+    deadlock awaiting a reporter the zero-leg run correctly never posts."""
+
+    def test_a_mixed_old_real_plus_new_skeleton_is_na(self):
+        """(a) THE DEADLOCK: an OLD real group run (111) + its report(111) sit on the
+        SHA next to a NEWER zero-leg skeleton run (222). The latest run (222) is
+        zero-leg, so NO reporter is expected — the gate must conclude n/a, NOT await
+        run 222's absent report and time out RED."""
+        runs = [_grp("111"), _rep("111"), _skel("222")]
+        # current run id is the newer skeleton's (222) — the very shape that deadlocked.
+        self.assertEqual(g.fm_group_run_id(runs), "222")
+        self.assertEqual(g.fm_report_status(runs), "n/a")
+
+    def test_a_end_to_end_concludes_without_awaiting(self):
+        """(a) end-to-end: the mixed old-real + new-skeleton head PASSES immediately
+        (no reporter await), never RED-on-timeout."""
+        code, out = run(tiny_cfg(), [[_grp("111"), _rep("111"), _skel("222"), GREEN]])
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertNotIn("reporter verdict never landed", out)
+
+    def test_b_old_skeleton_plus_new_real_awaits_new_reporter(self):
+        """(b) reversed order: an OLD zero-leg skeleton (111) sits next to the NEWER
+        real run (222). The latest run has real legs => require ITS reporter. Absent
+        => pending; present with external_id == 222 => ok; a stale-only 111 report
+        (there is none here) could never satisfy it."""
+        pending = [_skel("111"), _grp("222"), GREEN]
+        self.assertEqual(g.fm_group_run_id(pending), "222")
+        self.assertEqual(g.fm_report_status(pending), "pending")
+        ok = [_skel("111"), _grp("222"), _rep("222"), GREEN]
+        self.assertEqual(g.fm_report_status(ok), "ok")
+        # A report only for the OLD run id does NOT satisfy the latest real run.
+        stale_only = [_skel("111"), _grp("222"), _rep("111"), GREEN]
+        self.assertEqual(g.fm_report_status(stale_only), "pending")
+
+    def test_c_isolated_skeleton_is_na(self):
+        """(c) existing invariant preserved: an isolated zero-leg skeleton (with OR
+        without a locating url) requires no reporter."""
+        self.assertEqual(g.fm_report_status([_skel()]), "n/a")
+        self.assertEqual(g.fm_report_status([_skel("222")]), "n/a")
+
+    def test_d_forged_placeholder_success_is_latest_still_requires_reporter(self):
+        """(d) SECURITY (r2 carried forward): a REAL successful group whose PR-controlled
+        name embeds the `${{` placeholder counts as REAL for the run it belongs to. When
+        it is the LATEST run, the reporter is STILL required — it must not drop the
+        requirement by masquerading as the zero-leg skeleton (which needs a server-set
+        `skipped`, not `success`)."""
+        forged = R("opt-in group (g01 ${{ attacker)", conclusion="success",
+                   url="https://github.com/o/r/actions/runs/222/job/3")
+        self.assertTrue(g.is_real_fm_group(forged))
+        # Latest run 222 is this forged-but-real group => require reporter.
+        self.assertEqual(g.fm_report_status([forged, GREEN]), "pending")
+        # Its reporter, correlated to 222, satisfies it.
+        self.assertEqual(g.fm_report_status([forged, _rep("222"), GREEN]), "ok")
+        # A zero-leg skeleton on an OLDER run (111) does not drop the requirement.
+        self.assertEqual(g.fm_report_status([_skel("111"), forged, GREEN]), "pending")
+
+    def test_e_real_group_unparseable_url_fails_closed(self):
+        """(e) fail-closed semantics: a REAL group check with NO parseable run id means
+        real legs ran on a run we cannot identify — we must NOT declare the latest run
+        zero-leg. The reporter requirement is kept (degrading to any-report correlation),
+        never n/a. FM_GROUP has an empty url; alone it holds pending, and it must keep
+        the requirement even when a NEWER skeleton carries a parseable id."""
+        # Real group, no url => pending (require reporter), never n/a.
+        self.assertEqual(g.fm_report_status([FM_GROUP, GREEN]), "pending")
+        # A real-unparseable group is NOT masked away by a parseable skeleton: the
+        # skeleton (222) would otherwise be "the latest run" and look zero-leg, but the
+        # unparseable real leg forbids that n/a — fail closed to require the reporter.
+        self.assertEqual(g.fm_report_status([FM_GROUP, _skel("222"), GREEN]), "pending")
+        # With any legacy report present it degrades to any-report (never a false RED).
+        self.assertEqual(g.fm_report_status([FM_GROUP, FM_REPORT_OK, GREEN]), "ok")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — P1 gate fix (orchestrator lane)

Production incident (first hit #3524, ~00:32Z): a zero-leg feature-matrix run still posts one **skipped skeleton check** named with the unexpanded placeholder `opt-in group (${{ matrix.group }})`. The structural await from #3511 counted that as group presence → demanded the `feature-matrix report` verdict → the reporter correctly no-ops on zero-leg runs → **every docs/config-only PR times out RED after the full ~54-min gate budget**.

Fix: `is_fm_group` requires an expanded name (`${{` never appears in a real group name). Regression tests: the skeleton alone → `n/a` (no reporter requirement); a real group name → requirement unchanged. 98 gate tests + full suite (767) green.