### PR TITLE
experiment(shacl): core XSD dateTime comparator for mixed-timezone pairs (#3526)

### DIFF
--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -11,6 +11,7 @@ use crate::view::GraphView;
 use oxrdf::{Literal, Term};
 use rustc_hash::{FxHashMap, FxHashSet};
 use sparq_core::dict::{is_inline, is_literal_id, split_lang_dir, Id, TermParts};
+use sparq_core::temporal::{Temporal, TemporalKind};
 use sparq_core::Graph;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -2849,12 +2850,20 @@ fn cmp_literals(a: &Literal, b: &Literal) -> Option<Ordering> {
     if is_date_time(da) && is_date_time(db) {
         let (ta, tza) = timestamp(a.value(), da)?;
         let (tb, tzb) = timestamp(b.value(), db)?;
-        if tza != tzb {
-            // XSD order between a timezoned and an untimezoned value is
-            // INDETERMINATE (within the ±14h window) — not comparable.
-            return None;
-        }
-        return ta.partial_cmp(&tb);
+        // [GPT-5.6] Issue #3526: the core XSD ±14h mixed-timezone partial order is
+        // used here while this semantics change is under SHACL conformance evaluation.
+        return Temporal::cmp_t(
+            Temporal {
+                instant: ta,
+                has_tz: tza,
+                kind: TemporalKind::DateTime,
+            },
+            Temporal {
+                instant: tb,
+                has_tz: tzb,
+                kind: TemporalKind::DateTime,
+            },
+        );
     }
     None
 }


### PR DESCRIPTION
> 🤖 SPARQ agent

**Unarmed conformance experiment** for #3526 — do not merge on green alone; the W3C SHACL conformance ratchet legs (core ≥ 98, sparql ≥ 5) are the verdict:
- Counts hold/improve ⇒ core's XSD 1.1 ±14h partial order is both spec-correct and conformance-safe → promote this to the dedup fix.
- Any regression ⇒ SHACL's blanket-incomparable is load-bearing → document in eval.rs and close #3526 as won't-dedup.

One-line swap + evaluation comment; `cargo check -p sparq-shacl` green locally. Authored by sol (GPT-5.6); orchestrator-reviewed.