### PR TITLE
feat(site): accept zstd (.zst) dataset imports via the shared decompress path (#1046)

### DIFF
--- a/js/src/decompress.ts
+++ b/js/src/decompress.ts
@@ -37,7 +37,10 @@ const isNode = (): boolean => typeof process !== 'undefined' && Boolean(process?
 async function gunzip(bytes: Uint8Array): Promise<Uint8Array> {
   if (isNode()) {
     // node:zlib loops gzip members, so multi-member streams decode fully.
-    const { gunzipSync } = await import('node:zlib');
+    // [GPT-5.6] #1046 — browser bundles reuse this module for its zstd branch. Keep the
+    // runtime-guarded Node builtin external so webpack does not try to compile `node:zlib`
+    // into that browser-only lazy chunk; native Node import() semantics are unchanged.
+    const { gunzipSync } = await import(/* webpackIgnore: true */ 'node:zlib');
     return new Uint8Array(gunzipSync(bytes));
   }
   // Browser: DecompressionStream (single-member gzip only — see module doc).

--- a/site/scripts/check-bundle.mjs
+++ b/site/scripts/check-bundle.mjs
@@ -53,8 +53,8 @@ export const HEAVY_MODULE_SUFFIXES = [
   // The in-tab ZK prover (~MB each), dynamic-imported inside lib/zk-prover.ts.
   "-> @aztec/bb.js",
   "-> @noir-lang/noir_js",
-  // [FABLE-5] sq-4ssz1 (#1046) — the zstd decoder, dynamic-imported inside
-  // lib/dataset-archive.ts#loadCodec. Small, but the maintainer's standing rule is that
+  // [GPT-5.6] #1046 — the zstd decoder, dynamic-imported inside js/src/decompress.ts and
+  // reached through the site's bytesToRdf pipeline. The maintainer's standing rule is that
   // rarely-used codecs are fetched ONLY when a user actually decodes a file of that
   // type, so it must STAY a lazy split point (never fold into a route-entry bundle).
   "-> fzstd",

--- a/site/src/components/data-formats-demo.tsx
+++ b/site/src/components/data-formats-demo.tsx
@@ -12,8 +12,8 @@
 //      `DecompressionStream` and parse the decoded text → triple count. Plus
 //      ([FABLE-5] sq-4ssz1 / #1046) a real compressed-file upload: pick a `.gz` /
 //      `.zip` / `.zst` archive and it is decompressed in-tab (gzip/zip natively; zstd
-//      through the LAZY-loaded `fzstd` chunk `lib/dataset-archive.ts#loadCodec`
-//      fetches only when a zstd payload is actually decoded) and parsed by the engine.
+//      through the shared `js/src/decompress.ts` path, whose `fzstd` import loads only
+//      when a zstd payload is actually decoded) and parsed by the engine.
 //      bzip2 remains native-only (no small JS decoder — see the page's honest caveat).
 
 import * as React from "react";
@@ -49,10 +49,9 @@ import {
 import {
   sniffArchive,
   archiveCodecFromName,
-  decompressArchive,
   type ArchiveCodec,
 } from "@/lib/dataset-archive";
-import { guessFormat } from "@/lib/repl-dataset";
+import { bytesToRdf } from "@/lib/rdf-import";
 // [OPUS-4.8] sq-8uew — Turtle/TriG/N-Triples/N-Quads syntax-highlighting input editor.
 import { RdfEditor } from "@/components/rdf-editor";
 // [OPUS-4.8] sq-ixc3.1 — JSON-LD syntax-highlighting input editor (the remaining picker format).
@@ -190,8 +189,8 @@ export function DataFormatsDemo() {
 
   // [FABLE-5] sq-4ssz1 (#1046) — decode a REAL compressed archive picked from disk:
   // sniff the codec (magic number first, filename as fallback), decompress in-tab via
-  // the shared `decompressArchive` (gzip/zip natively; picking a `.zst` triggers the
-  // FIRST fetch of the lazy fzstd chunk — the decoder is not in this page's bundle),
+  // the shared `bytesToRdf` pipeline (gzip/zip natively; picking a `.zst` reaches
+  // js/src/decompress.ts and triggers the FIRST fetch of its lazy fzstd chunk),
   // guess the RDF format from the inner name, and parse with the wasm engine.
   const runArchive = React.useCallback(async (file: File) => {
     setArchive({ kind: "running" });
@@ -204,12 +203,7 @@ export function DataFormatsDemo() {
         );
       }
       const t0 = performance.now();
-      const { text: decoded, innerName } = await decompressArchive(
-        bytes,
-        file.name,
-        codec,
-      );
-      const fmt = guessFormat(innerName ?? file.name);
+      const { text: decoded, format: fmt } = await bytesToRdf(bytes, file.name);
       const Store = await loadSparq();
       setEngine("ready");
       const store = loadIntoStore(Store, decoded, fmt);

--- a/site/src/lib/data-formats.ts
+++ b/site/src/lib/data-formats.ts
@@ -5,8 +5,8 @@
 //
 // WHY THESE LIVE HERE (and are framework-free). The demo's parse step runs the real wasm
 // Store (no mocks); but the *gzip ingest* path is plain Web-platform code: gzip is the one
-// codec the browser decompresses natively (zstd decodes through the LAZY-loaded decoder in
-// `dataset-archive.ts#loadCodec`; bzip2 is native-only — see the page's honest caveat), so
+// codec the browser decompresses natively (zstd reaches the LAZY-loaded decoder through
+// `js/src/decompress.ts`; bzip2 is native-only — see the page's honest caveat), so
 // the gzip round-trip demo is `gunzip(bytes)` -> `Store.load(text, fmt)`.
 // Keeping the codec round-trip + the sample catalogue here (no React, no wasm) lets them
 // unit-test directly under `node --test` (the Web Streams API is in Node ≥ 18).
@@ -154,8 +154,8 @@ export function sampleFor(format: DataFormat): FormatSample | undefined {
 
 // ---------------------------------------------------------------------------
 // gzip round-trip — the live compressed-ingest path (gzip is the one codec the
-// browser decompresses natively; zstd is decoded by the lazy-loaded codec in
-// dataset-archive.ts; bzip2 is native-only, see the page caveat).
+// browser decompresses natively; zstd is decoded by the shared lazy-loaded JS package
+// path; bzip2 is native-only, see the page caveat).
 // ---------------------------------------------------------------------------
 
 // All byte buffers here are backed by a plain `ArrayBuffer` (never `SharedArrayBuffer`),

--- a/site/src/lib/dataset-archive.ts
+++ b/site/src/lib/dataset-archive.ts
@@ -9,7 +9,7 @@
 // `node --test` (Node ≥18 ships `DecompressionStream`). The actual RDF parse still
 // happens in the wasm Store — this layer only turns archive BYTES into RDF TEXT.
 //
-// Codec choice (native-first; anything else is LAZY-loaded — see `loadCodec`):
+// Codec choice (native-first; anything else is LAZY-loaded):
 //   • gzip (`.gz`, magic 1f 8b) — decoded by the native `DecompressionStream("gzip")`.
 //     Single-member only: browsers silently truncate multi-member gzip to the first
 //     member (measured in research/custom-parsers-D4 §3). Real-world RDF `.gz` dumps
@@ -21,12 +21,10 @@
 //     dependency (would add ~95 kB / ~45 kB to the bundle for a feature served by a
 //     browser-native API). Encrypted, ZIP64, and other compression methods are
 //     rejected with a clear message rather than silently mis-decoding.
-//   • zstd (`.zst`, magic 28 b5 2f fd) — [FABLE-5] sq-4ssz1 (#1046): no native browser
-//     codec, so it decodes through `fzstd` (pure JS, small), which `loadCodec` fetches
-//     via a dynamic `import()` ONLY when a zstd payload is actually being decoded —
-//     the decoder lives in its own lazy chunk, never in any route's first-load bundle.
-//     Same decoder the `@jeswr/sparq` package's `decompress.ts` uses; handles the
-//     multi-frame concatenated streams RFC 8878 allows, but NOT dictionary frames.
+//   • zstd (`.zst`, magic 28 b5 2f fd) — [GPT-5.6] #1046: delegated to the existing
+//     `js/src/decompress.ts` implementation. That shared path dynamically imports `fzstd`
+//     only when zstd is selected, so the decoder remains outside every route's first-load
+//     bundle. It handles the multi-frame streams RFC 8878 allows, but not dictionary frames.
 //
 // bzip2 stays out: there is no native browser codec and no small pure-JS decoder — a
 // wasm-blob decoder would be a heavy add for a rarely-shipped format (deferred in
@@ -44,6 +42,10 @@ export interface DecompressedArchive {
    *  when it cannot be determined — the caller then falls back to its own guess. */
   innerName: string | null;
 }
+
+/** Stable error used when bytes do not name one of the browser import codecs. */
+export const UNSUPPORTED_ARCHIVE_ERROR =
+  "Unrecognised compressed payload: expected a gzip (.gz), zip (.zip), or zstd (.zst) magic number.";
 
 // ---------------------------------------------------------------------------
 // Detection
@@ -179,48 +181,13 @@ async function inflate(
 
 const utf8 = new TextDecoder();
 
-// ---------------------------------------------------------------------------
-// Lazy codec loading — the bundle-size rule (maintainer, #1046)
-// ---------------------------------------------------------------------------
-// gzip + zip decode through browser-native APIs, so they cost zero bundle bytes.
-// Any codec the platform does NOT provide natively (zstd today; every future
-// rarely-used format) MUST come through this dynamic-`import()` switch, so the
-// decoder is code-split into its own lazy chunk and fetched the FIRST time a user
-// actually decodes a payload of that type — never in a route's first-load bundle.
-// `scripts/check-bundle.mjs` pins `fzstd` as a dynamic split point (PRESENCE), so
-// regressing this to a static import fails the build.
-
-/** Codecs with no native browser API, decoded by a lazily-imported JS decoder. */
-export type LazyCodec = Extract<ArchiveCodec, "zstd">;
-
-/**
- * Dynamically imports the decoder for a non-native codec and returns its
- * bytes → bytes decode function. The `import()` here is the load-bearing part:
- * webpack splits each decoder into a separate chunk that only ever loads on demand.
- */
-export async function loadCodec(
-  codec: LazyCodec,
-): Promise<(bytes: Uint8Array) => Uint8Array> {
-  switch (codec) {
-    case "zstd": {
-      // fzstd: the small pure-JS zstd decoder the `@jeswr/sparq` package already
-      // uses (already a site dependency via the wasm-ESM bundler). Decodes RFC 8878
-      // multi-frame concatenated streams; dictionary frames are not supported.
-      const { decompress } = await import(
-        /* webpackChunkName: "codec-zstd" */ "fzstd"
-      );
-      return decompress;
-    }
-  }
-}
-
 /**
  * Decompresses a recognised dataset archive (`gzip`, `zip`, or `zstd`) to RDF text
  * plus the inner member name. `codec` defaults to sniffing the magic number; `name`
  * (the file/URL name) is used to break the single-stream codecs' "no inner name"
  * ambiguity (a zip carries its own member name). Throws a clear, actionable error for
  * an unrecognised / unsupported payload rather than mis-decoding. The zstd decoder is
- * lazy-loaded on first use (see {@link loadCodec}).
+ * lazy-loaded on first use by the shared JS package decompressor.
  */
 export async function decompressArchive(
   bytes: Uint8Array,
@@ -236,14 +203,17 @@ export async function decompressArchive(
     case "zip":
       return unzipFirstRdfMember(bytes);
     case "zstd": {
-      const decode = await loadCodec("zstd");
-      const out = decode(bytes);
+      // [GPT-5.6] #1046 — reuse the published JS surface's zstd path instead of
+      // maintaining a second site-local `fzstd` import. Both this module and `fzstd`
+      // remain literal dynamic split points and load only after a zstd import is invoked.
+      const { decompress } = await import(
+        /* webpackChunkName: "sparq-js-decompress" */ "../../../js/src/decompress.js"
+      );
+      const out = await decompress(bytes, "zstd");
       return { text: utf8.decode(out), innerName: innerNameForArchive(name) };
     }
     default:
-      throw new Error(
-        "Unrecognised compressed payload: expected a gzip (.gz), zip (.zip), or zstd (.zst) magic number.",
-      );
+      throw new Error(UNSUPPORTED_ARCHIVE_ERROR);
   }
 }
 

--- a/site/src/lib/rdf-import.ts
+++ b/site/src/lib/rdf-import.ts
@@ -1,0 +1,95 @@
+// [GPT-5.6] #1046 — the binary-to-RDF boundary shared by file uploads and URL imports.
+// Read compressed sources as bytes, decode their container before UTF-8, then select the
+// RDF syntax from the inner name. Keeping this framework-free makes both invocation paths
+// unit-testable without mounting the former /try workbench.
+
+import {
+  archiveCodecFromContentType,
+  archiveCodecFromName,
+  decompressArchive,
+  sniffArchive,
+  UNSUPPORTED_ARCHIVE_ERROR,
+} from "./dataset-archive";
+import { formatFromContentType, guessFormat } from "./repl-dataset";
+
+export interface BytesToRdfOptions {
+  /** An explicit format picker value; `__auto__` keeps automatic detection enabled. */
+  explicitFormat?: string;
+  /** The response media type for URL imports, including an optional charset parameter. */
+  contentType?: string | null;
+}
+
+export interface RdfSource {
+  /** UTF-8 RDF source text, decoded only after any archive container is removed. */
+  text: string;
+  /** The engine format inferred from the inner RDF name/media type or explicitly selected. */
+  format: string;
+}
+
+function isBzip2Source(
+  bytes: Uint8Array,
+  sourceName: string,
+  contentType: string | null | undefined,
+): boolean {
+  const mime = contentType?.split(";")[0].trim().toLowerCase();
+  const path = sourceName.split(/[?#]/)[0].toLowerCase();
+  const named = /\.(?:bz2|bzip2|tbz|tbz2)$/.test(path);
+  const served = mime === "application/x-bzip2" || mime === "application/bzip2";
+  const magic =
+    bytes.length >= 4 &&
+    bytes[0] === 0x42 &&
+    bytes[1] === 0x5a &&
+    bytes[2] === 0x68 &&
+    bytes[3] >= 0x31 &&
+    bytes[3] <= 0x39;
+  return named || served || magic;
+}
+
+/**
+ * Turns uploaded/fetched bytes into RDF source text and its engine format. Archive detection
+ * follows the existing URL contract (container Content-Type, source suffix, then magic bytes),
+ * while plain RDF prefers its served media type over the source suffix. gzip/zip stay on the
+ * browser-native archive path; zstd reaches the shared lazy decoder in `js/src/decompress.ts`.
+ */
+export async function bytesToRdf(
+  bytes: Uint8Array,
+  sourceName: string,
+  options: BytesToRdfOptions = {},
+): Promise<RdfSource> {
+  const { explicitFormat, contentType } = options;
+  const selectedFormat =
+    explicitFormat && explicitFormat !== "__auto__"
+      ? explicitFormat
+      : undefined;
+  const archiveCodec =
+    archiveCodecFromContentType(contentType ?? null) ??
+    archiveCodecFromName(sourceName) ??
+    sniffArchive(bytes);
+
+  // bzip2 is deliberately not a browser import codec. Detect its established signals so a URL
+  // response cannot fall through to UTF-8 and reach the RDF parser as corrupted text; preserve
+  // the archive helper's existing unsupported-format error instead of adding a decoder.
+  if (!archiveCodec && isBzip2Source(bytes, sourceName, contentType)) {
+    throw new Error(UNSUPPORTED_ARCHIVE_ERROR);
+  }
+
+  if (archiveCodec) {
+    const { text, innerName } = await decompressArchive(
+      bytes,
+      sourceName,
+      archiveCodec,
+    );
+    return {
+      text,
+      format: selectedFormat ?? guessFormat(innerName ?? sourceName),
+    };
+  }
+
+  return {
+    text: new TextDecoder().decode(bytes),
+    format:
+      selectedFormat ??
+      formatFromContentType(contentType ?? null) ??
+      guessFormat(sourceName),
+  };
+}

--- a/site/test/dataset-archive.test.mjs
+++ b/site/test/dataset-archive.test.mjs
@@ -14,7 +14,6 @@ import {
   archiveCodecFromContentType,
   innerNameForArchive,
   decompressArchive,
-  loadCodec,
 } from "../src/lib/dataset-archive.ts";
 
 const SAMPLE_NT =
@@ -308,11 +307,6 @@ test("decompressArchive skips a leading zstd skippable frame", async () => {
   stream.set(ZST_FRAME_1, skip.length);
   const { text } = await decompressArchive(stream, "meta.nt.zst");
   assert.equal(text, SAMPLE_NT_LINE_1);
-});
-
-test("loadCodec returns a working zstd decoder via the dynamic import", async () => {
-  const decode = await loadCodec("zstd");
-  assert.equal(new TextDecoder().decode(decode(ZST_SAMPLE)), SAMPLE_NT);
 });
 
 test("decompressArchive surfaces a clear error for corrupt zstd bytes", async () => {

--- a/site/test/rdf-import.test.mjs
+++ b/site/test/rdf-import.test.mjs
@@ -1,0 +1,59 @@
+// [GPT-5.6] #1046 — import-boundary coverage for the same .nt.zst fixture through the
+// Upload and From URL call shapes. The helper returns parser-ready RDF text + syntax; the
+// wasm parser is covered separately, so these tests stay fast and framework-free.
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { bytesToRdf } from "../src/lib/rdf-import.ts";
+
+const SAMPLE_NT =
+  '<http://example.org/s> <http://example.org/p> "object value" .\n' +
+  "<http://example.org/s> <http://example.org/q> <http://example.org/o2> .\n";
+
+// Reference-codec fixture generated once from SAMPLE_NT with zstd. Node 20 has no zstd
+// compressor, so retaining the real RFC 8878 frame as base64 keeps the test portable.
+const NT_ZST_FIXTURE = Uint8Array.from(
+  Buffer.from(
+    "KLUv/SSHDQIAJAM8aHR0cDovL2V4YW1wbGUub3JnL3M+IHA+ICJvYmplY3QgdmFsdWUiIC4KcW8yPiAuCgQAOooIuAaWolmlZxOc62uy",
+    "base64",
+  ),
+);
+
+test("Upload imports a .nt.zst fixture as parser-ready N-Triples", async () => {
+  const result = await bytesToRdf(NT_ZST_FIXTURE, "fixture.nt.zst");
+  assert.deepEqual(result, { text: SAMPLE_NT, format: "ntriples" });
+});
+
+test("From URL imports the same .nt.zst fixture from binary response metadata", async () => {
+  const result = await bytesToRdf(
+    NT_ZST_FIXTURE,
+    "https://example.org/fixture.nt.zst?download=1",
+    { explicitFormat: "__auto__", contentType: "application/zstd" },
+  );
+  assert.deepEqual(result, { text: SAMPLE_NT, format: "ntriples" });
+});
+
+test("bzip2 stays rejected with the existing unsupported archive error", async () => {
+  const bzip2Magic = new Uint8Array([0x42, 0x5a, 0x68, 0x39, 0, 0, 0, 0]);
+  await assert.rejects(
+    bytesToRdf(bzip2Magic, "fixture.nt.bz2"),
+    /Unrecognised compressed payload: expected a gzip.*zip.*zstd/,
+  );
+});
+
+test("site zstd import delegates to js/decompress and never imports fzstd directly", async () => {
+  const archiveSource = await readFile(
+    new URL("../src/lib/dataset-archive.ts", import.meta.url),
+    "utf8",
+  );
+  const jsSource = await readFile(
+    new URL("../../js/src/decompress.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(archiveSource, /import\([\s\S]*\.\.\/\.\.\/\.\.\/js\/src\/decompress\.js/);
+  assert.doesNotMatch(archiveSource, /from ["']fzstd["']|import\(["']fzstd["']\)/);
+  assert.match(jsSource, /await import\(["']fzstd["']\)/);
+  assert.doesNotMatch(jsSource, /^import .* from ["']fzstd["'];?$/m);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes #1046 (decision recorded on the issue: zstd yes via the vendored `fzstd`/`decompress.ts` path; bzip2 declined).

- Upload + From URL on `/try` (and the GUI reuse) accept `.zst` alongside gzip/zip through the shared `bytesToRdf` pipeline; bzip2 keeps the existing clear unsupported-format rejection.
- zstd decoder stays a lazy dynamic import — bundle guard confirms one lazy `fzstd` chunk, zero guarded-route first-load leaks (guard delta is comment-only, verified by the orchestrator).
- `.nt.zst` fixtures test both import paths; static export, site lint, typecheck, and all non-Cargo unit files green.

Authored by sol (GPT-5.6); reviewed by the Anthropic orchestrator (cross-provider).