### PR TITLE
fix(ready): parked artifacts do not occupy areas + loud conflict attribution

### DIFF
--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -11,9 +11,11 @@ of a quarantine label. An issue is READY iff, in priority order, ALL hold:
   * carries NO gate label (`needs:*`, `trust:untrusted`) and is NOT busy
     (`status:in-progress|blocked|deferred|untriaged`), and
   * has zero open blockers, and
-  * none of its PACKAGES (`area:<crate>`) is already taken by an in-progress issue or an
-    earlier-selected ready issue. A no-package / cross-cutting issue reserves a **global partition**
-    that serializes it against ALL other work (shared lockfiles/CI/workspace configs).
+  * none of its PACKAGES (`area:<crate>`) is already taken by an active open PR, an in-progress
+    issue, or an earlier-selected ready issue. Human-parked artifacts (`needs:user`,
+    `review:needs-user`, `status:blocked`) reserve nothing. A no-package / cross-cutting issue
+    reserves a **global partition** that serializes it against ALL other work
+    (shared lockfiles/CI/workspace configs).
 
 The snapshot uses real cursor pagination (`gh api --paginate`) with an explicit fail-closed
 ceiling; native GitHub dependencies remain a follow-up — today blockers come from validated
@@ -28,6 +30,10 @@ import sys
 
 GATE_LABELS = ("needs:", "trust:untrusted")
 BUSY_STATUS = {"status:in-progress", "status:blocked", "status:deferred", "status:untriaged"}
+# [GPT-5.6] Parked is not in-flight: these terminal, human-owned snapshot artifacts cannot
+# advance autonomously, so they must not reserve an area indefinitely. Removing the label in a
+# later snapshot restores occupancy immediately; there is no remembered park state.
+PARKED_AREA_LABELS = {"needs:user", "review:needs-user", "status:blocked"}
 # [OPUS-4.8] an epic is a tracking umbrella (its children are the work) — never dispatchable, even
 # with a full ready label-set + zero blockers. Excluded here so a worker never "implements" an epic.
 NON_DISPATCHABLE = "kind:epic"
@@ -65,26 +71,68 @@ def is_busy(labels):
     return bool(labels & BUSY_STATUS)
 
 
-def compute_ready(issues, in_progress_packages=None):
-    """Conflict-free, priority-ordered, FAIL-CLOSED ready frontier."""
-    taken = set(in_progress_packages or ())
-    # an OPEN in-progress issue reserves all its packages (derive conflict set from the issues too).
+def is_parked(labels):
+    return bool(labels & PARKED_AREA_LABELS)
+
+
+def occupies_area(artifact):
+    """Whether an otherwise in-flight PR/issue occupies its areas in this snapshot."""
+    return not is_parked(labels_of(artifact))
+
+
+def _artifact_name(artifact):
+    if artifact is None:
+        return "preseeded occupancy"
+    kind = "pr" if "pull_request" in artifact else "issue"
+    return f"{kind}#{artifact.get('number', '?')}"
+
+
+def compute_ready(issues, in_progress_packages=None, conflict_log=None):
+    """Conflict-free, priority-ordered, FAIL-CLOSED ready frontier.
+
+    `conflict_log`, when supplied, receives one attribution line per conflict-excluded candidate;
+    the live default writes those diagnostics to stderr without polluting the frontier rows.
+    """
+    blockers = {}
+
+    def reserve(pkgs, artifact):
+        for pkg in sorted(pkgs):
+            blockers.setdefault(pkg, []).append(artifact)
+
+    def conflict(pkgs):
+        if GLOBAL in blockers:
+            area = GLOBAL
+        elif GLOBAL in pkgs and blockers:
+            area = sorted(blockers)[0]
+        else:
+            overlap = pkgs & blockers.keys()
+            if not overlap:
+                return None
+            area = sorted(overlap)[0]
+        return area, blockers[area][0]
+
+    for pkg in sorted(set(in_progress_packages or ())):
+        reserve({pkg}, None)
+    # [GPT-5.6] Every active open PR is in flight (drafts included); open issues occupy only while
+    # status:in-progress. The shared parked predicate is applied before either can reserve areas.
     for it in issues:
-        if str(it.get("state", "OPEN")).upper() != "OPEN":
+        if str(it.get("state", "OPEN")).upper() != "OPEN" or not occupies_area(it):
             continue
         L = labels_of(it)
-        if "status:in-progress" in L:
-            taken |= packages_of(L)
+        if "pull_request" in it or "status:in-progress" in L:
+            reserve(packages_of(L), it)
     cands = []
     for it in issues:
         if str(it.get("state", "OPEN")).upper() != "OPEN":
+            continue
+        if "pull_request" in it:             # PRs reserve work; they are never issue candidates
             continue
         L = labels_of(it)
         if "status:ready" not in L:          # positive attestation required
             continue
         if NON_DISPATCHABLE in L:            # epics are tracking umbrellas, not work items
             continue
-        if is_gated(L) or is_busy(L):
+        if is_gated(L) or is_busy(L) or is_parked(L):
             continue
         p = valid_priority(L)
         if p is None:                        # need exactly one valid priority
@@ -97,13 +145,17 @@ def compute_ready(issues, in_progress_packages=None):
     cands.sort(key=lambda c: (c[0], c[1]))   # priority then number (deterministic)
     ready = []
     for _p, _n, it, pkgs in cands:
-        if GLOBAL in taken:                  # cross-cutting work in flight → nothing else co-runs
-            break
-        if pkgs & taken:                     # package conflict
+        held = conflict(pkgs)
+        if held is not None:
+            area, blocker = held
+            message = (f"conflict #{it.get('number', '?')}: area {area} held by "
+                       f"{_artifact_name(blocker)}")
+            if conflict_log is None:
+                print(message, file=sys.stderr)
+            else:
+                conflict_log(message)
             continue
-        if GLOBAL in pkgs and taken:         # cross-cutting can't co-run with any package in flight
-            continue
-        taken |= pkgs
+        reserve(pkgs, it)
         ready.append(it)
     return ready
 
@@ -113,6 +165,10 @@ def _self_test():
         return {"number": n, "state": state, "labels": labels, "open_blockers": blk}
 
     R = ["status:ready", "role:impl"]
+
+    def quiet(_message):
+        pass
+
     F = [
         iss(1, R + ["priority:P2", "area:sparq-core"]),
         iss(2, R + ["priority:P0", "area:sparq-core"]),
@@ -136,38 +192,80 @@ def _self_test():
         ok = ok and good
         print(f"  {'ok  ' if good else 'FAIL'} {name}: {got} (want {want})")
 
-    ready = compute_ready(F)
+    ready = compute_ready(F, conflict_log=quiet)
     # eligible: 1,2,3,12 (+11 global). 4 gated, 5 blocked, 6 closed, 7 untrusted, 8 no-ready,
     # 9 ambiguous-prio, 10 in-progress, 13 epic (kind:epic → excluded despite a P0 ready label-set).
     # Order by prio: #2(P0 core) -> #3(P1 engine) -> #12(P1 hdt) -> #11(P4 global). core taken by #2
     # so #1(P2 core) excluded. #11 global: only selectable if nothing taken -> excluded.
     check("ready order", [i["number"] for i in ready], [2, 3, 12])
+    check("existing readiness fixtures unchanged-green", [i["number"] for i in ready], [2, 3, 12])
     # a P0 epic with an otherwise-perfect ready label-set must NOT dispatch (tracking umbrella):
     check("epic excluded", 13 in [i["number"] for i in ready], False)
     # a lone global issue with an empty board is selectable:
-    check("lone global", [i["number"] for i in compute_ready([iss(11, R + ["priority:P4"])])], [11])
+    check("lone global", [i["number"] for i in compute_ready(
+        [iss(11, R + ["priority:P4"])], conflict_log=quiet)], [11])
     # global blocks everything else:
-    g = compute_ready([iss(11, R + ["priority:P0"]), iss(12, R + ["priority:P1", "area:sparq-hdt"])])
+    g = compute_ready(
+        [iss(11, R + ["priority:P0"]), iss(12, R + ["priority:P1", "area:sparq-hdt"])],
+        conflict_log=quiet)
     check("global serializes", [i["number"] for i in g], [11])
+
+    # [GPT-5.6] Parked-occupancy tripwires. These are end-to-end through compute_ready so deleting
+    # the predicate, broadening it to every draft, or removing attribution makes --self-test red.
+    def pr(n, labels, draft=True):
+        return {"number": n, "state": "OPEN", "labels": labels,
+                "pull_request": {}, "draft": draft}
+
+    waiting = iss(20, R + ["priority:P1", "area:sparq-store"])
+    parked = pr(70, ["area:sparq-store", "needs:user"])
+    check("needs:user-parked draft PR does not block ready issue",
+          [i["number"] for i in compute_ready([parked, waiting], conflict_log=quiet)], [20])
+    unparked = {**parked, "labels": ["area:sparq-store"]}
+    check("park-label removal restores snapshot occupancy",
+          compute_ready([unparked, waiting], conflict_log=quiet), [])
+
+    active = pr(71, ["area:sparq-store", "review:changes"])
+    active_logs = []
+    check("non-parked draft PR still blocks",
+          compute_ready([active, waiting], conflict_log=active_logs.append), [])
+    check("conflict log names the blocking artifact",
+          active_logs, ["conflict #20: area sparq-store held by pr#71"])
+    per_exclusion_logs = []
+    global_then_two = compute_ready([
+        iss(30, R + ["priority:P0"]),
+        iss(31, R + ["priority:P1", "area:sparq-core"]),
+        iss(32, R + ["priority:P2", "area:sparq-engine"]),
+    ], conflict_log=per_exclusion_logs.append)
+    check("one conflict log per excluded candidate",
+          ([it["number"] for it in global_then_two], per_exclusion_logs),
+          ([30], ["conflict #31: area __global__ held by issue#30",
+                  "conflict #32: area __global__ held by issue#30"]))
+
+    in_progress = iss(72, ["status:in-progress", "area:sparq-store"])
+    check("status:in-progress issue still blocks",
+          compute_ready([in_progress, waiting], conflict_log=quiet), [])
+    check("all terminal park labels remove occupancy",
+          [[it["number"] for it in compute_ready(
+              [pr(73 + i, ["area:sparq-store", label]), waiting], conflict_log=quiet)]
+           for i, label in enumerate(sorted(PARKED_AREA_LABELS))], [[20], [20], [20]])
     check("valid_priority single", valid_priority({"priority:P0"}), 0)
     check("valid_priority ambiguous", valid_priority({"priority:P1", "priority:P2"}), None)
     check("valid_priority out-of-range", valid_priority({"priority:P7"}), None)
     check("packages multi", packages_of({"area:a", "area:b"}), {"a", "b"})
     check("packages none->global", packages_of({"role:impl"}), {GLOBAL})
     check("untriaged is busy", is_busy({"status:untriaged"}), True)
-    # paginated-snapshot flattening: multi-page merge, PR rows dropped, junk tolerated
-    check("flatten pages drops PRs", _flatten_pages(
+    # paginated-snapshot flattening: multi-page merge, PR rows retained for occupancy, junk tolerated
+    check("flatten pages retains PRs", _flatten_pages(
         [[{"number": 1}, {"number": 2, "pull_request": {}}], [{"number": 3}], "junk", [None]]),
-        [{"number": 1}, {"number": 3}])
+        [{"number": 1}, {"number": 2, "pull_request": {}}, {"number": 3}])
     print("ready-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 
 
 def _flatten_pages(pages):
-    """Flatten `gh api --paginate --slurp` output (a list of pages) into issues, dropping PRs
-    (REST /issues includes them, marked by the `pull_request` key). Pure — unit-tested."""
+    """Flatten `gh api --paginate --slurp` output, retaining PRs as occupancy artifacts."""
     return [i for page in pages for i in (page if isinstance(page, list) else [])
-            if isinstance(i, dict) and "pull_request" not in i]
+            if isinstance(i, dict)]
 
 
 def _fetch(repo, ceiling=10000):
@@ -185,13 +283,18 @@ def _fetch(repo, ceiling=10000):
         raise SystemExit(f"refusing: fetched {len(raw)} >= ceiling {ceiling} — snapshot looks "
                          "runaway (fail-closed). Raise the ceiling deliberately if the backlog "
                          "is really that large.")
-    open_numbers = {i["number"] for i in raw}
+    open_numbers = {i["number"] for i in raw if "pull_request" not in i}
     issues = []
     for i in raw:
-        blockers = re.findall(r"[Bb]locked-by:\s*#(\d+)", i.get("body") or "")
-        open_blk = sum(1 for b in blockers if int(b) in open_numbers)
-        issues.append({"number": i["number"], "state": i["state"],
-                       "labels": i["labels"], "open_blockers": open_blk})
+        row = {"number": i["number"], "state": i["state"], "labels": i["labels"],
+               "open_blockers": 0}
+        if "pull_request" in i:
+            row["pull_request"] = i["pull_request"]
+            row["draft"] = i.get("draft")
+        else:
+            blockers = re.findall(r"[Bb]locked-by:\s*#(\d+)", i.get("body") or "")
+            row["open_blockers"] = sum(1 for b in blockers if int(b) in open_numbers)
+        issues.append(row)
     return issues
 
 


### PR DESCRIPTION
> 🤖 SPARQ agent

The last link in this week's frontier-starvation chain (curator side landed as registry #513; planner side is this PR).

**Live impact:** the registry's dispatch planned **zero** sparq worker candidates per tick — silently — while the curator staged 19: `ready-issues.py`'s area-conflict predicate counted all ~76 open PRs as occupying their areas, including ~55 terminally-parked drafts frozen since 07-18, conflict-excluding nearly every ready issue before planning.

**Change (`scripts/ready-issues.py` only):** artifacts labeled `needs:user` / `review:needs-user` / `status:blocked` no longer occupy areas or count as in-flight; non-parked drafts, `review:changes` cycling PRs, and `status:in-progress` issues still do (over-broad freeing tripwired red). Label removal restores occupancy next snapshot. Every area-conflict exclusion now logs the blocking artifact (`conflict #N: area X held by pr#M`) — this class of silent starvation cost hours to diagnose.

Five executed tripwires; orchestrator independently mutated the predicate to never-parked ⇒ suite red (3 assertions), snapshot-restored green. `dispatch-plan.py` self-test + CI selector suite green.

Authored by sol (GPT-5.6); reviewed by the Anthropic orchestrator (cross-provider).