### PR TITLE
fix(bench): noise floor for µs-scale timing metrics in the hard zone — measured honest bands exceed 2x

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -502,6 +502,13 @@ jobs:
       # and already strictly gated by perf-gate.py above, and the nightly `schedule` backstop is a
       # pure verification run — so PR + schedule behavior is unchanged by this step.
       # The script self-tests first (repo convention: hermetic --self-test over inline fixtures).
+      #
+      # --report-out ([FABLE-5] round-2 review): floor-exempt (sub-noise-floor us/milli) metrics
+      # never fail this gate, and once a few regressed points are accepted the median REBASES —
+      # so any floor-exempt hit at >= 2.0x is written to bench-hardzone-report.json, which the
+      # "Soft-zone triage" step below merges into the rolling deduped `bench-flake` issue
+      # (tagged "floor-exempt hard-band"): the durable trail that survives the rebase. The file
+      # is written on pass AND fail; triage runs `if: always()` and tolerates its absence.
       - name: Hard zone — median-of-history regression gate (main pushes only)
         if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
         run: |
@@ -510,7 +517,8 @@ jobs:
           python3 scripts/bench_hardzone.py \
             --results bench-results.json \
             --prev-data prev-data.js \
-            --suite 'sparq engine'
+            --suite 'sparq engine' \
+            --report-out bench-hardzone-report.json
       # [OPUS-4.8] sq-owci — clean the working tree before github-action-benchmark switches branches.
       # ROOT CAUSE: the "Run benchmarks" step (scripts/ci-bench.sh) does `cd bench/zk && cargo bench`
       # and `cd bench/zk-trace && cargo bench` (two STANDALONE cargo projects, run WITHOUT --locked),
@@ -644,6 +652,11 @@ jobs:
       # hard gate: the median-of-history gate above ([FABLE-5] scripts/bench_hardzone.py) owns the
       # hard-zone failure; this step
       # only handles the soft (possible-flakiness) band and always exits 0 (its filing is best-effort).
+      # [FABLE-5] --hardzone-report: additionally merges the median gate's floor-exempt hard-band
+      # rows (bench-hardzone-report.json, written by the gate's --report-out on main pushes;
+      # absent on PR/schedule = no-op) into the same deduped issue, tagged "floor-exempt
+      # hard-band" — the gate never reds on those watch-only rows and their median rebases, so
+      # this issue trail is their only durable record.
       # Canonical repo only — fork PRs get a read-only token, so no issue can be filed there.
       - name: Soft-zone triage (file a deduped bench-flake issue; no @mentions)
         if: always() && github.repository == 'sparq-org/sparq'
@@ -666,6 +679,7 @@ jobs:
           # scripts/bench-thresholds.py from the benchmark-data history).
           python3 scripts/bench-triage.py --mode soft \
             --comparison bench-comparison.json \
+            --hardzone-report bench-hardzone-report.json \
             --soft 175 --hard 200 \
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             || echo "::warning::soft-zone triage filer failed (non-fatal)"

--- a/scripts/bench-triage.py
+++ b/scripts/bench-triage.py
@@ -283,18 +283,33 @@ def load_hardzone_soft_rows(path: str | None) -> list[dict]:
     except (json.JSONDecodeError, ValueError, OSError) as e:
         log(f"warning: could not parse hardzone report {path} ({e}) — skipping its rows")
         return []
+    if not isinstance(data, dict):
+        log(f"warning: hardzone report {path} is not a JSON object — skipping its rows")
+        return []
+    fe = data.get("floor_exempt_hard", [])
+    if not isinstance(fe, list):
+        # {"floor_exempt_hard": null} / a number / a string must degrade to zero merged
+        # rows with a warning — never TypeError out of ordinary soft filing.
+        log(f"warning: hardzone report {path}: floor_exempt_hard is "
+            f"{type(fe).__name__}, expected a list — skipping its rows")
+        return []
     out = []
-    for r in data.get("floor_exempt_hard", []) if isinstance(data, dict) else []:
+    dropped = 0
+    for r in fe:
         if not isinstance(r, dict):
+            dropped += 1
             continue
         name, cur, prev, ratio = (r.get("name"), r.get("current"), r.get("previous"),
                                   r.get("ratio_pct"))
         if (name is None or not isinstance(cur, (int, float))
                 or not isinstance(prev, (int, float)) or not isinstance(ratio, (int, float))):
+            dropped += 1
             continue
         out.append({"name": str(name), "current": float(cur), "previous": float(prev),
                     "ratio_pct": float(ratio), "unit": r.get("unit", ""),
                     "note": r.get("note") or "floor-exempt hard-band"})
+    if dropped:
+        log(f"warning: dropped {dropped} malformed floor_exempt_hard row(s) from {path}")
     return out
 
 
@@ -360,16 +375,60 @@ def _post_issue(title: str, body: str, labels: list[str], existing: str | None) 
         Path(body_file).unlink(missing_ok=True)
 
 
+# ── Markdown sanitizers for artifact-derived fields ────────────────────────────────
+def _md_cell(text) -> str:
+    """Sanitize an artifact-derived value for a plain Markdown table cell.
+
+    Metric names/units/notes arrive from bench artifacts; newlines/pipes could forge
+    table rows, a backtick could open a code span, and a bare @word would ping a GitHub
+    user from an auto-filed issue. Strip newlines, backslash-escape the escapables, and
+    split @-mentions with an empty HTML comment.
+    """
+    s = re.sub(r"[\r\n]+", " ", str(text))
+    s = s.replace("\\", "\\\\").replace("|", "\\|").replace("`", "\\`")
+    return s.replace("@", "@<!-- -->")
+
+
+def _md_code_cell(text) -> str:
+    """Backtick-wrap a value for a Markdown table cell, defusing span-breakers.
+
+    Backslash escapes do NOT work inside a code span, so embedded backticks (which would
+    terminate the span) are replaced with `'`; `\\|` is the one escape GFM honours inside
+    code spans in table cells, and the code span itself neutralizes @-mentions.
+    """
+    s = re.sub(r"[\r\n]+", " ", str(text)).replace("`", "'").replace("|", "\\|")
+    return f"`{s}`"
+
+
 # ── SOFT zone: one rolling deduped bench-flake issue per suite ──────────────────────
 def build_flake_body(suite: str, rows: list[dict], soft: float, hard: float, run_url: str) -> str:
+    tagged = any(r.get("note") for r in rows)
     lines = [
         "> 🤖 **SPARQ agent** — auto-filed by the benchmark self-monitoring soft zone "
         "(noise-reduction-bench-selfmonitor). No human is @-mentioned by design.",
         "",
-        f"Benchmarks in suite `{suite}` regressed into the **soft zone** — above the soft "
-        f"alert-threshold (`{soft}%`) but below the hard fail-threshold (`{hard}%`), so this "
-        "**could be shared-runner flakiness** rather than a real regression. It does **not** "
-        "fail CI. This is a rolling, deduped record — new soft-zone hits append below.",
+    ]
+    if tagged:
+        # Merged floor-exempt hard-band rows sit AT/ABOVE the hard ratio (vs their
+        # median-of-history) — a "everything below the hard threshold" preamble would lie.
+        lines.append(
+            f"Benchmarks in suite `{suite}` were flagged by the benchmark self-monitor. "
+            f"This run's rows fall in **two classes**: **soft-band** rows — above the soft "
+            f"alert-threshold (`{soft}%`) but below the hard fail-threshold (`{hard}%`) vs "
+            f"their single previous point — and tagged **floor-exempt hard-band** rows — "
+            f"at/above the hard ratio vs their median-of-history but under their unit's "
+            f"noise floor, so watch-only for the gate. Either way this **could be "
+            f"shared-runner flakiness** rather than a real regression, and it does **not** "
+            f"fail CI. This is a rolling, deduped record — new hits append below."
+        )
+    else:
+        lines.append(
+            f"Benchmarks in suite `{suite}` regressed into the **soft zone** — above the soft "
+            f"alert-threshold (`{soft}%`) but below the hard fail-threshold (`{hard}%`), so this "
+            "**could be shared-runner flakiness** rather than a real regression. It does **not** "
+            "fail CI. This is a rolling, deduped record — new soft-zone hits append below."
+        )
+    lines += [
         "",
         f"- **Run:** {run_url}",
         "",
@@ -379,12 +438,13 @@ def build_flake_body(suite: str, rows: list[dict], soft: float, hard: float, run
         "|---|---|---|---|",
     ]
     for r in sorted(rows, key=lambda x: -x["ratio_pct"]):
-        tag = f" — {r['note']}" if r.get("note") else ""
+        tag = f" — {_md_cell(r['note'])}" if r.get("note") else ""
+        unit = _md_cell(r["unit"])
         lines.append(
-            f"| `{r['name']}`{tag} | {r['previous']:g}{r['unit']} | "
-            f"{r['current']:g}{r['unit']} | {r['ratio_pct']:g}% |"
+            f"| {_md_code_cell(r['name'])}{tag} | {r['previous']:g}{unit} | "
+            f"{r['current']:g}{unit} | {r['ratio_pct']:g}% |"
         )
-    if any(r.get("note") for r in rows):
+    if tagged:
         lines += [
             "",
             "Rows tagged \"floor-exempt hard-band\" come from the median-of-history hard gate "
@@ -511,9 +571,10 @@ def build_regression_body(cluster_crates: list[str], rows: list[dict], ranked: l
         "|---|---|---|---|",
     ]
     for r in sorted(rows, key=lambda x: -x["ratio_pct"]):
+        unit = _md_cell(r["unit"])
         lines.append(
-            f"| `{r['name']}` | {r['previous']:g}{r['unit']} | "
-            f"{r['current']:g}{r['unit']} | {r['ratio_pct']:g}% |"
+            f"| {_md_code_cell(r['name'])} | {r['previous']:g}{unit} | "
+            f"{r['current']:g}{unit} | {r['ratio_pct']:g}% |"
         )
     lines += ["", "### Ranked suspect commits", ""]
     if ranked:
@@ -524,7 +585,7 @@ def build_regression_body(cluster_crates: list[str], rows: list[dict], ranked: l
             commit_link = f"[`{c['sha'][:10]}`]({repo}/commit/{c['sha']})"
             lines.append(
                 f"| {i} | {commit_link} | {pr_link} | "
-                f"{', '.join(c['overlap']) or '—'} | {c['subject']} |"
+                f"{', '.join(c['overlap']) or '—'} | {_md_cell(c['subject'])} |"
             )
     else:
         lines.append("_No commit in the baseline..head range touched the regressed crates; "
@@ -683,15 +744,50 @@ def self_test() -> int:
         assert "median-of-history" in mbody   # the tagged-row explainer paragraph
         stripped3 = mbody.replace("@-mentioned", "").replace("@-mention", "")
         assert "@" not in stripped3, "flake body with hardzone rows must not @-mention anyone"
+        # [FABLE-5 round 3] the preamble distinguishes the two row classes — a merged
+        # floor-exempt row sits AT/ABOVE the hard ratio, so the soft-only "below the hard
+        # fail-threshold" framing would contradict the table it introduces.
+        assert "two classes" in mbody, "tagged body must distinguish soft vs floor-exempt rows"
+        assert "regressed into the **soft zone**" not in mbody
         # untagged-only bodies carry no explainer paragraph (soft-band prose stays accurate).
         plain = build_flake_body("sparq-geo", soft_rows[1:], 175, 200, "http://run/4")
         assert "floor-exempt hard-band" not in plain
+        assert "regressed into the **soft zone**" in plain and "two classes" not in plain
         # fail-soft: no arg / absent file / unparsable file all -> [] (triage must not break).
         assert load_hardzone_soft_rows(None) == []
         assert load_hardzone_soft_rows(str(Path(td3) / "absent.json")) == []
         bad = Path(td3) / "bad.json"
         bad.write_text("{not json", encoding="utf-8")
         assert load_hardzone_soft_rows(str(bad)) == []
+        # [FABLE-5 round 3] fail-soft on WRONG-TYPED payloads: {"floor_exempt_hard": null},
+        # a number, and a non-object top level must all degrade to zero merged rows with a
+        # warning — never TypeError out of ordinary soft filing.
+        nul = Path(td3) / "nul.json"
+        nul.write_text(json.dumps({"floor_exempt_hard": None}), encoding="utf-8")
+        assert load_hardzone_soft_rows(str(nul)) == []
+        num = Path(td3) / "num.json"
+        num.write_text(json.dumps({"floor_exempt_hard": 7}), encoding="utf-8")
+        assert load_hardzone_soft_rows(str(num)) == []
+        arr = Path(td3) / "arr.json"
+        arr.write_text(json.dumps([1, 2]), encoding="utf-8")
+        assert load_hardzone_soft_rows(str(arr)) == []
+
+        # [FABLE-5 round 3] Markdown-injection hardening: pipes/backticks/newlines/@ in
+        # artifact-derived fields render escaped — no forged table rows, no code-span
+        # breakout, no naked @-mention.
+        evil = [{"name": "evil_us|`name\ninjected", "current": 12.0, "previous": 4.0,
+                 "ratio_pct": 300.0, "unit": "us|`u",
+                 "note": "pinged @someone | `boom`\nrow"}]
+        ebody = build_flake_body("sparq-engine+sparq-core", evil, 175, 200, "http://run/5")
+        evil_lines = [ln for ln in ebody.splitlines() if "evil_us" in ln]
+        assert len(evil_lines) == 1, evil_lines            # a newline never splits the row
+        erow = evil_lines[0]
+        # code-span cell: | escaped GFM-style, span-breaking ` defused, newline stripped.
+        assert "`evil_us\\|'name injected`" in erow, erow
+        assert "us\\|\\`u" in erow, erow                   # plain cell: | and ` escaped
+        assert "\\`boom\\`" in erow, erow                  # note ` cannot open a code span
+        assert "@someone" not in ebody                     # mention split by an HTML comment
+        assert "@<!-- -->someone" in ebody
 
     # nightly attribution ranking: overlap with regressed crates ranks first.
     commits = [

--- a/scripts/bench-triage.py
+++ b/scripts/bench-triage.py
@@ -17,6 +17,14 @@
 #             update ONE rolling deduped GitHub issue per benchmark suite (label `bench-flake`),
 #             listing the flagged benchmarks + runs. No @mentions.
 #
+# FLOOR-EXEMPT HARD-BAND ([FABLE-5]): the median-of-history hard gate (scripts/bench_hardzone.py)
+# never fails on a floor-exempt (sub-noise-floor us/milli) metric, and after a few accepted
+# points the regressed median REBASES — so those hits would leave NO durable trail from the gate
+# itself. `--hardzone-report` points at bench_hardzone.py's --report-out JSON; its
+# `floor_exempt_hard` rows (previous = the MEDIAN-of-history, tagged "floor-exempt hard-band")
+# are merged into the SOFT partition so they land in the same rolling deduped bench-flake issue.
+# This NEVER weakens a gate — those rows were watch-only for the gate already.
+#
 # NIGHTLY ATTRIBUTION (--mode nightly): when the scheduled/nightly bench detects a regression
 # vs the last green nightly baseline, rank the most likely culprit commits/PRs by intersecting
 # each commit's touched paths with the crates the regressed suite exercises (a small static
@@ -256,6 +264,51 @@ def zone_partition(rows: list[dict], soft: float, hard: float) -> dict[str, list
     return part
 
 
+def load_hardzone_soft_rows(path: str | None) -> list[dict]:
+    """Floor-exempt hard-band rows from bench_hardzone.py's --report-out JSON (fail-soft -> []).
+
+    The hard gate never fails on a floor-exempt metric and its median rebases after a few
+    accepted points, so these hits must land in the durable bench-flake issue trail instead.
+    Rows arrive in the normalized comparison shape with `previous` holding the
+    MEDIAN-of-history (not the single previous point) and a `note` tag rendered in the issue
+    table. Malformed rows are dropped (this path must never break the triage filer).
+    """
+    if not path:
+        return []
+    p = Path(path)
+    if not p.exists():
+        return []  # hardzone gate did not run on this event (PR/schedule) — nothing to merge
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        log(f"warning: could not parse hardzone report {path} ({e}) — skipping its rows")
+        return []
+    out = []
+    for r in data.get("floor_exempt_hard", []) if isinstance(data, dict) else []:
+        if not isinstance(r, dict):
+            continue
+        name, cur, prev, ratio = (r.get("name"), r.get("current"), r.get("previous"),
+                                  r.get("ratio_pct"))
+        if (name is None or not isinstance(cur, (int, float))
+                or not isinstance(prev, (int, float)) or not isinstance(ratio, (int, float))):
+            continue
+        out.append({"name": str(name), "current": float(cur), "previous": float(prev),
+                    "ratio_pct": float(ratio), "unit": r.get("unit", ""),
+                    "note": r.get("note") or "floor-exempt hard-band"})
+    return out
+
+
+def merge_hardzone_rows(soft_rows: list[dict], extra: list[dict]) -> list[dict]:
+    """Merge floor-exempt hard-band rows into the soft partition (tagged row wins by name).
+
+    A metric can appear both in the single-previous-point soft band and in the hardzone
+    report; the tagged median-of-history row is the more meaningful record, so it replaces
+    the untagged one rather than duplicating the table row.
+    """
+    have = {r["name"] for r in extra}
+    return [r for r in soft_rows if r["name"] not in have] + extra
+
+
 # ── gh helpers (fail-soft) ─────────────────────────────────────────────────────────
 def gh(*argv: str) -> str:
     return subprocess.run(["gh", *argv], check=True, capture_output=True, text=True).stdout.strip()
@@ -326,10 +379,21 @@ def build_flake_body(suite: str, rows: list[dict], soft: float, hard: float, run
         "|---|---|---|---|",
     ]
     for r in sorted(rows, key=lambda x: -x["ratio_pct"]):
+        tag = f" — {r['note']}" if r.get("note") else ""
         lines.append(
-            f"| `{r['name']}` | {r['previous']:g}{r['unit']} | "
+            f"| `{r['name']}`{tag} | {r['previous']:g}{r['unit']} | "
             f"{r['current']:g}{r['unit']} | {r['ratio_pct']:g}% |"
         )
+    if any(r.get("note") for r in rows):
+        lines += [
+            "",
+            "Rows tagged \"floor-exempt hard-band\" come from the median-of-history hard gate "
+            "(`scripts/bench_hardzone.py`): they are at/above the HARD ratio against their "
+            "median-of-history but sit under their unit's noise floor, so they are watch-only "
+            "for the gate. They are recorded here so a persistent sub-floor regression keeps a "
+            "durable trail even after the median rebases — for those rows the `previous` "
+            "column is the median-of-history, not the single previous point.",
+        ]
     lines += [
         "",
         "If these persist across several runs the swing is likely real — promote to a "
@@ -593,6 +657,42 @@ def self_test() -> int:
         assert baseline_sha(str(prev), "nonexistent suite") == "c2"  # falls back to only suite
         assert baseline_sha(str(Path(tdc) / "absent.js"), "sparq engine") == ""
 
+    # [FABLE-5] hardzone floor-exempt hard-band rows: loaded fail-soft, merged into the soft
+    # partition (tagged row wins on a name collision), rendered tagged in the flake body.
+    with tempfile.TemporaryDirectory() as td3:
+        hz = Path(td3) / "hardzone-report.json"
+        hz.write_text(json.dumps({"floor_exempt_hard": [
+            {"name": "tiny_query_us", "current": 12.0, "previous": 4.0, "ratio_pct": 300.0,
+             "unit": "us",
+             "note": "floor-exempt hard-band (>= 2x median-of-history; watch-only for the gate)"},
+            {"name": "malformed_row", "current": "not-a-number"},   # dropped, never crashes
+        ]}), encoding="utf-8")
+        extra = load_hardzone_soft_rows(str(hz))
+        assert [r["name"] for r in extra] == ["tiny_query_us"], extra
+        soft_rows = [
+            {"name": "tiny_query_us", "current": 8.0, "previous": 4.0, "ratio_pct": 200.0,
+             "unit": "us"},                                          # same-name untagged row
+            {"name": "geo_within_us", "current": 18.0, "previous": 10.0, "ratio_pct": 180.0,
+             "unit": "us"},
+        ]
+        merged = merge_hardzone_rows(soft_rows, extra)
+        assert [r["name"] for r in merged] == ["geo_within_us", "tiny_query_us"], merged
+        assert merged[-1]["note"].startswith("floor-exempt hard-band")
+        mbody = build_flake_body("sparq-engine+sparq-core", merged, 175, 200, "http://run/3")
+        assert "floor-exempt hard-band" in mbody and "tiny_query_us" in mbody
+        assert "median-of-history" in mbody   # the tagged-row explainer paragraph
+        stripped3 = mbody.replace("@-mentioned", "").replace("@-mention", "")
+        assert "@" not in stripped3, "flake body with hardzone rows must not @-mention anyone"
+        # untagged-only bodies carry no explainer paragraph (soft-band prose stays accurate).
+        plain = build_flake_body("sparq-geo", soft_rows[1:], 175, 200, "http://run/4")
+        assert "floor-exempt hard-band" not in plain
+        # fail-soft: no arg / absent file / unparsable file all -> [] (triage must not break).
+        assert load_hardzone_soft_rows(None) == []
+        assert load_hardzone_soft_rows(str(Path(td3) / "absent.json")) == []
+        bad = Path(td3) / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        assert load_hardzone_soft_rows(str(bad)) == []
+
     # nightly attribution ranking: overlap with regressed crates ranks first.
     commits = [
         {"sha": "a" * 40, "subject": "feat(geo): add index (#101)", "author": "x",
@@ -647,6 +747,10 @@ def main() -> int:
     ap.add_argument("--out", help="where build-comparison writes the normalized JSON")
     ap.add_argument("--soft", type=float, default=175.0, help="soft alert-threshold %% (150==1.5x)")
     ap.add_argument("--hard", type=float, default=200.0, help="hard fail-threshold %% (150==1.5x)")
+    ap.add_argument("--hardzone-report",
+                    help="bench_hardzone.py --report-out JSON; its floor_exempt_hard rows are "
+                         "merged into the soft partition tagged 'floor-exempt hard-band' "
+                         "(absent file = no-op; soft mode only)")
     ap.add_argument("--run-url", default="")
     ap.add_argument("--baseline-sha", default="")
     ap.add_argument("--head-sha", default="")
@@ -683,6 +787,14 @@ def main() -> int:
 
     repo = args.repo_url or "https://github.com/sparq-org/sparq"
     if args.mode == "soft":
+        # [FABLE-5] durable trail: floor-exempt hard-band hits from the median-of-history gate
+        # never red that gate and would vanish once the median rebases — merge them into the
+        # soft partition so the deduped bench-flake issue records every one.
+        extra = load_hardzone_soft_rows(args.hardzone_report)
+        if extra:
+            part["soft"] = merge_hardzone_rows(part["soft"], extra)
+            log(f"merged {len(extra)} floor-exempt hard-band row(s) from the hardzone report "
+                f"into the soft partition (durable bench-flake trail)")
         file_flake_issues(part, args.soft, args.hard, args.run_url)
     else:  # nightly
         file_regression_issues(part, args.soft, args.hard, args.baseline_sha,

--- a/scripts/bench-triage.py
+++ b/scripts/bench-triage.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import subprocess
 import sys
@@ -111,6 +112,31 @@ def log(msg: str) -> None:
     print(f"[{PROG}] {msg}", file=sys.stderr)
 
 
+def _finite_num(v) -> float | None:
+    """v as a float iff v is a REAL, FINITE number — else None. THE numeric admission gate.
+
+    [FABLE-5 round 4] Every numeric field this script consumes from an artifact routes
+    through here. Admissible inputs are int/float instances that are NOT bool (json
+    true/false must never pass as 1/0), whose float() conversion succeeds — an
+    out-of-float-range int like 10**400 raises OverflowError, which must DROP the value,
+    never crash the triage filer — and whose converted value is finite (json.loads happily
+    emits NaN/Infinity/-Infinity by default, so isfinite is load-bearing).
+    """
+    if not isinstance(v, (int, float)) or isinstance(v, bool):
+        return None
+    try:
+        f = float(v)
+    except (OverflowError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def _entry_date(e: dict) -> float:
+    """Numeric sort key for a data.js entry — junk/absent dates sort as 0, never TypeError."""
+    d = _finite_num(e.get("date"))
+    return 0.0 if d is None else d
+
+
 def metric_crates(name: str) -> list[str]:
     """Map a benchmark metric name to the crates it exercises (longest-prefix wins)."""
     lname = name.lower()
@@ -153,7 +179,9 @@ def classify(ratio_pct: float, soft: float, hard: float) -> str:
 def _to_ratio_pct(cur: float, prev: float) -> float | None:
     if prev == 0:
         return None
-    return (cur / prev) * 100.0
+    ratio = (cur / prev) * 100.0
+    # Two finite floats can still divide to inf (1e308 / 1e-308) — an undefined comparison.
+    return ratio if math.isfinite(ratio) else None
 
 
 def _parse_data_js(text: str) -> dict:
@@ -178,11 +206,13 @@ def baseline_sha(prev_data_js: str, suite: str) -> str:
         data = _parse_data_js(p.read_text(encoding="utf-8"))
         entries = data.get("entries", {})
         series = entries.get(suite) or (next(iter(entries.values())) if entries else [])
-        series = sorted(series, key=lambda e: e.get("date", 0))
+        series = sorted((e for e in series if isinstance(e, dict)), key=_entry_date)
         if not series:
             return ""
-        return (series[-1].get("commit") or {}).get("id", "") or ""
-    except (json.JSONDecodeError, ValueError, OSError):
+        commit = series[-1].get("commit")
+        cid = commit.get("id", "") if isinstance(commit, dict) else ""
+        return str(cid) if cid else ""
+    except (json.JSONDecodeError, ValueError, OSError, TypeError, AttributeError):
         return ""
 
 
@@ -194,7 +224,9 @@ def build_comparison(results_path: str, prev_data_js: str | None, suite: str) ->
     {name,value,unit}); `prev_data_js` is the previously-published dev/bench/data.js (the last
     committed point on the benchmark-data branch). We pair each current metric with its most
     recent previous value of the SAME name in `suite`. Metrics with no previous value are
-    emitted with previous=null (skipped by parse_comparison — nothing to compare).
+    emitted with previous=null (skipped by parse_comparison — nothing to compare). Every
+    numeric field is admitted through _finite_num only: bool / NaN / inf / out-of-float-range
+    values are dropped with a counted warning, never floated blindly.
     """
     current = json.loads(Path(results_path).read_text(encoding="utf-8"))
     cur_rows = current if isinstance(current, list) else current.get("benches", [])
@@ -205,25 +237,36 @@ def build_comparison(results_path: str, prev_data_js: str | None, suite: str) ->
             entries = data.get("entries", {})
             # prefer the named suite; fall back to the only/first suite present.
             series = entries.get(suite) or (next(iter(entries.values())) if entries else [])
-            ordered = sorted(series, key=lambda e: e.get("date", 0))
+            ordered = sorted((e for e in series if isinstance(e, dict)), key=_entry_date)
             for e in ordered:  # later entries overwrite earlier -> most-recent value wins
-                for b in e.get("benches", []):
-                    if b.get("name") is not None and isinstance(b.get("value"), (int, float)):
-                        prev_by_name[b["name"]] = float(b["value"])
-        except (json.JSONDecodeError, ValueError, OSError) as e:
+                benches = e.get("benches", [])
+                for b in (benches if isinstance(benches, list) else []):
+                    if not isinstance(b, dict):
+                        continue
+                    fv = _finite_num(b.get("value"))
+                    if b.get("name") is not None and fv is not None:
+                        prev_by_name[str(b["name"])] = fv
+        except (json.JSONDecodeError, ValueError, OSError, TypeError, AttributeError) as e:
             log(f"warning: could not parse previous data.js ({e}) — no comparison baseline")
     out = []
+    dropped = 0
     for b in cur_rows:
+        if not isinstance(b, dict):
+            dropped += 1
+            continue
         name = b.get("name")
-        val = b.get("value")
-        if name is None or not isinstance(val, (int, float)):
+        val = _finite_num(b.get("value"))
+        if name is None or val is None:
+            dropped += 1
             continue
         out.append({
-            "name": name,
-            "current": float(val),
-            "previous": prev_by_name.get(name),
+            "name": str(name),
+            "current": val,
+            "previous": prev_by_name.get(str(name)),
             "unit": b.get("unit", ""),
         })
+    if dropped:
+        log(f"warning: dropped {dropped} malformed/non-finite result row(s) from {results_path}")
     return out
 
 
@@ -233,27 +276,40 @@ def parse_comparison(path: str) -> list[dict]:
     This is the small normalized shape the workflow builds from github-action-benchmark's
     output (the action does not emit a stable machine file, so the workflow constructs this
     from the current run's results + the previous data.js point). Rows with no previous value
-    (a brand-new metric) are skipped — nothing to compare against.
+    (a brand-new metric) are skipped — nothing to compare against. Numeric fields are
+    admitted through _finite_num only: a present-but-non-finite/bool/unconvertible value is
+    a MALFORMED row, dropped with a counted warning (never a float() crash).
     """
     data = json.loads(Path(path).read_text(encoding="utf-8"))
     rows = data if isinstance(data, list) else data.get("benches", [])
     out = []
+    dropped = 0
     for r in rows:
+        if not isinstance(r, dict):
+            dropped += 1
+            continue
         name = r.get("name")
-        cur = r.get("current", r.get("value"))
-        prev = r.get("previous")
-        if name is None or cur is None or prev is None:
+        cur_raw = r.get("current", r.get("value"))
+        prev_raw = r.get("previous")
+        if name is None or cur_raw is None or prev_raw is None:
+            continue  # brand-new metric / incomplete row — nothing to compare
+        cur = _finite_num(cur_raw)
+        prev = _finite_num(prev_raw)
+        if cur is None or prev is None:
+            dropped += 1  # present but bool/NaN/inf/out-of-range — malformed, not "new"
             continue
-        ratio = _to_ratio_pct(float(cur), float(prev))
+        ratio = _to_ratio_pct(cur, prev)
         if ratio is None:
-            continue
+            continue  # zero previous / overflowing ratio — comparison undefined
         out.append({
-            "name": name,
-            "current": float(cur),
-            "previous": float(prev),
+            "name": str(name),
+            "current": cur,
+            "previous": prev,
             "ratio_pct": round(ratio, 1),
             "unit": r.get("unit", ""),
         })
+    if dropped:
+        log(f"warning: dropped {dropped} malformed/non-finite comparison row(s) from {path}")
     return out
 
 
@@ -271,7 +327,11 @@ def load_hardzone_soft_rows(path: str | None) -> list[dict]:
     accepted points, so these hits must land in the durable bench-flake issue trail instead.
     Rows arrive in the normalized comparison shape with `previous` holding the
     MEDIAN-of-history (not the single previous point) and a `note` tag rendered in the issue
-    table. Malformed rows are dropped (this path must never break the triage filer).
+    table. Malformed rows are dropped with a counted warning (this path must never break the
+    triage filer): every numeric field is admitted through _finite_num — bool rejected
+    (json true/false must not pass as 1/0), NaN/Infinity rejected, and the float() conversion
+    itself guarded (an out-of-float-range int like 10**400 raises OverflowError — a drop,
+    never a crash).
     """
     if not path:
         return []
@@ -299,15 +359,16 @@ def load_hardzone_soft_rows(path: str | None) -> list[dict]:
         if not isinstance(r, dict):
             dropped += 1
             continue
-        name, cur, prev, ratio = (r.get("name"), r.get("current"), r.get("previous"),
-                                  r.get("ratio_pct"))
-        if (name is None or not isinstance(cur, (int, float))
-                or not isinstance(prev, (int, float)) or not isinstance(ratio, (int, float))):
+        name = r.get("name")
+        cur = _finite_num(r.get("current"))
+        prev = _finite_num(r.get("previous"))
+        ratio = _finite_num(r.get("ratio_pct"))
+        if name is None or cur is None or prev is None or ratio is None:
             dropped += 1
             continue
-        out.append({"name": str(name), "current": float(cur), "previous": float(prev),
-                    "ratio_pct": float(ratio), "unit": r.get("unit", ""),
-                    "note": r.get("note") or "floor-exempt hard-band"})
+        out.append({"name": str(name), "current": cur, "previous": prev,
+                    "ratio_pct": ratio, "unit": str(r.get("unit") or ""),
+                    "note": str(r.get("note") or "floor-exempt hard-band")})
     if dropped:
         log(f"warning: dropped {dropped} malformed floor_exempt_hard row(s) from {path}")
     return out
@@ -375,62 +436,112 @@ def _post_issue(title: str, body: str, labels: list[str], existing: str | None) 
         Path(body_file).unlink(missing_ok=True)
 
 
-# ── Markdown sanitizers for artifact-derived fields ────────────────────────────────
-def _md_cell(text) -> str:
-    """Sanitize an artifact-derived value for a plain Markdown table cell.
+# ── defense-in-depth sanitizer for artifact-derived text in issue bodies ────────────
+def _sanitize(text, *, code: bool = False) -> str:
+    """[FABLE-5 round 4] THE sanitizer — every artifact-derived string interpolated into an
+    issue/comment body routes through here (via _md_cell / _md_code_cell / directly).
 
-    Metric names/units/notes arrive from bench artifacts; newlines/pipes could forge
-    table rows, a backtick could open a code span, and a bare @word would ping a GitHub
-    user from an auto-filed issue. Strip newlines, backslash-escape the escapables, and
-    split @-mentions with an empty HTML comment.
+    Layer 1 — HTML, first and unconditional: GitHub renders raw HTML in issue bodies, so a
+    value like `</td></tr></table><h1>forged</h1>` would BREAK OUT of the surrounding table
+    even with perfect Markdown escaping. Escape &, <, > (& first — that also defuses
+    entity-encoded smuggling such as `&#64;user` / `&lt;`). Applied inside code spans too,
+    belt-and-braces: a span that any renderer quirk fails to close must still contain no
+    live tags.
+
+    Layer 2 — Markdown, per cell type:
+      * plain (default): strip newlines (no forged table rows), backslash-escape the
+        escapables (\\ | ` — no forged cells / opened code spans), then split @-mentions
+        with an empty HTML comment. The comment is inserted AFTER the HTML escape so it
+        survives as a real comment; layer 1 already reduced every attacker-supplied < to
+        &lt;, so the only raw HTML left in the output is this trusted defusal comment.
+      * code span (code=True): backslash escapes do NOT work inside a code span, so
+        span-terminating backticks become `'`; `\\|` is the one escape GFM honours inside
+        code spans in table cells; the span itself neutralizes @-mentions.
     """
     s = re.sub(r"[\r\n]+", " ", str(text))
+    s = s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    if code:
+        s = s.replace("`", "'").replace("|", "\\|")
+        return f"`{s}`"
     s = s.replace("\\", "\\\\").replace("|", "\\|").replace("`", "\\`")
     return s.replace("@", "@<!-- -->")
 
 
-def _md_code_cell(text) -> str:
-    """Backtick-wrap a value for a Markdown table cell, defusing span-breakers.
+def _md_cell(text) -> str:
+    """Sanitize an artifact-derived value for a plain Markdown table cell / prose slot."""
+    return _sanitize(text)
 
-    Backslash escapes do NOT work inside a code span, so embedded backticks (which would
-    terminate the span) are replaced with `'`; `\\|` is the one escape GFM honours inside
-    code spans in table cells, and the code span itself neutralizes @-mentions.
+
+def _md_code_cell(text) -> str:
+    """Sanitize an artifact-derived value into a Markdown code span (table-cell safe)."""
+    return _sanitize(text, code=True)
+
+
+def _md_url(text) -> str:
+    """Sanitize an interpolated link DESTINATION (the `(...)` part of a Markdown link).
+
+    Strip all whitespace, then percent-encode every character that could terminate the
+    destination, escape out of it, or open raw HTML. Display text next to the destination
+    goes through _sanitize separately.
     """
-    s = re.sub(r"[\r\n]+", " ", str(text)).replace("`", "'").replace("|", "\\|")
-    return f"`{s}`"
+    s = re.sub(r"\s+", "", str(text))
+    for ch, enc in (("\\", "%5C"), ("(", "%28"), (")", "%29"), ("<", "%3C"),
+                    (">", "%3E"), ('"', "%22"), ("'", "%27"), ("`", "%60")):
+        s = s.replace(ch, enc)
+    return s
 
 
 # ── SOFT zone: one rolling deduped bench-flake issue per suite ──────────────────────
 def build_flake_body(suite: str, rows: list[dict], soft: float, hard: float, run_url: str) -> str:
-    tagged = any(r.get("note") for r in rows)
+    tagged_rows = [r for r in rows if r.get("note")]
+    plain_rows = [r for r in rows if not r.get("note")]
     lines = [
         "> 🤖 **SPARQ agent** — auto-filed by the benchmark self-monitoring soft zone "
         "(noise-reduction-bench-selfmonitor). No human is @-mentioned by design.",
         "",
     ]
-    if tagged:
-        # Merged floor-exempt hard-band rows sit AT/ABOVE the hard ratio (vs their
+    # [FABLE-5 round 4] the class sentence is derived from the row classes ACTUALLY present —
+    # soft-band only, floor-exempt only, or mixed — so the preamble never describes a class
+    # the table below does not contain.
+    if tagged_rows and plain_rows:
+        # MIXED: merged floor-exempt hard-band rows sit AT/ABOVE the hard ratio (vs their
         # median-of-history) — a "everything below the hard threshold" preamble would lie.
         lines.append(
-            f"Benchmarks in suite `{suite}` were flagged by the benchmark self-monitor. "
-            f"This run's rows fall in **two classes**: **soft-band** rows — above the soft "
-            f"alert-threshold (`{soft}%`) but below the hard fail-threshold (`{hard}%`) vs "
-            f"their single previous point — and tagged **floor-exempt hard-band** rows — "
-            f"at/above the hard ratio vs their median-of-history but under their unit's "
-            f"noise floor, so watch-only for the gate. Either way this **could be "
-            f"shared-runner flakiness** rather than a real regression, and it does **not** "
-            f"fail CI. This is a rolling, deduped record — new hits append below."
+            f"Benchmarks in suite {_md_code_cell(suite)} were flagged by the benchmark "
+            f"self-monitor. This run's rows fall in **two classes**: **soft-band** rows — "
+            f"above the soft alert-threshold (`{soft}%`) but below the hard fail-threshold "
+            f"(`{hard}%`) vs their single previous point — and tagged **floor-exempt "
+            f"hard-band** rows — at/above the hard ratio vs their median-of-history but "
+            f"under their unit's noise floor, so watch-only for the gate. Either way this "
+            f"**could be shared-runner flakiness** rather than a real regression, and it "
+            f"does **not** fail CI. This is a rolling, deduped record — new hits append below."
+        )
+    elif tagged_rows:
+        # FLOOR-EXEMPT ONLY: no soft-band row this run — claiming "two classes" (or any
+        # "below the hard fail-threshold" soft framing) would describe rows that are not
+        # in the table.
+        lines.append(
+            f"Benchmarks in suite {_md_code_cell(suite)} were flagged by the benchmark "
+            f"self-monitor. **Every row this run is a tagged floor-exempt hard-band hit** — "
+            f"at/above the hard ratio vs its median-of-history but under its unit's noise "
+            f"floor, so watch-only for the gate; there are no soft-band rows this run. At "
+            f"that scale the measured honest run-to-run bands exceed the hard threshold, so "
+            f"this **could be shared-runner flakiness** rather than a real regression, and "
+            f"it does **not** fail CI. This is a rolling, deduped record — new hits append "
+            f"below."
         )
     else:
+        # SOFT ONLY: the classic soft-zone framing stays exact.
         lines.append(
-            f"Benchmarks in suite `{suite}` regressed into the **soft zone** — above the soft "
-            f"alert-threshold (`{soft}%`) but below the hard fail-threshold (`{hard}%`), so this "
+            f"Benchmarks in suite {_md_code_cell(suite)} regressed into the **soft zone** — "
+            f"above the soft alert-threshold (`{soft}%`) but below the hard fail-threshold "
+            f"(`{hard}%`), so this "
             "**could be shared-runner flakiness** rather than a real regression. It does **not** "
             "fail CI. This is a rolling, deduped record — new soft-zone hits append below."
         )
     lines += [
         "",
-        f"- **Run:** {run_url}",
+        f"- **Run:** {_md_cell(run_url)}",
         "",
         "### Flagged benchmarks (this run)",
         "",
@@ -444,7 +555,7 @@ def build_flake_body(suite: str, rows: list[dict], soft: float, hard: float, run
             f"| {_md_code_cell(r['name'])}{tag} | {r['previous']:g}{unit} | "
             f"{r['current']:g}{unit} | {r['ratio_pct']:g}% |"
         )
-    if tagged:
+    if tagged_rows:
         lines += [
             "",
             "Rows tagged \"floor-exempt hard-band\" come from the median-of-history hard gate "
@@ -559,11 +670,11 @@ def build_regression_body(cluster_crates: list[str], rows: list[dict], ranked: l
         "",
         f"The nightly full-suite benchmark detected a regression **beyond the hard "
         f"fail-threshold (`{hard}%`)** vs the last green nightly baseline, in the "
-        f"`{'+'.join(cluster_crates)}` suite cluster.",
+        f"{_md_code_cell('+'.join(cluster_crates))} suite cluster.",
         "",
-        f"- **Run:** {run_url}",
-        f"- **Baseline (last green nightly):** `{baseline_sha[:12]}`",
-        f"- **Head:** `{head_sha[:12]}`",
+        f"- **Run:** {_md_cell(run_url)}",
+        f"- **Baseline (last green nightly):** {_md_code_cell(baseline_sha[:12])}",
+        f"- **Head:** {_md_code_cell(head_sha[:12])}",
         "",
         "### Regression table",
         "",
@@ -580,12 +691,13 @@ def build_regression_body(cluster_crates: list[str], rows: list[dict], ranked: l
     if ranked:
         lines += ["| rank | commit | PR | overlap crates | subject |", "|---|---|---|---|---|"]
         for i, c in enumerate(ranked[:10], 1):
-            pr = _pr_ref(c["subject"])
-            pr_link = f"[{pr}]({repo}/pull/{pr[1:]})" if pr else "—"
-            commit_link = f"[`{c['sha'][:10]}`]({repo}/commit/{c['sha']})"
+            pr = _pr_ref(c["subject"])  # regex-constrained to "#<digits>" — safe by shape
+            pr_link = f"[{pr}]({_md_url(repo)}/pull/{pr[1:]})" if pr else "—"
+            commit_link = (f"[{_md_code_cell(c['sha'][:10])}]"
+                           f"({_md_url(repo)}/commit/{_md_url(c['sha'])})")
             lines.append(
                 f"| {i} | {commit_link} | {pr_link} | "
-                f"{', '.join(c['overlap']) or '—'} | {_md_cell(c['subject'])} |"
+                f"{_md_cell(', '.join(c['overlap'])) or '—'} | {_md_cell(c['subject'])} |"
             )
     else:
         lines.append("_No commit in the baseline..head range touched the regressed crates; "
@@ -648,6 +760,19 @@ def self_test() -> int:
     # ratio helper.
     assert _to_ratio_pct(15, 10) == 150.0
     assert _to_ratio_pct(10, 0) is None
+    assert _to_ratio_pct(1e308, 1e-308) is None   # finite/finite can still overflow to inf
+
+    # [FABLE-5 round 4] _finite_num — THE numeric admission gate for every consumed field:
+    # bool rejected, NaN/inf rejected, the float() conversion guarded (10**400 raises
+    # OverflowError — a drop, never a crash), strings/None rejected, real numbers pass.
+    assert _finite_num(5) == 5.0 and _finite_num(2.5) == 2.5 and _finite_num(0) == 0.0
+    assert _finite_num(True) is None and _finite_num(False) is None
+    assert _finite_num(float("nan")) is None and _finite_num(float("inf")) is None
+    assert _finite_num(float("-inf")) is None
+    assert _finite_num(10**400) is None           # OverflowError path — dropped, not raised
+    assert _finite_num("5") is None and _finite_num(None) is None and _finite_num([1]) is None
+    # junk dates sort as 0 instead of TypeError-ing the whole comparison build.
+    assert _entry_date({"date": "garbage"}) == 0.0 and _entry_date({"date": 7}) == 7.0
 
     # suite->crate map: longest-prefix + fallback.
     assert metric_crates("watdiv_sf1_q1_us") == ["sparq-engine", "sparq-core"]
@@ -671,9 +796,16 @@ def self_test() -> int:
             {"name": "q02_type_person_count_us", "current": 11.0, "previous": 10.0},      # 110% ok
             {"name": "new_metric_us", "current": 5.0},                                    # no prev -> skip
             {"name": "zero_prev_us", "current": 5.0, "previous": 0.0},                    # prev 0 -> skip
+            # [FABLE-5 round 4] malformed numerics: dropped with a warning, NEVER a crash —
+            # bool current, string current (the old float() call ValueError'd on this),
+            # out-of-float-range int previous (OverflowError), NaN current.
+            {"name": "bool_cur_us", "current": True, "previous": 10.0},
+            {"name": "str_cur_us", "current": "fast", "previous": 10.0},
+            {"name": "huge_prev_us", "current": 5.0, "previous": 10**400},
+            {"name": "nan_cur_us", "current": float("nan"), "previous": 10.0},
         ]), encoding="utf-8")
         rows = parse_comparison(str(cmp))
-        assert len(rows) == 3, [r["name"] for r in rows]   # two skipped
+        assert len(rows) == 3, [r["name"] for r in rows]   # 2 skipped + 4 malformed dropped
         part = zone_partition(rows, 175, 200)
         assert [r["name"] for r in part["hard"]] == ["watdiv_q1_us"]
         assert [r["name"] for r in part["soft"]] == ["geo_within_us"]
@@ -690,20 +822,29 @@ def self_test() -> int:
         results.write_text(json.dumps([
             {"name": "watdiv_q1_us", "value": 30.0, "unit": "us"},
             {"name": "new_only_us", "value": 5.0, "unit": "us"},   # no prev -> previous null
+            {"name": "bool_val_us", "value": True, "unit": "us"},  # bool value -> dropped
+            {"name": "huge_val_us", "value": 10**400},             # OverflowError -> dropped
         ]), encoding="utf-8")
         prev = Path(tdc) / "prev-data.js"
         prev.write_text(
             'window.BENCHMARK_DATA = ' + json.dumps({"entries": {"sparq engine": [
+                # a garbage date sorts as 0 (oldest) instead of TypeError-ing the sort.
+                {"date": "garbage", "commit": {"id": "c0"}, "benches": [
+                    {"name": "watdiv_q1_us", "value": 7.0, "unit": "us"}]},
                 {"date": 1, "commit": {"id": "c1"}, "benches": [
                     {"name": "watdiv_q1_us", "value": 8.0, "unit": "us"}]},
                 {"date": 2, "commit": {"id": "c2"}, "benches": [
-                    {"name": "watdiv_q1_us", "value": 10.0, "unit": "us"}]},  # most-recent wins
+                    {"name": "watdiv_q1_us", "value": 10.0, "unit": "us"},  # most-recent wins
+                    {"name": "bool_prev_us", "value": True},                # never a baseline
+                    {"name": "huge_prev_us", "value": 10**400}]},           # never a baseline
             ]}}) + ';\n', encoding="utf-8")
         cmp_rows = build_comparison(str(results), str(prev), "sparq engine")
         by = {r["name"]: r for r in cmp_rows}
         assert by["watdiv_q1_us"]["previous"] == 10.0, by["watdiv_q1_us"]  # newest prev value
         assert by["watdiv_q1_us"]["current"] == 30.0
         assert by["new_only_us"]["previous"] is None
+        # [FABLE-5 round 4] non-finite/bool/out-of-range values never survive admission.
+        assert "bool_val_us" not in by and "huge_val_us" not in by, sorted(by)
         # feeding it through parse_comparison drops the no-previous row + computes ratio.
         cmp_file = Path(tdc) / "cmp.json"
         cmp_file.write_text(json.dumps(cmp_rows), encoding="utf-8")
@@ -727,6 +868,15 @@ def self_test() -> int:
              "unit": "us",
              "note": "floor-exempt hard-band (>= 2x median-of-history; watch-only for the gate)"},
             {"name": "malformed_row", "current": "not-a-number"},   # dropped, never crashes
+            # [FABLE-5 round 4] numeric admission on EVERY consumed field: bool current
+            # (isinstance(int,float) passes it — must be rejected), NaN current and inf
+            # previous (json.loads emits both by default), and an out-of-float-range int
+            # ratio_pct whose float() raises OverflowError — all dropped with a counted
+            # warning, never a crash.
+            {"name": "bool_row", "current": True, "previous": 4.0, "ratio_pct": 300.0},
+            {"name": "nan_row", "current": float("nan"), "previous": 4.0, "ratio_pct": 300.0},
+            {"name": "inf_row", "current": 12.0, "previous": float("inf"), "ratio_pct": 300.0},
+            {"name": "huge_row", "current": 12.0, "previous": 4.0, "ratio_pct": 10**400},
         ]}), encoding="utf-8")
         extra = load_hardzone_soft_rows(str(hz))
         assert [r["name"] for r in extra] == ["tiny_query_us"], extra
@@ -753,6 +903,17 @@ def self_test() -> int:
         plain = build_flake_body("sparq-geo", soft_rows[1:], 175, 200, "http://run/4")
         assert "floor-exempt hard-band" not in plain
         assert "regressed into the **soft zone**" in plain and "two classes" not in plain
+        # [FABLE-5 round 4] three-way class sentence — the FLOOR-EXEMPT-ONLY case: every row
+        # tagged, no soft-band row, so the body must claim NEITHER "two classes" NOR the
+        # soft-zone framing; the all-floor-exempt sentence + explainer paragraph instead.
+        fe_only = build_flake_body("sparq-engine+sparq-core", extra, 175, 200, "http://run/7")
+        assert "Every row this run is a tagged floor-exempt hard-band hit" in fe_only
+        assert "two classes" not in fe_only
+        assert "regressed into the **soft zone**" not in fe_only
+        assert "median-of-history" in fe_only          # explainer paragraph still present
+        assert "tiny_query_us" in fe_only
+        stripped_fe = fe_only.replace("@-mentioned", "").replace("@-mention", "")
+        assert "@" not in stripped_fe, "floor-exempt-only body must not @-mention anyone"
         # fail-soft: no arg / absent file / unparsable file all -> [] (triage must not break).
         assert load_hardzone_soft_rows(None) == []
         assert load_hardzone_soft_rows(str(Path(td3) / "absent.json")) == []
@@ -788,6 +949,21 @@ def self_test() -> int:
         assert "\\`boom\\`" in erow, erow                  # note ` cannot open a code span
         assert "@someone" not in ebody                     # mention split by an HTML comment
         assert "@<!-- -->someone" in ebody
+
+        # [FABLE-5 round 4] defense-in-depth HTML layer: GitHub renders raw HTML in issue
+        # bodies, so a raw-HTML table breakout in ANY interpolated field must render with
+        # < > & escaped — in plain cells AND inside code spans (belt-and-braces) alike.
+        breakout = "</td></tr></table><h1>forged</h1>"
+        forged = [{"name": f"sneaky_us{breakout}", "current": 12.0, "previous": 4.0,
+                   "ratio_pct": 300.0, "unit": f"us{breakout}", "note": f"n{breakout}"}]
+        hbody = build_flake_body("sparq-engine+sparq-core", forged, 175, 200, "http://run/6")
+        assert "<h1>" not in hbody and "</td>" not in hbody and "</table>" not in hbody, hbody
+        assert "&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;h1&gt;forged&lt;/h1&gt;" in hbody, hbody
+        # entity-encoded @-mention smuggling is defused by escaping & first.
+        amp_note = [{"name": "amp_us", "current": 12.0, "previous": 4.0, "ratio_pct": 300.0,
+                     "unit": "us", "note": "ping &#64;someone"}]
+        abody = build_flake_body("sparq-engine+sparq-core", amp_note, 175, 200, "http://run/8")
+        assert "&#64;" not in abody and "&amp;#64;" in abody, abody
 
     # nightly attribution ranking: overlap with regressed crates ranks first.
     commits = [
@@ -826,6 +1002,16 @@ def self_test() -> int:
         # no naked @mention (the only '@' allowed is inside '@-mention' prose).
         stripped = rbody.replace("@-mentioned", "").replace("@-mention", "")
         assert "@" not in stripped, "regression body must not @-mention anyone"
+        # [FABLE-5 round 4] a forged-HTML commit SUBJECT renders escaped in the suspect
+        # table too (every interpolated field routes through the one sanitizer).
+        evil_commits = [{"sha": "f" * 40, "subject": f"pwn {breakout} (#104)", "author": "m",
+                         "paths": ["crates/sparq-geo/src/lib.rs"]}]
+        ranked_evil = rank_suspects({"sparq-geo"}, evil_commits)
+        rbody2 = build_regression_body(["sparq-geo"], part2["hard"], ranked_evil, 200,
+                                       "http://run/10", "https://github.com/o/r",
+                                       "d" * 40, "e" * 40)
+        assert "<h1>" not in rbody2 and "</table>" not in rbody2, rbody2
+        assert "&lt;h1&gt;forged&lt;/h1&gt;" in rbody2 and "#104" in rbody2, rbody2
 
     log("self-test OK")
     return 0

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -162,8 +162,20 @@ def log(msg: str) -> None:
 
 
 def _is_num(v) -> bool:
-    """A finite real number (bool excluded — json true/false must not pass as 1/0)."""
-    return isinstance(v, (int, float)) and not isinstance(v, bool) and math.isfinite(v)
+    """A finite real number (bool excluded — json true/false must not pass as 1/0).
+
+    [FABLE-5 round 4] the float() probe is guarded: math.isfinite on an out-of-float-range
+    int (e.g. 10**400, which JSON happily round-trips) raises OverflowError, and a gate
+    CRASH is neither fail-open nor fail-closed — such a value is simply not a usable
+    measurement, so this reports False and evaluate() fails closed with the per-metric
+    record, exactly like NaN.
+    """
+    if not isinstance(v, (int, float)) or isinstance(v, bool):
+        return False
+    try:
+        return math.isfinite(float(v))
+    except (OverflowError, ValueError):
+        return False
 
 
 def parse_data_js(text: str) -> dict:
@@ -681,6 +693,19 @@ def self_test() -> int:
     check(code == 1 and len(rep["invalid"]) == 1, "non-numeric current value fails closed")
     code, rep = evaluate(_cur([("a", -1.0)]), history_values(series))
     check(code == 1 and len(rep["invalid"]) == 1, "negative current value fails closed")
+    #    [FABLE-5 round 4] bool and out-of-float-range int currents: isinstance(int,float)
+    #    admits bool, and math.isfinite(10**400) raises OverflowError — both must land in
+    #    the fail-closed invalid list, never pass as 1/0 and never crash the gate.
+    code, rep = evaluate(_cur([("a", True)]), history_values(series))
+    check(code == 1 and len(rep["invalid"]) == 1, "boolean current value fails closed")
+    code, rep = evaluate(_cur([("a", 10**400)]), history_values(series))
+    check(code == 1 and len(rep["invalid"]) == 1,
+          "out-of-float-range int current (10**400) fails closed — OverflowError guarded")
+    huge_hist = history_values(_series([[("a", 10.0)], [("a", 10**400)], [("a", 10.0)],
+                                        [("a", 10.0)]]))
+    code, rep = evaluate(_cur([("a", 10.0)]), huge_hist)
+    check(code == 1 and len(rep["invalid"]) == 1,
+          "out-of-float-range int inside the history window fails closed — no crash")
     bad_hist = history_values(_series([[("a", 10.0)], [("a", 10.0)],
                                        [("a", float("nan"))], [("a", 10.0)]]))
     code, rep = evaluate(_cur([("a", 10.0)]), bad_hist)

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -34,15 +34,24 @@
 #     DISAPPEAR_FAIL_FRACTION (30%) of the gateable metrics disappeared (suite breakage) — a
 #     plain rename or two must not red main.
 #   * HARD FAIL (exit 1) if any gated metric is >= HARD_RATIO (2.0x) its median (direction-adjusted).
-#   * NOISE FLOOR: a NOISY-classified metric whose median-of-window is below NOISE_FLOOR (20.0
-#     units) can never hard-fail the gate ALONE — at that scale the measured honest run-to-run
-#     bands EXCEED the 2.0x hard threshold (empirical bands at the NOISE_FLOOR constant below).
-#     Floor-exempt is NOT ungated: the metric still prints in the watch table flagged
-#     "under noise floor — watch only", still emits a ::warning at >= HARD_RATIO, and the Store
-#     step's soft comparison comment still fires. Floor-exempt metrics are also EXCLUDED from
-#     every uniform-shift computation (breadth/uniformity/cap) — their degenerate small-integer
-#     ratios would distort all three. DETERMINISTIC metrics (bytes/count/gates/rows/...) are
-#     NEVER floor-exempt — a 2x move on a deterministic output is real at any scale.
+#   * NOISE FLOOR (UNIT-AWARE): only a metric whose UNIT is in the FLOOR_EXEMPT_UNITS
+#     allow-list ("us" micros, "milli" — each with a measured per-unit floor) AND whose
+#     median-of-window is below that unit's floor can never hard-fail the gate ALONE — at that
+#     scale the measured honest run-to-run bands EXCEED the 2.0x hard threshold (empirical
+#     bands at the FLOOR_EXEMPT_UNITS constant below). EVERY other unit — "s" seconds,
+#     "ns_per_byte", "ratio", `*_per_s` throughputs, deterministic units, and anything
+#     UNKNOWN — is NEVER floor-exempt regardless of magnitude (a stable 10x on a 0.4 s load
+#     IS a real regression; unknown units fail toward gated). Floor-exempt is NOT ungated: the
+#     metric still prints in the watch table flagged "under noise floor — watch only", still
+#     emits a ::warning at >= HARD_RATIO, the Store step's soft comparison comment still
+#     fires, and every floor-exempt hit at >= HARD_RATIO is written to the --report-out JSON,
+#     which the Soft-zone triage step (scripts/bench-triage.py --hardzone-report) merges into
+#     the rolling deduped `bench-flake` issue — the DURABLE trail: a persistent sub-floor
+#     regression rebases the median after a few accepted points, so the issue trail is the
+#     record that survives. Floor-exempt metrics are also EXCLUDED from every uniform-shift
+#     computation (breadth/uniformity/cap) — their degenerate small-integer ratios would
+#     distort all three. DETERMINISTIC metrics (bytes/count/gates/rows/...) are NEVER
+#     floor-exempt — a 2x move on a deterministic output is real at any scale.
 #   * UNIFORM-SHIFT EXEMPTION (exit 0 + loud warning + full table to stdout AND the job summary):
 #     the run is treated as a runner-environment scaling — and the hard zone waived — ONLY if ALL
 #     four conditions hold (computed over the GATED, i.e. non-floor-exempt, metrics):
@@ -82,6 +91,8 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
+import io
 import json
 import math
 import os
@@ -103,20 +114,29 @@ HISTORY_WINDOW = 5      # median over the last up-to-5 published VALUES per metr
 MIN_HISTORY = 3         # a metric needs >= 3 history values to be gated at all
 DISAPPEAR_FAIL_FRACTION = 0.30  # > 30% of gateable metrics missing from results => suite breakage
 
-# NOISE FLOOR — a NOISY-classified metric whose median-of-window is below this many units is
-# watch-only: listed + flagged, but it can never hard-fail the gate alone, and it is excluded
-# from the uniform-shift breadth/uniformity/cap computations. WHY 20.0 (measured 2026-07-23
-# replay against the published benchmark-data history): µs-scale timing metrics have HONEST
-# run-to-run noise bands exceeding the 2.0x hard threshold. Within the honest pre-red-era
-# oldest-10 points alone, max/min bands: sameas_size32_query_us 2.55x (values ~4-9µs),
-# deeptax_d1000_query_us 3.25x (~4-13µs), lubm_q14_count_us 2.45x, vectors_hnsw_recall_at10
-# 4.0x (unit "milli", oscillates 1<->4 — degenerate resolution). Live replays: the honest head
-# fails sameas_size32_query_us at 2.14x (9 vs median 4.2); another honest entry fails
-# deeptax_d1000_query_us at 2.00x (8 vs 4). Every observed false-fail metric has a median
-# <~15 units; 20.0 covers them with margin while keeping the stable milli series
-# (vectors_diskann_recall_at10 ~34, vectors_pq_recall_at10 ~22) and every >= 20µs timing
-# metric fully hard-gated. DETERMINISTIC metrics are never floor-exempt regardless of scale.
-NOISE_FLOOR = 20.0
+# NOISE FLOOR — UNIT-AWARE ALLOW-LIST of (unit, floor) pairs. A metric is floor-exempt
+# (watch-only, never a hard fail alone, excluded from the uniform-shift computations) ONLY if
+# its unit appears here AND its median-of-window is below that unit's floor. Floors are
+# justified PER-UNIT by the measured honest run-to-run bands in the published benchmark-data
+# history (2026-07-23 replay):
+#   * "us" (micros, floor 20.0): µs-scale timing metrics have HONEST noise bands exceeding the
+#     2.0x hard threshold. Within the honest pre-red-era oldest-10 points alone, max/min bands:
+#     sameas_size32_query_us 2.55x (values ~4-9µs), deeptax_d1000_query_us 3.25x (~4-13µs),
+#     lubm_q14_count_us 2.45x. Live replays: the honest head fails sameas_size32_query_us at
+#     2.14x (9 vs median 4.2); another honest entry fails deeptax_d1000_query_us at 2.00x
+#     (8 vs 4). Every observed false-fail metric has a median <~15 units; 20.0 covers them
+#     with margin while keeping every >= 20µs timing metric fully hard-gated.
+#   * "milli" (floor 20.0): the empirically-degenerate HNSW recall family —
+#     vectors_hnsw_recall_at10 honestly oscillates 1<->4 (4.0x band) at integer-milli
+#     resolution; its stable siblings (vectors_diskann_recall_at10 ~34,
+#     vectors_pq_recall_at10 ~22) sit ABOVE the floor and stay hard-gated.
+# EVERY unit NOT in this allow-list is NEVER floor-exempt regardless of magnitude. That
+# includes "s" seconds (nine published series — load_s, text_build_s, rdfs_infer_s, ... at
+# ~0.4-15 s — where a stable 10x IS a real regression; a raw magnitude-only floor wrongly
+# exempted all of them), "ns_per_byte", "ratio", the `*_per_s` throughputs, every
+# deterministic unit, and any UNKNOWN/absent unit: unknown units FAIL TOWARD GATED.
+# DETERMINISTIC metrics are never floor-exempt even in an allow-listed unit.
+FLOOR_EXEMPT_UNITS: dict[str, float] = {"us": 20.0, "milli": 20.0}
 
 # Deterministic (byte/count/structural) metric classification. UNIT-first because the live metric
 # NAMES are trappy: bsbm_query01_count_us / lubm_*_count_us are TIMING metrics whose names contain
@@ -127,7 +147,8 @@ NOISE_FLOOR = 20.0
 # "milli" is NOISY, not deterministic: it carries the three vectors_*_recall_at10 series, and the
 # live history shows vectors_hnsw_recall_at10 honestly oscillating 1<->4 (randomized HNSW build
 # at degenerate integer-milli resolution) — a measurement, not a deterministic output. Its stable
-# siblings (diskann ~34, pq ~22) sit ABOVE NOISE_FLOOR and stay hard-gated as noisy metrics.
+# siblings (diskann ~34, pq ~22) sit ABOVE the milli floor (FLOOR_EXEMPT_UNITS) and stay
+# hard-gated as noisy metrics.
 # The anchored-name fallback only fires when a row carries no unit at all.
 DETERMINISTIC_UNITS = {"bytes", "count", "chars", "fixtures", "gates", "rows", "triples"}
 DETERMINISTIC_NAME_RE = re.compile(r"(_bytes|_count|_chars|_deficit|_gates|_rows|_triples)$")
@@ -180,6 +201,11 @@ def is_deterministic(name: str, unit: str) -> bool:
     return bool(DETERMINISTIC_NAME_RE.search(name))
 
 
+def _floor_desc() -> str:
+    """Compact rendering of the unit-aware floor allow-list for report/annotation text."""
+    return ", ".join(f"{u} < {f:g}" for u, f in sorted(FLOOR_EXEMPT_UNITS.items()))
+
+
 def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     """Pure gate logic — unit-tested by --self-test. No I/O, no env access.
 
@@ -189,7 +215,14 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
       rows          — [(name, cur, median, n, ratio, deterministic, larger_better, floor_exempt)]
       watch         — the >= WATCH_RATIO subset of rows (floor-exempt rows included, flagged)
       hard          — the >= HARD_RATIO subset of GATED rows (floor-exempt can never hard-fail)
-      floor_exempt  — the noisy-classified rows with median < NOISE_FLOOR (watch-only)
+      floor_exempt  — rows whose UNIT is in FLOOR_EXEMPT_UNITS with median under that unit's
+                      floor (watch-only; unit-aware allow-list, unknown units stay gated)
+      floor_exempt_hard — floor-exempt rows at >= HARD_RATIO, in the soft-triage comparison
+                      shape ({name,current,previous,ratio_pct,unit,note}; previous = the
+                      MEDIAN-of-history) — the durable-trail payload written by --report-out
+                      and merged into the deduped bench-flake issue by bench-triage.py
+      gated_compared / gated_watch — counts over the GATED (non-floor-exempt) rows, backing
+                      the uniform-shift annotation (gated numerator/denominator)
       invalid       — [(name, reason)] fail-closed numeric errors (any entry => exit 1)
       ungated       — [(name, n)] metrics with 1..MIN_HISTORY-1 history values (listed, not gated)
       new           — metric names present in results with NO history at all
@@ -202,6 +235,7 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     ungated: list[tuple[str, int]] = []
     new: list[str] = []
     stable_zero: list[str] = []
+    units: dict[str, str] = {}
 
     current_by_name: dict[str, dict] = {}
     for row in current:
@@ -258,11 +292,15 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
         else:
             # customSmallerIsBetter suite, EXCEPT `*_per_s` throughput (larger is better): invert.
             ratio = (med / val) if larger_better else (val / med)
-        # NOISE FLOOR: a noisy-classified metric whose median sits under the floor is compared
-        # and listed but can never hard-fail alone (measured honest bands exceed HARD_RATIO at
-        # that scale — see the NOISE_FLOOR constant). Deterministic metrics are NEVER exempt.
-        floor_exempt = (not det) and med < NOISE_FLOOR
+        # NOISE FLOOR — UNIT-AWARE: exempt ONLY allow-listed units ("us"/"milli") whose median
+        # sits under that unit's measured floor (see FLOOR_EXEMPT_UNITS). Every other unit —
+        # "s" seconds, "ns_per_byte", "ratio", `*_per_s`, unknown — is gated regardless of
+        # magnitude (unknown units fail toward gated), and deterministic metrics are NEVER
+        # exempt (belt-and-braces: no deterministic unit is allow-listed).
+        unit_floor = FLOOR_EXEMPT_UNITS.get(unit)
+        floor_exempt = (not det) and unit_floor is not None and med < unit_floor
         rows.append((name, val, med, len(pts), ratio, det, larger_better, floor_exempt))
+        units[name] = unit
 
     compared = len(rows)
     # Floor-exempt rows stay in the watch TABLE (flagged "under noise floor — watch only") but
@@ -273,6 +311,18 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     floor_exempt_rows = [r for r in rows if r[7]]
     watch = [r for r in rows if r[4] >= WATCH_RATIO]
     hard = [r for r in gated_rows if r[4] >= HARD_RATIO]
+    # DURABLE TRAIL — floor-exempt rows at/above HARD_RATIO never red the gate, and after a few
+    # accepted points the regressed median REBASES, erasing the gate-side evidence. Emit them in
+    # the soft-triage comparison-row shape (`previous` = the MEDIAN-of-history, tagged in `note`)
+    # so bench-triage.py --mode soft --hardzone-report merges them into the rolling deduped
+    # bench-flake issue (see --report-out).
+    floor_exempt_hard = [
+        {"name": r[0], "current": r[1], "previous": r[2],
+         "ratio_pct": round(r[4] * 100.0, 1), "unit": units.get(r[0], ""),
+         "note": f"floor-exempt hard-band (>= {HARD_RATIO:g}x median-of-history; "
+                 f"watch-only for the gate)"}
+        for r in floor_exempt_rows if r[4] >= HARD_RATIO
+    ]
 
     # Uniform-shift exemption — ALL four conditions must hold (see header), computed over the
     # GATED (non-floor-exempt) rows only.
@@ -325,7 +375,8 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
 
     report = {
         "compared": compared, "rows": rows, "watch": watch, "hard": hard,
-        "floor_exempt": floor_exempt_rows,
+        "floor_exempt": floor_exempt_rows, "floor_exempt_hard": floor_exempt_hard,
+        "gated_compared": len(gated_rows), "gated_watch": len(gated_watch),
         "invalid": invalid, "ungated": ungated, "new": new, "stable_zero": stable_zero,
         "disappeared": disappeared, "disappeared_frac": disappeared_frac,
         "uniform_shift": uniform, "exemption_reasons": exemption_reasons,
@@ -367,8 +418,8 @@ def render_report(report: dict, markdown: bool) -> list[str]:
         lines.extend(_table_lines(report["watch"], markdown))
     if report["floor_exempt"]:
         floor_watch = sum(1 for r in report["floor_exempt"] if r[4] >= WATCH_RATIO)
-        lines.append(f"{len(report['floor_exempt'])} noisy metric(s) under the noise floor "
-                     f"(median < {NOISE_FLOOR:g} units): watch-only, never a hard fail alone "
+        lines.append(f"{len(report['floor_exempt'])} noisy metric(s) under their unit's noise "
+                     f"floor (allow-list: {_floor_desc()}): watch-only, never a hard fail alone "
                      f"(measured honest bands at that scale exceed {HARD_RATIO}x); "
                      f"{floor_watch} currently >= {WATCH_RATIO}x median (flagged in the table).")
     if report["invalid"]:
@@ -428,14 +479,19 @@ def emit_report(report: dict) -> None:
         with open(summary_path, "a", encoding="utf-8") as f:
             f.write("\n".join(render_report(report, markdown=True)) + "\n")
     if report["uniform_shift"]:
+        # GATED numbers only — the exemption predicate is computed over the gated
+        # (non-floor-exempt) rows, so the annotation must report exactly those counts:
+        # total-row numbers would misstate the breadth and "no metric reached 4x" would be
+        # FALSE whenever a floor-exempt row honestly spiked past the cap.
         print(f"::warning title=bench hard zone — uniform environment shift, not gating::"
-              f"{len(report['watch'])} of {report['compared']} compared metrics are >= "
-              f"{WATCH_RATIO}x their median-of-history simultaneously, the shifted ratios are "
-              f"uniform (stdev/mean <= {UNIFORM_MAX_CV}), no metric reached "
-              f"{UNIFORM_CAP_RATIO}x, and every deterministic metric is within "
-              f"{DET_TOLERANCE:.0%} of its median. Treated as a runner-environment scaling and "
-              f"NOT failing the run — a masked code regression is implausible under these four "
-              f"conditions, not impossible, so review the table in the job summary.")
+              f"{report['gated_watch']} of {report['gated_compared']} GATED metrics "
+              f"(floor-exempt excluded) are >= {WATCH_RATIO}x their median-of-history "
+              f"simultaneously, the shifted ratios are uniform (stdev/mean <= "
+              f"{UNIFORM_MAX_CV}), no GATED metric reached {UNIFORM_CAP_RATIO}x, and every "
+              f"deterministic metric is within {DET_TOLERANCE:.0%} of its median. Treated as "
+              f"a runner-environment scaling and NOT failing the run — a masked code "
+              f"regression is implausible under these four conditions, not impossible, so "
+              f"review the table in the job summary.")
     for name, reason in report["invalid"]:
         print(f"::error title=bench hard zone — invalid measurement::{name}: {reason}")
     if report["disappeared_frac"] > DISAPPEAR_FAIL_FRACTION:
@@ -448,10 +504,12 @@ def emit_report(report: dict) -> None:
     if floor_hot:
         names = ", ".join(f"{r[0]} ({r[4]:.2f}x, median {r[2]:.6g})" for r in floor_hot)
         print(f"::warning title=bench hard zone — under noise floor, watch only::{names} "
-              f"at/above {HARD_RATIO}x median, but the median is under the {NOISE_FLOOR:g}-unit "
-              f"noise floor — measured honest run-to-run bands at that scale exceed "
-              f"{HARD_RATIO}x, so this cannot fail the gate alone. It stays visible here, in "
-              f"the watch table, and in the Store step's comparison comment.")
+              f"at/above {HARD_RATIO}x median, but the median is under the unit's noise floor "
+              f"(allow-list: {_floor_desc()}) — measured honest run-to-run bands at that scale "
+              f"exceed {HARD_RATIO}x, so this cannot fail the gate alone. It stays visible "
+              f"here, in the watch table, in the Store step's comparison comment, AND it is "
+              f"routed via the --report-out JSON into the soft-triage deduped bench-flake "
+              f"issue — the durable trail that survives the median rebasing.")
     if report["hard"] and not report["uniform_shift"]:
         for name, cur, med, n, ratio, _det, lb, _floor in report["hard"]:
             direction = "median/current (larger-is-better)" if lb else "current/median"
@@ -468,10 +526,16 @@ def build_parser() -> argparse.ArgumentParser:
                     help="previously-published data.js (prev-data.js; absent => warn + pass)")
     ap.add_argument("--suite", default="sparq engine",
                     help="data.js entries suite name (EXACT match; absent => warn + pass)")
+    ap.add_argument("--report-out", default=None,
+                    help="write a machine-readable report JSON here (carries the "
+                         "floor_exempt_hard rows bench-triage.py --hardzone-report merges "
+                         "into the deduped bench-flake issue — the durable trail for "
+                         "sub-floor watch-only regressions); optional")
     return ap
 
 
-def run_gate(results_path: str, prev_data_path: str, suite: str) -> int:
+def run_gate(results_path: str, prev_data_path: str, suite: str,
+             report_out: str | None = None) -> int:
     rp = Path(results_path)
     if not rp.exists():
         print(f"::error title=bench hard zone::results file {results_path} is absent — the "
@@ -519,6 +583,16 @@ def run_gate(results_path: str, prev_data_path: str, suite: str) -> int:
         return 0
     code, report = evaluate(current, history_values(series))
     emit_report(report)
+    if report_out:
+        # Written on pass AND fail (the step may fail on another metric while a floor-exempt
+        # row still needs its durable trail); the Soft-zone triage step runs `if: always()`.
+        Path(report_out).write_text(json.dumps(
+            {"suite": suite, "hard_ratio": HARD_RATIO,
+             "floor_exempt_units": FLOOR_EXEMPT_UNITS,
+             "floor_exempt_hard": report["floor_exempt_hard"]},
+            indent=2) + "\n", encoding="utf-8")
+        log(f"report JSON ({len(report['floor_exempt_hard'])} floor-exempt hard-band row(s)) "
+            f"written to {report_out}")
     if code == 0 and not report["hard"] and not report["uniform_shift"]:
         log(f"hard zone clean: {report['compared']} metrics compared against their "
             f"median-of-history; {len(report['watch'])} in the watch band, none failing.")
@@ -726,9 +800,10 @@ def self_test() -> int:
           and is_deterministic("zk_compose_filter_f64_gates", ""),
           "deterministic classification: unit-first, anchored-name fallback only when unit absent")
 
-    # 14. NOISE FLOOR — sub-floor timing metric at 3.0x median: watch-only, NEVER a hard fail
-    #     alone (measured honest µs-scale bands exceed 2x — see the NOISE_FLOOR constant).
-    #     MUTATION CHECK vs check 15: flipping NOISE_FLOOR to 0 must turn exactly THIS red.
+    # 14. NOISE FLOOR — sub-floor "us" timing metric at 3.0x median: watch-only, NEVER a hard
+    #     fail alone (measured honest µs-scale bands exceed 2x — see FLOOR_EXEMPT_UNITS).
+    #     MUTATION CHECK vs check 15: zeroing the "us" floor in FLOOR_EXEMPT_UNITS (or removing
+    #     the entry) must turn exactly THIS red.
     sub = history_values(_series([[("tiny_query_us", 4.0)]] * 5))
     code, rep = evaluate(_cur([("tiny_query_us", 12.0)]), sub)
     check(code == 0 and not rep["hard"] and len(rep["floor_exempt"]) == 1
@@ -736,6 +811,18 @@ def self_test() -> int:
           "sub-floor timing metric at 3.0x median is watch-only — no hard fail")
     check("under noise floor — watch only" in "\n".join(render_report(rep, markdown=False)),
           "sub-floor watch row is flagged 'under noise floor — watch only' in the report")
+    #     DURABLE TRAIL: the same hit is emitted in floor_exempt_hard in the soft-triage
+    #     comparison shape (previous = median-of-history, tagged "floor-exempt hard-band") —
+    #     the exact contract bench-triage.py --hardzone-report consumes.
+    check(rep["floor_exempt_hard"] == [{
+              "name": "tiny_query_us", "current": 12.0, "previous": 4.0, "ratio_pct": 300.0,
+              "unit": "us",
+              "note": f"floor-exempt hard-band (>= {HARD_RATIO:g}x median-of-history; "
+                      f"watch-only for the gate)"}],
+          "floor-exempt hard-band hit is emitted in the soft-triage comparison shape")
+    code, rep = evaluate(_cur([("tiny_query_us", 7.0)]), sub)  # 1.75x: watch, below hard band
+    check(code == 0 and len(rep["floor_exempt"]) == 1 and not rep["floor_exempt_hard"],
+          "a sub-floor row below the hard band is NOT routed to the durable trail")
 
     # 15. The floor is the DISCRIMINATOR: the same 3.0x shape with its median ABOVE the floor
     #     hard-fails; and a sub-floor DETERMINISTIC metric at 2.0x still hard-fails (the floor
@@ -750,6 +837,34 @@ def self_test() -> int:
                          det_small)
     check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
           "sub-floor DETERMINISTIC metric at 2.0x still hard-fails (floor never applies)")
+
+    # 15b. UNIT-AWARE floor ([FABLE-5] round-2 review): the floor is an explicit per-unit
+    #      allow-list ("us"/"milli"), NOT a raw magnitude comparison. The published history
+    #      carries nine `s`-unit series (load_s, text_build_s, rdfs_infer_s, ... at ~0.4-15 s)
+    #      whose RAW medians sit under 20 — a raw floor wrongly exempted ALL of them, so a
+    #      stable 0.4s -> 4s (10x) load regression would pass and rebase the median.
+    #      MUTATION CHECK: adding "s" to FLOOR_EXEMPT_UNITS must turn exactly THIS red.
+    load_hist = history_values(_series([[("load_s", 0.4)]] * 5))
+    code, rep = evaluate(_cur([("load_s", 4.0)], unit="s"), load_hist)
+    check(code == 1 and len(rep["hard"]) == 1 and rep["hard"][0][0] == "load_s"
+          and not rep["floor_exempt"],
+          "s-unit metric (median 0.4 s) at 10x median HARD-FAILS — seconds are never "
+          "floor-exempt regardless of magnitude")
+    #      Every other non-allow-listed unit with a small median stays gated too — including
+    #      an UNKNOWN unit and a missing unit (allow-list fails toward gated, never open).
+    for u in ("ns_per_byte", "ratio", "mystery_unit", ""):
+        code, rep = evaluate(_cur([("small_metric", 12.0)], unit=u),
+                             history_values(_series([[("small_metric", 4.0)]] * 5)))
+        check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
+              f"unit {u!r} (median 4) at 3.0x median hard-fails — not in the floor allow-list")
+    #      "milli" IS allow-listed: the empirically-degenerate HNSW recall family (honest
+    #      1<->4 oscillation at integer-milli resolution) stays watch-only under the floor.
+    code, rep = evaluate(_cur([("vectors_hnsw_recall_at10", 4.0)], unit="milli"),
+                         history_values(_series([[("vectors_hnsw_recall_at10", 1.0)]] * 5)))
+    check(code == 0 and not rep["hard"] and len(rep["floor_exempt"]) == 1
+          and len(rep["floor_exempt_hard"]) == 1,
+          "milli-unit metric (median 1) at 4.0x is floor-exempt (HNSW recall family) and "
+          "routed to the durable trail")
 
     # 16. Uniform-shift computations EXCLUDE floor-exempt metrics — degenerate sub-floor ratios
     #     must distort neither breadth (a) nor uniformity (b) nor the cap (c).
@@ -772,6 +887,24 @@ def self_test() -> int:
     code, rep = evaluate(mix_cur2, history_values(mix_series))
     check(code == 0 and rep["uniform_shift"],
           "a 4.0x sub-floor spike blocks neither the cap nor uniformity (excluded from both)")
+
+    # 16b. The uniform-shift ::warning reports GATED numerator/denominator + "no GATED metric
+    #      reached" wording — the predicate is gated-rows-only, so total-row numbers would
+    #      misstate the breadth (5/9 here) and "no metric reached 4x" would be FALSE (the
+    #      floor-exempt tiny0_us honestly sits at exactly 4.0x in this fixture).
+    buf = io.StringIO()
+    saved_summary = os.environ.pop("GITHUB_STEP_SUMMARY", None)  # keep the CI summary clean
+    try:
+        with contextlib.redirect_stdout(buf):
+            emit_report(rep)
+    finally:
+        if saved_summary is not None:
+            os.environ["GITHUB_STEP_SUMMARY"] = saved_summary
+    out = buf.getvalue()
+    check("4 of 4 GATED metrics" in out and "no GATED metric reached" in out,
+          "uniform-shift annotation reports the gated numerator/denominator + GATED wording")
+    check("5 of 9" not in out and "no metric reached" not in out,
+          "uniform-shift annotation no longer reports total-row numbers")
 
     # 17. Argument handling: the parser accepts the documented flags on a fixture path.
     ns = build_parser().parse_args(
@@ -804,6 +937,21 @@ def self_test() -> int:
         corrupt.write_text("window.BENCHMARK_DATA = {not json", encoding="utf-8")
         check(run_gate(str(results), str(corrupt), "sparq engine") == 1,
               "non-empty unparsable prev-data.js fails closed (corrupt published history)")
+        # --report-out: the run writes the machine-readable report JSON carrying the
+        # floor-exempt hard-band rows (the soft-triage durable-trail hand-off).
+        sub_results = Path(td) / "sub-results.json"
+        sub_results.write_text(json.dumps(_cur([("tiny_us", 12.0)])), encoding="utf-8")
+        sub_prev = Path(td) / "sub-prev.js"
+        sub_prev.write_text("window.BENCHMARK_DATA = " + json.dumps(
+            {"entries": {"sparq engine": _series([[("tiny_us", 4.0)]] * 5)}}) + ";",
+            encoding="utf-8")
+        report_path = Path(td) / "hardzone-report.json"
+        rc = run_gate(str(sub_results), str(sub_prev), "sparq engine", str(report_path))
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        check(rc == 0 and [r["name"] for r in payload["floor_exempt_hard"]] == ["tiny_us"]
+              and "floor-exempt hard-band" in payload["floor_exempt_hard"][0]["note"]
+              and payload["floor_exempt_hard"][0]["previous"] == 4.0,
+              "--report-out writes the floor-exempt hard-band rows for the soft-triage trail")
 
     if failures:
         log(f"self-test FAILED ({len(failures)}/{checks} checks): " + "; ".join(failures))
@@ -816,7 +964,7 @@ def main(argv: list[str]) -> int:
     if "--self-test" in argv:
         return self_test()
     args = build_parser().parse_args(argv)
-    return run_gate(args.results, args.prev_data, args.suite)
+    return run_gate(args.results, args.prev_data, args.suite, args.report_out)
 
 
 if __name__ == "__main__":

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -452,10 +452,14 @@ def render_report(report: dict, markdown: bool) -> list[str]:
                      f"{', '.join(report['stable_zero'])}")
     if report["uniform_shift"]:
         lines.append("")
-        lines.append("UNIFORM-SHIFT EXEMPTION applied: all four conditions hold (breadth, ratio "
-                     "uniformity, no >= 4x outlier, deterministic metrics unmoved). This makes a "
-                     "masked code regression implausible — NOT impossible — hence this loud "
-                     "record instead of a quiet pass.")
+        # GATED-only cap wording, matching the ::warning: the exemption predicate excludes
+        # floor-exempt rows, and one of those may honestly sit at/above the cap — "no >= 4x
+        # outlier" (unqualified) would be FALSE on exactly such a run.
+        lines.append(f"UNIFORM-SHIFT EXEMPTION applied: all four conditions hold over the GATED "
+                     f"(non-floor-exempt) metrics — breadth, ratio uniformity, no GATED metric "
+                     f"reached {UNIFORM_CAP_RATIO:g}x median, deterministic metrics unmoved. "
+                     f"This makes a masked code regression implausible — NOT impossible — hence "
+                     f"this loud record instead of a quiet pass.")
     elif report["exemption_reasons"]:
         lines.append("")
         lines.append("uniform-shift exemption NOT applied:")
@@ -895,16 +899,29 @@ def self_test() -> int:
     buf = io.StringIO()
     saved_summary = os.environ.pop("GITHUB_STEP_SUMMARY", None)  # keep the CI summary clean
     try:
-        with contextlib.redirect_stdout(buf):
-            emit_report(rep)
+        with tempfile.TemporaryDirectory(prefix="bench-hardzone-selftest-") as td16:
+            summary_file = Path(td16) / "step-summary.md"
+            os.environ["GITHUB_STEP_SUMMARY"] = str(summary_file)
+            with contextlib.redirect_stdout(buf):
+                emit_report(rep)
+            summary = summary_file.read_text(encoding="utf-8") if summary_file.exists() else ""
     finally:
         if saved_summary is not None:
             os.environ["GITHUB_STEP_SUMMARY"] = saved_summary
+        else:
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
     out = buf.getvalue()
     check("4 of 4 GATED metrics" in out and "no GATED metric reached" in out,
           "uniform-shift annotation reports the gated numerator/denominator + GATED wording")
     check("5 of 9" not in out and "no metric reached" not in out,
           "uniform-shift annotation no longer reports total-row numbers")
+    # [FABLE-5 round 3] the stdout report AND the step-summary prose use the gated-only cap
+    # wording too — the floor-exempt tiny0_us sits at exactly 4.0x in this fixture, so the
+    # old unqualified "no >= 4x outlier" claim would be FALSE in both sinks.
+    check("no GATED metric reached" in summary and summary.strip() != "",
+          "step-summary exemption prose claims the cap over GATED metrics only")
+    check(">= 4x outlier" not in out and ">= 4x outlier" not in summary,
+          "neither stdout nor the step summary carries the unqualified 4x-outlier claim")
 
     # 17. Argument handling: the parser accepts the documented flags on a fixture path.
     ns = build_parser().parse_args(

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -34,10 +34,19 @@
 #     DISAPPEAR_FAIL_FRACTION (30%) of the gateable metrics disappeared (suite breakage) — a
 #     plain rename or two must not red main.
 #   * HARD FAIL (exit 1) if any gated metric is >= HARD_RATIO (2.0x) its median (direction-adjusted).
+#   * NOISE FLOOR: a NOISY-classified metric whose median-of-window is below NOISE_FLOOR (20.0
+#     units) can never hard-fail the gate ALONE — at that scale the measured honest run-to-run
+#     bands EXCEED the 2.0x hard threshold (empirical bands at the NOISE_FLOOR constant below).
+#     Floor-exempt is NOT ungated: the metric still prints in the watch table flagged
+#     "under noise floor — watch only", still emits a ::warning at >= HARD_RATIO, and the Store
+#     step's soft comparison comment still fires. Floor-exempt metrics are also EXCLUDED from
+#     every uniform-shift computation (breadth/uniformity/cap) — their degenerate small-integer
+#     ratios would distort all three. DETERMINISTIC metrics (bytes/count/gates/rows/...) are
+#     NEVER floor-exempt — a 2x move on a deterministic output is real at any scale.
 #   * UNIFORM-SHIFT EXEMPTION (exit 0 + loud warning + full table to stdout AND the job summary):
 #     the run is treated as a runner-environment scaling — and the hard zone waived — ONLY if ALL
-#     four conditions hold:
-#       (a) >= UNIFORM_FRACTION (50%) of compared metrics are >= WATCH_RATIO (1.75x) median;
+#     four conditions hold (computed over the GATED, i.e. non-floor-exempt, metrics):
+#       (a) >= UNIFORM_FRACTION (50%) of gated metrics are >= WATCH_RATIO (1.75x) median;
 #       (b) ratio uniformity: over the >= 1.75x metrics, stdev(ratio)/mean(ratio) <= 0.15 — a
 #           multiplicative environment scaling moves every wall-clock metric by ~the same factor,
 #           while a hot-path code regression does not hit unrelated metric families uniformly;
@@ -94,14 +103,33 @@ HISTORY_WINDOW = 5      # median over the last up-to-5 published VALUES per metr
 MIN_HISTORY = 3         # a metric needs >= 3 history values to be gated at all
 DISAPPEAR_FAIL_FRACTION = 0.30  # > 30% of gateable metrics missing from results => suite breakage
 
+# NOISE FLOOR — a NOISY-classified metric whose median-of-window is below this many units is
+# watch-only: listed + flagged, but it can never hard-fail the gate alone, and it is excluded
+# from the uniform-shift breadth/uniformity/cap computations. WHY 20.0 (measured 2026-07-23
+# replay against the published benchmark-data history): µs-scale timing metrics have HONEST
+# run-to-run noise bands exceeding the 2.0x hard threshold. Within the honest pre-red-era
+# oldest-10 points alone, max/min bands: sameas_size32_query_us 2.55x (values ~4-9µs),
+# deeptax_d1000_query_us 3.25x (~4-13µs), lubm_q14_count_us 2.45x, vectors_hnsw_recall_at10
+# 4.0x (unit "milli", oscillates 1<->4 — degenerate resolution). Live replays: the honest head
+# fails sameas_size32_query_us at 2.14x (9 vs median 4.2); another honest entry fails
+# deeptax_d1000_query_us at 2.00x (8 vs 4). Every observed false-fail metric has a median
+# <~15 units; 20.0 covers them with margin while keeping the stable milli series
+# (vectors_diskann_recall_at10 ~34, vectors_pq_recall_at10 ~22) and every >= 20µs timing
+# metric fully hard-gated. DETERMINISTIC metrics are never floor-exempt regardless of scale.
+NOISE_FLOOR = 20.0
+
 # Deterministic (byte/count/structural) metric classification. UNIT-first because the live metric
 # NAMES are trappy: bsbm_query01_count_us / lubm_*_count_us are TIMING metrics whose names contain
 # "count", store_bytes_per_triple carries "bytes" mid-name, and rsp_persistentdict_triples_per_s
 # carries "triples" but is wall-clock throughput. The unit set below is the exact deterministic
 # unit vocabulary observed in the published benchmark-data history (bytes/count/chars/fixtures/
-# gates/milli/rows/triples); us / s / ns/byte / ratio / triples_per_s are the noisy families.
+# gates/rows/triples); us / s / ns/byte / ratio / triples_per_s / milli are the noisy families.
+# "milli" is NOISY, not deterministic: it carries the three vectors_*_recall_at10 series, and the
+# live history shows vectors_hnsw_recall_at10 honestly oscillating 1<->4 (randomized HNSW build
+# at degenerate integer-milli resolution) — a measurement, not a deterministic output. Its stable
+# siblings (diskann ~34, pq ~22) sit ABOVE NOISE_FLOOR and stay hard-gated as noisy metrics.
 # The anchored-name fallback only fires when a row carries no unit at all.
-DETERMINISTIC_UNITS = {"bytes", "count", "chars", "fixtures", "gates", "milli", "rows", "triples"}
+DETERMINISTIC_UNITS = {"bytes", "count", "chars", "fixtures", "gates", "rows", "triples"}
 DETERMINISTIC_NAME_RE = re.compile(r"(_bytes|_count|_chars|_deficit|_gates|_rows|_triples)$")
 
 # Direction: `*_per_s` metrics store raw throughput => LARGER is better (ratio = median/current).
@@ -157,9 +185,11 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
 
     `current` is this run's bench-results.json rows ({name,value,unit}); `hist` is the per-metric
     history value lists (see history_values). Returns (exit_code, report) where report carries:
-      compared      — number of ratio-gated metrics
-      rows          — [(name, cur, median, n, ratio, deterministic, larger_better)] all compared
-      watch / hard  — the >= WATCH_RATIO / >= HARD_RATIO subsets of rows
+      compared      — number of ratio-compared metrics (gated + floor-exempt)
+      rows          — [(name, cur, median, n, ratio, deterministic, larger_better, floor_exempt)]
+      watch         — the >= WATCH_RATIO subset of rows (floor-exempt rows included, flagged)
+      hard          — the >= HARD_RATIO subset of GATED rows (floor-exempt can never hard-fail)
+      floor_exempt  — the noisy-classified rows with median < NOISE_FLOOR (watch-only)
       invalid       — [(name, reason)] fail-closed numeric errors (any entry => exit 1)
       ungated       — [(name, n)] metrics with 1..MIN_HISTORY-1 history values (listed, not gated)
       new           — metric names present in results with NO history at all
@@ -228,23 +258,35 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
         else:
             # customSmallerIsBetter suite, EXCEPT `*_per_s` throughput (larger is better): invert.
             ratio = (med / val) if larger_better else (val / med)
-        rows.append((name, val, med, len(pts), ratio, det, larger_better))
+        # NOISE FLOOR: a noisy-classified metric whose median sits under the floor is compared
+        # and listed but can never hard-fail alone (measured honest bands exceed HARD_RATIO at
+        # that scale — see the NOISE_FLOOR constant). Deterministic metrics are NEVER exempt.
+        floor_exempt = (not det) and med < NOISE_FLOOR
+        rows.append((name, val, med, len(pts), ratio, det, larger_better, floor_exempt))
 
     compared = len(rows)
+    # Floor-exempt rows stay in the watch TABLE (flagged "under noise floor — watch only") but
+    # are excluded from the hard set AND from every uniform-shift computation below — their
+    # degenerate small-integer ratios would distort breadth (a), uniformity (b) and the cap (c)
+    # alike (the honest sub-floor history reaches 4.0x on pure noise).
+    gated_rows = [r for r in rows if not r[7]]
+    floor_exempt_rows = [r for r in rows if r[7]]
     watch = [r for r in rows if r[4] >= WATCH_RATIO]
-    hard = [r for r in rows if r[4] >= HARD_RATIO]
+    hard = [r for r in gated_rows if r[4] >= HARD_RATIO]
 
-    # Uniform-shift exemption — ALL four conditions must hold (see header).
+    # Uniform-shift exemption — ALL four conditions must hold (see header), computed over the
+    # GATED (non-floor-exempt) rows only.
     uniform = False
     exemption_reasons: list[str] = []
-    if compared and watch:
-        frac = len(watch) / compared
+    gated_watch = [r for r in gated_rows if r[4] >= WATCH_RATIO]
+    if gated_rows and gated_watch:
+        frac = len(gated_watch) / len(gated_rows)
         cond_a = frac >= UNIFORM_FRACTION
         if not cond_a:
             exemption_reasons.append(
-                f"(a) breadth: only {len(watch)}/{compared} compared metrics >= "
-                f"{WATCH_RATIO}x (< {UNIFORM_FRACTION:.0%})")
-        ratios = [r[4] for r in watch]
+                f"(a) breadth: only {len(gated_watch)}/{len(gated_rows)} gated metrics >= "
+                f"{WATCH_RATIO}x (< {UNIFORM_FRACTION:.0%}; floor-exempt metrics excluded)")
+        ratios = [r[4] for r in gated_watch]
         if len(ratios) >= 2:
             cv = statistics.stdev(ratios) / statistics.mean(ratios)
             cond_b = cv <= UNIFORM_MAX_CV
@@ -256,13 +298,14 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
             cond_b = False
             exemption_reasons.append(
                 "(b) uniformity: a single shifted metric is not an environment-wide scaling")
-        worst = max(r[4] for r in rows)
+        worst = max(r[4] for r in gated_rows)
         cond_c = worst < UNIFORM_CAP_RATIO
         if not cond_c:
             exemption_reasons.append(
-                f"(c) cap: worst ratio {worst:.2f}x >= {UNIFORM_CAP_RATIO}x — a catastrophic "
-                f"regression never hides in the herd")
-        det_moved = [r for r in rows if r[5] and abs(r[4] - 1.0) > DET_TOLERANCE]
+                f"(c) cap: worst gated ratio {worst:.2f}x >= {UNIFORM_CAP_RATIO}x — a "
+                f"catastrophic regression never hides in the herd")
+        # Deterministic rows are never floor-exempt, so gated_rows covers every one of them.
+        det_moved = [r for r in gated_rows if r[5] and abs(r[4] - 1.0) > DET_TOLERANCE]
         cond_d = not det_moved
         if not cond_d:
             names = ", ".join(f"{r[0]} ({r[4]:.3f}x)" for r in det_moved[:5])
@@ -282,6 +325,7 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
 
     report = {
         "compared": compared, "rows": rows, "watch": watch, "hard": hard,
+        "floor_exempt": floor_exempt_rows,
         "invalid": invalid, "ungated": ungated, "new": new, "stable_zero": stable_zero,
         "disappeared": disappeared, "disappeared_frac": disappeared_frac,
         "uniform_shift": uniform, "exemption_reasons": exemption_reasons,
@@ -290,18 +334,21 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
 
 
 def _table_lines(entries: list[tuple], markdown: bool) -> list[str]:
-    """Render [(name, cur, med, n, ratio, det, larger_better)] rows as a table."""
+    """Render [(name, cur, med, n, ratio, det, larger_better, floor_exempt)] rows as a table."""
     out = []
     if markdown:
-        out.append("| metric | current | median (n) | ratio | direction |")
-        out.append("|---|---:|---:|---:|---|")
-        for name, cur, med, n, ratio, _det, lb in sorted(entries, key=lambda t: -t[4]):
+        out.append("| metric | current | median (n) | ratio | direction | gating |")
+        out.append("|---|---:|---:|---:|---|---|")
+        for name, cur, med, n, ratio, _det, lb, floor in sorted(entries, key=lambda t: -t[4]):
+            gating = "under noise floor — watch only" if floor else "hard-zone"
             out.append(f"| `{name}` | {cur:.6g} | {med:.6g} (n={n}) | {ratio:.2f}x |"
-                       f" {'larger-is-better' if lb else 'smaller-is-better'} |")
+                       f" {'larger-is-better' if lb else 'smaller-is-better'} | {gating} |")
     else:
         out.append(f"  {'metric':<60} {'current':>14} {'median(n)':>18} {'ratio':>7}")
-        for name, cur, med, n, ratio, _det, lb in sorted(entries, key=lambda t: -t[4]):
+        for name, cur, med, n, ratio, _det, lb, floor in sorted(entries, key=lambda t: -t[4]):
             suffix = "  [larger-is-better]" if lb else ""
+            if floor:
+                suffix += "  [under noise floor — watch only]"
             out.append(f"  {name:<60} {cur:>14.4g} {med:>13.4g}(n={n}) {ratio:>6.2f}x{suffix}")
     return out
 
@@ -311,13 +358,19 @@ def render_report(report: dict, markdown: bool) -> list[str]:
     h2 = "## " if markdown else ""
     lines: list[str] = [f"{h2}bench hard zone — median-of-history gate"]
     lines.append(f"{report['compared']} metrics compared; {len(report['watch'])} >= "
-                 f"{WATCH_RATIO}x median; {len(report['hard'])} >= {HARD_RATIO}x median.")
+                 f"{WATCH_RATIO}x median; {len(report['hard'])} gated >= {HARD_RATIO}x median.")
     if report["watch"]:
         lines.append("")
         lines.append(f"**Watch band (>= {WATCH_RATIO}x median):**" if markdown
                      else f"metrics >= {WATCH_RATIO}x their median of the last up-to-"
                           f"{HISTORY_WINDOW} published values:")
         lines.extend(_table_lines(report["watch"], markdown))
+    if report["floor_exempt"]:
+        floor_watch = sum(1 for r in report["floor_exempt"] if r[4] >= WATCH_RATIO)
+        lines.append(f"{len(report['floor_exempt'])} noisy metric(s) under the noise floor "
+                     f"(median < {NOISE_FLOOR:g} units): watch-only, never a hard fail alone "
+                     f"(measured honest bands at that scale exceed {HARD_RATIO}x); "
+                     f"{floor_watch} currently >= {WATCH_RATIO}x median (flagged in the table).")
     if report["invalid"]:
         lines.append("")
         lines.append("**Fail-closed numeric errors (each one fails the run):**" if markdown
@@ -391,8 +444,16 @@ def emit_report(report: dict) -> None:
               f"({report['disappeared_frac']:.0%}) are missing from this run's results — more "
               f"than {DISAPPEAR_FAIL_FRACTION:.0%} of the gated suite disappeared at once, "
               f"which is a bench-suite breakage, not a rename. See the disappeared list above.")
+    floor_hot = [r for r in report["floor_exempt"] if r[4] >= HARD_RATIO]
+    if floor_hot:
+        names = ", ".join(f"{r[0]} ({r[4]:.2f}x, median {r[2]:.6g})" for r in floor_hot)
+        print(f"::warning title=bench hard zone — under noise floor, watch only::{names} "
+              f"at/above {HARD_RATIO}x median, but the median is under the {NOISE_FLOOR:g}-unit "
+              f"noise floor — measured honest run-to-run bands at that scale exceed "
+              f"{HARD_RATIO}x, so this cannot fail the gate alone. It stays visible here, in "
+              f"the watch table, and in the Store step's comparison comment.")
     if report["hard"] and not report["uniform_shift"]:
-        for name, cur, med, n, ratio, _det, lb in report["hard"]:
+        for name, cur, med, n, ratio, _det, lb, _floor in report["hard"]:
             direction = "median/current (larger-is-better)" if lb else "current/median"
             print(f"::error title=bench hard zone::{name} is {ratio:.2f}x its "
                   f"median-of-{n} history ({direction}: {cur:.6g} vs median {med:.6g}) — "
@@ -490,8 +551,10 @@ def self_test() -> int:
             failures.append(what)
             log(f"self-test FAIL: {what}")
 
-    # Baseline 5-commit history: four metrics stable at 10.0.
-    series = _series([[("a", 10.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)]] * 5)
+    # Baseline 5-commit history: four metrics stable at 100.0 — deliberately ABOVE NOISE_FLOOR
+    # so these fixtures keep exercising the hard zone proper (sub-floor behavior is tested in
+    # its own section below).
+    series = _series([[("a", 100.0), ("b", 100.0), ("c", 100.0), ("d", 100.0)]] * 5)
 
     # 1. Median semantics: window trims to the last 5 VALUES per metric.
     hist = history_values(_series([[("m", 100.0)], [("m", 1.0)], [("m", 2.0)], [("m", 3.0)],
@@ -500,8 +563,9 @@ def self_test() -> int:
     check(statistics.median(hist["m"]) == 3.0, "median of 5-value history is the middle value")
     hist_even = history_values(_series([[("m", 1.0)], [("m", 2.0)], [("m", 3.0)], [("m", 8.0)]]))
     check(statistics.median(hist_even["m"]) == 2.5, "median of an even count averages the middle two")
-    code, rep = evaluate(_cur([("m", 15.0)]), history_values(
-        _series([[("m", 10.0)], [("m", 10.0)], [("m", 10.0)], [("m", 10.0)], [("m", 30.0)]])))
+    code, rep = evaluate(_cur([("m", 150.0)]), history_values(
+        _series([[("m", 100.0)], [("m", 100.0)], [("m", 100.0)], [("m", 100.0)],
+                 [("m", 300.0)]])))
     check(code == 0 and not rep["hard"],
           "single outlier history point does not move the median (1.5x vs median passes)")
 
@@ -509,16 +573,16 @@ def self_test() -> int:
     #    collects all 5 of its values (the old per-commit window judged it from 1 point).
     sparse_pts: list[list[tuple]] = []
     for i in range(10):
-        commit: list[tuple] = [("dense", 10.0)]
+        commit: list[tuple] = [("dense", 100.0)]
         if i % 2 == 0:
-            commit.append(("sparse", 10.0 + i))  # values 10,12,14,16,18 at commits 0,2,4,6,8
+            commit.append(("sparse", 100.0 + 10 * i))  # 100,120,140,160,180 at commits 0,2,4,6,8
         sparse_pts.append(commit)
     hist_sparse = history_values(_series(sparse_pts))
-    check(hist_sparse["sparse"] == [10.0, 12.0, 14.0, 16.0, 18.0],
+    check(hist_sparse["sparse"] == [100.0, 120.0, 140.0, 160.0, 180.0],
           "sparse metric collects its last 5 values across the FULL retained history")
-    code, rep = evaluate(_cur([("sparse", 15.0), ("dense", 10.0)]), hist_sparse)
+    code, rep = evaluate(_cur([("sparse", 150.0), ("dense", 100.0)]), hist_sparse)
     check(code == 0 and rep["compared"] == 2,
-          "sparse metric is gated against its own 5-value median (14.0), not a 1-point window")
+          "sparse metric is gated against its own 5-value median (140.0), not a 1-point window")
 
     # 3. Insufficient history (< 3 values) => listed as ungated, not silently gated or failed.
     two_pt = history_values(_series([[("young", 10.0)], [("young", 10.0)]]))
@@ -589,25 +653,25 @@ def self_test() -> int:
           "_per_s throughput doubling is an improvement (ratio 0.5) — passes")
 
     # 8. Single-metric hard fail: one metric >= 2.0x median, the rest normal => exit 1.
-    lone = _cur([("a", 21.0), ("b", 10.2), ("c", 9.9), ("d", 10.0)])
+    lone = _cur([("a", 210.0), ("b", 102.0), ("c", 99.0), ("d", 100.0)])
     code, rep = evaluate(lone, history_values(series))
     check(code == 1 and not rep["uniform_shift"] and len(rep["hard"]) == 1
           and rep["hard"][0][0] == "a",
           "single sustained >= 2.0x regression hard-fails (no uniform exemption)")
-    watch_only = _cur([("a", 18.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)])
+    watch_only = _cur([("a", 180.0), ("b", 100.0), ("c", 100.0), ("d", 100.0)])
     code, rep = evaluate(watch_only, history_values(series))
     check(code == 0 and len(rep["watch"]) == 1 and not rep["hard"],
           "a lone watch-band metric (1.8x, < 2.0x) is reported but does not fail")
 
     # 9. Uniform-shift exemption POSITIVE: broad (3/4 >= 1.75x), uniform ratios (cv <= 0.15),
     #    nothing >= 4x, no deterministic metric moved => exempt, exit 0.
-    shifted = _cur([("a", 19.0), ("b", 19.5), ("c", 20.5), ("d", 11.0)])
+    shifted = _cur([("a", 190.0), ("b", 195.0), ("c", 205.0), ("d", 110.0)])
     code, rep = evaluate(shifted, history_values(series))
     check(code == 0 and rep["uniform_shift"] and len(rep["watch"]) == 3 and len(rep["hard"]) == 1,
           "uniform environment shift (3/4 >= 1.75x, uniform, capped, no det drift) is exempted")
 
     # 10. Uniformity rejection: broad shift with NON-uniform ratios => NOT exempt => fail.
-    ragged = _cur([("a", 18.0), ("b", 25.0), ("c", 35.0), ("d", 10.0)])  # ratios 1.8/2.5/3.5
+    ragged = _cur([("a", 180.0), ("b", 250.0), ("c", 350.0), ("d", 100.0)])  # 1.8/2.5/3.5
     code, rep = evaluate(ragged, history_values(series))
     check(code == 1 and not rep["uniform_shift"]
           and any("(b) uniformity" in r for r in rep["exemption_reasons"]),
@@ -617,7 +681,7 @@ def self_test() -> int:
     #     PASS — ratios 4.05/4.1/4.08/4.06 put 4/4 metrics in the watch band with CV ~0.005 and
     #     no deterministic metrics — so ONLY the cap (c) blocks the exemption. Removing the cap
     #     from the predicate would flip exactly this check red.
-    capped = _cur([("a", 40.5), ("b", 41.0), ("c", 40.8), ("d", 40.6)])
+    capped = _cur([("a", 405.0), ("b", 410.0), ("c", 408.0), ("d", 406.0)])
     code, rep = evaluate(capped, history_values(series))
     check(code == 1 and not rep["uniform_shift"] and len(rep["hard"]) == 4
           and len(rep["exemption_reasons"]) == 1
@@ -625,7 +689,7 @@ def self_test() -> int:
           "a >= 4x metric is the SOLE exemption blocker ((a)/(b)/(d) pass) — hard fail stands")
     #     Control: the SAME uniform shape kept below the cap (all ~1.9x) IS exempt — proving the
     #     cap is the discriminating condition, not breadth/uniformity/deterministic drift.
-    under_cap = _cur([("a", 19.0), ("b", 19.5), ("c", 19.2), ("d", 19.1)])
+    under_cap = _cur([("a", 190.0), ("b", 195.0), ("c", 192.0), ("d", 191.0)])
     code, rep = evaluate(under_cap, history_values(series))
     check(code == 0 and rep["uniform_shift"] and not rep["exemption_reasons"],
           "same uniform shape below the cap IS exempt — the 4x cap is the discriminating condition")
@@ -633,14 +697,14 @@ def self_test() -> int:
     # 12. Deterministic-metric drift blocks the exemption: same broad uniform timing shift, but a
     #     byte-count metric moved > 1% => NOT exempt => fail.
     det_series = [{"date": i, "benches": [
-        {"name": "a", "value": 10.0, "unit": "us"},
-        {"name": "b", "value": 10.0, "unit": "us"},
-        {"name": "c", "value": 10.0, "unit": "us"},
+        {"name": "a", "value": 100.0, "unit": "us"},
+        {"name": "b", "value": 100.0, "unit": "us"},
+        {"name": "c", "value": 100.0, "unit": "us"},
         {"name": "wasm_bundle_bytes", "value": 1000.0, "unit": "bytes"},
     ]} for i in range(5)]
-    det_cur = [{"name": "a", "value": 19.0, "unit": "us"},
-               {"name": "b", "value": 19.5, "unit": "us"},
-               {"name": "c", "value": 20.5, "unit": "us"},
+    det_cur = [{"name": "a", "value": 190.0, "unit": "us"},
+               {"name": "b", "value": 195.0, "unit": "us"},
+               {"name": "c", "value": 205.0, "unit": "us"},
                {"name": "wasm_bundle_bytes", "value": 1030.0, "unit": "bytes"}]  # +3%
     code, rep = evaluate(det_cur, history_values(det_series))
     check(code == 1 and not rep["uniform_shift"]
@@ -653,13 +717,63 @@ def self_test() -> int:
           "same shift with the deterministic metric unmoved IS exempt (control case)")
 
     # 13. Deterministic classification is unit-first (name traps are real: *_count_us is timing).
+    #     "milli" is NOISY: vectors_hnsw_recall_at10 honestly oscillates 1<->4 in the live
+    #     history (randomized HNSW build at degenerate resolution) — a measurement, not a count.
     check(is_deterministic("wasm_bundle_bytes", "bytes")
           and not is_deterministic("bsbm_query01_count_us", "us")
           and not is_deterministic("rsp_persistentdict_triples_per_s", "triples_per_s")
+          and not is_deterministic("vectors_hnsw_recall_at10", "milli")
           and is_deterministic("zk_compose_filter_f64_gates", ""),
           "deterministic classification: unit-first, anchored-name fallback only when unit absent")
 
-    # 14. Argument handling: the parser accepts the documented flags on a fixture path.
+    # 14. NOISE FLOOR — sub-floor timing metric at 3.0x median: watch-only, NEVER a hard fail
+    #     alone (measured honest µs-scale bands exceed 2x — see the NOISE_FLOOR constant).
+    #     MUTATION CHECK vs check 15: flipping NOISE_FLOOR to 0 must turn exactly THIS red.
+    sub = history_values(_series([[("tiny_query_us", 4.0)]] * 5))
+    code, rep = evaluate(_cur([("tiny_query_us", 12.0)]), sub)
+    check(code == 0 and not rep["hard"] and len(rep["floor_exempt"]) == 1
+          and len(rep["watch"]) == 1 and rep["watch"][0][0] == "tiny_query_us",
+          "sub-floor timing metric at 3.0x median is watch-only — no hard fail")
+    check("under noise floor — watch only" in "\n".join(render_report(rep, markdown=False)),
+          "sub-floor watch row is flagged 'under noise floor — watch only' in the report")
+
+    # 15. The floor is the DISCRIMINATOR: the same 3.0x shape with its median ABOVE the floor
+    #     hard-fails; and a sub-floor DETERMINISTIC metric at 2.0x still hard-fails (the floor
+    #     never applies to deterministic outputs — a 2x on a count/bytes/gates value is real).
+    over = history_values(_series([[("big_query_us", 40.0)]] * 5))
+    code, rep = evaluate(_cur([("big_query_us", 120.0)]), over)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
+          "the same 3.0x shape with median above the floor hard-fails")
+    det_small = history_values([{"date": i, "benches": [
+        {"name": "solid_fixture_count", "value": 5.0, "unit": "count"}]} for i in range(5)])
+    code, rep = evaluate([{"name": "solid_fixture_count", "value": 10.0, "unit": "count"}],
+                         det_small)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
+          "sub-floor DETERMINISTIC metric at 2.0x still hard-fails (floor never applies)")
+
+    # 16. Uniform-shift computations EXCLUDE floor-exempt metrics — degenerate sub-floor ratios
+    #     must distort neither breadth (a) nor uniformity (b) nor the cap (c).
+    mix_series = [{"date": i, "benches":
+                   [{"name": n, "value": 100.0, "unit": "us"} for n in "abcd"]
+                   + [{"name": f"tiny{j}_us", "value": 4.0, "unit": "us"} for j in range(5)]}
+                  for i in range(5)]
+    #     4 gated metrics uniformly ~2.05x (a hard fail without the exemption) + 5 sub-floor
+    #     metrics unmoved: excluding the floor-exempt rows, breadth is 4/4 => exempt (exit 0);
+    #     counting them, breadth would be 4/9 (44% < 50%) => condition (a) fails => exit 1.
+    mix_cur = _cur([("a", 210.0), ("b", 205.0), ("c", 208.0), ("d", 195.0)]
+                   + [(f"tiny{j}_us", 4.0) for j in range(5)])
+    code, rep = evaluate(mix_cur, history_values(mix_series))
+    check(code == 0 and rep["uniform_shift"] and len(rep["floor_exempt"]) == 5,
+          "breadth excludes floor-exempt metrics (4/4 gated uniform => exempt; 4/9 would fail)")
+    #     A sub-floor metric spiking 4.0x (the honest vectors_hnsw 1<->4 shape) must block
+    #     neither the cap (c) nor uniformity (b) for a genuine environment shift.
+    mix_cur2 = _cur([("a", 210.0), ("b", 205.0), ("c", 208.0), ("d", 195.0), ("tiny0_us", 16.0)]
+                    + [(f"tiny{j}_us", 4.0) for j in range(1, 5)])
+    code, rep = evaluate(mix_cur2, history_values(mix_series))
+    check(code == 0 and rep["uniform_shift"],
+          "a 4.0x sub-floor spike blocks neither the cap nor uniformity (excluded from both)")
+
+    # 17. Argument handling: the parser accepts the documented flags on a fixture path.
     ns = build_parser().parse_args(
         ["--results", "fixtures/bench-results.json", "--prev-data", "fixtures/prev-data.js",
          "--suite", "sparq engine"])
@@ -667,15 +781,15 @@ def self_test() -> int:
           and ns.prev_data == "fixtures/prev-data.js" and ns.suite == "sparq engine",
           "argument parser maps --results/--prev-data/--suite onto the expected namespace")
 
-    # 15. End-to-end run_gate over real files in a private tempdir: suite-name mismatch must
+    # 18. End-to-end run_gate over real files in a private tempdir: suite-name mismatch must
     #     warn + exit 0 (never fall back to another suite), exact match must gate.
     with tempfile.TemporaryDirectory(prefix="bench-hardzone-selftest-") as td:
         results = Path(td) / "bench-results.json"
-        results.write_text(json.dumps(_cur([("a", 21.0), ("b", 10.0), ("c", 10.0),
-                                            ("d", 10.0)])), encoding="utf-8")
+        results.write_text(json.dumps(_cur([("a", 210.0), ("b", 100.0), ("c", 100.0),
+                                            ("d", 100.0)])), encoding="utf-8")
         prev = Path(td) / "prev-data.js"
         payload = {"entries": {"sparq engine": _series(
-            [[("a", 10.0), ("b", 10.0), ("c", 10.0), ("d", 10.0)]] * 5)}}
+            [[("a", 100.0), ("b", 100.0), ("c", 100.0), ("d", 100.0)]] * 5)}}
         prev.write_text("window.BENCHMARK_DATA = " + json.dumps(payload) + ";",
                         encoding="utf-8")
         check(run_gate(str(results), str(prev), "some other suite") == 0,


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. Authored and reviewed by AI agents.

Follow-up to #3751. The median-of-history hard zone (`scripts/bench_hardzone.py`) hard-fails any metric ≥ 2.0x its median-of-last-≤5 — but a fresh empirical replay (2026-07-23) against the published benchmark-data history shows µs-scale timing metrics have **honest run-to-run noise bands exceeding 2.0x**, so the gate reds on noise even with a clean history.

## Empirical evidence (2026-07-23 replay of the published history)

Within the honest pre-red-era oldest-10 points alone, max/min bands:

| metric | unit | honest band | note |
|---|---|---:|---|
| `sameas_size32_query_us` | us | **2.55x** | values ~4–9µs |
| `deeptax_d1000_query_us` | us | **3.25x** | ~4–13µs |
| `lubm_q14_count_us` | us | **2.45x** | timing metric (name trap) |
| `vectors_hnsw_recall_at10` | milli | **4.0x** | oscillates 1↔4 — degenerate resolution |

Live replays: an honest head fails `sameas_size32_query_us` at 2.14x (9 vs median 4.2); another honest entry fails `deeptax_d1000_query_us` at 2.00x (8 vs 4). Every observed false-fail has a median ≲15 units. Reproduced in this worktree: replaying the **current honest published head** against its prior history — old gate **exit 1** (`vectors_hnsw_recall_at10` 3.00x on its honest 1↔4 oscillation), new gate **exit 0** with the same row flagged watch-only.

## Change

- **`NOISE_FLOOR = 20.0`**: a NOISY-classified metric (existing unit-first classification reused) whose median-of-window is under the floor can never hard-fail the gate **alone**. Empirical bands documented at the constant (numbers live only in the script comment, per repo hygiene).
- **Deterministic metrics are NEVER floor-exempt** — a 2x on counts/bytes/gates is real at any scale (self-tested).
- **Unit `milli` reclassified as noisy**: the live history proves `vectors_hnsw_recall_at10` is a measurement (randomized HNSW build), not a deterministic output — required for it to land under the floor, and it stops the metric's constant motion from vetoing exemption condition (d) on every genuine environment shift. Its stable siblings (`vectors_diskann_recall_at10` ~34, `vectors_pq_recall_at10` ~22) sit **above** the floor and stay fully hard-gated.
- **Uniform-shift exemption computes breadth/uniformity/cap over gated (non-floor-exempt) rows only** — degenerate sub-floor ratios (the honest history reaches 4.0x on pure noise) would distort all three: breadth dilution, cv blow-up, and a false ≥4x cap veto.

## Why floor-exempt ≠ ungated

A sub-floor metric still: (1) prints in the watch table flagged **"under noise floor — watch only"** (stdout + `GITHUB_STEP_SUMMARY`); (2) emits a `::warning` when ≥ 2.0x median; (3) gets the Store step's soft comparison comment, which fires independently of this gate. Only the *lone hard red* is removed — a genuine broad regression that also moves above-floor metrics still fails, and the ~230 above-floor metrics (incl. all deterministic families) are gated exactly as before.

## Verification

- `--self-test`: **43 checks green** — new: sub-floor timing at 3x ⇒ watch-only + flagged; same 3x shape above the floor ⇒ hard fail; sub-floor deterministic at 2x ⇒ hard fail; exemption breadth/cap/uniformity exclude floor-exempt rows (4/4-gated-exempt vs 4/9-would-fail discriminating fixture + 4.0x sub-floor spike no-veto). Existing hard-zone fixtures scaled ×10 above the floor so they keep testing the hard zone proper.
- **Mutation check** (snapshot to /tmp → flip `NOISE_FLOOR` to 0 → red → cmp-restore → green): exit 1 with exactly the 4 floor-discriminator checks red (`4/43`), above-floor twin stays green — the floor constant is load-bearing.
- `scripts/tests/test_ci_select_wiring.py`: 66 tests OK (untouched, confirmed).
- Live replay of the honest published head: old gate exit 1, new gate exit 0 (watch-flagged), as above.
