### PR TITLE
feat(ci): nextest CI retry profile + merge-queue dequeued feedback loop (#556) + transient-tolerant sweeps (#3759)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,10 +1,36 @@
-# [FABLE-5] sq-63ups. 🤖 SPARQ agent.
+# [FABLE-5] sq-63ups + registry jeswr/agent-account-registry#563 item 2. 🤖 SPARQ agent.
 #
-# ONLY the `default-miri` profile is configured here — the profile nextest selects
-# AUTOMATICALLY when running under `cargo miri nextest run` (verified on the work box:
-# "Nextest run ID … with nextest profile: default-miri"). Every normal `cargo nextest run`
-# in ci.yml uses the built-in `default` profile, which this file deliberately leaves
-# untouched, so adding this file changes NOTHING outside the Miri lane.
+# TWO profiles are configured here:
+#   • `default-miri` — the profile nextest selects AUTOMATICALLY when running under
+#     `cargo miri nextest run` (verified on the work box: "Nextest run ID … with
+#     nextest profile: default-miri"). Miri-lane only.
+#   • `ci` — the profile ci.yml's sharded `cargo nextest run --archive-file …` legs
+#     select EXPLICITLY via `--profile ci`. Local `cargo nextest run` invocations keep
+#     the built-in `default` profile (no retries), so a locally-reproducible flake
+#     stays loudly red on the work box.
+
+# [FABLE-5] registry#563 item 2 (maintainer-approved OSS adoption): CI retry profile.
+#
+# INCIDENT CLASS: flaky tests redding the single required `gate` check burn whole gate
+# evaluations and trigger review-fix ci-flavour re-dispatches for PRs that changed
+# nothing relevant — the retry belongs at the test runner, not in the fix lane.
+#
+# NOT A SILENT MASK: nextest marks a test that passes only on a retry as FLAKY in the
+# run log and repeats it in the end-of-run summary (`final-status-level = "flaky"`
+# below), so the flake signal still lands in the shard logs that the flake-triage
+# tooling (omnibus-flake-quarantine, bench-triage) reads. A test that fails every
+# attempt is a plain FAIL and reds the shard exactly as before — the floor is never
+# weakened. No JUnit emission: no CI consumer parses JUnit here, so the log/summary
+# flaky reporting is the surfaced signal.
+[profile.ci]
+# Moved from the inline `--retries 2` flag on ci.yml's shard run step (count unchanged
+# — sq-x4jy calibrated it for the transient binary race; sq-c76x kept it) so the retry
+# policy lives in ONE place next to the Miri profile instead of inside a shell array.
+retries = 2
+# Explicit pin of nextest's default: every flaky (retried-then-passed) test is repeated
+# in the final summary, so an upstream default change can never silently drop the flaky
+# signal this profile is obligated to surface.
+final-status-level = "flaky"
 
 [profile.default-miri]
 # The nightly miri lane (.github/workflows/miri.yml) was cancelled at its 90-minute job

--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -161,7 +161,7 @@
   "merge-queue dequeued feedback (advisory)": {
    "workflow": "merge-queue-feedback.yml",
    "owner_bead": "registry jeswr/agent-account-registry#563 item 3 (durable fix for registry#556)",
-   "promotion_criteria": "permanently advisory BY DESIGN: this job runs on pull_request [dequeued] AFTER a gate verdict exists on the head SHA, and its writes (disable-auto + review:changes + comment) are orchestration feedback, not a merge-worthiness verdict — a feedback hiccup must never red a later gate evaluation on the same SHA. Promote never; delete this entry only if the workflow is removed",
+   "promotion_criteria": "permanently advisory BY DESIGN: this job runs on pull_request_target [dequeued] (write-only, no PR-head checkout) AFTER a gate verdict exists on the head SHA, and its writes (disable-auto + review:changes swap + comment) are orchestration feedback, not a merge-worthiness verdict — a feedback hiccup must never red a later gate evaluation on the same SHA. Promote never; delete this entry only if the workflow is removed",
    "registered": "2026-07-24"
   }
  }

--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -157,6 +157,12 @@
    "owner_bead": "sq-lonae",
    "promotion_criteria": "advisory while the repo/org setting 'Allow GitHub Actions to create and approve pull requests' is disabled (GITHUB_TOKEN cannot open the Release-PR: known 403, live run 29988505600, contained loudly via captured-output signature + side-effect-free probe). Promote when a maintainer enables that setting or configures the ORCHESTRATOR_APP_ID/_PRIVATE_KEY secrets (batch-merge.yml App-token pattern): drop the ' (advisory)' name token, remove the 403-containment step, and delete this entry",
    "registered": "2026-07-23"
+  },
+  "merge-queue dequeued feedback (advisory)": {
+   "workflow": "merge-queue-feedback.yml",
+   "owner_bead": "registry jeswr/agent-account-registry#563 item 3 (durable fix for registry#556)",
+   "promotion_criteria": "permanently advisory BY DESIGN: this job runs on pull_request [dequeued] AFTER a gate verdict exists on the head SHA, and its writes (disable-auto + review:changes + comment) are orchestration feedback, not a merge-worthiness verdict — a feedback hiccup must never red a later gate evaluation on the same SHA. Promote never; delete this entry only if the workflow is removed",
+   "registered": "2026-07-24"
   }
  }
 }

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -24,7 +24,10 @@ jobs:
     name: arm reviewed PRs
     if: github.event_name != 'pull_request' || github.event.label.name == 'review:pass'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10 (was 5): headroom for the #3759 bounded transient-retry backoff (up to
+    # 10s+30s per idempotent READ during a platform blip) without hitting the
+    # job ceiling; the sweep itself is unchanged.
+    timeout-minutes: 10
     steps:
       # Run the trusted default-branch policy, never code from the candidate PR head.
       - name: Checkout auto-arm policy
@@ -32,11 +35,17 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-          sparse-checkout: scripts/auto-arm.py
+          # gh_retry.py is auto-arm.py's #3759 transient-retry dependency — the
+          # self-test below imports it, so a missing path fails BEFORE the live run.
+          sparse-checkout: |
+            scripts/auto-arm.py
+            scripts/gh_retry.py
           sparse-checkout-cone-mode: false
 
       - name: Self-test policy
-        run: python3 scripts/auto-arm.py --self-test
+        run: |
+          python3 scripts/gh_retry.py --self-test
+          python3 scripts/auto-arm.py --self-test
 
       - name: Arm eligible PRs
         env:

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -52,4 +52,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: python3 scripts/auto-arm.py --repo "$REPO" --default-branch "$DEFAULT_BRANCH"
+          # [FABLE-5] #3759 finding 5: the label-triggered (pull_request) invocation is
+          # EVENT mode — it has no per-PR cron backstop, so an exhausted transient must
+          # exit non-zero (visibly red + retried), NOT the sweep's lenient ::warning+0.
+          # The scheduled/dispatch runs are SWEEP mode (a missed cycle is cron-covered).
+          ARM_MODE: ${{ github.event_name == 'pull_request' && 'event' || 'sweep' }}
+        run: >-
+          python3 scripts/auto-arm.py
+          --repo "$REPO"
+          --default-branch "$DEFAULT_BRANCH"
+          --mode "$ARM_MODE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,8 +388,9 @@ jobs:
           shared-key: "test-workspace"
       # [OPUS-4.8] sq-x4jy: cargo-nextest is the test runner — each test in its OWN
       # process (a stray abort can't take the whole binary down), a never-executed
-      # BINARY reported as a DETERMINISTIC failure, and --retries 2 (set on the run
-      # side) lets a residual transient binary race self-heal. SHA-pinned install
+      # BINARY reported as a DETERMINISTIC failure, and retries = 2 (now set by
+      # .config/nextest.toml [profile.ci], selected on the run side — registry#563
+      # item 2) lets a residual transient binary race self-heal. SHA-pinned install
       # action (a pin already vetted elsewhere in this workflow).
       - name: Install cargo-nextest
         uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
@@ -586,7 +587,9 @@ jobs:
       #     uniform remainder, split evenly. Filter is applied FIRST, then the count
       #     partition runs over the filtered (not-heavy) set, so the three bulk shards
       #     cover every non-heavy test exactly once.
-      # --retries 2 preserved per shard (transient binary-race self-heal, sq-x4jy).
+      # retries = 2 preserved per shard via `--profile ci` (.config/nextest.toml —
+      # transient binary-race self-heal, sq-x4jy; moved off the inline flag by
+      # registry#563 item 2 so the retry policy has one home).
       #
       # [OPUS-4.8] `--extract-to . --extract-overwrite` is LOAD-BEARING — it is the fix
       # for the bulk-shard failures #159 originally shipped with. WHY: sparq-cli's
@@ -608,9 +611,13 @@ jobs:
       # PASS; without it they reproduce the exact NotFound panic. (Touching ONLY this
       # run-step keeps it on the build-once archive path — sq-vyxy stays closed.)
       # [OPUS-4.8] sq-c76x: TWO retry layers, each fixing a DIFFERENT failure class —
-      #   1. `--retries 2` (kept, unchanged): nextest's PER-TEST retry. A single flaky
-      #      test process re-runs in-place; the test passes iff any attempt passes. This
-      #      is the residual-variance / transient-binary-race self-heal (sq-x4jy).
+      #   1. `retries = 2` (kept, count unchanged — now sourced from
+      #      .config/nextest.toml [profile.ci] via `--profile ci`, registry#563 item 2):
+      #      nextest's PER-TEST retry. A single flaky test process re-runs in-place; the
+      #      test passes iff any attempt passes, and a retried-then-passing test is
+      #      reported FLAKY in the log + end-of-run summary (final-status-level =
+      #      "flaky"), so retries never silently mask a flaky test. This is the
+      #      residual-variance / transient-binary-race self-heal (sq-x4jy).
       #   2. The `for attempt` STEP-LEVEL retry below (new): re-invokes the WHOLE
       #      `cargo nextest run` up to MAX_ATTEMPTS times. This catches failures that a
       #      per-test retry CANNOT — a transient archive-extraction error, residual disk
@@ -705,7 +712,7 @@ jobs:
             esac
           fi
           common=(--archive-file nextest.tar.zst --workspace-remap . \
-                  --extract-to . --extract-overwrite --retries 2)
+                  --extract-to . --extract-overwrite --profile ci)
           if [ -n "${{ matrix.filter }}" ]; then
             # Dedicated heavy shard: intersect HEAVY with this shard's single test so
             # the shard's set is provably a SUBSET of HEAVY (belt-and-braces: if the

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -407,6 +407,18 @@ jobs:
         run: |
           python3 scripts/triage.py --self-test
           python3 scripts/retriage.py --self-test
+      # [FABLE-5] #3759 / registry#563 item 4: the transient-tolerant gh READ retry
+      # helper (scripts/gh_retry.py — bounded, transient-5xx-only, fail-closed
+      # read-allow-list so mutations/arm calls can never be wrapped) and the two arm
+      # sweeps that consume it. Their own workflows (auto-arm.yml / rearm-sweeper.yml)
+      # self-test only the DEFAULT-BRANCH copy at cron time, so a PR changing any of
+      # the three files would otherwise merge unvalidated — these hermetic self-tests
+      # (injected runners, no gh/network) red the offending PR instead.
+      - name: Self-test gh-retry helper + arm sweeps (#3759 transient tolerance)
+        run: |
+          python3 scripts/gh_retry.py --self-test
+          python3 scripts/auto-arm.py --self-test
+          python3 scripts/rearm-sweeper.py --self-test
       # [OPUS-4.8] sq-ur7o: every SHA-pinned `taiki-e/install-action` step MUST carry an
       # explicit `with: tool:`. install-action picks the tool from its @<tool> git ref; the
       # code-scanning=0 SHA-pin policy DROPS that selector, so without `with: tool:` the

--- a/.github/workflows/merge-queue-feedback.yml
+++ b/.github/workflows/merge-queue-feedback.yml
@@ -6,10 +6,30 @@
 # sits green-looking with a dead arm until an orchestrator sweep happens to re-derive
 # its state from the live rollup (registry#556). The merge queue's `dequeued`
 # pull_request activity type is a PUSH signal for exactly this edge, so this workflow
-# converts every dequeue into the fix lane's admission shape: auto-merge disabled,
-# `review:changes` applied, and a self-identified comment linking the failed
-# merge-group run — the registry's fix-enumeration then admits the PR on its next
-# tick instead of never.
+# converts every genuine (non-merge) dequeue into the fix lane's admission shape:
+# auto-merge disabled, review:pass swapped for `review:changes`, and a self-identified
+# comment linking the failed merge-group run — the registry's fix-enumeration then
+# admits the PR on its next tick instead of never.
+#
+# ── pull_request_target (NOT pull_request) ────────────────────────────────────────
+# [FABLE-5] #3759 finding 2. This workflow only WRITES (disable-auto, relabel,
+# comment) and needs NO checkout of the PR's code. On `pull_request` a fork PR's run
+# gets a READ-ONLY token (so the label/comment writes would fail) and the event may
+# not even fire on a conflict-dequeue. `pull_request_target` runs in the BASE-repo
+# context with the base repo's write token, so the writes succeed on fork PRs too and
+# the trigger is reliable.
+#
+#   SECURITY — pull_request_target runs with a REPO-WRITE token in the trusted base
+#   context. The classic pull_request_target pitfall is executing untrusted PR HEAD
+#   code with that token. This job does NEITHER of the dangerous things:
+#     * it NEVER checks out the PR head (`actions/checkout` is not used at all), and
+#     * it NEVER executes any code, script, or path from the PR — every step is a
+#       plain `gh` call keyed only on github.event fields (the PR NUMBER + the
+#       dequeue reason) and gh-api reads by that number.
+#   No PR-controlled value is ever interpolated into a shell command (the reason is
+#   passed through env and only echoed/switched on a fixed allow-list). If this
+#   workflow is ever extended to build/test PR code, it MUST move that work to a
+#   separate `pull_request`-triggered job — do not add a checkout of the PR head here.
 #
 # GATE INTEGRATION: the job name carries the whole-word `advisory` token, so the
 # ci-summary gate's discovery excludes it from the gating set (a dequeue-feedback
@@ -25,14 +45,14 @@
 name: merge-queue feedback
 
 on:
-  pull_request:
+  pull_request_target:
     types: [dequeued]
 
-# contents: write + pull-requests: write — disable auto-merge, label, comment (the
-# same scope pair auto-arm.yml holds for the enable direction). actions: read — list
-# this repo's merge_group workflow runs to find the failed run for the queue branch.
+# Least-privilege for a WRITE-only, NO-checkout job: pull-requests: write covers the
+# disable-auto / relabel / comment writes; actions: read lists this repo's merge_group
+# runs to find the failed run. NO contents write is needed — nothing is pushed and no
+# repo code is checked out (see the pull_request_target safety note above).
 permissions:
-  contents: write
   pull-requests: write
   actions: read
 
@@ -54,35 +74,99 @@ jobs:
       # CI_FAILURE, CI_TIMEOUT, MERGE_CONFLICT, QUEUE_CLEARED, MANUAL, ROLL_BACK).
       DEQUEUE_REASON: ${{ github.event.reason || 'UNKNOWN' }}
     steps:
-      - name: Disable dead arm, apply review:changes, comment with the failed run
+      # [FABLE-5] #3759 finding 3: a dequeue caused by a SUCCESSFUL queue merge is not
+      # a failure — GitHub emits pull_request.dequeued with merged==true when the PR
+      # landed. Exit 0 immediately; disabling the (already-consumed) arm, relabeling a
+      # merged PR, or commenting "dequeued — please fix" would be wrong and noisy.
+      - name: Skip successful-merge dequeues
+        if: github.event.pull_request.merged == true
+        run: |
+          echo "PR ${PR_NUMBER} dequeued via successful merge - no action."
+
+      - name: Route genuine dequeue to the fix lane
+        if: github.event.pull_request.merged != true
         run: |
           set -euo pipefail
 
-          # RACE GUARD: the PR can merge or close between the dequeue event and this
-          # job (e.g. a manual merge, a re-queue that already landed). Feedback on a
-          # non-open PR is meaningless — exit 0 with a log line, never an error.
+          # ── state read (finding 4) ──────────────────────────────────────────────
+          # A gh pr view failure has TWO very different causes we must not conflate:
+          #   * the PR is genuinely CLOSED/MERGED (a race between the dequeue event and
+          #     this job) — benign, exit 0; there is nothing to route.
+          #   * the state read itself FAILED (transient 5xx / API blip) — we CANNOT
+          #     prove the routing happened, so we must NOT masquerade it as a benign
+          #     skip. We read with an explicit success-vs-error distinction and a
+          #     bounded transient retry (the scripts/gh_retry.py 10s+30s schedule); on
+          #     a genuine read failure we exit NON-zero so the run is visibly red.
+          read_state() {
+            gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state
+          }
+
+          is_transient() {
+            printf '%s' "$1" | grep -qiE 'HTTP (50[234])|Bad Gateway|Service Unavailable|Gateway Timeout|connection reset|connection refused|i/o timeout|TLS handshake timeout|context deadline exceeded|temporary failure in name resolution|unexpected EOF'
+          }
+
+          # Bounded transient retry, printing the state on success (rc 0) or leaving
+          # STATE empty on a genuine read failure (rc 1).
+          retrying_state_read() {
+            local attempt err
+            for attempt in 1 2 3; do
+              if STATE=$(read_state 2>/tmp/pr_view_err); then
+                return 0
+              fi
+              err=$(cat /tmp/pr_view_err 2>/dev/null || true)
+              echo "gh pr view attempt ${attempt}/3 failed: ${err}"
+              if is_transient "$err" && [ "$attempt" -lt 3 ]; then
+                if [ "$attempt" -eq 1 ]; then sleep 10; else sleep 30; fi
+                continue
+              fi
+              return 1
+            done
+            return 1
+          }
+
+          STATE=""
+          if ! retrying_state_read; then
+            echo "::error::could not read PR #${PR_NUMBER} state (gh pr view failed on every attempt) — the dequeue may not have been routed to the fix lane. Failing the run so it is visibly red rather than a silent benign-skip."
+            exit 1
+          fi
+
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR #${PR_NUMBER} is ${STATE} (merged/closed race between the dequeue event and this job) — nothing to route; exiting 0."
+            exit 0
+          fi
+
+          # ensure_open_or_exit: re-read AFTER a write fails to classify a race vs a
+          # real write failure. A read failure here is NOT benign — it must not turn a
+          # failed write into a silent success (finding 4).
           ensure_open_or_exit() {
-            local st
-            st=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state 2>/dev/null || echo UNKNOWN)
-            if [ "$st" != "OPEN" ]; then
-              echo "PR #$PR_NUMBER is ${st} (merged/closed race between the dequeue event and this job) — nothing to route; exiting 0."
+            if ! retrying_state_read; then
+              echo "::error::state re-read for PR #${PR_NUMBER} failed after a write error — cannot prove the PR is closed, so cannot treat the write failure as benign."
+              exit 1
+            fi
+            if [ "$STATE" != "OPEN" ]; then
+              echo "PR #${PR_NUMBER} is ${STATE} (merged/closed race) — nothing to route; exiting 0."
               exit 0
             fi
           }
-          ensure_open_or_exit
 
           # (a) Disable the now-dead auto-merge arm. Best-effort: GitHub sometimes
           # clears it on dequeue already, and a raced merge/close makes it moot.
           gh pr merge "$PR_NUMBER" --repo "$REPO" --disable-auto \
             || echo "disable-auto returned non-zero (already disabled, or raced) — continuing."
 
-          # (b) Route to the fix lane. This label is the load-bearing signal the
-          # registry's fix-enumeration admits on its next tick; if it cannot be
-          # applied to a still-open PR, fail loudly (advisory job: visible in the
-          # Actions UI, never gating).
-          if ! gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "review:changes"; then
+          # (b) Route to the fix lane — ATOMICALLY. [FABLE-5] #3759 finding 1: add
+          # review:changes AND remove review:pass / review:needs-user in the SAME
+          # `gh pr edit` so the 10-min auto-arm sweep can never observe a window where
+          # review:pass still coexists with review:changes and re-arm the dequeued PR
+          # before remediation. (auto-arm.py ALSO treats review:changes as a hard
+          # exclusion — belt-and-suspenders.) --remove-label is idempotent: gh does not
+          # error when a label to remove is already absent.
+          if ! gh pr edit "$PR_NUMBER" --repo "$REPO" \
+                --add-label "review:changes" \
+                --remove-label "review:pass" \
+                --remove-label "review:needs-user"; then
             ensure_open_or_exit
-            echo "::error::failed to apply review:changes to open PR #$PR_NUMBER — the fix lane will not see this dequeue until the next label sweep."
+            echo "::error::failed to swap review:pass -> review:changes on open PR #${PR_NUMBER} — the fix lane will not see this dequeue until the next label sweep."
             exit 1
           fi
 
@@ -116,14 +200,14 @@ jobs:
           body_file=$(mktemp)
           {
             printf '%s\n\n' "> 🤖 SPARQ agent — autonomous orchestration."
-            printf '%s\n\n' "This PR was **dequeued from the merge queue** (reason: \`${DEQUEUE_REASON}\`). Its auto-merge arm has been disabled and \`review:changes\` applied, so the fix pipeline admits it on the next enumeration tick (durable feedback loop for registry#556)."
+            printf '%s\n\n' "This PR was **dequeued from the merge queue** (reason: \`${DEQUEUE_REASON}\`). Its auto-merge arm has been disabled and \`review:pass\` swapped for \`review:changes\`, so the fix pipeline admits it on the next enumeration tick (durable feedback loop for registry#556)."
             printf '%s\n' "$run_lines"
             printf '%s\n' "$flake_note"
           } > "$body_file"
 
           if ! gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file"; then
             ensure_open_or_exit
-            echo "::error::failed to comment the dequeue notification on open PR #$PR_NUMBER (label was applied — routing is intact, the explanation is missing)."
+            echo "::error::failed to comment the dequeue notification on open PR #${PR_NUMBER} (label was applied — routing is intact, the explanation is missing)."
             exit 1
           fi
-          echo "PR #$PR_NUMBER: dequeue (reason ${DEQUEUE_REASON}) routed to review:changes with notification."
+          echo "PR #${PR_NUMBER}: dequeue (reason ${DEQUEUE_REASON}) routed to review:changes with notification."

--- a/.github/workflows/merge-queue-feedback.yml
+++ b/.github/workflows/merge-queue-feedback.yml
@@ -1,0 +1,129 @@
+# [FABLE-5] registry jeswr/agent-account-registry#563 item 3 — durable fix for
+# registry#556 (invisible merge-group failures). 🤖 SPARQ agent.
+#
+# WHY: when the merge queue drops a PR (a failed/timed-out merge-group run, a queue
+# clear, a conflict), GitHub silently disables nothing and notifies nobody — the PR
+# sits green-looking with a dead arm until an orchestrator sweep happens to re-derive
+# its state from the live rollup (registry#556). The merge queue's `dequeued`
+# pull_request activity type is a PUSH signal for exactly this edge, so this workflow
+# converts every dequeue into the fix lane's admission shape: auto-merge disabled,
+# `review:changes` applied, and a self-identified comment linking the failed
+# merge-group run — the registry's fix-enumeration then admits the PR on its next
+# tick instead of never.
+#
+# GATE INTEGRATION: the job name carries the whole-word `advisory` token, so the
+# ci-summary gate's discovery excludes it from the gating set (a dequeue-feedback
+# hiccup on a PR head must never red a later gate evaluation on that same SHA). The
+# labels/comments it writes are exactly the fix lane's normal inputs.
+#
+# FLAKE-CLASSIFIED failures: an infra-flavoured dequeue reason (e.g. CI_TIMEOUT) is
+# noted in the comment but STILL routes to review:changes — the fix lane's ci-flavour
+# owns re-runs, so the routing is identical by design.
+#
+# No third-party actions (nothing to SHA-pin); every step is plain `gh` against the
+# workflow token, least-privilege scoped below.
+name: merge-queue feedback
+
+on:
+  pull_request:
+    types: [dequeued]
+
+# contents: write + pull-requests: write — disable auto-merge, label, comment (the
+# same scope pair auto-arm.yml holds for the enable direction). actions: read — list
+# this repo's merge_group workflow runs to find the failed run for the queue branch.
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+# One feedback job per PR at a time; never cancel a half-posted notification.
+concurrency:
+  group: merge-queue-feedback-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  feedback:
+    name: merge-queue dequeued feedback (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      # The dequeued activity payload carries the queue's removal reason (e.g.
+      # CI_FAILURE, CI_TIMEOUT, MERGE_CONFLICT, QUEUE_CLEARED, MANUAL, ROLL_BACK).
+      DEQUEUE_REASON: ${{ github.event.reason || 'UNKNOWN' }}
+    steps:
+      - name: Disable dead arm, apply review:changes, comment with the failed run
+        run: |
+          set -euo pipefail
+
+          # RACE GUARD: the PR can merge or close between the dequeue event and this
+          # job (e.g. a manual merge, a re-queue that already landed). Feedback on a
+          # non-open PR is meaningless — exit 0 with a log line, never an error.
+          ensure_open_or_exit() {
+            local st
+            st=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state 2>/dev/null || echo UNKNOWN)
+            if [ "$st" != "OPEN" ]; then
+              echo "PR #$PR_NUMBER is ${st} (merged/closed race between the dequeue event and this job) — nothing to route; exiting 0."
+              exit 0
+            fi
+          }
+          ensure_open_or_exit
+
+          # (a) Disable the now-dead auto-merge arm. Best-effort: GitHub sometimes
+          # clears it on dequeue already, and a raced merge/close makes it moot.
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --disable-auto \
+            || echo "disable-auto returned non-zero (already disabled, or raced) — continuing."
+
+          # (b) Route to the fix lane. This label is the load-bearing signal the
+          # registry's fix-enumeration admits on its next tick; if it cannot be
+          # applied to a still-open PR, fail loudly (advisory job: visible in the
+          # Actions UI, never gating).
+          if ! gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "review:changes"; then
+            ensure_open_or_exit
+            echo "::error::failed to apply review:changes to open PR #$PR_NUMBER — the fix lane will not see this dequeue until the next label sweep."
+            exit 1
+          fi
+
+          # (c) Best-effort discovery of the failed merge-group run: merge_group runs
+          # execute on the transient gh-readonly-queue/<base>/pr-<N>-<sha> branch,
+          # which is deleted on dequeue — but the WORKFLOW RUNS persist and keep that
+          # head_branch, so the Actions API finds them after the fact.
+          runs_json=$(gh api "repos/$REPO/actions/runs?event=merge_group&per_page=100" \
+            --jq "[.workflow_runs[]
+                   | select(.head_branch != null)
+                   | select(.head_branch | test(\"^gh-readonly-queue/.*/pr-${PR_NUMBER}-\"))]" \
+            2>/dev/null || echo "[]")
+          failed_runs=$(jq -r '[.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")]
+                               | sort_by(.run_started_at) | reverse | .[:3][]
+                               | "- [\(.name) (\(.conclusion))](\(.html_url))"' <<<"$runs_json")
+          if [ -n "$failed_runs" ]; then
+            run_lines="Failed merge-group run(s) for this PR's queue branch:"$'\n'"$failed_runs"
+          else
+            run_lines="The failed merge-group run was not discoverable from the Actions API at notification time (no non-success \`merge_group\` run recorded for \`gh-readonly-queue/*/pr-${PR_NUMBER}-*\`) — check this PR's checks tab for the queue history."
+          fi
+
+          # Infra-flake note: a timeout/queue-side reason is flagged, but the routing
+          # is deliberately IDENTICAL — the fix lane's ci-flavour handles re-runs.
+          flake_note=""
+          case "$DEQUEUE_REASON" in
+            CI_TIMEOUT|QUEUE_CLEARED|ROLL_BACK)
+              flake_note=$'\n'"Reason \`${DEQUEUE_REASON}\` is queue/infra-flavoured (likely not a fault in this PR's diff); it is still routed to \`review:changes\` because the fix lane's ci-flavour owns re-runs."
+              ;;
+          esac
+
+          body_file=$(mktemp)
+          {
+            printf '%s\n\n' "> 🤖 SPARQ agent — autonomous orchestration."
+            printf '%s\n\n' "This PR was **dequeued from the merge queue** (reason: \`${DEQUEUE_REASON}\`). Its auto-merge arm has been disabled and \`review:changes\` applied, so the fix pipeline admits it on the next enumeration tick (durable feedback loop for registry#556)."
+            printf '%s\n' "$run_lines"
+            printf '%s\n' "$flake_note"
+          } > "$body_file"
+
+          if ! gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file"; then
+            ensure_open_or_exit
+            echo "::error::failed to comment the dequeue notification on open PR #$PR_NUMBER (label was applied — routing is intact, the explanation is missing)."
+            exit 1
+          fi
+          echo "PR #$PR_NUMBER: dequeue (reason ${DEQUEUE_REASON}) routed to review:changes with notification."

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -29,7 +29,10 @@ jobs:
   sweep:
     name: restore dropped merge-queue arms
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10 (was 5): headroom for the #3759 bounded transient-retry backoff (up to
+    # 10s+30s per idempotent READ during a platform blip) without hitting the
+    # job ceiling; the sweep itself is unchanged.
+    timeout-minutes: 10
     env:
       # Secrets are not readable from step `if:` expressions — mirror the id into env
       # so the mint step can be skipped fail-soft when the App is not configured.
@@ -49,11 +52,17 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-          sparse-checkout: scripts/rearm-sweeper.py
+          # gh_retry.py is rearm-sweeper.py's #3759 transient-retry dependency — the
+          # self-test below imports it, so a missing path fails BEFORE the live run.
+          sparse-checkout: |
+            scripts/rearm-sweeper.py
+            scripts/gh_retry.py
           sparse-checkout-cone-mode: false
 
       - name: Self-test policy
-        run: python3 scripts/rearm-sweeper.py --self-test
+        run: |
+          python3 scripts/gh_retry.py --self-test
+          python3 scripts/rearm-sweeper.py --self-test
 
       - name: Re-arm dropped reviewed PRs
         env:

--- a/scripts/auto-arm.py
+++ b/scripts/auto-arm.py
@@ -38,6 +38,14 @@ HUMAN_OR_TRUST_LABELS = frozenset(
         "area:sparq-trust",
     }
 )
+# [FABLE-5] #3759 finding 1: a PR flipped to review:changes (e.g. by the merge-queue
+# dequeued-feedback loop) is in the fix lane and must NEVER be armed — even if a stale
+# review:pass is still present. This is belt-and-suspenders with the feedback workflow
+# atomically REMOVING review:pass when it adds review:changes: the sweep treats
+# review:changes (and review:needs) as a HARD exclusion independent of review:pass, so
+# a race that momentarily left BOTH labels on the PR can never re-arm the dequeued PR
+# before remediation.
+REVIEW_CHANGES_LABELS = frozenset({"review:changes", "review:needs"})
 PR_FIELDS = (
     "id,number,state,isDraft,headRefOid,baseRefName,labels,autoMergeRequest,"
     "mergeStateStatus"
@@ -171,6 +179,12 @@ class AutoArmer:
         blocked = self.security_labels(pr)
         if blocked:
             return f"security-surface ({', '.join(blocked)})"
+        # [FABLE-5] #3759 finding 1: review:changes is a HARD exclusion checked BEFORE
+        # review:pass, so a PR in the fix lane is never armed even with a stale
+        # review:pass still on it (a re-arm before remediation is the exact bug).
+        changes = sorted(pr.labels & REVIEW_CHANGES_LABELS)
+        if changes:
+            return f"changes-requested ({', '.join(changes)})"
         if pr.base_ref != self.default_branch:
             return f"non-default-base ({pr.base_ref or 'unknown'})"
         if require_review and REVIEW_LABEL not in pr.labels:
@@ -249,10 +263,22 @@ class AutoArmer:
         try:
             self.arm(current)
         except GhError as mutation_error:
+            # The arm mutation FAILED — this error is the primary run status and must
+            # survive whatever the follow-up diagnostic read does. The diagnostic
+            # read (classify_mutation_race -> refresh) is itself retriable, so it can
+            # raise GhError *or* GhTransientExhausted; if it exhausts transient
+            # retries we must NOT let that exhaustion propagate, or run_sweep's
+            # lenient GhTransientExhausted handler would convert a genuine arm failure
+            # into a false success (::warning + exit 0). Suppress the diagnostic's own
+            # failure and re-raise the ORIGINAL mutation error. (#3759 finding 5.)
             try:
                 race = self.classify_mutation_race(current)
-            except GhError:
-                raise mutation_error
+            except (GhError, gh_retry.GhTransientExhausted) as diag_error:
+                self.log(
+                    f"PR #{initial.number}: arm failed and the race diagnostic could "
+                    f"not resolve ({diag_error}); propagating the original arm error."
+                )
+                raise mutation_error from mutation_error
             if race:
                 self.log(f"PR #{initial.number}: skipped {race}")
                 return
@@ -265,13 +291,32 @@ class AutoArmer:
                 self.process(pr)
 
 
-def run_sweep(armer: AutoArmer, log: Callable[[str], None] = print) -> int:
-    """One periodic sweep. Exhausted TRANSIENT retries => ::warning + exit 0 (#3759):
-    the sweep is idempotent and cron-covered, so a missed cycle must not red main's
-    gate. Every other error propagates and fails loudly."""
+def run_sweep(
+    armer: AutoArmer, log: Callable[[str], None] = print, *, mode: str = "sweep"
+) -> int:
+    """Run the armer once. Exit policy depends on the INVOCATION MODE (#3759 finding 5).
+
+    ``mode="sweep"`` (the periodic cron) — exhausted TRANSIENT retries on the READ
+    path => ``::warning`` + exit 0: the sweep is idempotent and cron-covered, so a
+    missed cycle must not red main's gate.
+
+    ``mode="event"`` (the label-triggered auto-arm on a single PR) — there is NO cron
+    backstop for *this* PR right now, so the lenient exit does NOT apply: an exhausted
+    transient (or any other failure) exits NON-zero so the arm attempt is visibly red
+    and gets retried. Only the periodic sweep may swallow a transient.
+
+    A failed arm MUTATION always propagates as ``GhError`` in either mode (the
+    diagnostic read's own exhaustion can never overwrite it — see ``process``)."""
+    if mode not in ("sweep", "event"):
+        raise ValueError(f"mode must be 'sweep' or 'event', got {mode!r}")
     try:
         armer.run()
     except gh_retry.GhTransientExhausted as error:
+        if mode == "event":
+            # Event-driven arm: no per-PR cron backstop — fail loudly so it is retried.
+            raise GhError(
+                f"event-mode auto-arm exhausted transient retries: {error}"
+            ) from error
         log(
             "::warning title=auto-arm skipped a cycle on transient GitHub API "
             f"failures::{error} — bounded retries exhausted; a missed sweep is "
@@ -373,6 +418,18 @@ def self_test() -> None:
         assert not graphql_calls(fake), (label, fake.calls)
         assert any("security-surface" in message for message in messages), (label, messages)
 
+    # [FABLE-5] #3759 finding 1: review:changes is a HARD exclusion. A dequeued PR that
+    # still carries a STALE review:pass (a race left both on) must NEVER be armed — the
+    # fix-lane label wins. Both review-hold labels are checked independent of review:pass.
+    for hold in ("review:changes", "review:needs"):
+        fake, messages = exercise(fixture(labels=(REVIEW_LABEL, hold)))
+        assert not graphql_calls(fake), (hold, fake.calls)
+        assert any("changes-requested" in message for message in messages), (hold, messages)
+    # It also stops an arm when review:changes appears only on the live refresh.
+    fake, messages = exercise(clean, views=[fixture(labels=(REVIEW_LABEL, "review:changes"))])
+    assert not graphql_calls(fake), fake.calls
+    assert any("changes-requested" in message for message in messages), messages
+
     # Existing auto-merge arms are idempotent no-ops.
     fake, messages = exercise(fixture(armed=True))
     assert not graphql_calls(fake), fake.calls
@@ -464,6 +521,80 @@ def self_test() -> None:
     else:
         raise AssertionError("non-transient errors must not be swallowed")
 
+    # [FABLE-5] #3759 finding 5 (BLOCKING): a real arm MUTATION failure must be the
+    # run's status even when the follow-up race-diagnostic READ exhausts transient
+    # retries. Here the arm CAS fails (GhError) and the diagnostic refresh raises
+    # GhTransientExhausted; the ORIGINAL mutation error must propagate, NOT be
+    # rewritten into a lenient exit-0 success.
+    fake = FakeGh(clean, mutation_error=True)
+
+    def read_lists_then_exhausts(argv: list[str]) -> str:
+        # The pre-arm reads (pr list, the pre-arm pr view) succeed; the diagnostic
+        # refresh AFTER the failed arm is the one that exhausts transients.
+        if argv[:2] == ["pr", "view"] and getattr(read_lists_then_exhausts, "armed", False):
+            raise gh_retry.GhTransientExhausted("gh pr view: HTTP 504 (3 attempts)")
+        if argv[:2] == ["api", "graphql"]:
+            read_lists_then_exhausts.armed = True  # type: ignore[attr-defined]
+        return fake(argv)
+
+    def gh_marks_arm(argv: list[str]) -> str:
+        if argv[:2] == ["api", "graphql"]:
+            read_lists_then_exhausts.armed = True  # type: ignore[attr-defined]
+        return fake(argv)
+
+    read_lists_then_exhausts.armed = False  # type: ignore[attr-defined]
+    try:
+        run_sweep(
+            AutoArmer(
+                "sparq-org/sparq",
+                "main",
+                gh_marks_arm,
+                lambda _m: None,
+                gh_read=read_lists_then_exhausts,
+            ),
+            log=lambda _m: None,
+        )
+    except GhError as error:
+        assert "CAS rejection" in str(error), error
+    else:
+        raise AssertionError(
+            "a failed arm mutation must NOT be masked as success when the follow-up "
+            "diagnostic read exhausts its transient retries"
+        )
+
+    # [FABLE-5] #3759 finding 5: EVENT-mode (label-triggered) arm must NOT use the
+    # sweep's lenient exit — an exhausted transient exits NON-zero (there is no
+    # per-PR cron backstop), so the arm is visibly red and retried.
+    def exhausted_event(_argv: list[str]) -> str:
+        raise gh_retry.GhTransientExhausted("gh pr list: HTTP 504 (3 attempts)")
+
+    fake = FakeGh(clean)
+    try:
+        run_sweep(
+            AutoArmer(
+                "sparq-org/sparq", "main", fake, lambda _m: None, gh_read=exhausted_event
+            ),
+            log=lambda _m: None,
+            mode="event",
+        )
+    except GhError as error:
+        assert "event-mode" in str(error), error
+    else:
+        raise AssertionError("event-mode exhausted transient must exit non-zero")
+
+    # The SAME exhausted transient in SWEEP mode is still the lenient ::warning + 0.
+    fake = FakeGh(clean)
+    warnings = []
+    code = run_sweep(
+        AutoArmer(
+            "sparq-org/sparq", "main", fake, lambda _m: None, gh_read=exhausted_event
+        ),
+        log=warnings.append,
+        mode="sweep",
+    )
+    assert code == 0, code
+    assert warnings and warnings[0].startswith("::warning"), warnings
+
     print("auto-arm self-test: PASS")
 
 
@@ -471,6 +602,17 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--repo", help="owner/repository to sweep")
     parser.add_argument("--default-branch", default="main")
+    parser.add_argument(
+        "--mode",
+        choices=("sweep", "event"),
+        default="sweep",
+        help=(
+            "sweep: periodic cron (exhausted transient reads => ::warning + exit 0, "
+            "the cron backstop covers a missed cycle). event: label-triggered arm on a "
+            "single PR (no per-PR backstop — any failure, incl. exhausted transients, "
+            "exits non-zero so the arm is visibly red and retried)."
+        ),
+    )
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -479,7 +621,9 @@ def main() -> int:
         return 0
     if not args.repo:
         parser.error("--repo is required unless --self-test is used")
-    return run_sweep(AutoArmer(args.repo, args.default_branch, gh_read=run_gh_read))
+    return run_sweep(
+        AutoArmer(args.repo, args.default_branch, gh_read=run_gh_read), mode=args.mode
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/auto-arm.py
+++ b/scripts/auto-arm.py
@@ -7,6 +7,12 @@ to GitHub's explicit ``enablePullRequestAutoMerge`` GraphQL mutation.
 """
 
 # [GPT-5] Issue #447 — deterministic, hermetically self-tested auto-arm policy.
+# [FABLE-5] Issue #3759 / registry#563 item 4 — idempotent gh READS (pr list/view) go
+# through gh_retry.run_gh_read (bounded, transient-only retry); MUTATIONS (pr ready,
+# the enablePullRequestAutoMerge CAS) stay one-shot on the un-wrapped runner. When a
+# transient 5xx survives every bounded retry, the sweep exits ::warning + 0 instead of
+# redding main's gate — a missed cycle is harmless, the cron covers it. Any
+# non-transient error still fails loudly (GhFatalError -> GhError -> traceback).
 
 from __future__ import annotations
 
@@ -17,6 +23,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Callable
+
+import gh_retry
 
 
 REVIEW_LABEL = "review:pass"
@@ -87,6 +95,19 @@ def run_gh(argv: list[str]) -> str:
     return result.stdout
 
 
+def run_gh_read(argv: list[str]) -> str:
+    """Idempotent READ path: bounded transient-only retries (#3759).
+
+    Non-transient failures re-raise as :class:`GhError` so every existing per-PR
+    handler keeps working; exhausted transients propagate as
+    :class:`gh_retry.GhTransientExhausted` for the ::warning + exit-0 sweep policy.
+    """
+    try:
+        return gh_retry.run_gh_read(argv)
+    except gh_retry.GhFatalError as error:
+        raise GhError(str(error)) from error
+
+
 class AutoArmer:
     def __init__(
         self,
@@ -94,15 +115,20 @@ class AutoArmer:
         default_branch: str,
         gh: Callable[[list[str]], str] = run_gh,
         log: Callable[[str], None] = print,
+        *,
+        gh_read: Callable[[list[str]], str] | None = None,
     ) -> None:
         self.repo = repo
         self.default_branch = default_branch
         self.gh = gh
+        # Idempotent READS may go through a retrying runner (#3759); mutations
+        # (pr ready, the arm CAS) always use the one-shot `gh` runner above.
+        self.gh_read = gh_read if gh_read is not None else gh
         self.log = log
 
     def list_open(self) -> list[PullRequest]:
         raw = json.loads(
-            self.gh(
+            self.gh_read(
                 [
                     "pr",
                     "list",
@@ -121,7 +147,7 @@ class AutoArmer:
 
     def refresh(self, number: int) -> PullRequest:
         raw = json.loads(
-            self.gh(
+            self.gh_read(
                 [
                     "pr",
                     "view",
@@ -237,6 +263,22 @@ class AutoArmer:
         for pr in self.list_open():
             if REVIEW_LABEL in pr.labels:
                 self.process(pr)
+
+
+def run_sweep(armer: AutoArmer, log: Callable[[str], None] = print) -> int:
+    """One periodic sweep. Exhausted TRANSIENT retries => ::warning + exit 0 (#3759):
+    the sweep is idempotent and cron-covered, so a missed cycle must not red main's
+    gate. Every other error propagates and fails loudly."""
+    try:
+        armer.run()
+    except gh_retry.GhTransientExhausted as error:
+        log(
+            "::warning title=auto-arm skipped a cycle on transient GitHub API "
+            f"failures::{error} — bounded retries exhausted; a missed sweep is "
+            "harmless (the cron backstop covers it), so this run reports success."
+        )
+        return 0
+    return 0
 
 
 def fixture(
@@ -376,6 +418,52 @@ def self_test() -> None:
     assert not graphql_calls(fake), fake.calls
     assert any("non-default-base" in message for message in messages), messages
 
+    # [FABLE-5] #3759: READS route through gh_read; MUTATIONS stay on the one-shot
+    # runner (the retry helper itself refuses them — see gh_retry.assert_read_only).
+    fake = FakeGh(clean)
+    read_calls: list[list[str]] = []
+
+    def spy_read(argv: list[str]) -> str:
+        read_calls.append(argv)
+        gh_retry.assert_read_only(argv)  # every read the armer issues IS a read
+        return fake(argv)
+
+    AutoArmer(
+        "sparq-org/sparq", "main", fake, lambda _m: None, gh_read=spy_read
+    ).run()
+    assert [c[:2] for c in read_calls] == [["pr", "list"], ["pr", "view"]], read_calls
+    direct = [c for c in fake.calls if c not in read_calls]
+    assert [c[:2] for c in direct] == [["api", "graphql"]], fake.calls
+
+    # Exhausted transient retries abort the sweep as ::warning + exit 0 (a missed
+    # cycle is harmless); the arm mutation is never attempted on partial state.
+    def exhausted(_argv: list[str]) -> str:
+        raise gh_retry.GhTransientExhausted("gh pr list: HTTP 504 (3 attempts)")
+
+    fake = FakeGh(clean)
+    warnings: list[str] = []
+    code = run_sweep(
+        AutoArmer("sparq-org/sparq", "main", fake, lambda _m: None, gh_read=exhausted),
+        log=warnings.append,
+    )
+    assert code == 0, code
+    assert not fake.calls, fake.calls
+    assert warnings and warnings[0].startswith("::warning"), warnings
+
+    # A NON-transient failure still fails loudly: GhError escapes run_sweep untouched.
+    def fatal(_argv: list[str]) -> str:
+        raise GhError("gh pr list failed: HTTP 403 forbidden")
+
+    try:
+        run_sweep(
+            AutoArmer("sparq-org/sparq", "main", fake, lambda _m: None, gh_read=fatal),
+            log=warnings.append,
+        )
+    except GhError:
+        pass
+    else:
+        raise AssertionError("non-transient errors must not be swallowed")
+
     print("auto-arm self-test: PASS")
 
 
@@ -391,8 +479,7 @@ def main() -> int:
         return 0
     if not args.repo:
         parser.error("--repo is required unless --self-test is used")
-    AutoArmer(args.repo, args.default_branch).run()
-    return 0
+    return run_sweep(AutoArmer(args.repo, args.default_branch, gh_read=run_gh_read))
 
 
 if __name__ == "__main__":

--- a/scripts/gh_retry.py
+++ b/scripts/gh_retry.py
@@ -17,12 +17,23 @@ gate on transient GitHub 5xx blips (HTTP 502/504 at 15:22/22:42/14:29 — #3759)
     entrypoint can convert exactly that case into ``::warning`` + exit 0 (a missed
     cycle is harmless; the cron covers it) while everything else stays a hard red.
   * NEVER WRAPS MUTATIONS — arms/labels/merges must stay one-shot (a blind retry of
-    a CAS mutation is how double-arms happen). :func:`assert_read_only` fail-closed
-    ALLOW-LISTS the read shapes this helper accepts and raises
-    :class:`GhRetryUsageError` before ever invoking ``gh`` otherwise. Note ``gh api``
-    auto-switches to POST when field params are given, so REST calls carrying fields
-    are rejected unless the method is explicitly GET; ``gh api graphql`` is accepted
-    only when no query text contains a ``mutation`` operation.
+    a CAS mutation is how double-arms happen). :func:`assert_read_only` is
+    FAIL-CLOSED: it ALLOW-LISTS the read shapes this helper accepts and raises
+    :class:`GhRetryUsageError` before ever invoking ``gh`` for anything it cannot
+    AFFIRMATIVELY prove is a read. A call is retried ONLY when it positively matches a
+    known-safe read shape — an allow-listed read subcommand, or ``gh api`` whose
+    method is GET/HEAD with an INLINE, self-evidently-read body. Anything whose intent
+    cannot be read off the argv is refused (one-shot), never retried:
+
+      - ``gh api`` auto-switches to POST when field params are given, so a REST call
+        carrying fields is refused unless the method is explicitly GET/HEAD;
+      - ``gh api graphql`` is accepted only when the query text is present INLINE in
+        argv (``-f query=…`` / ``--field query=…``) AND contains no ``mutation``
+        (or ``subscription``) operation. A file-backed or stdin body
+        (``--input file.json`` / ``-F query=@file`` / ``-f query=@file`` / no inline
+        query at all) is OPAQUE to this guard — it cannot be proven a read, so it is
+        refused rather than retried. This closes the file-backed-mutation bypass:
+        the allow-list never says "retry" on a body it did not itself inspect.
 
 Usage::
 
@@ -83,7 +94,13 @@ _READ_SUBCOMMANDS = frozenset(
     }
 )
 
-_MUTATION_RE = re.compile(r"\bmutation\b", re.IGNORECASE)
+# A GraphQL document that starts (after leading whitespace/comments) with a mutation
+# or subscription operation is never a read. We also refuse the bare keyword anywhere
+# to stay conservative — an inline query naming these operations cannot be proven safe.
+_MUTATION_RE = re.compile(r"\b(?:mutation|subscription)\b", re.IGNORECASE)
+
+# Flags whose value carries the GraphQL query text inline in argv.
+_QUERY_FIELD_FLAGS = ("-f", "--field", "-F", "--raw-field")
 
 
 class GhRetryUsageError(ValueError):
@@ -123,6 +140,59 @@ def _has_field_params(argv: Sequence[str]) -> bool:
     )
 
 
+def _flag_values(argv: Sequence[str], flags: Sequence[str]) -> list[str]:
+    """Collect the values passed to any of ``flags`` in argv (``-f v`` and ``-f=v``)."""
+    values: list[str] = []
+    index = 0
+    argc = len(argv)
+    while index < argc:
+        arg = str(argv[index])
+        if arg in flags:
+            if index + 1 < argc:
+                values.append(str(argv[index + 1]))
+                index += 2
+                continue
+            values.append("")  # dangling flag; treated as opaque below
+        else:
+            for flag in flags:
+                if arg.startswith(flag + "="):
+                    values.append(arg.split("=", 1)[1])
+                    break
+        index += 1
+    return values
+
+
+def _graphql_uses_opaque_body(rest: Sequence[str]) -> bool:
+    """True if the GraphQL body is not fully inline in argv (file-backed / stdin).
+
+    ``gh api graphql`` can source its query from a file or stdin — ``--input file``,
+    ``-F query=@file``, ``-f query=@file`` — none of which places the query text in
+    argv where the mutation guard can inspect it. Such a call is OPAQUE: we cannot
+    prove it is a read, so the caller must refuse (one-shot), never retry.
+    """
+    if any(str(arg) in ("--input", "--input=-") or str(arg).startswith("--input=")
+           for arg in rest):
+        return True
+    for value in _flag_values(rest, _QUERY_FIELD_FLAGS):
+        # `key=@file` (and the bare `@file`/`@-` form) reads the value from a file/stdin.
+        payload = value.split("=", 1)[1] if "=" in value else value
+        if payload.startswith("@"):
+            return True
+    return False
+
+
+def _inline_graphql_query(rest: Sequence[str]) -> str | None:
+    """Return the inline ``query=…`` text if present in argv, else ``None``.
+
+    Only a ``query`` field whose value is present literally in argv counts; a
+    ``query=@file`` reference is not inline and yields ``None`` (handled as opaque).
+    """
+    for value in _flag_values(rest, _QUERY_FIELD_FLAGS):
+        if value.startswith("query=") and not value.startswith("query=@"):
+            return value.split("=", 1)[1]
+    return None
+
+
 def assert_read_only(argv: Sequence[str]) -> None:
     """Fail-closed guard: raise :class:`GhRetryUsageError` unless argv is a read."""
     if not argv:
@@ -132,12 +202,29 @@ def assert_read_only(argv: Sequence[str]) -> None:
         rest = [str(arg) for arg in argv[1:]]
         method = _explicit_method(rest)
         if "graphql" in rest:
-            if any(_MUTATION_RE.search(arg) for arg in rest):
+            # FAIL-CLOSED: a GraphQL call is retriable ONLY if we can read the whole
+            # query text off argv and prove it carries no mutation/subscription. A
+            # file-backed or stdin body (`--input`, `-F query=@file`, `-f query=@file`,
+            # or no inline query at all) is opaque — refuse it rather than retry.
+            if _graphql_uses_opaque_body(rest):
                 raise GhRetryUsageError(
-                    "refusing to wrap a GraphQL mutation — arms/mutations stay one-shot"
+                    "refusing to wrap gh api graphql with a file-backed/stdin body "
+                    "(--input / query=@file / stdin) — its query text is not inline in "
+                    "argv, so it cannot be proven a read; mutations stay one-shot"
+                )
+            inline_query = _inline_graphql_query(rest)
+            if inline_query is None:
+                raise GhRetryUsageError(
+                    "refusing to wrap gh api graphql with no inline `query=` text — "
+                    "cannot prove it is a read; mutations stay one-shot"
+                )
+            if _MUTATION_RE.search(inline_query):
+                raise GhRetryUsageError(
+                    "refusing to wrap a GraphQL mutation/subscription — "
+                    "arms/mutations stay one-shot"
                 )
             return
-        if method not in (None, "GET"):
+        if method not in (None, "GET", "HEAD"):
             raise GhRetryUsageError(
                 f"refusing to wrap gh api with method {method or '<missing>'} — "
                 "mutations stay one-shot"
@@ -272,6 +359,21 @@ def self_test() -> None:
         ["api", "-X", "POST", "repos/o/r/issues"],
         ["api", "--method=DELETE", "repos/o/r/labels/x"],
         [],
+        # [FABLE-5] #3759 finding 6: FAIL-CLOSED on file-backed / stdin GraphQL bodies.
+        # The query text is not inline in argv, so it CANNOT be proven a read — the
+        # substring-only guard used to accept these (the file could hold a mutation).
+        ["api", "graphql", "--input", "payload.json"],
+        ["api", "graphql", "--input=payload.json"],
+        ["api", "graphql", "--input", "-"],  # stdin body
+        ["api", "graphql", "-F", "query=@file.graphql"],
+        ["api", "graphql", "-f", "query=@file.graphql"],
+        ["api", "graphql", "--field", "query=@q.gql"],
+        # An inline query naming a mutation/subscription operation is still refused.
+        ["api", "graphql", "-f", "query=mutation Arm { enableAutoMerge { id } }"],
+        ["api", "graphql", "-F", "query=subscription S { x }"],
+        # graphql with no inline `query=` at all is opaque — refuse (cannot prove read).
+        ["api", "graphql", "-f", "owner=sparq-org"],
+        ["api", "graphql"],
     ]
     for argv in refused:
         boom = _FakeRun([(0, "", "")])
@@ -282,15 +384,27 @@ def self_test() -> None:
         else:
             raise AssertionError(f"must refuse to wrap mutation shape: {argv}")
 
-    # Allowed read shapes pass the guard (GraphQL queries, explicit-GET REST, views).
+    # Allowed read shapes pass the guard (INLINE GraphQL queries, explicit-GET REST,
+    # views). The rearm-sweeper's live-state query is an inline `-f query=query(...)`.
     for argv in (
         ["api", "graphql", "-f", "query=query($n:Int!){repository{pullRequest}}"],
+        ["api", "graphql", "--field", "query=query{viewer{login}}", "-F", "n=1"],
         ["api", "repos/o/r/actions/runs?event=merge_group"],
         ["api", "-X", "GET", "search/issues", "-f", "q=is:open"],
+        ["api", "-X", "HEAD", "repos/o/r"],
         ["pr", "view", "1", "--json", "state"],
         ["run", "list", "--limit", "5"],
     ):
         assert_read_only(argv)
+
+    # A file-backed body next to an inline non-query field is still opaque (the query
+    # itself is file-sourced) and must be refused — not smuggled through by the field.
+    try:
+        assert_read_only(["api", "graphql", "-F", "query=@q.gql", "-f", "n=1"])
+    except GhRetryUsageError:
+        pass
+    else:
+        raise AssertionError("file-backed graphql query must be refused")
 
     print("gh-retry self-test: PASS")
 

--- a/scripts/gh_retry.py
+++ b/scripts/gh_retry.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Bounded, transient-only retry for idempotent ``gh`` READ commands.
+
+[FABLE-5] sparq-org/sparq#3759 + registry jeswr/agent-account-registry#563 item 4.
+🤖 SPARQ agent.
+
+A minimal, stdlib-only vendored mirror of the registry's tenacity retry rule for the
+sweep scripts (auto-arm.py, rearm-sweeper.py) whose periodic runs were redding main's
+gate on transient GitHub 5xx blips (HTTP 502/504 at 15:22/22:42/14:29 — #3759):
+
+  * TRANSIENT-ONLY — only platform 5xx / network-transport failures retry (the
+    bounded marker list below). Any other error (401/403/404/422, GraphQL schema
+    errors, auth loss) raises :class:`GhFatalError` IMMEDIATELY — non-transient
+    failures must keep failing loudly.
+  * BOUNDED — 3 attempts, 10s/30s backoff (the #3759-specified schedule). Exhaustion
+    raises :class:`GhTransientExhausted`, a DISTINCT type so a periodic sweep's
+    entrypoint can convert exactly that case into ``::warning`` + exit 0 (a missed
+    cycle is harmless; the cron covers it) while everything else stays a hard red.
+  * NEVER WRAPS MUTATIONS — arms/labels/merges must stay one-shot (a blind retry of
+    a CAS mutation is how double-arms happen). :func:`assert_read_only` fail-closed
+    ALLOW-LISTS the read shapes this helper accepts and raises
+    :class:`GhRetryUsageError` before ever invoking ``gh`` otherwise. Note ``gh api``
+    auto-switches to POST when field params are given, so REST calls carrying fields
+    are rejected unless the method is explicitly GET; ``gh api graphql`` is accepted
+    only when no query text contains a ``mutation`` operation.
+
+Usage::
+
+    import gh_retry
+    stdout = gh_retry.run_gh_read(["pr", "list", "--repo", repo, "--json", "number"])
+
+Self-test (hermetic — injected runner/sleeper, no gh, no network)::
+
+    python3 scripts/gh_retry.py --self-test
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import time
+from typing import Callable, Sequence
+
+DEFAULT_ATTEMPTS = 3
+DEFAULT_DELAYS = (10.0, 30.0)
+
+# Bounded marker list, matched case-insensitively against gh's stderr/stdout.
+# Deliberately narrow: a marker earns its place by naming a GitHub platform 5xx or a
+# network-transport failure observed from the runners — never an auth/validation class.
+_TRANSIENT_MARKERS = (
+    "http 502",
+    "http 503",
+    "http 504",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+    "connection reset",
+    "connection refused",
+    "i/o timeout",
+    "tls handshake timeout",
+    "context deadline exceeded",
+    "temporary failure in name resolution",
+    "unexpected eof",
+    "request timed out",
+)
+
+# gh subcommand pairs this helper accepts as reads (fail-closed: everything not
+# listed — pr merge/ready/edit/comment, issue edit, api POST… — is refused).
+_READ_SUBCOMMANDS = frozenset(
+    {
+        ("pr", "list"),
+        ("pr", "view"),
+        ("pr", "checks"),
+        ("pr", "status"),
+        ("issue", "list"),
+        ("issue", "view"),
+        ("run", "list"),
+        ("run", "view"),
+        ("label", "list"),
+        ("search", "prs"),
+        ("search", "issues"),
+    }
+)
+
+_MUTATION_RE = re.compile(r"\bmutation\b", re.IGNORECASE)
+
+
+class GhRetryUsageError(ValueError):
+    """The caller tried to wrap a non-read ``gh`` invocation. Never retried."""
+
+
+class GhFatalError(RuntimeError):
+    """A non-transient ``gh`` failure — the caller must fail loudly."""
+
+
+class GhTransientExhausted(RuntimeError):
+    """Transient failures persisted through every bounded attempt."""
+
+
+def is_transient(detail: str) -> bool:
+    """True iff the failure text matches the bounded transient-marker list."""
+    lowered = detail.lower()
+    return any(marker in lowered for marker in _TRANSIENT_MARKERS)
+
+
+def _explicit_method(argv: Sequence[str]) -> str | None:
+    for index, arg in enumerate(argv):
+        if arg in ("-X", "--method"):
+            if index + 1 < len(argv):
+                return str(argv[index + 1]).upper()
+            return ""
+        if arg.startswith("--method="):
+            return arg.split("=", 1)[1].upper()
+    return None
+
+
+def _has_field_params(argv: Sequence[str]) -> bool:
+    field_flags = ("-f", "-F", "--field", "--raw-field", "--input")
+    return any(
+        arg in field_flags or any(arg.startswith(flag + "=") for flag in field_flags[2:])
+        for arg in argv
+    )
+
+
+def assert_read_only(argv: Sequence[str]) -> None:
+    """Fail-closed guard: raise :class:`GhRetryUsageError` unless argv is a read."""
+    if not argv:
+        raise GhRetryUsageError("empty gh argv")
+    head = str(argv[0])
+    if head == "api":
+        rest = [str(arg) for arg in argv[1:]]
+        method = _explicit_method(rest)
+        if "graphql" in rest:
+            if any(_MUTATION_RE.search(arg) for arg in rest):
+                raise GhRetryUsageError(
+                    "refusing to wrap a GraphQL mutation — arms/mutations stay one-shot"
+                )
+            return
+        if method not in (None, "GET"):
+            raise GhRetryUsageError(
+                f"refusing to wrap gh api with method {method or '<missing>'} — "
+                "mutations stay one-shot"
+            )
+        if method is None and _has_field_params(rest):
+            raise GhRetryUsageError(
+                "refusing to wrap gh api with field params and no explicit GET "
+                "(gh auto-switches to POST) — mutations stay one-shot"
+            )
+        return
+    if tuple(str(arg) for arg in argv[:2]) in _READ_SUBCOMMANDS:
+        return
+    raise GhRetryUsageError(
+        f"gh {' '.join(str(a) for a in argv[:2])} is not an allow-listed read — "
+        "mutations/arm calls must stay one-shot (never wrapped in retries)"
+    )
+
+
+def run_gh_read(
+    argv: Sequence[str],
+    *,
+    attempts: int = DEFAULT_ATTEMPTS,
+    delays: Sequence[float] = DEFAULT_DELAYS,
+    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    sleep: Callable[[float], None] = time.sleep,
+    log: Callable[[str], None] | None = None,
+) -> str:
+    """Run an idempotent ``gh`` READ with bounded, transient-only retries.
+
+    Returns stdout on success. Raises :class:`GhRetryUsageError` (not a read),
+    :class:`GhFatalError` (non-transient failure, first occurrence, never retried),
+    or :class:`GhTransientExhausted` (transient failure on every bounded attempt).
+    """
+    assert_read_only(argv)
+    if attempts < 1:
+        raise GhRetryUsageError("attempts must be >= 1")
+    emit = log or (lambda message: print(message, file=sys.stderr))
+    command = ["gh", *[str(arg) for arg in argv]]
+    label = " ".join(command[:4])
+    for attempt in range(1, attempts + 1):
+        result = run(command, capture_output=True, text=True, check=False)
+        if result.returncode == 0:
+            return result.stdout
+        detail = (
+            (result.stderr or "").strip()
+            or (result.stdout or "").strip()
+            or "unknown gh failure"
+        )
+        if not is_transient(detail):
+            raise GhFatalError(f"{label} failed (non-transient): {detail}")
+        if attempt == attempts:
+            raise GhTransientExhausted(
+                f"{label} failed transiently on every attempt "
+                f"({attempts} attempts): {detail}"
+            )
+        delay = float(delays[min(attempt - 1, len(delays) - 1)]) if delays else 0.0
+        emit(
+            f"[gh-retry] transient failure (attempt {attempt}/{attempts}), "
+            f"retrying in {delay:g}s: {label}: {detail}"
+        )
+        sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+# --------------------------------------------------------------------------- tests
+class _FakeRun:
+    """Scripted subprocess.run stand-in: pops one (rc, stdout, stderr) per call."""
+
+    def __init__(self, outcomes: list[tuple[int, str, str]]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, command, **_kwargs) -> subprocess.CompletedProcess:
+        self.calls.append(list(command))
+        rc, out, err = self.outcomes.pop(0)
+        return subprocess.CompletedProcess(command, rc, stdout=out, stderr=err)
+
+
+def self_test() -> None:
+    read = ["pr", "list", "--repo", "sparq-org/sparq", "--json", "number"]
+
+    # Transient then success: exactly one retry, first-delay backoff, stdout returned.
+    fake = _FakeRun([(1, "", "HTTP 504 Gateway Timeout"), (0, "[]", "")])
+    sleeps: list[float] = []
+    out = run_gh_read(read, run=fake, sleep=sleeps.append, log=lambda _m: None)
+    assert out == "[]", out
+    assert len(fake.calls) == 2, fake.calls
+    assert fake.calls[0][0] == "gh", fake.calls
+    assert sleeps == [10.0], sleeps
+
+    # Fatal (non-transient) fails LOUDLY on the first attempt — no retry, no sleep.
+    fake = _FakeRun([(1, "", "HTTP 404: Not Found (repos/x)")])
+    sleeps = []
+    try:
+        run_gh_read(read, run=fake, sleep=sleeps.append, log=lambda _m: None)
+    except GhFatalError as error:
+        assert "non-transient" in str(error), error
+    else:
+        raise AssertionError("HTTP 404 must raise GhFatalError")
+    assert len(fake.calls) == 1, fake.calls
+    assert sleeps == [], sleeps
+
+    # Bound: persistent transients exhaust after exactly `attempts` invocations with
+    # the #3759 backoff schedule, raising the DISTINCT exhaustion type.
+    fake = _FakeRun([(1, "", "connection reset by peer")] * 3)
+    sleeps = []
+    try:
+        run_gh_read(read, run=fake, sleep=sleeps.append, log=lambda _m: None)
+    except GhTransientExhausted as error:
+        assert "3 attempts" in str(error), error
+    else:
+        raise AssertionError("persistent transient must raise GhTransientExhausted")
+    assert len(fake.calls) == 3, fake.calls
+    assert sleeps == [10.0, 30.0], sleeps
+    assert not isinstance(GhTransientExhausted("x"), GhFatalError)
+
+    # Case-insensitive transient classification; auth/validation classes are fatal.
+    assert is_transient("HTTP 502 Bad Gateway")
+    assert is_transient("Post https://api.github.com/graphql: i/o TIMEOUT")
+    assert not is_transient("HTTP 403: Resource not accessible by integration")
+    assert not is_transient("HTTP 422: Validation Failed")
+    assert not is_transient("GraphQL: Could not resolve to a node")
+
+    # Mutation guard: every arm/label/merge shape is refused BEFORE gh is invoked.
+    refused = [
+        ["pr", "merge", "1", "--auto"],
+        ["pr", "ready", "1"],
+        ["pr", "edit", "1", "--add-label", "review:changes"],
+        ["pr", "comment", "1", "--body", "x"],
+        ["api", "graphql", "-f", "query=mutation($id:ID!){enablePullRequestAutoMerge}"],
+        ["api", "repos/o/r/issues/1/labels", "-f", "labels[]=x"],
+        ["api", "-X", "POST", "repos/o/r/issues"],
+        ["api", "--method=DELETE", "repos/o/r/labels/x"],
+        [],
+    ]
+    for argv in refused:
+        boom = _FakeRun([(0, "", "")])
+        try:
+            run_gh_read(argv, run=boom, sleep=lambda _s: None)
+        except GhRetryUsageError:
+            assert boom.calls == [], (argv, boom.calls)
+        else:
+            raise AssertionError(f"must refuse to wrap mutation shape: {argv}")
+
+    # Allowed read shapes pass the guard (GraphQL queries, explicit-GET REST, views).
+    for argv in (
+        ["api", "graphql", "-f", "query=query($n:Int!){repository{pullRequest}}"],
+        ["api", "repos/o/r/actions/runs?event=merge_group"],
+        ["api", "-X", "GET", "search/issues", "-f", "q=is:open"],
+        ["pr", "view", "1", "--json", "state"],
+        ["run", "list", "--limit", "5"],
+    ):
+        assert_read_only(argv)
+
+    print("gh-retry self-test: PASS")
+
+
+def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        self_test()
+        return 0
+    print(__doc__)
+    print("This is a library — import it; the only CLI entrypoint is --self-test.")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -266,11 +266,18 @@ class RearmSweeper:
             try:
                 self.arm(current.number)
             except GhError as error:
-                # The command is idempotent, but classify an API race loudly when possible.
+                # The arm MUTATION failed — that failure is the primary status. The
+                # follow-up live-state read is a diagnostic to classify an API race,
+                # and it is retriable: it can raise GhError, a decode error, OR
+                # GhTransientExhausted. [FABLE-5] #3759 finding 5: the diagnostic's
+                # OWN exhaustion must never escape here — if it did, main's lenient
+                # `except GhTransientExhausted -> exit 0` would convert a genuine
+                # failed arm into a false success. Catch exhaustion too; on any
+                # inconclusive diagnostic, record the arm failure as a real error.
                 try:
                     raced = self.live_state(current.number)
                     race_reason = self.decision(raced, live=True)
-                except (GhError, json.JSONDecodeError):
+                except (GhError, json.JSONDecodeError, gh_retry.GhTransientExhausted):
                     race_reason = None
                 if race_reason:
                     self.emit(current.number, "SKIP", f"arm raced: {race_reason}")
@@ -469,6 +476,92 @@ def self_test() -> None:
     assert [c[:2] for c in arm_calls(fake)] == [["pr", "merge"]], fake.calls
     assert all(c[:2] != ["pr", "merge"] for c in read_calls), read_calls
 
+    # [FABLE-5] #3759 finding 5: an arm MUTATION failure must be recorded as a real
+    # error even when the follow-up race-diagnostic READ (live_state) exhausts its
+    # transient retries. If the diagnostic's GhTransientExhausted escaped run(), main's
+    # lenient handler would turn a genuinely failed arm into a false success. Here the
+    # arm raises GhError; the post-arm live_state raises GhTransientExhausted.
+    dropped = fixture(4001)
+    snapshot = {
+        k: v for k, v in dropped.items() if k not in ("mergeQueueEntry", "autoMergeRequest")
+    }
+
+    class _ArmFailsDiagExhausts:
+        def __init__(self) -> None:
+            self.armed = False
+            self.calls: list[list[str]] = []
+
+        def __call__(self, argv: list[str]) -> str:
+            self.calls.append(argv)
+            if argv[:2] == ["pr", "list"]:
+                return json.dumps([snapshot])
+            if argv[:2] == ["api", "graphql"]:
+                if self.armed:
+                    # The post-arm diagnostic read exhausts transient retries.
+                    raise gh_retry.GhTransientExhausted(
+                        "gh api graphql: HTTP 504 (3 attempts)"
+                    )
+                pr = copy.deepcopy(dropped)
+                pr["labels"] = {
+                    "nodes": pr["labels"],
+                    "pageInfo": {"hasNextPage": False},
+                }
+                return json.dumps({"data": {"repository": {"pullRequest": pr}}})
+            if argv[:2] == ["pr", "merge"]:
+                self.armed = True
+                raise GhError("simulated arm failure")
+            raise AssertionError(f"unexpected fake gh call: {argv}")
+
+    fake_ad = _ArmFailsDiagExhausts()
+    messages = []
+    errors = RearmSweeper(
+        "sparq-org/sparq", "main", gh=fake_ad, gh_read=fake_ad, log=messages.append
+    ).run()
+    assert errors == 1, (errors, messages)
+    assert any("re-arm failed" in line for line in messages), messages
+    # The diagnostic exhaustion did NOT escape run() (no exception propagated here).
+
+    # [FABLE-5] #3759 finding 5: EVENT-mode exhausted transient on the enumeration read
+    # exits NON-zero (no per-PR backstop); SWEEP-mode is the lenient ::warning + 0.
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+
+    def _exhausted_read(_argv: list[str]) -> str:
+        raise gh_retry.GhTransientExhausted("gh pr list: HTTP 504 (3 attempts)")
+
+    original_run_gh_read = globals()["run_gh_read"]
+
+    class _ModeHarness:
+        """Drive main() with a stubbed enumeration read that exhausts transients."""
+
+        def __init__(self, mode: str) -> None:
+            self.mode = mode
+
+        def __enter__(self):
+            globals()["run_gh_read"] = _exhausted_read
+            self._argv = sys.argv
+            sys.argv = [
+                "rearm-sweeper.py", "--repo", "sparq-org/sparq", "--mode", self.mode,
+            ]
+            return self
+
+        def __exit__(self, *exc):
+            globals()["run_gh_read"] = original_run_gh_read
+            sys.argv = self._argv
+            return False
+
+    out, err = io.StringIO(), io.StringIO()
+    with _ModeHarness("event"), redirect_stdout(out), redirect_stderr(err):
+        event_code = main()
+    assert event_code == 1, event_code
+    assert "event-mode" in err.getvalue(), err.getvalue()
+
+    out, err = io.StringIO(), io.StringIO()
+    with _ModeHarness("sweep"), redirect_stdout(out), redirect_stderr(err):
+        sweep_code = main()
+    assert sweep_code == 0, sweep_code
+    assert "::warning" in out.getvalue(), out.getvalue()
+
     print("rearm-sweeper self-test: PASS")
 
 
@@ -477,6 +570,18 @@ def main() -> int:
     parser.add_argument("--repo", help="OWNER/REPOSITORY to sweep")
     parser.add_argument("--default-branch", default="main")
     parser.add_argument("--max-rearms", type=int, default=DEFAULT_MAX_REARMS)
+    parser.add_argument(
+        "--mode",
+        choices=("sweep", "event"),
+        default="sweep",
+        help=(
+            "sweep: periodic cron (exhausted transient READS on the enumeration path "
+            "=> ::warning + exit 0, the cron backstop covers a missed cycle). event: a "
+            "single-PR event-driven invocation with no per-PR backstop — an exhausted "
+            "transient exits non-zero so the run is visibly red. This workflow runs "
+            "sweep-only today; the flag keeps the exit contract explicit and testable."
+        ),
+    )
     parser.add_argument("--self-test", action="store_true")
     args = parser.parse_args()
 
@@ -492,8 +597,17 @@ def main() -> int:
         )
         return 1 if sweeper.run() else 0
     except gh_retry.GhTransientExhausted as error:
-        # [FABLE-5] #3759: the sweep is periodic + idempotent — a cycle missed on a
-        # transient platform 5xx must not red main's gate. Warn loudly, exit 0.
+        # [FABLE-5] #3759: only the periodic + idempotent SWEEP may swallow a missed
+        # cycle on a transient platform 5xx (the cron backstop covers it). An
+        # EVENT-driven invocation has no per-PR backstop, so it fails loudly (finding
+        # 5). A failed arm MUTATION never reaches here as GhTransientExhausted — its
+        # own diagnostic read cannot overwrite it (see run()).
+        if args.mode == "event":
+            print(
+                f"[{PROGRAM}] fatal: event-mode exhausted transient retries: {error}",
+                file=sys.stderr,
+            )
+            return 1
         print(
             f"::warning title={PROGRAM} skipped a cycle on transient GitHub API "
             f"failures::{error} — bounded retries exhausted; the next cron run "

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -2,6 +2,12 @@
 """Re-arm reviewed pull requests whose merge-queue arm was dropped by GitHub."""
 
 # [GPT-5.6] Issue #3675 — restore dropped arms without mistaking queued PRs for drops.
+# [FABLE-5] Issue #3759 / registry#563 item 4 — idempotent gh READS (pr list, the
+# GraphQL live-state QUERY) go through gh_retry.run_gh_read (bounded, transient-only
+# retry); the arm MUTATION (gh pr merge --auto) stays one-shot on the un-wrapped
+# runner. Exhausted transient retries end the sweep as ::warning + exit 0 (a missed
+# cycle is harmless — the cron covers it) instead of redding main's gate; any
+# non-transient error still fails loudly.
 
 from __future__ import annotations
 
@@ -12,6 +18,8 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Callable
+
+import gh_retry
 
 
 PROGRAM = "rearm-sweeper"
@@ -110,6 +118,19 @@ def run_gh(argv: list[str]) -> str:
     return result.stdout
 
 
+def run_gh_read(argv: list[str]) -> str:
+    """Idempotent READ path: bounded transient-only retries (#3759).
+
+    Non-transient failures re-raise as :class:`GhError` so the existing per-PR
+    error handling keeps working; exhausted transients propagate as
+    :class:`gh_retry.GhTransientExhausted` for the ::warning + exit-0 sweep policy.
+    """
+    try:
+        return gh_retry.run_gh_read(argv)
+    except gh_retry.GhFatalError as error:
+        raise GhError(str(error)) from error
+
+
 class RearmSweeper:
     def __init__(
         self,
@@ -118,6 +139,7 @@ class RearmSweeper:
         *,
         max_rearms: int = DEFAULT_MAX_REARMS,
         gh: Callable[[list[str]], str] = run_gh,
+        gh_read: Callable[[list[str]], str] | None = None,
         log: Callable[[str], None] = print,
     ) -> None:
         if not 1 <= max_rearms <= DEFAULT_MAX_REARMS:
@@ -126,6 +148,9 @@ class RearmSweeper:
         self.default_branch = default_branch
         self.max_rearms = max_rearms
         self.gh = gh
+        # Idempotent READS may go through a retrying runner (#3759); the arm
+        # MUTATION always uses the one-shot `gh` runner above.
+        self.gh_read = gh_read if gh_read is not None else gh
         self.log = log
         try:
             self.owner, self.name = repo.split("/", 1)
@@ -157,7 +182,7 @@ class RearmSweeper:
 
     def list_candidates(self) -> list[PullRequest]:
         raw = json.loads(
-            self.gh(
+            self.gh_read(
                 [
                     "pr",
                     "list",
@@ -180,7 +205,7 @@ class RearmSweeper:
 
     def live_state(self, number: int) -> PullRequest:
         response = json.loads(
-            self.gh(
+            self.gh_read(
                 [
                     "api",
                     "graphql",
@@ -420,6 +445,30 @@ def self_test() -> None:
         messages
     )
 
+    # [FABLE-5] #3759: READS route through gh_read (and really are reads — the retry
+    # helper's fail-closed guard accepts them); the arm MUTATION stays on the
+    # one-shot runner, so a retry wrapper can never double-fire it.
+    dropped = fixture(3759)
+    fake = FakeGh(
+        [{k: v for k, v in dropped.items() if k not in ("mergeQueueEntry", "autoMergeRequest")}],
+        {3759: dropped},
+    )
+    read_calls: list[list[str]] = []
+
+    def spy_read(argv: list[str]) -> str:
+        read_calls.append(argv)
+        gh_retry.assert_read_only(argv)
+        return fake(argv)
+
+    RearmSweeper(
+        "sparq-org/sparq", "main", gh=fake, gh_read=spy_read, log=lambda _m: None
+    ).run()
+    assert [c[:2] for c in read_calls] == [["pr", "list"], ["api", "graphql"]], (
+        read_calls
+    )
+    assert [c[:2] for c in arm_calls(fake)] == [["pr", "merge"]], fake.calls
+    assert all(c[:2] != ["pr", "merge"] for c in read_calls), read_calls
+
     print("rearm-sweeper self-test: PASS")
 
 
@@ -438,9 +487,19 @@ def main() -> int:
         parser.error("--repo is required unless --self-test is used")
     try:
         sweeper = RearmSweeper(
-            args.repo, args.default_branch, max_rearms=args.max_rearms
+            args.repo, args.default_branch, max_rearms=args.max_rearms,
+            gh_read=run_gh_read,
         )
         return 1 if sweeper.run() else 0
+    except gh_retry.GhTransientExhausted as error:
+        # [FABLE-5] #3759: the sweep is periodic + idempotent — a cycle missed on a
+        # transient platform 5xx must not red main's gate. Warn loudly, exit 0.
+        print(
+            f"::warning title={PROGRAM} skipped a cycle on transient GitHub API "
+            f"failures::{error} — bounded retries exhausted; the next cron run "
+            "covers this sweep, so this run reports success."
+        )
+        return 0
     except (GhError, ValueError, json.JSONDecodeError) as error:
         print(f"[{PROGRAM}] fatal: {error}", file=sys.stderr)
         return 1


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq.

Implements the maintainer-approved OSS adoptions from registry jeswr/agent-account-registry#563 — **item 2** (nextest CI retry profile), **item 3** (merge-queue `dequeued` feedback, the durable fix for registry#556), and the sparq side of **item 4** (transient-tolerant retry hygiene on the arm sweeps, fixes #3759).

## Adoption 2 — nextest `[profile.ci]` retries (flaky reds stop burning the gate)

**How tests actually run in CI (verified per leg):**

| Leg | Runner | This PR |
|---|---|---|
| ci.yml `test` (5 load-aware shards, archive-based) | `cargo nextest run --archive-file …` | **converted**: `--profile ci` (retries moved off the inline `--retries 2` flag into `.config/nextest.toml`, count unchanged) |
| miri.yml (24 shards) | `cargo miri nextest run` | untouched — auto-selects the existing `[profile.default-miri]` |
| ci.yml doctests | `cargo test --doc` | not convertible (nextest does not run doctests) |
| ci.yml conformance/ratchet suites (sparq-conformance W3C, shacl, geo, solid, policy, text, rsp, jsonld, service, http-protocol, sd-gsp, d-entail, rif, el, ql, dl) | plain `cargo test … -- --nocapture` | unconverted — these jobs do not install nextest, and their ratchets parse `--nocapture` output |
| feature-matrix.yml legs, gui.yml, zk-toolchain.yml, shacl-diff-fuzz.yml, metamorph.yml, differential-update.yml | plain `cargo test` | unconverted — no nextest in their toolchain setup (zk-toolchain deliberately so, per its in-file rationale; gui documents a retries=0 deterministic-lane rationale) |

Per the approved scope, only legs that already had nextest in their toolchain were converted; the rest are enumerated in follow-up bead `sq-yhcge` (per-leg evaluation: flake-proneness vs the cost of a toolchain step + ratchet-output compatibility).

**Incident class:** flaky tests redding the single required `gate` check burn whole gate evaluations and trigger review-fix ci-flavour re-dispatches for PRs whose diff changed nothing relevant.

**Not a silent mask:** `[profile.ci]` pins `final-status-level = "flaky"` — a retried-then-passing test is reported `FLAKY` in the shard log and repeated in the end-of-run summary, so the flake signal still lands where flake triage (omnibus-flake-quarantine, bench-triage) reads it. A test failing every attempt is a plain FAIL and reds the shard exactly as before. No JUnit emission: no CI consumer parses JUnit here, so nextest's log/summary flaky reporting is the surfaced signal. Local `cargo nextest run` keeps the default profile (no retries) so locally-reproducible flakes stay loudly red.

## Adoption 3 — merge-queue `dequeued` feedback (durable fix for registry#556)

New `.github/workflows/merge-queue-feedback.yml` on `pull_request: [dequeued]`:

- disables the now-dead auto-merge arm (best-effort `gh pr merge --disable-auto || …`),
- applies `review:changes` (the registry fix-enumeration's admission label — fail-loud if it cannot be applied to a still-open PR),
- comments (SPARQ-agent self-ID) with the dequeue reason and the failed merge-group run links, discovered best-effort from the Actions API (`event=merge_group` runs keep the `gh-readonly-queue/<base>/pr-<N>-…` head_branch after the queue branch is deleted; if none is found the comment says so),
- infra-flavoured reasons (`CI_TIMEOUT`/`QUEUE_CLEARED`/`ROLL_BACK`) are noted in the comment but still routed to `review:changes` — the fix lane's ci-flavour owns re-runs,
- race-tolerant: a PR merged/closed between the event and the job exits 0 with a log line.

Least-privilege permissions (`contents: write` + `pull-requests: write` for the disable/label/comment writes — the same pair auto-arm.yml holds for the enable direction — plus `actions: read` for run discovery); no third-party actions at all, so nothing to SHA-pin. The job name carries the whole-word `advisory` token (+ registry entry in `.github/advisory-registry.json`): it runs after a gate verdict already exists on the head SHA, and a feedback hiccup must never red a later gate evaluation on that SHA.

## Adoption 4 (sparq side) — transient-tolerant sweeps (fixes #3759)

New `scripts/gh_retry.py` — a minimal, stdlib-only vendored mirror of the registry's tenacity retry rule:

- **transient-only**: bounded marker list (HTTP 502/503/504 + network-transport failures); 401/403/404/422/GraphQL errors raise `GhFatalError` immediately,
- **bounded**: 3 attempts, 10s/30s backoff (the schedule specified on #3759); exhaustion raises the distinct `GhTransientExhausted`,
- **never wraps mutations**: a fail-closed read allow-list (`assert_read_only`) refuses `pr merge/ready/edit/comment`, GraphQL mutations, and REST POST shapes before ever invoking `gh` — arms stay one-shot.

`scripts/auto-arm.py` (the 502/504 reds at 15:22/22:42/14:29) and `scripts/rearm-sweeper.py` route their idempotent reads (`pr list`, `pr view`, the live-state GraphQL query) through it; the arm mutations stay on the un-wrapped one-shot runner. On exhausted transient retries, both sweeps exit `::warning` + code 0 — a missed cycle is harmless (the cron covers it) and no longer reds main's gate; any non-transient error still fails loudly. Both workflows' sparse-checkouts now include `gh_retry.py`, their self-test steps run it, and their timeouts get backoff headroom (5→10 min). The three self-tests also gate on every PR via docs-quality quick-gates (previously these scripts were only self-tested by their own cron workflows against the default branch — a PR changing them merged unvalidated).

## Gates run locally

- `actionlint` on all touched workflows: clean (ci.yml's 29 findings are the pre-existing info-level shellcheck notes, byte-identical count to origin/main)
- YAML/JSON/TOML parse: all touched files OK
- `python3 scripts/gh_retry.py --self-test` / `auto-arm.py --self-test` / `rearm-sweeper.py --self-test`: PASS (transient/fatal/bound + mutation-refusal + read-vs-mutation routing + warning-exit-0 cases)
- `scripts/tests/test_ci_select_wiring.py`: 66 tests OK (no pin updates needed — the shard step's env/`--no-tests=pass` pins are unchanged)
- `scripts/tests/test_ci_select.py` (95 OK), `test_ci_summary_gate.py` (OK)
- `check-advisory-registry.py` (self-test + enforce), `check-install-action-tool.py`, `check-fast-fix-ring-guard.py`: all clear
- `cargo nextest show-config … --profile ci` resolves the new profile (nextest 0.9.137)

Follow-up: bead `sq-yhcge` (unconverted plain-`cargo test` legs, per-leg evaluation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
