### PR TITLE
fix(ci): re-arm sweeper fails loudly once on missing arm capability + per-PR failures no longer abort the sweep (#3760)

### DIFF
--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -9,7 +9,12 @@ on:
     - cron: "4,14,24,34,44,54 * * * *"
   workflow_dispatch:
 
-# Enabling auto-merge needs only repository contents + pull-request write access.
+# Enabling auto-merge needs repository contents + pull-request WRITE access. Both are
+# load-bearing: enablePullRequestAutoMerge is a repository write operation, so demoting
+# `contents` to `read` makes every arm fail with "Resource not accessible by integration
+# (enablePullRequestAutoMerge)" — the #3760 outage, which the re-arm sweeper hit with
+# exactly that misconfiguration while THIS workflow armed fine (runs 30033315483 vs
+# 30027010495). Pinned by scripts/tests/test_arm_capability_wiring.py.
 permissions:
   contents: write
   pull-requests: write
@@ -47,6 +52,23 @@ jobs:
           python3 scripts/gh_retry.py --self-test
           python3 scripts/auto-arm.py --self-test
 
+      # [OPUS-5] #3760 — fail loud ONCE at the start when the token provably cannot arm,
+      # instead of a per-PR failure on every label event. Must use the same GH_TOKEN
+      # expression as the arm step below (pinned by the wiring test).
+      - name: Probe arm capability (one loud error, never per-PR)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: >-
+          python3 scripts/auto-arm.py
+          --repo "$REPO"
+          --default-branch "$DEFAULT_BRANCH"
+          --probe-arm-capability
+
+      # A per-PR arm failure no longer re-raises out of the sweep (pre-#3760 it did, so a
+      # single failing PR stopped every later candidate from ever being armed). Failures
+      # are collected, summarised, and the run exits non-zero.
       - name: Arm eligible PRs
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -719,6 +719,11 @@ jobs:
       #   * rearm-sweeper.py --self-test / auto-arm.py --self-test — probe verdicts
       #     (can-arm / cannot-arm / inconclusive), per-PR failure collection + continue,
       #     one-::error-per-run, and the exit semantics (an arm failure never exits 0).
+      #     [OPUS-5] #3766 adds the STICKY-FAILURE PRECEDENCE sequences —
+      #     `collected-failure > transient-exhaustion > clean` — because collecting the
+      #     failures was only half the job: the collected state lived in a LOCAL, so a
+      #     LATER candidate's exhausted transient unwound past the accumulated-failure
+      #     check and reported ::warning + exit 0, discarding a real arm failure.
       #   * test_arm_capability_wiring.py — cross-file pins: `contents: write` +
       #     `pull-requests: write` on both workflows (a downgrade reproduces #3760 and is
       #     invisible in a python-only diff), the probe step present and BEFORE the arm step

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -709,6 +709,28 @@ jobs:
         run: python3 scripts/check-fast-fix-ring-guard.py --self-test
       - name: "Enforce the fast-fix ring fail-closed cross-repo guard (#3475) — GATING"
         run: python3 scripts/check-fast-fix-ring-guard.py
+      # [OPUS-5] sparq-org/sparq#3760 — THE ARM PATH. The re-arm sweeper spent days unable
+      # to enable auto-merge at all ("Resource not accessible by integration
+      # (enablePullRequestAutoMerge)") because its job declared `contents: read` while the
+      # operation needs repository WRITE. Both arm policies now (a) probe their token's arm
+      # capability at job start and fail with ONE actionable ::error, and (b) collect per-PR
+      # arm failures instead of aborting the sweep. Their own self-tests only ran inside the
+      # scheduled arm workflows, i.e. never on the PR that broke them — so they gate HERE:
+      #   * rearm-sweeper.py --self-test / auto-arm.py --self-test — probe verdicts
+      #     (can-arm / cannot-arm / inconclusive), per-PR failure collection + continue,
+      #     one-::error-per-run, and the exit semantics (an arm failure never exits 0).
+      #   * test_arm_capability_wiring.py — cross-file pins: `contents: write` +
+      #     `pull-requests: write` on both workflows (a downgrade reproduces #3760 and is
+      #     invisible in a python-only diff), the probe step present and BEFORE the arm step
+      #     with a byte-identical GH_TOKEN expression, the remediation naming every
+      #     flippable lever, and no drift between the two deliberately duplicated copies.
+      # The wiring test needs PyYAML — installed once in the shared setup above.
+      - name: Self-test the re-arm sweeper policy (arm capability + failure isolation — #3760)
+        run: python3 scripts/rearm-sweeper.py --self-test
+      - name: Self-test the auto-arm policy (arm capability + failure isolation — #3760)
+        run: python3 scripts/auto-arm.py --self-test
+      - name: "Arm-path wiring inspection (contents: write + probe-before-arm — #3760)"
+        run: python3 scripts/tests/test_arm_capability_wiring.py
 
   # ----------------------------- ADVISORY -----------------------------
   # [FABLE-5] sq-6vshe.20: the three former advisory jobs as step-groups on ONE

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -12,13 +12,24 @@ on:
     - cron: "8,18,28,38,48,58 * * * *"
   workflow_dispatch:
 
-# Arming auto-merge needs push authority AND the merge must fire downstream push
-# workflows (flow-on autoclose) — a GITHUB_TOKEN-enabled arm risks the recursion
-# guard suppressing them. Arm with the sparq-orchestrator App token (the same
-# identity batch-merge.yml uses); fall back to the workflow token only when the
-# App is not configured, in which case failed arms surface loudly as errors.
+# [OPUS-5] #3760 — `contents: write` IS THE FIX, and it is load-bearing.
+#
+# Enabling auto-merge is a repository WRITE operation. With `contents: read` this job's
+# token is denied with
+#     GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)
+# which is exactly what run 30033315483 (2026-07-23T18:21Z) hit on PR #3454 — OPEN,
+# non-draft, CLEAN, review:pass. auto-arm.yml armed two PRs 90 minutes earlier
+# (run 30027010495, 16:52Z) on the SAME repository with the SAME plain GITHUB_TOKEN; its
+# only difference was `contents: write`. This is NOT a maintainer-only setting:
+# `allow_auto_merge` is already true and the `main` ruleset carries no integration
+# restriction. Do not downgrade this back to `contents: read` — the wiring pin in
+# scripts/tests/test_arm_capability_wiring.py reds if anyone does.
+#
+# The App token is still PREFERRED when configured (same identity batch-merge.yml uses,
+# so a merge it triggers is attributed to the App rather than github-actions[bot]); the
+# workflow token is the fallback and, with write, is sufficient to arm.
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 concurrency:
@@ -64,6 +75,26 @@ jobs:
           python3 scripts/gh_retry.py --self-test
           python3 scripts/rearm-sweeper.py --self-test
 
+      # [OPUS-5] #3760 — FAIL LOUD ONCE, AT THE START. Before this step existed, a token
+      # that could not arm produced one per-PR SKIP line every ten minutes and nothing
+      # else; the arm gap was only noticed by hand. This probe reds the job in seconds
+      # with a single ::error naming the exact permission/setting/secret to change. It
+      # MUST consume the same GH_TOKEN expression as the sweep step below, or it would
+      # attest a token the sweep does not use (pinned by the wiring test).
+      - name: Probe arm capability (one loud error, never per-PR)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: >-
+          python3 scripts/rearm-sweeper.py
+          --repo "$REPO"
+          --default-branch "$DEFAULT_BRANCH"
+          --probe-arm-capability
+
+      # A per-PR arm failure no longer aborts the sweep: failures are collected, every
+      # remaining candidate is still considered, the run summarises them, and it exits
+      # non-zero so a failed arm can never read as a green run.
       - name: Re-arm dropped reviewed PRs
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}

--- a/scripts/auto-arm.py
+++ b/scripts/auto-arm.py
@@ -13,6 +13,15 @@ to GitHub's explicit ``enablePullRequestAutoMerge`` GraphQL mutation.
 # transient 5xx survives every bounded retry, the sweep exits ::warning + 0 instead of
 # redding main's gate — a missed cycle is harmless, the cron covers it. Any
 # non-transient error still fails loudly (GhFatalError -> GhError -> traceback).
+# [OPUS-5] Issue #3760 — a startup arm-capability probe that fails LOUDLY ONCE, and per-PR
+#   arm failures that are COLLECTED instead of aborting every later candidate. Before this
+#   change a single failing mutation re-raised out of process() -> run() -> run_sweep(), so
+#   every PR after it was never even considered. #3759 finding 5's invariant is preserved
+#   and strengthened, not weakened: a failed arm still can NEVER read as success — it now
+#   exits non-zero via ArmOutcome.exit_code instead of by unwinding the sweep. Kept
+#   deliberately self-contained (auto-arm.yml sparse-checks out only this file, so it
+#   cannot import shared helpers); scripts/tests/test_arm_capability_wiring.py pins the
+#   load-bearing strings against scripts/rearm-sweeper.py so the copies cannot drift.
 
 from __future__ import annotations
 
@@ -21,12 +30,13 @@ import copy
 import json
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
 import gh_retry
 
 
+PROGRAM = "auto-arm"
 REVIEW_LABEL = "review:pass"
 HUMAN_OR_TRUST_LABELS = frozenset(
     {
@@ -55,6 +65,100 @@ ENABLE_AUTO_MERGE = """mutation($id:ID!,$oid:GitObjectID!){
     pullRequest{number headRefOid autoMergeRequest{enabledAt}}
   }
 }"""
+
+# --------------------------------------------------------------------------------------
+# [OPUS-5] #3760 — ARM CAPABILITY. See scripts/rearm-sweeper.py for the full measured
+# rationale. Short version: enabling auto-merge is a repository WRITE operation, so a job
+# whose `permissions:` block says `contents: read` is denied with
+# "Resource not accessible by integration (enablePullRequestAutoMerge)" — proven live by
+# sweeper run 30033315483 (contents: read, denied) vs this workflow's run 30027010495
+# (contents: write, armed two PRs with the same plain GITHUB_TOKEN 90 minutes earlier).
+# Repository.viewerPermission is null for App tokens and PullRequest.viewerCanEnableAutoMerge
+# is false for already-armed/queued/draft PRs even under ADMIN, so neither is a capability
+# signal; autoMergeAllowed is, and the mutation's own denial is the backstop.
+CAPABILITY_QUERY = """query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    autoMergeAllowed
+    viewerPermission
+  }
+  viewer{login}
+}"""
+
+# Deliberately disjoint from #3759's TRANSIENT set: a capability denial is permanent and
+# must never be swallowed by the lenient ::warning + exit-0 sweep policy.
+ARM_DENIAL_MARKERS = (
+    "resource not accessible by integration",
+    "must have write access",
+    "must have admin access",
+    "not authorized to enable auto-merge",
+    "auto merge is not allowed for this repository",
+    "auto-merge is not allowed for this repository",
+)
+
+ARM_REMEDIATION = (
+    "the arm token cannot call enablePullRequestAutoMerge. Fix in this order: "
+    "(1) .github/workflows/auto-arm.yml MUST declare `permissions:` with BOTH "
+    "`contents: write` and `pull-requests: write` — enabling auto-merge is a repository "
+    "WRITE operation and `contents: read` is denied with exactly this error (live proof: "
+    "sweeper run 30033315483 failed with contents: read while auto-arm run 30027010495 "
+    "armed successfully with contents: write on the same repo and the same GITHUB_TOKEN "
+    "90 minutes earlier); "
+    "(2) repository Settings -> General -> Pull Requests -> 'Allow auto-merge' must be ON "
+    "(GraphQL Repository.autoMergeAllowed must be true); "
+    "(3) if the repository's `main` ruleset gains a restriction on which integrations may "
+    "write, github-actions[bot] must be allowed or an App token used instead; "
+    "(4) the App path needs the repository/organization secrets ORCHESTRATOR_APP_ID and "
+    "ORCHESTRATOR_APP_PRIVATE_KEY (both are currently UNSET); "
+    "(5) on a `pull_request` event raised from a FORK, GITHUB_TOKEN is read-only no matter "
+    "what the permissions block says — such a PR can only be armed by the scheduled run."
+)
+
+CAN_ARM = "can-arm"
+CANNOT_ARM = "cannot-arm"
+INCONCLUSIVE = "inconclusive"
+
+# process() verdicts.
+ARMED = "armed"
+SKIPPED = "skipped"
+FAILED = "failed"
+
+
+def is_arm_denial(text: str) -> bool:
+    """True when a failure text is a token-capability denial, not a per-PR condition."""
+    lowered = str(text).lower()
+    return any(marker in lowered for marker in ARM_DENIAL_MARKERS)
+
+
+@dataclass(frozen=True)
+class CapabilityVerdict:
+    status: str
+    detail: str
+
+    @property
+    def blocks_sweep(self) -> bool:
+        """Only a decisive cannot-arm blocks; inconclusive must never red the run."""
+        return self.status == CANNOT_ARM
+
+
+@dataclass
+class ArmOutcome:
+    considered: int = 0
+    armed: int = 0
+    arm_failures: list[tuple[int, str]] = field(default_factory=list)
+    capability: str = INCONCLUSIVE
+
+    @property
+    def capability_failed(self) -> bool:
+        return self.capability == CANNOT_ARM
+
+    @property
+    def exit_code(self) -> int:
+        """Never exit 0 while an arm failed — a silent 0 is how #3760 hid for days.
+
+        This is how #3759 finding 5's invariant survives the #3760 refactor: the failed
+        arm no longer unwinds the sweep, so it must be the run's EXIT STATUS instead.
+        """
+        return 1 if self.capability_failed or self.arm_failures else 0
 
 
 class GhError(RuntimeError):
@@ -133,6 +237,13 @@ class AutoArmer:
         # (pr ready, the arm CAS) always use the one-shot `gh` runner above.
         self.gh_read = gh_read if gh_read is not None else gh
         self.log = log
+        # [OPUS-5] #3760 latches: the fleet must see exactly ONE ::error per run, never
+        # one per PR, and arming must stop once the token is known to be unable to arm.
+        self.capability_error_emitted = False
+        self.capability_lost = False
+        owner, _, name = repo.partition("/")
+        self.owner = owner
+        self.name = name
 
     def list_open(self) -> list[PullRequest]:
         raw = json.loads(
@@ -228,41 +339,140 @@ class AutoArmer:
             return f"head-moved ({attempted.head_oid[:12]} -> {current.head_oid[:12]})"
         return None
 
-    def process(self, initial: PullRequest) -> None:
+    def probe_arm_capability(self) -> CapabilityVerdict:
+        """Read-only startup probe: can this token arm at all in this repository?
+
+        Decisive only where it can read decisively; anything else is INCONCLUSIVE and must
+        never red the run (the mutation's own denial is the backstop). An exhausted #3759
+        transient is inconclusive too — the sweep's retrying reads stay the authority on
+        whether this cycle can proceed at all.
+        """
+        try:
+            raw = self.gh_read(
+                [
+                    "api",
+                    "graphql",
+                    "-f",
+                    f"query={CAPABILITY_QUERY}",
+                    "-f",
+                    f"owner={self.owner}",
+                    "-f",
+                    f"name={self.name}",
+                ]
+            )
+        except gh_retry.GhTransientExhausted as error:
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query exhausted transient retries ({error})"
+            )
+        except GhError as error:
+            if is_arm_denial(str(error)):
+                return CapabilityVerdict(
+                    CANNOT_ARM, f"the arm token was denied by GitHub ({error})"
+                )
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query failed, assuming armable ({error})"
+            )
+        try:
+            response = json.loads(raw)
+        except json.JSONDecodeError as error:
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query returned non-JSON ({error})"
+            )
+        if response.get("errors"):
+            detail = json.dumps(response["errors"], sort_keys=True)
+            if is_arm_denial(detail):
+                return CapabilityVerdict(
+                    CANNOT_ARM, f"the arm token was denied by GitHub ({detail})"
+                )
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query returned errors ({detail})"
+            )
+        data = response.get("data") or {}
+        repository = data.get("repository")
+        if not isinstance(repository, dict):
+            return CapabilityVerdict(
+                INCONCLUSIVE, "capability query returned no repository node"
+            )
+        # Diagnostics only — null for App tokens, so it can never be a gate.
+        login = str((data.get("viewer") or {}).get("login") or "unknown")
+        permission = repository.get("viewerPermission")
+        allowed = repository.get("autoMergeAllowed")
+        if allowed is False:
+            return CapabilityVerdict(
+                CANNOT_ARM,
+                "repository setting 'Allow auto-merge' is OFF "
+                "(GraphQL Repository.autoMergeAllowed=false)",
+            )
+        if allowed is not True:
+            return CapabilityVerdict(
+                INCONCLUSIVE,
+                f"autoMergeAllowed not reported (token={login}, "
+                f"viewerPermission={permission})",
+            )
+        return CapabilityVerdict(
+            CAN_ARM,
+            f"autoMergeAllowed=true (token={login}, viewerPermission={permission}); "
+            "write scope is confirmed by the first arm",
+        )
+
+    def fail_capability(self, detail: str) -> None:
+        """Emit the single ::error for this run and stop attempting further arms."""
+        self.capability_lost = True
+        if self.capability_error_emitted:
+            return
+        self.capability_error_emitted = True
+        self.log(
+            f"::error title={PROGRAM} cannot enable auto-merge::{detail} — "
+            f"{ARM_REMEDIATION}"
+        )
+
+    def process(self, initial: PullRequest) -> tuple[str, str | None]:
         reason = self.skip_reason(initial)
         if reason:
             self.log(f"PR #{initial.number}: skipped {reason}")
-            return
+            return SKIPPED, None
 
         if initial.is_draft and not self.mark_ready(initial):
-            return
+            return SKIPPED, None
 
         try:
             current = self.refresh(initial.number)
         except GhError as error:
             self.log(f"PR #{initial.number}: skipped state-refresh-failed ({error})")
-            return
+            return SKIPPED, None
 
         reason = self.skip_reason(current)
         if reason:
             self.log(f"PR #{initial.number}: skipped {reason}")
-            return
+            return SKIPPED, None
         if current.is_draft:
             self.log(f"PR #{initial.number}: skipped draft")
-            return
+            return SKIPPED, None
         if not current.node_id or not current.head_oid:
             self.log(f"PR #{initial.number}: skipped incomplete-live-state")
-            return
+            return SKIPPED, None
         if current.head_oid != initial.head_oid:
             self.log(
                 f"PR #{initial.number}: skipped head-moved "
                 f"({initial.head_oid[:12]} -> {current.head_oid[:12]})"
             )
-            return
+            return SKIPPED, None
 
         try:
             self.arm(current)
         except GhError as mutation_error:
+            message = str(mutation_error)
+            # [OPUS-5] #3760: a capability denial is NOT a per-PR condition — every
+            # remaining candidate would fail identically. Record it, stop arming, and
+            # surface exactly ONE ::error naming what to change.
+            if is_arm_denial(message):
+                self.log(
+                    f"PR #{initial.number}: arm-failed arm capability denied ({message})"
+                )
+                self.fail_capability(
+                    f"arming PR #{initial.number} was denied: {message}"
+                )
+                return FAILED, f"arm capability denied ({message})"
             # The arm mutation FAILED — this error is the primary run status and must
             # survive whatever the follow-up diagnostic read does. The diagnostic
             # read (classify_mutation_race -> refresh) is itself retriable, so it can
@@ -270,25 +480,69 @@ class AutoArmer:
             # retries we must NOT let that exhaustion propagate, or run_sweep's
             # lenient GhTransientExhausted handler would convert a genuine arm failure
             # into a false success (::warning + exit 0). Suppress the diagnostic's own
-            # failure and re-raise the ORIGINAL mutation error. (#3759 finding 5.)
+            # failure and keep the ORIGINAL mutation error as this PR's verdict.
+            # (#3759 finding 5 — its invariant now shows up as a non-zero EXIT rather
+            # than as an exception unwinding the whole sweep, per #3760.)
             try:
                 race = self.classify_mutation_race(current)
             except (GhError, gh_retry.GhTransientExhausted) as diag_error:
                 self.log(
-                    f"PR #{initial.number}: arm failed and the race diagnostic could "
-                    f"not resolve ({diag_error}); propagating the original arm error."
+                    f"PR #{initial.number}: arm-failed and the race diagnostic could "
+                    f"not resolve ({diag_error}); the original arm error stands ({message})"
                 )
-                raise mutation_error from mutation_error
+                return FAILED, message
             if race:
                 self.log(f"PR #{initial.number}: skipped {race}")
-                return
-            raise mutation_error
+                return SKIPPED, None
+            # Collect and CONTINUE — before #3760 this re-raised, so ONE bad PR stopped
+            # every later candidate from ever being armed.
+            self.log(f"PR #{initial.number}: arm-failed ({message})")
+            return FAILED, message
         self.log(f"PR #{initial.number}: armed head {current.head_oid[:12]}")
+        return ARMED, None
 
-    def run(self) -> None:
+    def run(self) -> ArmOutcome:
+        outcome = ArmOutcome()
+        verdict = self.probe_arm_capability()
+        outcome.capability = verdict.status
+        self.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
+        if verdict.blocks_sweep:
+            # Fail ONCE, before touching any PR: a broken token would otherwise fail
+            # identically on every candidate, on every label event, forever. This is not
+            # a transient, so it never reaches the #3759 ::warning + exit-0 path.
+            self.fail_capability(f"startup arm-capability probe failed: {verdict.detail}")
+            self.log(
+                f"[{PROGRAM}] complete: considered=0 armed=0 arm-failures=0 "
+                f"capability={verdict.status}"
+            )
+            return outcome
+
         for pr in self.list_open():
-            if REVIEW_LABEL in pr.labels:
-                self.process(pr)
+            if REVIEW_LABEL not in pr.labels:
+                continue
+            outcome.considered += 1
+            if self.capability_lost:
+                self.log(
+                    f"PR #{pr.number}: skipped arm capability lost this run "
+                    "(see the single ::error above)"
+                )
+                continue
+            status, failure = self.process(pr)
+            if status == ARMED:
+                outcome.armed += 1
+            elif status == FAILED:
+                outcome.arm_failures.append((pr.number, failure or "unknown"))
+                if self.capability_lost:
+                    outcome.capability = CANNOT_ARM
+
+        for number, reason in outcome.arm_failures:
+            self.log(f"[{PROGRAM}] arm-failure summary: PR #{number} — {reason}")
+        self.log(
+            f"[{PROGRAM}] complete: considered={outcome.considered} "
+            f"armed={outcome.armed} arm-failures={len(outcome.arm_failures)} "
+            f"capability={outcome.capability}"
+        )
+        return outcome
 
 
 def run_sweep(
@@ -305,12 +559,15 @@ def run_sweep(
     transient (or any other failure) exits NON-zero so the arm attempt is visibly red
     and gets retried. Only the periodic sweep may swallow a transient.
 
-    A failed arm MUTATION always propagates as ``GhError`` in either mode (the
-    diagnostic read's own exhaustion can never overwrite it — see ``process``)."""
+    A failed arm MUTATION always reds the run in either mode (the diagnostic read's own
+    exhaustion can never overwrite it — see ``process``). Since #3760 it no longer does so
+    by unwinding the sweep: it is COLLECTED so every later candidate is still considered,
+    and it surfaces as ``ArmOutcome.exit_code == 1``. A provable arm-capability failure is
+    likewise never a transient — it reds both modes with one ``::error``."""
     if mode not in ("sweep", "event"):
         raise ValueError(f"mode must be 'sweep' or 'event', got {mode!r}")
     try:
-        armer.run()
+        return armer.run().exit_code
     except gh_retry.GhTransientExhausted as error:
         if mode == "event":
             # Event-driven arm: no per-PR cron backstop — fail loudly so it is retried.
@@ -349,44 +606,112 @@ def fixture(
     }
 
 
+CAPABILITY_RESPONSE = {
+    "data": {
+        "repository": {"autoMergeAllowed": True, "viewerPermission": None},
+        "viewer": {"login": "github-actions[bot]"},
+    }
+}
+# The exact text GitHub returned in run 30033315483 — the #3760 regression anchor.
+DENIAL_TEXT = (
+    "gh api graphql failed: GraphQL: Resource not accessible by integration "
+    "(enablePullRequestAutoMerge)"
+)
+
+
+def capability_payload(auto_merge_allowed: bool | None) -> str:
+    payload = copy.deepcopy(CAPABILITY_RESPONSE)
+    payload["data"]["repository"]["autoMergeAllowed"] = auto_merge_allowed
+    return json.dumps(payload)
+
+
+def is_capability_query(argv: list[str]) -> bool:
+    return argv[:2] == ["api", "graphql"] and any(
+        "autoMergeAllowed" in arg for arg in argv
+    )
+
+
 class FakeGh:
     def __init__(
         self,
-        initial: dict,
+        initial: dict | list[dict],
         *,
         views: list[dict] | None = None,
         mutation_error: bool = False,
+        mutation_errors: dict[int, str] | None = None,
+        auto_merge_allowed: bool | None = True,
+        capability_error: str | None = None,
     ) -> None:
-        self.initial = copy.deepcopy(initial)
-        self.views = [copy.deepcopy(view) for view in (views or [initial])]
+        listing = initial if isinstance(initial, list) else [initial]
+        self.listing = [copy.deepcopy(item) for item in listing]
+        self.initial = self.listing[0] if self.listing else {}
+        self.views = [copy.deepcopy(view) for view in (views or self.listing)]
         self.mutation_error = mutation_error
+        self.mutation_errors = dict(mutation_errors or {})
+        self.auto_merge_allowed = auto_merge_allowed
+        self.capability_error = capability_error
         self.calls: list[list[str]] = []
 
     def __call__(self, argv: list[str]) -> str:
         self.calls.append(argv)
         if argv[:2] == ["pr", "list"]:
-            return json.dumps([self.initial])
+            return json.dumps(self.listing)
         if argv[:2] == ["pr", "ready"]:
             return ""
         if argv[:2] == ["pr", "view"]:
-            view = self.views.pop(0) if len(self.views) > 1 else self.views[0]
-            return json.dumps(view)
+            return json.dumps(self._view(int(argv[2])))
+        if is_capability_query(argv):
+            if self.capability_error is not None:
+                raise GhError(self.capability_error)
+            return capability_payload(self.auto_merge_allowed)
         if argv[:2] == ["api", "graphql"]:
             if self.mutation_error:
                 raise GhError("simulated expectedHeadOid CAS rejection")
+            node = next(arg for arg in argv if arg.startswith("id="))
+            failure = next(
+                (
+                    text
+                    for number, text in self.mutation_errors.items()
+                    if node.endswith(str(number))
+                ),
+                None,
+            )
+            if failure is not None:
+                raise GhError(failure)
             return json.dumps({"data": {"enablePullRequestAutoMerge": {}}})
         raise AssertionError(f"unexpected fake gh call: {argv}")
 
+    def _view(self, number: int) -> dict:
+        """Successive views for one PR are consumed in order; the last one sticks."""
+        matching = [view for view in self.views if int(view["number"]) == number]
+        if len(matching) > 1:
+            self.views.remove(matching[0])
+            return matching[0]
+        if matching:
+            return matching[0]
+        return self.views.pop(0) if len(self.views) > 1 else self.views[0]
 
-def exercise(initial: dict, **fake_kwargs) -> tuple[FakeGh, list[str]]:
+
+def exercise(
+    initial: dict | list[dict], **fake_kwargs
+) -> tuple[FakeGh, list[str], ArmOutcome]:
     fake = FakeGh(initial, **fake_kwargs)
     messages: list[str] = []
-    AutoArmer("sparq-org/sparq", "main", fake, messages.append).run()
-    return fake, messages
+    outcome = AutoArmer("sparq-org/sparq", "main", fake, messages.append).run()
+    return fake, messages, outcome
 
 
 def graphql_calls(fake: FakeGh) -> list[list[str]]:
-    return [call for call in fake.calls if call[:2] == ["api", "graphql"]]
+    """Only the ARM mutations — never the read-only capability probe."""
+    return [
+        call
+        for call in fake.calls
+        if call[:2] == ["api", "graphql"] and not is_capability_query(call)
+    ]
+
+
+def probe_query_calls(fake: FakeGh) -> list[list[str]]:
+    return [call for call in fake.calls if is_capability_query(call)]
 
 
 def self_test() -> None:
@@ -403,7 +728,7 @@ def self_test() -> None:
     # Reviewed, live, non-draft: arm once with the explicit method and head-OID CAS.
     clean = fixture()
     assert parse_pr(clean).merge_state == "CLEAN", clean
-    fake, messages = exercise(clean)
+    fake, messages, outcome = exercise(clean)
     mutations = graphql_calls(fake)
     assert len(mutations) == 1, mutations
     mutation = mutations[0]
@@ -414,7 +739,7 @@ def self_test() -> None:
 
     # Every named human/trust area is fail-closed before any mutation.
     for label in sorted(expected_guards):
-        fake, messages = exercise(fixture(labels=(REVIEW_LABEL, label)))
+        fake, messages, outcome = exercise(fixture(labels=(REVIEW_LABEL, label)))
         assert not graphql_calls(fake), (label, fake.calls)
         assert any("security-surface" in message for message in messages), (label, messages)
 
@@ -422,16 +747,16 @@ def self_test() -> None:
     # still carries a STALE review:pass (a race left both on) must NEVER be armed — the
     # fix-lane label wins. Both review-hold labels are checked independent of review:pass.
     for hold in ("review:changes", "review:needs"):
-        fake, messages = exercise(fixture(labels=(REVIEW_LABEL, hold)))
+        fake, messages, outcome = exercise(fixture(labels=(REVIEW_LABEL, hold)))
         assert not graphql_calls(fake), (hold, fake.calls)
         assert any("changes-requested" in message for message in messages), (hold, messages)
     # It also stops an arm when review:changes appears only on the live refresh.
-    fake, messages = exercise(clean, views=[fixture(labels=(REVIEW_LABEL, "review:changes"))])
+    fake, messages, outcome = exercise(clean, views=[fixture(labels=(REVIEW_LABEL, "review:changes"))])
     assert not graphql_calls(fake), fake.calls
     assert any("changes-requested" in message for message in messages), messages
 
     # Existing auto-merge arms are idempotent no-ops.
-    fake, messages = exercise(fixture(armed=True))
+    fake, messages, outcome = exercise(fixture(armed=True))
     assert not graphql_calls(fake), fake.calls
     assert any("already-armed" in message for message in messages), messages
 
@@ -442,7 +767,7 @@ def self_test() -> None:
         (fixture(armed=True), "already-armed"),
     )
     for refreshed, expected_reason in transitions:
-        fake, messages = exercise(clean, views=[refreshed])
+        fake, messages, outcome = exercise(clean, views=[refreshed])
         assert not graphql_calls(fake), (expected_reason, fake.calls)
         assert any(expected_reason in message for message in messages), (
             expected_reason,
@@ -452,26 +777,26 @@ def self_test() -> None:
     # Draft workers become ready, are refreshed, then are armed exactly once.
     draft = fixture(draft=True)
     ready = fixture(draft=False)
-    fake, messages = exercise(draft, views=[ready])
+    fake, messages, outcome = exercise(draft, views=[ready])
     assert any(call[:2] == ["pr", "ready"] for call in fake.calls), fake.calls
     assert len(graphql_calls(fake)) == 1, fake.calls
     assert any("draft -> marked ready" in message for message in messages), messages
 
     # A push between the list snapshot and the live refresh is skipped before mutation.
     moved = fixture(oid="b" * 40)
-    fake, messages = exercise(clean, views=[moved])
+    fake, messages, outcome = exercise(clean, views=[moved])
     assert not graphql_calls(fake), fake.calls
     assert any("head-moved" in message for message in messages), messages
 
     # A moved head makes the GraphQL CAS fail; classify it and never retry this sweep.
-    fake, messages = exercise(
+    fake, messages, outcome = exercise(
         clean, views=[clean, moved], mutation_error=True
     )
     assert len(graphql_calls(fake)) == 1, fake.calls
     assert any("head-moved" in message for message in messages), messages
 
     # Stacked PRs must never be armed into their non-default base.
-    fake, messages = exercise(fixture(base="feature-base"))
+    fake, messages, outcome = exercise(fixture(base="feature-base"))
     assert not graphql_calls(fake), fake.calls
     assert any("non-default-base" in message for message in messages), messages
 
@@ -488,9 +813,18 @@ def self_test() -> None:
     AutoArmer(
         "sparq-org/sparq", "main", fake, lambda _m: None, gh_read=spy_read
     ).run()
-    assert [c[:2] for c in read_calls] == [["pr", "list"], ["pr", "view"]], read_calls
+    # [OPUS-5] #3760: the capability probe is itself an idempotent READ (the retry
+    # helper's fail-closed guard accepts it — no mutation in the query), so it routes
+    # through gh_read and precedes the enumeration.
+    assert [c[:2] for c in read_calls] == [
+        ["api", "graphql"],
+        ["pr", "list"],
+        ["pr", "view"],
+    ], read_calls
+    assert is_capability_query(read_calls[0]), read_calls[0]
     direct = [c for c in fake.calls if c not in read_calls]
     assert [c[:2] for c in direct] == [["api", "graphql"]], fake.calls
+    assert not is_capability_query(direct[0]), direct
 
     # Exhausted transient retries abort the sweep as ::warning + exit 0 (a missed
     # cycle is harmless); the arm mutation is never attempted on partial state.
@@ -521,46 +855,50 @@ def self_test() -> None:
     else:
         raise AssertionError("non-transient errors must not be swallowed")
 
-    # [FABLE-5] #3759 finding 5 (BLOCKING): a real arm MUTATION failure must be the
-    # run's status even when the follow-up race-diagnostic READ exhausts transient
-    # retries. Here the arm CAS fails (GhError) and the diagnostic refresh raises
-    # GhTransientExhausted; the ORIGINAL mutation error must propagate, NOT be
-    # rewritten into a lenient exit-0 success.
+    # [FABLE-5] #3759 finding 5 (BLOCKING) — invariant preserved, mechanism changed by
+    # [OPUS-5] #3760: a real arm MUTATION failure must be the run's status even when the
+    # follow-up race-diagnostic READ exhausts transient retries. It used to prove this by
+    # PROPAGATING the mutation error out of run_sweep, which also aborted every later
+    # candidate (#3760). It now proves the same thing the way the fleet actually needs it:
+    # the failure is recorded and the run exits NON-ZERO. It must never be rewritten into
+    # a lenient exit-0 success.
     fake = FakeGh(clean, mutation_error=True)
 
     def read_lists_then_exhausts(argv: list[str]) -> str:
-        # The pre-arm reads (pr list, the pre-arm pr view) succeed; the diagnostic
-        # refresh AFTER the failed arm is the one that exhausts transients.
+        # The pre-arm reads (the capability probe, pr list, the pre-arm pr view) succeed;
+        # the diagnostic refresh AFTER the failed arm is the one that exhausts transients.
         if argv[:2] == ["pr", "view"] and getattr(read_lists_then_exhausts, "armed", False):
             raise gh_retry.GhTransientExhausted("gh pr view: HTTP 504 (3 attempts)")
-        if argv[:2] == ["api", "graphql"]:
-            read_lists_then_exhausts.armed = True  # type: ignore[attr-defined]
         return fake(argv)
 
     def gh_marks_arm(argv: list[str]) -> str:
-        if argv[:2] == ["api", "graphql"]:
+        # Only the ARM mutation flips the marker — never the read-only probe.
+        if argv[:2] == ["api", "graphql"] and not is_capability_query(argv):
             read_lists_then_exhausts.armed = True  # type: ignore[attr-defined]
         return fake(argv)
 
     read_lists_then_exhausts.armed = False  # type: ignore[attr-defined]
-    try:
-        run_sweep(
-            AutoArmer(
-                "sparq-org/sparq",
-                "main",
-                gh_marks_arm,
-                lambda _m: None,
-                gh_read=read_lists_then_exhausts,
-            ),
-            log=lambda _m: None,
-        )
-    except GhError as error:
-        assert "CAS rejection" in str(error), error
-    else:
-        raise AssertionError(
-            "a failed arm mutation must NOT be masked as success when the follow-up "
-            "diagnostic read exhausts its transient retries"
-        )
+    messages: list[str] = []
+    code = run_sweep(
+        AutoArmer(
+            "sparq-org/sparq",
+            "main",
+            gh_marks_arm,
+            messages.append,
+            gh_read=read_lists_then_exhausts,
+        ),
+        log=lambda _m: None,
+    )
+    assert code == 1, (
+        "a failed arm mutation must NOT be masked as success when the follow-up "
+        f"diagnostic read exhausts its transient retries (code={code}, {messages})"
+    )
+    assert any("CAS rejection" in message for message in messages), messages
+    assert any(
+        "arm-failure summary" in message for message in messages
+    ), messages
+    # It is a per-PR failure, not a capability failure: no ::error, no capability latch.
+    assert not [m for m in messages if m.startswith("::error")], messages
 
     # [FABLE-5] #3759 finding 5: EVENT-mode (label-triggered) arm must NOT use the
     # sweep's lenient exit — an exhausted transient exits NON-zero (there is no
@@ -595,7 +933,159 @@ def self_test() -> None:
     assert code == 0, code
     assert warnings and warnings[0].startswith("::warning"), warnings
 
+    # ---------------------------------------------------------------------------------
+    # [OPUS-5] #3760 — ARM CAPABILITY + PER-PR FAILURE ISOLATION.
+    # ---------------------------------------------------------------------------------
+
+    # The live #3760 error text classifies as a CAPABILITY denial; a CAS/race/transient
+    # does not (the denial set must stay disjoint from #3759's transient set, or a
+    # permanent denial could be swallowed as ::warning + exit 0).
+    assert is_arm_denial(DENIAL_TEXT), DENIAL_TEXT
+    assert is_arm_denial(DENIAL_TEXT.upper()), "denial matching must be case-insensitive"
+    for benign in (
+        "simulated expectedHeadOid CAS rejection",
+        "gh api graphql failed: HTTP 502: 502 Bad Gateway",
+        "gh api graphql failed: HTTP 504: Gateway Timeout",
+        "gh api graphql failed: Head branch was modified. Review and try again",
+    ):
+        assert not is_arm_denial(benign), benign
+
+    # (1) PROBE — can-arm: the probe runs BEFORE any mutation, the sweep proceeds, exit 0.
+    fake, messages, outcome = exercise(clean)
+    assert outcome.capability == CAN_ARM, outcome
+    assert outcome.armed == 1 and outcome.exit_code == 0, (outcome, messages)
+    assert len(probe_query_calls(fake)) == 1, fake.calls
+    assert fake.calls.index(probe_query_calls(fake)[0]) < fake.calls.index(
+        graphql_calls(fake)[0]
+    ), fake.calls
+    assert any("arm-capability probe: can-arm" in m for m in messages), messages
+
+    # (2) PROBE — cannot-arm (repository setting OFF): ONE ::error naming the exact
+    # setting, ZERO PRs touched (the listing never even runs), exit 1.
+    fake, messages, outcome = exercise(clean, auto_merge_allowed=False)
+    assert outcome.capability == CANNOT_ARM and outcome.exit_code == 1, outcome
+    assert not graphql_calls(fake), fake.calls
+    assert not [call for call in fake.calls if call[:2] == ["pr", "list"]], fake.calls
+    emitted = [message for message in messages if message.startswith("::error")]
+    assert len(emitted) == 1, emitted
+    assert "Allow auto-merge" in emitted[0], emitted
+    assert "contents: write" in emitted[0], emitted
+    assert "ORCHESTRATOR_APP_ID" in emitted[0], emitted
+
+    # (3) PROBE — cannot-arm (the token itself is denied by GitHub): same single error.
+    fake, messages, outcome = exercise(clean, capability_error=DENIAL_TEXT)
+    assert outcome.capability == CANNOT_ARM and outcome.exit_code == 1, outcome
+    assert not graphql_calls(fake), fake.calls
+    assert len([m for m in messages if m.startswith("::error")]) == 1, messages
+
+    # (4) PROBE — inconclusive must NEVER red the run or stop the sweep, including an
+    # exhausted #3759 transient on the probe read itself.
+    for kwargs in (
+        {"capability_error": "gh api graphql failed: HTTP 504: Gateway Timeout"},
+        {"auto_merge_allowed": None},
+    ):
+        fake, messages, outcome = exercise(clean, **kwargs)
+        assert outcome.capability == INCONCLUSIVE, (kwargs, outcome)
+        assert outcome.armed == 1 and outcome.exit_code == 0, (kwargs, outcome)
+        assert not [m for m in messages if m.startswith("::error")], messages
+
+    fake = FakeGh(clean)
+
+    def probe_exhausts(argv: list[str]) -> str:
+        if is_capability_query(argv):
+            raise gh_retry.GhTransientExhausted("gh api graphql: HTTP 504 (3 attempts)")
+        return fake(argv)
+
+    probe_verdict = AutoArmer(
+        "sparq-org/sparq", "main", fake, lambda _m: None, gh_read=probe_exhausts
+    ).probe_arm_capability()
+    assert probe_verdict.status == INCONCLUSIVE, probe_verdict
+    assert "transient" in probe_verdict.detail, probe_verdict
+
+    # (5) PER-PR ARM FAILURE — the pre-#3760 bug: a non-capability mutation failure on the
+    # FIRST PR re-raised out of run(), so PR #452 below was never armed. Now the failure is
+    # collected, the sweep continues, and the run still exits non-zero.
+    first = fixture(number=451)
+    second = fixture(number=452)
+    fake, messages, outcome = exercise(
+        [first, second],
+        mutation_errors={451: "gh api graphql failed: Pull request is in unstable status"},
+    )
+    assert outcome.considered == 2, outcome
+    assert outcome.armed == 1, (outcome, messages)
+    assert [number for number, _ in outcome.arm_failures] == [451], outcome
+    assert outcome.exit_code == 1, messages
+    assert any("PR #451: arm-failed" in m for m in messages), messages
+    assert any("PR #452: armed head" in m for m in messages), messages
+    assert any("arm-failure summary: PR #451" in m for m in messages), messages
+    assert not [m for m in messages if m.startswith("::error")], messages
+    assert outcome.capability == CAN_ARM, outcome
+
+    # (6) MID-SWEEP CAPABILITY DENIAL — stop after ONE ::error (never one per PR), leave
+    # the remaining candidates untouched, and still exit non-zero.
+    third = fixture(number=453)
+    fake, messages, outcome = exercise(
+        [first, second, third],
+        mutation_errors={number: DENIAL_TEXT for number in (451, 452, 453)},
+    )
+    assert len(graphql_calls(fake)) == 1, fake.calls
+    assert outcome.capability == CANNOT_ARM, outcome
+    assert outcome.armed == 0, outcome
+    assert [number for number, _ in outcome.arm_failures] == [451], outcome
+    assert outcome.exit_code == 1, messages
+    emitted = [message for message in messages if message.startswith("::error")]
+    assert len(emitted) == 1, emitted
+    assert "contents: write" in emitted[0], emitted
+    assert sum("arm capability lost" in m for m in messages) == 2, messages
+
+    # (7) EXIT SEMANTICS — an arm failure must never exit 0, in EITHER mode. A capability
+    # failure is not a transient, so --mode sweep must not convert it into ::warning + 0.
+    assert ArmOutcome().exit_code == 0
+    assert ArmOutcome(arm_failures=[(1, "x")]).exit_code == 1
+    assert ArmOutcome(capability=CANNOT_ARM).exit_code == 1
+    assert ArmOutcome(capability=INCONCLUSIVE).exit_code == 0
+    for mode in ("sweep", "event"):
+        blocked_fake = FakeGh(clean, auto_merge_allowed=False)
+        emitted = []
+        code = run_sweep(
+            AutoArmer("sparq-org/sparq", "main", blocked_fake, emitted.append),
+            log=emitted.append,
+            mode=mode,
+        )
+        assert code == 1, (mode, code, emitted)
+        assert len([m for m in emitted if m.startswith("::error")]) == 1, emitted
+        assert not [m for m in emitted if m.startswith("::warning")], emitted
+
+    # (8) The standalone probe entry point agrees with the in-sweep verdict.
+    blocked = AutoArmer(
+        "sparq-org/sparq",
+        "main",
+        FakeGh(clean, auto_merge_allowed=False),
+        lambda _message: None,
+    )
+    assert blocked.probe_arm_capability().status == CANNOT_ARM
+    assert probe_arm_capability_exit(blocked) == 1
+    healthy = AutoArmer(
+        "sparq-org/sparq", "main", FakeGh(clean), lambda _message: None
+    )
+    assert healthy.probe_arm_capability().status == CAN_ARM
+    assert probe_arm_capability_exit(healthy) == 0
+
     print("auto-arm self-test: PASS")
+
+
+def probe_arm_capability_exit(armer: AutoArmer) -> int:
+    """Run ONLY the startup probe: 0 = armable (or inconclusive), 1 = provably not.
+
+    Wired as its own workflow step so the job reds at second three with one actionable
+    ::error instead of failing per-PR on every label event, forever.
+    """
+    verdict = armer.probe_arm_capability()
+    armer.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
+    if verdict.blocks_sweep:
+        armer.fail_capability(f"startup arm-capability probe failed: {verdict.detail}")
+        return 1
+    return 0
 
 
 def main() -> int:
@@ -614,6 +1104,11 @@ def main() -> int:
         ),
     )
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument(
+        "--probe-arm-capability",
+        action="store_true",
+        help="only verify the token can enable auto-merge here; arm nothing",
+    )
     args = parser.parse_args()
 
     if args.self_test:
@@ -621,9 +1116,10 @@ def main() -> int:
         return 0
     if not args.repo:
         parser.error("--repo is required unless --self-test is used")
-    return run_sweep(
-        AutoArmer(args.repo, args.default_branch, gh_read=run_gh_read), mode=args.mode
-    )
+    armer = AutoArmer(args.repo, args.default_branch, gh_read=run_gh_read)
+    if args.probe_arm_capability:
+        return probe_arm_capability_exit(armer)
+    return run_sweep(armer, mode=args.mode)
 
 
 if __name__ == "__main__":

--- a/scripts/auto-arm.py
+++ b/scripts/auto-arm.py
@@ -22,6 +22,16 @@ to GitHub's explicit ``enablePullRequestAutoMerge`` GraphQL mutation.
 #   deliberately self-contained (auto-arm.yml sparse-checks out only this file, so it
 #   cannot import shared helpers); scripts/tests/test_arm_capability_wiring.py pins the
 #   load-bearing strings against scripts/rearm-sweeper.py so the copies cannot drift.
+# [OPUS-5] Issue #3766 — STICKY FAILURE PRECEDENCE. Collecting the failures (above) was
+#   only half the job: the collected state lived in a LOCAL of run(), so a
+#   GhTransientExhausted raised while processing a LATER candidate unwound past the
+#   accumulated-failure check and run_sweep's lenient handler reported ::warning + exit 0.
+#   Reproduced: PR #451's arm failed, PR #452's pre-arm refresh exhausted its retries, and
+#   the run exited 0 — discarding #451's real failure. Now the outcome lives on the ARMER
+#   (AutoArmer.outcome), a later candidate's exhaustion is recorded as its OWN
+#   warning-class per-candidate outcome without escaping the loop, and the exit status is
+#   computed at the END by arm_exit_code() from that final state.
+#   PRECEDENCE: collected-failure > transient-exhaustion > clean.
 
 from __future__ import annotations
 
@@ -146,10 +156,31 @@ class ArmOutcome:
     armed: int = 0
     arm_failures: list[tuple[int, str]] = field(default_factory=list)
     capability: str = INCONCLUSIVE
+    # [OPUS-5] #3766 — warning-class per-candidate outcomes: (number, detail) for every
+    # candidate whose own bounded read retries were exhausted. These NEVER downgrade a
+    # collected failure; they only matter when they are the run's ONLY problem.
+    transient_exhaustions: list[tuple[int, str]] = field(default_factory=list)
+    # Whole-sweep transient exhaustion (the enumeration read, or a backstop catch).
+    sweep_transient: str | None = None
 
     @property
     def capability_failed(self) -> bool:
         return self.capability == CANNOT_ARM
+
+    @property
+    def hard_failed(self) -> bool:
+        """A COLLECTED failure: the verdict that outranks every later transient (#3766)."""
+        return self.capability_failed or bool(self.arm_failures)
+
+    @property
+    def transient_detail(self) -> str | None:
+        """The first transient exhaustion, or None. Warning-class — never a verdict."""
+        if self.sweep_transient:
+            return self.sweep_transient
+        if self.transient_exhaustions:
+            number, reason = self.transient_exhaustions[0]
+            return f"PR #{number}: {reason}"
+        return None
 
     @property
     def exit_code(self) -> int:
@@ -157,8 +188,12 @@ class ArmOutcome:
 
         This is how #3759 finding 5's invariant survives the #3760 refactor: the failed
         arm no longer unwinds the sweep, so it must be the run's EXIT STATUS instead.
+
+        Deliberately independent of ``transient_exhaustions`` — a transient's exit is
+        MODE-dependent (#3759) and is applied by :func:`arm_exit_code`, whereas a
+        collected failure is non-zero in every mode.
         """
-        return 1 if self.capability_failed or self.arm_failures else 0
+        return 1 if self.hard_failed else 0
 
 
 class GhError(RuntimeError):
@@ -241,6 +276,9 @@ class AutoArmer:
         # one per PR, and arming must stop once the token is known to be unable to arm.
         self.capability_error_emitted = False
         self.capability_lost = False
+        # [OPUS-5] #3766: the collected outcome lives HERE, not only in a local of run(),
+        # so an exception escaping run() can never discard an already-earned failure.
+        self.outcome = ArmOutcome()
         owner, _, name = repo.partition("/")
         self.owner = owner
         self.name = name
@@ -460,6 +498,16 @@ class AutoArmer:
 
         try:
             self.arm(current)
+        except gh_retry.GhTransientExhausted as mutation_exhausted:
+            # [OPUS-5] #3766, fail CLOSED. The arm runs on the ONE-SHOT runner, which never
+            # raises this today (gh_retry refuses to wrap mutations) — but if it ever did,
+            # the mutation's outcome would be UNKNOWN, and an unknown arm must be a per-PR
+            # FAILURE, never the lenient warning-class outcome a transient normally gets.
+            self.log(
+                f"PR #{initial.number}: arm-failed (transient exhaustion on the arm "
+                f"mutation itself: {mutation_exhausted})"
+            )
+            return FAILED, f"transient exhaustion on the arm mutation ({mutation_exhausted})"
         except GhError as mutation_error:
             message = str(mutation_error)
             # [OPUS-5] #3760: a capability denial is NOT a per-PR condition — every
@@ -502,7 +550,10 @@ class AutoArmer:
         return ARMED, None
 
     def run(self) -> ArmOutcome:
-        outcome = ArmOutcome()
+        # [OPUS-5] #3766: publish the outcome on the ARMER before doing any work, so every
+        # failure collected below survives any exception that escapes this method and the
+        # exit status can be computed at the END from this state (see arm_exit_code).
+        outcome = self.outcome = ArmOutcome()
         verdict = self.probe_arm_capability()
         outcome.capability = verdict.status
         self.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
@@ -517,7 +568,18 @@ class AutoArmer:
             )
             return outcome
 
-        for pr in self.list_open():
+        try:
+            candidates = self.list_open()
+        except gh_retry.GhTransientExhausted as error:
+            # Whole-sweep transient: nothing has been collected yet, so this is a plain
+            # missed cycle. Recorded, not raised — the exit is decided at the end.
+            outcome.sweep_transient = str(error)
+            self.log(
+                f"[{PROGRAM}] candidate enumeration exhausted transient retries ({error})"
+            )
+            candidates = []
+
+        for pr in candidates:
             if REVIEW_LABEL not in pr.labels:
                 continue
             outcome.considered += 1
@@ -527,7 +589,21 @@ class AutoArmer:
                     "(see the single ::error above)"
                 )
                 continue
-            status, failure = self.process(pr)
+            try:
+                status, failure = self.process(pr)
+            except gh_retry.GhTransientExhausted as error:
+                # [OPUS-5] #3766 (BLOCKING, reproduced by cross-provider review): a LATER
+                # candidate's exhausted transient is its OWN warning-class per-candidate
+                # outcome. It must NOT escape this loop — an escaping exception carried the
+                # run past the accumulated-failure check, so PR #451's real arm failure was
+                # reported as ::warning + exit 0 once PR #452's refresh exhausted. The
+                # sweep continues; the verdict #451 already earned is untouchable.
+                outcome.transient_exhaustions.append((pr.number, str(error)))
+                self.log(
+                    f"PR #{pr.number}: skipped transient-exhausted ({error}); the sweep "
+                    "continues and this cannot downgrade an earlier arm failure"
+                )
+                continue
             if status == ARMED:
                 outcome.armed += 1
             elif status == FAILED:
@@ -537,12 +613,56 @@ class AutoArmer:
 
         for number, reason in outcome.arm_failures:
             self.log(f"[{PROGRAM}] arm-failure summary: PR #{number} — {reason}")
+        for number, reason in outcome.transient_exhaustions:
+            self.log(f"[{PROGRAM}] transient-exhaustion summary: PR #{number} — {reason}")
         self.log(
             f"[{PROGRAM}] complete: considered={outcome.considered} "
             f"armed={outcome.armed} arm-failures={len(outcome.arm_failures)} "
+            f"transient-exhaustions={len(outcome.transient_exhaustions)} "
             f"capability={outcome.capability}"
         )
         return outcome
+
+
+def arm_exit_code(
+    outcome: ArmOutcome, *, mode: str, log: Callable[[str], None] = print
+) -> int:
+    """Decide the run's exit status from the FINAL collected state (#3766).
+
+    PRECEDENCE — ``collected-failure > transient-exhaustion > clean``:
+
+    1. A COLLECTED arm/capability failure DOMINATES, in either mode. Nothing that happens
+       while processing a LATER candidate — an exhausted transient above all — can
+       downgrade a verdict an EARLIER candidate already earned. This check is reached from
+       the accumulated state, never short-circuited by an exception.
+    2. TRANSIENT EXHAUSTION alone (no collected failure anywhere) keeps #3759's intended
+       lenient policy: ``sweep`` reports ``::warning`` + exit 0, because a missed cycle is
+       harmless and the cron re-covers it. ``event`` has no per-PR backstop, so it fails
+       loudly instead.
+    3. CLEAN is 0.
+    """
+    if outcome.hard_failed:
+        if outcome.transient_detail:
+            log(
+                f"[{PROGRAM}] a transient exhaustion also occurred "
+                f"({outcome.transient_detail}) but a collected failure outranks it "
+                "(precedence: collected-failure > transient-exhaustion > clean): exit 1"
+            )
+        return outcome.exit_code
+    if outcome.transient_detail:
+        if mode == "event":
+            # Event-driven arm: no per-PR cron backstop — fail loudly so it is retried.
+            raise GhError(
+                "event-mode auto-arm exhausted transient retries: "
+                f"{outcome.transient_detail}"
+            )
+        log(
+            "::warning title=auto-arm skipped a cycle on transient GitHub API "
+            f"failures::{outcome.transient_detail} — bounded retries exhausted; a missed "
+            "sweep is harmless (the cron backstop covers it), so this run reports success."
+        )
+        return 0
+    return 0
 
 
 def run_sweep(
@@ -563,24 +683,23 @@ def run_sweep(
     exhaustion can never overwrite it — see ``process``). Since #3760 it no longer does so
     by unwinding the sweep: it is COLLECTED so every later candidate is still considered,
     and it surfaces as ``ArmOutcome.exit_code == 1``. A provable arm-capability failure is
-    likewise never a transient — it reds both modes with one ``::error``."""
+    likewise never a transient — it reds both modes with one ``::error``.
+
+    Since #3766 the exit is computed at the END from :class:`ArmOutcome`, whose precedence
+    is ``collected-failure > transient-exhaustion > clean`` — see :func:`arm_exit_code`."""
     if mode not in ("sweep", "event"):
         raise ValueError(f"mode must be 'sweep' or 'event', got {mode!r}")
     try:
-        return armer.run().exit_code
+        outcome = armer.run()
     except gh_retry.GhTransientExhausted as error:
-        if mode == "event":
-            # Event-driven arm: no per-PR cron backstop — fail loudly so it is retried.
-            raise GhError(
-                f"event-mode auto-arm exhausted transient retries: {error}"
-            ) from error
-        log(
-            "::warning title=auto-arm skipped a cycle on transient GitHub API "
-            f"failures::{error} — bounded retries exhausted; a missed sweep is "
-            "harmless (the cron backstop covers it), so this run reports success."
-        )
-        return 0
-    return 0
+        # [OPUS-5] #3766 STICKY BACKSTOP. run() already records a per-candidate exhaustion
+        # without unwinding; this is defence in depth for any read that is ever added
+        # OUTSIDE that guarded loop. The outcome is read back OFF THE ARMER, so everything
+        # already collected still reaches arm_exit_code — an exception can no longer
+        # short-circuit past the accumulated-failure check and report a false success.
+        outcome = armer.outcome
+        outcome.sweep_transient = outcome.sweep_transient or str(error)
+    return arm_exit_code(outcome, mode=mode, log=log)
 
 
 def fixture(
@@ -1071,6 +1190,152 @@ def self_test() -> None:
     assert healthy.probe_arm_capability().status == CAN_ARM
     assert probe_arm_capability_exit(healthy) == 0
 
+    # ---------------------------------------------------------------------------------
+    # [OPUS-5] #3766 — STICKY FAILURE PRECEDENCE:
+    #     collected-failure > transient-exhaustion > clean.
+    # The false pass this fixes (reproduced by the cross-provider review): PR #451's arm
+    # FAILED and was collected, then PR #452's pre-arm refresh exhausted its bounded
+    # retries; that exhaustion unwound run() and run_sweep's lenient handler reported
+    # ::warning + exit 0 — discarding a real arm failure. The collected verdict must be
+    # untouchable by anything that happens for a LATER candidate.
+    # ---------------------------------------------------------------------------------
+
+    def sequence(*, arm_fails: bool, mode: str):
+        """PR #451 (optionally arm-failing), then PR #452 whose refresh exhausts retries."""
+        sequence_fake = FakeGh(
+            [fixture(number=451), fixture(number=452)],
+            mutation_errors=(
+                {451: "gh api graphql failed: Pull request is in unstable status"}
+                if arm_fails
+                else None
+            ),
+        )
+
+        def read_452_exhausts(argv: list[str]) -> str:
+            if argv[:2] == ["pr", "view"] and argv[2] == "452":
+                raise gh_retry.GhTransientExhausted("gh pr view: HTTP 504 (3 attempts)")
+            return sequence_fake(argv)
+
+        lines: list[str] = []
+        armer = AutoArmer(
+            "sparq-org/sparq",
+            "main",
+            sequence_fake,
+            lines.append,
+            gh_read=read_452_exhausts,
+        )
+        try:
+            return lines, run_sweep(armer, log=lines.append, mode=mode)
+        except GhError as error:
+            return lines, error
+
+    # (9) THE #3766 SEQUENCE — arm failure on A, exhausted transient on a LATER B.
+    lines, code = sequence(arm_fails=True, mode="sweep")
+    assert code == 1, (
+        "a COLLECTED arm failure must dominate a LATER candidate's exhausted transient "
+        f"(code={code}, {lines})"
+    )
+    assert any("PR #451: arm-failed" in line for line in lines), lines
+    assert any("arm-failure summary: PR #451" in line for line in lines), lines
+    assert any("PR #452: skipped transient-exhausted" in line for line in lines), lines
+    assert any("precedence: collected-failure" in line for line in lines), lines
+    # The lenient ::warning must NOT be emitted while a real failure stands.
+    assert not [line for line in lines if line.startswith("::warning")], lines
+
+    # (10) CONTROL — the lenient policy is intact where it IS correct: a sweep whose ONLY
+    # problem is an exhausted transient still exits 0 with exactly one ::warning, and the
+    # candidates around it are still armed.
+    lines, code = sequence(arm_fails=False, mode="sweep")
+    assert code == 0, (code, lines)
+    warned = [line for line in lines if line.startswith("::warning")]
+    assert len(warned) == 1, warned
+    assert "452" in warned[0], warned
+    assert any("PR #451: armed head" in line for line in lines), lines
+
+    # (11) CONTROL — event mode is unchanged: a collected arm failure is non-zero, and an
+    # exhausted transient alone still fails loudly (no per-PR cron backstop).
+    lines, code = sequence(arm_fails=True, mode="event")
+    assert code == 1, (code, lines)
+    lines, result = sequence(arm_fails=False, mode="event")
+    assert isinstance(result, GhError) and "event-mode" in str(result), (result, lines)
+
+    # (12) The precedence rule itself, at the seam: a collected failure outranks a
+    # transient in BOTH modes; a transient alone is mode-dependent; clean is 0.
+    both = ArmOutcome(
+        arm_failures=[(451, "unstable")], transient_exhaustions=[(452, "HTTP 504")]
+    )
+    assert both.hard_failed and both.exit_code == 1, both
+    for mode in ("sweep", "event"):
+        assert arm_exit_code(both, mode=mode, log=lambda _m: None) == 1, mode
+    transient_only = ArmOutcome(transient_exhaustions=[(452, "HTTP 504")])
+    assert not transient_only.hard_failed and transient_only.exit_code == 0
+    assert arm_exit_code(transient_only, mode="sweep", log=lambda _m: None) == 0
+    try:
+        arm_exit_code(transient_only, mode="event", log=lambda _m: None)
+    except GhError as error:
+        assert "event-mode" in str(error), error
+    else:
+        raise AssertionError("event-mode transient exhaustion must not exit 0")
+    assert ArmOutcome().transient_detail is None
+    assert ArmOutcome(sweep_transient="HTTP 504").transient_detail == "HTTP 504"
+
+    # (13) FAIL CLOSED — an exhausted transient raised by the ARM MUTATION itself leaves the
+    # arm's outcome UNKNOWN, so it must be a per-PR failure (exit 1), never a lenient
+    # warning-class missed cycle. The one-shot runner cannot raise this today; the handler
+    # exists so a future refactor cannot open a second false-pass route.
+    mutation_fake = FakeGh(clean)
+
+    def gh_arm_exhausts(argv: list[str]) -> str:
+        if argv[:2] == ["api", "graphql"] and not is_capability_query(argv):
+            raise gh_retry.GhTransientExhausted("gh api graphql: HTTP 504 (3 attempts)")
+        return mutation_fake(argv)
+
+    lines = []
+    code = run_sweep(
+        AutoArmer(
+            "sparq-org/sparq", "main", gh_arm_exhausts, lines.append,
+            gh_read=mutation_fake,
+        ),
+        log=lines.append,
+        mode="sweep",
+    )
+    assert code == 1, (code, lines)
+    assert not [line for line in lines if line.startswith("::warning")], lines
+    assert any("transient exhaustion on the arm mutation" in line for line in lines), lines
+
+    # (14) END TO END through main() — the precedence must hold for the real entry point,
+    # not only for the seam the assertions above call directly.
+    import io
+    from contextlib import redirect_stdout
+
+    e2e = FakeGh(
+        [fixture(number=451), fixture(number=452)],
+        mutation_errors={451: "gh api graphql failed: Pull request is in unstable status"},
+    )
+
+    def e2e_read(argv: list[str]) -> str:
+        if argv[:2] == ["pr", "view"] and argv[2] == "452":
+            raise gh_retry.GhTransientExhausted("gh pr view: HTTP 504 (3 attempts)")
+        return e2e(argv)
+
+    saved_argv = sys.argv
+    saved_read = globals()["run_gh_read"]
+    saved_gh = globals()["run_gh"]
+    captured = io.StringIO()
+    try:
+        globals()["run_gh_read"] = e2e_read
+        globals()["run_gh"] = e2e
+        sys.argv = ["auto-arm.py", "--repo", "sparq-org/sparq", "--mode", "sweep"]
+        with redirect_stdout(captured):
+            e2e_code = main()
+    finally:
+        sys.argv = saved_argv
+        globals()["run_gh_read"] = saved_read
+        globals()["run_gh"] = saved_gh
+    assert e2e_code == 1, (e2e_code, captured.getvalue())
+    assert "arm-failure summary: PR #451" in captured.getvalue(), captured.getvalue()
+    assert "::warning" not in captured.getvalue(), captured.getvalue()
+
     print("auto-arm self-test: PASS")
 
 
@@ -1116,7 +1381,9 @@ def main() -> int:
         return 0
     if not args.repo:
         parser.error("--repo is required unless --self-test is used")
-    armer = AutoArmer(args.repo, args.default_branch, gh_read=run_gh_read)
+    # `run_gh` is passed EXPLICITLY (not left to the default argument) so the self-test can
+    # substitute both runners at the module level and drive main() end to end (#3766).
+    armer = AutoArmer(args.repo, args.default_branch, run_gh, gh_read=run_gh_read)
     if args.probe_arm_capability:
         return probe_arm_capability_exit(armer)
     return run_sweep(armer, mode=args.mode)

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -11,6 +11,16 @@
 # [OPUS-5] Issue #3760 — fail LOUDLY ONCE when the token cannot arm at all, and never let
 #   a single per-PR arm failure abort the rest of the sweep. A capability denial is NOT a
 #   transient: it never routes through the #3759 ::warning + exit-0 path.
+# [OPUS-5] Issue #3766 — STICKY FAILURE PRECEDENCE. Collecting the failures (above) was
+#   only half the job: the collected state lived in a LOCAL of run(), so a
+#   GhTransientExhausted raised while processing a LATER candidate unwound past the
+#   accumulated-failure check and main()'s lenient handler reported ::warning + exit 0.
+#   Reproduced: PR #3011's arm failed, PR #3012's live-state read exhausted its retries,
+#   and the run exited 0 — discarding #3011's real failure. Now the outcome lives on the
+#   SWEEPER (RearmSweeper.outcome), a later candidate's exhaustion is recorded as its OWN
+#   warning-class per-candidate outcome without escaping the loop, and the exit status is
+#   computed at the END by sweep_exit() from that final state.
+#   PRECEDENCE: collected-failure > transient-exhaustion > clean.
 
 from __future__ import annotations
 
@@ -153,17 +163,41 @@ class SweepOutcome:
     # (this preserves the pre-#3760 `errors` contract for the diagnostic read).
     state_failures: list[tuple[int, str]] = field(default_factory=list)
     capability: str = INCONCLUSIVE
+    # [OPUS-5] #3766 — warning-class per-candidate outcomes: (number, detail) for every
+    # candidate whose own bounded read retries were exhausted. These NEVER downgrade a
+    # collected failure; they only matter when they are the run's ONLY problem.
+    transient_exhaustions: list[tuple[int, str]] = field(default_factory=list)
+    # Whole-sweep transient exhaustion (the enumeration read, or a backstop catch).
+    sweep_transient: str | None = None
 
     @property
     def capability_failed(self) -> bool:
         return self.capability == CANNOT_ARM
 
     @property
+    def hard_failed(self) -> bool:
+        """A COLLECTED failure: the verdict that outranks every later transient (#3766)."""
+        return bool(self.capability_failed or self.arm_failures or self.state_failures)
+
+    @property
+    def transient_detail(self) -> str | None:
+        """The first transient exhaustion, or None. Warning-class — never a verdict."""
+        if self.sweep_transient:
+            return self.sweep_transient
+        if self.transient_exhaustions:
+            number, reason = self.transient_exhaustions[0]
+            return f"PR #{number}: {reason}"
+        return None
+
+    @property
     def exit_code(self) -> int:
-        """Never exit 0 while an arm failed — a silent 0 is how #3760 hid for days."""
-        if self.capability_failed or self.arm_failures or self.state_failures:
-            return 1
-        return 0
+        """Never exit 0 while an arm failed — a silent 0 is how #3760 hid for days.
+
+        Deliberately independent of ``transient_exhaustions`` — a transient's exit is
+        MODE-dependent (#3759) and is applied by :func:`sweep_exit`, whereas a collected
+        failure is non-zero in every mode.
+        """
+        return 1 if self.hard_failed else 0
 
 
 class GhError(RuntimeError):
@@ -273,6 +307,9 @@ class RearmSweeper:
         # one per PR, and the sweep must stop once the token is known to be unable to arm.
         self.capability_error_emitted = False
         self.capability_lost = False
+        # [OPUS-5] #3766: the collected outcome lives HERE, not only in a local of run(),
+        # so an exception escaping run() can never discard an already-earned failure.
+        self.outcome = SweepOutcome()
         try:
             self.owner, self.name = repo.split("/", 1)
         except ValueError as error:
@@ -442,7 +479,10 @@ class RearmSweeper:
         )
 
     def run(self) -> SweepOutcome:
-        outcome = SweepOutcome()
+        # [OPUS-5] #3766: publish the outcome on the SWEEPER before doing any work, so
+        # every failure collected below survives any exception that escapes this method and
+        # the exit status can be computed at the END from this state (see sweep_exit).
+        outcome = self.outcome = SweepOutcome()
         verdict = self.probe_arm_capability()
         outcome.capability = verdict.status
         self.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
@@ -457,83 +497,133 @@ class RearmSweeper:
             )
             return outcome
 
-        candidates = self.list_candidates()
+        try:
+            candidates = self.list_candidates()
+        except gh_retry.GhTransientExhausted as error:
+            # Whole-sweep transient: nothing has been collected yet, so this is a plain
+            # missed cycle. Recorded, not raised — the exit is decided at the end.
+            outcome.sweep_transient = str(error)
+            self.log(
+                f"[{PROGRAM}] candidate enumeration exhausted transient retries ({error})"
+            )
+            candidates = []
         outcome.candidates = len(candidates)
         self.log(
             f"[{PROGRAM}] found {len(candidates)} open PR(s) returned for "
             f"label {REVIEW_ATTESTATION}; re-arm limit={self.max_rearms}"
         )
         for snapshot in candidates:
-            if self.capability_lost:
+            # [OPUS-5] #3766 (BLOCKING, reproduced by cross-provider review): every read in
+            # this body is retriable, so a LATER candidate's exhausted transient could
+            # escape the loop, unwind run(), and land in main()'s lenient
+            # `except GhTransientExhausted -> ::warning + exit 0` — discarding an EARLIER
+            # candidate's collected arm failure (PR #3011 arm-failed, PR #3012 live-state
+            # exhausted, run reported success). The exhaustion is now this candidate's OWN
+            # warning-class outcome: the sweep continues and the verdict #3011 already
+            # earned is untouchable.
+            try:
+                if self.capability_lost:
+                    self.emit(
+                        snapshot.number,
+                        "SKIP",
+                        "arm capability lost this run (see the single ::error above)",
+                    )
+                    continue
+
+                reason = self.decision(snapshot, live=False)
+                if reason:
+                    self.emit(snapshot.number, "SKIP", reason)
+                    continue
+
+                try:
+                    current = self.live_state(snapshot.number)
+                except (GhError, json.JSONDecodeError) as error:
+                    self.emit(
+                        snapshot.number, "SKIP", f"live-state query failed ({error})"
+                    )
+                    outcome.state_failures.append((snapshot.number, str(error)))
+                    continue
+
+                reason = self.decision(current, live=True)
+                if reason:
+                    self.emit(current.number, "SKIP", reason)
+                    continue
+
+                # Both fields are absent here: and only here is the arm considered dropped.
+                if outcome.attempts >= self.max_rearms:
+                    self.emit(current.number, "SKIP", "per-run re-arm limit reached")
+                    continue
+                outcome.attempts += 1
+                try:
+                    self.arm(current.number)
+                except gh_retry.GhTransientExhausted as exhausted:
+                    # [OPUS-5] #3766, fail CLOSED. The arm runs on the ONE-SHOT runner,
+                    # which never raises this today (gh_retry refuses to wrap mutations) —
+                    # but if it ever did, the mutation's outcome would be UNKNOWN, and an
+                    # unknown arm must be a per-PR FAILURE, never the lenient
+                    # warning-class outcome a transient normally gets.
+                    detail = (
+                        "re-arm failed (transient exhaustion on the arm mutation "
+                        f"itself: {exhausted})"
+                    )
+                    self.emit(current.number, "ARM-FAILED", detail)
+                    outcome.arm_failures.append((current.number, detail))
+                    continue
+                except GhError as error:
+                    message = str(error)
+                    # [OPUS-5] #3760: a capability denial is NOT a per-PR condition — every
+                    # remaining candidate would fail identically. Record it, stop arming,
+                    # and surface exactly ONE ::error naming what to change.
+                    if is_arm_denial(message):
+                        self.emit(
+                            current.number,
+                            "ARM-FAILED",
+                            f"arm capability denied ({message})",
+                        )
+                        outcome.arm_failures.append(
+                            (current.number, f"arm capability denied ({message})")
+                        )
+                        outcome.capability = CANNOT_ARM
+                        self.fail_capability(
+                            f"arming PR #{current.number} was denied: {message}"
+                        )
+                        continue
+                    # The arm MUTATION failed — that failure is the primary status. The
+                    # follow-up live-state read is a diagnostic to classify an API race,
+                    # and it is retriable: it can raise GhError, a decode error, OR
+                    # GhTransientExhausted. [FABLE-5] #3759 finding 5: the diagnostic's
+                    # OWN exhaustion must never escape here — if it did, main's lenient
+                    # `except GhTransientExhausted -> exit 0` would convert a genuine
+                    # failed arm into a false success. Catch exhaustion too; on any
+                    # inconclusive diagnostic, record the arm failure as a real error.
+                    try:
+                        raced = self.live_state(current.number)
+                        race_reason = self.decision(raced, live=True)
+                    except (
+                        GhError,
+                        json.JSONDecodeError,
+                        gh_retry.GhTransientExhausted,
+                    ):
+                        race_reason = None
+                    if race_reason:
+                        self.emit(current.number, "SKIP", f"arm raced: {race_reason}")
+                    else:
+                        # Collect and CONTINUE — one bad PR must never abort the sweep.
+                        self.emit(
+                            current.number, "ARM-FAILED", f"re-arm failed ({message})"
+                        )
+                        outcome.arm_failures.append(
+                            (current.number, f"re-arm failed ({message})")
+                        )
+                    continue
+            except gh_retry.GhTransientExhausted as error:
+                outcome.transient_exhaustions.append((snapshot.number, str(error)))
                 self.emit(
                     snapshot.number,
                     "SKIP",
-                    "arm capability lost this run (see the single ::error above)",
+                    f"transient-exhausted ({error}); the sweep continues and this "
+                    "cannot downgrade an earlier arm failure",
                 )
-                continue
-
-            reason = self.decision(snapshot, live=False)
-            if reason:
-                self.emit(snapshot.number, "SKIP", reason)
-                continue
-
-            try:
-                current = self.live_state(snapshot.number)
-            except (GhError, json.JSONDecodeError) as error:
-                self.emit(snapshot.number, "SKIP", f"live-state query failed ({error})")
-                outcome.state_failures.append((snapshot.number, str(error)))
-                continue
-
-            reason = self.decision(current, live=True)
-            if reason:
-                self.emit(current.number, "SKIP", reason)
-                continue
-
-            # Both fields are absent here: and only here is the arm considered dropped.
-            if outcome.attempts >= self.max_rearms:
-                self.emit(current.number, "SKIP", "per-run re-arm limit reached")
-                continue
-            outcome.attempts += 1
-            try:
-                self.arm(current.number)
-            except GhError as error:
-                message = str(error)
-                # [OPUS-5] #3760: a capability denial is NOT a per-PR condition — every
-                # remaining candidate would fail identically. Record it, stop arming, and
-                # surface exactly ONE ::error naming what to change.
-                if is_arm_denial(message):
-                    self.emit(
-                        current.number, "ARM-FAILED", f"arm capability denied ({message})"
-                    )
-                    outcome.arm_failures.append(
-                        (current.number, f"arm capability denied ({message})")
-                    )
-                    outcome.capability = CANNOT_ARM
-                    self.fail_capability(
-                        f"arming PR #{current.number} was denied: {message}"
-                    )
-                    continue
-                # The arm MUTATION failed — that failure is the primary status. The
-                # follow-up live-state read is a diagnostic to classify an API race,
-                # and it is retriable: it can raise GhError, a decode error, OR
-                # GhTransientExhausted. [FABLE-5] #3759 finding 5: the diagnostic's
-                # OWN exhaustion must never escape here — if it did, main's lenient
-                # `except GhTransientExhausted -> exit 0` would convert a genuine
-                # failed arm into a false success. Catch exhaustion too; on any
-                # inconclusive diagnostic, record the arm failure as a real error.
-                try:
-                    raced = self.live_state(current.number)
-                    race_reason = self.decision(raced, live=True)
-                except (GhError, json.JSONDecodeError, gh_retry.GhTransientExhausted):
-                    race_reason = None
-                if race_reason:
-                    self.emit(current.number, "SKIP", f"arm raced: {race_reason}")
-                else:
-                    # Collect and CONTINUE — one bad PR must never abort the sweep.
-                    self.emit(current.number, "ARM-FAILED", f"re-arm failed ({message})")
-                    outcome.arm_failures.append(
-                        (current.number, f"re-arm failed ({message})")
-                    )
                 continue
             outcome.armed += 1
             self.emit(current.number, "ARMED", "dropped auto-merge request restored")
@@ -542,11 +632,14 @@ class RearmSweeper:
             self.log(f"[{PROGRAM}] arm-failure summary: PR #{number} — {reason}")
         for number, reason in outcome.state_failures:
             self.log(f"[{PROGRAM}] state-failure summary: PR #{number} — {reason}")
+        for number, reason in outcome.transient_exhaustions:
+            self.log(f"[{PROGRAM}] transient-exhaustion summary: PR #{number} — {reason}")
         self.log(
             f"[{PROGRAM}] complete: candidates={outcome.candidates} "
             f"re-arm-attempts={outcome.attempts} armed={outcome.armed} "
             f"arm-failures={len(outcome.arm_failures)} "
             f"state-failures={len(outcome.state_failures)} "
+            f"transient-exhaustions={len(outcome.transient_exhaustions)} "
             f"capability={outcome.capability}"
         )
         return outcome
@@ -1050,7 +1143,226 @@ def self_test() -> None:
     assert "::error" in out.getvalue(), out.getvalue()
     assert "::warning" not in out.getvalue(), out.getvalue()
 
+    # ---------------------------------------------------------------------------------
+    # [OPUS-5] #3766 — STICKY FAILURE PRECEDENCE:
+    #     collected-failure > transient-exhaustion > clean.
+    # The false pass this fixes (reproduced by the cross-provider review): PR #3011's arm
+    # FAILED and was collected, then PR #3012's live-state read exhausted its bounded
+    # retries; that exhaustion unwound run() and main()'s lenient handler reported
+    # ::warning + exit 0 — discarding a real arm failure. The collected verdict must be
+    # untouchable by anything that happens for a LATER candidate.
+    # ---------------------------------------------------------------------------------
+
+    def strip_live(pr: dict) -> dict:
+        return {
+            key: value
+            for key, value in pr.items()
+            if key not in ("mergeQueueEntry", "autoMergeRequest")
+        }
+
+    def exhausting_read(base: FakeGh, number: int) -> Callable[[list[str]], str]:
+        """A gh_read whose live-state query for ONE candidate exhausts its retries."""
+
+        def read(argv: list[str]) -> str:
+            if (
+                argv[:2] == ["api", "graphql"]
+                and not is_capability_query(argv)
+                and f"number={number}" in argv
+            ):
+                raise gh_retry.GhTransientExhausted(
+                    "gh api graphql: HTTP 504 (3 attempts)"
+                )
+            return base(argv)
+
+        return read
+
+    def sequence(*, arm_fails: bool):
+        """PR #3011 (optionally arm-failing), then PR #3012 whose live read exhausts."""
+        first_pr, second_pr = fixture(3011), fixture(3012)
+        base = FakeGh(
+            [strip_live(first_pr), strip_live(second_pr)],
+            {3011: first_pr, 3012: second_pr},
+            arm_errors=(
+                {3011: "gh pr merge 3011 failed: Pull request is in unstable status"}
+                if arm_fails
+                else None
+            ),
+        )
+        lines: list[str] = []
+        sweeper = RearmSweeper(
+            "sparq-org/sparq",
+            "main",
+            gh=base,
+            gh_read=exhausting_read(base, 3012),
+            log=lines.append,
+        )
+        # run() must RETURN here: an ESCAPING exhaustion is exactly the #3766 false pass.
+        return lines, sweeper.run()
+
+    # (9) THE #3766 SEQUENCE — arm failure on A, exhausted transient on a LATER B.
+    lines, outcome = sequence(arm_fails=True)
+    assert [number for number, _ in outcome.arm_failures] == [3011], outcome
+    assert [number for number, _ in outcome.transient_exhaustions] == [3012], outcome
+    assert outcome.hard_failed and outcome.exit_code == 1, outcome
+    for mode in ("sweep", "event"):
+        assert sweep_exit(outcome, mode, lines.append, lines.append) == 1, (mode, lines)
+    assert any("PR #3011: ARM-FAILED" in line for line in lines), lines
+    assert any("arm-failure summary: PR #3011" in line for line in lines), lines
+    assert any(
+        "transient-exhausted" in line and "3012" in line for line in lines
+    ), lines
+    assert any("precedence: collected-failure" in line for line in lines), lines
+    # The lenient ::warning must NOT be emitted while a real failure stands.
+    assert not [line for line in lines if line.startswith("::warning")], lines
+
+    # (10) CONTROL — the lenient policy is intact where it IS correct: a sweep whose ONLY
+    # problem is an exhausted transient still exits 0 with exactly one ::warning, and the
+    # candidates around it are still armed.
+    lines, outcome = sequence(arm_fails=False)
+    assert outcome.armed == 1 and not outcome.hard_failed, outcome
+    assert [number for number, _ in outcome.transient_exhaustions] == [3012], outcome
+    warned: list[str] = []
+    assert sweep_exit(outcome, "sweep", warned.append, warned.append) == 0, warned
+    assert len(warned) == 1 and warned[0].startswith("::warning"), warned
+    assert "3012" in warned[0], warned
+    assert any("PR #3011: ARMED" in line for line in lines), lines
+
+    # (11) CONTROL — event mode is unchanged: no per-PR cron backstop, so the same
+    # transient-only outcome fails loudly on the stderr channel.
+    loud: list[str] = []
+    assert sweep_exit(outcome, "event", loud.append, loud.append) == 1, loud
+    assert any("event-mode" in line for line in loud), loud
+
+    # (12) The precedence rule itself, at the seam.
+    assert SweepOutcome().transient_detail is None
+    assert SweepOutcome(sweep_transient="HTTP 504").transient_detail == "HTTP 504"
+    assert (
+        SweepOutcome(transient_exhaustions=[(1, "HTTP 504")]).transient_detail
+        == "PR #1: HTTP 504"
+    )
+    assert SweepOutcome(transient_exhaustions=[(1, "HTTP 504")]).exit_code == 0
+    dominated = SweepOutcome(
+        arm_failures=[(1, "unstable")], transient_exhaustions=[(2, "HTTP 504")]
+    )
+    assert dominated.hard_failed and dominated.exit_code == 1, dominated
+    for mode in ("sweep", "event"):
+        assert sweep_exit(dominated, mode, lambda _l: None, lambda _l: None) == 1, mode
+
+    # (13) FAIL CLOSED — an exhausted transient raised by the ARM MUTATION itself leaves the
+    # arm's outcome UNKNOWN, so it must be a per-PR failure (exit 1), never a lenient
+    # warning-class missed cycle. The one-shot runner cannot raise this today; the handler
+    # exists so a future refactor cannot open a second false-pass route.
+    only = fixture(3031)
+    mutation_base = FakeGh([strip_live(only)], {3031: only})
+
+    def gh_arm_exhausts(argv: list[str]) -> str:
+        if argv[:2] == ["pr", "merge"]:
+            raise gh_retry.GhTransientExhausted("gh pr merge: HTTP 504 (3 attempts)")
+        return mutation_base(argv)
+
+    lines = []
+    outcome = RearmSweeper(
+        "sparq-org/sparq", "main", gh=gh_arm_exhausts, gh_read=mutation_base,
+        log=lines.append,
+    ).run()
+    assert [number for number, _ in outcome.arm_failures] == [3031], outcome
+    assert not outcome.transient_exhaustions, outcome
+    assert sweep_exit(outcome, "sweep", lines.append, lines.append) == 1, lines
+    assert not [line for line in lines if line.startswith("::warning")], lines
+    assert any(
+        "transient exhaustion on the arm mutation" in line for line in lines
+    ), lines
+
+    # (14) END TO END through main() — the precedence must hold for the real entry point,
+    # not only for the seam the assertions above call directly.
+    original_run_gh = globals()["run_gh"]
+
+    class _StickyPrecedenceHarness:
+        """A collected arm failure on PR #3011 must dominate PR #3012's exhaustion."""
+
+        def __enter__(self):
+            first_pr, second_pr = fixture(3011), fixture(3012)
+            fake = FakeGh(
+                [strip_live(first_pr), strip_live(second_pr)],
+                {3011: first_pr, 3012: second_pr},
+                arm_errors={
+                    3011: "gh pr merge 3011 failed: Pull request is in unstable status"
+                },
+            )
+            self._argv = sys.argv
+            globals()["run_gh"] = fake
+            globals()["run_gh_read"] = exhausting_read(fake, 3012)
+            sys.argv = [
+                "rearm-sweeper.py", "--repo", "sparq-org/sparq", "--mode", "sweep",
+            ]
+            return self
+
+        def __exit__(self, *exc):
+            globals()["run_gh"] = original_run_gh
+            globals()["run_gh_read"] = original_run_gh_read
+            sys.argv = self._argv
+            return False
+
+    out, err = io.StringIO(), io.StringIO()
+    with _StickyPrecedenceHarness(), redirect_stdout(out), redirect_stderr(err):
+        sticky_code = main()
+    assert sticky_code == 1, (sticky_code, out.getvalue(), err.getvalue())
+    assert "arm-failure summary: PR #3011" in out.getvalue(), out.getvalue()
+    assert "::warning" not in out.getvalue(), out.getvalue()
+
     print("rearm-sweeper self-test: PASS")
+
+
+def sweep_exit(
+    outcome: SweepOutcome,
+    mode: str,
+    log: Callable[[str], None] = print,
+    fail: Callable[[str], None] | None = None,
+) -> int:
+    """Decide the run's exit status from the FINAL collected state (#3766).
+
+    PRECEDENCE — ``collected-failure > transient-exhaustion > clean``:
+
+    1. A COLLECTED arm/state/capability failure DOMINATES, in either mode. Nothing that
+       happens while processing a LATER candidate — an exhausted transient above all — can
+       downgrade a verdict an EARLIER candidate already earned. This check is reached from
+       the accumulated state, never short-circuited by an exception.
+    2. TRANSIENT EXHAUSTION alone (no collected failure anywhere) keeps #3759's intended
+       lenient policy: ``sweep`` reports ``::warning`` + exit 0, because a missed cycle is
+       harmless and the next cron run re-covers it. ``event`` has no per-PR backstop, so it
+       fails loudly instead.
+    3. CLEAN is 0.
+    """
+    if fail is None:
+
+        def fail(message: str) -> None:
+            print(message, file=sys.stderr)
+
+    if outcome.hard_failed:
+        if outcome.transient_detail:
+            log(
+                f"[{PROGRAM}] a transient exhaustion also occurred "
+                f"({outcome.transient_detail}) but a collected failure outranks it "
+                "(precedence: collected-failure > transient-exhaustion > clean): exit 1"
+            )
+        return outcome.exit_code
+    if outcome.transient_detail:
+        # [FABLE-5] #3759: only the periodic + idempotent SWEEP may swallow a missed cycle
+        # on a transient platform 5xx (the cron backstop covers it). An EVENT-driven
+        # invocation has no per-PR backstop, so it fails loudly (finding 5).
+        if mode == "event":
+            fail(
+                f"[{PROGRAM}] fatal: event-mode exhausted transient retries: "
+                f"{outcome.transient_detail}"
+            )
+            return 1
+        log(
+            f"::warning title={PROGRAM} skipped a cycle on transient GitHub API "
+            f"failures::{outcome.transient_detail} — bounded retries exhausted; the next "
+            "cron run covers this sweep, so this run reports success."
+        )
+        return 0
+    return 0
 
 
 def probe_arm_capability_exit(sweeper: RearmSweeper) -> int:
@@ -1097,35 +1409,29 @@ def main() -> int:
         return 0
     if not args.repo:
         parser.error("--repo is required unless --self-test is used")
+    sweeper: RearmSweeper | None = None
     try:
         sweeper = RearmSweeper(
             args.repo, args.default_branch, max_rearms=args.max_rearms,
-            gh_read=run_gh_read,
+            gh=run_gh, gh_read=run_gh_read,
         )
         if args.probe_arm_capability:
             return probe_arm_capability_exit(sweeper)
-        return sweeper.run().exit_code
+        outcome = sweeper.run()
     except gh_retry.GhTransientExhausted as error:
-        # [FABLE-5] #3759: only the periodic + idempotent SWEEP may swallow a missed
-        # cycle on a transient platform 5xx (the cron backstop covers it). An
-        # EVENT-driven invocation has no per-PR backstop, so it fails loudly (finding
-        # 5). A failed arm MUTATION never reaches here as GhTransientExhausted — its
-        # own diagnostic read cannot overwrite it (see run()).
-        if args.mode == "event":
-            print(
-                f"[{PROGRAM}] fatal: event-mode exhausted transient retries: {error}",
-                file=sys.stderr,
-            )
-            return 1
-        print(
-            f"::warning title={PROGRAM} skipped a cycle on transient GitHub API "
-            f"failures::{error} — bounded retries exhausted; the next cron run "
-            "covers this sweep, so this run reports success."
-        )
-        return 0
+        # [OPUS-5] #3766 STICKY BACKSTOP. run() already records a per-candidate exhaustion
+        # without unwinding; this is defence in depth for any read that is ever added
+        # OUTSIDE that guarded loop. The outcome is read back OFF THE SWEEPER, so everything
+        # already collected still reaches sweep_exit below — an exception can no longer
+        # short-circuit past the accumulated-failure check and report a false success.
+        outcome = sweeper.outcome if sweeper is not None else SweepOutcome()
+        outcome.sweep_transient = outcome.sweep_transient or str(error)
     except (GhError, ValueError, json.JSONDecodeError) as error:
         print(f"[{PROGRAM}] fatal: {error}", file=sys.stderr)
         return 1
+    # The exit is computed HERE, at the end, from the final collected state:
+    # collected-failure > transient-exhaustion > clean.
+    return sweep_exit(outcome, args.mode)
 
 
 if __name__ == "__main__":

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -8,6 +8,9 @@
 # runner. Exhausted transient retries end the sweep as ::warning + exit 0 (a missed
 # cycle is harmless — the cron covers it) instead of redding main's gate; any
 # non-transient error still fails loudly.
+# [OPUS-5] Issue #3760 — fail LOUDLY ONCE when the token cannot arm at all, and never let
+#   a single per-PR arm failure abort the rest of the sweep. A capability denial is NOT a
+#   transient: it never routes through the #3759 ::warning + exit-0 path.
 
 from __future__ import annotations
 
@@ -16,7 +19,7 @@ import copy
 import json
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
 import gh_retry
@@ -47,6 +50,120 @@ LIVE_QUERY = """query($owner:String!,$name:String!,$number:Int!){
     }
   }
 }"""
+
+# --------------------------------------------------------------------------------------
+# [OPUS-5] #3760 — ARM CAPABILITY.
+#
+# LIVE ROOT CAUSE. Sweeper run 30033315483 (2026-07-23T18:21Z) failed arming PR #3454
+# (OPEN, non-draft, CLEAN, review:pass) with
+#     GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)
+# while auto-arm run 30027010495 (2026-07-23T16:52Z, ~90 minutes earlier, SAME repo, SAME
+# plain GITHUB_TOKEN, no App token) armed two PRs successfully. The ONLY difference was the
+# job `permissions:` block: auto-arm.yml declared `contents: write`, rearm-sweeper.yml
+# declared `contents: read`. Enabling auto-merge is a repository WRITE operation, so
+# `contents: read` is denied with exactly this error. It is NOT a maintainer-only setting:
+# `allow_auto_merge` is already true on the repository and the `main` ruleset carries no
+# integration restriction.
+#
+# PROBE DESIGN — what is and is NOT a usable capability signal (all measured):
+#   * Repository.autoMergeAllowed IS usable: it is the repository "Allow auto-merge"
+#     setting, readable read-only, and false means no token can ever arm here.
+#   * Repository.viewerPermission is NOT usable: GitHub documents it as "will return null
+#     if authenticated as a GitHub App", and the Actions GITHUB_TOKEN *is* an App
+#     installation token. Kept in the query as diagnostics only — never gate on it.
+#   * PullRequest.viewerCanEnableAutoMerge is NOT a token-capability signal: measured
+#     false, under an ADMIN user token, for already-armed (#2521), queued (#3764), draft
+#     and merged PRs. It conflates PR state with permission, so gating on it would refuse
+#     legitimate arms.
+#   * A mutation against a bogus node id is NOT a probe: an authorized token gets
+#     NOT_FOUND ("Could not resolve to a node ..."), so the denial class cannot be
+#     distinguished without actually being denied.
+# Hence: the startup probe fails loud on the signals it can read decisively, stays
+# INCONCLUSIVE (never a false red) otherwise, and the first real denial from the mutation
+# itself is promoted to a capability verdict — one ::error, sweep stopped, exit 1 once.
+CAPABILITY_QUERY = """query($owner:String!,$name:String!){
+  repository(owner:$owner,name:$name){
+    autoMergeAllowed
+    viewerPermission
+  }
+  viewer{login}
+}"""
+
+# Substrings that mark a token-capability denial rather than a per-PR condition. Matched
+# case-insensitively against the whole gh/GraphQL failure text. Deliberately disjoint from
+# the #3759 transient set: a denial is permanent and must never be swallowed as a transient.
+ARM_DENIAL_MARKERS = (
+    "resource not accessible by integration",
+    "must have write access",
+    "must have admin access",
+    "not authorized to enable auto-merge",
+    "auto merge is not allowed for this repository",
+    "auto-merge is not allowed for this repository",
+)
+
+# One remediation string, naming every exact thing a human can flip, in fix order.
+ARM_REMEDIATION = (
+    "the arm token cannot call enablePullRequestAutoMerge. Fix in this order: "
+    "(1) .github/workflows/rearm-sweeper.yml MUST declare `permissions:` with BOTH "
+    "`contents: write` and `pull-requests: write` — enabling auto-merge is a repository "
+    "WRITE operation and `contents: read` is denied with exactly this error (live proof: "
+    "sweeper run 30033315483 failed with contents: read while auto-arm run 30027010495 "
+    "armed successfully with contents: write on the same repo and the same GITHUB_TOKEN "
+    "90 minutes earlier); "
+    "(2) repository Settings -> General -> Pull Requests -> 'Allow auto-merge' must be ON "
+    "(GraphQL Repository.autoMergeAllowed must be true); "
+    "(3) if the repository's `main` ruleset gains a restriction on which integrations may "
+    "write, github-actions[bot] must be allowed or the App path used instead; "
+    "(4) to arm as the sparq-orchestrator App instead of GITHUB_TOKEN, set the "
+    "repository/organization secrets ORCHESTRATOR_APP_ID and ORCHESTRATOR_APP_PRIVATE_KEY "
+    "(both are currently UNSET, so the mint step is skipped and the job falls back to "
+    "GITHUB_TOKEN)."
+)
+
+CAN_ARM = "can-arm"
+CANNOT_ARM = "cannot-arm"
+INCONCLUSIVE = "inconclusive"
+
+
+def is_arm_denial(text: str) -> bool:
+    """True when a failure text is a token-capability denial, not a per-PR condition."""
+    lowered = str(text).lower()
+    return any(marker in lowered for marker in ARM_DENIAL_MARKERS)
+
+
+@dataclass(frozen=True)
+class CapabilityVerdict:
+    status: str
+    detail: str
+
+    @property
+    def blocks_sweep(self) -> bool:
+        """Only a decisive cannot-arm blocks; inconclusive must never red the run."""
+        return self.status == CANNOT_ARM
+
+
+@dataclass
+class SweepOutcome:
+    candidates: int = 0
+    attempts: int = 0
+    armed: int = 0
+    # (number, reason) for every PR whose arm was attempted and failed.
+    arm_failures: list[tuple[int, str]] = field(default_factory=list)
+    # Live-state query failures: not arm failures, but still surfaced and still red
+    # (this preserves the pre-#3760 `errors` contract for the diagnostic read).
+    state_failures: list[tuple[int, str]] = field(default_factory=list)
+    capability: str = INCONCLUSIVE
+
+    @property
+    def capability_failed(self) -> bool:
+        return self.capability == CANNOT_ARM
+
+    @property
+    def exit_code(self) -> int:
+        """Never exit 0 while an arm failed — a silent 0 is how #3760 hid for days."""
+        if self.capability_failed or self.arm_failures or self.state_failures:
+            return 1
+        return 0
 
 
 class GhError(RuntimeError):
@@ -152,6 +269,10 @@ class RearmSweeper:
         # MUTATION always uses the one-shot `gh` runner above.
         self.gh_read = gh_read if gh_read is not None else gh
         self.log = log
+        # [OPUS-5] #3760 latches: the fleet must see exactly ONE ::error per run, never
+        # one per PR, and the sweep must stop once the token is known to be unable to arm.
+        self.capability_error_emitted = False
+        self.capability_lost = False
         try:
             self.owner, self.name = repo.split("/", 1)
         except ValueError as error:
@@ -232,15 +353,125 @@ class RearmSweeper:
     def emit(self, number: int, verdict: str, detail: str) -> None:
         self.log(f"[{PROGRAM}] PR #{number}: {verdict} — {detail}")
 
-    def run(self) -> int:
-        attempts = 0
-        errors = 0
+    def probe_arm_capability(self) -> CapabilityVerdict:
+        """Read-only startup probe: can this token arm at all in this repository?
+
+        Decisive only in the directions it can actually read (see the ARM CAPABILITY note
+        above). Anything unreadable is INCONCLUSIVE and must not red the run — the real
+        mutation is the backstop and its denial is promoted to a capability verdict. An
+        exhausted #3759 transient is likewise inconclusive: the sweep's own retrying reads
+        remain the authority on whether the cycle can proceed.
+        """
+        try:
+            raw = self.gh_read(
+                [
+                    "api",
+                    "graphql",
+                    "-f",
+                    f"query={CAPABILITY_QUERY}",
+                    "-f",
+                    f"owner={self.owner}",
+                    "-f",
+                    f"name={self.name}",
+                ]
+            )
+        except gh_retry.GhTransientExhausted as error:
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query exhausted transient retries ({error})"
+            )
+        except GhError as error:
+            if is_arm_denial(str(error)):
+                return CapabilityVerdict(
+                    CANNOT_ARM, f"the arm token was denied by GitHub ({error})"
+                )
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query failed, assuming armable ({error})"
+            )
+        try:
+            response = json.loads(raw)
+        except json.JSONDecodeError as error:
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query returned non-JSON ({error})"
+            )
+        if response.get("errors"):
+            detail = json.dumps(response["errors"], sort_keys=True)
+            if is_arm_denial(detail):
+                return CapabilityVerdict(
+                    CANNOT_ARM, f"the arm token was denied by GitHub ({detail})"
+                )
+            return CapabilityVerdict(
+                INCONCLUSIVE, f"capability query returned errors ({detail})"
+            )
+        data = response.get("data") or {}
+        repository = data.get("repository")
+        if not isinstance(repository, dict):
+            return CapabilityVerdict(
+                INCONCLUSIVE, "capability query returned no repository node"
+            )
+        # Diagnostics only — null for App tokens, so it can never be a gate.
+        login = str((data.get("viewer") or {}).get("login") or "unknown")
+        permission = repository.get("viewerPermission")
+        allowed = repository.get("autoMergeAllowed")
+        if allowed is False:
+            return CapabilityVerdict(
+                CANNOT_ARM,
+                "repository setting 'Allow auto-merge' is OFF "
+                "(GraphQL Repository.autoMergeAllowed=false)",
+            )
+        if allowed is not True:
+            return CapabilityVerdict(
+                INCONCLUSIVE,
+                f"autoMergeAllowed not reported (token={login}, "
+                f"viewerPermission={permission})",
+            )
+        return CapabilityVerdict(
+            CAN_ARM,
+            f"autoMergeAllowed=true (token={login}, viewerPermission={permission}); "
+            "write scope is confirmed by the first arm",
+        )
+
+    def fail_capability(self, detail: str) -> None:
+        """Emit the single ::error for this run and stop attempting further arms."""
+        self.capability_lost = True
+        if self.capability_error_emitted:
+            return
+        self.capability_error_emitted = True
+        self.log(
+            f"::error title={PROGRAM} cannot enable auto-merge::{detail} — "
+            f"{ARM_REMEDIATION}"
+        )
+
+    def run(self) -> SweepOutcome:
+        outcome = SweepOutcome()
+        verdict = self.probe_arm_capability()
+        outcome.capability = verdict.status
+        self.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
+        if verdict.blocks_sweep:
+            # Fail ONCE, before touching any PR: a broken token would otherwise fail
+            # identically on every candidate, every ten minutes, forever. This is NOT a
+            # transient, so it never reaches the #3759 ::warning + exit-0 path.
+            self.fail_capability(f"startup arm-capability probe failed: {verdict.detail}")
+            self.log(
+                f"[{PROGRAM}] complete: candidates=0 re-arm-attempts=0 armed=0 "
+                f"arm-failures=0 state-failures=0 capability={verdict.status}"
+            )
+            return outcome
+
         candidates = self.list_candidates()
+        outcome.candidates = len(candidates)
         self.log(
             f"[{PROGRAM}] found {len(candidates)} open PR(s) returned for "
             f"label {REVIEW_ATTESTATION}; re-arm limit={self.max_rearms}"
         )
         for snapshot in candidates:
+            if self.capability_lost:
+                self.emit(
+                    snapshot.number,
+                    "SKIP",
+                    "arm capability lost this run (see the single ::error above)",
+                )
+                continue
+
             reason = self.decision(snapshot, live=False)
             if reason:
                 self.emit(snapshot.number, "SKIP", reason)
@@ -250,7 +481,7 @@ class RearmSweeper:
                 current = self.live_state(snapshot.number)
             except (GhError, json.JSONDecodeError) as error:
                 self.emit(snapshot.number, "SKIP", f"live-state query failed ({error})")
-                errors += 1
+                outcome.state_failures.append((snapshot.number, str(error)))
                 continue
 
             reason = self.decision(current, live=True)
@@ -259,13 +490,29 @@ class RearmSweeper:
                 continue
 
             # Both fields are absent here: and only here is the arm considered dropped.
-            if attempts >= self.max_rearms:
+            if outcome.attempts >= self.max_rearms:
                 self.emit(current.number, "SKIP", "per-run re-arm limit reached")
                 continue
-            attempts += 1
+            outcome.attempts += 1
             try:
                 self.arm(current.number)
             except GhError as error:
+                message = str(error)
+                # [OPUS-5] #3760: a capability denial is NOT a per-PR condition — every
+                # remaining candidate would fail identically. Record it, stop arming, and
+                # surface exactly ONE ::error naming what to change.
+                if is_arm_denial(message):
+                    self.emit(
+                        current.number, "ARM-FAILED", f"arm capability denied ({message})"
+                    )
+                    outcome.arm_failures.append(
+                        (current.number, f"arm capability denied ({message})")
+                    )
+                    outcome.capability = CANNOT_ARM
+                    self.fail_capability(
+                        f"arming PR #{current.number} was denied: {message}"
+                    )
+                    continue
                 # The arm MUTATION failed — that failure is the primary status. The
                 # follow-up live-state read is a diagnostic to classify an API race,
                 # and it is retriable: it can raise GhError, a decode error, OR
@@ -282,16 +529,27 @@ class RearmSweeper:
                 if race_reason:
                     self.emit(current.number, "SKIP", f"arm raced: {race_reason}")
                 else:
-                    self.emit(current.number, "SKIP", f"re-arm failed ({error})")
-                    errors += 1
+                    # Collect and CONTINUE — one bad PR must never abort the sweep.
+                    self.emit(current.number, "ARM-FAILED", f"re-arm failed ({message})")
+                    outcome.arm_failures.append(
+                        (current.number, f"re-arm failed ({message})")
+                    )
                 continue
+            outcome.armed += 1
             self.emit(current.number, "ARMED", "dropped auto-merge request restored")
 
+        for number, reason in outcome.arm_failures:
+            self.log(f"[{PROGRAM}] arm-failure summary: PR #{number} — {reason}")
+        for number, reason in outcome.state_failures:
+            self.log(f"[{PROGRAM}] state-failure summary: PR #{number} — {reason}")
         self.log(
-            f"[{PROGRAM}] complete: candidates={len(candidates)} "
-            f"re-arm-attempts={attempts} errors={errors}"
+            f"[{PROGRAM}] complete: candidates={outcome.candidates} "
+            f"re-arm-attempts={outcome.attempts} armed={outcome.armed} "
+            f"arm-failures={len(outcome.arm_failures)} "
+            f"state-failures={len(outcome.state_failures)} "
+            f"capability={outcome.capability}"
         )
-        return errors
+        return outcome
 
 
 def fixture(
@@ -315,16 +573,56 @@ def fixture(
     }
 
 
+CAPABILITY_RESPONSE = {
+    "data": {
+        "repository": {"autoMergeAllowed": True, "viewerPermission": None},
+        "viewer": {"login": "github-actions[bot]"},
+    }
+}
+# The exact text GitHub returned in run 30033315483 — the #3760 regression anchor.
+DENIAL_TEXT = (
+    "gh pr merge 3454 failed: GraphQL: Resource not accessible by integration "
+    "(enablePullRequestAutoMerge)"
+)
+
+
+def capability_payload(auto_merge_allowed: bool | None) -> str:
+    payload = copy.deepcopy(CAPABILITY_RESPONSE)
+    payload["data"]["repository"]["autoMergeAllowed"] = auto_merge_allowed
+    return json.dumps(payload)
+
+
+def is_capability_query(argv: list[str]) -> bool:
+    return argv[:2] == ["api", "graphql"] and any(
+        "autoMergeAllowed" in arg for arg in argv
+    )
+
+
 class FakeGh:
-    def __init__(self, snapshots: list[dict], live: dict[int, dict]) -> None:
+    def __init__(
+        self,
+        snapshots: list[dict],
+        live: dict[int, dict],
+        *,
+        auto_merge_allowed: bool | None = True,
+        capability_error: str | None = None,
+        arm_errors: dict[int, str] | None = None,
+    ) -> None:
         self.snapshots = copy.deepcopy(snapshots)
         self.live = copy.deepcopy(live)
+        self.auto_merge_allowed = auto_merge_allowed
+        self.capability_error = capability_error
+        self.arm_errors = dict(arm_errors or {})
         self.calls: list[list[str]] = []
 
     def __call__(self, argv: list[str]) -> str:
         self.calls.append(argv)
         if argv[:2] == ["pr", "list"]:
             return json.dumps(self.snapshots)
+        if is_capability_query(argv):
+            if self.capability_error is not None:
+                raise GhError(self.capability_error)
+            return capability_payload(self.auto_merge_allowed)
         if argv[:2] == ["api", "graphql"]:
             number = int(
                 next(arg.split("=", 1)[1] for arg in argv if arg.startswith("number="))
@@ -338,6 +636,9 @@ class FakeGh:
                 }
             return json.dumps({"data": {"repository": {"pullRequest": pr}}})
         if argv[:2] == ["pr", "merge"]:
+            failure = self.arm_errors.get(int(argv[2]))
+            if failure is not None:
+                raise GhError(failure)
             return ""
         raise AssertionError(f"unexpected fake gh call: {argv}")
 
@@ -346,10 +647,17 @@ def arm_calls(fake: FakeGh) -> list[list[str]]:
     return [call for call in fake.calls if call[:2] == ["pr", "merge"]]
 
 
+def probe_query_calls(fake: FakeGh) -> list[list[str]]:
+    return [call for call in fake.calls if is_capability_query(call)]
+
+
 def exercise(
     *prs: dict,
     live_prs: tuple[dict, ...] | None = None,
     max_rearms: int = DEFAULT_MAX_REARMS,
+    auto_merge_allowed: bool | None = True,
+    capability_error: str | None = None,
+    arm_errors: dict[int, str] | None = None,
 ):
     snapshots = [
         {
@@ -360,12 +668,18 @@ def exercise(
         for pr in prs
     ]
     current = live_prs if live_prs is not None else prs
-    fake = FakeGh(snapshots, {int(pr["number"]): pr for pr in current})
+    fake = FakeGh(
+        snapshots,
+        {int(pr["number"]): pr for pr in current},
+        auto_merge_allowed=auto_merge_allowed,
+        capability_error=capability_error,
+        arm_errors=arm_errors,
+    )
     messages: list[str] = []
-    errors = RearmSweeper(
+    outcome = RearmSweeper(
         "sparq-org/sparq", "main", max_rearms=max_rearms, gh=fake, log=messages.append
     ).run()
-    return fake, messages, errors
+    return fake, messages, outcome
 
 
 def self_test() -> None:
@@ -379,28 +693,33 @@ def self_test() -> None:
 
     # Mutation tripwire (a): autoMergeRequest is null while a queue entry is live.
     queued = fixture(3678, queued=True)
-    fake, messages, errors = exercise(fixture(3678), live_prs=(queued,))
-    assert errors == 0, messages
+    fake, messages, outcome = exercise(fixture(3678), live_prs=(queued,))
+    assert outcome.exit_code == 0, messages
     assert not arm_calls(fake), fake.calls
     assert any("SKIP" in line and "mergeQueueEntry" in line for line in messages), (
         messages
     )
-    query_call = next(call for call in fake.calls if call[:2] == ["api", "graphql"])
+    query_call = next(
+        call
+        for call in fake.calls
+        if call[:2] == ["api", "graphql"] and not is_capability_query(call)
+    )
     query_text = next(arg for arg in query_call if arg.startswith("query="))
     assert "autoMergeRequest{" in query_text, query_text
     assert "mergeQueueEntry{" in query_text, query_text
 
     # Mutation tripwire (b): needs:* is a hard exclusion, independent of queue state.
     held = fixture(3682, labels=(REVIEW_ATTESTATION, "needs:user"))
-    fake, messages, errors = exercise(fixture(3682), live_prs=(held,))
-    assert errors == 0, messages
+    fake, messages, outcome = exercise(fixture(3682), live_prs=(held,))
+    assert outcome.exit_code == 0, messages
     assert not arm_calls(fake), fake.calls
     assert any("SKIP" in line and "needs:user" in line for line in messages), messages
 
     # Mutation tripwire (c): a reviewed PR with neither live field must be re-armed.
     dropped = fixture(3675)
-    fake, messages, errors = exercise(dropped)
-    assert errors == 0, messages
+    fake, messages, outcome = exercise(dropped)
+    assert outcome.exit_code == 0, messages
+    assert outcome.armed == 1, outcome
     assert len(arm_calls(fake)) == 1, fake.calls
     assert arm_calls(fake)[0] == [
         "pr",
@@ -414,8 +733,8 @@ def self_test() -> None:
 
     # CI state alone is never an arm verdict: live removal of review:pass must stop it.
     unattested = fixture(105, labels=())
-    fake, messages, errors = exercise(fixture(105), live_prs=(unattested,))
-    assert errors == 0, messages
+    fake, messages, outcome = exercise(fixture(105), live_prs=(unattested,))
+    assert outcome.exit_code == 0, messages
     assert not arm_calls(fake), fake.calls
     assert any("review:pass attestation absent" in line for line in messages), messages
     list_call = next(call for call in fake.calls if call[:2] == ["pr", "list"])
@@ -445,8 +764,8 @@ def self_test() -> None:
         assert any(expected in line for line in messages), messages
 
     # The hard bound limits commands, while every excess candidate still gets a decision.
-    fake, messages, errors = exercise(fixture(201), fixture(202), max_rearms=1)
-    assert errors == 0, messages
+    fake, messages, outcome = exercise(fixture(201), fixture(202), max_rearms=1)
+    assert outcome.exit_code == 0, messages
     assert len(arm_calls(fake)) == 1, fake.calls
     assert any("PR #202: SKIP" in line and "limit" in line for line in messages), (
         messages
@@ -470,9 +789,14 @@ def self_test() -> None:
     RearmSweeper(
         "sparq-org/sparq", "main", gh=fake, gh_read=spy_read, log=lambda _m: None
     ).run()
-    assert [c[:2] for c in read_calls] == [["pr", "list"], ["api", "graphql"]], (
-        read_calls
-    )
+    # [OPUS-5] #3760: the capability probe is itself an idempotent READ, so it routes
+    # through gh_read (the retrying runner) and precedes the enumeration.
+    assert [c[:2] for c in read_calls] == [
+        ["api", "graphql"],
+        ["pr", "list"],
+        ["api", "graphql"],
+    ], read_calls
+    assert is_capability_query(read_calls[0]), read_calls[0]
     assert [c[:2] for c in arm_calls(fake)] == [["pr", "merge"]], fake.calls
     assert all(c[:2] != ["pr", "merge"] for c in read_calls), read_calls
 
@@ -495,6 +819,8 @@ def self_test() -> None:
             self.calls.append(argv)
             if argv[:2] == ["pr", "list"]:
                 return json.dumps([snapshot])
+            if is_capability_query(argv):
+                return capability_payload(True)
             if argv[:2] == ["api", "graphql"]:
                 if self.armed:
                     # The post-arm diagnostic read exhausts transient retries.
@@ -514,10 +840,11 @@ def self_test() -> None:
 
     fake_ad = _ArmFailsDiagExhausts()
     messages = []
-    errors = RearmSweeper(
+    outcome = RearmSweeper(
         "sparq-org/sparq", "main", gh=fake_ad, gh_read=fake_ad, log=messages.append
     ).run()
-    assert errors == 1, (errors, messages)
+    assert outcome.exit_code == 1, (outcome, messages)
+    assert len(outcome.arm_failures) == 1, outcome
     assert any("re-arm failed" in line for line in messages), messages
     # The diagnostic exhaustion did NOT escape run() (no exception propagated here).
 
@@ -562,7 +889,182 @@ def self_test() -> None:
     assert sweep_code == 0, sweep_code
     assert "::warning" in out.getvalue(), out.getvalue()
 
+    # ---------------------------------------------------------------------------------
+    # [OPUS-5] #3760 — ARM CAPABILITY + PER-PR FAILURE ISOLATION.
+    # ---------------------------------------------------------------------------------
+
+    # The live #3760 error text must classify as a CAPABILITY denial, and near-misses
+    # must NOT — a race/CAS/transient stays per-PR, and the denial set must stay disjoint
+    # from #3759's transient set (a denial must never be swallowed as ::warning + 0).
+    assert is_arm_denial(DENIAL_TEXT), DENIAL_TEXT
+    assert is_arm_denial(DENIAL_TEXT.upper()), "denial matching must be case-insensitive"
+    for benign in (
+        "gh pr merge 1 failed: GraphQL: Head branch was modified. Review and try again",
+        "gh pr merge 1 failed: HTTP 502: 502 Bad Gateway",
+        "gh pr merge 1 failed: HTTP 504: Gateway Timeout",
+        "gh pr merge 1 failed: Pull request is in unstable status",
+    ):
+        assert not is_arm_denial(benign), benign
+
+    # (1) PROBE — can-arm: the sweep proceeds, the verdict is logged, exit 0, and the
+    # probe really runs BEFORE any arm so a broken token never touches a PR.
+    fake, messages, outcome = exercise(fixture(3001))
+    assert outcome.capability == CAN_ARM, outcome
+    assert outcome.exit_code == 0, messages
+    assert len(arm_calls(fake)) == 1, fake.calls
+    assert any("arm-capability probe: can-arm" in line for line in messages), messages
+    assert len(probe_query_calls(fake)) == 1, fake.calls
+    assert fake.calls.index(probe_query_calls(fake)[0]) < min(
+        index for index, call in enumerate(fake.calls) if call[:2] == ["pr", "merge"]
+    ), fake.calls
+
+    # (2) PROBE — cannot-arm (repository setting OFF): ONE ::error naming the exact
+    # setting, ZERO PRs touched (not even enumerated), exit 1.
+    fake, messages, outcome = exercise(fixture(3002), auto_merge_allowed=False)
+    assert outcome.capability == CANNOT_ARM, outcome
+    assert outcome.exit_code == 1, messages
+    assert not arm_calls(fake), fake.calls
+    assert not [call for call in fake.calls if call[:2] == ["pr", "list"]], fake.calls
+    emitted = [line for line in messages if line.startswith("::error")]
+    assert len(emitted) == 1, emitted
+    assert "Allow auto-merge" in emitted[0], emitted
+    assert "contents: write" in emitted[0], emitted
+    assert "ORCHESTRATOR_APP_ID" in emitted[0], emitted
+
+    # (3) PROBE — cannot-arm (the token itself is denied): same single loud error.
+    fake, messages, outcome = exercise(
+        fixture(3003),
+        capability_error="gh api graphql failed: Resource not accessible by integration",
+    )
+    assert outcome.capability == CANNOT_ARM, outcome
+    assert outcome.exit_code == 1, messages
+    assert not arm_calls(fake), fake.calls
+    assert len([line for line in messages if line.startswith("::error")]) == 1, messages
+
+    # (4) PROBE — inconclusive must NEVER red the run or stop the sweep: a transient 502,
+    # a repository that does not report the field, and an exhausted #3759 retry all pass.
+    for kwargs in (
+        {"capability_error": "gh api graphql failed: HTTP 502: 502 Bad Gateway"},
+        {"auto_merge_allowed": None},
+    ):
+        fake, messages, outcome = exercise(fixture(3004), **kwargs)
+        assert outcome.capability == INCONCLUSIVE, (kwargs, outcome)
+        assert outcome.exit_code == 0, (kwargs, messages)
+        assert len(arm_calls(fake)) == 1, (kwargs, fake.calls)
+        assert not [line for line in messages if line.startswith("::error")], messages
+
+    exhausting = FakeGh([], {})
+
+    def _probe_exhausts(argv: list[str]) -> str:
+        if is_capability_query(argv):
+            raise gh_retry.GhTransientExhausted("gh api graphql: HTTP 504 (3 attempts)")
+        return exhausting(argv)
+
+    probe_verdict = RearmSweeper(
+        "sparq-org/sparq", "main", gh=exhausting, gh_read=_probe_exhausts,
+        log=lambda _line: None,
+    ).probe_arm_capability()
+    assert probe_verdict.status == INCONCLUSIVE, probe_verdict
+    assert "transient" in probe_verdict.detail, probe_verdict
+
+    # (5) PER-PR ARM FAILURE — a non-capability failure on the FIRST PR must not abort
+    # the sweep: the second PR is still armed, the failure is summarised, exit is 1.
+    fake, messages, outcome = exercise(
+        fixture(3011),
+        fixture(3012),
+        arm_errors={3011: "gh pr merge 3011 failed: Pull request is in unstable status"},
+    )
+    assert [call[2] for call in arm_calls(fake)] == ["3011", "3012"], fake.calls
+    assert outcome.armed == 1, outcome
+    assert [number for number, _ in outcome.arm_failures] == [3011], outcome
+    assert outcome.exit_code == 1, messages
+    assert any("PR #3011: ARM-FAILED" in line for line in messages), messages
+    assert any("PR #3012: ARMED" in line for line in messages), messages
+    assert any("arm-failure summary: PR #3011" in line for line in messages), messages
+    assert any(
+        "arm-failures=1" in line and "armed=1" in line for line in messages
+    ), messages
+    # A per-PR failure is NOT a capability failure, so it emits no ::error.
+    assert not [line for line in messages if line.startswith("::error")], messages
+
+    # (6) MID-SWEEP CAPABILITY DENIAL — the #3760 error on the first PR must stop the
+    # sweep after ONE ::error (never one per PR) and still exit non-zero.
+    fake, messages, outcome = exercise(
+        fixture(3021),
+        fixture(3022),
+        fixture(3023),
+        arm_errors={number: DENIAL_TEXT for number in (3021, 3022, 3023)},
+    )
+    assert [call[2] for call in arm_calls(fake)] == ["3021"], fake.calls
+    assert outcome.capability == CANNOT_ARM, outcome
+    assert outcome.armed == 0, outcome
+    assert [number for number, _ in outcome.arm_failures] == [3021], outcome
+    assert outcome.exit_code == 1, messages
+    emitted = [line for line in messages if line.startswith("::error")]
+    assert len(emitted) == 1, emitted
+    assert "contents: write" in emitted[0], emitted
+    assert sum("arm capability lost" in line for line in messages) == 2, messages
+
+    # (7) EXIT SEMANTICS — an arm failure must never exit 0, and the pre-#3760
+    # live-state `errors` contract still reds the run.
+    assert SweepOutcome().exit_code == 0
+    assert SweepOutcome(arm_failures=[(1, "x")]).exit_code == 1
+    assert SweepOutcome(state_failures=[(1, "x")]).exit_code == 1
+    assert SweepOutcome(capability=CANNOT_ARM).exit_code == 1
+    assert SweepOutcome(capability=INCONCLUSIVE).exit_code == 0
+
+    # (8) The standalone probe entry point must agree with the in-sweep verdict, in both
+    # directions, and a cannot-arm probe must exit non-zero exactly once.
+    blocked = RearmSweeper(
+        "sparq-org/sparq",
+        "main",
+        gh=FakeGh([], {}, auto_merge_allowed=False),
+        log=lambda _line: None,
+    )
+    assert blocked.probe_arm_capability().status == CANNOT_ARM
+    assert probe_arm_capability_exit(blocked) == 1
+    healthy = RearmSweeper(
+        "sparq-org/sparq", "main", gh=FakeGh([], {}), log=lambda _line: None
+    )
+    assert healthy.probe_arm_capability().status == CAN_ARM
+    assert probe_arm_capability_exit(healthy) == 0
+
+    # A capability failure is NOT a transient: --mode sweep must still exit 1 (it must
+    # never be converted into the #3759 ::warning + exit-0 missed cycle).
+    class _CannotArmHarness:
+        def __enter__(self):
+            self._argv = sys.argv
+            globals()["run_gh_read"] = lambda argv: capability_payload(False)
+            sys.argv = ["rearm-sweeper.py", "--repo", "sparq-org/sparq", "--mode", "sweep"]
+            return self
+
+        def __exit__(self, *exc):
+            globals()["run_gh_read"] = original_run_gh_read
+            sys.argv = self._argv
+            return False
+
+    out, err = io.StringIO(), io.StringIO()
+    with _CannotArmHarness(), redirect_stdout(out), redirect_stderr(err):
+        cannot_arm_code = main()
+    assert cannot_arm_code == 1, cannot_arm_code
+    assert "::error" in out.getvalue(), out.getvalue()
+    assert "::warning" not in out.getvalue(), out.getvalue()
+
     print("rearm-sweeper self-test: PASS")
+
+
+def probe_arm_capability_exit(sweeper: RearmSweeper) -> int:
+    """Run ONLY the startup probe: 0 = armable (or inconclusive), 1 = provably not.
+
+    Wired as its own workflow step so the job reds at second three with one actionable
+    ::error instead of burning a sweep and reporting a per-PR SKIP every ten minutes.
+    """
+    verdict = sweeper.probe_arm_capability()
+    sweeper.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
+    if verdict.blocks_sweep:
+        sweeper.fail_capability(f"startup arm-capability probe failed: {verdict.detail}")
+        return 1
+    return 0
 
 
 def main() -> int:
@@ -583,6 +1085,11 @@ def main() -> int:
         ),
     )
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument(
+        "--probe-arm-capability",
+        action="store_true",
+        help="only verify the token can enable auto-merge here; arm nothing",
+    )
     args = parser.parse_args()
 
     if args.self_test:
@@ -595,7 +1102,9 @@ def main() -> int:
             args.repo, args.default_branch, max_rearms=args.max_rearms,
             gh_read=run_gh_read,
         )
-        return 1 if sweeper.run() else 0
+        if args.probe_arm_capability:
+            return probe_arm_capability_exit(sweeper)
+        return sweeper.run().exit_code
     except gh_retry.GhTransientExhausted as error:
         # [FABLE-5] #3759: only the periodic + idempotent SWEEP may swallow a missed
         # cycle on a transient platform 5xx (the cron backstop covers it). An

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -30,6 +30,11 @@
 #     only its own file, so they CANNOT import a shared helper) while keeping the same
 #     denial-marker set. This pins the duplication instead of letting it rot.
 #   * EXIT SEMANTICS — neither script may lose its non-zero exit on an arm failure.
+#   * STICKY PRECEDENCE (#3766) — collecting failures is only half the job. Both scripts
+#     must compute the exit from the FINAL accumulated state with the precedence
+#     `collected-failure > transient-exhaustion > clean`, so a LATER candidate's exhausted
+#     transient can never downgrade an EARLIER candidate's real arm failure to the lenient
+#     ::warning + exit 0. Pinned in both (deliberately duplicated) files.
 #
 # Needs PyYAML (already a docs-quality dependency); everything else is stdlib. Run:
 #   python3 scripts/tests/test_arm_capability_wiring.py
@@ -273,6 +278,71 @@ class TestScriptContract(unittest.TestCase):
         self.assertEqual(
             self.auto.ArmOutcome(capability=self.auto.CANNOT_ARM).exit_code, 1
         )
+
+    @staticmethod
+    def _outcome_class(module: ModuleType):
+        return getattr(module, "SweepOutcome", None) or module.ArmOutcome
+
+    def test_both_outcomes_carry_sticky_transient_state(self) -> None:
+        # #3766: the per-candidate transient must be RECORDED state, not an exception that
+        # unwinds the run — an exception is what discarded the earlier collected failure.
+        for module in (self.rearm, self.auto):
+            outcome = self._outcome_class(module)()
+            for attribute in (
+                "transient_exhaustions",
+                "sweep_transient",
+                "hard_failed",
+                "transient_detail",
+            ):
+                self.assertTrue(
+                    hasattr(outcome, attribute),
+                    f"{module.PROGRAM}: {attribute} is load-bearing for #3766",
+                )
+
+    def test_a_collected_failure_outranks_a_later_transient_exhaustion(self) -> None:
+        for module in (self.rearm, self.auto):
+            outcome_class = self._outcome_class(module)
+            dominated = outcome_class(
+                arm_failures=[(451, "unstable")],
+                transient_exhaustions=[(452, "HTTP 504")],
+            )
+            self.assertTrue(dominated.hard_failed, module.PROGRAM)
+            self.assertEqual(
+                dominated.exit_code,
+                1,
+                f"{module.PROGRAM}: a LATER candidate's exhausted transient must never "
+                "downgrade a COLLECTED arm failure to success (#3766)",
+            )
+            # ... while the lenient policy survives where it IS correct.
+            transient_only = outcome_class(transient_exhaustions=[(452, "HTTP 504")])
+            self.assertFalse(transient_only.hard_failed, module.PROGRAM)
+            self.assertEqual(transient_only.exit_code, 0, module.PROGRAM)
+            self.assertIsNotNone(transient_only.transient_detail, module.PROGRAM)
+
+    def test_both_publish_the_outcome_on_the_runner(self) -> None:
+        # The exit is computed at the END from this state, so it must be reachable after an
+        # exception escapes run() — a local variable is exactly what #3766 lost.
+        rearm_runner = self.rearm.RearmSweeper(
+            "o/r", "main", gh=lambda _argv: "", log=lambda _line: None
+        )
+        auto_runner = self.auto.AutoArmer("o/r", "main", lambda _argv: "", lambda _l: None)
+        for runner, module in ((rearm_runner, self.rearm), (auto_runner, self.auto)):
+            self.assertIsInstance(
+                runner.outcome, self._outcome_class(module), module.PROGRAM
+            )
+
+    def test_both_expose_an_end_of_run_precedence_function(self) -> None:
+        self.assertTrue(callable(self.rearm.sweep_exit))
+        self.assertTrue(callable(self.auto.arm_exit_code))
+        for module in (self.rearm, self.auto):
+            source = (REARM_PY if module is self.rearm else AUTO_ARM_PY).read_text(
+                encoding="utf-8"
+            )
+            self.assertIn(
+                "collected-failure > transient-exhaustion > clean",
+                source,
+                f"{module.PROGRAM}: the precedence rule must be documented in-source",
+            )
 
     def test_capability_probe_query_reads_the_repository_setting(self) -> None:
         for module in (self.rearm, self.auto):

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# [OPUS-5] sparq-org/sparq#3760 — cross-file INSPECTION pins for the arm path.
+#
+# THE OUTAGE. The re-arm sweeper could not enable auto-merge at all:
+#   run 30033315483 (2026-07-23T18:21Z) failed arming PR #3454 (OPEN, non-draft, CLEAN,
+#   review:pass) with "GraphQL: Resource not accessible by integration
+#   (enablePullRequestAutoMerge)", and had been doing so every ten minutes.
+# THE CAUSE. rearm-sweeper.yml declared `permissions: contents: read`. Enabling auto-merge
+# is a repository WRITE operation. auto-arm.yml armed two PRs 90 minutes earlier
+# (run 30027010495, 16:52Z) on the same repository with the same plain GITHUB_TOKEN — its
+# only difference was `contents: write`. `allow_auto_merge` was already true and the `main`
+# ruleset carried no integration restriction, so nothing maintainer-only was involved.
+#
+# A `permissions:` block cannot be unit-tested by execution, so this suite pins the SHAPE
+# of everything the fix depends on:
+#   * PERMISSION PIN — both arm workflows must declare `contents: write` AND
+#     `pull-requests: write`. A silent downgrade to `read` reproduces #3760 exactly, and
+#     it is invisible in a diff review of a python-only change.
+#   * PROBE WIRED, AND FIRST — each workflow must run `--probe-arm-capability` as its own
+#     step BEFORE the arming step, so a token that cannot arm reds the job once instead of
+#     failing per-PR forever.
+#   * SAME TOKEN — the probe step's GH_TOKEN expression must be byte-identical to the arm
+#     step's. A probe that attests a different token than the sweep uses is worse than no
+#     probe: it would report can-arm while the sweep is denied.
+#   * REMEDIATION CONTENT — the single ::error must name every flippable thing
+#     (`contents: write`, the repository "Allow auto-merge" setting, and the
+#     ORCHESTRATOR_APP_ID / ORCHESTRATOR_APP_PRIVATE_KEY secrets). An ::error that says
+#     only "permission denied" is what made this cost days.
+#   * NO-DRIFT — the two scripts must stay self-contained (each workflow sparse-checks out
+#     only its own file, so they CANNOT import a shared helper) while keeping the same
+#     denial-marker set. This pins the duplication instead of letting it rot.
+#   * EXIT SEMANTICS — neither script may lose its non-zero exit on an arm failure.
+#
+# Needs PyYAML (already a docs-quality dependency); everything else is stdlib. Run:
+#   python3 scripts/tests/test_arm_capability_wiring.py
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+REARM_YML = WORKFLOWS / "rearm-sweeper.yml"
+AUTO_ARM_YML = WORKFLOWS / "auto-arm.yml"
+REARM_PY = REPO_ROOT / "scripts" / "rearm-sweeper.py"
+AUTO_ARM_PY = REPO_ROOT / "scripts" / "auto-arm.py"
+
+PROBE_FLAG = "--probe-arm-capability"
+# The exact string GitHub returned in run 30033315483 — the regression anchor.
+LIVE_DENIAL = (
+    "GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge)"
+)
+# Every remediation lever a human can actually pull, by exact name.
+REQUIRED_REMEDIATION_TOKENS = (
+    "contents: write",
+    "pull-requests: write",
+    "Allow auto-merge",
+    "autoMergeAllowed",
+    "ORCHESTRATOR_APP_ID",
+    "ORCHESTRATOR_APP_PRIVATE_KEY",
+)
+
+ARM_WORKFLOWS = {
+    "rearm-sweeper.yml": (REARM_YML, "scripts/rearm-sweeper.py"),
+    "auto-arm.yml": (AUTO_ARM_YML, "scripts/auto-arm.py"),
+}
+
+
+def load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def load_module(path: Path, name: str) -> ModuleType:
+    """Import a hyphenated script by path (the scripts are not importable by name)."""
+    # Both scripts import the sibling gh_retry helper (#3759), which is only importable
+    # with scripts/ on the path — the workflows get that for free by running from there.
+    scripts_dir = str(REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, path
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def steps_of(document: dict) -> list[dict]:
+    steps: list[dict] = []
+    for job in (document.get("jobs") or {}).values():
+        steps.extend(job.get("steps") or [])
+    return steps
+
+
+def run_of(step: dict) -> str:
+    return str(step.get("run") or "")
+
+
+class TestPermissionPin(unittest.TestCase):
+    """#3760: `contents: read` on an arming job IS the bug. Pin write on both."""
+
+    def test_both_arm_workflows_declare_contents_and_pull_requests_write(self) -> None:
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            document = load(path)
+            permissions = document.get("permissions")
+            self.assertIsInstance(
+                permissions,
+                dict,
+                f"{name} must declare an explicit permissions block",
+            )
+            self.assertEqual(
+                permissions.get("contents"),
+                "write",
+                f"{name}: enablePullRequestAutoMerge is a repository WRITE operation; "
+                f"`contents: read` reproduces #3760 ({LIVE_DENIAL})",
+            )
+            self.assertEqual(
+                permissions.get("pull-requests"),
+                "write",
+                f"{name} must keep `pull-requests: write`",
+            )
+
+    def test_arm_workflows_do_not_narrow_permissions_at_the_job_level(self) -> None:
+        # A job-level `permissions:` REPLACES the workflow-level block, so a job-level
+        # narrowing would silently reintroduce the outage.
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            for job_id, job in (load(path).get("jobs") or {}).items():
+                if "permissions" not in job:
+                    continue
+                permissions = job["permissions"]
+                self.assertIsInstance(permissions, dict, f"{name}:{job_id}")
+                self.assertEqual(
+                    permissions.get("contents"), "write", f"{name}:{job_id}"
+                )
+                self.assertEqual(
+                    permissions.get("pull-requests"), "write", f"{name}:{job_id}"
+                )
+
+
+class TestProbeWiring(unittest.TestCase):
+    """The probe must exist, run first, and attest the token the arm step uses."""
+
+    def test_probe_step_exists_and_precedes_the_arm_step(self) -> None:
+        for name, (path, script) in ARM_WORKFLOWS.items():
+            steps = steps_of(load(path))
+            probe_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if PROBE_FLAG in run_of(step) and script in run_of(step)
+            ]
+            arm_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if script in run_of(step)
+                and PROBE_FLAG not in run_of(step)
+                and "--self-test" not in run_of(step)
+            ]
+            self.assertEqual(
+                len(probe_indexes), 1, f"{name} must run {PROBE_FLAG} exactly once"
+            )
+            self.assertTrue(arm_indexes, f"{name} must still have an arming step")
+            self.assertLess(
+                probe_indexes[0],
+                min(arm_indexes),
+                f"{name}: the capability probe must run BEFORE any arm",
+            )
+
+    def test_probe_and_arm_steps_use_the_identical_token_expression(self) -> None:
+        for name, (path, script) in ARM_WORKFLOWS.items():
+            steps = steps_of(load(path))
+            probe = next(
+                step
+                for step in steps
+                if PROBE_FLAG in run_of(step) and script in run_of(step)
+            )
+            arm = next(
+                step
+                for step in steps
+                if script in run_of(step)
+                and PROBE_FLAG not in run_of(step)
+                and "--self-test" not in run_of(step)
+            )
+            probe_token = (probe.get("env") or {}).get("GH_TOKEN")
+            arm_token = (arm.get("env") or {}).get("GH_TOKEN")
+            self.assertTrue(probe_token, f"{name}: probe step needs GH_TOKEN")
+            self.assertEqual(
+                probe_token,
+                arm_token,
+                f"{name}: a probe on a DIFFERENT token than the arm step would attest "
+                "capability the sweep does not have",
+            )
+
+    def test_self_test_step_survives(self) -> None:
+        for name, (path, script) in ARM_WORKFLOWS.items():
+            steps = steps_of(load(path))
+            self.assertTrue(
+                any(
+                    "--self-test" in run_of(step) and script in run_of(step)
+                    for step in steps
+                ),
+                f"{name} must keep running the policy self-test before arming",
+            )
+
+
+class TestScriptContract(unittest.TestCase):
+    """Pin the behaviour the workflows depend on, in both (deliberately duplicated) files."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rearm = load_module(REARM_PY, "rearm_sweeper_under_test")
+        cls.auto = load_module(AUTO_ARM_PY, "auto_arm_under_test")
+
+    def test_both_expose_the_probe_and_denial_classifier(self) -> None:
+        for module in (self.rearm, self.auto):
+            self.assertTrue(callable(module.is_arm_denial))
+            self.assertTrue(callable(module.probe_arm_capability_exit))
+            self.assertEqual(module.CAN_ARM, "can-arm")
+            self.assertEqual(module.CANNOT_ARM, "cannot-arm")
+            self.assertEqual(module.INCONCLUSIVE, "inconclusive")
+
+    def test_the_live_denial_text_classifies_as_a_capability_denial(self) -> None:
+        for module in (self.rearm, self.auto):
+            self.assertTrue(
+                module.is_arm_denial(f"gh pr merge 3454 failed: {LIVE_DENIAL}"),
+                "the exact run-30033315483 error must be recognised",
+            )
+
+    def test_per_pr_conditions_are_not_misclassified_as_capability_denials(self) -> None:
+        # A race/CAS/transient must stay per-PR, or one flaky PR would stop the sweep.
+        for module in (self.rearm, self.auto):
+            for benign in (
+                "Head branch was modified. Review and try again",
+                "HTTP 502: 502 Bad Gateway",
+                "Pull request is in unstable status",
+                "simulated expectedHeadOid CAS rejection",
+            ):
+                self.assertFalse(module.is_arm_denial(benign), (module.PROGRAM, benign))
+
+    def test_denial_marker_sets_do_not_drift_between_the_two_scripts(self) -> None:
+        # The workflows sparse-check out only their own script, so a shared import is
+        # impossible; pin the duplication instead of letting the copies diverge.
+        self.assertEqual(
+            tuple(self.rearm.ARM_DENIAL_MARKERS),
+            tuple(self.auto.ARM_DENIAL_MARKERS),
+            "both arm scripts must classify the same denial set",
+        )
+
+    def test_remediation_names_every_flippable_lever(self) -> None:
+        for module in (self.rearm, self.auto):
+            for token in REQUIRED_REMEDIATION_TOKENS:
+                self.assertIn(
+                    token,
+                    module.ARM_REMEDIATION,
+                    f"{module.PROGRAM}: the single ::error must name {token!r}",
+                )
+
+    def test_exit_semantics_never_return_zero_on_an_arm_failure(self) -> None:
+        self.assertEqual(self.rearm.SweepOutcome().exit_code, 0)
+        self.assertEqual(
+            self.rearm.SweepOutcome(arm_failures=[(1, "denied")]).exit_code, 1
+        )
+        self.assertEqual(
+            self.rearm.SweepOutcome(capability=self.rearm.CANNOT_ARM).exit_code, 1
+        )
+        self.assertEqual(self.auto.ArmOutcome().exit_code, 0)
+        self.assertEqual(self.auto.ArmOutcome(arm_failures=[(1, "denied")]).exit_code, 1)
+        self.assertEqual(
+            self.auto.ArmOutcome(capability=self.auto.CANNOT_ARM).exit_code, 1
+        )
+
+    def test_capability_probe_query_reads_the_repository_setting(self) -> None:
+        for module in (self.rearm, self.auto):
+            self.assertIn("autoMergeAllowed", module.CAPABILITY_QUERY)
+
+    def test_a_null_viewer_permission_never_blocks(self) -> None:
+        # MEASURED: Repository.viewerPermission is null when authenticated as a GitHub App,
+        # and the Actions GITHUB_TOKEN *is* an App installation token — so it can only ever
+        # be diagnostics. PullRequest.viewerCanEnableAutoMerge is likewise unusable: it is
+        # false for already-armed (#2521), queued (#3764), draft and merged PRs even under
+        # an ADMIN user token. Gating on either would refuse legitimate arms. This pins the
+        # only thing that matters behaviourally: a null viewerPermission with the setting
+        # ON must still read as can-arm.
+        for module in (self.rearm, self.auto):
+            response = {
+                "data": {
+                    "repository": {
+                        "autoMergeAllowed": True,
+                        "viewerPermission": None,
+                    },
+                    "viewer": {"login": "github-actions[bot]"},
+                }
+            }
+            verdict = self._probe_with(module, response)
+            self.assertEqual(verdict.status, module.CAN_ARM, verdict)
+            # ... and the setting being OFF must be decisive regardless.
+            response["data"]["repository"]["autoMergeAllowed"] = False
+            verdict = self._probe_with(module, response)
+            self.assertEqual(verdict.status, module.CANNOT_ARM, verdict)
+            self.assertIn("Allow auto-merge", verdict.detail)
+
+    @staticmethod
+    def _probe_with(module: ModuleType, response: dict):
+        import json
+
+        def fake_gh(_argv: list[str]) -> str:
+            return json.dumps(response)
+
+        runner = (
+            module.RearmSweeper("o/r", "main", gh=fake_gh, log=lambda _line: None)
+            if hasattr(module, "RearmSweeper")
+            else module.AutoArmer("o/r", "main", fake_gh, lambda _line: None)
+        )
+        return runner.probe_arm_capability()
+
+    def test_both_scripts_stay_import_free_of_each_other(self) -> None:
+        for path in (REARM_PY, AUTO_ARM_PY):
+            source = path.read_text(encoding="utf-8")
+            self.assertNotIn("import rearm_sweeper", source, path)
+            self.assertNotIn("import auto_arm", source, path)
+
+
+class TestSelfTestsRunInCi(unittest.TestCase):
+    """The self-tests are only worth writing if something runs them on every PR."""
+
+    def test_docs_quality_runs_both_self_tests_and_this_wiring_suite(self) -> None:
+        document = load(WORKFLOWS / "docs-quality.yml")
+        gating = [
+            run_of(step)
+            for job_id, job in (document.get("jobs") or {}).items()
+            for step in (job.get("steps") or [])
+            if "advisory" not in str(job.get("name", job_id)).lower()
+        ]
+        blob = "\n".join(gating)
+        for needle in (
+            "scripts/rearm-sweeper.py --self-test",
+            "scripts/auto-arm.py --self-test",
+            "scripts/tests/test_arm_capability_wiring.py",
+        ):
+            self.assertIn(
+                needle,
+                blob,
+                f"docs-quality.yml must run `{needle}` in a GATING job",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration.

Closes #3760.

## Diagnosis — and the honest answer to "is this maintainer-only?": **no, it is not**

**Which token made the failing call.** The `sweep` job's `GH_TOKEN` is
`${{ steps.app-token.outputs.token || github.token }}`. `ORCHESTRATOR_APP_ID` was
**empty** in the failing run (visible in its step env dump), so the App mint step was
skipped and the arm ran on the plain **GITHUB_TOKEN**.

**Why it could not call `enablePullRequestAutoMerge`.** Enabling auto-merge is a
repository **WRITE** operation, and `rearm-sweeper.yml` declared `permissions: contents: read`.

| | token | `permissions` | outcome |
|---|---|---|---|
| re-arm sweeper run [30033315483](https://github.com/sparq-org/sparq/actions/runs/30033315483) — 2026-07-23 **18:21Z** | plain `GITHUB_TOKEN` | `contents: **read**` + `pull-requests: write` | ❌ `PR #3454: SKIP — re-arm failed (gh pr merge 3454 failed: GraphQL: Resource not accessible by integration (enablePullRequestAutoMerge))` — PR #3454 was OPEN, non-draft, CLEAN, `review:pass`; the orchestrator armed it by hand with a user token |
| auto-arm run [30027010495](https://github.com/sparq-org/sparq/actions/runs/30027010495) — 2026-07-23 **16:52Z**, 90 min earlier | plain `GITHUB_TOKEN` (auto-arm has no App path at all) | `contents: **write**` + `pull-requests: write` | ✅ `armed head 65eda1b325f6`, `armed head e8afddf96f3b` |

Same repository, same hour, same token identity, opposite results. The only difference is
the `permissions` block, so `contents: write` is the fix.

**Ruled out, with evidence — none of these needs a maintainer:**

* `allow_auto_merge` is **already `true`** on the repository (`GET /repos/sparq-org/sparq`).
* The `main` ruleset has **no integration restriction** — its rules are
  `deletion, non_fast_forward, pull_request, required_status_checks, code_quality, copilot_code_review, merge_queue`, with a single `RepositoryRole` bypass actor.
* The App path is genuinely unconfigured (`ORCHESTRATOR_APP_ID` / `ORCHESTRATOR_APP_PRIVATE_KEY` are unset — the same reason the batch-merge omnibus path degrades to hygiene-only), **but it is not needed**: a `GITHUB_TOKEN` with `contents: write` arms fine, as auto-arm proves every day. The App token remains preferred when the secrets do appear.

The auto-arm reds on 2026-07-23 were a **different** class, and I checked rather than
assumed: all of them were `gh pr list --repo failed: HTTP 502/504` on
`api.github.com/graphql`, not permission denials.

## The fix

1. **`rearm-sweeper.yml`: `contents: read` → `contents: write`.** The one-line root-cause fix, with the live evidence in the file so it is not "cleaned up" later.
2. **Startup arm-capability probe, failing loud exactly once.** Both policies gain `--probe-arm-capability`, wired as its own step *before* arming. A provable cannot-arm emits **one** `::error` naming every flippable lever — `contents: write` + `pull-requests: write`, repository *Settings → General → Pull Requests → Allow auto-merge*, a future ruleset integration restriction, the `ORCHESTRATOR_APP_ID` / `ORCHESTRATOR_APP_PRIVATE_KEY` secrets, and (auto-arm only) the fork-PR token downgrade — then exits non-zero **once, before any PR is touched**. Signals it cannot read decisively stay `inconclusive` and never red the run, so a transient 502 on the probe cannot invent an outage.
3. **A per-PR arm failure no longer aborts the sweep.** Failures are collected, the sweep continues to every remaining candidate, each failure is summarised at the end, and the run exits non-zero. This was a real second defect in **auto-arm**: `process()` re-raised the mutation error out of `run()`, so a single failing PR stopped every later PR from being armed at all.
4. **A denial mid-sweep is a capability verdict, not a per-PR one.** The first `Resource not accessible by integration`-class failure emits the single `::error`, stops arming (the remaining candidates log `arm capability lost this run`), and exits 1 — never one error per PR, never ten identical failures per run.

## Probe design — what is *not* a capability signal (measured, and recorded in the source)

I tried the obvious probes first and they are all unusable; the findings are comments in
`scripts/rearm-sweeper.py` so nobody re-derives them:

* `Repository.viewerPermission` — GitHub documents it as *"will return null if
  authenticated as a GitHub App"*, and the Actions `GITHUB_TOKEN` **is** an App
  installation token. Diagnostics only, never a gate.
* `PullRequest.viewerCanEnableAutoMerge` — measured **false** under an **ADMIN user
  token** for already-armed (#2521), queued (#3764), draft and merged PRs. It conflates PR
  state with permission; gating on it would refuse legitimate arms.
* The mutation against a bogus node id — an *authorized* token gets `NOT_FOUND`
  ("Could not resolve to a node with the global id of ..."), so the denial class cannot be
  distinguished without actually being denied.

What is left, and what the probe uses: `Repository.autoMergeAllowed` (decisive when
false), a denied repository read (decisive), and the mutation's own denial as the backstop.

## Tests

* `scripts/rearm-sweeper.py --self-test` / `scripts/auto-arm.py --self-test` — probe verdicts (**can-arm / cannot-arm / inconclusive**, both cannot-arm routes: setting-off and token-denied), probe-runs-before-any-arm, **one `::error` per run**, **per-PR failure collection + continue** (PR #452 is still armed after #451 fails), mid-sweep denial stops the sweep after one error, and **end-of-run exit semantics** (`arm_failures` ⇒ exit 1; an arm failure can never exit 0). Both PASS.
* `scripts/tests/test_arm_capability_wiring.py` (new, 15 tests) — cross-file pins: `contents: write` + `pull-requests: write` on **both** workflows and no job-level narrowing, the probe step present and *before* the arm step with a **byte-identical `GH_TOKEN` expression** (a probe on a different token than the sweep uses is worse than no probe), the live #3760 error text classifying as a denial while races/502s/CAS rejections do **not**, remediation naming every lever, and no drift between the two deliberately duplicated copies (each workflow sparse-checks out only its own script, so a shared import is impossible).
* **Mutation-verified**, not assumed: six regressions each red the pins — `contents: write`→`read` on either workflow, probe step removed, probe token diverging from the arm token, a denial marker dropped, and the remediation losing `contents: write`.
* **Live**, read-only: `--probe-arm-capability` against `sparq-org/sparq` returns `can-arm — autoMergeAllowed=true`, exit 0; a full sweep with arming stubbed out ran end-to-end (`candidates=1 ... capability=can-arm`, exit 0) — **nothing was armed by this work**.
* `check-advisory-registry.py`, `check-install-action-tool.py`, YAML parse of all three touched workflows: green.

The arm self-tests previously only ran *inside the scheduled arm workflows* — i.e. never on
the PR that broke them. All three suites now gate in `docs-quality` `quick-gates`.

## Residual honesty

The write-scope half of the capability question cannot be proven read-only from inside the
job: no GitHub API exposes an installation token's `contents` scope, and
`viewerPermission` is null for Apps. The startup probe is therefore decisive about the
repository setting and about a denied read, and the **first mutation** is what confirms
write. That is why the mid-sweep denial path exists and why it fails loud once instead of
degrading to a per-PR skip. Everything a human might need to flip is named in that one
error; today, nothing needs flipping.

## Rebased onto #3764 (#3759 transient-tolerant sweeps) — one deliberate test change, called out

#3764 landed the `gh_retry` read layer while this was in flight, so both scripts were
re-integrated on top of it rather than merged blindly:

* The capability probe is itself an **idempotent READ**, so it routes through `gh_read`
  (the bounded retrying runner — `gh_retry.assert_read_only` accepts it, the query carries
  no mutation) and runs before the enumeration. The `#3759` read-routing self-tests now pin
  that ordering explicitly.
* `ARM_DENIAL_MARKERS` is deliberately **disjoint from #3759's transient set**, and the
  self-tests assert both directions: a denial must never be swallowed as `::warning` +
  exit 0, and a 502/504/CAS must never be misread as a denial. A `cannot-arm` verdict reds
  **both** `--mode sweep` and `--mode event`.
* An exhausted transient on the probe read is `inconclusive`, never `cannot-arm`.
* **The one behavioural change to an existing #3759 test, stated plainly:** finding 5's
  invariant is *"a failed arm mutation must never read as success, even when the follow-up
  race diagnostic exhausts its retries."* It used to be proven by the mutation error
  **propagating out of `run_sweep`** — which is precisely the #3760 defect (it aborted
  every later candidate). The invariant is unchanged and still asserted; the mechanism is
  now `ArmOutcome.exit_code == 1` with the failure summarised, plus explicit assertions
  that the run does not exit 0 and that the CAS text still surfaces. Nothing about #3759
  is weakened — the failure is now *both* visible and non-aborting.
