### PR TITLE
fix(dispatch-plan): mirror registry plan_package semantics (#3691)

### DIFF
--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -71,7 +71,12 @@ def plan_dispatch(ready_issues, routing_doc):
     for it in ready_issues:
         labels = labels_of(it)
         role = _role_of(labels)
-        package = sorted(packages_of(labels))[0]
+        # Package semantics mirror the registry's plan_package byte-for-byte (issue #3691):
+        # exactly one unique area -> that area; zero or multiple -> the serializing GLOBAL
+        # partition. The old first-of-sorted pick disagreed with the registry cross-check on
+        # multi-area issues, perma-deferring them at dispatch.
+        pkgs = packages_of(labels)
+        package = next(iter(pkgs)) if len(pkgs) == 1 else _ready.GLOBAL
         model_chain, agent, escalate = resolve(labels, routing_doc)
         if role is None:
             # No declared role → the resolver returned [defaults]; do NOT guess an agent/role.
@@ -203,6 +208,15 @@ def _self_test():
     p_norole = plan_dispatch([iss(7, ["priority:P1", "area:sparq-core"])], doc)
     row = p_norole[0]
     chk("no-role -> flagged", (row["role"], row["agent"], row["model_chain"]), (None, None, []))
+
+        # --- #3691 package-semantics fixtures (mirror registry plan_package) --------------------------
+    one = plan_dispatch([iss(90, R + ["priority:P2", "role:impl", "area:sparq-core"])], doc)
+    chk("#3691 exactly-one area maps to that area", one[0]["package"], "sparq-core")
+    multi = plan_dispatch([iss(91, R + ["priority:P2", "role:perf", "area:bench", "area:sparq-serve"])], doc)
+    chk("#3691 multi-area maps to the GLOBAL serializing partition (first-of-sorted pick => red)",
+        multi[0]["package"], _ready.GLOBAL)
+    zero = plan_dispatch([iss(92, R + ["priority:P2", "role:docs"])], doc)
+    chk("#3691 zero-area maps to GLOBAL", zero[0]["package"], _ready.GLOBAL)
 
     print("dispatch-plan self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes #3691.

**Live impact:** every multi-area ready issue perma-deferred at dispatch ('plan package disagrees with labels') because `plan_dispatch` picked the first-of-sorted area while the registry's `plan_package` maps zero-or-multiple areas to the `__global__` serializing partition. #3390 and then #3391 sat at the head of the priority order consuming the planner's single capacity slot every tick — head-of-line blocking the other 18 staged candidates for hours.

**Fix:** `package = next(iter(pkgs)) if len(pkgs) == 1 else _ready.GLOBAL` — byte-for-byte the registry semantics (`dispatch-claim.py plan_package`, which documents it 'Mirrors dispatch-plan.py:_plan_package'; the mirror had drifted). Three self-test fixtures (one/multi/zero area) with a mutation tripwire — reintroducing the first-of-sorted pick goes red (verified locally: FAIL on the multi-area fixture, restored green).

Authored by the Anthropic orchestrator; sol cross-provider review to follow before arm.