### PR TITLE
fix(ci): gate exits immediately on an unsatisfiable draft-tier hold instead of burning the 68-minute budget (#3758)

### DIFF
--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -206,7 +206,7 @@ no check-run there either — not a byte-identical copy of the PR check-set.)
 | `artifact-exact-equality` (wasm feature-OFF byte identity) | `vectorized-feature-off.yml` | kept iff `sparq-wasm` is in the affected closure (in-step `ci_select.py` verdict; ci-full label / selector error / full mode ⇒ run) |
 
 **The integrity invariant — a draft-tier gate result must NEVER admit a PR to the
-merge queue.** The load-bearing mechanism is rule 1 (structural); rules 2–6 are
+merge queue.** The load-bearing mechanism is rule 1 (structural); rules 2–7 are
 belts (all in `scripts/ci_summary_gate.py`, unit-tested in
 `scripts/tests/test_ci_summary_gate.py`; the name/trigger wiring pinned by
 `scripts/tests/test_ci_select_wiring.py`):
@@ -263,6 +263,29 @@ belts (all in `scripts/ci_summary_gate.py`, unit-tested in
    Attempt-scoped job listing supplies the completed leg inventory and prevents
    an old attempt that reused the run id from leaking into the verdict; the
    workflow-run conclusion supplies the verdict when an entire job evaporates.
+7. **An UNSATISFIABLE rule-4 hold ends immediately, and a gate re-run is NOT the
+   remedy (#3758).** [OPUS-5] Converting a PR back to **draft** mid-wave makes the
+   draft-tier wave the newest run of every selecting workflow, so rule 6 discards
+   the earlier full-tier selects and rule 4's hold demands a successor that — while
+   the PR stays a draft and the head's Actions queue is idle — nothing will ever
+   dispatch. The hold pins the settle counter at 0, and with every sibling terminal
+   (`pending == 0`) the sq-90cv4 hang detector used to be bypassed entirely, so the
+   only exit was the ~68-minute absolute poll budget — burned again on every gate
+   re-run, since the hold is a pure function of the head's check-run set. Two
+   additive exits now end it: (a) while the hold is up with zero pending siblings
+   the gate counts **non-terminal Actions workflow runs on this head SHA** (its own
+   workflow excluded); `unsat_grace_polls` consecutive **zero** observations (~3 min
+   — a registration-grace window, since a re-dispatch appears as a `queued` run
+   within seconds) prove the hold unsatisfiable and RED at once; (b) the base-budget
+   hang branch now also fires for a zero-pending hold, where repo-wide runner
+   saturation is deliberately **not** an extension reason (nothing of ours is
+   starving in that queue) — but live per-head activity **is**: a probe that just
+   saw a non-terminal run on this SHA vetoes both exits, leaving the pre-existing
+   absolute-budget bound in place. Both route through rule 4's own verdict — the exit can
+   never render a pass — and the RED states the remedy explicitly: **re-running the
+   `ci-summary` gate cannot clear it**; only a **full-tier re-dispatch of the
+   selecting workflows** on this head, **`ready_for_review`**, or a **new head
+   commit** can. Repair automation must not re-run the gate on this verdict.
 
 **Why the queue can never latch a draft-tier result.** Rule 1 is structural: the
 queue and branch protection admit a PR only on a successful check-run of the
@@ -270,7 +293,7 @@ exact context `gate`, and no draft-tier run ever emits one. This matters more
 than it may look, because the `merge_group` run deliberately omits two lanes
 (`bench.yml`'s deterministic byte ratchet and the heavy recall shards,
 sq-6vshe.6) on the premise that their full form already ran on the PR head —
-a premise a draft-built head would otherwise break. Rules 2–6 alone would NOT
+a premise a draft-built head would otherwise break. Rules 2–7 alone would NOT
 close that: a concluded draft-tier `gate` success would remain the *latest* run
 of the required context from the un-draft moment until the ready_for_review
 `ci-summary` run registers its check-run (seconds of event latency; indefinitely

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -286,6 +286,11 @@ belts (all in `scripts/ci_summary_gate.py`, unit-tested in
    pre-existing absolute-budget bound in place; an `unknown` observation also
    **resets** the consecutive-confirmation counter (N consecutive polls must mean N
    consecutive *confirmed* observations) and is never logged as an idle queue.
+   "Only a confirmed zero is evidence" is enforced as a **fail-closed allow-list**,
+   not a deny-list: the report's `(state, count)` pair is validated at construction
+   (a state outside the enum, or a count that contradicts the state, raises), every
+   consumer branches **affirmatively** on confirmed-idle / confirmed-busy, and
+   anything the loop does not recognise is treated as **`unknown`** — never as idle.
    Both route through rule 4's own verdict — the exit can
    never render a pass — and the RED states the remedy explicitly: **re-running the
    `ci-summary` gate cannot clear it**; only a **full-tier re-dispatch of the

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -274,14 +274,19 @@ belts (all in `scripts/ci_summary_gate.py`, unit-tested in
    re-run, since the hold is a pure function of the head's check-run set. Two
    additive exits now end it: (a) while the hold is up with zero pending siblings
    the gate counts **non-terminal Actions workflow runs on this head SHA** (its own
-   workflow excluded); `unsat_grace_polls` consecutive **zero** observations (~3 min
-   — a registration-grace window, since a re-dispatch appears as a `queued` run
-   within seconds) prove the hold unsatisfiable and RED at once; (b) the base-budget
-   hang branch now also fires for a zero-pending hold, where repo-wide runner
-   saturation is deliberately **not** an extension reason (nothing of ours is
-   starving in that queue) — but live per-head activity **is**: a probe that just
-   saw a non-terminal run on this SHA vetoes both exits, leaving the pre-existing
-   absolute-budget bound in place. Both route through rule 4's own verdict — the exit can
+   workflow excluded); `unsat_grace_polls` consecutive **confirmed-zero**
+   observations (~3 min — a registration-grace window, since a re-dispatch appears
+   as a `queued` run within seconds) prove the hold unsatisfiable and RED at once;
+   (b) the base-budget hang branch now also fires for a zero-pending hold, where
+   repo-wide runner saturation is deliberately **not** an extension reason (nothing
+   of ours is starving in that queue) — but anything short of a **confirmed-idle**
+   head is. The probe is three-state (`confirmed-zero` / `confirmed-nonzero` /
+   **`unknown`**) and only a confirmed zero is evidence, so live per-head activity
+   **and** an unknown/failed/unwired probe alike veto both exits, leaving the
+   pre-existing absolute-budget bound in place; an `unknown` observation also
+   **resets** the consecutive-confirmation counter (N consecutive polls must mean N
+   consecutive *confirmed* observations) and is never logged as an idle queue.
+   Both route through rule 4's own verdict — the exit can
    never render a pass — and the RED states the remedy explicitly: **re-running the
    `ci-summary` gate cannot clear it**; only a **full-tier re-dispatch of the
    selecting workflows** on this head, **`ready_for_review`**, or a **new head

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -135,6 +135,43 @@
 #     cannot merge anyway, so a false RED here is cheap; a false PASS is the
 #     invariant violation).
 #
+# UNSATISFIABLE awaiting_full HOLD (#3758). [OPUS-5] The awaiting_full hold above
+# is SATISFIABLE only while some run on the head SHA can still register a
+# strictly-later FULL-tier select. A PR converted to DRAFT mid-wave breaks that:
+# the draft-tier wave becomes the newest run of every selecting workflow, the
+# #3505 resolver discards the earlier full-tier selects as superseded, and while
+# the PR stays a draft with an idle Actions queue NO full-tier run for this head
+# will ever be dispatched. The hold then pins `stable` at 0 (clean convergence
+# unreachable) and — because every sibling is terminal — `pending == 0`, which the
+# sq-90cv4 genuine-hang branch required to be > 0. Only the ABSOLUTE poll budget
+# exited: ~68 min of a runner slot per attempt, and re-running the GATE cannot
+# change the head's check-run set, so every attempt repeats the identical stall
+# (observed 3x on PR #3470 head 552368bd, run 30002198053). Two ADDITIVE exits:
+#   * UNSATISFIABILITY PROBE — while awaiting_full holds with pending == 0 the
+#     loop asks Actions how many non-terminal workflow runs exist ON THIS HEAD
+#     SHA (excluding this gate's own workflow). Zero means the awaited successor
+#     cannot arrive from anything currently running; UNSAT_GRACE_POLLS
+#     CONSECUTIVE zero observations (a registration-grace window for the
+#     ready_for_review re-runs, which appear as queued runs the instant the event
+#     fires) conclude the hold UNSATISFIABLE and RED immediately through the
+#     stale-draft-tier verdict belt. Probe unavailable/failed => UNKNOWN => never
+#     concludes (the belt below still bounds the wait).
+#   * BASE-BUDGET WIDENING — the genuine-hang branch now also fires for an
+#     awaiting_full hold with pending == 0, and in that state repo-wide runner
+#     SATURATION is explicitly NOT an extension reason: with zero pending
+#     siblings nothing of ours is starving in that queue, and Actions creates a
+#     run (status=queued) the instant the triggering event fires regardless of
+#     pool depth. Live progress (a rising completed count) still extends, and so
+#     does live PER-HEAD activity — a probe that saw a non-terminal run on this
+#     SHA this poll vetoes the shortcut, leaving the pre-#3758 absolute-budget
+#     bound in place. The per-head probe, not the repo-wide queue, is the
+#     authoritative satisfiability signal for a zero-pending hold.
+# Both exits are exit-1-only and route through render_verdict's stale-draft-tier
+# belt, so they can never synthesise a pass; a hold that IS satisfiable (a queued
+# full-tier run exists) waits exactly as before. The RED names the remedy
+# (UNSAT_HOLD_REMEDY): a GATE re-run cannot clear this state — only a full-tier
+# re-dispatch of the selecting workflows, ready_for_review, or a new head can.
+#
 # Exit-0 paths, exhaustively (fail-fast adds NO exit-0 path — it only ever
 # returns 1): (1) render_verdict over a stable-empty set;
 # (2) render_verdict over an all-terminal set with zero non-passing GATING checks
@@ -217,6 +254,22 @@ FM_REPORT_NAME = "feature-matrix report"
 RUNS_URL_RE = re.compile(r"/actions/runs/(\d+)(?:/|$)")
 ACTIONS_JOB_URL_RE = re.compile(r"/actions/runs/\d+/job/\d+(?:/|$)")
 
+# [OPUS-5] #3758: the stale-draft-tier RED is ACTIONABLE ONLY outside this gate,
+# and the repair automation guessed wrong — it re-ran the `ci-summary` gate three
+# times on PR #3470's head, each attempt re-deriving the identical hold from the
+# identical check-run set and burning another ~68 min of a runner slot. The hold is
+# a pure function of the head's check-run set, so this text is load-bearing
+# operator/automation guidance and is emitted by EVERY path that REDs on the hold.
+UNSAT_HOLD_REMEDY = (
+    "RE-RUNNING THIS `ci-summary` GATE CANNOT CLEAR THIS STATE (#3758): the hold is a "
+    "pure function of the check-run set on this head SHA, which a gate re-run does not "
+    "change — every re-run re-derives the same verdict. Exactly three things clear it: "
+    "(1) re-dispatch the SELECTING workflows (ci / bench / feature-matrix / fuzz) at "
+    "FULL tier on this head SHA, (2) mark the PR `ready_for_review` so the "
+    "ready_for_review full-tier wave is dispatched, or (3) push a new head commit. "
+    "Automated repair lanes: do NOT re-run this workflow for this verdict."
+)
+
 
 @dataclass
 class Config:
@@ -234,6 +287,13 @@ class Config:
     sat_queue_min: int = 5      # queued workflow-runs in the repo => saturation
     progress_window: int = 15   # polls over which a completed-count rise = progress
     max_consec_fetch_failures: int = 5
+    # [OPUS-5] #3758: CONSECUTIVE polls that must confirm "awaiting_full holds,
+    # every sibling terminal, and ZERO non-terminal workflow runs on this head
+    # SHA" before the hold is declared unsatisfiable. 9 x 20s ~= 3 min — a
+    # registration-grace window for the ready_for_review full-tier re-runs (which
+    # appear as queued runs within seconds of the event) — versus the ~68 min the
+    # absolute budget used to burn.
+    unsat_grace_polls: int = 9
     summary_path: str = field(default_factory=lambda: os.environ.get("GITHUB_STEP_SUMMARY", ""))
 
 
@@ -1083,7 +1143,8 @@ def render_verdict(runs: list[dict], summary_path: str = "", tier_ctx: TierConte
                 "(ci/bench/feature-matrix/fuzz share one select name — one full-tier "
                 "select must never release the hold for the others). A draft-tier leg "
                 "set must never admit a non-draft PR to the merge queue "
-                "(docs/branch-protection.md §Draft-tier CI).",
+                "(docs/branch-protection.md §Draft-tier CI). "
+                + UNSAT_HOLD_REMEDY,
                 summary_path,
             )
             print("::error::ci-summary failed — stale draft-tier leg set on a non-draft head.")
@@ -1227,14 +1288,74 @@ def failfast_failures(runs: list[dict]) -> list[dict]:
     return out
 
 
+def _conclude_unsatisfiable_hold(
+    runs: list[dict],
+    cfg: Config,
+    tier_ctx: TierContext | None,
+    *,
+    attempt: int,
+    evidence: str,
+) -> int:
+    """[OPUS-5] #3758: end an UNSATISFIABLE draft-tier `awaiting_full` hold NOW.
+
+    `evidence` states, in operator language, WHY no full-tier successor can arrive
+    (the caller's proof: an idle head with zero non-terminal workflow runs, or the
+    base budget reached with an idle head and no progress).
+
+    The verdict itself is DELEGATED to render_verdict so this exit renders the same
+    stale-draft-tier belt message, over the same sibling set, as the budget-
+    exhaustion path always has — this is a shortcut to an EXISTING red, never a new
+    classification. render_verdict's belt tests the identical predicate the caller's
+    `awaiting_full` did (full tier + pull_request + draft_selects_unsuperseded), so
+    it necessarily REDs; the explicit non-zero coercion below is a belt in case a
+    future refactor loosens that coupling — an unsatisfiable hold must NEVER be
+    reported as a silent pass.
+    """
+    stale = draft_selects_unsuperseded(runs)
+    _emit(
+        "### ci-summary: the draft-tier `awaiting_full` hold on this head SHA is "
+        f"UNSATISFIABLE (#3758) — concluding at poll {attempt} instead of holding to "
+        f"poll {cfg.max_total_polls}. {len(stale)} draft-marked select instance(s) are "
+        f"waiting for a strictly-later FULL-tier successor, every sibling check is "
+        f"terminal, and {evidence} — so no run can register that successor and the "
+        "hold can never clear. Waiting out the remaining budget would only occupy a "
+        "runner slot to reach the identical verdict.",
+        cfg.summary_path,
+    )
+    print(
+        "::notice::ci-summary: unsatisfiable draft-tier awaiting_full hold detected "
+        f"at poll {attempt} ({evidence}) — exiting early with the stale-draft-tier "
+        "verdict (#3758)."
+    )
+    code = render_verdict(runs, cfg.summary_path, tier_ctx)
+    if code == 0:
+        _emit(
+            "### ci-summary: FAILED — stale draft-tier run, full run pending. The "
+            "unsatisfiable draft-tier hold above must never render as a pass "
+            f"({len(stale)} draft-marked select instance(s) with no full-tier "
+            "successor). Fail-closed (#3758). " + UNSAT_HOLD_REMEDY,
+            cfg.summary_path,
+        )
+        print(
+            "::error::ci-summary failed — unsatisfiable draft-tier hold could not be "
+            "rendered as a verdict; fail-closed."
+        )
+        return 1
+    return code
+
+
 def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
-             tier_ctx: TierContext | None = None) -> int:
+             tier_ctx: TierContext | None = None, fetch_head_activity=None) -> int:
     """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url,
     started_at,id} dicts (raises FetchError on API failure); `fetch_queue_depth()`
     -> int queued workflow-run count for the repo, or None when unknown (API
     failure — the gate then falls back to the progress signal alone). tier_ctx
     carries the draft-tier integrity context (None => pre-draft-tier semantics).
-    Returns the exit code."""
+    fetch_head_activity() -> int count of non-terminal Actions workflow runs on
+    THIS head SHA excluding this gate's own workflow, or None when unknown; it is
+    consulted ONLY inside a draft-tier `awaiting_full` hold with zero pending
+    siblings (#3758), and None/absent simply means the unsatisfiability exit never
+    fires. Returns the exit code."""
     prev_names: list[str] | None = None
     stable = 0
     runs: list[dict] = []
@@ -1246,6 +1367,10 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     # observed on the PREVIOUS poll — the red fires only when a fresh re-poll
     # re-observes the identical set (header §FAIL-FAST).
     ff_suspect: tuple | None = None
+    # [OPUS-5] #3758: consecutive polls that have CONFIRMED an unsatisfiable
+    # awaiting_full hold (hold up, zero pending siblings, zero non-terminal
+    # workflow runs on this head). Reset by any contrary observation.
+    unsat_confirms = 0
 
     attempt = 0
     while attempt < cfg.max_total_polls:
@@ -1371,6 +1496,66 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 continue  # no sleep: the grace re-poll is deliberately immediate
             ff_suspect = None
 
+        # [OPUS-5] #3758 UNSATISFIABILITY PROBE. The awaiting_full hold pins
+        # `stable` at 0, so with every sibling terminal (pending == 0) NO exit below
+        # can fire before the absolute budget — and the hold is satisfiable only if
+        # some run on this head can still register a strictly-later full-tier select.
+        # Ask Actions directly: how many non-terminal workflow runs exist on THIS
+        # head SHA (this gate's own workflow excluded)? Zero means nothing is running
+        # that could produce the successor — the PR was re-drafted and the
+        # full-tier wave is neither running nor queued. UNSAT_GRACE_POLLS
+        # CONSECUTIVE zero observations (registration grace: a ready_for_review
+        # re-dispatch appears as a queued run within seconds) prove the hold cannot
+        # clear, and the gate REDs now through the same stale-draft-tier belt the
+        # budget-exhaustion path uses. A probe that is absent or fails is UNKNOWN and
+        # never concludes anything (the base-budget widening below still bounds it).
+        # head_busy is THIS poll's per-head evidence that the hold may still be
+        # satisfiable; it also vetoes the base-budget shortcut further below, so the
+        # per-head probe — not the repo-wide queue depth — stays the authoritative
+        # satisfiability signal for a zero-pending hold.
+        head_busy = False
+        if awaiting_full and pending == 0:
+            head_activity = None
+            if fetch_head_activity is not None:
+                try:
+                    head_activity = fetch_head_activity()
+                except Exception as exc:  # never let a probe crash the gate
+                    print(f"  (head-activity probe raised {exc!r} — treating as unknown)")
+                    head_activity = None
+            if head_activity is None:
+                print(
+                    "  awaiting_full hold with 0 pending sibling(s): head-activity "
+                    "probe unavailable (unknown) — cannot prove the hold unsatisfiable, "
+                    "still waiting (#3758)."
+                )
+            elif head_activity > 0:
+                unsat_confirms = 0
+                head_busy = True
+                print(
+                    f"  awaiting_full hold with 0 pending sibling(s): {head_activity} "
+                    "non-terminal workflow run(s) on this head SHA could still register "
+                    "the full-tier successor — still settling (#3758)."
+                )
+            else:
+                unsat_confirms += 1
+                print(
+                    "  awaiting_full hold with 0 pending sibling(s) and NO queued/"
+                    "in-progress workflow run on this head SHA — no full-tier successor "
+                    f"can arrive ({unsat_confirms}/{cfg.unsat_grace_polls} confirming "
+                    "poll(s), #3758)."
+                )
+                if attempt >= cfg.min_polls and unsat_confirms >= cfg.unsat_grace_polls:
+                    return _conclude_unsatisfiable_hold(
+                        runs, cfg, tier_ctx, attempt=attempt,
+                        evidence=(
+                            f"{unsat_confirms} consecutive poll(s) found ZERO queued or "
+                            "in-progress workflow runs on this head SHA (this gate's own "
+                            "workflow excluded)"
+                        ),
+                    )
+        else:
+            unsat_confirms = 0
+
         # Clean convergence: everything terminal, held for the settle, past the floor.
         if attempt >= cfg.min_polls and pending == 0 and stable >= cfg.settle_polls:
             return render_verdict(runs, cfg.summary_path, tier_ctx)
@@ -1378,7 +1563,10 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         # ADAPTIVE SATURATION BUDGET (sq-90cv4): at/after the base budget with work
         # still pending, extend ONLY while the evidence says throughput-starvation
         # (deep queue) or live progress — otherwise it's a genuine hang: RED.
-        if attempt >= cfg.base_polls and pending > 0:
+        # [OPUS-5] #3758 WIDENING: an awaiting_full hold with pending == 0 is also a
+        # non-converging state whose evidence must be consulted here — previously
+        # `pending > 0` excluded it, leaving the absolute budget as its only exit.
+        if attempt >= cfg.base_polls and (pending > 0 or awaiting_full):
             progressing = (
                 len(completed_hist) > cfg.progress_window
                 and completed_hist[-1] > completed_hist[-1 - cfg.progress_window]
@@ -1393,7 +1581,31 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 print(f"  (queue-depth fetch raised {exc!r} — treating depth as unknown)")
                 depth = None
             saturated = depth is not None and depth >= cfg.sat_queue_min
-            if not (saturated or progressing):
+            # [OPUS-5] #3758: with ZERO pending siblings (a pure awaiting_full hold)
+            # repo-wide runner saturation explains NOTHING — none of OUR work is
+            # starving in that queue, and Actions creates a run (status=queued) the
+            # instant its triggering event fires regardless of pool depth, which the
+            # per-head probe above would have seen. Only LIVE PROGRESS (the sibling
+            # set still churning) justifies extending this state. For pending > 0 the
+            # sq-90cv4 semantics are byte-identical to before.
+            hold_only = pending == 0 and awaiting_full
+            # ...and conversely, LIVE PER-HEAD ACTIVITY (head_busy: the probe saw a
+            # non-terminal run on this SHA this poll) DOES keep a zero-pending hold
+            # alive — that run may yet register the awaited full-tier select, so the
+            # gate falls back to the pre-#3758 bound (the absolute budget) rather
+            # than concluding unsatisfiability the probe just contradicted.
+            if not (progressing or (saturated and not hold_only)
+                    or (hold_only and head_busy)):
+                if hold_only:
+                    return _conclude_unsatisfiable_hold(
+                        runs, cfg, tier_ctx, attempt=attempt,
+                        evidence=(
+                            "the base poll budget was reached with every sibling terminal, "
+                            f"an idle Actions queue (depth="
+                            f"{depth if depth is not None else 'unknown'} < {cfg.sat_queue_min}) "
+                            f"and no completions in the last {cfg.progress_window} poll(s)"
+                        ),
+                    )
                 print(
                     f"::error::ci-summary timed out — {pending} sibling check-run(s) never "
                     f"finished within the base budget, the Actions queue is idle "
@@ -1406,7 +1618,9 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 extension_started = True
                 print(
                     f"::notice::ci-summary base budget reached with {pending} sibling(s) still "
-                    f"pending, but the runner pool shows saturation/progress "
+                    f"pending"
+                    + (" (awaiting the full-tier re-run)" if awaiting_full else "")
+                    + f", but the runner pool shows saturation/progress "
                     f"(queued runs={depth if depth is not None else 'unknown'}, "
                     f"progressing={progressing}) — this is a throughput signal, not a hang. "
                     f"Extending the wait (adaptive budget, sq-90cv4) up to poll "
@@ -1608,6 +1822,46 @@ def make_fetch_pr_draft(repo: str, pr_number: str):
     return fetch
 
 
+def make_fetch_head_activity(repo: str, sha: str, self_run_id: str = ""):
+    """[OPUS-5] #3758: the per-head UNSATISFIABILITY probe. Returns a
+    () -> int | None fetcher giving the number of NON-TERMINAL (queued /
+    in_progress / requested / waiting / pending) Actions workflow runs on THIS head
+    SHA, excluding every run of this gate's OWN workflow — a ci-summary run can
+    never register the full-tier select the awaiting_full hold waits for, and two
+    concurrent gate runs on one head must not each count the other as a candidate
+    (that is the 68-minute mutual stall this exit exists to end).
+
+    Zero therefore means: nothing is running or queued on this commit that could
+    produce the awaited strictly-later full-tier successor. None means UNKNOWN (API
+    failure) — run_gate then never concludes unsatisfiability from it. Reuses the
+    existing workflow-run lister (same endpoint, same self-run merge) so the probe
+    and the #3505 resolver read one consistent view of the head."""
+
+    list_runs = make_fetch_workflow_runs(repo, sha, self_run_id)
+
+    def fetch():
+        try:
+            runs = list_runs()
+        except FetchError as exc:
+            print(f"  (head-activity probe failed: {exc} — treating as unknown)")
+            return None
+        self_id = _as_int(self_run_id)
+        self_workflow = ""
+        for run in runs:
+            if _as_int(run.get("id")) == self_id:
+                self_workflow = workflow_identity(run)
+                break
+        return sum(
+            1
+            for run in runs
+            if run.get("status") != "completed"
+            and _as_int(run.get("id")) != self_id
+            and not (self_workflow and workflow_identity(run) == self_workflow)
+        )
+
+    return fetch
+
+
 def make_fetch_queue_depth(repo: str):
     """Queued workflow-run count for the repo — the saturation signal. Returns None
     (unknown) on any failure so a permissions/API blip degrades to progress-only,
@@ -1637,7 +1891,8 @@ def make_fetch_queue_depth(repo: str):
 
 
 def _self_test() -> int:
-    """Hermetic mutation checks for the three #3505 safety properties."""
+    """Hermetic mutation checks: the three #3505 safety properties + the #3758
+    unsatisfiable-hold exit (fast RED on an idle head; a satisfiable hold waits)."""
 
     def require(condition: bool, message: str) -> None:
         if not condition:
@@ -1726,9 +1981,55 @@ def _self_test() -> int:
         "cancelled workflow never failed loud after bounded redispatch grace",
     )
 
+    # [OPUS-5] #3758: the unsatisfiable awaiting_full hold exits FAST and RED, and a
+    # SATISFIABLE hold (a non-terminal run still on the head) does not exit early.
+    hold_ctx = TierContext(run_tier="full", event_name="pull_request")
+    draft_select = {
+        "name": "select (change-based test selection, draft-tier)",
+        "status": "completed",
+        "conclusion": "success",
+        "details_url": "",
+        "html_url": "",
+        "started_at": "2026-07-23T11:24:01Z",
+        "id": 5001,
+        "external_id": "",
+    }
+    hold_cfg = Config(
+        self_run_id="999", interval=0, min_polls=1, settle_polls=2, base_polls=50,
+        sat_interval=0, max_total_polls=6, unsat_grace_polls=2, summary_path="",
+    )
+    unsat_log = io.StringIO()
+    with redirect_stdout(unsat_log):
+        unsat_code = run_gate(
+            hold_cfg, lambda: [dict(draft_select)], lambda: 0,
+            sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
+            fetch_head_activity=lambda: 0,
+        )
+    require(unsat_code == 1, "unsatisfiable draft-tier hold did not RED (#3758)")
+    require(
+        "UNSATISFIABLE" in unsat_log.getvalue()
+        and "concluding at poll 2" in unsat_log.getvalue(),
+        "unsatisfiable draft-tier hold did not conclude at the grace poll (#3758)",
+    )
+    busy_log = io.StringIO()
+    with redirect_stdout(busy_log):
+        busy_code = run_gate(
+            hold_cfg, lambda: [dict(draft_select)], lambda: 0,
+            sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
+            fetch_head_activity=lambda: 1,
+        )
+    require(busy_code == 1, "satisfiable-hold budget exhaustion must still RED")
+    require(
+        "UNSATISFIABLE" not in busy_log.getvalue()
+        and "attempt 6:" in busy_log.getvalue(),
+        "a SATISFIABLE hold (non-terminal run on the head) exited early (#3758)",
+    )
+
     print(
         "ci-summary --self-test: ALL ASSERTIONS PASSED "
-        "(superseded cancellation ignored; newest failure preserved; redispatch bounded once)"
+        "(superseded cancellation ignored; newest failure preserved; redispatch "
+        "bounded once; unsatisfiable draft-tier hold exits fast + RED while a "
+        "satisfiable hold still waits)"
     )
     return 0
 
@@ -1762,7 +2063,11 @@ def main() -> int:
     print(f"ci-summary: evaluating tier={run_tier} (event={event_name or '<unset>'}).")
     cfg = Config(self_run_id=self_run_id)
     return run_gate(cfg, make_fetch_runs(repo, sha, self_run_id), make_fetch_queue_depth(repo),
-                    tier_ctx=tier_ctx)
+                    tier_ctx=tier_ctx,
+                    # [OPUS-5] #3758: consulted ONLY inside a draft-tier awaiting_full
+                    # hold with zero pending siblings — no extra API traffic on any
+                    # normal poll.
+                    fetch_head_activity=make_fetch_head_activity(repo, sha, self_run_id))
 
 
 if __name__ == "__main__":

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -154,18 +154,27 @@
 #     CONSECUTIVE zero observations (a registration-grace window for the
 #     ready_for_review re-runs, which appear as queued runs the instant the event
 #     fires) conclude the hold UNSATISFIABLE and RED immediately through the
-#     stale-draft-tier verdict belt. Probe unavailable/failed => UNKNOWN => never
-#     concludes (the belt below still bounds the wait).
+#     stale-draft-tier verdict belt.
 #   * BASE-BUDGET WIDENING — the genuine-hang branch now also fires for an
 #     awaiting_full hold with pending == 0, and in that state repo-wide runner
 #     SATURATION is explicitly NOT an extension reason: with zero pending
 #     siblings nothing of ours is starving in that queue, and Actions creates a
 #     run (status=queued) the instant the triggering event fires regardless of
 #     pool depth. Live progress (a rising completed count) still extends, and so
-#     does live PER-HEAD activity — a probe that saw a non-terminal run on this
-#     SHA this poll vetoes the shortcut, leaving the pre-#3758 absolute-budget
-#     bound in place. The per-head probe, not the repo-wide queue, is the
-#     authoritative satisfiability signal for a zero-pending hold.
+#     does anything short of a CONFIRMED-IDLE head. The per-head probe, not the
+#     repo-wide queue, is the authoritative satisfiability signal for a
+#     zero-pending hold.
+#   * THREE-STATE PROBE (PR #3765 review finding 1). The probe returns a
+#     HeadActivityReport whose state is CONFIRMED_IDLE / CONFIRMED_BUSY / UNKNOWN,
+#     and ONLY CONFIRMED_IDLE is evidence. UNKNOWN — probe absent, API failure,
+#     exception, or a non-report return — is a NON-OBSERVATION: it can never
+#     satisfy either exit (both fall back to the pre-#3758 absolute-budget bound)
+#     and it is never logged as an idle queue. It also RESETS the confirming
+#     streak (finding 2), because "N consecutive polls" must mean N consecutive
+#     CONFIRMED observations — [zero, unknown, zero] proves nothing about
+#     consecutiveness. The earlier `int | None` probe let a falsy count stand in
+#     for a confirmed zero, so a transient probe failure could RED a hold that was
+#     in fact SATISFIABLE while reporting an idle queue it had never seen.
 # Both exits are exit-1-only and route through render_verdict's stale-draft-tier
 # belt, so they can never synthesise a pass; a hold that IS satisfiable (a queued
 # full-tier run exists) waits exactly as before. The RED names the remedy
@@ -194,6 +203,7 @@ import sys
 import time
 from contextlib import redirect_stdout
 from dataclasses import dataclass, field
+from enum import Enum
 
 ADVISORY_RE = re.compile(r"\b(advisory|informational)\b")
 _PASSING = ("success", "skipped", "neutral")
@@ -269,6 +279,56 @@ UNSAT_HOLD_REMEDY = (
     "ready_for_review full-tier wave is dispatched, or (3) push a new head commit. "
     "Automated repair lanes: do NOT re-run this workflow for this verdict."
 )
+
+
+class HeadActivity(Enum):
+    """[OPUS-5] PR #3765 review finding 1: the THREE states of the per-head
+    unsatisfiability probe, kept DISTINCT in the type system.
+
+    The probe originally returned `int | None` and the call sites branched on
+    truthiness, so `None` (UNKNOWN — probe absent, failed, or raised) took the same
+    branch as a CONFIRMED zero. A transient API blip could therefore "prove" an idle
+    head and RED a hold that was in fact SATISFIABLE, while the log claimed an idle
+    queue it had never observed. Only ``CONFIRMED_IDLE`` is evidence; the other two
+    states must both fall through to continued polling.
+    """
+
+    CONFIRMED_IDLE = "confirmed-zero"      # observed: 0 non-terminal runs on the head
+    CONFIRMED_BUSY = "confirmed-nonzero"   # observed: >= 1 non-terminal run
+    UNKNOWN = "unknown"                    # NOT observed: absent / failed / raised
+
+
+@dataclass(frozen=True)
+class HeadActivityReport:
+    """One per-head probe observation (#3758): a `HeadActivity` state plus the
+    observed count (None iff UNKNOWN) and an operator-facing reason for UNKNOWN.
+
+    Construct through `confirmed()` / `unknown()` — never by truthiness of a bare
+    count, which is the conflation PR #3765 finding 1 removed."""
+
+    state: HeadActivity
+    count: int | None = None
+    detail: str = ""
+
+    @classmethod
+    def confirmed(cls, count: int) -> HeadActivityReport:
+        """An ACTUAL observation of `count` non-terminal runs on the head SHA."""
+        return cls(
+            HeadActivity.CONFIRMED_IDLE if count == 0 else HeadActivity.CONFIRMED_BUSY,
+            count,
+        )
+
+    @classmethod
+    def unknown(cls, detail: str) -> HeadActivityReport:
+        """NO observation was obtained (`detail` says why). Never evidence."""
+        return cls(HeadActivity.UNKNOWN, None, detail)
+
+    @property
+    def confirms_idle(self) -> bool:
+        """The ONLY predicate any exit may condition on. Deliberately NOT
+        `not self.count`: an UNKNOWN report carries count=None, which is falsy —
+        exactly the bug (PR #3765 finding 1)."""
+        return self.state is HeadActivity.CONFIRMED_IDLE
 
 
 @dataclass
@@ -1344,6 +1404,34 @@ def _conclude_unsatisfiable_hold(
     return code
 
 
+def _probe_head_activity(fetch_head_activity) -> HeadActivityReport:
+    """[OPUS-5] PR #3765 finding 1: call the per-head probe and normalise EVERY
+    non-observation to `HeadActivity.UNKNOWN`. The four non-observations — no probe
+    wired, `None` returned (API failure), an exception, or a value that is not a
+    `HeadActivityReport` (e.g. a bare count from a future refactor) — are all
+    UNKNOWN, so no exit can mistake them for a confirmed-idle head."""
+    if fetch_head_activity is None:
+        return HeadActivityReport.unknown("no probe wired")
+    try:
+        report = fetch_head_activity()
+    except Exception as exc:  # never let a probe crash the gate
+        print(f"  (head-activity probe raised {exc!r} — treating as unknown)")
+        return HeadActivityReport.unknown(f"probe raised {type(exc).__name__}")
+    if isinstance(report, HeadActivityReport):
+        return report
+    if report is None:
+        return HeadActivityReport.unknown("probe unavailable (API failure)")
+    # Fail-safe: a bare int/whatever is NOT a confirmed observation here. Coercing it
+    # to "confirmed" is precisely how finding 1 arose, so it degrades to UNKNOWN.
+    print(
+        f"  (head-activity probe returned {report!r}, not a HeadActivityReport — "
+        "treating as unknown)"
+    )
+    return HeadActivityReport.unknown(
+        f"probe unavailable (non-report return of type {type(report).__name__})"
+    )
+
+
 def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
              tier_ctx: TierContext | None = None, fetch_head_activity=None) -> int:
     """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url,
@@ -1351,11 +1439,12 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     -> int queued workflow-run count for the repo, or None when unknown (API
     failure — the gate then falls back to the progress signal alone). tier_ctx
     carries the draft-tier integrity context (None => pre-draft-tier semantics).
-    fetch_head_activity() -> int count of non-terminal Actions workflow runs on
-    THIS head SHA excluding this gate's own workflow, or None when unknown; it is
-    consulted ONLY inside a draft-tier `awaiting_full` hold with zero pending
-    siblings (#3758), and None/absent simply means the unsatisfiability exit never
-    fires. Returns the exit code."""
+    fetch_head_activity() -> HeadActivityReport for THIS head SHA (non-terminal
+    Actions workflow runs, this gate's own workflow excluded); it is consulted ONLY
+    inside a draft-tier `awaiting_full` hold with zero pending siblings (#3758).
+    Absent / failing / raising / non-report => HeadActivity.UNKNOWN, which is never
+    evidence: neither unsatisfiability exit can fire on it (PR #3765 finding 1).
+    Returns the exit code."""
     prev_names: list[str] | None = None
     stable = 0
     runs: list[dict] = []
@@ -1369,7 +1458,12 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     ff_suspect: tuple | None = None
     # [OPUS-5] #3758: consecutive polls that have CONFIRMED an unsatisfiable
     # awaiting_full hold (hold up, zero pending siblings, zero non-terminal
-    # workflow runs on this head). Reset by any contrary observation.
+    # workflow runs on this head). PR #3765 finding 2: "consecutive" means
+    # consecutive CONFIRMED OBSERVATIONS, so this resets on any contrary
+    # observation AND on any NON-observation — an UNKNOWN/raising probe, or a poll
+    # that never reached the probe at all (fetch failure, fail-fast grace re-poll).
+    # Otherwise [confirmed-zero, unknown, confirmed-zero] would reach a 2-poll
+    # grace while claiming "2 consecutive polls", which is not what it proved.
     unsat_confirms = 0
 
     attempt = 0
@@ -1398,6 +1492,10 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 f"attempt {attempt}: check-run fetch failed ({exc}) — skipping this poll "
                 f"({consec_fetch_failures}/{cfg.max_consec_fetch_failures} consecutive)."
             )
+            # PR #3765 finding 2: this poll observed NOTHING (not even the sibling set
+            # the hold is derived from), so it cannot sit inside a run of consecutive
+            # CONFIRMED observations.
+            unsat_confirms = 0
             sleep_fn(cfg.sat_interval if extension_started else cfg.interval)
             continue
         consec_fetch_failures = 0
@@ -1493,6 +1591,9 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                     f"  fail-fast: {len(ff)} concluded gating failure(s) observed — "
                     f"immediate grace re-poll to confirm before concluding."
                 )
+                # PR #3765 finding 2: the grace re-poll skips the probe, so this poll
+                # contributes no CONFIRMED observation to the consecutive streak.
+                unsat_confirms = 0
                 continue  # no sleep: the grace re-poll is deliberately immediate
             ff_suspect = None
 
@@ -1507,36 +1608,32 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         # CONSECUTIVE zero observations (registration grace: a ready_for_review
         # re-dispatch appears as a queued run within seconds) prove the hold cannot
         # clear, and the gate REDs now through the same stale-draft-tier belt the
-        # budget-exhaustion path uses. A probe that is absent or fails is UNKNOWN and
-        # never concludes anything (the base-budget widening below still bounds it).
-        # head_busy is THIS poll's per-head evidence that the hold may still be
-        # satisfiable; it also vetoes the base-budget shortcut further below, so the
-        # per-head probe — not the repo-wide queue depth — stays the authoritative
-        # satisfiability signal for a zero-pending hold.
-        head_busy = False
+        # budget-exhaustion path uses. A probe that is absent, fails, raises, or hands
+        # back a non-report is UNKNOWN — NOT an observation — so it can never conclude
+        # anything AND it RESETS the confirming streak (PR #3765 findings 1+2). `head`
+        # is THIS poll's per-head report; it also gates the base-budget shortcut
+        # further below, so the per-head probe — not the repo-wide queue depth — stays
+        # the authoritative satisfiability signal for a zero-pending hold.
+        head = HeadActivityReport.unknown("probe not consulted (no zero-pending hold)")
         if awaiting_full and pending == 0:
-            head_activity = None
-            if fetch_head_activity is not None:
-                try:
-                    head_activity = fetch_head_activity()
-                except Exception as exc:  # never let a probe crash the gate
-                    print(f"  (head-activity probe raised {exc!r} — treating as unknown)")
-                    head_activity = None
-            if head_activity is None:
+            head = _probe_head_activity(fetch_head_activity)
+            if head.state is HeadActivity.UNKNOWN:
+                # PR #3765 finding 2: a non-observation BREAKS consecutiveness.
+                unsat_confirms = 0
                 print(
                     "  awaiting_full hold with 0 pending sibling(s): head-activity "
-                    "probe unavailable (unknown) — cannot prove the hold unsatisfiable, "
-                    "still waiting (#3758)."
+                    f"probe UNKNOWN ({head.detail}) — this head's Actions queue was "
+                    "NOT observed, so the hold cannot be proven unsatisfiable; the "
+                    "confirming streak is RESET and the gate keeps polling (#3758)."
                 )
-            elif head_activity > 0:
+            elif head.state is HeadActivity.CONFIRMED_BUSY:
                 unsat_confirms = 0
-                head_busy = True
                 print(
-                    f"  awaiting_full hold with 0 pending sibling(s): {head_activity} "
+                    f"  awaiting_full hold with 0 pending sibling(s): {head.count} "
                     "non-terminal workflow run(s) on this head SHA could still register "
                     "the full-tier successor — still settling (#3758)."
                 )
-            else:
+            else:  # HeadActivity.CONFIRMED_IDLE — the ONLY evidential state
                 unsat_confirms += 1
                 print(
                     "  awaiting_full hold with 0 pending sibling(s) and NO queued/"
@@ -1548,9 +1645,9 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                     return _conclude_unsatisfiable_hold(
                         runs, cfg, tier_ctx, attempt=attempt,
                         evidence=(
-                            f"{unsat_confirms} consecutive poll(s) found ZERO queued or "
-                            "in-progress workflow runs on this head SHA (this gate's own "
-                            "workflow excluded)"
+                            f"{unsat_confirms} consecutive poll(s) CONFIRMED ZERO queued "
+                            "or in-progress workflow runs on this head SHA (this gate's "
+                            "own workflow excluded)"
                         ),
                     )
         else:
@@ -1585,36 +1682,77 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             # repo-wide runner saturation explains NOTHING — none of OUR work is
             # starving in that queue, and Actions creates a run (status=queued) the
             # instant its triggering event fires regardless of pool depth, which the
-            # per-head probe above would have seen. Only LIVE PROGRESS (the sibling
-            # set still churning) justifies extending this state. For pending > 0 the
-            # sq-90cv4 semantics are byte-identical to before.
+            # per-head probe above would have seen. LIVE PROGRESS (the sibling set
+            # still churning) justifies extending this state — as does any per-head
+            # observation short of a CONFIRMED idle (next comment). Repo-wide
+            # saturation never does. For pending > 0 the sq-90cv4 semantics are
+            # byte-identical to before.
             hold_only = pending == 0 and awaiting_full
-            # ...and conversely, LIVE PER-HEAD ACTIVITY (head_busy: the probe saw a
-            # non-terminal run on this SHA this poll) DOES keep a zero-pending hold
-            # alive — that run may yet register the awaited full-tier select, so the
-            # gate falls back to the pre-#3758 bound (the absolute budget) rather
-            # than concluding unsatisfiability the probe just contradicted.
-            if not (progressing or (saturated and not hold_only)
-                    or (hold_only and head_busy)):
+            depth_txt = depth if depth is not None else "unknown"
+            # ...and conversely, anything OTHER than a CONFIRMED-IDLE head keeps a
+            # zero-pending hold alive. [OPUS-5] PR #3765 finding 1: this used to be
+            # `head_busy` (confirmed non-zero only), so an UNKNOWN probe — absent,
+            # failed, raised — silently satisfied the exit condition and could RED a
+            # SATISFIABLE hold on a transient blip, logging an idle queue it had never
+            # observed. Only `confirms_idle` is evidence; CONFIRMED_BUSY (that run may
+            # yet register the awaited select) and UNKNOWN (nothing was observed at
+            # all) both fall back to the pre-#3758 bound, the absolute budget.
+            if hold_only:
+                extend = progressing or not head.confirms_idle
+            else:
+                extend = progressing or saturated   # sq-90cv4, byte-identical
+            if not extend:
                 if hold_only:
                     return _conclude_unsatisfiable_hold(
                         runs, cfg, tier_ctx, attempt=attempt,
                         evidence=(
                             "the base poll budget was reached with every sibling terminal, "
-                            f"an idle Actions queue (depth="
-                            f"{depth if depth is not None else 'unknown'} < {cfg.sat_queue_min}) "
-                            f"and no completions in the last {cfg.progress_window} poll(s)"
+                            "the per-head probe CONFIRMED ZERO queued or in-progress "
+                            "workflow runs on this head SHA, and no completions landed in "
+                            f"the last {cfg.progress_window} poll(s) (repo-wide Actions "
+                            f"queue depth={depth_txt} is deliberately NOT an extension "
+                            "reason with zero pending siblings)"
                         ),
                     )
                 print(
                     f"::error::ci-summary timed out — {pending} sibling check-run(s) never "
                     f"finished within the base budget, the Actions queue is idle "
-                    f"(depth={depth if depth is not None else 'unknown'} < {cfg.sat_queue_min}) "
+                    f"(depth={depth_txt} < {cfg.sat_queue_min}) "
                     f"and no completions landed in the last {cfg.progress_window} poll(s): "
                     f"genuine hang, not a still-settling set. See the per-poll log above."
                 )
                 return 1
-            if not extension_started:
+            if hold_only:
+                # [OPUS-5] PR #3765 finding 1: state the REAL reason this zero-pending
+                # hold is still being waited on. The sq-90cv4 notice below would
+                # misreport it as a throughput signal, and an UNKNOWN probe must never
+                # be logged as an idle queue.
+                if progressing:
+                    reason = "live sibling progress (the set is still churning)"
+                elif head.state is HeadActivity.UNKNOWN:
+                    reason = (
+                        f"the head-activity probe is UNKNOWN ({head.detail}) — this "
+                        "head's Actions queue was NOT observed, so unsatisfiability is "
+                        "NOT proven"
+                    )
+                else:
+                    reason = (
+                        f"{head.count} non-terminal workflow run(s) on this head SHA "
+                        "could still register the full-tier successor"
+                    )
+                if not extension_started:
+                    extension_started = True
+                    print(
+                        "::notice::ci-summary base budget reached with every sibling "
+                        "terminal and the draft-tier `awaiting_full` hold still up: "
+                        f"{reason}. Extending the wait to the absolute budget (poll "
+                        f"{cfg.max_total_polls}) instead of concluding — repo-wide "
+                        f"runner saturation (queue depth={depth_txt}) is deliberately "
+                        "NOT an extension reason for a zero-pending hold (#3758)."
+                    )
+                else:
+                    print(f"  hold extension (poll {attempt}): {reason} — still waiting.")
+            elif not extension_started:
                 extension_started = True
                 print(
                     f"::notice::ci-summary base budget reached with {pending} sibling(s) still "
@@ -1824,39 +1962,42 @@ def make_fetch_pr_draft(repo: str, pr_number: str):
 
 def make_fetch_head_activity(repo: str, sha: str, self_run_id: str = ""):
     """[OPUS-5] #3758: the per-head UNSATISFIABILITY probe. Returns a
-    () -> int | None fetcher giving the number of NON-TERMINAL (queued /
-    in_progress / requested / waiting / pending) Actions workflow runs on THIS head
-    SHA, excluding every run of this gate's OWN workflow — a ci-summary run can
-    never register the full-tier select the awaiting_full hold waits for, and two
+    () -> HeadActivityReport fetcher counting the NON-TERMINAL (queued / in_progress
+    / requested / waiting / pending) Actions workflow runs on THIS head SHA,
+    excluding every run of this gate's OWN workflow — a ci-summary run can never
+    register the full-tier select the awaiting_full hold waits for, and two
     concurrent gate runs on one head must not each count the other as a candidate
     (that is the 68-minute mutual stall this exit exists to end).
 
-    Zero therefore means: nothing is running or queued on this commit that could
-    produce the awaited strictly-later full-tier successor. None means UNKNOWN (API
-    failure) — run_gate then never concludes unsatisfiability from it. Reuses the
-    existing workflow-run lister (same endpoint, same self-run merge) so the probe
-    and the #3505 resolver read one consistent view of the head."""
+    A CONFIRMED zero therefore means: nothing is running or queued on this commit
+    that could produce the awaited strictly-later full-tier successor. An API failure
+    yields `HeadActivityReport.unknown(...)` — never a zero count (PR #3765 finding
+    1: run_gate must be unable to mistake a non-observation for an idle head).
+    Reuses the existing workflow-run lister (same endpoint, same self-run merge) so
+    the probe and the #3505 resolver read one consistent view of the head."""
 
     list_runs = make_fetch_workflow_runs(repo, sha, self_run_id)
 
-    def fetch():
+    def fetch() -> HeadActivityReport:
         try:
             runs = list_runs()
         except FetchError as exc:
             print(f"  (head-activity probe failed: {exc} — treating as unknown)")
-            return None
+            return HeadActivityReport.unknown(f"probe unavailable (API failure: {exc})")
         self_id = _as_int(self_run_id)
         self_workflow = ""
         for run in runs:
             if _as_int(run.get("id")) == self_id:
                 self_workflow = workflow_identity(run)
                 break
-        return sum(
-            1
-            for run in runs
-            if run.get("status") != "completed"
-            and _as_int(run.get("id")) != self_id
-            and not (self_workflow and workflow_identity(run) == self_workflow)
+        return HeadActivityReport.confirmed(
+            sum(
+                1
+                for run in runs
+                if run.get("status") != "completed"
+                and _as_int(run.get("id")) != self_id
+                and not (self_workflow and workflow_identity(run) == self_workflow)
+            )
         )
 
     return fetch
@@ -2003,7 +2144,7 @@ def _self_test() -> int:
         unsat_code = run_gate(
             hold_cfg, lambda: [dict(draft_select)], lambda: 0,
             sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
-            fetch_head_activity=lambda: 0,
+            fetch_head_activity=lambda: HeadActivityReport.confirmed(0),
         )
     require(unsat_code == 1, "unsatisfiable draft-tier hold did not RED (#3758)")
     require(
@@ -2016,7 +2157,7 @@ def _self_test() -> int:
         busy_code = run_gate(
             hold_cfg, lambda: [dict(draft_select)], lambda: 0,
             sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
-            fetch_head_activity=lambda: 1,
+            fetch_head_activity=lambda: HeadActivityReport.confirmed(1),
         )
     require(busy_code == 1, "satisfiable-hold budget exhaustion must still RED")
     require(
@@ -2025,11 +2166,60 @@ def _self_test() -> int:
         "a SATISFIABLE hold (non-terminal run on the head) exited early (#3758)",
     )
 
+    # [OPUS-5] PR #3765 review findings 1+2: an UNKNOWN probe is NOT a confirmed-idle
+    # head. (1) It must never conclude unsatisfiability — not even at/after the base
+    # budget, where the exit condition used to be satisfied by a falsy count.
+    # (2) It must RESET the consecutive-confirmation counter, so an interleaved
+    # [zero, unknown, zero] can never reach a 2-poll grace.
+    for label, probe in (
+        ("none", lambda: None),
+        ("raises", lambda: (_ for _ in ()).throw(RuntimeError("probe boom"))),
+        ("bare-int-0", lambda: 0),   # the pre-fix conflation, now UNKNOWN
+    ):
+        unknown_log = io.StringIO()
+        with redirect_stdout(unknown_log):
+            unknown_code = run_gate(
+                Config(self_run_id="999", interval=0, min_polls=1, settle_polls=2,
+                       base_polls=3, sat_interval=0, max_total_polls=6,
+                       unsat_grace_polls=2, sat_queue_min=5, summary_path=""),
+                lambda: [dict(draft_select)], lambda: 0,
+                sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
+                fetch_head_activity=probe,
+            )
+        require(unknown_code == 1, f"UNKNOWN probe ({label}) must still RED at the cap")
+        require(
+            "UNSATISFIABLE" not in unknown_log.getvalue()
+            and "probe is UNKNOWN" in unknown_log.getvalue()
+            and "attempt 6:" in unknown_log.getvalue(),
+            f"an UNKNOWN probe ({label}) concluded unsatisfiability or claimed an idle "
+            "queue instead of polling on (PR #3765 finding 1)",
+        )
+    interleaved = iter([HeadActivityReport.confirmed(0), None,
+                        HeadActivityReport.confirmed(0)])
+    inter_log = io.StringIO()
+    with redirect_stdout(inter_log):
+        inter_code = run_gate(
+            Config(self_run_id="999", interval=0, min_polls=1, settle_polls=2,
+                   base_polls=9, sat_interval=0, max_total_polls=3,
+                   unsat_grace_polls=2, sat_queue_min=5, summary_path=""),
+            lambda: [dict(draft_select)], lambda: 0,
+            sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
+            fetch_head_activity=lambda: next(interleaved, None),
+        )
+    require(inter_code == 1, "interleaved-unknown hold must still RED at the cap")
+    require(
+        "UNSATISFIABLE" not in inter_log.getvalue()
+        and "2/2 confirming poll(s)" not in inter_log.getvalue(),
+        "[zero, unknown, zero] reached the 2-poll grace — the UNKNOWN probe did not "
+        "reset the consecutive-confirmation counter (PR #3765 finding 2)",
+    )
+
     print(
         "ci-summary --self-test: ALL ASSERTIONS PASSED "
         "(superseded cancellation ignored; newest failure preserved; redispatch "
         "bounded once; unsatisfiable draft-tier hold exits fast + RED while a "
-        "satisfiable hold still waits)"
+        "satisfiable hold still waits; an UNKNOWN probe neither concludes nor "
+        "sustains a confirming streak)"
     )
     return 0
 

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -175,6 +175,24 @@
 #     consecutiveness. The earlier `int | None` probe let a falsy count stand in
 #     for a confirmed zero, so a transient probe failure could RED a hold that was
 #     in fact SATISFIABLE while reporting an idle queue it had never seen.
+#   * FAIL-CLOSED ALLOW-LIST (PR #3765 review round 3). THE INVARIANT: only an
+#     affirmatively-CONFIRMED_IDLE report whose count AGREES with that state can
+#     satisfy either exit; anything unrecognised is UNKNOWN, NEVER idle. Round 2
+#     left the state handling as a DENY-list — `if UNKNOWN / elif CONFIRMED_BUSY /
+#     else <assume idle>` — so a MALFORMED report object fell into the idle branch:
+#     HeadActivityReport("bogus", None, "malformed") accrued the full confirming
+#     streak and turned the gate RED as proven-unsatisfiable on a state nobody had
+#     ever observed. Now enforced twice (belt and braces — the exploit was DIRECT
+#     CONSTRUCTION): (a) `_head_report_violation` is the one definition of a
+#     well-formed (state, count) pair and `__post_init__` RAISES on any violation,
+#     so a malformed instance cannot be built — a state outside the enum, a
+#     CONFIRMED_IDLE whose count is not 0, a CONFIRMED_BUSY whose count is not >= 1,
+#     an UNKNOWN carrying a count; and (b) every consumer branches AFFIRMATIVELY —
+#     `confirms_idle` first (state AND count), `CONFIRMED_BUSY` explicitly, and a
+#     terminal `else` that treats everything remaining as UNKNOWN — while
+#     `_probe_head_activity`, the single accessor, re-checks the invariant via
+#     `normalized()` so a report that bypassed `__post_init__` still degrades to
+#     UNKNOWN instead of being read as evidence.
 # Both exits are exit-1-only and route through render_verdict's stale-draft-tier
 # belt, so they can never synthesise a pass; a hold that IS satisfiable (a queued
 # full-tier run exists) waits exactly as before. The RED names the remedy
@@ -332,21 +350,69 @@ class HeadActivity(Enum):
     UNKNOWN = "unknown"                    # NOT observed: absent / failed / raised
 
 
+def _head_report_violation(state, count) -> str | None:
+    """[OPUS-5] PR #3765 round-3 finding: the SINGLE definition of a WELL-FORMED
+    (state, count) pair for a `HeadActivityReport`. Returns None when the pair is
+    well-formed, else an operator-facing reason it is not.
+
+    THE INVARIANT (one place, two enforcers): only an affirmatively-CONFIRMED_IDLE
+    report whose count is CONSISTENT with that state can ever satisfy an
+    unsatisfiability exit. Anything unrecognised — a state outside the enum, a
+    confirmed state with no count, a CONFIRMED_IDLE whose count is not 0, a
+    CONFIRMED_BUSY whose count is not >= 1, an UNKNOWN that carries a count — is
+    UNKNOWN, NEVER idle. This function is called from `__post_init__` (so a malformed
+    instance cannot be CONSTRUCTED) and from `normalized()` (so a malformed instance
+    that reached a consumer anyway — smuggled past the frozen dataclass via
+    `object.__setattr__`, a subclass, or unpickling — still degrades to UNKNOWN
+    rather than being read as evidence). Belt and braces, because the round-2
+    exploit was DIRECT CONSTRUCTION: `HeadActivityReport("bogus", None, "malformed")`
+    fell through a consumer-side DENY-list (`if UNKNOWN / elif CONFIRMED_BUSY /
+    else assume idle`) into the idle branch, accrued the full confirming streak, and
+    turned the gate RED as proven-unsatisfiable on a state nobody had ever observed."""
+    if not isinstance(state, HeadActivity):
+        return f"state {state!r} is not a HeadActivity member"
+    if isinstance(count, bool) or not (count is None or isinstance(count, int)):
+        return f"count {count!r} is neither None nor an int"
+    if state is HeadActivity.UNKNOWN:
+        if count is not None:
+            return f"UNKNOWN carries count={count!r}; a NON-observation has no count"
+        return None
+    if count is None:
+        return f"{state.name} carries no count; a CONFIRMED observation must have one"
+    if state is HeadActivity.CONFIRMED_IDLE and count != 0:
+        return f"CONFIRMED_IDLE with count={count!r}; an idle head has exactly 0"
+    if state is HeadActivity.CONFIRMED_BUSY and count < 1:
+        return f"CONFIRMED_BUSY with count={count!r}; a busy head has >= 1"
+    return None
+
+
 @dataclass(frozen=True)
 class HeadActivityReport:
     """One per-head probe observation (#3758): a `HeadActivity` state plus the
     observed count (None iff UNKNOWN) and an operator-facing reason for UNKNOWN.
 
     Construct through `confirmed()` / `unknown()` — never by truthiness of a bare
-    count, which is the conflation PR #3765 finding 1 removed."""
+    count, which is the conflation PR #3765 finding 1 removed. [OPUS-5] round 3: the
+    invariants in `_head_report_violation` are now enforced at CONSTRUCTION
+    (`__post_init__` raises `ValueError`), so a malformed report cannot exist, and
+    re-checked at every consumer via `normalized()`."""
 
     state: HeadActivity
     count: int | None = None
     detail: str = ""
 
+    def __post_init__(self) -> None:
+        """[OPUS-5] PR #3765 round 3: reject a malformed report AT CONSTRUCTION. The
+        dataclass is frozen, so this validates (it never assigns) — a `ValueError`
+        here means no malformed instance is ever handed to the poll loop."""
+        bad = _head_report_violation(self.state, self.count)
+        if bad is not None:
+            raise ValueError(f"malformed HeadActivityReport: {bad}")
+
     @classmethod
     def confirmed(cls, count: int) -> HeadActivityReport:
-        """An ACTUAL observation of `count` non-terminal runs on the head SHA."""
+        """An ACTUAL observation of `count` non-terminal runs on the head SHA.
+        A negative / non-int count is malformed and raises (`__post_init__`)."""
         return cls(
             HeadActivity.CONFIRMED_IDLE if count == 0 else HeadActivity.CONFIRMED_BUSY,
             count,
@@ -357,12 +423,50 @@ class HeadActivityReport:
         """NO observation was obtained (`detail` says why). Never evidence."""
         return cls(HeadActivity.UNKNOWN, None, detail)
 
+    def normalized(self) -> HeadActivityReport:
+        """[OPUS-5] PR #3765 round 3: the CONSUMER-side half of the belt-and-braces.
+        Returns `self` when well-formed, else an UNKNOWN report naming the violation.
+        `__post_init__` already makes a malformed instance unconstructible, so this
+        only ever fires for one that bypassed it (`object.__setattr__` on the frozen
+        instance, a subclass overriding `__post_init__`, unpickling) — and then it
+        degrades to UNKNOWN instead of being mistaken for an idle head."""
+        bad = _head_report_violation(self.state, self.count)
+        if bad is None:
+            return self
+        return HeadActivityReport.unknown(f"malformed report ({bad})")
+
+    @property
+    def why_unknown(self) -> str:
+        """[OPUS-5] round 3: operator-facing text for a NON-observation, used by the
+        allow-lists' terminal `else`. Every UNKNOWN this loop can actually see carries
+        a `detail` (`_probe_head_activity` supplies one for all five non-observations);
+        the fallback exists only so an unrecognised state still logs something true
+        rather than an empty parenthesis."""
+        return self.detail or f"unrecognised state {self.state!r}"
+
     @property
     def confirms_idle(self) -> bool:
-        """The ONLY predicate any exit may condition on. Deliberately NOT
-        `not self.count`: an UNKNOWN report carries count=None, which is falsy —
-        exactly the bug (PR #3765 finding 1)."""
-        return self.state is HeadActivity.CONFIRMED_IDLE
+        """The ONLY predicate any exit may condition on: an ALLOW-LIST of one.
+        Deliberately NOT `not self.count` — an UNKNOWN report carries count=None,
+        which is falsy (PR #3765 finding 1) — and deliberately not the state test
+        alone: the count must AGREE with the state, so a CONFIRMED_IDLE smuggled in
+        with count=7 or count=None is not idle either (round-3 finding)."""
+        return (
+            self.state is HeadActivity.CONFIRMED_IDLE
+            and _head_report_violation(self.state, self.count) is None
+        )
+
+    @property
+    def confirms_busy(self) -> bool:
+        """The MIRROR allow-list, so a consumer's branch chain is TOTAL:
+        `confirms_idle` / `confirms_busy` / everything else is UNKNOWN. Also
+        count-consistent, so a CONFIRMED_BUSY smuggled in with count=0 is not busy
+        either — it must not be narrated as "0 non-terminal run(s) could still
+        register", a claim that contradicts itself (round-3 finding)."""
+        return (
+            self.state is HeadActivity.CONFIRMED_BUSY
+            and _head_report_violation(self.state, self.count) is None
+        )
 
 
 @dataclass
@@ -1456,11 +1560,14 @@ def _conclude_unsatisfiable_hold(
 
 
 def _probe_head_activity(fetch_head_activity) -> HeadActivityReport:
-    """[OPUS-5] PR #3765 finding 1: call the per-head probe and normalise EVERY
-    non-observation to `HeadActivity.UNKNOWN`. The four non-observations — no probe
-    wired, `None` returned (API failure), an exception, or a value that is not a
-    `HeadActivityReport` (e.g. a bare count from a future refactor) — are all
-    UNKNOWN, so no exit can mistake them for a confirmed-idle head."""
+    """[OPUS-5] PR #3765 finding 1: the SINGLE accessor for the per-head probe. It
+    normalises EVERY non-observation to `HeadActivity.UNKNOWN`. The five
+    non-observations — no probe wired, `None` returned (API failure), an exception, a
+    value that is not a `HeadActivityReport` (e.g. a bare count from a future
+    refactor), and (round 3) a `HeadActivityReport` whose (state, count) pair
+    VIOLATES the report invariant — are all UNKNOWN, so no exit can mistake any of
+    them for a confirmed-idle head. Every consumer reads the report through this
+    accessor; none of them may re-derive "idle" from the raw fetcher."""
     if fetch_head_activity is None:
         return HeadActivityReport.unknown("no probe wired")
     try:
@@ -1469,7 +1576,17 @@ def _probe_head_activity(fetch_head_activity) -> HeadActivityReport:
         print(f"  (head-activity probe raised {exc!r} — treating as unknown)")
         return HeadActivityReport.unknown(f"probe raised {type(exc).__name__}")
     if isinstance(report, HeadActivityReport):
-        return report
+        # [OPUS-5] round 3: a report OBJECT is not automatically a valid observation.
+        # `__post_init__` makes a malformed one unconstructible, but one that bypassed
+        # it (object.__setattr__ on the frozen instance, a subclass, unpickling) must
+        # still degrade to UNKNOWN here rather than reach the idle branch.
+        checked = report.normalized()
+        if checked is not report:
+            print(
+                f"  (head-activity probe returned a malformed report {report!r} "
+                f"— {checked.detail}; treating as unknown)"
+            )
+        return checked
     if report is None:
         return HeadActivityReport.unknown("probe unavailable (API failure)")
     # Fail-safe: a bare int/whatever is NOT a confirmed observation here. Coercing it
@@ -1668,23 +1785,16 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         head = HeadActivityReport.unknown("probe not consulted (no zero-pending hold)")
         if awaiting_full and pending == 0:
             head = _probe_head_activity(fetch_head_activity)
-            if head.state is HeadActivity.UNKNOWN:
-                # PR #3765 finding 2: a non-observation BREAKS consecutiveness.
-                unsat_confirms = 0
-                print(
-                    "  awaiting_full hold with 0 pending sibling(s): head-activity "
-                    f"probe UNKNOWN ({head.detail}) — this head's Actions queue was "
-                    "NOT observed, so the hold cannot be proven unsatisfiable; the "
-                    "confirming streak is RESET and the gate keeps polling (#3758)."
-                )
-            elif head.state is HeadActivity.CONFIRMED_BUSY:
-                unsat_confirms = 0
-                print(
-                    f"  awaiting_full hold with 0 pending sibling(s): {head.count} "
-                    "non-terminal workflow run(s) on this head SHA could still register "
-                    "the full-tier successor — still settling (#3758)."
-                )
-            else:  # HeadActivity.CONFIRMED_IDLE — the ONLY evidential state
+            # [OPUS-5] PR #3765 round 3: an ALLOW-LIST, not a deny-list. This used to
+            # read `if UNKNOWN / elif CONFIRMED_BUSY / else <assume CONFIRMED_IDLE>`,
+            # so EVERY unrecognised report — a state outside the enum, a CONFIRMED_IDLE
+            # whose count contradicts it — landed in the idle branch and could accrue
+            # the full streak and RED the gate as proven-unsatisfiable. The affirmative
+            # `confirms_idle` test now comes FIRST and everything else resets, so the
+            # invariant holds by construction of the branch order: ONLY an
+            # affirmatively-CONFIRMED_IDLE report with a consistent count can satisfy
+            # this exit; anything unrecognised is UNKNOWN, NEVER idle.
+            if head.confirms_idle:
                 unsat_confirms += 1
                 print(
                     "  awaiting_full hold with 0 pending sibling(s) and NO queued/"
@@ -1701,6 +1811,29 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                             "own workflow excluded)"
                         ),
                     )
+            elif head.confirms_busy:
+                # PR #3765 finding 2: a live head BREAKS consecutiveness. Affirmative
+                # (state AND a count that agrees) for the same reason as the branch
+                # above, so a CONFIRMED_BUSY with count=0 is not narrated here as "0
+                # run(s) could still register" — it falls to the UNKNOWN else.
+                unsat_confirms = 0
+                print(
+                    f"  awaiting_full hold with 0 pending sibling(s): {head.count} "
+                    "non-terminal workflow run(s) on this head SHA could still register "
+                    "the full-tier successor — still settling (#3758)."
+                )
+            else:
+                # UNKNOWN, and — fail-closed — every state this loop does not
+                # affirmatively recognise. A non-observation BREAKS consecutiveness
+                # (PR #3765 finding 2) and can never conclude anything.
+                unsat_confirms = 0
+                print(
+                    "  awaiting_full hold with 0 pending sibling(s): head-activity "
+                    f"probe UNKNOWN ({head.why_unknown}) — this head's "
+                    "Actions queue was NOT observed, so the hold cannot be proven "
+                    "unsatisfiable; the confirming streak is RESET and the gate keeps "
+                    "polling (#3758)."
+                )
         else:
             unsat_confirms = 0
 
@@ -1748,6 +1881,13 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             # observed. Only `confirms_idle` is evidence; CONFIRMED_BUSY (that run may
             # yet register the awaited select) and UNKNOWN (nothing was observed at
             # all) both fall back to the pre-#3758 bound, the absolute budget.
+            # [OPUS-5] round 3: this is an ALLOW-LIST too, and now a total one.
+            # `confirms_idle` is AFFIRMATIVE (CONFIRMED_IDLE *and* a count that agrees
+            # with it), so every other report extends the wait — CONFIRMED_BUSY,
+            # UNKNOWN, and any unrecognised/self-contradictory report, which
+            # `_probe_head_activity` has already degraded to UNKNOWN. There is no
+            # (state, count) pair for which this exit fires without a confirmed
+            # observation of an idle head.
             if hold_only:
                 extend = progressing or not head.confirms_idle
             else:
@@ -1778,18 +1918,21 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 # hold is still being waited on. The sq-90cv4 notice below would
                 # misreport it as a throughput signal, and an UNKNOWN probe must never
                 # be logged as an idle queue.
+                # [OPUS-5] round 3: allow-list here as well — the previous `else`
+                # ASSUMED CONFIRMED_BUSY and printed `head.count`, so an unrecognised
+                # report would have been narrated as a live head with a `None` count.
                 if progressing:
                     reason = "live sibling progress (the set is still churning)"
-                elif head.state is HeadActivity.UNKNOWN:
-                    reason = (
-                        f"the head-activity probe is UNKNOWN ({head.detail}) — this "
-                        "head's Actions queue was NOT observed, so unsatisfiability is "
-                        "NOT proven"
-                    )
-                else:
+                elif head.confirms_busy:
                     reason = (
                         f"{head.count} non-terminal workflow run(s) on this head SHA "
                         "could still register the full-tier successor"
+                    )
+                else:  # UNKNOWN, and any state not affirmatively recognised above
+                    reason = (
+                        f"the head-activity probe is UNKNOWN ({head.why_unknown}) — "
+                        "this head's Actions queue was NOT observed, so "
+                        "unsatisfiability is NOT proven"
                     )
                 if not extension_started:
                     extension_started = True
@@ -2265,12 +2408,68 @@ def _self_test() -> int:
         "reset the consecutive-confirmation counter (PR #3765 finding 2)",
     )
 
+    # [OPUS-5] PR #3765 ROUND-3 finding: a MALFORMED report is UNKNOWN, never idle.
+    # The loop's state handling was a DENY-list, so HeadActivityReport("bogus", None,
+    # "malformed") reached the idle branch, accrued 2/2 and turned the gate RED as
+    # proven-unsatisfiable. Both halves of the belt-and-braces are asserted here.
+    for label, state, count in (
+        ("bogus-state", "bogus", None),
+        ("idle-count-none", HeadActivity.CONFIRMED_IDLE, None),
+        ("idle-count-nonzero", HeadActivity.CONFIRMED_IDLE, 7),
+        ("busy-count-zero", HeadActivity.CONFIRMED_BUSY, 0),
+    ):
+        # (a) construction-time: a malformed report cannot even be built.
+        try:
+            HeadActivityReport(state, count, "malformed")
+        except ValueError:
+            pass
+        else:
+            require(False, f"malformed HeadActivityReport ({label}) was constructible")
+        # (b) consumer-side: one smuggled past __post_init__ is still UNKNOWN.
+        smuggled = HeadActivityReport.unknown("smuggled")
+        object.__setattr__(smuggled, "state", state)
+        object.__setattr__(smuggled, "count", count)
+        # The two allow-list predicates the consumers branch on must BOTH refuse it,
+        # so the branch chain confirms_idle / confirms_busy / else falls through to
+        # UNKNOWN — the invariant, independent of the accessor's normalisation.
+        require(
+            not smuggled.confirms_idle and not smuggled.confirms_busy,
+            f"a malformed report ({label}) satisfied an allow-list predicate — "
+            "confirms_idle/confirms_busy must require the count to AGREE with the "
+            "state (PR #3765 round 3)",
+        )
+        require(
+            smuggled.normalized().state is HeadActivity.UNKNOWN,
+            f"normalized() did not degrade a malformed report ({label}) to UNKNOWN",
+        )
+        bad_log = io.StringIO()
+        with redirect_stdout(bad_log):
+            bad_code = run_gate(
+                Config(self_run_id="999", interval=0, min_polls=1, settle_polls=2,
+                       base_polls=3, sat_interval=0, max_total_polls=6,
+                       unsat_grace_polls=2, sat_queue_min=5, summary_path=""),
+                lambda: [dict(draft_select)], lambda: 0,
+                sleep_fn=lambda _s: None, tier_ctx=hold_ctx,
+                fetch_head_activity=lambda rep=smuggled: rep,
+            )
+        require(bad_code == 1, f"malformed report ({label}) must still RED at the cap")
+        require(
+            "UNSATISFIABLE" not in bad_log.getvalue()
+            and "confirming poll(s)" not in bad_log.getvalue()
+            and "probe UNKNOWN" in bad_log.getvalue()
+            and "attempt 6:" in bad_log.getvalue(),
+            f"a malformed report ({label}) concluded unsatisfiability or accrued the "
+            "confirming streak — the consumer allow-list is not fail-closed "
+            "(PR #3765 round 3)",
+        )
+
     print(
         "ci-summary --self-test: ALL ASSERTIONS PASSED "
         "(superseded cancellation ignored; newest failure preserved; redispatch "
         "bounded once; unsatisfiable draft-tier hold exits fast + RED while a "
         "satisfiable hold still waits; an UNKNOWN probe neither concludes nor "
-        "sustains a confirming streak)"
+        "sustains a confirming streak; a malformed report is unconstructible AND "
+        "degrades to UNKNOWN at every consumer)"
     )
     return 0
 

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1872,6 +1872,245 @@ class TestUnknownProbeIsNotConfirmedZero(unittest.TestCase):
         self.assertNotIn("2/2 confirming poll(s)", out)
 
 
+def smuggle(state, count, detail="smuggled"):
+    """[OPUS-5] PR #3765 round 3: build a MALFORMED HeadActivityReport that BYPASSES
+    `__post_init__`, so the CONSUMER-side allow-list can be exercised independently of
+    the construction-time guard. `object.__setattr__` past the frozen dataclass is the
+    same shape as the realistic bypasses (a subclass overriding `__post_init__`,
+    unpickling) — and is the only way to get such an object to the poll loop now that
+    direct construction raises. The belt-and-braces obligation is that BOTH halves
+    hold: construction raises, AND a report that got past it is still UNKNOWN."""
+    rep = g.HeadActivityReport.unknown(detail)
+    object.__setattr__(rep, "state", state)
+    object.__setattr__(rep, "count", count)
+    return rep
+
+
+class TestMalformedReportIsNeverIdle(unittest.TestCase):
+    """[OPUS-5] PR #3765 ROUND-3 finding (reproduced by the reviewer): malformed
+    HeadActivityReport instances bypassed normalisation. The poll loop's state
+    handling was a DENY-list — `if UNKNOWN / elif CONFIRMED_BUSY / else <assume
+    CONFIRMED_IDLE>` — so `HeadActivityReport("bogus", None, "malformed")` fell into
+    the idle branch, accrued the full 2/2 confirming streak and turned the gate RED as
+    proven-UNSATISFIABLE: a garbage state concluded the head was idle. Round 2's tests
+    covered bare-int and None RETURNS but not malformed report OBJECTS.
+
+    THE INVARIANT under test, both halves: only an affirmatively-CONFIRMED_IDLE report
+    whose count AGREES with that state can satisfy the exit — anything unrecognised is
+    UNKNOWN, NEVER idle — enforced at CONSTRUCTION (`__post_init__` raises) and again
+    at every CONSUMER (the affirmative `confirms_idle` branch first, everything else
+    resetting)."""
+
+    DRAFTS = TestUnsatisfiableDraftTierHold.DRAFTS
+
+    def _hold_polls(self):
+        return [list(self.DRAFTS) + [GREEN, GREEN2]]
+
+    # The four malformed shapes the reviewer named. Each is a (state, count) pair
+    # that the round-2 deny-list either read as idle or narrated incoherently.
+    MALFORMED = (
+        ("bogus-state-string", "bogus", None),
+        ("confirmed-idle-count-none", g.HeadActivity.CONFIRMED_IDLE, None),
+        ("confirmed-idle-count-nonzero", g.HeadActivity.CONFIRMED_IDLE, 7),
+        ("confirmed-busy-count-zero", g.HeadActivity.CONFIRMED_BUSY, 0),
+    )
+
+    def test_malformed_report_reaching_the_poll_loop_is_treated_as_unknown(self):
+        """THE round-3 regression. Each malformed report reaching the poll loop must
+        be UNKNOWN: never concludes UNSATISFIABLE, never accrues the confirming
+        streak, and the log says the probe is UNKNOWN. The pre-fix behaviour was
+        `2/2 confirming poll(s)` + `UNSATISFIABLE` at poll 2 for the first three."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        for label, state, count in self.MALFORMED:
+            with self.subTest(malformed=label):
+                p = probe(smuggle(state, count))
+                code, out = run(cfg, self._hold_polls(),
+                                tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                head_activity=p)
+                # Fail-closed, not fail-silent: still RED, but only at the cap via
+                # the pre-existing stale-draft-tier belt — never as a PROVEN unsat.
+                self.assertEqual(code, 1, out)
+                self.assertNotIn("UNSATISFIABLE", out)
+                self.assertNotIn("confirming poll(s)", out)   # streak never accrued
+                self.assertNotIn("CONFIRMED ZERO", out)
+                self.assertIn("probe UNKNOWN", out)
+                self.assertIn("malformed report", out)
+                # It ran the whole budget rather than shortcutting at the base one.
+                self.assertIn("attempt 3:", out)
+                self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_malformed_report_never_takes_the_base_budget_shortcut(self):
+        """The SECOND consumer (the base-budget widening at `attempt >= base_polls`)
+        must also refuse a malformed report: an unrecognised state is not a confirmed
+        idle head, so the exit is vetoed and the log must not narrate it as a live
+        head with a `None` count (the round-2 `else` assumed CONFIRMED_BUSY there)."""
+        cfg = tiny_cfg(base_polls=2, max_total_polls=4, min_polls=1)
+        for label, state, count in self.MALFORMED:
+            with self.subTest(malformed=label):
+                code, out = run(cfg, self._hold_polls(),
+                                tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                head_activity=probe(smuggle(state, count)))
+                self.assertEqual(code, 1, out)
+                self.assertNotIn("UNSATISFIABLE", out)
+                self.assertIn("probe is UNKNOWN", out)
+                self.assertNotIn("could still register", out)   # not narrated as busy
+                self.assertNotIn("None non-terminal workflow run", out)
+                self.assertIn("attempt 4:", out)
+
+    def test_malformed_report_cannot_bridge_two_confirmations(self):
+        """Consecutiveness, the finding-2 invariant, holds for THIS non-observation
+        too: [confirmed-zero, malformed, confirmed-zero] must not reach the grace,
+        while the paired [confirmed-zero, confirmed-zero] does (already pinned by
+        test_two_consecutive_confirmations_do_satisfy_the_grace)."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        for label, state, count in self.MALFORMED:
+            with self.subTest(malformed=label):
+                code, out = run(cfg, self._hold_polls(),
+                                tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                head_activity=probe(0, smuggle(state, count), 0))
+                self.assertEqual(code, 1, out)
+                self.assertIn("1/2 confirming poll(s)", out)
+                self.assertNotIn("2/2 confirming poll(s)", out)
+                self.assertNotIn("UNSATISFIABLE", out)
+
+    def test_a_malformed_report_still_pins_a_satisfiable_hold_open(self):
+        """The soundness half: a malformed report must not RED a hold that is in fact
+        SATISFIABLE. With the full-tier wave landing mid-poll the gate still PASSES —
+        the malformed probe neither concluded nor short-circuited the wait."""
+        fulls = [R(SELECT_FULL, started=f"2026-07-23T11:40:0{i}Z", rid=10 + i)
+                 for i in range(1, 5)]
+        polls = [
+            list(self.DRAFTS) + [GREEN, GREEN2],
+            list(self.DRAFTS) + [GREEN, GREEN2],
+            list(self.DRAFTS) + fulls + [GREEN, GREEN2],
+            list(self.DRAFTS) + fulls + [GREEN, GREEN2],
+            list(self.DRAFTS) + fulls + [GREEN, GREEN2],
+        ]
+        for label, state, count in self.MALFORMED:
+            with self.subTest(malformed=label):
+                code, out = run(tiny_cfg(), polls,
+                                tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                head_activity=probe(smuggle(state, count)))
+                self.assertEqual(code, 0, out)
+                self.assertIn("PASSED", out)
+                self.assertNotIn("UNSATISFIABLE", out)
+
+    def test_direct_construction_of_a_malformed_report_raises(self):
+        """The belt (the reviewer's exploit was DIRECT CONSTRUCTION): each malformed
+        (state, count) pair is rejected by `__post_init__`, so no such instance can
+        exist in the first place. The message names the violated invariant."""
+        for label, state, count in self.MALFORMED:
+            with self.subTest(malformed=label):
+                with self.assertRaises(ValueError) as ctx:
+                    g.HeadActivityReport(state, count, "malformed")
+                self.assertIn("malformed HeadActivityReport", str(ctx.exception))
+        # The reviewer's exact expression.
+        with self.assertRaises(ValueError):
+            g.HeadActivityReport("bogus", None, "malformed")
+        # Plus the remaining inconsistent pairs: UNKNOWN may not carry a count, a
+        # confirmed count may not be a bool or a non-int, and a busy count may not
+        # be negative.
+        for state, count in (
+            (g.HeadActivity.UNKNOWN, 0),
+            (g.HeadActivity.UNKNOWN, 3),
+            (g.HeadActivity.CONFIRMED_IDLE, False),
+            (g.HeadActivity.CONFIRMED_BUSY, True),
+            (g.HeadActivity.CONFIRMED_BUSY, -1),
+            (g.HeadActivity.CONFIRMED_BUSY, "2"),
+            (None, None),
+        ):
+            with self.subTest(state=state, count=count):
+                with self.assertRaises(ValueError):
+                    g.HeadActivityReport(state, count)
+
+    def test_the_well_formed_constructors_still_build_and_classify(self):
+        """The paired positive — `__post_init__` must not have broken the only two
+        sanctioned constructors, nor `normalized()` (a well-formed report is returned
+        AS-IS, identity-equal, so the accessor adds no allocation on the hot path)."""
+        idle = g.HeadActivityReport.confirmed(0)
+        self.assertTrue(idle.confirms_idle)
+        self.assertFalse(idle.confirms_busy)
+        self.assertIs(idle.normalized(), idle)
+        busy = g.HeadActivityReport.confirmed(4)
+        self.assertIs(busy.state, g.HeadActivity.CONFIRMED_BUSY)
+        self.assertFalse(busy.confirms_idle)
+        self.assertTrue(busy.confirms_busy)
+        self.assertIs(busy.normalized(), busy)
+        unk = g.HeadActivityReport.unknown("api down")
+        self.assertFalse(unk.confirms_idle)
+        self.assertFalse(unk.confirms_busy)
+        self.assertIs(unk.normalized(), unk)
+        self.assertEqual(unk.why_unknown, "api down")
+
+    def test_confirms_idle_requires_the_count_to_agree_with_the_state(self):
+        """Type-level pin on the consumer allow-list's sole predicate: `confirms_idle`
+        is not the state test alone. A smuggled CONFIRMED_IDLE whose count contradicts
+        it is NOT idle, and `normalized()` degrades it to UNKNOWN naming the
+        violation."""
+        for state, count in ((g.HeadActivity.CONFIRMED_IDLE, None),
+                             (g.HeadActivity.CONFIRMED_IDLE, 7),
+                             (g.HeadActivity.CONFIRMED_BUSY, 0),
+                             ("bogus", None)):
+            with self.subTest(state=state, count=count):
+                rep = smuggle(state, count)
+                # BOTH allow-list predicates refuse it, so the consumer branch chain
+                # confirms_idle / confirms_busy / else falls through to UNKNOWN.
+                self.assertFalse(rep.confirms_idle)
+                self.assertFalse(rep.confirms_busy)
+                norm = rep.normalized()
+                self.assertIsNot(norm, rep)
+                self.assertIs(norm.state, g.HeadActivity.UNKNOWN)
+                self.assertIsNone(norm.count)
+                self.assertFalse(norm.confirms_idle)
+                self.assertIn("malformed report", norm.detail)
+
+    def test_the_poll_loop_allow_list_is_fail_closed_without_the_accessor(self):
+        """The SECOND half of the belt-and-braces, pinned INDEPENDENTLY. The tests
+        above reach the loop through `_probe_head_activity`, which normalises — so
+        they would still pass on a loop whose own state handling was the round-2
+        DENY-list. This one patches the accessor out (the shape of a future refactor
+        that adds a probe path around it) and asserts the POLL LOOP is fail-closed on
+        its own: an unrecognised report must not accrue the streak or conclude.
+
+        Without this test the deny-list is invisible: restoring `if UNKNOWN / elif
+        CONFIRMED_BUSY / else <idle>` leaves all 162 other tests green while
+        reproducing the reviewer's exploit exactly (2/2 confirming + UNSATISFIABLE)."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        real = g._probe_head_activity
+        for label, state, count in self.MALFORMED:
+            with self.subTest(malformed=label):
+                bad = smuggle(state, count)
+                g._probe_head_activity = lambda _f, rep=bad: rep   # accessor bypassed
+                try:
+                    code, out = run(cfg, self._hold_polls(),
+                                    tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                    head_activity=lambda: bad)
+                finally:
+                    g._probe_head_activity = real
+                self.assertEqual(code, 1, out)
+                self.assertNotIn("UNSATISFIABLE", out)
+                self.assertNotIn("confirming poll(s)", out)
+                self.assertNotIn("CONFIRMED ZERO", out)
+                self.assertIn("probe UNKNOWN", out)
+                self.assertIn("attempt 3:", out)
+        # The accessor must be back exactly as it was (no leaked patch).
+        self.assertIs(g._probe_head_activity, real)
+
+    def test_the_probe_accessor_normalises_a_malformed_report(self):
+        """The single accessor is where normalisation happens, so pin it directly:
+        `_probe_head_activity` must hand back UNKNOWN for a malformed report and the
+        report ITSELF for a well-formed one."""
+        bad = smuggle(g.HeadActivity.CONFIRMED_IDLE, 7)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            got = g._probe_head_activity(lambda: bad)
+        self.assertIs(got.state, g.HeadActivity.UNKNOWN)
+        self.assertFalse(got.confirms_idle)
+        self.assertIn("malformed report", out.getvalue())
+        good = g.HeadActivityReport.confirmed(0)
+        self.assertIs(g._probe_head_activity(lambda: good), good)
+
+
 class TestMergeGroupChangeClassAccounting(unittest.TestCase):
     """[FABLE-5] merge-group change-class gate (extends #3420/#3421): the expected
     per-class leg accounting for a MERGE-GROUP sibling set. On a docs-only/

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -85,11 +85,12 @@ RED = R("clippy", conclusion="failure")
 
 def tiny_cfg(**over):
     """Small budgets so the loop phases are reachable in a handful of polls:
-    base budget = 4 polls, absolute cap = 8, settle = 2, floor = 2."""
+    base budget = 4 polls, absolute cap = 8, settle = 2, floor = 2. The #3758
+    unsatisfiable-hold grace is 2 confirming polls (prod: 9)."""
     base = dict(self_run_id="999", interval=0, min_polls=2, settle_polls=2,
                 base_polls=4, sat_interval=0, max_total_polls=8,
                 sat_queue_min=5, progress_window=2, max_consec_fetch_failures=3,
-                summary_path="")
+                summary_path="", unsat_grace_polls=2)
     base.update(over)
     return g.Config(**base)
 
@@ -112,10 +113,12 @@ def scripted(polls, repeat_last=True):
     return fetch
 
 
-def run(cfg, polls, depth=0, tier_ctx=None):
+def run(cfg, polls, depth=0, tier_ctx=None, head_activity=None):
     """Drive run_gate with scripted polls + a constant queue depth (None = the
     depth API is unavailable). Returns (exit_code, captured_output). tier_ctx
-    (default None) exercises the draft-tier integrity semantics."""
+    (default None) exercises the draft-tier integrity semantics. head_activity is
+    the #3758 per-head unsatisfiability probe: a callable, or omitted (None) for
+    "no probe wired" — which must leave every pre-#3758 path byte-identical."""
     out = io.StringIO()
     fetch = scripted(polls)
 
@@ -124,7 +127,7 @@ def run(cfg, polls, depth=0, tier_ctx=None):
 
     with redirect_stdout(out):
         code = g.run_gate(cfg, fetch, depth_fn, sleep_fn=lambda s: None,
-                          tier_ctx=tier_ctx)
+                          tier_ctx=tier_ctx, fetch_head_activity=head_activity)
     return code, out.getvalue()
 
 
@@ -1242,6 +1245,320 @@ class TestDraftTierIntegrity(unittest.TestCase):
                 url="https://github.com/o/r/actions/runs/111/job/5")
         code, out = run(tiny_cfg(), [[art, GREEN]])
         self.assertEqual(code, 0, out)
+
+
+def probe(*values):
+    """#3758 head-activity probe stub: yields values[i] on call i (an Exception
+    instance is RAISED), repeating the last one. A value is the count of
+    non-terminal workflow runs on the head SHA (0 => the awaiting_full hold can
+    never be satisfied), or None => the probe is unavailable/unknown."""
+    state = {"i": 0, "calls": 0}
+
+    def fetch():
+        state["calls"] += 1
+        value = values[min(state["i"], len(values) - 1)]
+        state["i"] += 1
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    fetch.state = state
+    return fetch
+
+
+class TestUnsatisfiableDraftTierHold(unittest.TestCase):
+    """[OPUS-5] #3758: an `awaiting_full` hold on a head whose Actions queue is
+    IDLE and whose every sibling is terminal (pending == 0) is UNSATISFIABLE — no
+    full-tier successor can ever register, so the hold pins `stable` at 0 forever
+    and (pre-fix) only the ~68-minute absolute budget exited, while a GATE re-run
+    re-derived the identical stall (PR #3470 head 552368bd, run 30002198053 x3).
+    The exit is ADDITIVE: RED (never a silent pass), naming what actually clears
+    the state; a SATISFIABLE hold still waits, and the pending>0 hang path and
+    normal green sets are untouched."""
+
+    # The live incident's shape: four draft-marked select instances (ci / bench /
+    # feature-matrix / fuzz share one select name), zero full-tier selects, every
+    # sibling terminal, PR still a draft.
+    DRAFTS = [R(SELECT_DRAFT, started=f"2026-07-23T11:24:0{i}Z", rid=i)
+              for i in range(1, 5)]
+
+    def _hold_polls(self):
+        return [list(self.DRAFTS) + [GREEN, GREEN2]]
+
+    def test_unsatisfiable_hold_with_idle_head_reds_immediately(self):
+        """Zero non-terminal workflow runs on the head for `unsat_grace_polls`
+        consecutive polls => conclude at once, with the stale-draft-tier verdict
+        and the "a gate re-run cannot clear this" remedy."""
+        p = probe(0)
+        cfg = tiny_cfg()
+        code, out = run(cfg, self._hold_polls(),
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=p)
+        self.assertEqual(code, 1, out)
+        self.assertIn("UNSATISFIABLE", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+        self.assertIn("4 draft-marked select instance(s)", out)
+        # It must NOT have burned the budget: the grace is 2 confirming polls, so
+        # the loop concludes well before the base budget (4) and absolute cap (8).
+        self.assertLessEqual(p.state["calls"], cfg.unsat_grace_polls + 1)
+        self.assertIn(f"concluding at poll {cfg.unsat_grace_polls}", out)
+        self.assertNotIn("attempt 5:", out)
+
+    def test_red_message_names_what_actually_clears_the_state(self):
+        """LOAD-BEARING for the repair lanes (they re-ran the gate 3x): the RED
+        must say a gate re-run cannot help, and name the three things that do."""
+        code, out = run(tiny_cfg(), self._hold_polls(),
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0))
+        self.assertEqual(code, 1)
+        self.assertIn("RE-RUNNING THIS `ci-summary` GATE CANNOT CLEAR THIS STATE", out)
+        self.assertIn("re-dispatch the SELECTING workflows", out)
+        self.assertIn("ready_for_review", out)
+        self.assertIn("push a new head commit", out)
+
+    def test_satisfiable_hold_still_waits_and_passes_when_the_full_select_lands(self):
+        """A QUEUED full-tier run on the head (probe > 0) means the hold CAN be
+        satisfied: the gate must keep waiting — and when the full-tier selects
+        register it still PASSES. No early RED on a live head."""
+        fulls = [R(SELECT_FULL, started=f"2026-07-23T11:40:0{i}Z", rid=10 + i)
+                 for i in range(1, 5)]
+        polls = [
+            list(self.DRAFTS) + [GREEN, GREEN2],           # hold, head busy
+            list(self.DRAFTS) + [GREEN, GREEN2],           # hold, head busy
+            list(self.DRAFTS) + [GREEN, GREEN2],           # hold, head busy
+            list(self.DRAFTS) + fulls + [GREEN, GREEN2],   # full-tier wave lands
+            list(self.DRAFTS) + fulls + [GREEN, GREEN2],
+            list(self.DRAFTS) + fulls + [GREEN, GREEN2],
+        ]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(2))
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertIn("could still register", out)
+        self.assertNotIn("UNSATISFIABLE", out)
+
+    def test_live_head_activity_vetoes_the_base_budget_shortcut(self):
+        """A probe that keeps seeing a non-terminal run on this head contradicts
+        unsatisfiability, so the base-budget shortcut must NOT fire either — the
+        gate falls back to the pre-#3758 absolute-budget bound and REDs there."""
+        code, out = run(tiny_cfg(), self._hold_polls(), depth=0,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(1))
+        self.assertEqual(code, 1)
+        self.assertNotIn("UNSATISFIABLE", out)
+        self.assertIn("attempt 8:", out)                 # rode the absolute cap
+        self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_a_queued_run_appearing_resets_the_confirming_streak(self):
+        """The probe evidence must be CONSECUTIVE: idle, then a queued run, then
+        idle again must never accumulate the 2-poll grace, so the FAST exit cannot
+        fire. (The run still ends RED via the base-budget belt on the first idle
+        poll at/after the base budget — never on the strength of non-consecutive
+        idle observations.)"""
+        code, out = run(tiny_cfg(), self._hold_polls(),
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0, 3, 0, 3, 0, 3, 0, 3))
+        self.assertEqual(code, 1)
+        self.assertIn("1/2 confirming poll(s)", out)
+        self.assertNotIn("2/2 confirming poll(s)", out)
+        self.assertNotIn("concluding at poll 2", out)   # the grace never accrued
+        self.assertIn("concluding at poll 5", out)      # base budget + the veto poll
+        self.assertIn("base poll budget was reached", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_unknown_probe_never_concludes_unsatisfiability(self):
+        """An unavailable probe (None) or one that RAISES is UNKNOWN — it can never
+        prove the hold unsatisfiable. The base-budget widening still bounds the
+        wait (idle repo queue + no progress) rather than the absolute cap."""
+        for label, p in (("none", probe(None)),
+                         ("raises", probe(RuntimeError("boom")))):
+            with self.subTest(probe=label):
+                code, out = run(tiny_cfg(), self._hold_polls(),
+                                tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                head_activity=p)
+                self.assertEqual(code, 1, out)
+                self.assertIn("probe unavailable" if label == "none"
+                              else "probe raised", out)
+                self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_no_probe_wired_still_ends_at_the_base_budget(self):
+        """(2) The widened genuine-hang condition: with NO probe at all, an
+        awaiting_full hold + pending == 0 + idle repo queue + no progress must
+        conclude at the BASE budget (poll 4 here) instead of the absolute cap
+        (poll 8) — the pre-fix behaviour burned the whole budget."""
+        code, out = run(tiny_cfg(), self._hold_polls(), depth=0,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertIn("UNSATISFIABLE", out)
+        self.assertIn("base poll budget was reached", out)
+        self.assertIn("attempt 4:", out)
+        self.assertNotIn("attempt 5:", out)
+
+    def test_repo_saturation_does_not_extend_a_zero_pending_hold(self):
+        """A DEEP repo-wide Actions queue is not evidence that THIS head's hold can
+        be satisfied — nothing of ours is pending in that queue, and a real
+        re-dispatch would show up as a queued run on the head. So the hold still
+        concludes at the base budget under saturation (contrast:
+        test_saturation_extension_then_green, where pending > 0)."""
+        code, out = run(tiny_cfg(), self._hold_polls(), depth=50,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertIn("UNSATISFIABLE", out)
+        self.assertNotIn("Extending the wait", out)
+
+    def test_live_progress_still_extends_a_zero_pending_hold(self):
+        """Progress (the completed count still rising) DOES justify extending: the
+        set is churning, so a full-tier successor may still be landing."""
+        polls = [
+            list(self.DRAFTS) + [GREEN],
+            list(self.DRAFTS) + [GREEN, GREEN2],
+            list(self.DRAFTS) + [GREEN, GREEN2, R("msrv")],
+            list(self.DRAFTS) + [GREEN, GREEN2, R("msrv"), R("docs")],
+            list(self.DRAFTS) + [GREEN, GREEN2, R("msrv"), R("docs"), R("wasm")],
+            list(self.DRAFTS) + [GREEN, GREEN2, R("msrv"), R("docs"), R("wasm"),
+                                 R("fuzz")],
+        ]
+        code, out = run(tiny_cfg(), polls, depth=0,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)              # ends RED at the absolute cap belt
+        self.assertIn("Extending the wait", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+
+    # ---- everything else must be untouched ---------------------------------
+    def test_pending_hang_path_unchanged_by_the_probe(self):
+        """(3) The pending>0 genuine-hang path keeps its own message and never
+        routes through the unsatisfiable-hold exit, even with the probe wired and
+        an awaiting_full hold up."""
+        polls = [list(self.DRAFTS) + [GREEN, PENDING]]
+        code, out = run(tiny_cfg(), polls, depth=0,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0))
+        self.assertEqual(code, 1)
+        self.assertIn("genuine hang, not a still-settling set", out)
+        self.assertNotIn("UNSATISFIABLE", out)
+
+    def test_probe_is_not_consulted_without_a_hold(self):
+        """A normal green set must be unaffected: the probe is never called (no
+        extra API traffic on the happy path) and the verdict is still PASS."""
+        p = probe(0)
+        code, out = run(tiny_cfg(), [[GREEN, GREEN2]],
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=p)
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertEqual(p.state["calls"], 0)
+
+    def test_probe_not_consulted_on_a_draft_tier_run(self):
+        """awaiting_full is a FULL-tier pull_request concept; a draft-tier run must
+        never consult the probe nor take the exit."""
+        p = probe(0)
+        code, out = run(tiny_cfg(), [[R(SELECT_DRAFT), GREEN]],
+                        tier_ctx=draft_ctx(counting(True)), head_activity=p)
+        self.assertEqual(code, 0, out)
+        self.assertIn("DRAFT-TIER verdict", out)
+        self.assertEqual(p.state["calls"], 0)
+
+    def test_failing_leg_still_fails_fast_inside_an_unsatisfiable_hold(self):
+        """The fail-fast belt keeps priority: a concluded gating FAILURE inside the
+        hold must RED with the fail-fast message, not the unsatisfiability one."""
+        polls = [list(self.DRAFTS) + [RED, GREEN]]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0))
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED (fail-fast)", out)
+
+    def test_exit_can_never_render_a_pass(self):
+        """Belt: _conclude_unsatisfiable_hold delegates to render_verdict, and if a
+        future refactor ever let that render a PASS over an unsatisfiable hold, the
+        coercion must still RED."""
+        cfg = tiny_cfg()
+        out = io.StringIO()
+        original = g.render_verdict
+        try:
+            g.render_verdict = lambda runs, path="", ctx=None: 0
+            with redirect_stdout(out):
+                code = g._conclude_unsatisfiable_hold(
+                    list(self.DRAFTS) + [GREEN], cfg,
+                    draft_ctx(counting(True), run_tier="full"),
+                    attempt=3, evidence="a synthetic pass-rendering verdict")
+        finally:
+            g.render_verdict = original
+        self.assertEqual(code, 1)
+        self.assertIn("must never render as a pass", out.getvalue())
+
+    def test_grace_default_is_a_bounded_minutes_scale_window(self):
+        """Prod knob sanity: the grace must be several polls (registration window
+        for the ready_for_review re-dispatch) but a small fraction of the absolute
+        budget that used to be the only exit."""
+        prod = g.Config()
+        self.assertGreaterEqual(prod.unsat_grace_polls, 3)
+        self.assertLess(prod.unsat_grace_polls * prod.interval, 10 * 60)
+        self.assertLess(prod.unsat_grace_polls, prod.base_polls)
+
+
+class TestHeadActivityProbeWiring(unittest.TestCase):
+    """[OPUS-5] #3758: the live probe must count only NON-TERMINAL runs on the head
+    and must exclude this gate's OWN workflow — two concurrent ci-summary runs on
+    one head must not each count the other as a candidate successor (that mutual
+    stall is the bug)."""
+
+    def _probe(self, runs, self_run_id="999"):
+        original = g.make_fetch_workflow_runs
+        try:
+            g.make_fetch_workflow_runs = lambda repo, sha, sid="": (lambda: list(runs))
+            fetch = g.make_fetch_head_activity("o/r", "deadbeef", self_run_id)
+        finally:
+            g.make_fetch_workflow_runs = original
+        with redirect_stdout(io.StringIO()):
+            return fetch()
+
+    def test_counts_only_non_terminal_foreign_runs(self):
+        self.assertEqual(
+            self._probe([
+                W(999, 1, name="ci-summary", status="in_progress", conclusion=None),
+                W(101, 2, name="CI"),                                     # completed
+                W(102, 3, name="bench", status="queued", conclusion=None),
+            ]),
+            1,
+        )
+
+    def test_own_workflow_runs_never_count(self):
+        """A SECOND ci-summary run on the same head (same workflow_id) is not a
+        candidate successor — a gate run cannot register a full-tier select."""
+        self.assertEqual(
+            self._probe([
+                W(999, 1, name="ci-summary", status="in_progress", conclusion=None),
+                W(998, 1, name="ci-summary", status="in_progress", conclusion=None),
+                W(101, 2, name="CI"),
+            ]),
+            0,
+        )
+
+    def test_all_terminal_head_is_zero(self):
+        self.assertEqual(
+            self._probe([W(999, 1, name="ci-summary", status="in_progress",
+                           conclusion=None),
+                         W(101, 2, name="CI"), W(102, 3, name="bench")]),
+            0,
+        )
+
+    def test_fetch_failure_is_unknown_not_zero(self):
+        """A failed probe must be UNKNOWN (None) — never 0, which would assert an
+        idle head and could fire the RED on no evidence."""
+        original = g.make_fetch_workflow_runs
+        try:
+            def boom(repo, sha, sid=""):
+                def fetch():
+                    raise g.FetchError("api down")
+                return fetch
+            g.make_fetch_workflow_runs = boom
+            fetch = g.make_fetch_head_activity("o/r", "deadbeef", "999")
+        finally:
+            g.make_fetch_workflow_runs = original
+        with redirect_stdout(io.StringIO()):
+            self.assertIsNone(fetch())
 
 
 class TestMergeGroupChangeClassAccounting(unittest.TestCase):

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1248,10 +1248,16 @@ class TestDraftTierIntegrity(unittest.TestCase):
 
 
 def probe(*values):
-    """#3758 head-activity probe stub: yields values[i] on call i (an Exception
-    instance is RAISED), repeating the last one. A value is the count of
-    non-terminal workflow runs on the head SHA (0 => the awaiting_full hold can
-    never be satisfied), or None => the probe is unavailable/unknown."""
+    """#3758 head-activity probe stub: yields values[i] on call i, repeating the
+    last one. A value is written in the CALLER's shorthand and translated to the
+    real three-state contract (PR #3765 finding 1):
+      * int          => HeadActivityReport.confirmed(n) — an ACTUAL observation of n
+                        non-terminal workflow runs on the head SHA (0 => the
+                        awaiting_full hold cannot be satisfied by anything running)
+      * None         => HeadActivityReport.unknown(...)  — probe unavailable
+      * Exception    => RAISED from the probe (also UNKNOWN, via run_gate's guard)
+      * a HeadActivityReport / anything else => returned verbatim, so a test can
+                        hand back a raw value the production contract forbids."""
     state = {"i": 0, "calls": 0}
 
     def fetch():
@@ -1260,6 +1266,10 @@ def probe(*values):
         state["i"] += 1
         if isinstance(value, Exception):
             raise value
+        if value is None:
+            return g.HeadActivityReport.unknown("probe unavailable (API failure)")
+        if isinstance(value, int) and not isinstance(value, bool):
+            return g.HeadActivityReport.confirmed(value)
         return value
 
     fetch.state = state
@@ -1368,9 +1378,11 @@ class TestUnsatisfiableDraftTierHold(unittest.TestCase):
         self.assertIn("stale draft-tier run, full run pending", out)
 
     def test_unknown_probe_never_concludes_unsatisfiability(self):
-        """An unavailable probe (None) or one that RAISES is UNKNOWN — it can never
-        prove the hold unsatisfiable. The base-budget widening still bounds the
-        wait (idle repo queue + no progress) rather than the absolute cap."""
+        """An unavailable probe (None) or one that RAISES is UNKNOWN — a
+        NON-observation, which can never prove the hold unsatisfiable. [PR #3765
+        finding 1] Neither exit may fire on it: the gate falls back to the
+        pre-#3758 absolute-budget bound (poll 8) and REDs there via the
+        stale-draft-tier belt, and it must never claim an idle queue it never saw."""
         for label, p in (("none", probe(None)),
                          ("raises", probe(RuntimeError("boom")))):
             with self.subTest(probe=label):
@@ -1380,32 +1392,46 @@ class TestUnsatisfiableDraftTierHold(unittest.TestCase):
                 self.assertEqual(code, 1, out)
                 self.assertIn("probe unavailable" if label == "none"
                               else "probe raised", out)
+                self.assertIn("probe is UNKNOWN", out)
                 self.assertIn("stale draft-tier run, full run pending", out)
+                # NOT concluded from a non-observation, and no idle-queue claim.
+                self.assertNotIn("UNSATISFIABLE", out)
+                self.assertNotIn("idle Actions queue", out)
+                self.assertIn("attempt 8:", out)        # rode the absolute bound
 
-    def test_no_probe_wired_still_ends_at_the_base_budget(self):
-        """(2) The widened genuine-hang condition: with NO probe at all, an
-        awaiting_full hold + pending == 0 + idle repo queue + no progress must
-        conclude at the BASE budget (poll 4 here) instead of the absolute cap
-        (poll 8) — the pre-fix behaviour burned the whole budget."""
+    def test_no_probe_wired_never_takes_the_base_budget_shortcut(self):
+        """[PR #3765 finding 1] With NO probe wired there is NO per-head evidence at
+        all, so the widened base-budget branch must not fire either: the per-head
+        probe is the authoritative satisfiability signal, and an unwired probe is
+        UNKNOWN exactly like a failed one. The wait falls back to the pre-#3758
+        absolute cap (poll 8) and still REDs there — bounded, just not "proven"."""
         code, out = run(tiny_cfg(), self._hold_polls(), depth=0,
                         tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertNotIn("UNSATISFIABLE", out)
+        self.assertIn("probe is UNKNOWN (no probe wired)", out)
+        self.assertIn("attempt 8:", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_repo_saturation_does_not_extend_a_zero_pending_hold(self):
+        """A DEEP repo-wide Actions queue is not evidence that THIS head's hold can
+        be satisfied — nothing of ours is pending in that queue, and a real
+        re-dispatch would show up as a queued run on the head. So a CONFIRMED-idle
+        head still concludes at the base budget under saturation (contrast:
+        test_saturation_extension_then_green, where pending > 0). The grace is
+        lifted above the budget here so the fast exit cannot pre-empt this path."""
+        code, out = run(tiny_cfg(unsat_grace_polls=99), self._hold_polls(), depth=50,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0))
         self.assertEqual(code, 1)
         self.assertIn("UNSATISFIABLE", out)
         self.assertIn("base poll budget was reached", out)
         self.assertIn("attempt 4:", out)
         self.assertNotIn("attempt 5:", out)
-
-    def test_repo_saturation_does_not_extend_a_zero_pending_hold(self):
-        """A DEEP repo-wide Actions queue is not evidence that THIS head's hold can
-        be satisfied — nothing of ours is pending in that queue, and a real
-        re-dispatch would show up as a queued run on the head. So the hold still
-        concludes at the base budget under saturation (contrast:
-        test_saturation_extension_then_green, where pending > 0)."""
-        code, out = run(tiny_cfg(), self._hold_polls(), depth=50,
-                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
-        self.assertEqual(code, 1)
-        self.assertIn("UNSATISFIABLE", out)
         self.assertNotIn("Extending the wait", out)
+        # The evidence must not misreport a depth-50 queue as idle (PR #3765 f1).
+        self.assertNotIn("idle Actions queue", out)
+        self.assertIn("CONFIRMED ZERO queued or in-progress workflow runs", out)
 
     def test_live_progress_still_extends_a_zero_pending_hold(self):
         """Progress (the completed count still rising) DOES justify extending: the
@@ -1515,38 +1541,37 @@ class TestHeadActivityProbeWiring(unittest.TestCase):
             return fetch()
 
     def test_counts_only_non_terminal_foreign_runs(self):
-        self.assertEqual(
-            self._probe([
-                W(999, 1, name="ci-summary", status="in_progress", conclusion=None),
-                W(101, 2, name="CI"),                                     # completed
-                W(102, 3, name="bench", status="queued", conclusion=None),
-            ]),
-            1,
-        )
+        report = self._probe([
+            W(999, 1, name="ci-summary", status="in_progress", conclusion=None),
+            W(101, 2, name="CI"),                                     # completed
+            W(102, 3, name="bench", status="queued", conclusion=None),
+        ])
+        self.assertEqual(report.state, g.HeadActivity.CONFIRMED_BUSY)
+        self.assertEqual(report.count, 1)
+        self.assertFalse(report.confirms_idle)
 
     def test_own_workflow_runs_never_count(self):
         """A SECOND ci-summary run on the same head (same workflow_id) is not a
         candidate successor — a gate run cannot register a full-tier select."""
-        self.assertEqual(
-            self._probe([
-                W(999, 1, name="ci-summary", status="in_progress", conclusion=None),
-                W(998, 1, name="ci-summary", status="in_progress", conclusion=None),
-                W(101, 2, name="CI"),
-            ]),
-            0,
-        )
+        report = self._probe([
+            W(999, 1, name="ci-summary", status="in_progress", conclusion=None),
+            W(998, 1, name="ci-summary", status="in_progress", conclusion=None),
+            W(101, 2, name="CI"),
+        ])
+        self.assertEqual(report.state, g.HeadActivity.CONFIRMED_IDLE)
+        self.assertEqual(report.count, 0)
+        self.assertTrue(report.confirms_idle)
 
     def test_all_terminal_head_is_zero(self):
-        self.assertEqual(
-            self._probe([W(999, 1, name="ci-summary", status="in_progress",
-                           conclusion=None),
-                         W(101, 2, name="CI"), W(102, 3, name="bench")]),
-            0,
-        )
+        report = self._probe([W(999, 1, name="ci-summary", status="in_progress",
+                                conclusion=None),
+                              W(101, 2, name="CI"), W(102, 3, name="bench")])
+        self.assertEqual(report.state, g.HeadActivity.CONFIRMED_IDLE)
+        self.assertTrue(report.confirms_idle)
 
     def test_fetch_failure_is_unknown_not_zero(self):
-        """A failed probe must be UNKNOWN (None) — never 0, which would assert an
-        idle head and could fire the RED on no evidence."""
+        """A failed probe must be UNKNOWN — never a zero COUNT, which would assert
+        an idle head and could fire the RED on no evidence (PR #3765 finding 1)."""
         original = g.make_fetch_workflow_runs
         try:
             def boom(repo, sha, sid=""):
@@ -1558,7 +1583,175 @@ class TestHeadActivityProbeWiring(unittest.TestCase):
         finally:
             g.make_fetch_workflow_runs = original
         with redirect_stdout(io.StringIO()):
-            self.assertIsNone(fetch())
+            report = fetch()
+        self.assertEqual(report.state, g.HeadActivity.UNKNOWN)
+        self.assertIsNone(report.count)
+        self.assertFalse(report.confirms_idle)
+        self.assertIn("api down", report.detail)
+
+
+class TestUnknownProbeIsNotConfirmedZero(unittest.TestCase):
+    """[OPUS-5] PR #3765 cross-provider review, findings 1 + 2 — one bug class: an
+    UNKNOWN probe result (absent / API failure / exception / non-report) was treated
+    as a CONFIRMED-ZERO observation of the head's Actions queue.
+
+    * FINDING 1 — the base-budget exit's veto was `head_busy` (confirmed non-zero
+      ONLY), so an UNKNOWN probe silently SATISFIED the exit condition: a transient
+      probe failure could RED a hold that was in fact SATISFIABLE, and the evidence
+      line reported "an idle Actions queue (depth=50 < 5)" for a queue of depth 50
+      it had never observed as idle.
+    * FINDING 2 — `unsat_confirms` was not reset on UNKNOWN, so [zero, unknown,
+      zero] reached a two-poll grace while claiming "2 consecutive poll(s)".
+
+    The fix makes the probe THREE-STATE (`HeadActivityReport`): only
+    `confirms_idle` is evidence; every non-observation falls through to continued
+    polling and RESETS the confirming streak."""
+
+    DRAFTS = TestUnsatisfiableDraftTierHold.DRAFTS
+    FULLS = [R(SELECT_FULL, started=f"2026-07-23T11:40:0{i}Z", rid=10 + i)
+             for i in range(1, 5)]
+
+    def _hold_polls(self):
+        return [list(self.DRAFTS) + [GREEN, GREEN2]]
+
+    # ---- finding 1 ---------------------------------------------------------
+    def test_transient_probe_failure_at_the_base_budget_does_not_red(self):
+        """THE finding-1 regression. The head really IS busy (a full-tier wave is
+        queued, so the hold is SATISFIABLE) but the probe blips at exactly the base
+        budget poll. Pre-fix the blip took the base-budget exit and RED a
+        satisfiable hold; the gate must instead keep polling — and when the
+        full-tier selects land it PASSES. depth=50 pins the misreport too: a deep
+        repo queue must never be logged as idle."""
+        polls = [
+            list(self.DRAFTS) + [GREEN, GREEN2],                   # 1  hold
+            list(self.DRAFTS) + [GREEN, GREEN2],                   # 2  hold
+            list(self.DRAFTS) + [GREEN, GREEN2],                   # 3  hold
+            list(self.DRAFTS) + [GREEN, GREEN2],                   # 4  base budget
+            list(self.DRAFTS) + self.FULLS + [GREEN, GREEN2],      # 5  wave lands
+            list(self.DRAFTS) + self.FULLS + [GREEN, GREEN2],      # 6  settles
+            list(self.DRAFTS) + self.FULLS + [GREEN, GREEN2],
+        ]
+        code, out = run(tiny_cfg(), polls, depth=50,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        # busy, busy, busy, TRANSIENT FAILURE at the base budget
+                        head_activity=probe(1, 1, 1, None, 1))
+        self.assertEqual(code, 0, out)                  # no false RED
+        self.assertIn("PASSED", out)
+        self.assertNotIn("UNSATISFIABLE", out)
+        self.assertIn("probe is UNKNOWN", out)          # honest reason logged
+        self.assertIn("attempt 5:", out)                # it kept polling
+        # ...and it never claimed the depth-50 queue was idle.
+        self.assertNotIn("idle Actions queue", out)
+        self.assertNotIn("depth=50 < 5", out)
+
+    def test_unknown_probe_at_the_base_budget_logs_probe_unknown_not_idle(self):
+        """The log-honesty half of finding 1: when the gate keeps polling because
+        the probe is UNKNOWN it must SAY so, and must not attribute the wait to a
+        throughput/saturation signal (saturation is not an extension reason for a
+        zero-pending hold at all)."""
+        code, out = run(tiny_cfg(), self._hold_polls(), depth=50,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(None))
+        self.assertEqual(code, 1)                       # still bounded: RED at cap
+        self.assertIn("probe is UNKNOWN", out)
+        self.assertIn("NOT observed", out)
+        self.assertIn("deliberately", out)              # saturation is not the reason
+        self.assertNotIn("throughput signal", out)
+        self.assertNotIn("UNSATISFIABLE", out)
+        self.assertNotIn("idle Actions queue", out)
+
+    def test_a_bare_int_return_is_unknown_not_a_confirmed_count(self):
+        """The ROOT CAUSE of finding 1 was a bare falsy return. The contract is now
+        a HeadActivityReport, and a bare `0` — the pre-fix "idle head" value — must
+        degrade to UNKNOWN rather than fire the RED."""
+        code, out = run(tiny_cfg(), self._hold_polls(),
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=lambda: 0)   # the FORBIDDEN bare-count return
+        self.assertEqual(code, 1)
+        self.assertNotIn("UNSATISFIABLE", out)
+        self.assertIn("not a HeadActivityReport", out)
+        self.assertIn("probe is UNKNOWN", out)
+        self.assertIn("attempt 8:", out)
+
+    def test_unknown_report_count_is_none_and_never_confirms_idle(self):
+        """Type-level pin: `confirms_idle` must be a STATE test, not a truthiness
+        test on the count — an UNKNOWN report's count is None, which is falsy."""
+        unknown = g.HeadActivityReport.unknown("api down")
+        self.assertIs(unknown.state, g.HeadActivity.UNKNOWN)
+        self.assertIsNone(unknown.count)
+        self.assertFalse(unknown.confirms_idle)
+        self.assertFalse(bool(unknown.count))           # the trap it replaces
+        idle = g.HeadActivityReport.confirmed(0)
+        self.assertIs(idle.state, g.HeadActivity.CONFIRMED_IDLE)
+        self.assertTrue(idle.confirms_idle)
+        busy = g.HeadActivityReport.confirmed(3)
+        self.assertIs(busy.state, g.HeadActivity.CONFIRMED_BUSY)
+        self.assertFalse(busy.confirms_idle)
+
+    # ---- finding 2 ---------------------------------------------------------
+    def test_interleaved_unknown_resets_the_confirming_streak(self):
+        """THE finding-2 regression. [confirmed-zero, UNKNOWN, confirmed-zero] must
+        never reach the two-poll grace: "N consecutive polls" is a claim about N
+        consecutive CONFIRMED observations. A probe that RAISES is handled
+        identically to one that returns unknown. The budget knobs isolate the
+        counter (base_polls above the cap), so ONLY the streak can conclude."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        for label, middle in (("none", None), ("raises", RuntimeError("boom"))):
+            with self.subTest(unknown=label):
+                code, out = run(cfg, self._hold_polls(),
+                                tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                                head_activity=probe(0, middle, 0))
+                self.assertEqual(code, 1, out)          # RED, but at the cap
+                self.assertIn("1/2 confirming poll(s)", out)
+                self.assertNotIn("2/2 confirming poll(s)", out)
+                self.assertNotIn("UNSATISFIABLE", out)
+                self.assertIn("attempt 3:", out)
+                self.assertIn("stale draft-tier run, full run pending", out)
+
+    def test_two_consecutive_confirmations_do_satisfy_the_grace(self):
+        """The paired positive — without it the test above would also pass on a
+        gate that had simply stopped concluding. Same knobs, no interleaved
+        UNKNOWN: [confirmed-zero, confirmed-zero] DOES reach the grace and REDs at
+        poll 2 naming the hold."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        code, out = run(cfg, self._hold_polls(),
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0, 0))
+        self.assertEqual(code, 1)
+        self.assertIn("2/2 confirming poll(s)", out)
+        self.assertIn("UNSATISFIABLE", out)
+        self.assertIn("concluding at poll 2", out)
+        self.assertIn("2 consecutive poll(s) CONFIRMED ZERO", out)
+        self.assertNotIn("attempt 3:", out)
+
+    def test_confirmed_busy_still_resets_the_streak(self):
+        """Unchanged by the fix (and the contrast that shows the reset is about
+        NON-observation, not just about zero-vs-nonzero): a confirmed BUSY poll
+        also breaks the streak."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        code, out = run(cfg, self._hold_polls(),
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0, 2, 0))
+        self.assertEqual(code, 1)
+        self.assertNotIn("2/2 confirming poll(s)", out)
+        self.assertNotIn("UNSATISFIABLE", out)
+
+    def test_a_skipped_poll_does_not_bridge_two_confirmations(self):
+        """Same invariant, one layer out: a poll whose check-run fetch FAILED
+        observed nothing at all (not even the hold), so it cannot sit inside a run
+        of consecutive confirmations either."""
+        cfg = tiny_cfg(base_polls=99, max_total_polls=3, min_polls=1)
+        polls = [
+            list(self.DRAFTS) + [GREEN, GREEN2],
+            g.FetchError("transient"),
+            list(self.DRAFTS) + [GREEN, GREEN2],
+        ]
+        code, out = run(cfg, polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"),
+                        head_activity=probe(0))
+        self.assertEqual(code, 1)
+        self.assertIn("check-run fetch failed", out)
+        self.assertNotIn("2/2 confirming poll(s)", out)
 
 
 class TestMergeGroupChangeClassAccounting(unittest.TestCase):


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration.

Closes #3758.

## Root cause (diagnosed live on PR #3470's head `552368bd`, run `30002198053`)

The PR was converted back to **DRAFT** mid-wave (`ready_for_review` 10:57 → full-tier wave 11:11 → **`convert_to_draft` 11:23:55** → draft-tier waves 11:24 and 11:30). Consequences, in order:

1. The draft-tier wave became the **newest run of every selecting workflow**, so the #3505 newest-run resolver correctly discarded the 11:11 full-tier selects as superseded (`ignored 297 check-run(s)` on every poll).
2. The resolved set therefore held **4 draft-marked select instances and zero unmarked ones**, and every draft-marked instance out-timestamps every full-tier select anyway — so `draft_selects_unsuperseded` (per-instance, strictly-later, deliberately fail-closed) could never find a successor.
3. Nothing could produce one: the PR stayed a draft, the head was unchanged, and the head's Actions queue was empty. **The `awaiting_full` hold was provably UNSATISFIABLE.**
4. The hold pins `stable` at `0/2` (`ci_summary_gate.py:1321`), so the clean-convergence exit was unreachable; and the sq-90cv4 genuine-hang fast-RED required `pending > 0` (`:1381`), which an all-terminal sibling set (`0 running` on **every** poll of **every** attempt) never satisfies. So the idle-queue / no-progress evidence was never consulted and the **only** exit was the absolute 155-poll budget — ~68 min of a runner slot.
5. Compounding: re-running the **gate** cannot change the head's check-run set, so the repair lane's two re-runs (attempts 2 and 3) re-derived the byte-identical stall.

## Fix — two ADDITIVE exit paths (not a rewrite)

* **Unsatisfiability probe.** While `awaiting_full` holds with `pending == 0`, the loop asks Actions how many **non-terminal workflow runs exist on this head SHA**, excluding every run of this gate's own workflow (so two concurrent `ci-summary` runs on one head cannot each count the other as a candidate — that mutual stall is part of the bug). `unsat_grace_polls` (**9**, ≈3 min) **consecutive zero** observations — a registration-grace window, since a re-dispatch appears as a `queued` run within seconds of its event — prove the hold cannot clear, and the gate REDs immediately. A probe result is **three-state** (`HeadActivityReport`: `confirmed-zero` / `confirmed-nonzero` / **`unknown`**) and only a CONFIRMED zero is evidence — a probe that is absent, fails, raises, or returns a non-report is **UNKNOWN**, which never concludes anything and **resets the confirming streak** (so "N consecutive polls" always means N consecutive *confirmed* observations).
* **Base-budget widening.** The genuine-hang branch now also fires for a zero-pending `awaiting_full` hold. In that state repo-wide runner **saturation is deliberately not an extension reason**: nothing of ours is starving in that queue, and Actions creates a `queued` run the instant its triggering event fires regardless of pool depth. Live **progress** still extends, and **anything short of a CONFIRMED-idle head vetoes both exits** — live per-head activity *and* an unknown/failed/unwired probe alike — falling back to the pre-existing absolute bound. The per-head probe, not the repo-wide depth, is the authoritative satisfiability signal here, so with no confirmed per-head observation the gate does not shortcut at all. The `pending > 0` hang path is byte-identical.

Both exits are **exit-1 only** and delegate the verdict to `render_verdict`'s stale-draft-tier belt — same message, same sibling set as budget exhaustion — with an explicit non-zero coercion so an unsatisfiable hold can **never** be reported as a silent pass.

**The RED now names what actually clears the state** (`UNSAT_HOLD_REMEDY`, emitted by *every* path that REDs on the hold, including budget exhaustion): re-running this `ci-summary` gate **cannot** help — only (1) a **full-tier re-dispatch of the selecting workflows** (ci / bench / feature-matrix / fuzz) on this head, (2) **`ready_for_review`**, or (3) a **new head commit**. Load-bearing: the repair lanes otherwise waste hours on doomed gate re-runs.

Preserved unchanged: the #3505 newest-run resolver + bounded cancelled-run redispatch (#3677), the sq-90cv4 saturation budget for pending work, fail-closed selection semantics, the fail-fast belt (which keeps priority inside the hold), the feature-matrix reporter await, and every draft-tier integrity belt.

## Tests

`scripts/tests/test_ci_summary_gate.py`: **147 green** (+25 new, three new classes). Unsatisfiable hold + idle head ⇒ immediate RED naming the hold and the remedy; satisfiable hold (queued full-tier run) still waits **and still passes** when the four full-tier selects land; non-consecutive idle evidence never accrues the grace; unknown/raising probe never concludes; no-probe-wired still ends at the base budget; saturation does not extend a zero-pending hold while progress and per-head activity do; `pending > 0` hang path, normal green sets, draft-tier runs and fail-fast all unchanged; the probe is never even called without a hold. The live probe's counting / self-workflow exclusion / fetch-failure-is-UNKNOWN semantics are pinned. The review round adds `TestUnknownProbeIsNotConfirmedZero`: a transient probe failure at the base budget with a live head does **not** RED and still PASSES when the wave lands; interleaved `[zero, unknown, zero]` never reaches the two-poll grace while `[zero, zero]` does; a raising probe behaves identically to an unknown one; a bare-int return degrades to UNKNOWN; a check-run-fetch-failure poll cannot bridge two confirmations; and the log never claims an idle queue it did not observe. `python3 scripts/ci_summary_gate.py --self-test` gains the same fast-RED + satisfiable-hold-waits pair (both are HARD CI steps).

`scripts/tests/test_ci_select_wiring.py`: 66 green (unchanged pins).

**Mutation check:** snapshot → invert the new exit comparison (`>= cfg.unsat_grace_polls` → `<`) → suite RED on two independent assertions (`concluding at poll N` and the probe-call bound) → `cp`-restore → `cmp`-verified byte-identical → suite + `--self-test` green again.

## Cross-provider review round (2 findings, both fixed — `ea6981a5`)

Both findings were the same bug class: the probe returned `int | None` and the call sites
branched on **truthiness**, so an UNKNOWN result took the same branch as a CONFIRMED ZERO.

* **Finding 1 (base-budget exit conflated unknown with confirmed-zero) — FIXED.** The veto was
  `head_busy` (confirmed *non-zero* only), so an UNKNOWN probe silently satisfied the exit
  condition: a transient probe failure could RED a **satisfiable** hold, and the evidence line
  misreported it (`"an idle Actions queue (depth=50 < 5)"` for a queue of depth 50). Only a
  CONFIRMED-idle head may now take the exit; UNKNOWN falls through to continued polling (the
  pre-#3758 conservative bound) and the log says **"the head-activity probe is UNKNOWN … this
  head's Actions queue was NOT observed"** instead of claiming an idle queue. The conclude-
  evidence now cites the per-head confirmation and labels the repo-wide depth explicitly as
  *deliberately not an extension reason* rather than asserting it is idle.
* **Finding 2 (`unsat_confirms` not reset on unknown/raise) — FIXED.** Any **non-observation**
  now resets the counter — an UNKNOWN/raising probe, and also a poll that never reached the
  probe at all (check-run fetch failure, fail-fast grace re-poll) — so consecutiveness means
  consecutive *confirmed* observations, exactly as the RED claims.
* **Root-cause hardening.** The probe's return type is now explicit about all three states
  (`HeadActivity` enum + frozen `HeadActivityReport`, built through `confirmed()` / `unknown()`),
  and the sole exit predicate is `confirms_idle` — a **state** test, deliberately not
  `not count`, because an UNKNOWN report's `count` is `None` (falsy). `_probe_head_activity`
  normalises all four non-observations, including a bare-count return from a future refactor.

**Reviewer confirmations preserved (re-verified after the fix):** the exit still **cannot
PASS** (exit-1-only, delegated to `render_verdict` with the non-zero coercion belt); #3505
newest-run resolution, fail-closed selection semantics, the sq-90cv4 saturation bounds for
`pending > 0` (byte-identical predicate: `progressing or saturated`) and #3677 once-only
cancelled-run redispatch all remain intact.

**Mutation check (this round):** snapshot → (a) drop the finding-2 counter reset ⇒ the
interleaved-unknown test (both sub-cases) **and** `--self-test` go RED; (b) restore the
finding-1 `head_busy` veto ⇒ **6** tests + `--self-test` go RED → `cp`-restore, `cmp`-verified
byte-identical after each, suite + `--self-test` green again.

No workflow change is required (the probe is wired from the existing `REPO`/`SHA`/`SELF_RUN_ID` env). `docs/branch-protection.md` §Draft-tier CI gains **rule 7** recording the exit and the remedy.

