### PR TITLE
fix(ci): un-red the main gate — bench history-switch churn guard, median-of-history hard zone, release-plz 403 containment

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -145,6 +145,12 @@
    "owner_bead": "sq-6vshe",
    "promotion_criteria": "not promotable to a gate: the ring runs post-hoc via workflow_run (on ci-summary completion), never on a PR/merge_group head commit, so it produces no gating check-run by design (sparq-org/sparq#3474 moved it here so the REGISTRY_RING_TOKEN doorbell is unreachable from PR-head content); it only notifies the registry doorbell after a gating-leg failure and must never gate a PR",
    "registered": "2026-07-18"
+  },
+  "release-plz / Release-PR (advisory)": {
+   "workflow": "release-plz.yml",
+   "owner_bead": "sq-lonae",
+   "promotion_criteria": "advisory while the repo/org setting 'Allow GitHub Actions to create and approve pull requests' is disabled (GITHUB_TOKEN cannot open the Release-PR: known 403, live run 29988505600, contained loudly via captured-output signature + side-effect-free probe). Promote when a maintainer enables that setting or configures the ORCHESTRATOR_APP_ID/_PRIVATE_KEY secrets (batch-merge.yml App-token pattern): drop the ' (advisory)' name token, remove the 403-containment step, and delete this entry",
+   "registered": "2026-07-23"
   }
  }
 }

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -478,24 +478,30 @@ jobs:
       # ROOT CAUSE: the "Run benchmarks" step (scripts/ci-bench.sh) does `cd bench/zk && cargo bench`
       # and `cd bench/zk-trace && cargo bench` (two STANDALONE cargo projects, run WITHOUT --locked),
       # so Cargo re-resolves and REWRITES their committed bench/zk{,-trace}/Cargo.lock. That leaves the
-      # working tree dirty. The Store step below then runs with auto-push=true (main only), and the
-      # action internally does `git fetch ... benchmark-data:benchmark-data` + `git switch benchmark-data`,
-      # which ABORTS: "Your local changes to the following files would be overwritten by checkout:
-      # bench/zk-trace/Cargo.lock, bench/zk/Cargo.lock ... Aborting" (live: Benchmarks run 27867742598).
-      # That failed the whole (non-gating) Benchmarks job on every main push and masked real CI signal.
-      # It only ever bit main because on PRs auto-push=false, so the action never switches branches.
+      # working tree dirty. The Store step below then does `git fetch ... benchmark-data:benchmark-data`
+      # + `git switch benchmark-data` internally, which ABORTS: "Your local changes to the following
+      # files would be overwritten by checkout: bench/zk-trace/Cargo.lock, bench/zk/Cargo.lock ...
+      # Aborting" (live: Benchmarks run 27867742598). That failed the whole Benchmarks job and masked
+      # real CI signal.
       #
-      # FIX: restore exactly the TRACKED files the build/bench dirtied, so the action's branch switch is
-      # clean. `git checkout --` only touches tracked paths, so the UNtracked run outputs the next step
-      # reads (bench-results.json, prev-data.js) are left intact. Enumerating via `git diff --name-only`
-      # (tracked-modified only) future-proofs this against any other lockfile a future bench may rewrite.
-      # This does NOT alter the measurement — bench-results.json is already written; we only drop the
-      # incidental lockfile churn. main-guarded to mirror the auto-push gate (the only path that switches).
-      - name: Clean bench-induced tracked churn before history switch (main only)
-        # [SONNET-4.6] sq-mel85: push-to-main ONLY. This cleanup exists solely so the
-        # auto-push branch switch below is clean; the nightly `schedule` backstop never
-        # switches branches (auto-push is push-gated), so it needs no cleanup.
-        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
+      # [FABLE-5] UNCONDITIONAL — a previous revision (sq-mel85) guarded this step
+      # `github.event_name != 'schedule' && github.ref == 'refs/heads/main'` on the claim that the
+      # nightly `schedule` backstop "never switches branches (auto-push is push-gated)". That claim
+      # was WRONG: github-action-benchmark fetches + switches to the benchmark-data branch to READ
+      # the comparison history on EVERY event, regardless of auto-push (the branch switch serves the
+      # compare, not just the push) — proven live by the nightly schedule run 29989729092, which
+      # aborted on exactly this lockfile churn with auto-push=false. PR runs never bit only because
+      # the PR leg is `--deterministic-only` (sq-6vshe.6), which skips the zk/zk-trace cargo benches
+      # that rewrite the lockfiles — not because the action skipped the switch. Restoring tracked
+      # churn is safe on every event: bench-results.json is already written, so the measurement is
+      # untouched, and the run outputs the later steps read (bench-results.json, prev-data.js) are
+      # UNtracked and left intact. Hence: no `if:` — this cleanup always runs.
+      #
+      # FIX MECHANICS: restore exactly the TRACKED files the build/bench dirtied, so the action's
+      # branch switch is clean. `git checkout --` only touches tracked paths. Enumerating via
+      # `git diff --name-only` (tracked-modified only) future-proofs this against any other lockfile
+      # a future bench may rewrite.
+      - name: Clean bench-induced tracked churn before history switch
         run: |
           set -euo pipefail
           dirty="$(git diff --name-only)"
@@ -549,41 +555,63 @@ jobs:
           # [OPUS-4.8] TWO-ZONE self-monitoring thresholds (noise-reduction-bench-selfmonitor;
           # maintainer-directed). GitHub-hosted runners are noisy, so a single global switch would
           # either trip constantly on µs-scale wall-clock jitter or be so loose it catches nothing.
-          # Instead this action now gates in TWO empirically-derived zones:
           #   * alert-threshold: '175%'  — SOFT zone. Emits an alert COMMENT but does NOT fail the
           #     step (comment-only for the soft band; the "Soft-zone triage" step below files/updates a
           #     deduped `bench-flake` issue for it — NO @mention of anyone). 175% ≈ p95 run-to-run
           #     timing swing (43.66%) + ~30pp headroom.
-          #   * fail-threshold: '200%' + fail-on-alert: true — HARD zone. A regression at/above 200%
-          #     is clearly BEYOND any observed shared-runner noise (worst observed noise swing over the
-          #     20-commit history = 185.0%), so the STEP FAILS CI. An agent must fix it.
-          # WHERE THE TIMING HARD-FAIL BITES (honest — it does NOT re-noise the per-PR gate): under
-          # sq-6vshe.6 (also maintainer-directed) the PR run is `--deterministic-only`, so on a PR this
-          # step sees ONLY the deterministic byte-count metrics (0.00% noise; already strictly gated by
-          # the "Hard gate" perf-gate.py step above — this fail-on-alert is a redundant looser backstop
-          # there and never trips on runner noise). The NOISY TIMING metrics run on push-to-main + the
-          # nightly EC2 lane, so the timing hard-fail bites THERE (a post-merge / nightly hard signal),
-          # NOT on the per-PR path — deliberately, so this change does not re-introduce the merge-queue
-          # flapping sq-6vshe.6 removed. Pre-merge timing coverage stays the nightly attribution lane
-          # (bench-ec2.yml), which files a P1 `bench-regression` issue into the dispatch frontier.
+          # [FABLE-5] fail-on-alert is now FALSE — the HARD zone moved to the deterministic
+          # median-of-history gate below (scripts/bench_hardzone.py). The action's fail-on-alert
+          # compared each metric against the SINGLE previous benchmark-data point, so one slow-runner
+          # environment shift flipped 9+ unrelated µs-scale metrics uniformly ~1.8-2.1x "worse" and
+          # hard-failed main pushes while interleaved pushes stayed green (live flap over 24h: red at
+          # runs like 29988505852 between green runs, 2026-07-22/23) — the two-zone calibration's own
+          # worst-observed noise swing (185.0%, below) was exceeded by pure runner variance. The
+          # bench_hardzone.py step keeps a HARD gate on main pushes, but against the MEDIAN of the
+          # last up-to-5 published points (a single-point environment shift cannot move a median-of-5)
+          # with a uniform-shift exemption (an across-the-board ratio shift = runner environment,
+          # never a real code regression in every unrelated metric at once).
           # DERIVATION (no hard-coded perf numbers in markdown — the numbers live here + are recomputable):
-          #   scripts/bench-thresholds.py recomputes both from the benchmark-data history; over 20
-          #   commits × 322 timing metrics (6137 adjacent-pair samples) the pooled p95 run-to-run swing
-          #   was 43.66% and the worst 185.0%; deterministic byte-count metrics are 0.00% noise. Re-run
-          #   that script and refresh these two values if the noise floor shifts.
+          #   scripts/bench-thresholds.py recomputes the soft threshold from the benchmark-data
+          #   history; over 20 commits × 322 timing metrics (6137 adjacent-pair samples) the pooled
+          #   p95 run-to-run swing was 43.66% and the worst 185.0%; deterministic byte-count metrics
+          #   are 0.00% noise. Re-run that script and refresh if the noise floor shifts.
           # The DETERMINISTIC byte-count ratchet remains the strict, separate "Hard gate" step ABOVE
-          # (scripts/perf-gate.py) — this action's zones govern only the NOISY timing metrics.
+          # (scripts/perf-gate.py) — the zones here govern only the NOISY timing metrics.
           # NO alert-comment-cc-users: the maintainer is never @-mentioned; soft-zone flakiness routes
-          # to a deduped issue and hard-zone timing failures block the run for an agent to fix.
+          # to a deduped issue and hard-zone regressions fail the median gate for an agent to fix.
           alert-threshold: '175%'
-          fail-threshold: '200%'
           comment-on-alert: true
-          fail-on-alert: true
+          fail-on-alert: false
+      # [FABLE-5] HARD zone — deterministic median-of-history regression gate (replaces the action's
+      # single-previous-point fail-on-alert, which flapped on runner environment shifts; see the
+      # fail-on-alert comment above). scripts/bench_hardzone.py compares each metric in THIS run's
+      # bench-results.json against the MEDIAN of its last up-to-5 published points in prev-data.js
+      # (fetched from the benchmark-data branch by the "Fetch previous benchmark series" step above;
+      # absent history = warn + pass, first-run safe). It FAILS only if a metric is >= 2.0x its
+      # median — a sustained real regression still hard-fails, while a one-off slow-runner point
+      # cannot move a median-of-5 — and it EXEMPTS (loud warning, exit 0) a uniform environment
+      # shift where >= 50% of all compared metrics are simultaneously >= 1.75x median (an
+      # across-the-board shift is the runner, never a real code regression in every unrelated
+      # metric at once). Everything >= 1.75x median is printed as a table either way.
+      # Guarded to the SAME main-push condition as auto-push: PR runs are `--deterministic-only`
+      # and already strictly gated by perf-gate.py above, and the nightly `schedule` backstop is a
+      # pure verification run — so PR + schedule behavior is unchanged by this step.
+      # The script self-tests first (repo convention: hermetic --self-test over inline fixtures).
+      - name: Hard zone — median-of-history regression gate (main pushes only)
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          python3 scripts/bench_hardzone.py --self-test
+          python3 scripts/bench_hardzone.py \
+            --results bench-results.json \
+            --prev-data prev-data.js \
+            --suite 'sparq engine'
       # [OPUS-4.8] SOFT-ZONE triage (noise-reduction-bench-selfmonitor). Runs AFTER the action —
-      # `if: always()` so it still fires when the action HARD-FAILED (hard zone) above; it re-derives
+      # `if: always()` so it still fires when the hard-zone gate above FAILED; it re-derives
       # the two zones from the SAME thresholds and files/updates a deduped `bench-flake` GitHub issue
       # for any SOFT-zone metric (>=175% and <200%), with NO @mention of anyone. It NEVER weakens the
-      # hard gate: the action's own fail-on-alert already failed the step for the hard zone; this step
+      # hard gate: the median-of-history gate above ([FABLE-5] scripts/bench_hardzone.py) owns the
+      # hard-zone failure; this step
       # only handles the soft (possible-flakiness) band and always exits 0 (its filing is best-effort).
       # Canonical repo only — fork PRs get a read-only token, so no issue can be filed there.
       - name: Soft-zone triage (file a deduped bench-flake issue; no @mentions)

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -474,6 +474,43 @@ jobs:
               benchmark-data:benchmark-data
             echo "Created and pushed orphan benchmark-data branch."
           fi
+      # [FABLE-5] HARD zone — deterministic median-of-history regression gate (replaces the action's
+      # single-previous-point fail-on-alert, which flapped on runner environment shifts; see the
+      # fail-on-alert comment on the Store step below). scripts/bench_hardzone.py compares each
+      # metric in THIS run's bench-results.json against the MEDIAN of its last up-to-5 published
+      # VALUES in prev-data.js (fetched by the "Fetch previous benchmark series" step above; absent
+      # history = warn + pass, first-run safe). It FAILS if a gated metric is >= 2.0x its median
+      # (direction-adjusted: `*_per_s` throughput is larger-is-better), fails CLOSED on
+      # NaN/non-numeric/negative/zero-boundary measurements and on >30% of gated metrics
+      # disappearing, and EXEMPTS a runner-environment scaling ONLY when four conditions ALL hold
+      # (>=50% of compared metrics >=1.75x AND their ratios uniform (cv<=0.15) AND nothing >=4x
+      # AND every deterministic byte/count metric within 1% of median) — see the script header for
+      # why those four make a masked code regression implausible, not impossible (hence the loud
+      # warning + table, never a quiet pass).
+      #
+      # ORDERING ([FABLE-5] round-1 review): this step runs BEFORE the Store step DELIBERATELY.
+      # Store auto-pushes this run's point into the benchmark-data history (main pushes), so if the
+      # gate ran after it, a REJECTED regression would already be published — and after a few red
+      # runs the regressed points would BECOME the median, silently re-baselining the gate. Gating
+      # first means a hard-zone failure publishes NOTHING. There is no data dependency on Store:
+      # both inputs (bench-results.json, prev-data.js) exist before it. CONSEQUENCE: on a hard-zone
+      # failure the run publishes nothing and Store's comparison comment/summary never fires — so
+      # the script prints its own per-metric table to stdout AND to GITHUB_STEP_SUMMARY; that table
+      # is the only visible evidence of what tripped.
+      #
+      # Guarded to the SAME main-push condition as auto-push: PR runs are `--deterministic-only`
+      # and already strictly gated by perf-gate.py above, and the nightly `schedule` backstop is a
+      # pure verification run — so PR + schedule behavior is unchanged by this step.
+      # The script self-tests first (repo convention: hermetic --self-test over inline fixtures).
+      - name: Hard zone — median-of-history regression gate (main pushes only)
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          python3 scripts/bench_hardzone.py --self-test
+          python3 scripts/bench_hardzone.py \
+            --results bench-results.json \
+            --prev-data prev-data.js \
+            --suite 'sparq engine'
       # [OPUS-4.8] sq-owci — clean the working tree before github-action-benchmark switches branches.
       # ROOT CAUSE: the "Run benchmarks" step (scripts/ci-bench.sh) does `cd bench/zk && cargo bench`
       # and `cd bench/zk-trace && cargo bench` (two STANDALONE cargo projects, run WITHOUT --locked),
@@ -497,23 +534,38 @@ jobs:
       # untouched, and the run outputs the later steps read (bench-results.json, prev-data.js) are
       # UNtracked and left intact. Hence: no `if:` — this cleanup always runs.
       #
-      # FIX MECHANICS: restore exactly the TRACKED files the build/bench dirtied, so the action's
-      # branch switch is clean. `git checkout --` only touches tracked paths. Enumerating via
-      # `git diff --name-only` (tracked-modified only) future-proofs this against any other lockfile
-      # a future bench may rewrite.
+      # FIX MECHANICS ([FABLE-5] round-1 review): ALLOW-LIST restore, not `git checkout -- .`.
+      # The ONLY tracked churn this bench run is known to induce is the bench/**/Cargo.lock
+      # re-resolve (bench/zk + bench/zk-trace today; the glob future-proofs any standalone bench
+      # project a future suite adds). Exactly those paths are restored; if ANY OTHER tracked path
+      # is dirty, that is unknown churn — something wrote to the checkout that nothing should
+      # write to — so the step prints the paths and FAILS loudly instead of silently discarding
+      # evidence. Untracked run outputs (bench-results.json, prev-data.js) are never touched.
       - name: Clean bench-induced tracked churn before history switch
         run: |
           set -euo pipefail
           dirty="$(git diff --name-only)"
-          if [ -n "$dirty" ]; then
-            echo "Restoring tracked files the benchmark run modified (incidental Cargo.lock re-resolve):"
-            while IFS= read -r f; do echo "  $f"; done <<< "$dirty"
-            # Restore ALL tracked modifications. `git checkout -- .` only rewrites TRACKED paths,
-            # so the untracked run outputs the next step reads (bench-results.json, prev-data.js)
-            # are left intact — and it is whitespace-safe (no word-splitting of the path list).
-            git checkout -- .
-          else
+          if [ -z "$dirty" ]; then
             echo "Working tree clean — no tracked churn to restore."
+          else
+            unknown=0
+            while IFS= read -r f; do
+              case "$f" in
+                bench/*/Cargo.lock)
+                  echo "Restoring known bench-induced churn: $f"
+                  git checkout -- "$f"
+                  ;;
+                *)
+                  echo "::error title=unknown tracked churn::'$f' is modified but is NOT known bench-induced churn (bench/**/Cargo.lock) — refusing to discard it."
+                  unknown=1
+                  ;;
+              esac
+            done <<< "$dirty"
+            if [ "$unknown" = "1" ]; then
+              echo "::error::Unknown tracked modifications after the bench run (listed above). Unknown churn means something unexpected wrote to tracked paths — investigate; this step never silently discards it."
+              git status --porcelain
+              exit 1
+            fi
           fi
           git status --porcelain
       - name: Store + compare against history
@@ -560,16 +612,19 @@ jobs:
           #     deduped `bench-flake` issue for it — NO @mention of anyone). 175% ≈ p95 run-to-run
           #     timing swing (43.66%) + ~30pp headroom.
           # [FABLE-5] fail-on-alert is now FALSE — the HARD zone moved to the deterministic
-          # median-of-history gate below (scripts/bench_hardzone.py). The action's fail-on-alert
-          # compared each metric against the SINGLE previous benchmark-data point, so one slow-runner
-          # environment shift flipped 9+ unrelated µs-scale metrics uniformly ~1.8-2.1x "worse" and
-          # hard-failed main pushes while interleaved pushes stayed green (live flap over 24h: red at
-          # runs like 29988505852 between green runs, 2026-07-22/23) — the two-zone calibration's own
-          # worst-observed noise swing (185.0%, below) was exceeded by pure runner variance. The
-          # bench_hardzone.py step keeps a HARD gate on main pushes, but against the MEDIAN of the
-          # last up-to-5 published points (a single-point environment shift cannot move a median-of-5)
-          # with a uniform-shift exemption (an across-the-board ratio shift = runner environment,
-          # never a real code regression in every unrelated metric at once).
+          # median-of-history gate ABOVE (scripts/bench_hardzone.py, which runs BEFORE this Store
+          # step so a rejected regression is never auto-pushed into the history it is judged by).
+          # The action's fail-on-alert compared each metric against the SINGLE previous
+          # benchmark-data point, so one slow-runner environment shift flipped 9+ unrelated
+          # µs-scale metrics uniformly ~1.8-2.1x "worse" and hard-failed main pushes while
+          # interleaved pushes stayed green (live flap over 24h: red at runs like 29988505852
+          # between green runs, 2026-07-22/23) — the two-zone calibration's own worst-observed
+          # noise swing (185.0%, below) was exceeded by pure runner variance. The bench_hardzone.py
+          # step keeps a HARD gate on main pushes, but against the MEDIAN of each metric's last
+          # up-to-5 published values (a single-point environment shift cannot move a median-of-5),
+          # with a four-condition uniform-shift exemption (breadth + ratio uniformity + a 4x cap +
+          # deterministic metrics unmoved — conditions that make a MASKED code regression
+          # implausible, not impossible, so the exemption always warns loudly with a full table).
           # DERIVATION (no hard-coded perf numbers in markdown — the numbers live here + are recomputable):
           #   scripts/bench-thresholds.py recomputes the soft threshold from the benchmark-data
           #   history; over 20 commits × 322 timing metrics (6137 adjacent-pair samples) the pooled
@@ -582,30 +637,6 @@ jobs:
           alert-threshold: '175%'
           comment-on-alert: true
           fail-on-alert: false
-      # [FABLE-5] HARD zone — deterministic median-of-history regression gate (replaces the action's
-      # single-previous-point fail-on-alert, which flapped on runner environment shifts; see the
-      # fail-on-alert comment above). scripts/bench_hardzone.py compares each metric in THIS run's
-      # bench-results.json against the MEDIAN of its last up-to-5 published points in prev-data.js
-      # (fetched from the benchmark-data branch by the "Fetch previous benchmark series" step above;
-      # absent history = warn + pass, first-run safe). It FAILS only if a metric is >= 2.0x its
-      # median — a sustained real regression still hard-fails, while a one-off slow-runner point
-      # cannot move a median-of-5 — and it EXEMPTS (loud warning, exit 0) a uniform environment
-      # shift where >= 50% of all compared metrics are simultaneously >= 1.75x median (an
-      # across-the-board shift is the runner, never a real code regression in every unrelated
-      # metric at once). Everything >= 1.75x median is printed as a table either way.
-      # Guarded to the SAME main-push condition as auto-push: PR runs are `--deterministic-only`
-      # and already strictly gated by perf-gate.py above, and the nightly `schedule` backstop is a
-      # pure verification run — so PR + schedule behavior is unchanged by this step.
-      # The script self-tests first (repo convention: hermetic --self-test over inline fixtures).
-      - name: Hard zone — median-of-history regression gate (main pushes only)
-        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
-        run: |
-          set -euo pipefail
-          python3 scripts/bench_hardzone.py --self-test
-          python3 scripts/bench_hardzone.py \
-            --results bench-results.json \
-            --prev-data prev-data.js \
-            --suite 'sparq engine'
       # [OPUS-4.8] SOFT-ZONE triage (noise-reduction-bench-selfmonitor). Runs AFTER the action —
       # `if: always()` so it still fires when the hard-zone gate above FAILED; it re-derives
       # the two zones from the SAME thresholds and files/updates a deduped `bench-flake` GitHub issue

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -75,9 +75,15 @@ jobs:
   # 29990467905 — ORCHESTRATOR_APP_ID empty, HAVE_APP_TOKEN=false, hygiene-only mode), so there is
   # no working token to switch to. Instead: (1) the job name now contains the whole word
   # "advisory", which ci-summary's `\b(advisory|informational)\b` name rule excludes from the
-  # gating set; (2) the KNOWN 403 (PR-creation setting disabled) is tolerated loudly — a
-  # `::warning` naming the needed setting, exit 0 — while ANY OTHER failure still fails the (now
-  # advisory) job, never silently swallowed. DURABLE FIX (maintainer): enable
+  # gating set (registered in .github/advisory-registry.json; owner bead sq-lonae); (2) the KNOWN
+  # 403 (PR-creation setting disabled) is tolerated loudly — a `::warning` naming the needed
+  # setting, exit 0 — but ONLY when BOTH the CAPTURED release-plz output matches the exact
+  # blocked-PR-creation signature (Failed to open PR + 403 on the /pulls URL) AND a
+  # side-effect-free live probe of the same call returns 403 ([FABLE-5] round-1 review:
+  # signature + probe together, so a coincidental 403 — e.g. a secondary-rate-limit response to
+  # the probe — can never launder an unrelated failure, and a non-403 real error with a flaky
+  # probe can never be swallowed). ANY OTHER failure still fails the (now advisory) job, never
+  # silently swallowed. DURABLE FIX (maintainer): enable
   # Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"
   # (or configure the ORCHESTRATOR_APP secrets and switch this job's token to a minted App token).
   release-plz-pr:
@@ -107,36 +113,75 @@ jobs:
         run: |
           rustup default stable
           rustup show active-toolchain
-      # [OPUS-4.8] sq-v286.4: official release-plz action, SHA-pinned (code-scanning=0;
-      # the repo SHA-pins ALL actions). v0.5.130 — pin verified to peel to this commit via
-      # `gh api repos/release-plz/action/git/tags/<annotated> --jq .object.sha`.
-      - name: Run release-plz (open/update Release-PR)
-        id: releasepr
-        # [FABLE-5] continue-on-error so the containment step below can classify the failure:
-        # the KNOWN 403 (Actions PR-creation setting disabled) is tolerated with a ::warning;
-        # anything else re-fails the job. See the job-level comment.
-        continue-on-error: true
-        uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
+      # [FABLE-5] round-1 review: the release-pr invocation moved OUT of the composite
+      # release-plz/action into a direct `run:` step, because the containment below must classify
+      # the failure from release-plz's CAPTURED output — and a `uses:` step's output cannot be
+      # tee'd. The tools are installed with the SAME taiki-e/install-action SHA pin the repo uses
+      # everywhere (v2.83.4; explicit `with: tool:` per sq-ur7o), at the SAME versions the pinned
+      # release-plz/action v0.5.131 installs internally (release-plz@0.3.160 via binstall,
+      # cargo-semver-checks@0.48 — release-plz shells out to it for API-break detection), so the
+      # behavior is unchanged; only the invocation is now wrapped and captured. The unchanged
+      # `release` job below still uses the pinned release-plz/action (no containment needed there).
+      - name: Install release-plz + cargo-semver-checks (pinned)
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
-          command: release-pr
+          tool: release-plz@0.3.160,cargo-semver-checks@0.48
+      - name: Run release-plz release-pr (output captured for failure classification)
+        id: releasepr
+        # continue-on-error so the containment step below can classify the failure from the
+        # captured log: the KNOWN 403 (Actions PR-creation setting disabled) is tolerated with a
+        # ::warning; anything else re-fails the job. See the job-level comment.
+        continue-on-error: true
         env:
           # GITHUB_TOKEN is what release-plz uses to open/update the Release-PR.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # The commit ident the release-plz/action's git-config sub-action would set for
+          # GITHUB_TOKEN (release-plz commits the version bump onto the Release-PR branch).
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # Same invocation the pinned action's release-pr branch runs; 2>&1 | tee captures
+          # BOTH streams (release-plz logs errors to stderr) for the containment step.
+          release-plz release-pr \
+            --git-token "${GITHUB_TOKEN}" \
+            --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
+            -o json 2>&1 | tee /tmp/release-plz-pr.log
+          exit "${PIPESTATUS[0]}"
       # [FABLE-5] Classify a release-plz failure: tolerate ONLY the known 403 (repo setting
       # "Allow GitHub Actions to create and approve pull requests" disabled — live: run
-      # 29988505600). The probe below deterministically reproduces the exact call release-plz
-      # failed on (POST /repos/:repo/pulls with this job's GITHUB_TOKEN) WITHOUT side effects:
-      # head==base is invalid, so a token PERMITTED to create PRs gets 422 Validation Failed and
-      # no PR is ever created, while a token blocked by the Actions PR-creation setting gets the
-      # same 403 release-plz hit (the authorization check precedes body validation). 403 =>
-      # loud ::warning + exit 0; anything else => the failure was NOT the known blocked-setting
-      # condition, so fail the (advisory) job — never silently swallow a different error.
+      # 29988505600), established by TWO independent conditions that must BOTH hold
+      # (round-1 review — the probe alone could misclassify e.g. a rate-limit 403):
+      #   (a) SIGNATURE — the captured release-plz output contains a "Failed to open PR" line
+      #       carrying a 403 on the POST /repos/:repo/pulls URL (the exact live failure shape);
+      #   (b) PROBE — re-running the same call NOW with this job's GITHUB_TOKEN returns 403.
+      #       The probe is side-effect-free: head==base is invalid, so a token PERMITTED to
+      #       create PRs gets 422 Validation Failed and no PR is ever created, while a token
+      #       blocked by the Actions PR-creation setting gets the same 403 release-plz hit
+      #       (the authorization check precedes body validation).
+      # (a)+(b) => loud ::warning + exit 0. Anything else — signature mismatch (a different
+      # release-plz error, even if the probe happens to 403), or a non-403 probe — keeps the
+      # failure a real failure of this (advisory) job. Never silently swallow a different error.
       - name: Contain the known 403 (Actions PR-creation setting disabled)
         if: steps.releasepr.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          log=/tmp/release-plz-pr.log
+          if [ ! -s "$log" ]; then
+            echo "::error::release-plz release-pr failed but left no captured output at $log — cannot classify the failure; treating as a real failure."
+            exit 1
+          fi
+          # (a) SIGNATURE: a single line must carry all three markers — "Failed to open PR",
+          # a 403, and the POST /pulls URL for THIS repo. grep -F for the URL (dots literal).
+          if ! grep "Failed to open PR" "$log" | grep -F "403" | grep -Fq "api.github.com/repos/${GITHUB_REPOSITORY}/pulls"; then
+            echo "::error::release-plz release-pr failed, but the captured output does NOT match the known blocked-PR-creation signature (a 'Failed to open PR' line with a 403 on api.github.com/repos/${GITHUB_REPOSITORY}/pulls) — this is a DIFFERENT, real failure (even if a 403 probe would succeed, e.g. rate limiting). Captured output follows."
+            sed 's/^/  | /' "$log"
+            exit 1
+          fi
+          echo "captured output matches the known blocked-PR-creation signature; probing the live call."
+          # (b) PROBE: the same POST /pulls with this job's token, side-effect-free (head==base).
           code=$(curl -sS -o /tmp/rp-probe.json -w '%{http_code}' -X POST \
             -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "Accept: application/vnd.github+json" \
@@ -144,10 +189,10 @@ jobs:
             -d '{"title":"release-plz 403 probe (never created: head==base is invalid)","head":"main","base":"main"}')
           echo "PR-creation probe HTTP status: ${code}"
           if [ "${code}" = "403" ]; then
-            echo "::warning title=release-plz Release-PR blocked by repo setting::GITHUB_TOKEN cannot create pull requests: the repo/org setting 'Settings → Actions → General → Allow GitHub Actions to create and approve pull requests' is disabled, so the Release-PR was NOT opened (known condition; tolerated as advisory). Durable fix: a maintainer enables that setting, or configures the ORCHESTRATOR_APP_ID/_PRIVATE_KEY App secrets and switches this job's token to a minted App token (batch-merge.yml pattern), which bypasses the setting."
+            echo "::warning title=release-plz Release-PR blocked by repo setting::GITHUB_TOKEN cannot create pull requests: the repo/org setting 'Settings → Actions → General → Allow GitHub Actions to create and approve pull requests' is disabled, so the Release-PR was NOT opened (known condition, established by captured-output signature + live probe; tolerated as advisory). Durable fix: a maintainer enables that setting, or configures the ORCHESTRATOR_APP_ID/_PRIVATE_KEY App secrets and switches this job's token to a minted App token (batch-merge.yml pattern), which bypasses the setting."
             exit 0
           fi
-          echo "::error::release-plz release-pr failed, and the PR-creation probe returned HTTP ${code} (not the known 403 blocked-setting condition) — this is a DIFFERENT, real failure. See the 'Run release-plz' step log above. Probe response body follows."
+          echo "::error::release-plz release-pr failed with the blocked-PR-creation signature in its output, but the live PR-creation probe returned HTTP ${code} (not 403) — the blocked-setting condition is not reproducible right now, so this is treated as a real failure. Probe response body follows."
           cat /tmp/rp-probe.json || true
           exit 1
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -64,8 +64,24 @@ concurrency:
 
 jobs:
   # ---- 1. Release-PR: open/update the version-bump + changelog PR on every push to main.
+  #
+  # [FABLE-5] ADVISORY + 403 containment. The repo/org setting "Allow GitHub Actions to create
+  # and approve pull requests" is DISABLED, so GITHUB_TOKEN cannot create PRs: every main push
+  # failed with `ERROR Failed to open PR ... HTTP status client error (403 Forbidden) for url
+  # (https://api.github.com/repos/sparq-org/sparq/pulls)` (live: run 29988505600), and the old
+  # job name carried no "advisory" token, so the failure GATED the ci-summary `gate` red on main.
+  # The in-repo App-token pattern (ORCHESTRATOR_APP_ID / create-github-app-token, batch-merge.yml)
+  # would bypass that setting, but the App secrets are NOT configured (live: batch-merge run
+  # 29990467905 — ORCHESTRATOR_APP_ID empty, HAVE_APP_TOKEN=false, hygiene-only mode), so there is
+  # no working token to switch to. Instead: (1) the job name now contains the whole word
+  # "advisory", which ci-summary's `\b(advisory|informational)\b` name rule excludes from the
+  # gating set; (2) the KNOWN 403 (PR-creation setting disabled) is tolerated loudly — a
+  # `::warning` naming the needed setting, exit 0 — while ANY OTHER failure still fails the (now
+  # advisory) job, never silently swallowed. DURABLE FIX (maintainer): enable
+  # Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"
+  # (or configure the ORCHESTRATOR_APP secrets and switch this job's token to a minted App token).
   release-plz-pr:
-    name: release-plz / Release-PR
+    name: release-plz / Release-PR (advisory)
     # Guard against forks: release-plz needs repo write + would open PRs on a fork clone.
     # Mirrors bench-ec2.yml's `github.repository == 'sparq-org/sparq'` guard.
     if: github.repository == 'sparq-org/sparq'
@@ -95,12 +111,45 @@ jobs:
       # the repo SHA-pins ALL actions). v0.5.130 — pin verified to peel to this commit via
       # `gh api repos/release-plz/action/git/tags/<annotated> --jq .object.sha`.
       - name: Run release-plz (open/update Release-PR)
+        id: releasepr
+        # [FABLE-5] continue-on-error so the containment step below can classify the failure:
+        # the KNOWN 403 (Actions PR-creation setting disabled) is tolerated with a ::warning;
+        # anything else re-fails the job. See the job-level comment.
+        continue-on-error: true
         uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release-pr
         env:
           # GITHUB_TOKEN is what release-plz uses to open/update the Release-PR.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # [FABLE-5] Classify a release-plz failure: tolerate ONLY the known 403 (repo setting
+      # "Allow GitHub Actions to create and approve pull requests" disabled — live: run
+      # 29988505600). The probe below deterministically reproduces the exact call release-plz
+      # failed on (POST /repos/:repo/pulls with this job's GITHUB_TOKEN) WITHOUT side effects:
+      # head==base is invalid, so a token PERMITTED to create PRs gets 422 Validation Failed and
+      # no PR is ever created, while a token blocked by the Actions PR-creation setting gets the
+      # same 403 release-plz hit (the authorization check precedes body validation). 403 =>
+      # loud ::warning + exit 0; anything else => the failure was NOT the known blocked-setting
+      # condition, so fail the (advisory) job — never silently swallow a different error.
+      - name: Contain the known 403 (Actions PR-creation setting disabled)
+        if: steps.releasepr.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /tmp/rp-probe.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls" \
+            -d '{"title":"release-plz 403 probe (never created: head==base is invalid)","head":"main","base":"main"}')
+          echo "PR-creation probe HTTP status: ${code}"
+          if [ "${code}" = "403" ]; then
+            echo "::warning title=release-plz Release-PR blocked by repo setting::GITHUB_TOKEN cannot create pull requests: the repo/org setting 'Settings → Actions → General → Allow GitHub Actions to create and approve pull requests' is disabled, so the Release-PR was NOT opened (known condition; tolerated as advisory). Durable fix: a maintainer enables that setting, or configures the ORCHESTRATOR_APP_ID/_PRIVATE_KEY App secrets and switches this job's token to a minted App token (batch-merge.yml pattern), which bypasses the setting."
+            exit 0
+          fi
+          echo "::error::release-plz release-pr failed, and the PR-creation probe returned HTTP ${code} (not the known 403 blocked-setting condition) — this is a DIFFERENT, real failure. See the 'Run release-plz' step log above. Probe response body follows."
+          cat /tmp/rp-probe.json || true
+          exit 1
 
   # ---- 2. release: when the Release-PR's version commit is on main, create the v<version>
   #         git tag. That tag fires the EXISTING release.yml (push: tags: ["v*"]) which does

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# [FABLE-5] Hard-zone benchmark gate — median-of-history regression check (bench.yml, main pushes).
+#
+# WHY — github-action-benchmark's fail-on-alert compares each metric against the SINGLE previous
+# benchmark-data point. On shared GitHub-hosted runners a one-off slow-runner environment shift
+# flips many unrelated µs-scale timing metrics uniformly "worse" and hard-fails the run, while the
+# very next push (back on a normal runner) goes green — a noise flap, not a regression signal
+# (live 24h flap on main pushes 2026-07-22/23, e.g. red run 29988505852 between green neighbours).
+# This script replaces that single-point hard zone with a deterministic MEDIAN-OF-HISTORY gate:
+#
+#   * Per metric, take the MEDIAN of its last up-to-HISTORY_WINDOW (5) published points from the
+#     benchmark-data history (the dev/bench/data.js the workflow already fetched as prev-data.js).
+#     A single slow-runner point cannot move a median-of-5, so a one-off environment shift no
+#     longer reds main — while a REAL regression (the current run sustained above its history)
+#     still hard-fails.
+#   * HARD FAIL (exit 1) only if any compared metric is >= HARD_RATIO (2.0x) its median.
+#   * UNIFORM-SHIFT EXEMPTION (exit 0 + loud warning): if >= UNIFORM_FRACTION (50%) of ALL
+#     compared metrics are simultaneously >= WATCH_RATIO (1.75x) median, the whole run is a
+#     runner-environment shift — a real code regression never degrades every unrelated metric
+#     across every suite at once — so the gate refuses to red main on it (it warns loudly instead;
+#     the soft-zone triage step files the bench-flake issue).
+#   * TRANSPARENCY: every metric >= WATCH_RATIO (1.75x) median is printed as a table either way.
+#   * ABSENT HISTORY (no prev-data.js / empty series / no overlapping metrics): warn + exit 0
+#     (first-run safe; nothing to compare is not a failure).
+#
+# The DETERMINISTIC byte-count metrics stay strictly gated by scripts/perf-gate.py (the committed
+# best-ever floor ratchet) — this gate is the noisy-timing hard zone only, and it runs ONLY where
+# the Store step auto-pushes (push-to-main), so PR behavior is unchanged.
+#
+# USAGE
+#   scripts/bench_hardzone.py --results bench-results.json --prev-data prev-data.js \
+#       --suite 'sparq engine'
+#   scripts/bench_hardzone.py --self-test          # hermetic; no network, no git, no writes
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from pathlib import Path
+
+PROG = "bench-hardzone"
+
+HARD_RATIO = 2.0        # >= 2.0x median => hard fail (unless the uniform-shift exemption fires)
+WATCH_RATIO = 1.75      # >= 1.75x median => printed in the watch table; feeds the uniform check
+UNIFORM_FRACTION = 0.5  # >= 50% of compared metrics in the watch band => environment shift, exempt
+HISTORY_WINDOW = 5      # median over the last up-to-5 published points per metric
+
+
+def log(msg: str) -> None:
+    print(f"[{PROG}] {msg}", file=sys.stderr)
+
+
+def parse_data_js(text: str) -> dict:
+    """Parse a github-action-benchmark data.js payload (window.BENCHMARK_DATA = {...};)."""
+    m = re.search(r"window\.BENCHMARK_DATA\s*=\s*", text)
+    if m:
+        text = text[m.end():]
+    text = text.strip().rstrip(";").strip()
+    return json.loads(text)
+
+
+def history_values(series: list[dict], window: int = HISTORY_WINDOW) -> dict[str, list[float]]:
+    """Per-metric values from the last up-to-`window` entries of a benchmark-data series.
+
+    `series` is entries[suite] from data.js: a list of {commit, date, benches:[{name,value,..}]}.
+    Entries are ordered by date; only the most recent `window` entries contribute. A metric absent
+    from some of those entries simply contributes fewer points (median over what exists).
+    """
+    ordered = sorted(series, key=lambda e: e.get("date", 0))[-window:]
+    vals: dict[str, list[float]] = {}
+    for entry in ordered:
+        for b in entry.get("benches", []):
+            name = b.get("name")
+            v = b.get("value")
+            if name is not None and isinstance(v, (int, float)):
+                vals.setdefault(name, []).append(float(v))
+    return vals
+
+
+def evaluate(current: list[dict], hist: dict[str, list[float]]) -> tuple[int, dict]:
+    """Pure gate logic — unit-tested by --self-test.
+
+    `current` is this run's bench-results.json rows ({name,value,unit}); `hist` is the per-metric
+    history value lists (see history_values). Returns (exit_code, report) where report carries
+    {compared, watch: [(name, cur, median, n, ratio)...], hard: [...same...], uniform_shift}.
+    """
+    watch: list[tuple[str, float, float, int, float]] = []
+    hard: list[tuple[str, float, float, int, float]] = []
+    compared = 0
+    for row in current:
+        name = row.get("name")
+        val = row.get("value")
+        if name is None or not isinstance(val, (int, float)):
+            continue
+        past = hist.get(name)
+        if not past:
+            continue  # brand-new metric — no history to compare against
+        med = statistics.median(past)
+        if med <= 0:
+            continue  # cannot form a ratio (degenerate/zero baseline)
+        compared += 1
+        ratio = float(val) / med
+        entry = (name, float(val), med, len(past), ratio)
+        if ratio >= WATCH_RATIO:
+            watch.append(entry)
+        if ratio >= HARD_RATIO:
+            hard.append(entry)
+    if compared == 0:
+        log("no overlapping metrics with history — nothing to compare; passing.")
+        return 0, {"compared": 0, "watch": [], "hard": [], "uniform_shift": False}
+    if watch:
+        log(f"metrics >= {WATCH_RATIO}x their median of the last {HISTORY_WINDOW} points "
+            f"({len(watch)}/{compared} compared):")
+        log(f"  {'metric':<60} {'current':>14} {'median(n)':>18} {'ratio':>7}")
+        for name, cur, med, n, ratio in sorted(watch, key=lambda t: -t[4]):
+            log(f"  {name:<60} {cur:>14.4g} {med:>13.4g}(n={n}) {ratio:>6.2f}x")
+    uniform = len(watch) / compared >= UNIFORM_FRACTION
+    if uniform:
+        # An across-the-board shift is the runner environment, never a real code regression in
+        # every unrelated metric at once — refuse to red main on it, loudly.
+        print(f"::warning title=bench hard zone — uniform environment shift, not gating::"
+              f"{len(watch)} of {compared} compared metrics are >= {WATCH_RATIO}x their "
+              f"median-of-{HISTORY_WINDOW} history simultaneously. A uniform shift across "
+              f"unrelated metrics is a runner-environment change, not a code regression — "
+              f"NOT failing the run. See the per-metric table in the step log.")
+        return 0, {"compared": compared, "watch": watch, "hard": hard, "uniform_shift": True}
+    if hard:
+        for name, cur, med, n, ratio in hard:
+            print(f"::error title=bench hard zone::{name} is {ratio:.2f}x its "
+                  f"median-of-{n} history ({cur:.6g} vs median {med:.6g}) — at/above the "
+                  f"{HARD_RATIO}x hard threshold, and the shift is NOT uniform across metrics "
+                  f"(so it is not a runner-environment artifact). Treating as a real regression.")
+        return 1, {"compared": compared, "watch": watch, "hard": hard, "uniform_shift": False}
+    log(f"hard zone clean: {compared} metrics compared against their median-of-history; "
+        f"{len(watch)} in the watch band, none at/above {HARD_RATIO}x.")
+    return 0, {"compared": compared, "watch": watch, "hard": hard, "uniform_shift": False}
+
+
+def run_gate(results_path: str, prev_data_path: str, suite: str) -> int:
+    rp = Path(results_path)
+    if not rp.exists():
+        log(f"results file {results_path} is absent — nothing to gate; passing.")
+        return 0
+    current = json.loads(rp.read_text(encoding="utf-8"))
+    if not isinstance(current, list):
+        current = current.get("benches", [])
+    pp = Path(prev_data_path)
+    if not pp.exists():
+        print(f"::warning title=bench hard zone — no history::{prev_data_path} is absent "
+              f"(benchmark-data branch missing or empty — first run). Nothing to compare; passing.")
+        return 0
+    try:
+        data = parse_data_js(pp.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"::warning title=bench hard zone — unparsable history::could not parse "
+              f"{prev_data_path} ({e}); nothing to compare; passing.")
+        return 0
+    entries = data.get("entries", {})
+    series = entries.get(suite) or (next(iter(entries.values())) if entries else [])
+    if not series:
+        print(f"::warning title=bench hard zone — empty history::no published points for suite "
+              f"'{suite}' in {prev_data_path}; nothing to compare; passing.")
+        return 0
+    code, _report = evaluate(current, history_values(series))
+    return code
+
+
+# ── self-test (hermetic: inline fixtures; no network, no git, no writes) ─────────────────────────
+def _series(points: list[list[tuple[str, float]]]) -> list[dict]:
+    """Build a data.js-shaped series from [[(name, value), ...] per commit] (oldest first)."""
+    return [
+        {"date": i, "benches": [{"name": n, "value": v, "unit": "us"} for n, v in benches]}
+        for i, benches in enumerate(points)
+    ]
+
+
+def _cur(rows: list[tuple[str, float]]) -> list[dict]:
+    return [{"name": n, "value": v, "unit": "us"} for n, v in rows]
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(cond: bool, what: str) -> None:
+        if cond:
+            log(f"self-test ok: {what}")
+        else:
+            failures.append(what)
+            log(f"self-test FAIL: {what}")
+
+    # 1. median computation: window trims to the last 5 points; median over what remains.
+    hist = history_values(_series([[("m", 100.0)], [("m", 1.0)], [("m", 2.0)], [("m", 3.0)],
+                                   [("m", 4.0)], [("m", 5.0)]]))
+    check(hist["m"] == [1.0, 2.0, 3.0, 4.0, 5.0], "history window keeps only the last 5 points")
+    check(statistics.median(hist["m"]) == 3.0, "median of 5-point history is the middle point")
+    hist_even = history_values(_series([[("m", 1.0)], [("m", 2.0)], [("m", 3.0)], [("m", 8.0)]]))
+    check(statistics.median(hist_even["m"]) == 2.5, "median of an even count averages the middle two")
+    # A single outlier point cannot move a median-of-5 into failing territory.
+    hist_outlier = history_values(_series([[("m", 10.0)], [("m", 10.0)], [("m", 10.0)],
+                                           [("m", 10.0)], [("m", 30.0)]]))
+    code, rep = evaluate(_cur([("m", 15.0)]), history_values(
+        _series([[("m", 10.0)], [("m", 10.0)], [("m", 10.0)], [("m", 10.0)], [("m", 30.0)]])))
+    check(statistics.median(hist_outlier["m"]) == 10.0 and code == 0 and not rep["hard"],
+          "single outlier history point does not move the median (1.5x vs median passes)")
+
+    # 2. absent history: no overlapping metrics => pass (exit 0), nothing compared.
+    code, rep = evaluate(_cur([("new_metric", 42.0)]), {})
+    check(code == 0 and rep["compared"] == 0, "absent history passes with nothing compared")
+
+    # 3. uniform-shift exemption: >= 50% of compared metrics >= 1.75x median => exit 0, flagged.
+    series = _series([[("a", 10.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)]] * 5)
+    shifted = _cur([("a", 19.0), ("b", 19.5), ("c", 20.5), ("d", 11.0)])  # 3/4 >= 1.75x, 1 >= 2.0x
+    code, rep = evaluate(shifted, history_values(series))
+    check(code == 0 and rep["uniform_shift"] and len(rep["watch"]) == 3 and len(rep["hard"]) == 1,
+          "uniform environment shift (3/4 metrics >= 1.75x) is exempted despite a >= 2.0x metric")
+
+    # 4. single-metric hard fail: one metric >= 2.0x median, the rest normal => exit 1.
+    lone = _cur([("a", 21.0), ("b", 10.2), ("c", 9.9), ("d", 10.0)])  # only a regresses (2.1x)
+    code, rep = evaluate(lone, history_values(series))
+    check(code == 1 and not rep["uniform_shift"] and len(rep["hard"]) == 1
+          and rep["hard"][0][0] == "a",
+          "single sustained >= 2.0x regression hard-fails (no uniform exemption)")
+    # 4b. watch band alone (>= 1.75x but < 2.0x, minority of metrics) does NOT fail.
+    watch_only = _cur([("a", 18.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)])
+    code, rep = evaluate(watch_only, history_values(series))
+    check(code == 0 and len(rep["watch"]) == 1 and not rep["hard"],
+          "a lone watch-band metric (1.8x, < 2.0x) is reported but does not fail")
+
+    if failures:
+        log(f"self-test FAILED ({len(failures)}): " + "; ".join(failures))
+        return 1
+    log("self-test OK")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if "--self-test" in argv:
+        return self_test()
+    ap = argparse.ArgumentParser(prog=PROG, description=__doc__)
+    ap.add_argument("--results", required=True, help="this run's bench-results.json")
+    ap.add_argument("--prev-data", required=True,
+                    help="previously-published data.js (prev-data.js; absent => warn + pass)")
+    ap.add_argument("--suite", default="sparq engine", help="data.js entries suite name")
+    args = ap.parse_args(argv)
+    return run_gate(args.results, args.prev_data, args.suite)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -18,9 +18,13 @@
 #     pre-existing suite inconsistency this gate compensates for by inverting the ratio
 #     (median/current) for names matching `_per_s$`. (Candidate follow-up: store the inverse —
 #     seconds-per-triple — so the whole suite is genuinely smaller-is-better.)
-#   * FAIL-CLOSED NUMERICS: a current value or history window that is NaN/non-numeric/negative,
-#     or a value that crosses a zero boundary (current 0 vs positive median, or vice versa),
-#     HARD-FAILS with a per-metric message — never silently skipped. The one deliberate carve-out
+#   * FAIL-CLOSED NUMERICS: a current value or history-window value that is NaN/non-numeric/
+#     negative, or a value that crosses a zero boundary (current 0 vs positive median, or vice
+#     versa), HARD-FAILS with a per-metric message — never silently skipped. Current values are
+#     validated BEFORE the no-history / insufficient-history early exits (a bad current on a
+#     brand-new or young metric still fails the run), and every value inside a metric's median
+#     window is checked individually (a negative history point cannot hide behind a positive
+#     median). The one deliberate carve-out
 #     (grounded in the LIVE history): current == 0 AND median == 0 is a legitimate stable value —
 #     four published series are all-zero by design (geo_compliance_deficit, nlq_ask_repairs,
 #     rsp_*_w{2,3}_rows, and the sub-resolution sameas_size8_closure_s), so a blanket "<= 0 fails"
@@ -181,6 +185,18 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
 
     for name in sorted(current_by_name):
         row = current_by_name[name]
+        val = row.get("value")
+        unit = row.get("unit") or ""
+        # FAIL-CLOSED, pre-history: validate the current value BEFORE the no-history /
+        # insufficient-history early exits — a NaN/non-numeric/negative current on a brand-new
+        # or young metric must still fail the run, not slide out through "new"/"ungated".
+        if not _is_num(val):
+            invalid.append((name, f"current value {val!r} is not a finite number — fail-closed"))
+            continue
+        val = float(val)
+        if val < 0:
+            invalid.append((name, f"negative current measurement ({val:g}) — fail-closed"))
+            continue
         pts = hist.get(name)
         if not pts:
             new.append(name)
@@ -188,22 +204,16 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
         if len(pts) < MIN_HISTORY:
             ungated.append((name, len(pts)))
             continue
-        val = row.get("value")
-        unit = row.get("unit") or ""
-        if not _is_num(val):
-            invalid.append((name, f"current value {val!r} is not a finite number — fail-closed"))
-            continue
-        bad_hist = [p for p in pts if not _is_num(p)]
+        # FAIL-CLOSED, per-window value: every value inside the median window must itself be a
+        # finite non-negative number — a negative history point must not hide behind a positive
+        # median. Zeros stay legal here: the stable-zero carve-out below needs all-zero windows.
+        bad_hist = [p for p in pts if not _is_num(p) or p < 0]
         if bad_hist:
-            invalid.append((name, f"history window contains non-numeric value(s) {bad_hist!r} "
-                                  f"— fail-closed (published history is corrupt for this metric)"))
+            invalid.append((name, f"history window contains non-finite/negative value(s) "
+                                  f"{bad_hist!r} — fail-closed (published history is corrupt "
+                                  f"for this metric)"))
             continue
         med = float(statistics.median(pts))
-        val = float(val)
-        if val < 0 or med < 0:
-            invalid.append((name, f"negative measurement (current {val:g}, median {med:g}) "
-                                  f"— fail-closed"))
-            continue
         larger_better = bool(LARGER_IS_BETTER_RE.search(name))
         det = is_deterministic(name, unit)
         if val == 0 and med == 0:
@@ -533,6 +543,23 @@ def self_test() -> int:
                                        [("a", float("nan"))], [("a", 10.0)]]))
     code, rep = evaluate(_cur([("a", 10.0)]), bad_hist)
     check(code == 1 and len(rep["invalid"]) == 1, "NaN inside the history window fails closed")
+    #    Pre-history validation: a bad CURRENT value must fail even when the metric has no or
+    #    young history — never slide out through the "new"/"ungated" early exits.
+    code, rep = evaluate(_cur([("brandnew", float("nan"))]), {})
+    check(code == 1 and len(rep["invalid"]) == 1 and not rep["new"],
+          "NaN current on a NO-history metric fails closed (not silently listed as new)")
+    young_hist = history_values(_series([[("young", 10.0)], [("young", 10.0)]]))
+    code, rep = evaluate([{"name": "young", "value": "junk", "unit": "us"}], young_hist)
+    check(code == 1 and len(rep["invalid"]) == 1 and not rep["ungated"],
+          "non-numeric current on a young-history metric fails closed (not silently ungated)")
+    code, rep = evaluate(_cur([("fresh", -3.0)]), {})
+    check(code == 1 and len(rep["invalid"]) == 1 and not rep["new"],
+          "negative current on a no-history metric fails closed")
+    #    Per-window negativity: a negative history point must not hide behind a positive median.
+    neg_hist = history_values(_series([[("a", -1.0)], [("a", 10.0)], [("a", 10.0)]]))
+    code, rep = evaluate(_cur([("a", 10.0)]), neg_hist)
+    check(code == 1 and len(rep["invalid"]) == 1,
+          "negative history value inside the window fails closed despite a positive median")
     code, rep = evaluate(_cur([("a", 0.0)]), history_values(series))
     check(code == 1 and len(rep["invalid"]) == 1,
           "current 0 vs positive median is a zero-boundary change — fails closed")
@@ -586,12 +613,22 @@ def self_test() -> int:
           and any("(b) uniformity" in r for r in rep["exemption_reasons"]),
           "broad but NON-uniform shift (cv > 0.15) is NOT exempt — hard fail stands")
 
-    # 11. The 4x cap: broad + uniform-enough band, but one metric >= 4x => NOT exempt.
-    capped = _cur([("a", 19.0), ("b", 19.5), ("c", 41.0), ("d", 10.0)])  # c at 4.1x
+    # 11. The 4x cap ISOLATED: conditions (a) breadth, (b) uniformity and (d) deterministic all
+    #     PASS — ratios 4.05/4.1/4.08/4.06 put 4/4 metrics in the watch band with CV ~0.005 and
+    #     no deterministic metrics — so ONLY the cap (c) blocks the exemption. Removing the cap
+    #     from the predicate would flip exactly this check red.
+    capped = _cur([("a", 40.5), ("b", 41.0), ("c", 40.8), ("d", 40.6)])
     code, rep = evaluate(capped, history_values(series))
-    check(code == 1 and not rep["uniform_shift"]
-          and any("(c) cap" in r for r in rep["exemption_reasons"]),
-          "a >= 4x metric blocks the exemption — catastrophic regressions never hide in the herd")
+    check(code == 1 and not rep["uniform_shift"] and len(rep["hard"]) == 4
+          and len(rep["exemption_reasons"]) == 1
+          and "(c) cap" in rep["exemption_reasons"][0],
+          "a >= 4x metric is the SOLE exemption blocker ((a)/(b)/(d) pass) — hard fail stands")
+    #     Control: the SAME uniform shape kept below the cap (all ~1.9x) IS exempt — proving the
+    #     cap is the discriminating condition, not breadth/uniformity/deterministic drift.
+    under_cap = _cur([("a", 19.0), ("b", 19.5), ("c", 19.2), ("d", 19.1)])
+    code, rep = evaluate(under_cap, history_values(series))
+    check(code == 0 and rep["uniform_shift"] and not rep["exemption_reasons"],
+          "same uniform shape below the cap IS exempt — the 4x cap is the discriminating condition")
 
     # 12. Deterministic-metric drift blocks the exemption: same broad uniform timing shift, but a
     #     byte-count metric moved > 1% => NOT exempt => fail.

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -8,20 +8,54 @@
 # (live 24h flap on main pushes 2026-07-22/23, e.g. red run 29988505852 between green neighbours).
 # This script replaces that single-point hard zone with a deterministic MEDIAN-OF-HISTORY gate:
 #
-#   * Per metric, take the MEDIAN of its last up-to-HISTORY_WINDOW (5) published points from the
-#     benchmark-data history (the dev/bench/data.js the workflow already fetched as prev-data.js).
-#     A single slow-runner point cannot move a median-of-5, so a one-off environment shift no
-#     longer reds main — while a REAL regression (the current run sustained above its history)
-#     still hard-fails.
-#   * HARD FAIL (exit 1) only if any compared metric is >= HARD_RATIO (2.0x) its median.
-#   * UNIFORM-SHIFT EXEMPTION (exit 0 + loud warning): if >= UNIFORM_FRACTION (50%) of ALL
-#     compared metrics are simultaneously >= WATCH_RATIO (1.75x) median, the whole run is a
-#     runner-environment shift — a real code regression never degrades every unrelated metric
-#     across every suite at once — so the gate refuses to red main on it (it warns loudly instead;
-#     the soft-zone triage step files the bench-flake issue).
-#   * TRANSPARENCY: every metric >= WATCH_RATIO (1.75x) median is printed as a table either way.
-#   * ABSENT HISTORY (no prev-data.js / empty series / no overlapping metrics): warn + exit 0
-#     (first-run safe; nothing to compare is not a failure).
+#   * Per metric, take the MEDIAN of its last up-to-HISTORY_WINDOW (5) published VALUES — collected
+#     PER METRIC across the FULL retained history (the dev/bench/data.js the workflow already
+#     fetched as prev-data.js), NOT just the values inside the last 5 commits, so a sparse metric
+#     is never judged from a 1-point "median". A metric needs >= MIN_HISTORY (3) values to be
+#     gated at all; below that it is listed as "insufficient history — ungated".
+#   * DIRECTION: the suite is customSmallerIsBetter, but `*_per_s` metrics
+#     (rsp_persistentdict_triples_per_s) store RAW THROUGHPUT, where larger is BETTER — a
+#     pre-existing suite inconsistency this gate compensates for by inverting the ratio
+#     (median/current) for names matching `_per_s$`. (Candidate follow-up: store the inverse —
+#     seconds-per-triple — so the whole suite is genuinely smaller-is-better.)
+#   * FAIL-CLOSED NUMERICS: a current value or history window that is NaN/non-numeric/negative,
+#     or a value that crosses a zero boundary (current 0 vs positive median, or vice versa),
+#     HARD-FAILS with a per-metric message — never silently skipped. The one deliberate carve-out
+#     (grounded in the LIVE history): current == 0 AND median == 0 is a legitimate stable value —
+#     four published series are all-zero by design (geo_compliance_deficit, nlq_ask_repairs,
+#     rsp_*_w{2,3}_rows, and the sub-resolution sameas_size8_closure_s), so a blanket "<= 0 fails"
+#     would permanently red main; stable zeros are instead compared at ratio 1.0 and listed.
+#   * DISAPPEARED METRICS: metrics with a gateable history (>= MIN_HISTORY values) that are absent
+#     from this run's results are warn-listed loudly; the run HARD-FAILS only if more than
+#     DISAPPEAR_FAIL_FRACTION (30%) of the gateable metrics disappeared (suite breakage) — a
+#     plain rename or two must not red main.
+#   * HARD FAIL (exit 1) if any gated metric is >= HARD_RATIO (2.0x) its median (direction-adjusted).
+#   * UNIFORM-SHIFT EXEMPTION (exit 0 + loud warning + full table to stdout AND the job summary):
+#     the run is treated as a runner-environment scaling — and the hard zone waived — ONLY if ALL
+#     four conditions hold:
+#       (a) >= UNIFORM_FRACTION (50%) of compared metrics are >= WATCH_RATIO (1.75x) median;
+#       (b) ratio uniformity: over the >= 1.75x metrics, stdev(ratio)/mean(ratio) <= 0.15 — a
+#           multiplicative environment scaling moves every wall-clock metric by ~the same factor,
+#           while a hot-path code regression does not hit unrelated metric families uniformly;
+#       (c) NO metric is >= UNIFORM_CAP_RATIO (4.0x) median — a catastrophic regression must never
+#           hide in the herd;
+#       (d) every compared DETERMINISTIC metric (byte/count/row/gate-class, classified by unit
+#           with an anchored-name fallback — see DETERMINISTIC_UNITS) is within DET_TOLERANCE (1%)
+#           of its median — an environment shift moves wall-clock, never deterministic outputs; if
+#           any deterministic metric moved, there is NO exemption.
+#     HONESTY: the four conditions make a MASKED code regression implausible, not impossible —
+#     which is exactly why the exemption still emits a ::warning and the full per-metric table
+#     into GITHUB_STEP_SUMMARY instead of passing quietly. The exemption never covers fail-closed
+#     numeric errors or the disappeared-metrics breakage check.
+#   * TRANSPARENCY: every metric >= WATCH_RATIO (1.75x) median is printed as a table either way,
+#     to stdout and (when anything is notable) to GITHUB_STEP_SUMMARY — load-bearing because this
+#     gate runs BEFORE the Store step: on a hard-zone failure nothing is published and Store's
+#     comparison comment never fires, so this table is the only visible evidence.
+#   * SUITE NAME: exact match only. If the suite key is absent from the history, warn loudly and
+#     exit 0 — NEVER fall back to a different suite's series.
+#   * ABSENT HISTORY (no prev-data.js / empty file / empty series): warn + exit 0 (first-run /
+#     bootstrap safe; the fetch step creates an EMPTY prev-data.js when the branch has no data.js
+#     yet). A NON-empty but unparsable prev-data.js hard-fails (corrupt published history).
 #
 # The DETERMINISTIC byte-count metrics stay strictly gated by scripts/perf-gate.py (the committed
 # best-ever floor ratchet) — this gate is the noisy-timing hard zone only, and it runs ONLY where
@@ -30,26 +64,53 @@
 # USAGE
 #   scripts/bench_hardzone.py --results bench-results.json --prev-data prev-data.js \
 #       --suite 'sparq engine'
-#   scripts/bench_hardzone.py --self-test          # hermetic; no network, no git, no writes
+#   scripts/bench_hardzone.py --self-test    # hermetic; no network, no git, no repo writes
+#                                            # (end-to-end fixtures use a private tempdir)
 from __future__ import annotations
 
 import argparse
 import json
+import math
+import os
 import re
 import statistics
 import sys
+import tempfile
 from pathlib import Path
 
 PROG = "bench-hardzone"
 
 HARD_RATIO = 2.0        # >= 2.0x median => hard fail (unless the uniform-shift exemption fires)
 WATCH_RATIO = 1.75      # >= 1.75x median => printed in the watch table; feeds the uniform check
-UNIFORM_FRACTION = 0.5  # >= 50% of compared metrics in the watch band => environment shift, exempt
-HISTORY_WINDOW = 5      # median over the last up-to-5 published points per metric
+UNIFORM_FRACTION = 0.5  # exemption (a): >= 50% of compared metrics in the watch band
+UNIFORM_MAX_CV = 0.15   # exemption (b): stdev/mean over the watch-band ratios must be <= 0.15
+UNIFORM_CAP_RATIO = 4.0  # exemption (c): NO metric may be >= 4.0x median
+DET_TOLERANCE = 0.01    # exemption (d): deterministic metrics must sit within 1% of median
+HISTORY_WINDOW = 5      # median over the last up-to-5 published VALUES per metric
+MIN_HISTORY = 3         # a metric needs >= 3 history values to be gated at all
+DISAPPEAR_FAIL_FRACTION = 0.30  # > 30% of gateable metrics missing from results => suite breakage
+
+# Deterministic (byte/count/structural) metric classification. UNIT-first because the live metric
+# NAMES are trappy: bsbm_query01_count_us / lubm_*_count_us are TIMING metrics whose names contain
+# "count", store_bytes_per_triple carries "bytes" mid-name, and rsp_persistentdict_triples_per_s
+# carries "triples" but is wall-clock throughput. The unit set below is the exact deterministic
+# unit vocabulary observed in the published benchmark-data history (bytes/count/chars/fixtures/
+# gates/milli/rows/triples); us / s / ns/byte / ratio / triples_per_s are the noisy families.
+# The anchored-name fallback only fires when a row carries no unit at all.
+DETERMINISTIC_UNITS = {"bytes", "count", "chars", "fixtures", "gates", "milli", "rows", "triples"}
+DETERMINISTIC_NAME_RE = re.compile(r"(_bytes|_count|_chars|_deficit|_gates|_rows|_triples)$")
+
+# Direction: `*_per_s` metrics store raw throughput => LARGER is better (ratio = median/current).
+LARGER_IS_BETTER_RE = re.compile(r"_per_s$")
 
 
 def log(msg: str) -> None:
     print(f"[{PROG}] {msg}", file=sys.stderr)
+
+
+def _is_num(v) -> bool:
+    """A finite real number (bool excluded — json true/false must not pass as 1/0)."""
+    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
 
 
 def parse_data_js(text: str) -> dict:
@@ -61,89 +122,296 @@ def parse_data_js(text: str) -> dict:
     return json.loads(text)
 
 
-def history_values(series: list[dict], window: int = HISTORY_WINDOW) -> dict[str, list[float]]:
-    """Per-metric values from the last up-to-`window` entries of a benchmark-data series.
+def history_values(series: list[dict], window: int = HISTORY_WINDOW) -> dict[str, list]:
+    """Per-metric last up-to-`window` published VALUES across the FULL retained series.
 
     `series` is entries[suite] from data.js: a list of {commit, date, benches:[{name,value,..}]}.
-    Entries are ordered by date; only the most recent `window` entries contribute. A metric absent
-    from some of those entries simply contributes fewer points (median over what exists).
+    Entries are ordered by date; every entry contributes, and the window is applied PER METRIC to
+    the metric's own value sequence — a metric published in only some entries still collects up to
+    `window` values from across the whole retained history (the old per-commit windowing judged
+    sparse metrics from as little as ONE point). Values are kept RAW (including non-numeric junk)
+    so evaluate() can fail closed on garbage that lands inside a metric's window.
     """
-    ordered = sorted(series, key=lambda e: e.get("date", 0))[-window:]
-    vals: dict[str, list[float]] = {}
+    ordered = sorted(series, key=lambda e: e.get("date", 0))
+    vals: dict[str, list] = {}
     for entry in ordered:
         for b in entry.get("benches", []):
             name = b.get("name")
-            v = b.get("value")
-            if name is not None and isinstance(v, (int, float)):
-                vals.setdefault(name, []).append(float(v))
-    return vals
+            if name is not None:
+                vals.setdefault(name, []).append(b.get("value"))
+    return {n: v[-window:] for n, v in vals.items()}
 
 
-def evaluate(current: list[dict], hist: dict[str, list[float]]) -> tuple[int, dict]:
-    """Pure gate logic — unit-tested by --self-test.
+def is_deterministic(name: str, unit: str) -> bool:
+    if unit:
+        return unit in DETERMINISTIC_UNITS
+    return bool(DETERMINISTIC_NAME_RE.search(name))
+
+
+def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
+    """Pure gate logic — unit-tested by --self-test. No I/O, no env access.
 
     `current` is this run's bench-results.json rows ({name,value,unit}); `hist` is the per-metric
-    history value lists (see history_values). Returns (exit_code, report) where report carries
-    {compared, watch: [(name, cur, median, n, ratio)...], hard: [...same...], uniform_shift}.
+    history value lists (see history_values). Returns (exit_code, report) where report carries:
+      compared      — number of ratio-gated metrics
+      rows          — [(name, cur, median, n, ratio, deterministic, larger_better)] all compared
+      watch / hard  — the >= WATCH_RATIO / >= HARD_RATIO subsets of rows
+      invalid       — [(name, reason)] fail-closed numeric errors (any entry => exit 1)
+      ungated       — [(name, n)] metrics with 1..MIN_HISTORY-1 history values (listed, not gated)
+      new           — metric names present in results with NO history at all
+      stable_zero   — metrics compared as legitimate 0 == 0
+      disappeared   — gateable metrics absent from this run's results
+      disappeared_frac / uniform_shift / exemption_reasons
     """
-    watch: list[tuple[str, float, float, int, float]] = []
-    hard: list[tuple[str, float, float, int, float]] = []
-    compared = 0
+    rows: list[tuple] = []
+    invalid: list[tuple[str, str]] = []
+    ungated: list[tuple[str, int]] = []
+    new: list[str] = []
+    stable_zero: list[str] = []
+
+    current_by_name: dict[str, dict] = {}
     for row in current:
         name = row.get("name")
-        val = row.get("value")
-        if name is None or not isinstance(val, (int, float)):
+        if name is not None:
+            current_by_name[name] = row
+
+    gateable = {n for n, pts in hist.items() if len(pts) >= MIN_HISTORY}
+    disappeared = sorted(n for n in gateable if n not in current_by_name)
+    disappeared_frac = (len(disappeared) / len(gateable)) if gateable else 0.0
+
+    for name in sorted(current_by_name):
+        row = current_by_name[name]
+        pts = hist.get(name)
+        if not pts:
+            new.append(name)
             continue
-        past = hist.get(name)
-        if not past:
-            continue  # brand-new metric — no history to compare against
-        med = statistics.median(past)
-        if med <= 0:
-            continue  # cannot form a ratio (degenerate/zero baseline)
-        compared += 1
-        ratio = float(val) / med
-        entry = (name, float(val), med, len(past), ratio)
-        if ratio >= WATCH_RATIO:
-            watch.append(entry)
-        if ratio >= HARD_RATIO:
-            hard.append(entry)
-    if compared == 0:
-        log("no overlapping metrics with history — nothing to compare; passing.")
-        return 0, {"compared": 0, "watch": [], "hard": [], "uniform_shift": False}
-    if watch:
-        log(f"metrics >= {WATCH_RATIO}x their median of the last {HISTORY_WINDOW} points "
-            f"({len(watch)}/{compared} compared):")
-        log(f"  {'metric':<60} {'current':>14} {'median(n)':>18} {'ratio':>7}")
-        for name, cur, med, n, ratio in sorted(watch, key=lambda t: -t[4]):
-            log(f"  {name:<60} {cur:>14.4g} {med:>13.4g}(n={n}) {ratio:>6.2f}x")
-    uniform = len(watch) / compared >= UNIFORM_FRACTION
-    if uniform:
-        # An across-the-board shift is the runner environment, never a real code regression in
-        # every unrelated metric at once — refuse to red main on it, loudly.
+        if len(pts) < MIN_HISTORY:
+            ungated.append((name, len(pts)))
+            continue
+        val = row.get("value")
+        unit = row.get("unit") or ""
+        if not _is_num(val):
+            invalid.append((name, f"current value {val!r} is not a finite number — fail-closed"))
+            continue
+        bad_hist = [p for p in pts if not _is_num(p)]
+        if bad_hist:
+            invalid.append((name, f"history window contains non-numeric value(s) {bad_hist!r} "
+                                  f"— fail-closed (published history is corrupt for this metric)"))
+            continue
+        med = float(statistics.median(pts))
+        val = float(val)
+        if val < 0 or med < 0:
+            invalid.append((name, f"negative measurement (current {val:g}, median {med:g}) "
+                                  f"— fail-closed"))
+            continue
+        larger_better = bool(LARGER_IS_BETTER_RE.search(name))
+        det = is_deterministic(name, unit)
+        if val == 0 and med == 0:
+            # Stable zero — legitimate for deterministic zero-counts and the sub-resolution
+            # timing series that live history proves are all-zero by design. Compared, not skipped.
+            stable_zero.append(name)
+            ratio = 1.0
+        elif val == 0 or med == 0:
+            invalid.append((name, f"zero-boundary change (current {val:g} vs median {med:g}) — "
+                                  f"ratio undefined; fail-closed"))
+            continue
+        else:
+            # customSmallerIsBetter suite, EXCEPT `*_per_s` throughput (larger is better): invert.
+            ratio = (med / val) if larger_better else (val / med)
+        rows.append((name, val, med, len(pts), ratio, det, larger_better))
+
+    compared = len(rows)
+    watch = [r for r in rows if r[4] >= WATCH_RATIO]
+    hard = [r for r in rows if r[4] >= HARD_RATIO]
+
+    # Uniform-shift exemption — ALL four conditions must hold (see header).
+    uniform = False
+    exemption_reasons: list[str] = []
+    if compared and watch:
+        frac = len(watch) / compared
+        cond_a = frac >= UNIFORM_FRACTION
+        if not cond_a:
+            exemption_reasons.append(
+                f"(a) breadth: only {len(watch)}/{compared} compared metrics >= "
+                f"{WATCH_RATIO}x (< {UNIFORM_FRACTION:.0%})")
+        ratios = [r[4] for r in watch]
+        if len(ratios) >= 2:
+            cv = statistics.stdev(ratios) / statistics.mean(ratios)
+            cond_b = cv <= UNIFORM_MAX_CV
+            if not cond_b:
+                exemption_reasons.append(
+                    f"(b) uniformity: stdev/mean over the watch-band ratios is {cv:.3f} "
+                    f"(> {UNIFORM_MAX_CV}) — the shift is not a uniform scaling")
+        else:
+            cond_b = False
+            exemption_reasons.append(
+                "(b) uniformity: a single shifted metric is not an environment-wide scaling")
+        worst = max(r[4] for r in rows)
+        cond_c = worst < UNIFORM_CAP_RATIO
+        if not cond_c:
+            exemption_reasons.append(
+                f"(c) cap: worst ratio {worst:.2f}x >= {UNIFORM_CAP_RATIO}x — a catastrophic "
+                f"regression never hides in the herd")
+        det_moved = [r for r in rows if r[5] and abs(r[4] - 1.0) > DET_TOLERANCE]
+        cond_d = not det_moved
+        if not cond_d:
+            names = ", ".join(f"{r[0]} ({r[4]:.3f}x)" for r in det_moved[:5])
+            exemption_reasons.append(
+                f"(d) deterministic drift: {len(det_moved)} deterministic metric(s) moved "
+                f"> {DET_TOLERANCE:.0%} of median ({names}) — an environment shift moves "
+                f"wall-clock, never deterministic outputs")
+        uniform = cond_a and cond_b and cond_c and cond_d
+
+    fail = False
+    if invalid:
+        fail = True
+    if disappeared_frac > DISAPPEAR_FAIL_FRACTION:
+        fail = True
+    if hard and not uniform:
+        fail = True
+
+    report = {
+        "compared": compared, "rows": rows, "watch": watch, "hard": hard,
+        "invalid": invalid, "ungated": ungated, "new": new, "stable_zero": stable_zero,
+        "disappeared": disappeared, "disappeared_frac": disappeared_frac,
+        "uniform_shift": uniform, "exemption_reasons": exemption_reasons,
+    }
+    return (1 if fail else 0), report
+
+
+def _table_lines(entries: list[tuple], markdown: bool) -> list[str]:
+    """Render [(name, cur, med, n, ratio, det, larger_better)] rows as a table."""
+    out = []
+    if markdown:
+        out.append("| metric | current | median (n) | ratio | direction |")
+        out.append("|---|---:|---:|---:|---|")
+        for name, cur, med, n, ratio, _det, lb in sorted(entries, key=lambda t: -t[4]):
+            out.append(f"| `{name}` | {cur:.6g} | {med:.6g} (n={n}) | {ratio:.2f}x |"
+                       f" {'larger-is-better' if lb else 'smaller-is-better'} |")
+    else:
+        out.append(f"  {'metric':<60} {'current':>14} {'median(n)':>18} {'ratio':>7}")
+        for name, cur, med, n, ratio, _det, lb in sorted(entries, key=lambda t: -t[4]):
+            suffix = "  [larger-is-better]" if lb else ""
+            out.append(f"  {name:<60} {cur:>14.4g} {med:>13.4g}(n={n}) {ratio:>6.2f}x{suffix}")
+    return out
+
+
+def render_report(report: dict, markdown: bool) -> list[str]:
+    """Human-readable report lines (plain for stdout, markdown for GITHUB_STEP_SUMMARY)."""
+    h2 = "## " if markdown else ""
+    lines: list[str] = [f"{h2}bench hard zone — median-of-history gate"]
+    lines.append(f"{report['compared']} metrics compared; {len(report['watch'])} >= "
+                 f"{WATCH_RATIO}x median; {len(report['hard'])} >= {HARD_RATIO}x median.")
+    if report["watch"]:
+        lines.append("")
+        lines.append(f"**Watch band (>= {WATCH_RATIO}x median):**" if markdown
+                     else f"metrics >= {WATCH_RATIO}x their median of the last up-to-"
+                          f"{HISTORY_WINDOW} published values:")
+        lines.extend(_table_lines(report["watch"], markdown))
+    if report["invalid"]:
+        lines.append("")
+        lines.append("**Fail-closed numeric errors (each one fails the run):**" if markdown
+                     else "fail-closed numeric errors (each one fails the run):")
+        lines.extend(f"  - `{n}`: {reason}" if markdown else f"  {n}: {reason}"
+                     for n, reason in report["invalid"])
+    if report["disappeared"]:
+        lines.append("")
+        frac = report["disappeared_frac"]
+        verdict = ("FAIL — suite breakage" if frac > DISAPPEAR_FAIL_FRACTION
+                   else "warn only (below the "
+                        f"{DISAPPEAR_FAIL_FRACTION:.0%} suite-breakage threshold)")
+        lines.append(f"**Disappeared metrics** ({len(report['disappeared'])}, "
+                     f"{frac:.0%} of gateable — {verdict}):" if markdown else
+                     f"DISAPPEARED metrics ({len(report['disappeared'])}, {frac:.0%} of "
+                     f"gateable — {verdict}):")
+        lines.extend(f"  - `{n}`" if markdown else f"  {n}" for n in report["disappeared"])
+    if report["ungated"]:
+        lines.append("")
+        names = ", ".join(f"{n} (n={c})" for n, c in report["ungated"])
+        lines.append(f"insufficient history — ungated (need >= {MIN_HISTORY} values): {names}")
+    if report["new"]:
+        shown = ", ".join(report["new"][:15])
+        more = f" (+{len(report['new']) - 15} more)" if len(report["new"]) > 15 else ""
+        lines.append(f"new metrics with no history yet (ungated): {shown}{more}")
+    if report["stable_zero"]:
+        lines.append(f"stable-zero metrics compared at ratio 1.0: "
+                     f"{', '.join(report['stable_zero'])}")
+    if report["uniform_shift"]:
+        lines.append("")
+        lines.append("UNIFORM-SHIFT EXEMPTION applied: all four conditions hold (breadth, ratio "
+                     "uniformity, no >= 4x outlier, deterministic metrics unmoved). This makes a "
+                     "masked code regression implausible — NOT impossible — hence this loud "
+                     "record instead of a quiet pass.")
+    elif report["exemption_reasons"]:
+        lines.append("")
+        lines.append("uniform-shift exemption NOT applied:")
+        lines.extend(f"  - {r}" for r in report["exemption_reasons"])
+    return lines
+
+
+def emit_report(report: dict) -> None:
+    """Print the report to stdout, and to GITHUB_STEP_SUMMARY when anything is notable.
+
+    Load-bearing: this gate runs BEFORE the Store step, so on a hard-zone failure the run
+    publishes nothing and Store's comparison comment never fires — this output is the only
+    visible evidence of what tripped.
+    """
+    for line in render_report(report, markdown=False):
+        print(line)
+    notable = (report["watch"] or report["hard"] or report["invalid"]
+               or report["disappeared"] or report["uniform_shift"])
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if notable and summary_path:
+        with open(summary_path, "a", encoding="utf-8") as f:
+            f.write("\n".join(render_report(report, markdown=True)) + "\n")
+    if report["uniform_shift"]:
         print(f"::warning title=bench hard zone — uniform environment shift, not gating::"
-              f"{len(watch)} of {compared} compared metrics are >= {WATCH_RATIO}x their "
-              f"median-of-{HISTORY_WINDOW} history simultaneously. A uniform shift across "
-              f"unrelated metrics is a runner-environment change, not a code regression — "
-              f"NOT failing the run. See the per-metric table in the step log.")
-        return 0, {"compared": compared, "watch": watch, "hard": hard, "uniform_shift": True}
-    if hard:
-        for name, cur, med, n, ratio in hard:
+              f"{len(report['watch'])} of {report['compared']} compared metrics are >= "
+              f"{WATCH_RATIO}x their median-of-history simultaneously, the shifted ratios are "
+              f"uniform (stdev/mean <= {UNIFORM_MAX_CV}), no metric reached "
+              f"{UNIFORM_CAP_RATIO}x, and every deterministic metric is within "
+              f"{DET_TOLERANCE:.0%} of its median. Treated as a runner-environment scaling and "
+              f"NOT failing the run — a masked code regression is implausible under these four "
+              f"conditions, not impossible, so review the table in the job summary.")
+    for name, reason in report["invalid"]:
+        print(f"::error title=bench hard zone — invalid measurement::{name}: {reason}")
+    if report["disappeared_frac"] > DISAPPEAR_FAIL_FRACTION:
+        print(f"::error title=bench hard zone — suite breakage::"
+              f"{len(report['disappeared'])} gateable metrics "
+              f"({report['disappeared_frac']:.0%}) are missing from this run's results — more "
+              f"than {DISAPPEAR_FAIL_FRACTION:.0%} of the gated suite disappeared at once, "
+              f"which is a bench-suite breakage, not a rename. See the disappeared list above.")
+    if report["hard"] and not report["uniform_shift"]:
+        for name, cur, med, n, ratio, _det, lb in report["hard"]:
+            direction = "median/current (larger-is-better)" if lb else "current/median"
             print(f"::error title=bench hard zone::{name} is {ratio:.2f}x its "
-                  f"median-of-{n} history ({cur:.6g} vs median {med:.6g}) — at/above the "
-                  f"{HARD_RATIO}x hard threshold, and the shift is NOT uniform across metrics "
-                  f"(so it is not a runner-environment artifact). Treating as a real regression.")
-        return 1, {"compared": compared, "watch": watch, "hard": hard, "uniform_shift": False}
-    log(f"hard zone clean: {compared} metrics compared against their median-of-history; "
-        f"{len(watch)} in the watch band, none at/above {HARD_RATIO}x.")
-    return 0, {"compared": compared, "watch": watch, "hard": hard, "uniform_shift": False}
+                  f"median-of-{n} history ({direction}: {cur:.6g} vs median {med:.6g}) — "
+                  f"at/above the {HARD_RATIO}x hard threshold, and the uniform-shift exemption "
+                  f"does not apply. Treating as a real regression.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(prog=PROG, description=__doc__)
+    ap.add_argument("--results", required=True, help="this run's bench-results.json")
+    ap.add_argument("--prev-data", required=True,
+                    help="previously-published data.js (prev-data.js; absent => warn + pass)")
+    ap.add_argument("--suite", default="sparq engine",
+                    help="data.js entries suite name (EXACT match; absent => warn + pass)")
+    return ap
 
 
 def run_gate(results_path: str, prev_data_path: str, suite: str) -> int:
     rp = Path(results_path)
     if not rp.exists():
-        log(f"results file {results_path} is absent — nothing to gate; passing.")
-        return 0
-    current = json.loads(rp.read_text(encoding="utf-8"))
+        print(f"::error title=bench hard zone::results file {results_path} is absent — the "
+              f"benchmark step should have written it on this path; fail-closed.")
+        return 1
+    try:
+        current = json.loads(rp.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"::error title=bench hard zone::could not parse {results_path} ({e}) — "
+              f"fail-closed (this run's own artifact is corrupt).")
+        return 1
     if not isinstance(current, list):
         current = current.get("benches", [])
     pp = Path(prev_data_path)
@@ -151,24 +419,43 @@ def run_gate(results_path: str, prev_data_path: str, suite: str) -> int:
         print(f"::warning title=bench hard zone — no history::{prev_data_path} is absent "
               f"(benchmark-data branch missing or empty — first run). Nothing to compare; passing.")
         return 0
-    try:
-        data = parse_data_js(pp.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, ValueError) as e:
-        print(f"::warning title=bench hard zone — unparsable history::could not parse "
-              f"{prev_data_path} ({e}); nothing to compare; passing.")
+    text = pp.read_text(encoding="utf-8")
+    if not text.strip():
+        # The fetch step creates an EMPTY prev-data.js when the branch has no data.js yet
+        # (`git show ... > prev-data.js` truncates before git show fails) — bootstrap, not corrupt.
+        print(f"::warning title=bench hard zone — no history::{prev_data_path} is empty "
+              f"(benchmark-data branch has no data.js yet — bootstrap). Nothing to compare; "
+              f"passing.")
         return 0
+    try:
+        data = parse_data_js(text)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"::error title=bench hard zone::could not parse non-empty {prev_data_path} "
+              f"({e}) — fail-closed (the published history is corrupt; investigate the "
+              f"benchmark-data branch).")
+        return 1
     entries = data.get("entries", {})
-    series = entries.get(suite) or (next(iter(entries.values())) if entries else [])
+    # EXACT suite match only — never fall back to a different suite's series.
+    series = entries.get(suite)
+    if series is None:
+        print(f"::warning title=bench hard zone — suite not found::suite '{suite}' is not in "
+              f"{prev_data_path} (available: {sorted(entries)}). Refusing to compare against a "
+              f"different suite's series; nothing to compare; passing.")
+        return 0
     if not series:
         print(f"::warning title=bench hard zone — empty history::no published points for suite "
               f"'{suite}' in {prev_data_path}; nothing to compare; passing.")
         return 0
-    code, _report = evaluate(current, history_values(series))
+    code, report = evaluate(current, history_values(series))
+    emit_report(report)
+    if code == 0 and not report["hard"] and not report["uniform_shift"]:
+        log(f"hard zone clean: {report['compared']} metrics compared against their "
+            f"median-of-history; {len(report['watch'])} in the watch band, none failing.")
     return code
 
 
-# ── self-test (hermetic: inline fixtures; no network, no git, no writes) ─────────────────────────
-def _series(points: list[list[tuple[str, float]]]) -> list[dict]:
+# ── self-test (hermetic: inline fixtures; no network, no git, no repo writes) ────────────────────
+def _series(points: list[list[tuple]]) -> list[dict]:
     """Build a data.js-shaped series from [[(name, value), ...] per commit] (oldest first)."""
     return [
         {"date": i, "benches": [{"name": n, "value": v, "unit": "us"} for n, v in benches]}
@@ -176,74 +463,208 @@ def _series(points: list[list[tuple[str, float]]]) -> list[dict]:
     ]
 
 
-def _cur(rows: list[tuple[str, float]]) -> list[dict]:
-    return [{"name": n, "value": v, "unit": "us"} for n, v in rows]
+def _cur(rows: list[tuple], unit: str = "us") -> list[dict]:
+    return [{"name": n, "value": v, "unit": unit} for n, v in rows]
 
 
 def self_test() -> int:
     failures: list[str] = []
+    checks = 0
 
     def check(cond: bool, what: str) -> None:
+        nonlocal checks
+        checks += 1
         if cond:
             log(f"self-test ok: {what}")
         else:
             failures.append(what)
             log(f"self-test FAIL: {what}")
 
-    # 1. median computation: window trims to the last 5 points; median over what remains.
+    # Baseline 5-commit history: four metrics stable at 10.0.
+    series = _series([[("a", 10.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)]] * 5)
+
+    # 1. Median semantics: window trims to the last 5 VALUES per metric.
     hist = history_values(_series([[("m", 100.0)], [("m", 1.0)], [("m", 2.0)], [("m", 3.0)],
                                    [("m", 4.0)], [("m", 5.0)]]))
-    check(hist["m"] == [1.0, 2.0, 3.0, 4.0, 5.0], "history window keeps only the last 5 points")
-    check(statistics.median(hist["m"]) == 3.0, "median of 5-point history is the middle point")
+    check(hist["m"] == [1.0, 2.0, 3.0, 4.0, 5.0], "history window keeps only the last 5 values")
+    check(statistics.median(hist["m"]) == 3.0, "median of 5-value history is the middle value")
     hist_even = history_values(_series([[("m", 1.0)], [("m", 2.0)], [("m", 3.0)], [("m", 8.0)]]))
     check(statistics.median(hist_even["m"]) == 2.5, "median of an even count averages the middle two")
-    # A single outlier point cannot move a median-of-5 into failing territory.
-    hist_outlier = history_values(_series([[("m", 10.0)], [("m", 10.0)], [("m", 10.0)],
-                                           [("m", 10.0)], [("m", 30.0)]]))
     code, rep = evaluate(_cur([("m", 15.0)]), history_values(
         _series([[("m", 10.0)], [("m", 10.0)], [("m", 10.0)], [("m", 10.0)], [("m", 30.0)]])))
-    check(statistics.median(hist_outlier["m"]) == 10.0 and code == 0 and not rep["hard"],
+    check(code == 0 and not rep["hard"],
           "single outlier history point does not move the median (1.5x vs median passes)")
 
-    # 2. absent history: no overlapping metrics => pass (exit 0), nothing compared.
+    # 2. SPARSE-metric per-metric windowing: a metric present in only 5 of 10 commits still
+    #    collects all 5 of its values (the old per-commit window judged it from 1 point).
+    sparse_pts: list[list[tuple]] = []
+    for i in range(10):
+        commit: list[tuple] = [("dense", 10.0)]
+        if i % 2 == 0:
+            commit.append(("sparse", 10.0 + i))  # values 10,12,14,16,18 at commits 0,2,4,6,8
+        sparse_pts.append(commit)
+    hist_sparse = history_values(_series(sparse_pts))
+    check(hist_sparse["sparse"] == [10.0, 12.0, 14.0, 16.0, 18.0],
+          "sparse metric collects its last 5 values across the FULL retained history")
+    code, rep = evaluate(_cur([("sparse", 15.0), ("dense", 10.0)]), hist_sparse)
+    check(code == 0 and rep["compared"] == 2,
+          "sparse metric is gated against its own 5-value median (14.0), not a 1-point window")
+
+    # 3. Insufficient history (< 3 values) => listed as ungated, not silently gated or failed.
+    two_pt = history_values(_series([[("young", 10.0)], [("young", 10.0)]]))
+    code, rep = evaluate(_cur([("young", 100.0)]), two_pt)
+    check(code == 0 and rep["compared"] == 0 and rep["ungated"] == [("young", 2)],
+          "a metric with only 2 history values is ungated + listed (even at 10x)")
+
+    # 4. Absent history: no overlapping metrics => pass (exit 0), nothing compared.
     code, rep = evaluate(_cur([("new_metric", 42.0)]), {})
-    check(code == 0 and rep["compared"] == 0, "absent history passes with nothing compared")
+    check(code == 0 and rep["compared"] == 0 and rep["new"] == ["new_metric"],
+          "absent history passes with nothing compared; metric listed as new")
 
-    # 3. uniform-shift exemption: >= 50% of compared metrics >= 1.75x median => exit 0, flagged.
-    series = _series([[("a", 10.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)]] * 5)
-    shifted = _cur([("a", 19.0), ("b", 19.5), ("c", 20.5), ("d", 11.0)])  # 3/4 >= 1.75x, 1 >= 2.0x
-    code, rep = evaluate(shifted, history_values(series))
-    check(code == 0 and rep["uniform_shift"] and len(rep["watch"]) == 3 and len(rep["hard"]) == 1,
-          "uniform environment shift (3/4 metrics >= 1.75x) is exempted despite a >= 2.0x metric")
+    # 5. Fail-closed numerics: NaN / non-numeric / negative current, NaN in the history
+    #    window, and zero-boundary changes all hard-fail with a per-metric record.
+    code, rep = evaluate(_cur([("a", float("nan"))]), history_values(series))
+    check(code == 1 and len(rep["invalid"]) == 1, "NaN current value fails closed")
+    code, rep = evaluate([{"name": "a", "value": "fast", "unit": "us"}], history_values(series))
+    check(code == 1 and len(rep["invalid"]) == 1, "non-numeric current value fails closed")
+    code, rep = evaluate(_cur([("a", -1.0)]), history_values(series))
+    check(code == 1 and len(rep["invalid"]) == 1, "negative current value fails closed")
+    bad_hist = history_values(_series([[("a", 10.0)], [("a", 10.0)],
+                                       [("a", float("nan"))], [("a", 10.0)]]))
+    code, rep = evaluate(_cur([("a", 10.0)]), bad_hist)
+    check(code == 1 and len(rep["invalid"]) == 1, "NaN inside the history window fails closed")
+    code, rep = evaluate(_cur([("a", 0.0)]), history_values(series))
+    check(code == 1 and len(rep["invalid"]) == 1,
+          "current 0 vs positive median is a zero-boundary change — fails closed")
+    zero_series = history_values(_series([[("z", 0.0)]] * 5))
+    code, rep = evaluate(_cur([("z", 5.0)]), zero_series)
+    check(code == 1 and len(rep["invalid"]) == 1,
+          "positive current vs zero median is a zero-boundary change — fails closed")
+    code, rep = evaluate(_cur([("z", 0.0)]), zero_series)
+    check(code == 0 and rep["stable_zero"] == ["z"] and rep["compared"] == 1,
+          "stable zero (current 0, median 0) is legitimate — compared at ratio 1.0")
 
-    # 4. single-metric hard fail: one metric >= 2.0x median, the rest normal => exit 1.
-    lone = _cur([("a", 21.0), ("b", 10.2), ("c", 9.9), ("d", 10.0)])  # only a regresses (2.1x)
+    # 6. Disappeared metrics: warn below the 30% threshold, hard-fail above it.
+    code, rep = evaluate(_cur([("a", 10.0), ("b", 10.0), ("c", 10.0)]), history_values(series))
+    check(code == 0 and rep["disappeared"] == ["d"] and rep["disappeared_frac"] == 0.25,
+          "1 of 4 gateable metrics disappeared (25%) => loud warn-list, no fail")
+    code, rep = evaluate(_cur([("a", 10.0), ("b", 10.0)]), history_values(series))
+    check(code == 1 and rep["disappeared"] == ["c", "d"],
+          "2 of 4 gateable metrics disappeared (50% > 30%) => suite breakage, hard fail")
+
+    # 7. `_per_s` direction inversion (throughput: larger is better).
+    thr = history_values(_series([[("rsp_x_triples_per_s", 1000.0)]] * 5))
+    code, rep = evaluate(_cur([("rsp_x_triples_per_s", 500.0)], unit="triples_per_s"), thr)
+    check(code == 1 and len(rep["hard"]) == 1 and abs(rep["hard"][0][4] - 2.0) < 1e-9,
+          "_per_s throughput halving is a 2.0x regression (ratio inverted) — hard fail")
+    code, rep = evaluate(_cur([("rsp_x_triples_per_s", 2000.0)], unit="triples_per_s"), thr)
+    check(code == 0 and not rep["watch"],
+          "_per_s throughput doubling is an improvement (ratio 0.5) — passes")
+
+    # 8. Single-metric hard fail: one metric >= 2.0x median, the rest normal => exit 1.
+    lone = _cur([("a", 21.0), ("b", 10.2), ("c", 9.9), ("d", 10.0)])
     code, rep = evaluate(lone, history_values(series))
     check(code == 1 and not rep["uniform_shift"] and len(rep["hard"]) == 1
           and rep["hard"][0][0] == "a",
           "single sustained >= 2.0x regression hard-fails (no uniform exemption)")
-    # 4b. watch band alone (>= 1.75x but < 2.0x, minority of metrics) does NOT fail.
     watch_only = _cur([("a", 18.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)])
     code, rep = evaluate(watch_only, history_values(series))
     check(code == 0 and len(rep["watch"]) == 1 and not rep["hard"],
           "a lone watch-band metric (1.8x, < 2.0x) is reported but does not fail")
 
+    # 9. Uniform-shift exemption POSITIVE: broad (3/4 >= 1.75x), uniform ratios (cv <= 0.15),
+    #    nothing >= 4x, no deterministic metric moved => exempt, exit 0.
+    shifted = _cur([("a", 19.0), ("b", 19.5), ("c", 20.5), ("d", 11.0)])
+    code, rep = evaluate(shifted, history_values(series))
+    check(code == 0 and rep["uniform_shift"] and len(rep["watch"]) == 3 and len(rep["hard"]) == 1,
+          "uniform environment shift (3/4 >= 1.75x, uniform, capped, no det drift) is exempted")
+
+    # 10. Uniformity rejection: broad shift with NON-uniform ratios => NOT exempt => fail.
+    ragged = _cur([("a", 18.0), ("b", 25.0), ("c", 35.0), ("d", 10.0)])  # ratios 1.8/2.5/3.5
+    code, rep = evaluate(ragged, history_values(series))
+    check(code == 1 and not rep["uniform_shift"]
+          and any("(b) uniformity" in r for r in rep["exemption_reasons"]),
+          "broad but NON-uniform shift (cv > 0.15) is NOT exempt — hard fail stands")
+
+    # 11. The 4x cap: broad + uniform-enough band, but one metric >= 4x => NOT exempt.
+    capped = _cur([("a", 19.0), ("b", 19.5), ("c", 41.0), ("d", 10.0)])  # c at 4.1x
+    code, rep = evaluate(capped, history_values(series))
+    check(code == 1 and not rep["uniform_shift"]
+          and any("(c) cap" in r for r in rep["exemption_reasons"]),
+          "a >= 4x metric blocks the exemption — catastrophic regressions never hide in the herd")
+
+    # 12. Deterministic-metric drift blocks the exemption: same broad uniform timing shift, but a
+    #     byte-count metric moved > 1% => NOT exempt => fail.
+    det_series = [{"date": i, "benches": [
+        {"name": "a", "value": 10.0, "unit": "us"},
+        {"name": "b", "value": 10.0, "unit": "us"},
+        {"name": "c", "value": 10.0, "unit": "us"},
+        {"name": "wasm_bundle_bytes", "value": 1000.0, "unit": "bytes"},
+    ]} for i in range(5)]
+    det_cur = [{"name": "a", "value": 19.0, "unit": "us"},
+               {"name": "b", "value": 19.5, "unit": "us"},
+               {"name": "c", "value": 20.5, "unit": "us"},
+               {"name": "wasm_bundle_bytes", "value": 1030.0, "unit": "bytes"}]  # +3%
+    code, rep = evaluate(det_cur, history_values(det_series))
+    check(code == 1 and not rep["uniform_shift"]
+          and any("(d) deterministic" in r for r in rep["exemption_reasons"]),
+          "a moved deterministic metric (bytes +3%) blocks the exemption — hard fail stands")
+    det_cur_ok = [dict(r) for r in det_cur]
+    det_cur_ok[3]["value"] = 1000.0  # deterministic metric unmoved => exemption restored
+    code, rep = evaluate(det_cur_ok, history_values(det_series))
+    check(code == 0 and rep["uniform_shift"],
+          "same shift with the deterministic metric unmoved IS exempt (control case)")
+
+    # 13. Deterministic classification is unit-first (name traps are real: *_count_us is timing).
+    check(is_deterministic("wasm_bundle_bytes", "bytes")
+          and not is_deterministic("bsbm_query01_count_us", "us")
+          and not is_deterministic("rsp_persistentdict_triples_per_s", "triples_per_s")
+          and is_deterministic("zk_compose_filter_f64_gates", ""),
+          "deterministic classification: unit-first, anchored-name fallback only when unit absent")
+
+    # 14. Argument handling: the parser accepts the documented flags on a fixture path.
+    ns = build_parser().parse_args(
+        ["--results", "fixtures/bench-results.json", "--prev-data", "fixtures/prev-data.js",
+         "--suite", "sparq engine"])
+    check(ns.results == "fixtures/bench-results.json"
+          and ns.prev_data == "fixtures/prev-data.js" and ns.suite == "sparq engine",
+          "argument parser maps --results/--prev-data/--suite onto the expected namespace")
+
+    # 15. End-to-end run_gate over real files in a private tempdir: suite-name mismatch must
+    #     warn + exit 0 (never fall back to another suite), exact match must gate.
+    with tempfile.TemporaryDirectory(prefix="bench-hardzone-selftest-") as td:
+        results = Path(td) / "bench-results.json"
+        results.write_text(json.dumps(_cur([("a", 21.0), ("b", 10.0), ("c", 10.0),
+                                            ("d", 10.0)])), encoding="utf-8")
+        prev = Path(td) / "prev-data.js"
+        payload = {"entries": {"sparq engine": _series(
+            [[("a", 10.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)]] * 5)}}
+        prev.write_text("window.BENCHMARK_DATA = " + json.dumps(payload) + ";",
+                        encoding="utf-8")
+        check(run_gate(str(results), str(prev), "some other suite") == 0,
+              "suite-name mismatch warns + exits 0 (no cross-suite fallback)")
+        check(run_gate(str(results), str(prev), "sparq engine") == 1,
+              "exact suite match gates for real (2.1x lone regression fails end-to-end)")
+        empty = Path(td) / "empty-prev.js"
+        empty.write_text("", encoding="utf-8")
+        check(run_gate(str(results), str(empty), "sparq engine") == 0,
+              "empty prev-data.js (bootstrap fetch artifact) warns + exits 0")
+        corrupt = Path(td) / "corrupt-prev.js"
+        corrupt.write_text("window.BENCHMARK_DATA = {not json", encoding="utf-8")
+        check(run_gate(str(results), str(corrupt), "sparq engine") == 1,
+              "non-empty unparsable prev-data.js fails closed (corrupt published history)")
+
     if failures:
-        log(f"self-test FAILED ({len(failures)}): " + "; ".join(failures))
+        log(f"self-test FAILED ({len(failures)}/{checks} checks): " + "; ".join(failures))
         return 1
-    log("self-test OK")
+    log(f"self-test OK ({checks} checks)")
     return 0
 
 
 def main(argv: list[str]) -> int:
     if "--self-test" in argv:
         return self_test()
-    ap = argparse.ArgumentParser(prog=PROG, description=__doc__)
-    ap.add_argument("--results", required=True, help="this run's bench-results.json")
-    ap.add_argument("--prev-data", required=True,
-                    help="previously-published data.js (prev-data.js; absent => warn + pass)")
-    ap.add_argument("--suite", default="sparq engine", help="data.js entries suite name")
-    args = ap.parse_args(argv)
+    args = build_parser().parse_args(argv)
     return run_gate(args.results, args.prev_data, args.suite)
 
 

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -441,39 +441,68 @@ class TestPhase2LaneScoping(unittest.TestCase):
                          "already gated the PR head + re-runs on push-to-main; the noisy timing suite "
                          "moved to the nightly EC2 lane — keeping it on merge_group only dragged the queue)")
 
-    def test_bench_main_history_and_ratchet_exclude_schedule(self):
+    def test_bench_history_lane_scoping(self):
         # CRITICAL (design §6.1 continuity, criterion (d)): the auto-ratchet + history +
-        # dashboard writes must stay on the push-to-main path and NOT fire on the new
+        # dashboard WRITES must stay on the push-to-main path and NOT fire on the
         # nightly `schedule` backstop (a scheduled run shares the last main commit's SHA,
         # so writing history would append a duplicate point + ratchet off a non-landing
-        # run). Every such step's guard must exclude schedule.
+        # run). Every such write step's guard must exclude schedule + non-main.
         steps = self.bench["jobs"]["bench"]["steps"]
-        names = [
+        main_only_names = [
             "Auto-ratchet the perf floor (commit improvements back to main)",
             "Ensure benchmark-data history branch exists",
             "Seed Pages dashboard onto benchmark-data (if absent)",
-            # [SONNET-4.6] sq-mel85 nit: the cleanup step (restores Cargo.lock churn before
-            # the benchmark-data branch switch) must also be schedule-excluded — the nightly
-            # backstop never switches branches, so it needs no cleanup, and running it on
-            # schedule would be a no-op that can't break anything, but pinning the guard
-            # prevents silent removal of the schedule-exclusion that would leave the step
-            # active on a path where `git checkout -- .` could discard useful artefacts.
-            "Clean bench-induced tracked churn before history switch (main only)",
+            # [FABLE-5] the median-of-history hard zone gates ONLY main pushes: PR runs
+            # are --deterministic-only + perf-gate.py-gated, and the schedule backstop
+            # is a pure verification run — its guard must equal auto-push's (asserted
+            # exactly below) so the gate and the publish can never diverge.
+            "Hard zone — median-of-history regression gate (main pushes only)",
         ]
         by_name = {s.get("name"): s for s in steps}
-        for n in names:
+        for n in main_only_names:
             self.assertIn(n, by_name, f"bench.yml lost the '{n}' step")
             cond = str(by_name[n].get("if", ""))
             self.assertIn("github.event_name != 'schedule'", cond,
                           f"'{n}' must exclude the schedule backstop (main continuity)")
             self.assertIn("refs/heads/main", cond,
                           f"'{n}' must stay push-to-main scoped")
-        # The github-action-benchmark auto-push must also be schedule-excluded.
+        # [FABLE-5] The churn-clean step is UNCONDITIONAL — a previous revision
+        # (sq-mel85) schedule-excluded it on the WRONG claim that the nightly backstop
+        # "never switches branches": github-action-benchmark fetches + switches to
+        # benchmark-data to READ the comparison history on EVERY event regardless of
+        # auto-push (proven live by schedule run 29989729092 aborting on lockfile
+        # churn). Pin the absence of any event/ref guard so a well-meaning
+        # re-introduction of the old condition can't re-break the nightly run.
+        clean = by_name.get("Clean bench-induced tracked churn before history switch")
+        self.assertIsNotNone(
+            clean, "bench.yml lost the 'Clean bench-induced tracked churn before "
+            "history switch' step (and it must carry no ' (main only)' suffix)")
+        self.assertNotIn(
+            "if", clean,
+            "the churn-clean step must be UNCONDITIONAL: the Store action switches to "
+            "benchmark-data to read history on EVERY event, so schedule runs need the "
+            "clean too (live failure: nightly run 29989729092)")
+        # The github-action-benchmark auto-push stays schedule- and non-main-excluded.
         store = by_name.get("Store + compare against history")
         self.assertIsNotNone(store, "bench.yml lost the history Store step")
-        self.assertIn("github.event_name != 'schedule'",
-                      str(store.get("with", {}).get("auto-push", "")),
+        auto_push = str(store.get("with", {}).get("auto-push", ""))
+        self.assertIn("github.event_name != 'schedule'", auto_push,
                       "history auto-push must not fire on the schedule backstop")
+        self.assertIn("refs/heads/main", auto_push,
+                      "history auto-push must stay push-to-main scoped")
+        # The hard-zone guard must equal the auto-push expression EXACTLY (modulo the
+        # `${{ }}` wrapper `with:` inputs require): the gate runs before Store, and any
+        # drift between the two conditions would either publish an ungated point or
+        # gate a run that publishes nothing.
+        hardzone_cond = str(by_name[
+            "Hard zone — median-of-history regression gate (main pushes only)"].get("if", ""))
+        auto_push_expr = auto_push.strip()
+        if auto_push_expr.startswith("${{") and auto_push_expr.endswith("}}"):
+            auto_push_expr = auto_push_expr[3:-2].strip()
+        self.assertEqual(
+            hardzone_cond.strip(), auto_push_expr,
+            "the hard-zone gate's `if:` must equal the Store auto-push condition "
+            "exactly — the gate and the publish must cover the same runs")
 
     # ---- wasm lane (ci.yml) --------------------------------------------------------
     def test_wasm_job_guarded_by_its_seed_closure(self):


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. This PR was authored and reviewed by AI agents; the maintainer has NOT reviewed it.

Three independent legs have kept the `gate` red on main since 2026-07-22. One PR, one fix per leg, nothing else touched.

## 1. bench.yml — schedule-run lockfile abort (live: run 29989729092)

The "Clean bench-induced tracked churn before history switch" step was guarded `github.event_name != 'schedule' && github.ref == 'refs/heads/main'` on the claim that the nightly schedule backstop "never switches branches (auto-push is push-gated)". That claim was **wrong**: github-action-benchmark does `git fetch` + `git switch benchmark-data` to **read** the comparison history on every event, regardless of auto-push. Proven live: schedule run **29989729092** failed at 08:15:12Z inside the Store step with `Your local changes to the following files would be overwritten by checkout: bench/zk-trace/Cargo.lock, bench/zk/Cargo.lock ... Aborting` — with `auto-push=false`. (PR runs never bit only because the PR leg is `--deterministic-only` and skips the zk/zk-trace cargo benches that rewrite the lockfiles.)

**Fix:** the clean step is now unconditional (the `if:` removed). Restoring tracked churn is always safe: `bench-results.json` is already written before this step (the measurement is untouched), `git checkout -- .` rewrites tracked paths only, and the run outputs later steps read (`bench-results.json`, `prev-data.js`) are untracked. The comment block is rewritten to keep the sq-owci root cause and correct the wrong sq-mel85 claim, citing the live run.

## 2. bench.yml — push-run fail-on-alert noise flap (live: run 29988505852 + 24h pattern)

The Store step used `fail-on-alert: true` + `fail-threshold: 200%`, comparing each metric against the **single** previous benchmark-data point. Main pushes over the last 24h flapped: success at 10:40/23:04/02:30 interleaved with failures at 01:38/03:32/04:20/05:31/07:31 (e.g. run **29988505852**), and failing runs show 9+ **unrelated** µs-scale metrics uniformly 1.78–2.07x "worse" — a slow-runner environment shift, not a regression (the two-zone calibration comment itself recorded the worst observed noise swing at 185%, now exceeded by pure runner variance).

**Fix:** `fail-on-alert: false` (alert-threshold, comment-on-alert, comment-always, summary-always, and the soft-zone triage step are all untouched), plus a new deterministic hard-zone step BEFORE Store (round-1 review: gate-then-publish, so a rejected regression is never pushed into the history it is judged by): `scripts/bench_hardzone.py` reads this run's `bench-results.json` and the already-fetched `prev-data.js` (the "Fetch previous benchmark series" step's output; absent history ⇒ warn + pass), computes each metric's **median of its last up-to-5 published points**, and fails only if a metric is ≥ 2.0x that median — with a **uniform-shift exemption**: if ≥ 50% of all compared metrics are ≥ 1.75x median simultaneously, it prints a loud "uniform environment shift — not gating" warning and passes, and it prints a per-metric table of everything ≥ 1.75x either way.

**Why this is more honest than single-point fail-on-alert:** a real regression is *sustained* — the current run sits above its whole recent history, so it still hard-fails against a median-of-5. A one-off slow runner cannot move a median-of-5, and a shift that degrades every unrelated metric across every suite at once is by construction the runner environment, never a code change — the old gate redded main on exactly that, teaching agents to ignore it. The new gate refuses to red main on environment noise while keeping (not weakening) the hard-fail on genuine sustained regressions, and it says loudly which zone it saw.

The new step carries the **same main-push guard as auto-push** (`event != schedule && ref == main`), so PR behavior is unchanged — deterministic byte-count metrics on PRs stay strictly gated by the existing `perf-gate.py` floor ratchet. The script follows the repo `--self-test` convention (hermetic inline fixtures: median computation incl. window trim + even-count, absent history, uniform-shift exemption, single-metric hard fail, watch-band-no-fail) and the workflow runs `--self-test` before the real invocation. Self-test verified green locally and mutation-checked (flipped an expected median value ⇒ self-test went RED ⇒ restored byte-identical from a /tmp snapshot ⇒ green).

## 3. release-plz — 403 on every main push (live: run 29988505600)

Every main push fails: `ERROR Failed to open PR ... HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/sparq-org/sparq/pulls)` (run **29988505600**) — the repo/org setting **"Allow GitHub Actions to create and approve pull requests" is disabled**, so `GITHUB_TOKEN` cannot create PRs. The job name `release-plz / Release-PR` carried no advisory token, so the failure gated `ci-summary` red.

**App-token option checked first and ruled out on live evidence:** the repo *does* have an App-token pattern (`ORCHESTRATOR_APP_ID`/`ORCHESTRATOR_APP_PRIVATE_KEY` + `actions/create-github-app-token`, batch-merge.yml / rearm-sweeper.yml), which would bypass the setting — but the secrets are **not configured**: batch-merge run **29990467905** (2026-07-23 08:11) logs `ORCHESTRATOR_APP_ID:` empty, `HAVE_APP_TOKEN: false`, "hygiene-only mode — no App token". Switching release-plz to that pattern would just fall back to `GITHUB_TOKEN` and 403 again.

**Fix (advisory + tolerate):** the job is renamed **`release-plz / Release-PR (advisory)`** (ci-summary excludes `\b(advisory|informational)\b` names from the gating set), and the known 403 is loud-but-tolerated: on failure, a follow-up step re-probes the exact failing call (`POST /repos/:repo/pulls` with the same token; `head==base` is invalid, so a *permitted* token gets 422 and no PR is ever created, while the blocked setting returns the same 403 — the authorization check precedes body validation). 403 ⇒ `::warning` naming the exact setting + exit 0; **any other result fails the (now advisory) job** — non-403 errors are never silently swallowed.

**Durable fix (maintainer):** enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** — or configure the `ORCHESTRATOR_APP_ID`/`ORCHESTRATOR_APP_PRIVATE_KEY` secrets and switch this job's token to a minted App token (batch-merge.yml pattern). Either lands the Release-PR flow for real; this PR just stops the setting gap from redding the gate.

## Verification

- `python3 -c "import yaml,...safe_load"` green on both touched workflows; `actionlint` + `typos` green on all touched files.
- `python3 scripts/bench_hardzone.py --self-test` green; mutation check red-on-wrong-expected, restored byte-identical.
- End-to-end smoke: real `window.BENCHMARK_DATA = {...}` fixture ⇒ clean pass; absent `prev-data.js` ⇒ warn + exit 0.
- All action SHA pins are repo-vetted: the release-pr job now installs release-plz@0.3.160 + cargo-semver-checks@0.48 (the exact versions the pinned release-plz/action v0.5.131 installs internally) via the repo-standard `taiki-e/install-action` pin (v2.83.4, explicit `with: tool:` per sq-ur7o), so its output can be tee-captured for failure classification; the tag-cutting `release` job still uses the pinned release-plz/action unchanged.


## Round 1 review dispositions (cross-provider codex review, 8 findings — all addressed in f99b999f0)

1. **C2 registry**: `release-plz / Release-PR (advisory)` registered in `.github/advisory-registry.json` (owner bead sq-lonae) in the exact format `scripts/check-advisory-registry.py` validates.
2. **Ordering**: hard-zone gate now runs BEFORE Store (same main-push-only guard); on failure nothing is published and the step prints its own table to stdout + `GITHUB_STEP_SUMMARY` (Store's comparison comment never fires on a red gate).
3. **Exemption tightened to four mandatory conditions**: breadth ≥50%, watch-ratio stdev/mean ≤0.15, no metric ≥4.0x, all deterministic metrics within 1% of median (unit-first classification); the exemption warns loudly + prints the full table, and the honest wording is "implausible, not impossible" — the "never a code regression" claim is gone.
4. **Fail-closed numerics**: NaN/non-numeric/negative/zero-boundary → per-metric hard fail; stable 0==0 passes (four live series are all-zero by design, so a blanket ≤0 rule would permanently red main); disappeared metrics warn-listed, >30% of gateable metrics disappeared → hard fail. **Direction**: `_per_s$` metrics (`rsp_persistentdict_triples_per_s`) gate larger-is-better (ratio = median/current). *Candidate follow-up*: the suite is `customSmallerIsBetter` but stores raw throughput for that metric — emitting the inverse (seconds-per-triple) would remove the special case.
5. **Windowing**: last ≤5 values PER METRIC across the full retained history; ≥3 values to gate (else "insufficient history — ungated"); exact suite-name match only, absent suite → loud warn + exit 0.
6. **Self-tests**: 32 checks covering every behavior above, count printed dynamically; parser fixture validates argument handling; mutation check on the new uniformity-rejection assertion (cp-snapshot → red → cmp-verified restore).
7. **release-plz containment**: release-pr runs as a wrapped `run:` step with tee-captured output; tolerate requires BOTH the captured blocked-PR-creation signature AND the side-effect-free probe 403 — any other combination stays a real failure.
8. **Churn clean**: allow-list restore of `bench/**/Cargo.lock` only; any other dirty tracked path is printed and the step fails loudly.
