### PR TITLE
fix(ci): re-arm sweeper for dropped auto-merge arms (#3675)

### DIFF
--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -1,0 +1,67 @@
+# [GPT-5.6] Issue #3675 — restore auto-merge arms GitHub drops after merge-group churn.
+#
+# NOT A GATE. This runs only on schedule / workflow_dispatch, never on a PR head. The
+# review:pass label is the pipeline's attested verdict and remains mandatory; CI state
+# alone can never make this workflow arm a PR. A null autoMergeRequest is insufficient:
+# queued PRs expose a live mergeQueueEntry while autoMergeRequest is null and are skipped.
+name: re-arm sweeper
+
+on:
+  schedule:
+    # Offset from auto-arm's ten-minute cron so both policies do not start together.
+    - cron: "8,18,28,38,48,58 * * * *"
+  workflow_dispatch:
+
+# Arming auto-merge needs push authority AND the merge must fire downstream push
+# workflows (flow-on autoclose) — a GITHUB_TOKEN-enabled arm risks the recursion
+# guard suppressing them. Arm with the sparq-orchestrator App token (the same
+# identity batch-merge.yml uses); fall back to the workflow token only when the
+# App is not configured, in which case failed arms surface loudly as errors.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: re-arm-sweeper
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: restore dropped merge-queue arms
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      # Secrets are not readable from step `if:` expressions — mirror the id into env
+      # so the mint step can be skipped fail-soft when the App is not configured.
+      ORCHESTRATOR_APP_ID: ${{ secrets.ORCHESTRATOR_APP_ID }}
+    steps:
+      - name: Mint the sparq-orchestrator App token (arms must fire merge events)
+        id: app-token
+        if: env.ORCHESTRATOR_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ORCHESTRATOR_APP_ID }}
+          private-key: ${{ secrets.ORCHESTRATOR_APP_PRIVATE_KEY }}
+
+      # Always execute the trusted default-branch policy, including on manual dispatch.
+      - name: Checkout re-arm policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: scripts/rearm-sweeper.py
+          sparse-checkout-cone-mode: false
+
+      - name: Self-test policy
+        run: python3 scripts/rearm-sweeper.py --self-test
+
+      - name: Re-arm dropped reviewed PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: >-
+          python3 scripts/rearm-sweeper.py
+          --repo "$REPO"
+          --default-branch "$DEFAULT_BRANCH"
+          --max-rearms 10

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Re-arm reviewed pull requests whose merge-queue arm was dropped by GitHub."""
+
+# [GPT-5.6] Issue #3675 — restore dropped arms without mistaking queued PRs for drops.
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Callable
+
+
+PROGRAM = "rearm-sweeper"
+REVIEW_ATTESTATION = "review:pass"
+EXCLUDED_LABELS = frozenset(
+    {
+        "review:changes",
+        "review:needs",
+        "review:needs-user",
+        "trust:untrusted",
+    }
+)
+DEFAULT_MAX_REARMS = 10
+PR_LIST_FIELDS = "number,state,isDraft,baseRefName,labels"
+LIVE_QUERY = """query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      number
+      state
+      isDraft
+      baseRefName
+      labels(first:100){nodes{name} pageInfo{hasNextPage}}
+      autoMergeRequest{enabledAt}
+      mergeQueueEntry{id}
+    }
+  }
+}"""
+
+
+class GhError(RuntimeError):
+    """A GitHub CLI command failed."""
+
+
+@dataclass(frozen=True)
+class PullRequest:
+    number: int
+    state: str
+    is_draft: bool
+    base_ref: str
+    labels: frozenset[str]
+    has_auto_merge: bool = False
+    has_queue_entry: bool = False
+    labels_truncated: bool = False
+
+
+def normalized_labels(raw: object) -> frozenset[str]:
+    if not isinstance(raw, list):
+        return frozenset()
+    return frozenset(
+        str(label.get("name", "")).strip().lower()
+        for label in raw
+        if isinstance(label, dict) and str(label.get("name", "")).strip()
+    )
+
+
+def parse_list_pr(raw: dict) -> PullRequest:
+    return PullRequest(
+        number=int(raw["number"]),
+        state=str(raw.get("state", "")).upper(),
+        is_draft=bool(raw.get("isDraft")),
+        base_ref=str(raw.get("baseRefName", "")),
+        labels=normalized_labels(raw.get("labels")),
+    )
+
+
+def parse_live_pr(number: int, raw: dict | None) -> PullRequest:
+    if not isinstance(raw, dict):
+        return PullRequest(number, "UNKNOWN", False, "", frozenset())
+    labels = raw.get("labels") or {}
+    return PullRequest(
+        number=int(raw.get("number", number)),
+        state=str(raw.get("state", "")).upper(),
+        is_draft=bool(raw.get("isDraft")),
+        base_ref=str(raw.get("baseRefName", "")),
+        labels=normalized_labels(labels.get("nodes")),
+        has_auto_merge=raw.get("autoMergeRequest") is not None,
+        has_queue_entry=raw.get("mergeQueueEntry") is not None,
+        labels_truncated=bool((labels.get("pageInfo") or {}).get("hasNextPage")),
+    )
+
+
+def exclusion_labels(labels: frozenset[str]) -> list[str]:
+    """Return every fail-closed hold label, including the whole needs:* namespace."""
+    return sorted(
+        label
+        for label in labels
+        if label.startswith("needs:") or label in EXCLUDED_LABELS
+    )
+
+
+def run_gh(argv: list[str]) -> str:
+    result = subprocess.run(["gh", *argv], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown gh failure"
+        raise GhError(f"gh {' '.join(argv[:3])} failed: {detail}")
+    return result.stdout
+
+
+class RearmSweeper:
+    def __init__(
+        self,
+        repo: str,
+        default_branch: str,
+        *,
+        max_rearms: int = DEFAULT_MAX_REARMS,
+        gh: Callable[[list[str]], str] = run_gh,
+        log: Callable[[str], None] = print,
+    ) -> None:
+        if not 1 <= max_rearms <= DEFAULT_MAX_REARMS:
+            raise ValueError(f"max_rearms must be between 1 and {DEFAULT_MAX_REARMS}")
+        self.repo = repo
+        self.default_branch = default_branch
+        self.max_rearms = max_rearms
+        self.gh = gh
+        self.log = log
+        try:
+            self.owner, self.name = repo.split("/", 1)
+        except ValueError as error:
+            raise ValueError("repo must be OWNER/REPOSITORY") from error
+        if not self.owner or not self.name or "/" in self.name:
+            raise ValueError("repo must be OWNER/REPOSITORY")
+
+    def decision(self, pr: PullRequest, *, live: bool) -> str | None:
+        # State is deliberately first: closed/merged PRs may report other fields as UNKNOWN.
+        if pr.state != "OPEN":
+            return f"not-open ({pr.state or 'UNKNOWN'})"
+        if pr.is_draft:
+            return "draft"
+        if pr.base_ref != self.default_branch:
+            return f"non-default-base ({pr.base_ref or 'UNKNOWN'})"
+        if live and pr.labels_truncated:
+            return "live label set exceeds query page"
+        if REVIEW_ATTESTATION not in pr.labels:
+            return "review:pass attestation absent"
+        excluded = exclusion_labels(pr.labels)
+        if excluded:
+            return f"hard exclusion ({', '.join(excluded)})"
+        if live and pr.has_queue_entry:
+            return "live mergeQueueEntry"
+        if live and pr.has_auto_merge:
+            return "live autoMergeRequest"
+        return None
+
+    def list_candidates(self) -> list[PullRequest]:
+        raw = json.loads(
+            self.gh(
+                [
+                    "pr",
+                    "list",
+                    "--repo",
+                    self.repo,
+                    "--state",
+                    "open",
+                    "--label",
+                    REVIEW_ATTESTATION,
+                    "--limit",
+                    "1000",
+                    "--json",
+                    PR_LIST_FIELDS,
+                ]
+            )
+        )
+        if not isinstance(raw, list):
+            raise GhError("gh pr list returned a non-list response")
+        return [parse_list_pr(item) for item in raw]
+
+    def live_state(self, number: int) -> PullRequest:
+        response = json.loads(
+            self.gh(
+                [
+                    "api",
+                    "graphql",
+                    "-f",
+                    f"query={LIVE_QUERY}",
+                    "-f",
+                    f"owner={self.owner}",
+                    "-f",
+                    f"name={self.name}",
+                    "-F",
+                    f"number={number}",
+                ]
+            )
+        )
+        if response.get("errors"):
+            raise GhError(f"GraphQL returned errors: {response['errors']}")
+        repository = (response.get("data") or {}).get("repository") or {}
+        return parse_live_pr(number, repository.get("pullRequest"))
+
+    def arm(self, number: int) -> None:
+        # No merge-method flag: the repository's merge queue chooses the strategy.
+        self.gh(["pr", "merge", str(number), "--repo", self.repo, "--auto"])
+
+    def emit(self, number: int, verdict: str, detail: str) -> None:
+        self.log(f"[{PROGRAM}] PR #{number}: {verdict} — {detail}")
+
+    def run(self) -> int:
+        attempts = 0
+        errors = 0
+        candidates = self.list_candidates()
+        self.log(
+            f"[{PROGRAM}] found {len(candidates)} open PR(s) returned for "
+            f"label {REVIEW_ATTESTATION}; re-arm limit={self.max_rearms}"
+        )
+        for snapshot in candidates:
+            reason = self.decision(snapshot, live=False)
+            if reason:
+                self.emit(snapshot.number, "SKIP", reason)
+                continue
+
+            try:
+                current = self.live_state(snapshot.number)
+            except (GhError, json.JSONDecodeError) as error:
+                self.emit(snapshot.number, "SKIP", f"live-state query failed ({error})")
+                errors += 1
+                continue
+
+            reason = self.decision(current, live=True)
+            if reason:
+                self.emit(current.number, "SKIP", reason)
+                continue
+
+            # Both fields are absent here: and only here is the arm considered dropped.
+            if attempts >= self.max_rearms:
+                self.emit(current.number, "SKIP", "per-run re-arm limit reached")
+                continue
+            attempts += 1
+            try:
+                self.arm(current.number)
+            except GhError as error:
+                # The command is idempotent, but classify an API race loudly when possible.
+                try:
+                    raced = self.live_state(current.number)
+                    race_reason = self.decision(raced, live=True)
+                except (GhError, json.JSONDecodeError):
+                    race_reason = None
+                if race_reason:
+                    self.emit(current.number, "SKIP", f"arm raced: {race_reason}")
+                else:
+                    self.emit(current.number, "SKIP", f"re-arm failed ({error})")
+                    errors += 1
+                continue
+            self.emit(current.number, "ARMED", "dropped auto-merge request restored")
+
+        self.log(
+            f"[{PROGRAM}] complete: candidates={len(candidates)} "
+            f"re-arm-attempts={attempts} errors={errors}"
+        )
+        return errors
+
+
+def fixture(
+    number: int,
+    *,
+    state: str = "OPEN",
+    draft: bool = False,
+    base: str = "main",
+    labels: tuple[str, ...] = (REVIEW_ATTESTATION,),
+    armed: bool = False,
+    queued: bool = False,
+) -> dict:
+    return {
+        "number": number,
+        "state": state,
+        "isDraft": draft,
+        "baseRefName": base,
+        "labels": [{"name": label} for label in labels],
+        "autoMergeRequest": {"enabledAt": "2026-07-21T00:00:00Z"} if armed else None,
+        "mergeQueueEntry": {"id": f"MQE_{number}"} if queued else None,
+    }
+
+
+class FakeGh:
+    def __init__(self, snapshots: list[dict], live: dict[int, dict]) -> None:
+        self.snapshots = copy.deepcopy(snapshots)
+        self.live = copy.deepcopy(live)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str]) -> str:
+        self.calls.append(argv)
+        if argv[:2] == ["pr", "list"]:
+            return json.dumps(self.snapshots)
+        if argv[:2] == ["api", "graphql"]:
+            number = int(
+                next(arg.split("=", 1)[1] for arg in argv if arg.startswith("number="))
+            )
+            pr = self.live.get(number)
+            if pr is not None:
+                pr = copy.deepcopy(pr)
+                pr["labels"] = {
+                    "nodes": pr["labels"],
+                    "pageInfo": {"hasNextPage": False},
+                }
+            return json.dumps({"data": {"repository": {"pullRequest": pr}}})
+        if argv[:2] == ["pr", "merge"]:
+            return ""
+        raise AssertionError(f"unexpected fake gh call: {argv}")
+
+
+def arm_calls(fake: FakeGh) -> list[list[str]]:
+    return [call for call in fake.calls if call[:2] == ["pr", "merge"]]
+
+
+def exercise(
+    *prs: dict,
+    live_prs: tuple[dict, ...] | None = None,
+    max_rearms: int = DEFAULT_MAX_REARMS,
+):
+    snapshots = [
+        {
+            key: copy.deepcopy(value)
+            for key, value in pr.items()
+            if key != "mergeQueueEntry" and key != "autoMergeRequest"
+        }
+        for pr in prs
+    ]
+    current = live_prs if live_prs is not None else prs
+    fake = FakeGh(snapshots, {int(pr["number"]): pr for pr in current})
+    messages: list[str] = []
+    errors = RearmSweeper(
+        "sparq-org/sparq", "main", max_rearms=max_rearms, gh=fake, log=messages.append
+    ).run()
+    return fake, messages, errors
+
+
+def self_test() -> None:
+    expected_exact_exclusions = {
+        "review:changes",
+        "review:needs",
+        "review:needs-user",
+        "trust:untrusted",
+    }
+    assert EXCLUDED_LABELS == expected_exact_exclusions, EXCLUDED_LABELS
+
+    # Mutation tripwire (a): autoMergeRequest is null while a queue entry is live.
+    queued = fixture(3678, queued=True)
+    fake, messages, errors = exercise(fixture(3678), live_prs=(queued,))
+    assert errors == 0, messages
+    assert not arm_calls(fake), fake.calls
+    assert any("SKIP" in line and "mergeQueueEntry" in line for line in messages), (
+        messages
+    )
+    query_call = next(call for call in fake.calls if call[:2] == ["api", "graphql"])
+    query_text = next(arg for arg in query_call if arg.startswith("query="))
+    assert "autoMergeRequest{" in query_text, query_text
+    assert "mergeQueueEntry{" in query_text, query_text
+
+    # Mutation tripwire (b): needs:* is a hard exclusion, independent of queue state.
+    held = fixture(3682, labels=(REVIEW_ATTESTATION, "needs:user"))
+    fake, messages, errors = exercise(fixture(3682), live_prs=(held,))
+    assert errors == 0, messages
+    assert not arm_calls(fake), fake.calls
+    assert any("SKIP" in line and "needs:user" in line for line in messages), messages
+
+    # Mutation tripwire (c): a reviewed PR with neither live field must be re-armed.
+    dropped = fixture(3675)
+    fake, messages, errors = exercise(dropped)
+    assert errors == 0, messages
+    assert len(arm_calls(fake)) == 1, fake.calls
+    assert arm_calls(fake)[0] == [
+        "pr",
+        "merge",
+        "3675",
+        "--repo",
+        "sparq-org/sparq",
+        "--auto",
+    ], arm_calls(fake)
+    assert any("ARMED" in line for line in messages), messages
+
+    # CI state alone is never an arm verdict: live removal of review:pass must stop it.
+    unattested = fixture(105, labels=())
+    fake, messages, errors = exercise(fixture(105), live_prs=(unattested,))
+    assert errors == 0, messages
+    assert not arm_calls(fake), fake.calls
+    assert any("review:pass attestation absent" in line for line in messages), messages
+    list_call = next(call for call in fake.calls if call[:2] == ["pr", "list"])
+    label_arg = list_call.index("--label")
+    assert list_call[label_arg + 1] == REVIEW_ATTESTATION, list_call
+
+    # Every named exclusion is fail-closed, including one added after enumeration.
+    for label in (*sorted(EXCLUDED_LABELS), "needs:security"):
+        held = fixture(100, labels=(REVIEW_ATTESTATION, label))
+        fake, messages, _ = exercise(
+            fixture(100),
+            live_prs=(held,),
+        )
+        assert not arm_calls(fake), (label, fake.calls)
+        assert any("hard exclusion" in line for line in messages), (label, messages)
+    for pr, expected in (
+        (fixture(101, armed=True), "autoMergeRequest"),
+        (fixture(102, state="CLOSED", base="", queued=True), "not-open"),
+        (fixture(103, draft=True), "draft"),
+        (fixture(104, base="stacked-base"), "non-default-base"),
+    ):
+        fake, messages, _ = exercise(
+            fixture(pr["number"]),
+            live_prs=(pr,),
+        )
+        assert not arm_calls(fake), fake.calls
+        assert any(expected in line for line in messages), messages
+
+    # The hard bound limits commands, while every excess candidate still gets a decision.
+    fake, messages, errors = exercise(fixture(201), fixture(202), max_rearms=1)
+    assert errors == 0, messages
+    assert len(arm_calls(fake)) == 1, fake.calls
+    assert any("PR #202: SKIP" in line and "limit" in line for line in messages), (
+        messages
+    )
+
+    print("rearm-sweeper self-test: PASS")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="OWNER/REPOSITORY to sweep")
+    parser.add_argument("--default-branch", default="main")
+    parser.add_argument("--max-rearms", type=int, default=DEFAULT_MAX_REARMS)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        return 0
+    if not args.repo:
+        parser.error("--repo is required unless --self-test is used")
+    try:
+        sweeper = RearmSweeper(
+            args.repo, args.default_branch, max_rearms=args.max_rearms
+        )
+        return 1 if sweeper.run() else 0
+    except (GhError, ValueError, json.JSONDecodeError) as error:
+        print(f"[{PROGRAM}] fatal: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes #3675.

Armed `review:pass` PRs silently lose their auto-merge arm when a sibling merge-group lands and moves `main` (live case: #3678's merge dropped #3682's arm). The pipeline's self-arm only fires on label events, so the label being already present means no event ever re-arms — the PR sits CLEAN + attested + unarmed indefinitely.

**`scripts/rearm-sweeper.py`** (cron every 10 min via **`.github/workflows/rearm-sweeper.yml`**):
- Candidates: OPEN, non-draft, base = default branch, labeled `review:pass` (the pipeline's attested verdict — CI state alone can never arm; this is the arm-gate-on-verdict invariant).
- Fail-closed exclusions: entire `needs:*` namespace, `review:changes`, `review:needs`, `review:needs-user`, `trust:untrusted`, truncated live label pages.
- Dropped-detection via GraphQL: a queued PR reads `autoMergeRequest=null` but has a live `mergeQueueEntry` — only **both null** counts as dropped. Live re-probe before every arm; state checked first (merged PRs report other fields UNKNOWN).
- Bounded 10 re-arms/run, idempotent `gh pr merge --auto`, loud ARMED/SKIP per PR, races re-classified, errors → exit 1.
- Self-test mutation tripwires: (a) queued-but-unarmed fixture must be SKIPPED, (b) `needs:user` fixture must never arm, (c) genuinely dropped fixture must arm, plus bound/attestation/base checks. actionlint clean.

Arms via the **sparq-orchestrator App token** (same mint pattern as `batch-merge.yml`, fail-soft when unconfigured) so resulting merges still fire downstream push workflows (flow-on autoclose).

Note: no `dashboard.yml` keep-alive exists in this repo; if cron registration lags after merge, a manual `workflow_dispatch` primes it.