### PR TITLE
fix(ci): unpatchable Dependabot advisories no longer red the main gate (fail-closed name allow-list)

### DIFF
--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -65,6 +65,19 @@
 # ([OPUS-4.8] sq-8ic6: "readme-template (template, advisory)" was PROMOTED to the HARD
 #  gate "readme-template (template)" — no advisory token, so it now GATES — once the
 #  sq-9jw5 README-overhaul backlog cleared and sq-ixsf tightened the stub classifier.)
+# [OPUS-5] PLATFORM-MANAGED companion rule (ci_summary_gate.py
+#  PLATFORM_MANAGED_ADVISORY_NAMES / is_platform_managed_advisory). The name-token rule
+#  above only reaches check-runs whose name THIS repo controls. A GitHub-MANAGED job
+#  cannot carry the token, so it is excluded by an EXACT, case-insensitive, whole-name
+#  allow-list — currently just:
+#   • "Dependabot"   (GitHub's managed `Dependabot Updates` workflow, event=dynamic,
+#                     path `dynamic/dependabot/dependabot-updates`; its only job name)
+#  That check reports Dependabot's own ability to act on an UPSTREAM advisory — it REDs
+#  on `security_update_not_possible`, where no reachable version clears every advisory
+#  on the package — not this repo's code health, so it must not halt the line. Nothing
+#  is suppressed: the Dependabot ALERT stays open, Dependabot keeps retrying, and the
+#  actionable cargo dependency-vulnerability GATE (`cargo deny check advisories` inside
+#  "supply-chain gates (…)") is untouched. Unknown/new names FAIL CLOSED (still gate).
 # REQUIRED checks (gate / build+test / clippy / coverage / the conformance + perf
 # ratchets / wasm / MSRV / supply-chain / …) do NOT contain those words, so they
 # still gate normally. Rationale: an advisory job that concludes `failure` (e.g.

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -159,6 +159,40 @@ from contextlib import redirect_stdout
 from dataclasses import dataclass, field
 
 ADVISORY_RE = re.compile(r"\b(advisory|informational)\b")
+# [OPUS-5] PLATFORM-MANAGED advisory check-runs — an EXACT, fail-closed allow-list.
+# The advisory NAME-TOKEN rule above only works for check-runs whose name THIS repo
+# controls: we can append "(advisory)" to a job we author. A GitHub-MANAGED job has a
+# name GitHub picks, so it can never carry the token — and it therefore GATES, however
+# non-gating it actually is. Entries here are matched WHOLE and case-insensitively
+# (never as a substring / prefix / wildcard), so an unknown or newly-introduced name
+# still GATES: adding a platform surface is a deliberate, reviewed edit to this set.
+#
+#   • "dependabot" — the sole job of GitHub's managed `Dependabot Updates` workflow
+#     (event=dynamic, path `dynamic/dependabot/dependabot-updates`). Verified against
+#     the Actions Jobs API over the newest 60 runs of that workflow on this repo: the
+#     ONLY job name it has ever emitted is exactly "Dependabot" (37 success /
+#     23 failure), so this allow-list is complete for the surface as it stands, and no
+#     repo-authored workflow declares a job of that name (a collision would need a new
+#     job deliberately named "Dependabot").
+#     WHY NON-GATING: this check reports DEPENDABOT'S OWN ability to act on an upstream
+#     advisory, not this repo's code health. It concludes `failure` on outcomes nobody
+#     in this repo can fix — notably `security_update_not_possible`, i.e. the reachable
+#     update path cannot land a version that clears every advisory on the package (live
+#     case: main run 30136978362, 2026-07-25T00:46Z, npm `brace-expansion` — the 1.x
+#     tree is pinned by `minimatch@3`'s `^1.1.7`, so the only unaffected release, 5.0.8,
+#     is unreachable). Under the stop-the-line rule that red halted `main` for a
+#     condition with no in-repo remedy.
+#     SECURITY POSTURE IS UNCHANGED: nothing here suppresses an alert or a scanner.
+#     The Dependabot alert stays OPEN and visible, Dependabot keeps retrying weekly and
+#     will open the PR the moment a reachable patch exists, and the actionable Rust
+#     dependency-vulnerability GATE — `cargo deny check advisories` inside
+#     "supply-chain gates (deny + vet + SBOM + VEX + OpenSSF + js-sbom)" — is untouched
+#     and still REDs on a real finding. Honest caveat: that lane covers the CARGO graph;
+#     this repo has no in-repo npm vulnerability gate today (the js-sbom step generates
+#     CycloneDX SBOMs, it does not fail on advisories), so Dependabot alerts remain the
+#     npm surveillance surface — which is exactly why this change must not, and does
+#     not, touch alerting.
+PLATFORM_MANAGED_ADVISORY_NAMES = frozenset({"dependabot"})
 _PASSING = ("success", "skipped", "neutral")
 # [FABLE-5] draft-tier CI: the marker ci-select.yml appends to the select job name
 # on a draft-assembled run ("select (change-based test selection, draft-tier)").
@@ -755,11 +789,28 @@ def draft_selects_unsuperseded(runs: list[dict]) -> list[str]:
     return sorted(out)
 
 
+def is_platform_managed_advisory(name: str) -> bool:
+    """[OPUS-5] Is this a GitHub-MANAGED advisory check-run whose name we cannot
+    tag with the advisory token? EXACT whole-name, case-insensitive membership in
+    PLATFORM_MANAGED_ADVISORY_NAMES (see that constant for the per-name rationale
+    and the security-posture argument). Deliberately NOT a substring/prefix/wildcard
+    rule: an unknown or renamed platform check FAILS CLOSED (it keeps gating), so
+    widening this exclusion is always an explicit, reviewed edit."""
+    return name.strip().lower() in PLATFORM_MANAGED_ADVISORY_NAMES
+
+
 def is_advisory(name: str) -> bool:
     """Whole-word advisory/informational match (sq-wjth): excludes the standalone
     words (hyphen-/paren-/comma-delimited too) but NOT substrings — notably
-    "cargo-deny (advisories, ...)" is plural and GATES."""
-    return bool(ADVISORY_RE.search(name.lower()))
+    "cargo-deny (advisories, ...)" is plural and GATES.
+
+    [OPUS-5] ...OR the exact platform-managed allow-list. This stays the SINGLE
+    non-gating classifier so every consumer inherits the same answer — the verdict
+    (render_verdict), fail-fast (failfast_failures) AND the resolver's run-level
+    synthetic check (advisory_only_failure). Splitting them would leave the
+    Dependabot workflow's red run to acquire a synthetic gating verdict and red the
+    gate anyway."""
+    return bool(ADVISORY_RE.search(name.lower())) or is_platform_managed_advisory(name)
 
 
 def is_select(name: str) -> bool:

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -655,6 +655,124 @@ class TestAdvisoryRule(unittest.TestCase):
         self.assertFalse(g.is_advisory("gate"))
 
 
+# [OPUS-5] PLATFORM-MANAGED advisory exclusion (the exact fail-closed allow-list).
+# LIVE DEFECT: main gate run 30136978362 (2026-07-25T00:46Z) failed fast on
+# "✗ Dependabot: failure" — the GitHub-managed Dependabot Updates job (run
+# 30136987253) concluded `security_update_not_possible` for npm `brace-expansion`,
+# an UPSTREAM condition with no in-repo remedy. Because the name is chosen by
+# GitHub it cannot carry the "(advisory)" token, so the name-token rule could not
+# reach it and it GATED. These tests pin all four halves of the fix:
+#   (1) exactly "Dependabot" failing does NOT red the verdict;
+#   (2) an unknown/new platform-ish name still REDs (fail-closed — no wildcards);
+#   (3) the pre-existing advisory-name rule is untouched; and
+#   (4) a REAL gating failure alongside a Dependabot failure still REDs.
+class TestPlatformManagedAdvisoryRule(unittest.TestCase):
+    DEPENDABOT = "Dependabot"
+
+    def test_predicate_matches_only_the_exact_allow_listed_name(self):
+        self.assertTrue(g.is_platform_managed_advisory(self.DEPENDABOT))
+        # Case-insensitive + surrounding-whitespace tolerant whole-name match.
+        self.assertTrue(g.is_platform_managed_advisory("  dependabot "))
+        self.assertTrue(g.is_platform_managed_advisory("DEPENDABOT"))
+        # (2) FAIL-CLOSED: no substring/prefix/suffix/wildcard reach. Every one of
+        # these is an unknown name and must keep gating.
+        for unknown in (
+            "Dependabot Updates",
+            "Dependabot alerts",
+            "dependabot-security-check",
+            "verify Dependabot lockfile",
+            "Dependabot / npm_and_yarn",
+            "supply-chain gates (deny + vet + SBOM + VEX + OpenSSF + js-sbom)",
+            "build + test",
+            "gate",
+        ):
+            self.assertFalse(g.is_platform_managed_advisory(unknown), unknown)
+            self.assertFalse(g.is_advisory(unknown), unknown)
+        # (3) The name-token rule is a SEPARATE concern and is not absorbed by the
+        # allow-list — an advisory-named leg is not "platform managed".
+        self.assertFalse(g.is_platform_managed_advisory("vale (prose, advisory)"))
+        self.assertTrue(g.is_advisory("vale (prose, advisory)"))
+        # ...and the union predicate every consumer reads sees both rules.
+        self.assertTrue(g.is_advisory(self.DEPENDABOT))
+
+    def test_dependabot_failure_does_not_red_the_verdict(self):
+        # (1) The live defect, end to end through the real verdict path.
+        runs = [R(self.DEPENDABOT, conclusion="failure"), GREEN, GREEN2]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+        self.assertIn("1 advisory check(s) excluded", out)
+
+    def test_unknown_platform_managed_name_still_reds(self):
+        # (2) Fail-closed at the VERDICT level, not just the predicate: a renamed or
+        # newly-added platform job is a gating leg until this allow-list is edited.
+        for unknown in ("Dependabot Updates", "Dependabot alerts", "dependabot-security"):
+            with self.subTest(name=unknown):
+                code, out = run(tiny_cfg(), [[R(unknown, conclusion="failure"), GREEN]])
+                self.assertEqual(code, 1, out)
+                self.assertIn(unknown, out)
+
+    def test_existing_advisory_name_rule_still_excludes(self):
+        # (3) Regression guard for sq-wjth alongside the new rule, including the
+        # plural "advisories" that must keep GATING.
+        runs = [R("vale (prose, advisory)", conclusion="failure"),
+                R("unsafe report (cargo-geiger, informational)", conclusion="failure"),
+                R(self.DEPENDABOT, conclusion="failure"),
+                GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0, out)
+        self.assertIn("3 advisory check(s) excluded", out)
+        code, _ = run(tiny_cfg(), [[
+            R("cargo-deny (advisories, bans, licenses, sources)", conclusion="failure"),
+            R(self.DEPENDABOT, conclusion="failure"),
+        ]])
+        self.assertEqual(code, 1)
+
+    def test_real_failure_alongside_dependabot_still_reds(self):
+        # (4) The exclusion must not become a blanket amnesty: a genuine gating
+        # failure sharing the sibling set still REDs, and the Dependabot leg is not
+        # what the verdict blames.
+        runs = [R(self.DEPENDABOT, conclusion="failure"), RED, GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1, out)
+        self.assertIn("clippy", out)
+        failing_lines = [ln for ln in out.splitlines() if ln.startswith("- ✗ ")]
+        self.assertTrue(failing_lines)
+        self.assertNotIn(f"- ✗ {self.DEPENDABOT}: failure", failing_lines)
+
+    def test_dependabot_failure_does_not_fail_fast(self):
+        # Fail-fast reuses is_advisory, so the exclusion must hold there too: a
+        # Dependabot red while siblings are still running must not short-circuit.
+        dependabot = R(self.DEPENDABOT, conclusion="failure")
+        self.assertEqual(g.failfast_failures([dependabot, PENDING]), [])
+        code, out = run(tiny_cfg(), [[dependabot, PENDING], [dependabot, GREEN]])
+        self.assertEqual(code, 0, out)
+        self.assertNotIn("fail-fast", out)
+
+    def test_dependabot_only_workflow_failure_gets_no_synthetic_gating_verdict(self):
+        # The resolver's run-level evidence path also reads is_advisory: GitHub's
+        # Dependabot workflow RUN concludes failure, so without the exclusion a
+        # synthetic "workflow-run verdict (…)" would red the gate even though the
+        # only failing job is the excluded one.
+        newest = W(103, 7, name="Dependabot Updates", conclusion="failure")
+        dependabot_job = {
+            "id": 2001,
+            "name": self.DEPENDABOT,
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-21T14:05:00Z",
+            "html_url": "https://github.test/o/r/actions/runs/103/job/2",
+        }
+        resolved, _ = g.resolve_newest_workflow_runs(
+            [], [newest], "999", attempt_jobs={103: [dependabot_job]}
+        )
+        self.assertNotIn(
+            "workflow-run verdict (id:7)", [r.get("name") for r in resolved]
+        )
+        code, out = run(tiny_cfg(), [resolved])
+        self.assertEqual(code, 0, out)
+
+
 # [FABLE-5] sq-fmx4u.3: change-based test-selection semantics (design §5.3).
 # The three load-bearing safety invariants, exactly as the bead states them:
 #   (1) skipped-not-affected + select SUCCESS      => gate SUCCESS (no hang, no RED)


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. Authored and reviewed by AI agents.

## The defect (live evidence)

`main` gate run [**30136978362**](https://github.com/sparq-org/sparq/actions/runs/30136978362)
(2026-07-25T00:46Z) failed fast:

```
### ci-summary: FAILED (fail-fast) — 1 gating check(s) concluded failure while 74
sibling(s) were still running; …
- ✗ Dependabot: failure
```

It was the **only** gating failure — and it was not the first: the preceding main gate
run [**30131008188**](https://github.com/sparq-org/sparq/actions/runs/30131008188)
(2026-07-24T22:29Z) red on the identical single line.

The underlying job is GitHub's managed **Dependabot Updates** run
[**30136987253**](https://github.com/sparq-org/sparq/actions/runs/30136987253)
(`{"command":"security","dependencies":["brace-expansion"]}`), which ends:

```
security_update_not_possible
  "dependency-name": "brace-expansion",
  "explanation": "A patched version exists for brace-expansion,
                  but the available update path still resolves it to 1.1.16"
```

### Root cause of the gate red

`scripts/ci_summary_gate.py` classifies non-gating check-runs **purely by NAME token**
(`ADVISORY_RE = \b(advisory|informational)\b`, `is_advisory()`). That rule can only reach
check-runs whose name *this repo* controls — we can append `(advisory)` to a job we
author. A **GitHub-managed** job's name is chosen by GitHub, so `Dependabot` cannot carry
the token and therefore **GATES**. Result: an upstream condition with no in-repo remedy
trips the stop-the-line rule.

### Honest correction to the initial diagnosis

The brief for this fix stated that every advisory entry had `"patched-versions": []` —
i.e. that **no** upstream patch exists. Reading the updater log, that is **not** the
cause. `patched-versions: []` is just how the job definition is serialised (GitHub passes
`affected-versions` ranges instead); the updater's own explanation is that a patched
version *does* exist but is **unreachable**:

| lock instance | version | pinned by | range |
|---|---|---|---|
| `node_modules/brace-expansion` | 1.1.15 | `minimatch@3.1.5` | `^1.1.7` |
| `node_modules/glob/…/brace-expansion` | 2.1.1 | `minimatch@9.0.9` | `^2.0.2` |
| `node_modules/readdir-glob/…/brace-expansion` | 2.1.1 | `minimatch@5.1.9` | `^2.0.1` |
| `…/typescript-estree/…/brace-expansion` | 5.0.6 | `minimatch@10.2.5` | `^5.0.5` |

One advisory in the set is affected `<= 5.0.7`, so **5.0.8** is the only unaffected
release; `^1.1.7` / `^2.0.x` cap the resolver at `1.1.16` / `2.1.2`. Clearing it needs the
**`minimatch` dependents** moved, which a security update will not do. The gate fix is
unchanged by this correction — but the causal story recorded in the code comment and in
the tracking issue is the accurate one.

### Impact, stated honestly

The merge queue was **not** blocked — PR #3764 merged at 00:44 during this very red (the
ruleset requires only the `gate` context, and that PR's own gate was green). So the cost
was **false alarm + telemetry noise on `main`**, not stalled merges. It is **recurrent**,
not a one-off: `brace-expansion` and `postcss` both fail this way, and `sharp` failed
identically 3× on 2026-07-22 — 23 of the newest 60 Dependabot runs concluded `failure`.

## The fix

A small, documented, **exact, fail-closed allow-list** beside the existing name-token
rule, in `scripts/ci_summary_gate.py`:

```python
PLATFORM_MANAGED_ADVISORY_NAMES = frozenset({"dependabot"})

def is_platform_managed_advisory(name: str) -> bool:
    return name.strip().lower() in PLATFORM_MANAGED_ADVISORY_NAMES
```

- **Whole-name, case-insensitive match only** — no substring / prefix / suffix /
  wildcard. `Dependabot Updates`, `Dependabot alerts`, `dependabot-security-check`,
  `verify Dependabot lockfile` all still **GATE**. An unknown or renamed platform check
  **fails closed**; widening the exclusion is always an explicit, reviewed edit.
- `is_advisory()` remains the **single** non-gating classifier
  (`ADVISORY_RE.search(...) or is_platform_managed_advisory(...)`) so all three consumers
  inherit one answer: the verdict (`render_verdict`), fail-fast (`failfast_failures`),
  **and** the resolver's run-level synthetic check (`advisory_only_failure`). Splitting
  them would let the red Dependabot *workflow run* acquire a synthetic
  `workflow-run verdict (…)` gating failure and red the gate anyway — pinned by a test.
- The `ADVISORY/INFORMATIONAL` doc block in `.github/workflows/ci-summary.yml` gains the
  matching companion paragraph, so the documented contract stays true.

### Names excluded, and how they were verified

Exactly one: **`Dependabot`**.

Verified against the Actions API rather than assumed:

```
$ gh api repos/sparq-org/sparq/actions/runs/30136987253 -q '{name,path,workflow_id}'
{"name":"npm_and_yarn in /. for brace-expansion - Update #1480516022",
 "path":"dynamic/dependabot/dependabot-updates","workflow_id":294954269}

# every job name across the newest 60 runs of that workflow:
$ for id in $(gh api ".../workflows/294954269/runs?per_page=100" \
                -q '.workflow_runs[].id' | head -60); do
    gh api ".../actions/runs/$id/jobs" -q '.jobs[] | "\(.name)|\(.conclusion)"'
  done | sort | uniq -c
     37 Dependabot|success
     23 Dependabot|failure
```

The workflow **run** name is dynamic per update (`npm_and_yarn in /. for … - Update #…`),
but the **job** name — which is what becomes the check-run — has only ever been exactly
`Dependabot`. Cross-checked against the live head SHA
(`gh api repos/sparq-org/sparq/commits/9260d85b/check-runs`): one `Dependabot` entry,
`app=github-actions`, no siblings. And `grep` over `.github/workflows/` confirms no
repo-authored workflow declares a job named `Dependabot`, so a collision would require
deliberately adding one.

## Security posture: unchanged, and nothing suppressed

- **No `dependabot.yml` `ignore:` entry** was added — that would hide the future patch
  notification too.
- The Dependabot **alert stays open and visible**; Dependabot keeps retrying weekly and
  will open the PR the moment a reachable patch exists. This change touches CI
  *classification* only, never alerting.
- The actionable dependency-vulnerability **GATE is untouched**: `cargo deny check
  advisories` inside `supply-chain gates (deny + vet + SBOM + VEX + OpenSSF + js-sbom)`
  still REDs on a real finding (it was green on this SHA).
- **Honest caveat, stated rather than glossed:** that lane covers the **cargo** graph.
  There is **no in-repo npm vulnerability gate** today — the `js-sbom` step *generates*
  CycloneDX SBOMs, it does not fail on advisories. So Dependabot alerts remain the npm
  surveillance surface, which is precisely why this change must not, and does not, weaken
  alerting. Adding a real npm advisory gate is captured as follow-up in the issue below
  (it needs a tolerated-findings policy first, since it would red on exactly these
  unreachable advisories).

## Tracking route taken: **issue**, not a VEX record — #3767

<https://github.com/sparq-org/sparq/issues/3767>

A VEX record is **structurally unavailable** for an npm finding:
`supply-chain/vex.cdx.json` is held in **set equality** with `deny.toml
[advisories].ignore` by the **gating** `scripts/check-vex-deny-drift.py` (5 ids today, all
cargo/RustSec). Adding an npm GHSA there would red that check as unjustified drift. The
markdown precedent `supply-chain/gui-tauri-advisories.md` is likewise a *Rust* workspace
disposition, wired into `compliance/cra/evidence.md`. So #3767 is the honest home: it
records the state, the real constraint chain, the `postcss` / `sharp` siblings, what to do
when a patch becomes reachable, and the "do **not** add an ignore entry" instruction.

## Tests

`scripts/tests/test_ci_summary_gate.py` — new `TestPlatformManagedAdvisoryRule`, 7 cases:

1. `test_predicate_matches_only_the_exact_allow_listed_name` — exact/case/whitespace
   match; 8 unknown names (incl. `Dependabot Updates`, `Dependabot / npm_and_yarn`) assert
   **False** on both predicates.
2. `test_dependabot_failure_does_not_red_the_verdict` — the live defect: a failing check
   named exactly `Dependabot` → exit 0, `1 advisory check(s) excluded`.
3. `test_unknown_platform_managed_name_still_reds` — fail-closed at the **verdict** level,
   not just the predicate.
4. `test_existing_advisory_name_rule_still_excludes` — sq-wjth regression guard, including
   plural `advisories` still GATING.
5. `test_real_failure_alongside_dependabot_still_reds` — real gating failure alongside a
   Dependabot failure → exit 1, and `clippy` (not `Dependabot`) is what the verdict blames.
6. `test_dependabot_failure_does_not_fail_fast` — the fail-fast path inherits the rule.
7. `test_dependabot_only_workflow_failure_gets_no_synthetic_gating_verdict` — the
   resolver's run-level evidence path inherits it too.

```
$ python3 scripts/tests/test_ci_summary_gate.py
Ran 127 tests in 0.054s
OK
$ python3 scripts/tests/test_vex_deny_drift.py && python3 scripts/check-vex-deny-drift.py
Ran 11 tests in 0.005s
OK
VEX ↔ deny.toml in sync: 5 advisory id(s) match 1:1.
```

### Mutation check (snapshot → mutate → red → restore → cmp → green)

Snapshot to `/tmp` first (never `git checkout` to restore uncommitted work), then remove
the exclusion:

```
$ md5sum scripts/ci_summary_gate.py $SNAP
4ae865fcc9b324ea6c388d2b6d6b3aa3  scripts/ci_summary_gate.py
4ae865fcc9b324ea6c388d2b6d6b3aa3  $SNAP

# mutate: `return bool(ADVISORY_RE.search(name.lower()))`   (drop the allow-list)
$ python3 scripts/tests/test_ci_summary_gate.py
Ran 127 tests in 0.059s
FAILED (failures=6)

FAIL: test_dependabot_failure_does_not_red_the_verdict
AssertionError: 1 != 0 : … all-terminal stable for 2/2 poll(s)
### ci-summary: FAILED — 1 non-passing gating check(s) of 3 gating (0 advisory check(s) excluded)
- ✗ Dependabot: failure
```

The mutant reproduces the **exact** production line (`- ✗ Dependabot: failure`).
`test_unknown_platform_managed_name_still_reds` correctly stays green under the mutation —
it asserts REDs, which the mutant preserves.

```
$ cp $SNAP scripts/ci_summary_gate.py && cmp $SNAP scripts/ci_summary_gate.py
cmp: IDENTICAL      (md5 4ae865fc… restored; no MUTATION marker remains)
$ python3 scripts/tests/test_ci_summary_gate.py
Ran 127 tests in 0.054s
OK
```

## Coordination

Based on `origin/main` (`9260d85b`); diff deliberately minimal (**+184 / −2** across 3
files) and confined to the classification area + tests. Another agent is concurrently
editing `scripts/ci_summary_gate.py` on `fable/gate-unsatisfiable-hold-3758` in a
**different region** (the poll-loop exit logic for unsatisfiable draft-tier holds), so
**this may need a trivial rebase** against that branch — the two changes touch
`ADVISORY_RE` / `is_advisory()` and the poll loop respectively, with no overlap in intent.

Not armed.
