### PR TITLE
fix(ci): gate resolves required legs to the newest run — superseded/cancelled runs are non-events (#3505)

### DIFF
--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -12,8 +12,9 @@
 # (Pattern ported from jeswr/prod-solid-server's pr-gate.yml, incl. its stability-
 # window race fix.)
 #
-# SEMANTICS: success / skipped / neutral are non-failing; failure / cancelled /
-# timed_out / action_required / stale fail the gate. The gate EXCLUDES ITSELF (no
+# SEMANTICS: success / skipped / neutral are non-failing; a genuine newest-run
+# failure / timed_out / action_required / stale fails the gate. Cancelled runs are
+# re-dispatched once, never treated as a test failure. The gate EXCLUDES ITSELF (no
 # self-deadlock). It waits until EVERY discovered sibling check-run is terminal
 # (pending == 0) AND that all-terminal state has HELD for a short settle window,
 # bounded below by a startup-race floor and above by the job timeout. This converges
@@ -120,7 +121,7 @@
 # FAIL-FAST + FAST-FIX RING (2026-07-17 maintainer directive). [FABLE-5]
 # (1) FAIL-FAST: while polling, the moment any GATING leg has CONCLUDED failure the
 # gate REDs immediately instead of waiting for every other leg — a genuine `failure`
-# is never forgiven by any later state (only cancelled/stale are supersedable), so
+# from the authoritative NEWEST workflow run/attempt is never forgiven, so
 # every eventual render REDs anyway; the wait was pure latency on the verdict. A red
 # PR learns its fate in roughly the time of its fastest failing leg (~2-4 min for
 # clippy/fmt/test-compile classes) instead of the full sibling wall-clock (~30-40
@@ -149,6 +150,24 @@
 # by a PR to exfiltrate the token. `workflow_run` always runs the default-branch copy
 # of the file, isolated from PR-head content — see that file's header for the full
 # threat model + adversarial self-check.
+#
+# NEWEST WORKFLOW RUN WINS (#3505). [GPT-5.6] Check-run presence/name is not the
+# authority for Actions attempts: concurrency cancellation leaves terminal job
+# checks from an older run on the same SHA; re-runs reuse a run id; duplicate job
+# names collide across workflows; and a disabled/rewritten job can evaporate its
+# check-run even though the workflow run itself is green. The script therefore
+# lists workflow-runs for this head SHA and selects the newest run by
+# created_at/id and its newest run_attempt per workflow_id. Every older run is a
+# NON-EVENT, regardless of cancelled/failure conclusion. It reads completed runs
+# (and every re-run attempt) through the attempt-scoped Jobs API, then uses the
+# workflow-run verdict as a run-level backstop when checks are missing. A newest
+# FAILURE still REDs exactly as before.
+# A newest CANCELLED run is auto-re-dispatched ONCE; run_attempt is the durable
+# marker and an in-process attempted-set prevents repeated POSTs during API lag.
+# If that retry is cancelled or does not advance, the gate fails loudly with
+# "superseded-legs, re-run required" instead of misreporting a test failure or
+# hanging. Total wait caps are unchanged; this remains a pure waiter/poller and
+# never executes tests.
 #
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
 # scripts/ci_summary_gate.py (extracted from the previous inline bash so the
@@ -190,17 +209,19 @@ on:
   push:
     branches: [main]
 
-# Read-only: the gate READS check-runs + commit statuses for the head commit, plus
-# the repo's queued workflow-run count (`actions: read` — the sq-90cv4 saturation
-# signal; a permissions failure there degrades to the progress-only signal, it never
+# The gate READS check-runs + commit statuses for the head commit, plus
+# the repo's queued workflow-run count (the read side of `actions` — the sq-90cv4
+# saturation signal; a permissions failure there degrades to the progress-only signal, it never
 # fails the gate by itself), plus the PR's live draft state (`pull-requests: read`
 # — the draft-tier conclusion-time re-check; a failure there fail-closes to RED,
-# never to a pass).
+# never to a pass). `actions: write` is narrowly required by #3505 for the bounded
+# once-only POST that re-runs a newest cancelled workflow; it grants no source write
+# and the gate remains test-execution-free.
 permissions:
   checks: read
   statuses: read
   contents: read
-  actions: read
+  actions: write
   pull-requests: read
 
 # One in-flight gate per PR (or per branch on push). Cancel a superseded run so a

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -562,6 +562,10 @@ jobs:
       # still-settling, idle-queue hang => RED, absolute cap bounded) are pinned by a
       # hermetic stdlib-unittest suite (NO gh, NO network — injected fetchers). A
       # regression in the gate's own logic must red CI before every merge depends on it.
+      # [GPT-5.6] #3505 adds a script-native mutation tripwire: superseded cancellation
+      # must pass, newest failure must fail, and cancelled-run redispatch must stop at one.
+      - name: "Self-test ci-summary #3505 mutations (supersession + failure + bounded redispatch)"
+        run: python3 scripts/ci_summary_gate.py --self-test
       - name: Self-test ci-summary gate loop (verdict semantics + adaptive saturation budget — sq-90cv4)
         run: python3 scripts/tests/test_ci_summary_gate.py
       # [FABLE-5] sq-fmx4u.3: the change-based test-selection stack is now

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -25,20 +25,22 @@ without a second concurrent author to race against). The required check is:
 
 | Required check (job name) | Workflow | What it gates |
 |---|---|---|
-| **`ci-summary / gate`** | [`.github/workflows/ci-summary.yml`](../.github/workflows/ci-summary.yml) | **The single gate.** Polls every *other* check-run on the PR head commit and passes iff none failed (`success`/`skipped`/`neutral` are non-failing). |
+| **`ci-summary / gate`** | [`.github/workflows/ci-summary.yml`](../.github/workflows/ci-summary.yml) | **The single gate.** Polls Actions workflow-runs plus external check-runs on the PR head commit and passes iff the newest run/attempt of every gating workflow succeeds (`success`/`skipped`/`neutral` are non-failing). |
 
 > **Select only `ci-summary / gate`** in the ruleset's "Require status checks that must
 > pass" list. Do **not** add the individual job names below — `ci-summary` already
 > aggregates them. This is deliberate: `needs:` cannot span workflows, so requiring each
 > job by name was brittle (every rename / added gate broke the rule and silently weakened
 > the gate). The aggregator adapts automatically — add or rename jobs freely and the gate
-> still covers them, because it discovers the live set of check-runs at run time. See the
-> header of `ci-summary.yml` for the full semantics (stability window + self-exclusion).
+> still covers them, because it discovers the live workflow/check set at run time. See the
+> header of `ci-summary.yml` for the full semantics (newest-run resolution, bounded
+> cancelled-run re-dispatch, stability window, and self-exclusion).
 
 ### What `ci-summary` aggregates (informational — do NOT add these individually)
 
-The gate covers **every** check-run on the head commit. As of this writing those are the
-jobs below; this table is a map for reviewers, **not** a list of required checks.
+The gate covers **every newest Actions workflow run** and every external check-run on the
+head commit. As of this writing those expose the jobs below; this table is a map for
+reviewers, **not** a list of required checks.
 
 > **Advisory/informational checks are non-gating by NAME (sq-wjth).** `ci-summary`
 > excludes any check whose name contains the word `advisory` or `informational`
@@ -250,12 +252,17 @@ belts (all in `scripts/ci_summary_gate.py`, unit-tested in
    (`pull-requests: read`); if the PR was un-drafted meanwhile it concludes
    FAILURE with the same stale-draft-tier message, and an unreadable state
    fail-closes to FAILURE (a draft PR cannot merge anyway).
-6. **Superseded-cancellation forgiveness.** The ready_for_review re-run's per-PR
-   concurrency groups cancel the in-flight draft-tier runs, leaving
-   `cancelled` check-runs on the same SHA; the gate excuses a cancelled/stale
-   check-run **only** when a later run of the same (tier-normalized) name exists —
-   a genuine `failure`/`timed_out` is never forgiven, and a cancellation with no
-   successor still REDs.
+6. **Newest workflow run wins (#3505).** [GPT-5.6] The ready_for_review re-run's
+   per-PR concurrency groups cancel the in-flight draft-tier runs, leaving terminal
+   checks on the same SHA. The gate resolves them by `workflow_id`: only the newest
+   run (by creation/run id) and its newest `run_attempt` is authoritative. Every
+   older run is a non-event even if its conclusion was `cancelled` or `failure`; a
+   genuine failure in the newest run/attempt still REDs. A newest cancelled run is
+   re-dispatched once (`actions: write`); if the retry is cancelled or never
+   advances, the gate REDs loudly with `superseded-legs, re-run required`.
+   Attempt-scoped job listing supplies the completed leg inventory and prevents
+   an old attempt that reused the run id from leaking into the verdict; the
+   workflow-run conclusion supplies the verdict when an entire job evaporates.
 
 **Why the queue can never latch a draft-tier result.** Rule 1 is structural: the
 queue and branch protection admit a PR only on a successful check-run of the

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -9,10 +9,10 @@
 # for `gh`).
 #
 # SEMANTICS (faithful port of the bash — sq-prg4 / sq-ipkku / sq-wjth):
-#   * Discovers every check-run on the head commit EXCEPT this gate's own run
-#     (matched by an ANCHORED "/runs/<SELF_RUN_ID>(/|$)" test on details_url —
-#     strictly tighter than the old substring `contains`, which could in principle
-#     match a longer run id sharing the prefix).
+#   * Discovers every check-run AND every Actions workflow-run on the head commit.
+#     For each workflow, only its newest run/attempt is authoritative; every job
+#     from an older run is a supersession artifact, regardless of conclusion.
+#     This gate's own workflow is excluded by SELF_RUN_ID/workflow identity.
 #   * pending = check-runs with status != "completed". The settle window is re-armed
 #     ONLY by pending work (the sq-ipkku / #997 guard): an injection of
 #     already-terminal check-runs can never starve convergence.
@@ -50,9 +50,9 @@
 #
 # FAIL-FAST ON A CONCLUDED GATING FAILURE (2026-07-17 maintainer directive).
 # [FABLE-5] Mid-poll, if any GATING leg has CONCLUDED failure, the gate REDs NOW
-# instead of waiting for every other sibling to finish: a genuine `failure` is
-# never forgiven by any later state (forgive_superseded excuses only
-# cancelled/stale), so every future render over any superset of this sibling set
+# instead of waiting for every other sibling to finish: a genuine `failure` in
+# the authoritative newest workflow run/attempt is never forgiven, so every
+# future render over any superset of this already-resolved sibling set
 # REDs anyway — the remaining wait is pure latency on the red verdict (and on the
 # fast-fix trigger it fires, ci-summary.yml `fix-ring`). Soundness guards, each
 # reusing the FINAL render's own classification (failfast_failures):
@@ -72,6 +72,25 @@
 #     normal settle path, byte-identical to before.
 # Fail-fast is an exit-1-only path: it can never conclude success, so every
 # exit-0 invariant below is untouched.
+#
+# AUTHORITATIVE WORKFLOW-RUN RESOLUTION (#3505). [GPT-5.6] A check-run name is not
+# a stable attempt identity: distinct workflows may reuse one name, a re-run may
+# reuse one Actions run id, and a disabled/rewritten workflow may leave its newest
+# green run with no corresponding check-run on the commit. The live fetcher now
+# lists Actions workflow-runs for SHA and selects exactly the newest run by
+# created_at/id and its newest run_attempt for each workflow_id. Check-runs from
+# every older run are NON-EVENTS even when they concluded failure/cancelled;
+# completed runs and re-run attempts are read through the attempt-scoped jobs
+# endpoint; and a run-level synthetic check preserves the newest run's terminal
+# verdict when job check-runs evaporate.
+# A newest genuine FAILURE therefore still REDs. A newest CANCELLED run is never
+# rendered as failure directly: the resolver asks Actions to re-run it once when
+# run_attempt == 1, using both run_attempt (durable server-side marker) and an
+# in-process attempted-set (API-lag guard) to bound dispatch. A cancelled retry or
+# a dispatch that never advances emits the distinct loud
+# "superseded-legs, re-run required" failure. The poll/absolute time budgets are
+# unchanged, and re-dispatch remains orchestration only — this waiter executes no
+# test command.
 #
 # DRAFT-TIER INTEGRITY (bead: draft-tier CI). [FABLE-5] Draft PR heads run a REDUCED
 # leg set (coverage / bench / CodeQL / heavy shards / wasm-equality skipped — see
@@ -129,12 +148,14 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import re
 import subprocess
 import sys
 import time
+from contextlib import redirect_stdout
 from dataclasses import dataclass, field
 
 ADVISORY_RE = re.compile(r"\b(advisory|informational)\b")
@@ -155,9 +176,10 @@ DRAFT_TIER_MARKER = ", draft-tier"
 # the sibling set (see run_gate).
 GATE_CHECK_NAME = "gate"
 DRAFT_TIER_GATE_NAME = GATE_CHECK_NAME + DRAFT_TIER_MARKER
-# Conclusions a LATER same-normalized-name check-run may excuse (superseded-run
-# forgiveness). Deliberately ONLY the supersession artifacts — a genuine failure /
-# timed_out is never forgiven by a later attempt.
+# Conclusions a LATER same-workflow/name check-run may excuse after authoritative
+# workflow-run resolution. Deliberately ONLY check-level supersession artifacts;
+# failures from OLDER workflow runs are removed by resolve_newest_workflow_runs,
+# while a failure in the newest run/attempt is never forgiven here.
 _SUPERSEDABLE = ("cancelled", "stale")
 # [FABLE-5] sq-fmx4u.3: the change-based test-selection pre-job (the reusable
 # .github/workflows/ci-select.yml job, called from ci.yml + feature-matrix.yml).
@@ -193,6 +215,7 @@ FM_REPORT_NAME = "feature-matrix report"
 # CURRENT group run (feature-matrix reruns on the same head on ready_for_review /
 # label events, so several group runs — hence several reports — can share a head SHA).
 RUNS_URL_RE = re.compile(r"/actions/runs/(\d+)(?:/|$)")
+ACTIONS_JOB_URL_RE = re.compile(r"/actions/runs/\d+/job/\d+(?:/|$)")
 
 
 @dataclass
@@ -218,6 +241,10 @@ class FetchError(RuntimeError):
     """A poll's API fetch failed (transient or otherwise)."""
 
 
+class SupersededLegsError(RuntimeError):
+    """A newest cancelled workflow could not be auto-re-dispatched safely."""
+
+
 @dataclass
 class TierContext:
     """[FABLE-5] Draft-tier CI: which tier THIS gate run is evaluating, and how to
@@ -232,10 +259,349 @@ class TierContext:
     draft_check_retries: int = 3
 
 
+def _as_int(value, default: int = 0) -> int:
+    """GitHub JSON sometimes exposes numeric ids/attempts as strings."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def workflow_identity(run: dict) -> str:
+    """Stable identity for newest-run selection.
+
+    workflow_id is the authoritative Actions identity. The path/name fallbacks
+    keep hermetic fixtures and a degraded API payload fail-closed instead of
+    collapsing unrelated workflows into one empty key.
+    """
+    workflow_id = run.get("workflow_id")
+    if workflow_id not in (None, ""):
+        return f"id:{workflow_id}"
+    if run.get("path"):
+        return f"path:{run['path']}"
+    return f"name:{run.get('name') or '<unnamed>'}"
+
+
+def _workflow_order_key(run: dict) -> tuple:
+    """Newest order: creation/run id chooses the run; attempt breaks a same-run tie."""
+    return (
+        run.get("created_at") or "",
+        _as_int(run.get("id")),
+        _as_int(run.get("run_attempt"), 1),
+    )
+
+
+def newest_workflow_runs(workflow_runs: list[dict]) -> dict[str, dict]:
+    """Return the newest Actions run for every workflow on the already-filtered SHA."""
+    newest: dict[str, dict] = {}
+    for run in workflow_runs:
+        key = workflow_identity(run)
+        if key not in newest or _workflow_order_key(run) > _workflow_order_key(newest[key]):
+            newest[key] = run
+    return newest
+
+
+def _workflow_run_id_of_check(run: dict) -> int:
+    """Actions run id embedded in a job check's details/html URL, else 0."""
+    url = run.get("details_url") or run.get("html_url") or ""
+    match = RUNS_URL_RE.search(url)
+    return _as_int(match.group(1)) if match else 0
+
+
+def _is_actions_job_check(run: dict) -> bool:
+    """True for Actions-created job checks, false for manually posted run links."""
+    url = run.get("details_url") or run.get("html_url") or ""
+    return bool(ACTIONS_JOB_URL_RE.search(url))
+
+
+def _workflow_summary_check(run: dict, *, force_pending: bool = False) -> dict:
+    """Run-level evidence used when jobs are pending/evaporated or failure is hidden."""
+    completed = run.get("status") == "completed" and not force_pending
+    return {
+        # Never copy the workflow display name here: a workflow containing the
+        # word "advisory" must not accidentally advisory-exclude its authoritative
+        # run-level FAILURE. Job checks retain the existing name-based policy.
+        "name": f"workflow-run verdict ({workflow_identity(run)})",
+        "status": "completed" if completed else (
+            "queued" if force_pending else (run.get("status") or "queued")
+        ),
+        "conclusion": run.get("conclusion") if completed else None,
+        "details_url": run.get("html_url") or run.get("url") or "",
+        "html_url": run.get("html_url") or "",
+        "started_at": run.get("run_started_at") or run.get("created_at") or "",
+        "id": _as_int(run.get("id")),
+        "external_id": "",
+        "_workflow_summary": True,
+        "_workflow_name": run.get("name") or run.get("path") or "",
+        "_workflow_id": workflow_identity(run),
+    }
+
+
+def _attempt_job_check(job: dict, workflow_run: dict) -> dict:
+    """Normalize an attempt-scoped Actions job to the existing check-run vocabulary."""
+    return {
+        "name": job.get("name") or "<unnamed Actions job>",
+        "status": job.get("status") or "queued",
+        "conclusion": job.get("conclusion"),
+        "details_url": job.get("html_url") or "",
+        "html_url": job.get("html_url") or "",
+        "started_at": job.get("started_at") or workflow_run.get("run_started_at")
+        or workflow_run.get("created_at") or "",
+        "id": _as_int(job.get("id")),
+        "external_id": "",
+        "_workflow_job_inventory": True,
+        "_workflow_id": workflow_identity(workflow_run),
+        "_workflow_run_id": _as_int(workflow_run.get("id")),
+        "_workflow_run_attempt": _as_int(workflow_run.get("run_attempt"), 1),
+    }
+
+
+def resolve_newest_workflow_runs(
+    check_runs: list[dict],
+    workflow_runs: list[dict],
+    self_run_id: str,
+    *,
+    attempt_jobs: dict[int, list[dict]] | None = None,
+    redispatch_pending_ids: set[int] | None = None,
+) -> tuple[list[dict], int]:
+    """Resolve Actions checks through newest workflow runs, preserving external checks.
+
+    Returns ``(resolved_checks, superseded_check_count)``. Check-runs whose URL
+    belongs to an older run of a known workflow are dropped regardless of their
+    conclusion. A completed latest run (and every run_attempt > 1) is represented
+    by its attempt-scoped Jobs API payload, so evaporated checks and old-attempt
+    checks sharing the same run id cannot poison the verdict. Unknown run ids are
+    preserved: manually-posted checks (notably ``feature-matrix report``) may link
+    to a workflow_run whose own head SHA differs from the commit on which it posts
+    the check.
+    """
+    attempt_jobs = attempt_jobs or {}
+    redispatch_pending_ids = redispatch_pending_ids or set()
+    newest = newest_workflow_runs(workflow_runs)
+    all_by_id = {_as_int(r.get("id")): r for r in workflow_runs if _as_int(r.get("id"))}
+    self_id = _as_int(self_run_id)
+    self_workflow = ""
+    if self_id in all_by_id:
+        self_workflow = workflow_identity(all_by_id[self_id])
+
+    resolved: list[dict] = []
+    superseded = 0
+    for check in check_runs:
+        run_id = _workflow_run_id_of_check(check)
+        workflow_run = all_by_id.get(run_id)
+        if workflow_run is None:
+            resolved.append(check)  # external/manually-posted check
+            continue
+        key = workflow_identity(workflow_run)
+        latest = newest.get(key)
+        if key == self_workflow:
+            continue
+        if latest is None:
+            superseded += 1
+            continue
+        latest_id = _as_int(latest.get("id"))
+        if run_id != latest_id:
+            # #3505: every conclusion from an older workflow run is a NON-EVENT.
+            superseded += 1
+            continue
+        if latest_id in redispatch_pending_ids:
+            # The once-only retry has been requested but no new attempt is visible.
+            # Every check attached to this cancelled attempt is stale, including
+            # manually posted summaries whose URL intentionally lacks `/job/`.
+            superseded += 1
+            continue
+        attempt = _as_int(latest.get("run_attempt"), 1)
+        if latest_id in attempt_jobs and _is_actions_job_check(check):
+            # Completed runs and re-run attempts use the Jobs API as authority;
+            # commit check-runs can be missing or belong to an earlier attempt.
+            superseded += 1
+            continue
+        if attempt > 1:
+            # Manually-posted checks (notably feature-matrix report/per-leg checks)
+            # link to the run WITHOUT `/job/`; keep only ones posted at/after this
+            # attempt's run_started_at so attempt-1 reports cannot satisfy attempt 2.
+            if (
+                (check.get("started_at") or "")
+                < (latest.get("run_started_at") or latest.get("created_at") or "")
+            ):
+                superseded += 1
+                continue
+        enriched = dict(check)
+        enriched["_workflow_id"] = key
+        enriched["_workflow_run_id"] = latest_id
+        enriched["_workflow_run_attempt"] = attempt
+        resolved.append(enriched)
+
+    selected = [r for key, r in newest.items() if key != self_workflow]
+    for workflow_run in selected:
+        run_id = _as_int(workflow_run.get("id"))
+        force_pending = run_id in redispatch_pending_ids
+        if run_id in attempt_jobs and not force_pending:
+            resolved.extend(
+                _attempt_job_check(job, workflow_run)
+                for job in attempt_jobs.get(run_id, [])
+            )
+
+        visible = [r for r in resolved if r.get("_workflow_id") == workflow_identity(workflow_run)]
+        status = workflow_run.get("status")
+        conclusion = workflow_run.get("conclusion")
+        # Run-level state closes three check-run holes:
+        #   * pending run whose jobs have not registered yet (hold, never early-pass),
+        #   * terminal run with no surviving job check (evaporation), and
+        #   * non-success run whose failing job check vanished (fail closed).
+        visible_required_failure = any(
+            r.get("status") == "completed"
+            and r.get("conclusion") not in _PASSING
+            and not is_advisory(r.get("name", ""))
+            for r in visible
+        )
+        visible_advisory_failure = any(
+            r.get("_workflow_job_inventory") is True
+            and r.get("status") == "completed"
+            and r.get("conclusion") not in _PASSING
+            and is_advisory(r.get("name", ""))
+            for r in visible
+        )
+        # A complete Jobs API inventory lets the established advisory-name policy
+        # remain authoritative: an advisory job may make its workflow run red, but
+        # that advisory-only failure must not acquire a synthetic gating verdict.
+        advisory_only_failure = (
+            run_id in attempt_jobs
+            and visible_advisory_failure
+            and not visible_required_failure
+        )
+        need_summary = (
+            force_pending
+            or status != "completed"
+            or not visible
+            or (
+                conclusion not in _PASSING
+                and not visible_required_failure
+                and not advisory_only_failure
+            )
+        )
+        if need_summary:
+            resolved.append(_workflow_summary_check(workflow_run, force_pending=force_pending))
+
+    return resolved, superseded
+
+
+class WorkflowRunResolver:
+    """Live/testable newest-run resolver with once-only cancelled-run re-dispatch."""
+
+    def __init__(
+        self,
+        *,
+        self_run_id: str,
+        fetch_checks,
+        fetch_workflows,
+        fetch_attempt_jobs,
+        redispatch,
+        redispatch_settle_polls: int = 3,
+    ):
+        self.self_run_id = self_run_id
+        self.fetch_checks = fetch_checks
+        self.fetch_workflows = fetch_workflows
+        self.fetch_attempt_jobs = fetch_attempt_jobs
+        self.redispatch = redispatch
+        self.redispatch_settle_polls = max(1, redispatch_settle_polls)
+        # Durable bound: only run_attempt==1 is eligible. This set is the second
+        # bound, preventing repeated POSTs while the list API still shows attempt 1.
+        self._redispatch_seen: dict[tuple[str, int, int], int] = {}
+        self._terminal_jobs_cache: dict[tuple[int, int], list[dict]] = {}
+
+    def __call__(self) -> list[dict]:
+        checks = self.fetch_checks()
+        workflows = self.fetch_workflows()
+        newest = newest_workflow_runs(workflows)
+        self_id = _as_int(self.self_run_id)
+        self_workflow = ""
+        for run in workflows:
+            if _as_int(run.get("id")) == self_id:
+                self_workflow = workflow_identity(run)
+                break
+
+        redispatch_pending: set[int] = set()
+        for key, run in newest.items():
+            if key == self_workflow:
+                continue
+            if run.get("status") != "completed" or run.get("conclusion") != "cancelled":
+                continue
+            run_id = _as_int(run.get("id"))
+            attempt = _as_int(run.get("run_attempt"), 1)
+            marker = (key, run_id, attempt)
+            if attempt > 1:
+                raise SupersededLegsError(
+                    f"superseded-legs, re-run required (#3505): newest workflow "
+                    f"{run.get('name') or key!r} run {run_id} was cancelled on "
+                    f"attempt {attempt}; the gate auto-re-dispatches at most once"
+                )
+            if marker not in self._redispatch_seen:
+                try:
+                    self.redispatch(run_id)
+                except FetchError as exc:
+                    raise SupersededLegsError(
+                        f"superseded-legs, re-run required (#3505): newest workflow "
+                        f"{run.get('name') or key!r} run {run_id} is cancelled and "
+                        f"its once-only auto-redispatch failed: {exc}"
+                    ) from exc
+                self._redispatch_seen[marker] = 0
+                print(
+                    f"::notice::ci-summary #3505: newest workflow "
+                    f"{run.get('name') or key!r} run {run_id} was cancelled; "
+                    "requested its one bounded re-run (run_attempt marker=1)."
+                )
+            else:
+                self._redispatch_seen[marker] += 1
+                if self._redispatch_seen[marker] >= self.redispatch_settle_polls:
+                    raise SupersededLegsError(
+                        f"superseded-legs, re-run required (#3505): workflow "
+                        f"{run.get('name') or key!r} run {run_id} stayed cancelled "
+                        "after its once-only auto-redispatch request"
+                    )
+            redispatch_pending.add(run_id)
+
+        attempt_jobs: dict[int, list[dict]] = {}
+        for key, run in newest.items():
+            run_id = _as_int(run.get("id"))
+            if key == self_workflow or run_id in redispatch_pending:
+                continue
+            attempt = _as_int(run.get("run_attempt"), 1)
+            if attempt > 1 or run.get("status") == "completed":
+                cache_key = (run_id, attempt)
+                if cache_key not in self._terminal_jobs_cache:
+                    jobs = self.fetch_attempt_jobs(run_id, attempt)
+                    if run.get("status") == "completed":
+                        self._terminal_jobs_cache[cache_key] = jobs
+                    else:
+                        attempt_jobs[run_id] = jobs
+                        continue
+                attempt_jobs[run_id] = self._terminal_jobs_cache[cache_key]
+
+        resolved, superseded = resolve_newest_workflow_runs(
+            checks,
+            workflows,
+            self.self_run_id,
+            attempt_jobs=attempt_jobs,
+            redispatch_pending_ids=redispatch_pending,
+        )
+        if superseded:
+            print(
+                f"  workflow-run resolver: ignored {superseded} check-run(s) from "
+                "superseded runs/attempts (#3505)."
+            )
+        return resolved
+
+
 def normalized_name(name: str) -> str:
     """A check-run name with the draft-tier marker stripped — the identity under
     which a draft-assembled select and its full-tier successor are the SAME leg."""
     return name.replace(DRAFT_TIER_MARKER, "")
+
+
+def _leg_identity(run: dict) -> tuple[str, str]:
+    """Workflow-qualified leg identity; legacy/external checks use an empty scope."""
+    return (run.get("_workflow_id") or "", normalized_name(run.get("name", "")))
 
 
 def is_draft_tier(name: str) -> bool:
@@ -274,8 +640,8 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
     RED the fresh full-tier gate. Branch protection itself honours only the
     LATEST run of a check name, so excusing a superseded cancellation aligns the
     gate with the enforcement layer. SAFETY: only cancelled/stale are ever
-    forgiven (a genuine failure/timed_out always gates, no matter what runs
-    later), and a cancellation with NO successor still fails the gate. Call this
+    forgiven here (a genuine failure/timed_out in this already-newest/external
+    check set always gates), and a cancellation with NO successor still fails. Call this
     over the RAW list (self-run included) so THIS gate run's own fresh `gate`
     check-run can supersede its cancelled predecessor.
 
@@ -309,13 +675,13 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
     for r in runs:
         if r.get("conclusion") in _SUPERSEDABLE:
             r_name = r.get("name", "")
-            key = normalized_name(r_name)
+            key = _leg_identity(r)
             mine = _order_key(r)
             pure_select = is_pure_select(r_name)
             r_tier = is_draft_tier(r_name)
             if any(
                 o is not r
-                and normalized_name(o.get("name", "")) == key
+                and _leg_identity(o) == key
                 and o.get("conclusion") not in _SUPERSEDABLE
                 and (
                     # pure select: any SAME-TIER same-name success proves a
@@ -367,12 +733,12 @@ def draft_selects_unsuperseded(runs: list[dict]) -> list[str]:
     exhaustion ("stale draft-tier run, full run pending") rather than ever
     passing over draft-assembled legs. Re-running the selecting workflows (or
     pushing a new head) clears it."""
-    groups: dict[str, tuple[list[dict], list[dict]]] = {}
+    groups: dict[tuple[str, str], tuple[list[dict], list[dict]]] = {}
     for r in runs:
         name = r.get("name", "")
         if not is_select(name):
             continue
-        marked, unmarked = groups.setdefault(normalized_name(name), ([], []))
+        marked, unmarked = groups.setdefault(_leg_identity(r), ([], []))
         (marked if is_draft_tier(name) else unmarked).append(r)
     out: list[str] = []
     for marked, unmarked in groups.values():
@@ -847,11 +1213,7 @@ def failfast_failures(runs: list[dict]) -> list[dict]:
     exactly as the settle loop always has). `timed_out`/`cancelled`/`stale`
     conclusions deliberately do NOT qualify: only an unambiguous `failure`
     fails fast; everything else waits for the full render."""
-    inflight = {
-        normalized_name(r.get("name", ""))
-        for r in runs
-        if r.get("status") != "completed"
-    }
+    inflight = {_leg_identity(r) for r in runs if r.get("status") != "completed"}
     out: list[dict] = []
     for r in runs:
         if r.get("status") != "completed" or r.get("conclusion") != "failure":
@@ -859,7 +1221,7 @@ def failfast_failures(runs: list[dict]) -> list[dict]:
         name = r.get("name", "")
         if is_advisory(name):
             continue
-        if normalized_name(name) in inflight:
+        if _leg_identity(r) in inflight:
             continue
         out.append(r)
     return out
@@ -890,6 +1252,15 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         attempt += 1
         try:
             raw = fetch_runs()
+        except SupersededLegsError as exc:
+            _emit(
+                f"### ci-summary: FAILED — {exc}. The gate did not treat the "
+                "cancelled newest run as a test failure and did not dispatch it "
+                "more than once; a fresh workflow run or new head is required.",
+                cfg.summary_path,
+            )
+            print(f"::error::ci-summary failed — {exc}")
+            return 1
         except FetchError as exc:
             consec_fetch_failures += 1
             if consec_fetch_failures >= cfg.max_consec_fetch_failures:
@@ -962,7 +1333,8 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
 
         # [FABLE-5] FAIL-FAST (header §FAIL-FAST): a concluded gating failure in
         # the (already forgiveness-filtered) sibling set decides the verdict now
-        # — a genuine `failure` is never forgiven, so every later render REDs
+        # — a genuine `failure` in the authoritative newest run is never forgiven,
+        # so every later render REDs
         # anyway; waiting out the remaining legs only delays the red and the
         # fast-fix trigger behind it. Applies only while siblings are still
         # outstanding (pending / awaiting_full): an all-terminal set renders via
@@ -980,7 +1352,7 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                         f"### ci-summary: FAILED (fail-fast) — {len(ff)} gating "
                         f"check(s) concluded failure while {pending} sibling(s) "
                         f"were still running; no later state can turn this verdict "
-                        f"green (a genuine failure is never forgiven), so the gate "
+                        f"green (a newest-run failure is never forgiven), so the gate "
                         f"REDs now instead of waiting out the remaining legs.",
                         cfg.summary_path,
                     )
@@ -1093,7 +1465,7 @@ def _gh_json_lines(args: list[str]) -> list[dict]:
     return out
 
 
-def make_fetch_runs(repo: str, sha: str):
+def make_fetch_check_runs(repo: str, sha: str):
     def fetch() -> list[dict]:
         # started_at + id feed the superseded-run ordering (draft-tier CI): a
         # cancelled/stale check-run is forgiven only for a strictly LATER
@@ -1112,6 +1484,101 @@ def make_fetch_runs(repo: str, sha: str):
         )
 
     return fetch
+
+
+def make_fetch_workflow_runs(repo: str, sha: str, self_run_id: str = ""):
+    """List Actions workflow runs on SHA; resolution happens by workflow_id."""
+
+    self_cache: list[dict] = []
+
+    def fetch() -> list[dict]:
+        runs = _gh_json_lines(
+            [
+                f"repos/{repo}/actions/runs?head_sha={sha}&per_page=100",
+                "--paginate",
+                "--jq",
+                ".workflow_runs[] | {id, workflow_id, name, path, head_sha, status, "
+                "conclusion, created_at, run_started_at, run_attempt, html_url}",
+            ]
+        )
+        # The current run endpoint is fetched once and merged defensively. It
+        # guarantees self-workflow identity even during list-index lag (otherwise
+        # an older ci-summary run on this SHA could acquire a synthetic pending
+        # summary and make the gate wait on itself).
+        if self_run_id and not self_cache:
+            self_cache.extend(
+                _gh_json_lines(
+                    [
+                        f"repos/{repo}/actions/runs/{self_run_id}",
+                        "--jq",
+                        "{id, workflow_id, name, path, head_sha, status, conclusion, "
+                        "created_at, run_started_at, run_attempt, html_url}",
+                    ]
+                )
+            )
+        known_ids = {_as_int(run.get("id")) for run in runs}
+        runs.extend(run for run in self_cache if _as_int(run.get("id")) not in known_ids)
+        return runs
+
+    return fetch
+
+
+def make_fetch_attempt_jobs(repo: str):
+    """Read the selected run attempt's jobs (authoritative leg inventory)."""
+
+    def fetch(run_id: int, attempt: int) -> list[dict]:
+        endpoint = (
+            f"repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100"
+            if attempt > 1
+            else f"repos/{repo}/actions/runs/{run_id}/jobs?filter=latest&per_page=100"
+        )
+        return _gh_json_lines(
+            [
+                endpoint,
+                "--paginate",
+                "--jq",
+                ".jobs[] | {id, name, status, conclusion, started_at, completed_at, html_url}",
+            ]
+        )
+
+    return fetch
+
+
+def make_redispatch_workflow(repo: str):
+    """Return the once-only Actions re-run POST used for newest cancellations."""
+
+    def redispatch(run_id: int) -> None:
+        try:
+            proc = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    "--method",
+                    "POST",
+                    f"repos/{repo}/actions/runs/{run_id}/rerun",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            raise FetchError(f"redispatch subprocess raised: {exc}") from exc
+        if proc.returncode != 0:
+            raise FetchError(
+                proc.stderr.strip()[:300] or f"redispatch gh api exited {proc.returncode}"
+            )
+
+    return redispatch
+
+
+def make_fetch_runs(repo: str, sha: str, self_run_id: str = ""):
+    """Build the authoritative check fetcher (kept under the historical name)."""
+    return WorkflowRunResolver(
+        self_run_id=self_run_id,
+        fetch_checks=make_fetch_check_runs(repo, sha),
+        fetch_workflows=make_fetch_workflow_runs(repo, sha, self_run_id),
+        fetch_attempt_jobs=make_fetch_attempt_jobs(repo),
+        redispatch=make_redispatch_workflow(repo),
+    )
 
 
 def make_fetch_pr_draft(repo: str, pr_number: str):
@@ -1169,7 +1636,109 @@ def make_fetch_queue_depth(repo: str):
     return fetch
 
 
+def _self_test() -> int:
+    """Hermetic mutation checks for the three #3505 safety properties."""
+
+    def require(condition: bool, message: str) -> None:
+        if not condition:
+            raise AssertionError(message)
+
+    old_cancelled = {
+        "id": 101,
+        "workflow_id": 7,
+        "name": "CI",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "created_at": "2026-07-21T13:40:00Z",
+        "run_started_at": "2026-07-21T13:40:01Z",
+        "run_attempt": 1,
+        "html_url": "https://github.test/actions/runs/101",
+    }
+    newest_green = {
+        **old_cancelled,
+        "id": 102,
+        "status": "completed",
+        "conclusion": "success",
+        "created_at": "2026-07-21T14:30:00Z",
+        "run_started_at": "2026-07-21T14:30:01Z",
+        "html_url": "https://github.test/actions/runs/102",
+    }
+    cancelled_check = {
+        "name": "test shard",
+        "status": "completed",
+        "conclusion": "cancelled",
+        "details_url": "https://github.test/actions/runs/101/job/1",
+        "html_url": "",
+        "started_at": "2026-07-21T13:40:01Z",
+        "id": 1001,
+        "external_id": "",
+    }
+    resolved, dropped = resolve_newest_workflow_runs(
+        [cancelled_check], [old_cancelled, newest_green], "999"
+    )
+    with redirect_stdout(io.StringIO()):
+        superseded_code = render_verdict(resolved)
+    require(dropped == 1, "superseded cancelled fixture was not discarded")
+    require(
+        superseded_code == 0,
+        "superseded cancelled fixture failed (mutation: treat-superseded-as-failure)",
+    )
+
+    newest_failure = {
+        **newest_green,
+        "id": 103,
+        "conclusion": "failure",
+        "created_at": "2026-07-21T14:40:00Z",
+        "run_started_at": "2026-07-21T14:40:01Z",
+        "html_url": "https://github.test/actions/runs/103",
+    }
+    failure_resolved, _ = resolve_newest_workflow_runs(
+        [], [newest_green, newest_failure], "999"
+    )
+    with redirect_stdout(io.StringIO()):
+        failure_code = render_verdict(failure_resolved)
+    require(
+        failure_code == 1,
+        "newest-run FAILURE passed (mutation: genuine-failure detection weakened)",
+    )
+
+    cancelled_latest = {**old_cancelled, "id": 104}
+    posts: list[int] = []
+    resolver = WorkflowRunResolver(
+        self_run_id="999",
+        fetch_checks=lambda: [],
+        fetch_workflows=lambda: [cancelled_latest],
+        fetch_attempt_jobs=lambda run_id, attempt: [],
+        redispatch=lambda run_id: posts.append(run_id),
+        redispatch_settle_polls=2,
+    )
+    with redirect_stdout(io.StringIO()):
+        resolver()
+        resolver()
+        bounded_error = None
+        try:
+            resolver()
+        except SupersededLegsError as exc:
+            bounded_error = exc
+    require(posts == [104], "cancelled workflow redispatch was not bounded to one POST")
+    require(
+        bounded_error is not None,
+        "cancelled workflow never failed loud after bounded redispatch grace",
+    )
+
+    print(
+        "ci-summary --self-test: ALL ASSERTIONS PASSED "
+        "(superseded cancellation ignored; newest failure preserved; redispatch bounded once)"
+    )
+    return 0
+
+
 def main() -> int:
+    if sys.argv[1:] == ["--self-test"]:
+        return _self_test()
+    if sys.argv[1:]:
+        print("usage: ci_summary_gate.py [--self-test]", file=sys.stderr)
+        return 2
     repo = os.environ.get("REPO", "")
     sha = os.environ.get("SHA", "")
     self_run_id = os.environ.get("SELF_RUN_ID", "")
@@ -1192,7 +1761,7 @@ def main() -> int:
     )
     print(f"ci-summary: evaluating tier={run_tier} (event={event_name or '<unset>'}).")
     cfg = Config(self_run_id=self_run_id)
-    return run_gate(cfg, make_fetch_runs(repo, sha), make_fetch_queue_depth(repo),
+    return run_gate(cfg, make_fetch_runs(repo, sha, self_run_id), make_fetch_queue_depth(repo),
                     tier_ctx=tier_ctx)
 
 

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -1148,6 +1148,9 @@ class TestDraftTierWiring(unittest.TestCase):
         self.assertEqual(perms.get("pull-requests"), "read",
                          "the gate needs pull-requests:read for the conclusion-time "
                          "draft re-check")
+        self.assertEqual(perms.get("actions"), "write",
+                         "#3505 needs actions:write only for the bounded once-only "
+                         "re-run of a newest cancelled workflow")
         step = next(s for s in self.summary["jobs"]["gate"]["steps"]
                     if "ci_summary_gate.py" in str(s.get("run", "")))
         env = step.get("env", {})

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -58,6 +58,24 @@ def R(name, status="completed", conclusion="success", url="", started="", rid=0,
             "external_id": external_id}
 
 
+def W(run_id, workflow_id, *, name="CI", status="completed", conclusion="success",
+      created="2026-07-21T14:00:00Z", attempt=1):
+    """Actions workflow-run fixture for the #3505 authoritative resolver."""
+    return {
+        "id": run_id,
+        "workflow_id": workflow_id,
+        "name": name,
+        "path": f".github/workflows/{name.lower().replace(' ', '-')}.yml",
+        "head_sha": "deadbeef",
+        "status": status,
+        "conclusion": conclusion,
+        "created_at": created,
+        "run_started_at": created,
+        "run_attempt": attempt,
+        "html_url": f"https://github.test/o/r/actions/runs/{run_id}",
+    }
+
+
 GREEN = R("build + test")
 GREEN2 = R("clippy")
 PENDING = R("coverage", status="queued", conclusion=None)
@@ -393,6 +411,238 @@ class TestSelfExclusionAndFetch(unittest.TestCase):
         code, out = run(tiny_cfg(), polls)
         self.assertEqual(code, 1)
         self.assertIn("consecutive check-run fetch failures", out)
+
+
+class TestNewestWorkflowRunResolution(unittest.TestCase):
+    """[GPT-5.6] #3505: workflow identity/attempt, not stale check presence, wins."""
+
+    def test_newest_order_prefers_new_run_id_then_same_run_attempt(self):
+        same_time = "2026-07-21T14:00:00Z"
+        old_rerun = W(101, 7, created=same_time, attempt=2)
+        new_run = W(102, 7, created=same_time, attempt=1)
+        self.assertEqual(g.newest_workflow_runs([old_rerun, new_run])["id:7"]["id"], 102)
+        attempt_one = W(102, 7, created=same_time, attempt=1)
+        attempt_two = W(102, 7, created=same_time, attempt=2)
+        self.assertEqual(
+            g.newest_workflow_runs([attempt_one, attempt_two])["id:7"]["run_attempt"], 2
+        )
+
+    def test_superseded_cancelled_and_failure_are_non_events(self):
+        old_cancel = W(101, 7, conclusion="cancelled", created="2026-07-21T13:00:00Z")
+        old_failure = W(102, 7, conclusion="failure", created="2026-07-21T13:30:00Z")
+        newest = W(103, 7, created="2026-07-21T14:00:00Z")
+        checks = [
+            R("test shard", conclusion="cancelled", rid=1001,
+              url="https://github.test/o/r/actions/runs/101/job/1"),
+            R("test shard", conclusion="failure", rid=1002,
+              url="https://github.test/o/r/actions/runs/102/job/2"),
+        ]
+        resolved, dropped = g.resolve_newest_workflow_runs(
+            checks, [old_cancel, old_failure, newest], "999"
+        )
+        self.assertEqual(dropped, 2)
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 0, out)
+        self.assertNotIn("cancelled", [r.get("conclusion") for r in resolved])
+        self.assertNotIn("failure", [r.get("conclusion") for r in resolved])
+
+    def test_newest_failure_still_fails_when_job_check_evaporated(self):
+        newest = W(103, 7, conclusion="failure")
+        resolved, _ = g.resolve_newest_workflow_runs([], [newest], "999")
+        self.assertEqual(len(resolved), 1, "run-level failure evidence must be synthesized")
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 1)
+        self.assertIn("workflow-run verdict (id:7)", out)
+
+    def test_newest_failure_cannot_be_advisory_excluded_by_workflow_name(self):
+        newest = W(103, 7, name="all advisory", conclusion="failure")
+        resolved, _ = g.resolve_newest_workflow_runs([], [newest], "999")
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 1, out)
+
+    def test_authoritative_advisory_job_failure_remains_non_gating(self):
+        newest = W(103, 7, conclusion="failure")
+        advisory_job = {
+            "id": 2001,
+            "name": "vale (prose, advisory)",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-21T14:05:00Z",
+            "html_url": "https://github.test/o/r/actions/runs/103/job/2",
+        }
+        resolved, _ = g.resolve_newest_workflow_runs(
+            [], [newest], "999", attempt_jobs={103: [advisory_job]}
+        )
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 0, out)
+
+    def test_green_run_with_evaporated_check_resolves_without_hang(self):
+        newest = W(103, 7)
+        resolved, _ = g.resolve_newest_workflow_runs([], [newest], "999")
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+
+    def test_completed_jobs_listing_recovers_evaporated_required_leg(self):
+        newest = W(103, 7, conclusion="failure")
+        failed_job = {
+            "id": 2001,
+            "name": "required test shard",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-21T14:05:00Z",
+            "html_url": "https://github.test/o/r/actions/runs/103/job/2",
+        }
+        resolved, _ = g.resolve_newest_workflow_runs(
+            [], [newest], "999", attempt_jobs={103: [failed_job]}
+        )
+        self.assertEqual([r["name"] for r in resolved], ["required test shard"])
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 1, out)
+
+    def test_evaporated_feature_group_still_requires_reporter(self):
+        newest = W(103, 7)
+        group_job = {
+            "id": 2001,
+            "name": "opt-in group (0)",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-21T14:05:00Z",
+            "html_url": "https://github.test/o/r/actions/runs/103/job/2",
+        }
+        resolved, _ = g.resolve_newest_workflow_runs(
+            [], [newest], "999", attempt_jobs={103: [group_job]}
+        )
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 1)
+        self.assertIn("reporter verdict never landed", out)
+
+    def test_rerun_attempt_uses_attempt_jobs_not_old_same_run_id_checks(self):
+        rerun = W(103, 7, attempt=2)
+        old_failure = R(
+            "test shard", conclusion="failure", rid=1001,
+            url="https://github.test/o/r/actions/runs/103/job/1",
+        )
+        latest_job = {
+            "id": 2001,
+            "name": "test shard",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-21T14:05:00Z",
+            "html_url": "https://github.test/o/r/actions/runs/103/job/2",
+        }
+        resolved, dropped = g.resolve_newest_workflow_runs(
+            [old_failure], [rerun], "999", attempt_jobs={103: [latest_job]}
+        )
+        self.assertEqual(dropped, 1)
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 0, out)
+
+    def test_rerun_attempt_keeps_only_current_manually_posted_run_checks(self):
+        rerun = W(103, 7, attempt=2)
+        rerun["run_started_at"] = "2026-07-21T14:05:00Z"
+        old_report = R(
+            g.FM_REPORT_NAME, started="2026-07-21T14:00:00Z", rid=1001,
+            url="https://github.test/o/r/actions/runs/103", external_id="103",
+        )
+        current_report = R(
+            g.FM_REPORT_NAME, started="2026-07-21T14:06:00Z", rid=1002,
+            url="https://github.test/o/r/actions/runs/103", external_id="103",
+        )
+        resolved, dropped = g.resolve_newest_workflow_runs(
+            [old_report, current_report], [rerun], "999", attempt_jobs={103: []}
+        )
+        reports = [r for r in resolved if r.get("name") == g.FM_REPORT_NAME]
+        self.assertEqual([r["id"] for r in reports], [1002])
+        self.assertEqual(dropped, 1)
+
+    def test_duplicate_job_names_do_not_cross_workflow_identity(self):
+        a = W(101, 7, name="CI A")
+        b = W(102, 8, name="CI B")
+        a_failure = R(
+            "shared job", conclusion="failure", rid=1001,
+            url="https://github.test/o/r/actions/runs/101/job/1",
+        )
+        b_running = R(
+            "shared job", status="in_progress", conclusion=None, rid=1002,
+            url="https://github.test/o/r/actions/runs/102/job/2",
+        )
+        resolved, _ = g.resolve_newest_workflow_runs(
+            [a_failure, b_running], [a, b], "999"
+        )
+        self.assertEqual(len(g.failfast_failures(resolved)), 1,
+                         "another workflow's same-name in-flight job must not mask failure")
+
+    def test_cancelled_auto_redispatch_is_bounded_once(self):
+        cancelled = W(104, 7, conclusion="cancelled")
+        posts = []
+        resolver = g.WorkflowRunResolver(
+            self_run_id="999",
+            fetch_checks=lambda: [],
+            fetch_workflows=lambda: [cancelled],
+            fetch_attempt_jobs=lambda run_id, attempt: [],
+            redispatch=lambda run_id: posts.append(run_id),
+            redispatch_settle_polls=2,
+        )
+        first = resolver()
+        self.assertTrue(any(r.get("status") != "completed" for r in first),
+                        "a dispatched cancellation must become pending, not failure")
+        resolver()
+        with self.assertRaisesRegex(g.SupersededLegsError, "superseded-legs"):
+            resolver()
+        self.assertEqual(posts, [104], "API lag must never cause a second POST")
+
+    def test_completed_run_jobs_are_authoritative_and_cached(self):
+        complete = W(104, 7)
+        calls = []
+        job = {
+            "id": 2001,
+            "name": "required test shard",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-21T14:05:00Z",
+            "html_url": "https://github.test/o/r/actions/runs/104/job/2",
+        }
+
+        def fetch_jobs(run_id, attempt):
+            calls.append((run_id, attempt))
+            return [job]
+
+        resolver = g.WorkflowRunResolver(
+            self_run_id="999",
+            fetch_checks=lambda: [],
+            fetch_workflows=lambda: [complete],
+            fetch_attempt_jobs=fetch_jobs,
+            redispatch=lambda run_id: self.fail("green run must not redispatch"),
+        )
+        first = resolver()
+        second = resolver()
+        self.assertEqual([r["name"] for r in first], ["required test shard"])
+        self.assertEqual([r["name"] for r in second], ["required test shard"])
+        self.assertEqual(calls, [(104, 1)], "terminal job inventory should be cached")
+
+    def test_cancelled_retry_attempt_fails_loud_without_third_attempt(self):
+        cancelled_retry = W(104, 7, conclusion="cancelled", attempt=2)
+        posts = []
+        resolver = g.WorkflowRunResolver(
+            self_run_id="999",
+            fetch_checks=lambda: [],
+            fetch_workflows=lambda: [cancelled_retry],
+            fetch_attempt_jobs=lambda run_id, attempt: [],
+            redispatch=lambda run_id: posts.append(run_id),
+        )
+        with self.assertRaisesRegex(g.SupersededLegsError, "attempt 2"):
+            resolver()
+        self.assertEqual(posts, [])
+
+    def test_unrecoverable_cancellation_uses_distinct_loud_gate_message(self):
+        code, out = run(
+            tiny_cfg(),
+            [g.SupersededLegsError("superseded-legs, re-run required (#3505): fixture")],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("superseded-legs, re-run required", out)
+        self.assertIn("did not dispatch it more than once", out)
 
 
 class TestAdvisoryRule(unittest.TestCase):


### PR DESCRIPTION
> 🤖 SPARQ agent — sol-authored (GPT-5.6), orchestrator rescue-committed.

Fixes #3505, the binding merge-path bug: the required `gate` aggregator concluded FAILURE (or hung) off CANCELLED/superseded/evaporated check-runs, so armed review:pass PRs could not enter the merge queue for hours (live loop on #3668/#3669/#3671: rerun→green→new CI wave→concurrency-cancels old legs→gate fails→no admission).

Changes: per required leg, resolve to the NEWEST run/attempt for (workflow, head); superseded runs are non-events regardless of conclusion; a newest-run CANCELLED leg triggers ONE bounded auto-redispatch (marker-guarded) instead of failing the gate; evaporated check-runs resolved via workflow-run listing; genuine newest-run FAILUREs fail exactly as before; gate context name unchanged (branch protection intact); actions:write added for the rerun endpoint (documented in docs/branch-protection.md).

Validation: ci_summary_gate --self-test, 120 aggregator tests, 66 wiring tests, ruff, actionlint on both workflows — all green. Cross-provider adversarial review (Anthropic/Opus) to follow before arm.