### PR TITLE
fix(ci): a stale-ref import and a whole-repo sweep must not brick the gating arm check

### DIFF
--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -40,12 +40,21 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-          # gh_retry.py is auto-arm.py's #3759 transient-retry dependency — the
-          # self-test below imports it, so a missing path fails BEFORE the live run.
-          sparse-checkout: |
-            scripts/auto-arm.py
-            scripts/gh_retry.py
-          sparse-checkout-cone-mode: false
+          # [OPUS-5] #3776 — CHECK OUT THE WHOLE DIRECTORY, never a file-by-file manifest.
+          # This step's `ref:` is the DEFAULT BRANCH, but on a `pull_request` event the
+          # WORKFLOW FILE (and so this manifest) comes from the PR's own ref. Enumerating
+          # individual files therefore couples a default-branch script to a per-ref
+          # snapshot of its dependency list: #3766 added `import gh_retry` to
+          # scripts/auto-arm.py and `scripts/gh_retry.py` to this list in one commit, and
+          # every PR ref cut before that commit kept the one-entry manifest — so the new
+          # script ran without gh_retry.py and died with ModuleNotFoundError on a GATING
+          # check (#3434, run 30143852994). A directory pattern cannot go stale when a new
+          # sibling import is added, so the skew is structurally impossible from here on.
+          # Cone mode (the actions/checkout default) is what makes `scripts` recursive;
+          # do NOT reintroduce `sparse-checkout-cone-mode: false`, under which this bare
+          # word would be a gitignore pattern with different semantics. Pinned by
+          # scripts/tests/test_arm_capability_wiring.py::TestSparseCheckoutManifest.
+          sparse-checkout: scripts
 
       - name: Self-test policy
         run: |

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -88,8 +88,20 @@ jobs:
           # exit non-zero (visibly red + retried), NOT the sweep's lenient ::warning+0.
           # The scheduled/dispatch runs are SWEEP mode (a missed cycle is cron-covered).
           ARM_MODE: ${{ github.event_name == 'pull_request' && 'event' || 'sweep' }}
+          # [OPUS-5] #3776: WHICH PR this run answers for. Empty on schedule/dispatch (=>
+          # whole-repo sweep, the backstop); the triggering PR's number on a label event,
+          # so one permanently un-armable PR can no longer red this GATING check on every
+          # OTHER PR's label event. Pinned by
+          # scripts/tests/test_arm_capability_wiring.py::TestEventModeIsPerPr.
+          # NOTE: this expression is the FORWARD-LOOKING half only. Like the
+          # sparse-checkout manifest above, it is snapshotted per PR ref, so already-stale
+          # refs never pass it — which is why scripts/auto-arm.py ALSO derives the number
+          # from the runner environment (GITHUB_EVENT_PATH / GITHUB_REF). That script comes
+          # from the default branch, so it is the only half that can heal a frozen ref.
+          ARM_PR: ${{ github.event.pull_request.number }}
         run: >-
           python3 scripts/auto-arm.py
           --repo "$REPO"
           --default-branch "$DEFAULT_BRANCH"
           --mode "$ARM_MODE"
+          --pr "$ARM_PR"

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -63,12 +63,16 @@ jobs:
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
-          # gh_retry.py is rearm-sweeper.py's #3759 transient-retry dependency — the
-          # self-test below imports it, so a missing path fails BEFORE the live run.
-          sparse-checkout: |
-            scripts/rearm-sweeper.py
-            scripts/gh_retry.py
-          sparse-checkout-cone-mode: false
+          # [OPUS-5] #3776 — CHECK OUT THE WHOLE DIRECTORY, never a file-by-file manifest.
+          # A file-by-file list has to be updated by hand every time a script gains a
+          # sibling import; forgetting once is what bricked the GATING arm check on every
+          # stale PR ref (#3776 — see auto-arm.yml for the full account). This sweep runs
+          # only on schedule/dispatch so its workflow file and its `ref:` are always the
+          # same commit, but the enumeration is the same latent trap; a directory pattern
+          # cannot go stale. Cone mode (the actions/checkout default) is what makes
+          # `scripts` recursive — do NOT reintroduce `sparse-checkout-cone-mode: false`.
+          # Pinned by scripts/tests/test_arm_capability_wiring.py.
+          sparse-checkout: scripts
 
       - name: Self-test policy
         run: |

--- a/scripts/auto-arm.py
+++ b/scripts/auto-arm.py
@@ -32,17 +32,36 @@ to GitHub's explicit ``enablePullRequestAutoMerge`` GraphQL mutation.
 #   warning-class per-candidate outcome without escaping the loop, and the exit status is
 #   computed at the END by arm_exit_code() from that final state.
 #   PRECEDENCE: collected-failure > transient-exhaustion > clean.
+# [OPUS-5] Issue #3776, second half — AN EVENT-TRIGGERED RUN JUDGES THE PR THAT TRIGGERED IT.
+#   `arm reviewed PRs` is a GATING check, and run() swept EVERY open review:pass PR in BOTH
+#   modes. Combined with #3766's (correct) sticky exit, ONE permanently un-armable PR redded
+#   the gating check on every OTHER PR's label event. Live blast radius, measured: sparq had
+#   exactly two review:pass PRs — #3434 and #2521 — and run 30144214363 reported
+#   `considered=2 armed=0 arm-failures=1` because #3434 cannot be armed at all until the
+#   `workflows: write` question (#3777) is decided. One PR taxed the entire queue.
+#   In `--mode event` the run is now scoped to the triggering PR (--pr, or derived from the
+#   runner environment — see resolve_scope_pr). This is a CORRECTNESS fix, not a policy
+#   change: judging unrelated PRs on someone else's label event is wrong independently of
+#   whether the check gates. It NARROWS which PRs a run is ACCOUNTABLE for; it does not
+#   weaken accountability — within its own scope the #3766 precedence
+#   (collected-failure > transient-exhaustion > clean) is untouched, and the triggering PR's
+#   own arm failure is still a hard non-zero exit that no later transient can discard.
+#   `--mode sweep` (the cron) keeps whole-repo scope and #3759's lenient transient policy.
+#   DELIBERATELY NOT CHANGED HERE: whether `arm reviewed PRs` should be a GATING check at
+#   all. That is a policy decision about what may block a merge, not a correctness fix — the
+#   argument and the costed options live in #3777.
 
 from __future__ import annotations
 
 import argparse
 import copy
 import json
+import os
 import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Callable, Mapping
 
 
 # --------------------------------------------------------------------------------------
@@ -450,10 +469,18 @@ class AutoArmer:
         log: Callable[[str], None] = print,
         *,
         gh_read: Callable[[list[str]], str] | None = None,
+        scope_pr: int | None = None,
     ) -> None:
         self.repo = repo
         self.default_branch = default_branch
         self.gh = gh
+        # [OPUS-5] #3776: WHICH PRs this run is accountable for. None = the whole repository
+        # (the cron sweep). A number = EXACTLY that PR and nothing else (an event-triggered
+        # run must judge the PR whose label event triggered it, never a bystander).
+        # Deliberately orthogonal to `mode`, which decides only the EXIT POLICY for an
+        # exhausted transient (#3759 finding 5) — scope answers "whose failure is this run's
+        # business", mode answers "how loud is a missed cycle".
+        self.scope_pr = scope_pr
         # Idempotent READS may go through a retrying runner (#3759); mutations
         # (pr ready, the arm CAS) always use the one-shot `gh` runner above.
         self.gh_read = gh_read if gh_read is not None else gh
@@ -487,6 +514,31 @@ class AutoArmer:
             )
         )
         return [parse_pr(item) for item in raw]
+
+    @property
+    def scope_description(self) -> str:
+        """Human-readable scope, logged before any work so a run states its own remit."""
+        if self.scope_pr is None:
+            return "EVERY open review:pass PR in the repository (whole-repo sweep)"
+        return (
+            f"PR #{self.scope_pr} ONLY — the PR whose label event triggered this run; "
+            "another PR's arm failure is NOT this run's business (#3776)"
+        )
+
+    def candidates(self) -> list[PullRequest]:
+        """The PRs this run is ACCOUNTABLE for — the #3776 scoping seam.
+
+        SCOPED (``scope_pr`` set, i.e. ``--mode event``): exactly the triggering PR. The
+        unrelated PRs are not merely excused, they are never even READ, so nothing about
+        them can reach this run's outcome or its exit status.
+
+        UNSCOPED (``scope_pr is None``, i.e. ``--mode sweep``): every open PR, unchanged.
+        The cron is the whole-repo backstop and must stay one — narrowing it would turn
+        this fix into "event mode does nothing and nothing else covers the repo".
+        """
+        if self.scope_pr is not None:
+            return [self.refresh(self.scope_pr)]
+        return self.list_open()
 
     def refresh(self, number: int) -> PullRequest:
         raw = json.loads(
@@ -740,6 +792,7 @@ class AutoArmer:
         # failure collected below survives any exception that escapes this method and the
         # exit status can be computed at the END from this state (see arm_exit_code).
         outcome = self.outcome = ArmOutcome()
+        self.log(f"[{PROGRAM}] scope: {self.scope_description}")
         verdict = self.probe_arm_capability()
         outcome.capability = verdict.status
         self.log(f"[{PROGRAM}] arm-capability probe: {verdict.status} — {verdict.detail}")
@@ -755,7 +808,7 @@ class AutoArmer:
             return outcome
 
         try:
-            candidates = self.list_open()
+            candidates = self.candidates()
         except gh_retry.GhTransientExhausted as error:
             # Whole-sweep transient: nothing has been collected yet, so this is a plain
             # missed cycle. Recorded, not raised — the exit is decided at the end.
@@ -805,7 +858,8 @@ class AutoArmer:
             f"[{PROGRAM}] complete: considered={outcome.considered} "
             f"armed={outcome.armed} arm-failures={len(outcome.arm_failures)} "
             f"transient-exhaustions={len(outcome.transient_exhaustions)} "
-            f"capability={outcome.capability}"
+            f"capability={outcome.capability} "
+            f"scope={'all' if self.scope_pr is None else f'pr-{self.scope_pr}'}"
         )
         return outcome
 
@@ -856,6 +910,11 @@ def run_sweep(
 ) -> int:
     """Run the armer once. Exit policy depends on the INVOCATION MODE (#3759 finding 5).
 
+    SCOPE and MODE are separate axes (#3776). ``AutoArmer.scope_pr`` decides WHICH PRs the
+    run is accountable for; ``mode`` decides only how loud an exhausted transient is. An
+    event-triggered run is scoped to its triggering PR, so the failures this function can
+    ever see are that PR's own.
+
     ``mode="sweep"`` (the periodic cron) — exhausted TRANSIENT retries on the READ
     path => ``::warning`` + exit 0: the sweep is idempotent and cron-covered, so a
     missed cycle must not red main's gate.
@@ -886,6 +945,69 @@ def run_sweep(
         outcome = armer.outcome
         outcome.sweep_transient = outcome.sweep_transient or str(error)
     return arm_exit_code(outcome, mode=mode, log=log)
+
+
+# [OPUS-5] #3776: emitted when an EVENT-mode run cannot work out which PR triggered it.
+# It falls back to whole-repo scope — the pre-#3776 behaviour — rather than exiting
+# non-zero, because a hard failure here would brick the GATING check for exactly the
+# stale-ref population this issue is about. Loud, not fatal.
+SCOPE_UNRESOLVED_WARNING = (
+    "::warning title=auto-arm could not identify the triggering PR::--mode event was "
+    "requested but neither --pr nor the runner environment (GITHUB_EVENT_PATH's "
+    "pull_request.number, GITHUB_REF's refs/pull/<n>/…) yielded a PR number, so this run "
+    "falls back to WHOLE-REPO scope. Consequence: an unrelated un-armable PR can red this "
+    "run (sparq #3776). REMEDY: pass --pr <number> from the workflow "
+    "(`${{ github.event.pull_request.number }}`)."
+)
+
+# refs/pull/<n>/merge (or /head) — what GITHUB_REF holds on a pull_request event.
+PULL_REF = re.compile(r"^refs/pull/(\d+)/")
+
+
+def resolve_scope_pr(
+    explicit: str | int | None = None,
+    env: Mapping[str, str] | None = None,
+) -> int | None:
+    """Identify the PR whose event triggered this run, or ``None`` if undeterminable.
+
+    Three sources, most explicit first:
+
+    1. ``--pr`` — what the workflow passes.
+    2. ``GITHUB_EVENT_PATH`` → the event payload's ``pull_request.number``.
+    3. ``GITHUB_REF`` → ``refs/pull/<n>/merge``.
+
+    The two environment sources are LOAD-BEARING, not belt-and-braces. ``--pr`` reaches
+    this script from the WORKFLOW FILE, which on a `pull_request` event GitHub resolves
+    from the PR's own — possibly months-old — ref, while this script always comes from the
+    default branch: that skew IS #3776. Deriving the number from the RUNNER's environment
+    instead means every already-stale PR ref gets per-PR scoping the moment this lands,
+    with no per-ref workflow update and no rebase.
+
+    Raises ``ValueError`` only for an explicitly supplied non-numeric ``--pr`` — a typo in
+    the wiring must be loud, never silently a whole-repo sweep.
+    """
+    if explicit is not None and str(explicit).strip():
+        text = str(explicit).strip()
+        if not text.isdigit():
+            # Positive integers only: a sign, a ref name or an empty-ish token must be a
+            # loud wiring error, never `gh pr view -5` or a silent whole-repo sweep.
+            raise ValueError(f"--pr must be a PR number, got {explicit!r}")
+        return int(text)
+    environment = os.environ if env is None else env
+    event_path = (environment.get("GITHUB_EVENT_PATH") or "").strip()
+    if event_path:
+        try:
+            with open(event_path, encoding="utf-8") as handle:
+                payload = json.load(handle)
+            number = (payload.get("pull_request") or {}).get("number")
+            if number is not None:
+                return int(number)
+        except (OSError, ValueError, TypeError, AttributeError):
+            # A malformed/absent payload is not this script's problem to die on; fall
+            # through to the ref, then to the documented whole-repo fallback.
+            pass
+    match = PULL_REF.match((environment.get("GITHUB_REF") or "").strip())
+    return int(match.group(1)) if match else None
 
 
 def fixture(
@@ -921,6 +1043,14 @@ CAPABILITY_RESPONSE = {
 DENIAL_TEXT = (
     "gh api graphql failed: GraphQL: Resource not accessible by integration "
     "(enablePullRequestAutoMerge)"
+)
+# The exact text GitHub returned for PR #3434 in run 30144214363 — the PERMANENTLY
+# un-armable PR that poisoned the gating arm check for the whole repository (#3776/#3777).
+# It is deliberately NOT an ARM_DENIAL_MARKER: it is a per-PR condition (that PR modifies a
+# workflow file), so it is collected per-PR rather than latching capability_lost.
+WORKFLOWS_DENIAL = (
+    "gh api graphql -f failed: gh: Pull request refusing to allow a GitHub App to create "
+    "or update workflow `.github/workflows/zk-toolchain.yml` without `workflows` permission"
 )
 
 
@@ -998,11 +1128,13 @@ class FakeGh:
 
 
 def exercise(
-    initial: dict | list[dict], **fake_kwargs
+    initial: dict | list[dict], *, scope_pr: int | None = None, **fake_kwargs
 ) -> tuple[FakeGh, list[str], ArmOutcome]:
     fake = FakeGh(initial, **fake_kwargs)
     messages: list[str] = []
-    outcome = AutoArmer("sparq-org/sparq", "main", fake, messages.append).run()
+    outcome = AutoArmer(
+        "sparq-org/sparq", "main", fake, messages.append, scope_pr=scope_pr
+    ).run()
     return fake, messages, outcome
 
 
@@ -1522,6 +1654,217 @@ def self_test() -> None:
     assert "arm-failure summary: PR #451" in captured.getvalue(), captured.getvalue()
     assert "::warning" not in captured.getvalue(), captured.getvalue()
 
+    # ---------------------------------------------------------------------------------
+    # [OPUS-5] #3776 — AN EVENT-TRIGGERED RUN JUDGES THE PR THAT TRIGGERED IT.
+    # The live shape, replayed: two review:pass PRs, one of them (#3434) permanently
+    # un-armable because it modifies a workflow file and the arm token has no
+    # `workflows: write` (#3777). Pre-#3776 an event run swept BOTH, so #3434's failure
+    # redded the GATING `arm reviewed PRs` check on #2521's label event — and on every
+    # other PR's. The DISCRIMINATION is the test: an UNRELATED PR's failure must be
+    # invisible, while the TRIGGERING PR's own failure must still be fatal.
+    # ---------------------------------------------------------------------------------
+    assert not is_arm_denial(WORKFLOWS_DENIAL), (
+        "the workflows-permission refusal is a PER-PR condition, not a token-capability "
+        "denial: misclassifying it would latch capability_lost and skip every other PR"
+    )
+
+    def scoped(*, scope_pr: int | None, mode: str, failing: int | None = 3434):
+        """Two review:pass PRs — #2521 arms cleanly, #3434 can never be armed."""
+        scoped_fake = FakeGh(
+            [fixture(number=2521), fixture(number=3434)],
+            mutation_errors={failing: WORKFLOWS_DENIAL} if failing else None,
+        )
+        lines: list[str] = []
+        armer = AutoArmer(
+            "sparq-org/sparq", "main", scoped_fake, lines.append, scope_pr=scope_pr
+        )
+        try:
+            return scoped_fake, lines, run_sweep(armer, log=lines.append, mode=mode)
+        except GhError as error:
+            return scoped_fake, lines, error
+
+    # (15) HALF ONE — an un-armable UNRELATED PR must NOT fail an event-mode run for #2521.
+    scoped_fake, lines, code = scoped(scope_pr=2521, mode="event")
+    assert code == 0, (
+        "an event-mode run for PR #2521 must not fail because a DIFFERENT PR (#3434) "
+        f"cannot be armed (code={code}, {lines})"
+    )
+    assert any("PR #2521: armed head" in line for line in lines), lines
+    assert any("PR #2521 ONLY" in line for line in lines), lines
+    assert any("considered=1" in line and "scope=pr-2521" in line for line in lines), lines
+    # Not merely excused — never even READ, so nothing about it can reach this outcome.
+    assert not [line for line in lines if "3434" in line], lines
+    assert not [call for call in scoped_fake.calls if "3434" in " ".join(call)], (
+        scoped_fake.calls
+    )
+
+    # (16) HALF TWO, THE DISCRIMINATION — the TRIGGERING PR's own arm failure is still a
+    # hard non-zero exit. Narrowing WHICH PRs a run answers for must not weaken
+    # accountability for the one it does.
+    scoped_fake, lines, code = scoped(scope_pr=3434, mode="event")
+    assert code == 1, (
+        f"the triggering PR's OWN arm failure must still red the run (code={code}, {lines})"
+    )
+    assert any("PR #3434: arm-failed" in line for line in lines), lines
+    assert any("arm-failure summary: PR #3434" in line for line in lines), lines
+    assert not [line for line in lines if line.startswith("::warning")], lines
+    assert not [call for call in scoped_fake.calls if "2521" in " ".join(call)], (
+        scoped_fake.calls
+    )
+
+    # (17) SWEEP MODE IS STILL WHOLE-REPO. Without this the scoping fix could silently
+    # become "event mode does nothing and nothing else covers the repository".
+    scoped_fake, lines, code = scoped(scope_pr=None, mode="sweep", failing=None)
+    assert code == 0, (code, lines)
+    assert sum("armed head" in line for line in lines) == 2, lines
+    assert any("considered=2" in line and "scope=all" in line for line in lines), lines
+    assert any("whole-repo sweep" in line for line in lines), lines
+    # ... and the whole-repo sweep stays ACCOUNTABLE for every PR in it: #3434's failure
+    # reds the sweep even though it arms #2521 fine.
+    scoped_fake, lines, code = scoped(scope_pr=None, mode="sweep")
+    assert code == 1, (code, lines)
+    assert any("PR #2521: armed head" in line for line in lines), lines
+    assert any("PR #3434: arm-failed" in line for line in lines), lines
+
+    # (18) #3766 STICKY FAILURE, NOW WITHIN SCOPE. The triggering PR's arm fails and then
+    # its OWN race diagnostic exhausts its bounded retries: the earned failure must stand
+    # (exit 1, no lenient ::warning). Scope narrows accountability; it never softens it.
+    sticky_fake = FakeGh(
+        [fixture(number=3434)], mutation_errors={3434: WORKFLOWS_DENIAL}
+    )
+    sticky_views: list[list[str]] = []
+
+    def diagnostic_exhausts(argv: list[str]) -> str:
+        if argv[:2] == ["pr", "view"] and argv[2] == "3434":
+            sticky_views.append(argv)
+            # 1: candidates(), 2: the pre-arm refresh, 3: the post-failure diagnostic.
+            if len(sticky_views) >= 3:
+                raise gh_retry.GhTransientExhausted("gh pr view: HTTP 504 (3 attempts)")
+        return sticky_fake(argv)
+
+    lines = []
+    code = run_sweep(
+        AutoArmer(
+            "sparq-org/sparq",
+            "main",
+            sticky_fake,
+            lines.append,
+            gh_read=diagnostic_exhausts,
+            scope_pr=3434,
+        ),
+        log=lines.append,
+        mode="event",
+    )
+    assert len(sticky_views) == 3, sticky_views
+    assert code == 1, (code, lines)
+    assert not [line for line in lines if line.startswith("::warning")], lines
+    assert any("race diagnostic could not resolve" in line for line in lines), lines
+    assert any("arm-failure summary: PR #3434" in line for line in lines), lines
+
+    # (19) THE CALL SITE, END TO END THROUGH main(). The scoping is only real if the entry
+    # point applies it in event mode and does NOT apply one in sweep mode — exactly the
+    # production-call-site class a unit test on candidates() would miss.
+    def through_main(*argv_tail: str, environ: dict[str, str] | None = None):
+        call_fake = FakeGh(
+            [fixture(number=2521), fixture(number=3434)],
+            mutation_errors={3434: WORKFLOWS_DENIAL},
+        )
+        saved = (sys.argv, globals()["run_gh_read"], globals()["run_gh"], dict(os.environ))
+        buffer = io.StringIO()
+        try:
+            globals()["run_gh_read"] = call_fake
+            globals()["run_gh"] = call_fake
+            if environ is not None:
+                os.environ.clear()
+                os.environ.update(environ)
+            sys.argv = ["auto-arm.py", "--repo", "sparq-org/sparq", *argv_tail]
+            with redirect_stdout(buffer):
+                return main(), buffer.getvalue()
+        finally:
+            sys.argv, globals()["run_gh_read"], globals()["run_gh"] = saved[:3]
+            os.environ.clear()
+            os.environ.update(saved[3])
+
+    scoped_code, scoped_out = through_main(
+        "--mode", "event", "--pr", "2521", environ={}
+    )
+    assert scoped_code == 0, (scoped_code, scoped_out)
+    assert "scope=pr-2521" in scoped_out and "3434" not in scoped_out, scoped_out
+    assert "::warning" not in scoped_out, scoped_out
+    # The stale-ref path: NO --pr, but the runner environment names the PR. This is what
+    # scopes PR refs whose frozen workflow snapshot cannot pass --pr at all.
+    stale_code, stale_out = through_main(
+        "--mode", "event", environ={"GITHUB_REF": "refs/pull/2521/merge"}
+    )
+    assert stale_code == 0, (stale_code, stale_out)
+    assert "scope=pr-2521" in stale_out and "3434" not in stale_out, stale_out
+    assert "could not identify the triggering PR" not in stale_out, stale_out
+    # Undeterminable => loud ::warning + the documented whole-repo fallback, never a hard
+    # failure (that would brick the gating check for the stale refs this issue is about).
+    fallback_code, fallback_out = through_main("--mode", "event", environ={})
+    assert fallback_code == 1, (fallback_code, fallback_out)
+    assert "could not identify the triggering PR" in fallback_out, fallback_out
+    assert "scope=all" in fallback_out, fallback_out
+    # SWEEP through main() stays whole-repo even when the environment names a PR.
+    sweep_code, sweep_out = through_main(
+        "--mode", "sweep", environ={"GITHUB_REF": "refs/pull/2521/merge"}
+    )
+    assert sweep_code == 1, (sweep_code, sweep_out)
+    assert "scope=all" in sweep_out and "considered=2" in sweep_out, sweep_out
+    assert "arm-failure summary: PR #3434" in sweep_out, sweep_out
+
+    # (20) SCOPE RESOLUTION, source by source. Explicit beats payload beats ref; a typo in
+    # the wiring is loud rather than a silent whole-repo sweep.
+    import tempfile
+
+    assert resolve_scope_pr("2521", {}) == 2521
+    assert resolve_scope_pr(" 2521 ", {}) == 2521
+    assert resolve_scope_pr(2521, {}) == 2521
+    assert resolve_scope_pr("", {}) is None
+    assert resolve_scope_pr(None, {}) is None
+    assert resolve_scope_pr("", {"GITHUB_REF": "refs/pull/3434/merge"}) == 3434
+    assert resolve_scope_pr("", {"GITHUB_REF": "refs/pull/3434/head"}) == 3434
+    assert resolve_scope_pr("", {"GITHUB_REF": "refs/heads/main"}) is None
+    assert resolve_scope_pr("42", {"GITHUB_REF": "refs/pull/3434/merge"}) == 42
+    for rejected in ("main", "-5", "3434.0", "refs/pull/7/merge", "  "):
+        try:
+            resolve_scope_pr(rejected, {})
+        except ValueError:
+            pass
+        else:
+            if str(rejected).strip():
+                raise AssertionError(f"--pr {rejected!r} must be rejected loudly")
+    with tempfile.TemporaryDirectory() as scope_tmp:
+        payload_path = f"{scope_tmp}/event.json"
+        with open(payload_path, "w", encoding="utf-8") as handle:
+            json.dump({"pull_request": {"number": 777}}, handle)
+        assert (
+            resolve_scope_pr(
+                "",
+                {"GITHUB_EVENT_PATH": payload_path, "GITHUB_REF": "refs/pull/3434/merge"},
+            )
+            == 777
+        ), "the event payload is more specific than the ref"
+        assert resolve_scope_pr("9", {"GITHUB_EVENT_PATH": payload_path}) == 9
+        with open(payload_path, "w", encoding="utf-8") as handle:
+            json.dump({"schedule": "4,14,24,34,44,54 * * * *"}, handle)
+        assert resolve_scope_pr("", {"GITHUB_EVENT_PATH": payload_path}) is None
+        with open(payload_path, "w", encoding="utf-8") as handle:
+            handle.write("{not json")
+        assert resolve_scope_pr("", {"GITHUB_EVENT_PATH": payload_path}) is None
+        assert (
+            resolve_scope_pr(
+                "", {"GITHUB_EVENT_PATH": f"{scope_tmp}/missing.json"}
+            )
+            is None
+        )
+    try:
+        resolve_scope_pr("main", {})
+    except ValueError as error:
+        assert "--pr must be a PR number" in str(error), error
+    else:
+        raise AssertionError("a non-numeric --pr must be loud, never a whole-repo sweep")
+
     print("auto-arm self-test: PASS")
 
 
@@ -1548,10 +1891,22 @@ def main() -> int:
         choices=("sweep", "event"),
         default="sweep",
         help=(
-            "sweep: periodic cron (exhausted transient reads => ::warning + exit 0, "
-            "the cron backstop covers a missed cycle). event: label-triggered arm on a "
-            "single PR (no per-PR backstop — any failure, incl. exhausted transients, "
-            "exits non-zero so the arm is visibly red and retried)."
+            "sweep: periodic cron over the WHOLE repository (exhausted transient reads "
+            "=> ::warning + exit 0, the cron backstop covers a missed cycle). event: "
+            "label-triggered arm scoped to the TRIGGERING PR ALONE (--pr / #3776), with "
+            "no per-PR backstop — so any failure of THAT PR, incl. exhausted transients, "
+            "exits non-zero so the arm is visibly red and retried."
+        ),
+    )
+    parser.add_argument(
+        "--pr",
+        default="",
+        help=(
+            "the number of the PR whose label event triggered this run. Scopes an "
+            "event-mode run to that PR ALONE (#3776) — an unrelated PR that cannot be "
+            "armed must never red a GATING check on this one. Empty in sweep mode; if it "
+            "is empty in event mode the number is derived from the runner environment "
+            "(see resolve_scope_pr), which is what scopes already-stale PR refs too."
         ),
     )
     parser.add_argument("--self-test", action="store_true")
@@ -1567,9 +1922,31 @@ def main() -> int:
         return 0
     if not args.repo:
         parser.error("--repo is required unless --self-test is used")
+    # [OPUS-5] #3776 THE CALL SITE. Scope is applied in EVENT mode only: the periodic sweep
+    # is the whole-repo backstop and must never be narrowed, or per-PR scoping would leave
+    # nothing covering the repository at all.
+    scope_pr: int | None = None
+    if args.mode == "event":
+        try:
+            scope_pr = resolve_scope_pr(args.pr, os.environ)
+        except ValueError as error:
+            parser.error(str(error))
+        if scope_pr is None:
+            print(SCOPE_UNRESOLVED_WARNING)
+    elif str(args.pr).strip():
+        print(
+            f"[{PROGRAM}] ignoring --pr {args.pr} in sweep mode: the periodic sweep is "
+            "the whole-repo backstop by design (#3776)"
+        )
     # `run_gh` is passed EXPLICITLY (not left to the default argument) so the self-test can
     # substitute both runners at the module level and drive main() end to end (#3766).
-    armer = AutoArmer(args.repo, args.default_branch, run_gh, gh_read=run_gh_read)
+    armer = AutoArmer(
+        args.repo,
+        args.default_branch,
+        run_gh,
+        gh_read=run_gh_read,
+        scope_pr=scope_pr,
+    )
     if args.probe_arm_capability:
         return probe_arm_capability_exit(armer)
     return run_sweep(armer, mode=args.mode)

--- a/scripts/auto-arm.py
+++ b/scripts/auto-arm.py
@@ -38,12 +38,198 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from typing import Callable
 
-import gh_retry
+
+# --------------------------------------------------------------------------------------
+# [OPUS-5] Issue #3776 — A MISSING RESILIENCE HELPER MUST NEVER BRICK THE GATING ARM CHECK.
+#
+# THE OUTAGE. `arm reviewed PRs` is a GATING check and auto-arm.yml runs on `pull_request`,
+# so GitHub resolves the WORKFLOW FILE from the PR's own ref while that workflow's checkout
+# step resolves the SCRIPT from `ref: default_branch`. #3766 (6137b7b3, merged
+# 2026-07-25T01:38:35Z) added `import gh_retry` here AND added `scripts/gh_retry.py` to
+# auto-arm.yml's file-by-file `sparse-checkout` list in the SAME commit — atomic on main,
+# not atomic across refs. Every PR ref whose workflow snapshot predates 01:38Z still
+# enumerates `scripts/auto-arm.py` alone, so the runner pairs the NEW default-branch script
+# with a checkout that never materialises gh_retry.py:
+#     File "/home/runner/work/sparq/sparq/scripts/auto-arm.py", line 46, in <module>
+#       import gh_retry
+#   ModuleNotFoundError: No module named 'gh_retry'
+# (sparq #3434, run 30143852994, 2026-07-25T04:20Z — branch cut 2026-07-18.) ci-summary
+# fail-fasts on a failing GATING check, so no reviewed PR on a stale ref could merge.
+#
+# WHY THE FIX MUST LIVE HERE, NOT IN THE WORKFLOW. The stale PR refs cannot be rewritten,
+# so the manifest those runs use is already frozen: editing auto-arm.yml's sparse list heals
+# only refs snapshotted AFTER the edit. The only code that reaches an already-stale PR is
+# code fetched from the DEFAULT BRANCH — this file. Hence the guard here; auto-arm.yml's
+# switch to whole-directory sparse-checkout is the forward-looking half, not the remedy.
+#
+# THE DEGRADATION, EXPLICITLY. gh_retry is a RESILIENCE helper (bounded, transient-only
+# retry for idempotent READS). Losing it must cost RETRIES — never the arm:
+#   * reads become ONE-SHOT via _DegradedGhRetry.run_gh_read. The load-bearing work is
+#     unchanged: candidates are still enumerated, every skip rule is still evaluated, a
+#     draft is still marked ready, and the arm mutation is still issued.
+#   * FAIL-CLOSED classification. With no retries there is nothing to exhaust, so a read
+#     failure raises GhFatalError (loud red). It is NEVER reported as GhTransientExhausted:
+#     that type is precisely what #3759 converts into ::warning + exit 0, so synthesising
+#     it here would turn a 403 into a false success. Degraded mode therefore trades
+#     transient tolerance for LOUDNESS, which is the safe direction — and strictly better
+#     than the guaranteed red it replaces.
+#   * assert_read_only stays a REAL fail-closed guard, not a no-op, so the self-test
+#     assertion "every read this script issues IS a read" cannot go vacuous when degraded.
+#   * exactly ONE loud ::warning at import time names the cause and the remedy.
+# Deliberately DUPLICATED into the sibling arm script — each workflow sparse-checks out only
+# its own script, so neither may import a shared helper (that very constraint is what caused
+# this outage). scripts/tests/test_arm_capability_wiring.py pins the two copies together and
+# proves the degraded path still mutates.
+class _DegradedGhRetry:
+    """One-shot stand-in for scripts/gh_retry.py when that file was not checked out."""
+
+    # Mirrors gh_retry._READ_SUBCOMMANDS.
+    READ_SUBCOMMANDS = frozenset(
+        {
+            ("pr", "list"),
+            ("pr", "view"),
+            ("pr", "checks"),
+            ("pr", "status"),
+            ("issue", "list"),
+            ("issue", "view"),
+            ("run", "list"),
+            ("run", "view"),
+            ("label", "list"),
+            ("search", "prs"),
+            ("search", "issues"),
+        }
+    )
+    MUTATION_RE = re.compile(r"\b(?:mutation|subscription)\b", re.IGNORECASE)
+    QUERY_FIELD_FLAGS = ("-f", "--field", "-F", "--raw-field")
+    FIELD_FLAGS = ("-f", "-F", "--field", "--raw-field", "--input")
+
+    class GhRetryUsageError(ValueError):
+        """argv could not be PROVEN a read. Refused, never wrapped."""
+
+    class GhFatalError(RuntimeError):
+        """A non-retried ``gh`` failure — the caller must fail loudly."""
+
+    class GhTransientExhausted(RuntimeError):
+        """Never raised by this stand-in: with zero retries there is nothing to exhaust.
+
+        Kept so ``except gh_retry.GhTransientExhausted`` clauses stay valid (and so the
+        self-test can still raise it through an injected runner).
+        """
+
+    @classmethod
+    def _field_values(cls, rest: list[str], flags: tuple[str, ...]) -> list[str]:
+        values: list[str] = []
+        index = 0
+        while index < len(rest):
+            arg = rest[index]
+            if arg in flags:
+                values.append(rest[index + 1] if index + 1 < len(rest) else "")
+                index += 2
+                continue
+            for flag in flags:
+                if arg.startswith(flag + "="):
+                    values.append(arg.split("=", 1)[1])
+                    break
+            index += 1
+        return values
+
+    @classmethod
+    def assert_read_only(cls, argv) -> None:
+        """Fail-closed: refuse anything not AFFIRMATIVELY provable as a read."""
+        rest = [str(arg) for arg in argv]
+        if not rest:
+            raise cls.GhRetryUsageError("empty gh argv")
+        if rest[0] != "api":
+            if tuple(rest[:2]) in cls.READ_SUBCOMMANDS:
+                return
+            raise cls.GhRetryUsageError(
+                f"gh {' '.join(rest[:2])} is not an allow-listed read — "
+                "mutations/arm calls stay one-shot"
+            )
+        tail = rest[1:]
+        method = None
+        for index, arg in enumerate(tail):
+            if arg in ("-X", "--method"):
+                method = tail[index + 1].upper() if index + 1 < len(tail) else ""
+                break
+            if arg.startswith("--method="):
+                method = arg.split("=", 1)[1].upper()
+                break
+        if "graphql" in tail:
+            inline = None
+            for value in cls._field_values(tail, cls.QUERY_FIELD_FLAGS):
+                if value.startswith("query=") and not value.startswith("query=@"):
+                    inline = value.split("=", 1)[1]
+            if inline is None:
+                raise cls.GhRetryUsageError(
+                    "refusing gh api graphql with no inline `query=` text (file-backed / "
+                    "stdin bodies are opaque) — cannot prove it is a read"
+                )
+            if cls.MUTATION_RE.search(inline):
+                raise cls.GhRetryUsageError(
+                    "refusing a GraphQL mutation/subscription — arms stay one-shot"
+                )
+            return
+        if method not in (None, "GET", "HEAD"):
+            raise cls.GhRetryUsageError(
+                f"refusing gh api with method {method or '<missing>'}"
+            )
+        if method is None and any(
+            arg in cls.FIELD_FLAGS
+            or any(arg.startswith(flag + "=") for flag in cls.FIELD_FLAGS[2:])
+            for arg in tail
+        ):
+            raise cls.GhRetryUsageError(
+                "refusing gh api with field params and no explicit GET "
+                "(gh auto-switches to POST)"
+            )
+
+    @classmethod
+    def run_gh_read(cls, argv, *, run=subprocess.run) -> str:
+        """Do the read ONCE. No retry, and no transient classification (see above).
+
+        ``run`` is injectable so the wiring test can prove a failing read raises
+        GhFatalError and NEVER the lenient GhTransientExhausted.
+        """
+        cls.assert_read_only(argv)
+        command = ["gh", *[str(arg) for arg in argv]]
+        result = run(command, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            detail = (
+                (result.stderr or "").strip()
+                or (result.stdout or "").strip()
+                or "unknown gh failure"
+            )
+            raise cls.GhFatalError(
+                f"{' '.join(command[:4])} failed (degraded: scripts/gh_retry.py was not "
+                f"checked out, so this read was NOT retried): {detail}"
+            )
+        return result.stdout
+
+
+try:
+    import gh_retry
+
+    GH_RETRY_DEGRADED = False
+except ImportError as _gh_retry_missing:  # pragma: no cover - see the wiring test
+    gh_retry = _DegradedGhRetry  # type: ignore[assignment]
+    GH_RETRY_DEGRADED = True
+    print(
+        "::warning title=auto-arm running WITHOUT transient-retry (scripts/gh_retry.py "
+        f"not checked out)::{_gh_retry_missing} — this run's idempotent gh READS are "
+        "ONE-SHOT: a GitHub 5xx blip will red it instead of being retried. Arming itself "
+        "is UNAFFECTED and proceeds. CAUSE: this script came from the default branch "
+        "while the `sparse-checkout` manifest came from an older workflow snapshot on the "
+        "PR ref, which does not list scripts/gh_retry.py (sparq #3776 / #3766). REMEDY: "
+        "rebase the PR onto the default branch, or re-run once the PR ref carries a "
+        "workflow file that sparse-checks out the whole scripts/ directory."
+    )
 
 
 PROGRAM = "auto-arm"

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -27,12 +27,193 @@ from __future__ import annotations
 import argparse
 import copy
 import json
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from typing import Callable
 
-import gh_retry
+
+# --------------------------------------------------------------------------------------
+# [OPUS-5] Issue #3776 — A MISSING RESILIENCE HELPER MUST NEVER BRICK AN ARM SWEEP.
+#
+# THE OUTAGE was in the SIBLING script: auto-arm.yml runs on `pull_request`, so its WORKFLOW
+# FILE (and therefore its file-by-file `sparse-checkout` manifest) comes from the PR's own
+# ref while the SCRIPT comes from `ref: default_branch`. #3766 added `import gh_retry` and
+# the matching manifest entry in one commit — atomic on main, not across refs — so every
+# stale PR ref got the new script without gh_retry.py and died with
+# `ModuleNotFoundError: No module named 'gh_retry'` on a GATING check (sparq #3434, run
+# 30143852994). See scripts/auto-arm.py for the full account.
+#
+# THIS script is NOT exposed to that ref skew today: rearm-sweeper.yml triggers only on
+# `schedule` / `workflow_dispatch`, so its workflow file and its `ref: default_branch`
+# checkout are always the same commit, and it is explicitly NOT A GATE. The guard is here
+# for the two ways that changes: adding any per-ref trigger to rearm-sweeper.yml, or adding
+# a second sibling import without remembering the manifest. Same class, same remedy — a
+# missing resilience helper must degrade, not abort.
+#
+# THE DEGRADATION, EXPLICITLY. gh_retry is a RESILIENCE helper (bounded, transient-only
+# retry for idempotent READS). Losing it must cost RETRIES — never the arm:
+#   * reads become ONE-SHOT via _DegradedGhRetry.run_gh_read. The load-bearing work is
+#     unchanged: candidates are still enumerated, every skip rule is still evaluated, a
+#     draft is still marked ready, and the arm mutation is still issued.
+#   * FAIL-CLOSED classification. With no retries there is nothing to exhaust, so a read
+#     failure raises GhFatalError (loud red). It is NEVER reported as GhTransientExhausted:
+#     that type is precisely what #3759 converts into ::warning + exit 0, so synthesising
+#     it here would turn a 403 into a false success. Degraded mode therefore trades
+#     transient tolerance for LOUDNESS, which is the safe direction — and strictly better
+#     than the guaranteed red it replaces.
+#   * assert_read_only stays a REAL fail-closed guard, not a no-op, so the self-test
+#     assertion "every read this script issues IS a read" cannot go vacuous when degraded.
+#   * exactly ONE loud ::warning at import time names the cause and the remedy.
+# Deliberately DUPLICATED into the sibling arm script — each workflow sparse-checks out only
+# its own script, so neither may import a shared helper (that very constraint is what caused
+# this outage). scripts/tests/test_arm_capability_wiring.py pins the two copies together and
+# proves the degraded path still mutates.
+class _DegradedGhRetry:
+    """One-shot stand-in for scripts/gh_retry.py when that file was not checked out."""
+
+    # Mirrors gh_retry._READ_SUBCOMMANDS.
+    READ_SUBCOMMANDS = frozenset(
+        {
+            ("pr", "list"),
+            ("pr", "view"),
+            ("pr", "checks"),
+            ("pr", "status"),
+            ("issue", "list"),
+            ("issue", "view"),
+            ("run", "list"),
+            ("run", "view"),
+            ("label", "list"),
+            ("search", "prs"),
+            ("search", "issues"),
+        }
+    )
+    MUTATION_RE = re.compile(r"\b(?:mutation|subscription)\b", re.IGNORECASE)
+    QUERY_FIELD_FLAGS = ("-f", "--field", "-F", "--raw-field")
+    FIELD_FLAGS = ("-f", "-F", "--field", "--raw-field", "--input")
+
+    class GhRetryUsageError(ValueError):
+        """argv could not be PROVEN a read. Refused, never wrapped."""
+
+    class GhFatalError(RuntimeError):
+        """A non-retried ``gh`` failure — the caller must fail loudly."""
+
+    class GhTransientExhausted(RuntimeError):
+        """Never raised by this stand-in: with zero retries there is nothing to exhaust.
+
+        Kept so ``except gh_retry.GhTransientExhausted`` clauses stay valid (and so the
+        self-test can still raise it through an injected runner).
+        """
+
+    @classmethod
+    def _field_values(cls, rest: list[str], flags: tuple[str, ...]) -> list[str]:
+        values: list[str] = []
+        index = 0
+        while index < len(rest):
+            arg = rest[index]
+            if arg in flags:
+                values.append(rest[index + 1] if index + 1 < len(rest) else "")
+                index += 2
+                continue
+            for flag in flags:
+                if arg.startswith(flag + "="):
+                    values.append(arg.split("=", 1)[1])
+                    break
+            index += 1
+        return values
+
+    @classmethod
+    def assert_read_only(cls, argv) -> None:
+        """Fail-closed: refuse anything not AFFIRMATIVELY provable as a read."""
+        rest = [str(arg) for arg in argv]
+        if not rest:
+            raise cls.GhRetryUsageError("empty gh argv")
+        if rest[0] != "api":
+            if tuple(rest[:2]) in cls.READ_SUBCOMMANDS:
+                return
+            raise cls.GhRetryUsageError(
+                f"gh {' '.join(rest[:2])} is not an allow-listed read — "
+                "mutations/arm calls stay one-shot"
+            )
+        tail = rest[1:]
+        method = None
+        for index, arg in enumerate(tail):
+            if arg in ("-X", "--method"):
+                method = tail[index + 1].upper() if index + 1 < len(tail) else ""
+                break
+            if arg.startswith("--method="):
+                method = arg.split("=", 1)[1].upper()
+                break
+        if "graphql" in tail:
+            inline = None
+            for value in cls._field_values(tail, cls.QUERY_FIELD_FLAGS):
+                if value.startswith("query=") and not value.startswith("query=@"):
+                    inline = value.split("=", 1)[1]
+            if inline is None:
+                raise cls.GhRetryUsageError(
+                    "refusing gh api graphql with no inline `query=` text (file-backed / "
+                    "stdin bodies are opaque) — cannot prove it is a read"
+                )
+            if cls.MUTATION_RE.search(inline):
+                raise cls.GhRetryUsageError(
+                    "refusing a GraphQL mutation/subscription — arms stay one-shot"
+                )
+            return
+        if method not in (None, "GET", "HEAD"):
+            raise cls.GhRetryUsageError(
+                f"refusing gh api with method {method or '<missing>'}"
+            )
+        if method is None and any(
+            arg in cls.FIELD_FLAGS
+            or any(arg.startswith(flag + "=") for flag in cls.FIELD_FLAGS[2:])
+            for arg in tail
+        ):
+            raise cls.GhRetryUsageError(
+                "refusing gh api with field params and no explicit GET "
+                "(gh auto-switches to POST)"
+            )
+
+    @classmethod
+    def run_gh_read(cls, argv, *, run=subprocess.run) -> str:
+        """Do the read ONCE. No retry, and no transient classification (see above).
+
+        ``run`` is injectable so the wiring test can prove a failing read raises
+        GhFatalError and NEVER the lenient GhTransientExhausted.
+        """
+        cls.assert_read_only(argv)
+        command = ["gh", *[str(arg) for arg in argv]]
+        result = run(command, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            detail = (
+                (result.stderr or "").strip()
+                or (result.stdout or "").strip()
+                or "unknown gh failure"
+            )
+            raise cls.GhFatalError(
+                f"{' '.join(command[:4])} failed (degraded: scripts/gh_retry.py was not "
+                f"checked out, so this read was NOT retried): {detail}"
+            )
+        return result.stdout
+
+
+try:
+    import gh_retry
+
+    GH_RETRY_DEGRADED = False
+except ImportError as _gh_retry_missing:  # pragma: no cover - see the wiring test
+    gh_retry = _DegradedGhRetry  # type: ignore[assignment]
+    GH_RETRY_DEGRADED = True
+    print(
+        "::warning title=rearm-sweeper running WITHOUT transient-retry (scripts/gh_retry.py "
+        f"not checked out)::{_gh_retry_missing} — this run's idempotent gh READS are "
+        "ONE-SHOT: a GitHub 5xx blip will red it instead of being retried. Arming itself "
+        "is UNAFFECTED and proceeds. CAUSE: this script came from the default branch "
+        "while the `sparse-checkout` manifest came from an older workflow snapshot on the "
+        "PR ref, which does not list scripts/gh_retry.py (sparq #3776 / #3766). REMEDY: "
+        "rebase the PR onto the default branch, or re-run once the PR ref carries a "
+        "workflow file that sparse-checks out the whole scripts/ directory."
+    )
 
 
 PROGRAM = "rearm-sweeper"

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import re
 import shutil
 import subprocess
 import sys
@@ -746,6 +747,215 @@ class TestSparseCheckoutManifest(unittest.TestCase):
                                 "the manifest omits — check out the directory instead"
                             )
         self.assertEqual([], offenders, "\n".join(offenders))
+
+
+# --------------------------------------------------------------------------------------
+# [OPUS-5] #3776 SECOND HALF — AN EVENT-TRIGGERED RUN JUDGES THE PR THAT TRIGGERED IT.
+#
+# `AutoArmer.run()` swept EVERY open review:pass PR in BOTH modes. #3766 then made the exit
+# status STICKY over collected failures — correct for the cron sweep, catastrophic combined
+# with whole-repo scope on a GATING check: ONE permanently un-armable PR reds
+# `arm reviewed PRs` on every OTHER PR's label event.
+#
+# MEASURED blast radius (run 30144214363, 2026-07-25T04:33Z): sparq had exactly two
+# review:pass PRs and the sweep reported `considered=2 armed=0 arm-failures=1` — #3434
+# cannot be armed at all until the `workflows: write` question (#3777) is decided, so the
+# gating arm check was poisoned for the whole repository by one PR.
+#
+# The fix is SCOPE, not leniency. Two halves are pinned below, and the DISCRIMINATION
+# between them is the test:
+#   * an UNRELATED PR's un-armability must be invisible to an event-mode run, and
+#   * the TRIGGERING PR's own arm failure must still be a hard non-zero exit that no later
+#     transient can discard (#3766's precedence, unchanged, within the narrower scope).
+# Plus the two ways this could silently become a no-op: sweep mode must still cover the
+# whole repository, and the WORKFLOW must actually plumb the triggering PR number through
+# to the script (a production call site — the class a unit test on candidates() misses).
+UNARMABLE = 3434  # modifies a workflow file; no `workflows: write` on the arm token
+ARMABLE = 2521
+
+
+def arm_run(module: ModuleType, *, scope_pr: int | None, mode: str, failing=UNARMABLE):
+    """Replay the live shape: two review:pass PRs, one of them permanently un-armable."""
+    fake = module.FakeGh(
+        [module.fixture(number=ARMABLE), module.fixture(number=UNARMABLE)],
+        mutation_errors={failing: module.WORKFLOWS_DENIAL} if failing else None,
+    )
+    lines: list[str] = []
+    armer = module.AutoArmer(
+        "sparq-org/sparq", "main", fake, lines.append, scope_pr=scope_pr
+    )
+    try:
+        return fake, lines, module.run_sweep(armer, log=lines.append, mode=mode)
+    except module.GhError as error:  # event-mode transient exhaustion raises
+        return fake, lines, error
+
+
+class TestEventModeIsPerPr(unittest.TestCase):
+    """An event-triggered run must be accountable for the triggering PR and no other."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.auto = load_module(AUTO_ARM_PY, "auto_arm_under_test")
+
+    def test_an_unarmable_unrelated_pr_does_not_fail_an_event_run(self) -> None:
+        fake, lines, code = arm_run(self.auto, scope_pr=ARMABLE, mode="event")
+        self.assertEqual(
+            0,
+            code,
+            f"an event run for PR #{ARMABLE} must not fail because a DIFFERENT PR "
+            f"(#{UNARMABLE}) cannot be armed — that is what poisoned the gating check "
+            f"for the whole repo (#3776)\n" + "\n".join(lines),
+        )
+        self.assertTrue(any(f"PR #{ARMABLE}: armed head" in l for l in lines), lines)
+        # Not merely excused — never even READ, so nothing about it can reach this outcome.
+        self.assertEqual(
+            [], [l for l in lines if str(UNARMABLE) in l], "the bystander must be untouched"
+        )
+        self.assertEqual(
+            [], [c for c in fake.calls if str(UNARMABLE) in " ".join(c)], fake.calls
+        )
+
+    def test_the_triggering_prs_own_failure_is_still_fatal(self) -> None:
+        # THE DISCRIMINATION. Narrowing WHICH PRs a run answers for must not weaken
+        # accountability for the one it does: this is the half that keeps the check honest.
+        fake, lines, code = arm_run(self.auto, scope_pr=UNARMABLE, mode="event")
+        self.assertEqual(
+            1,
+            code,
+            "the TRIGGERING PR's own arm failure must still red the run\n"
+            + "\n".join(lines),
+        )
+        self.assertTrue(any(f"PR #{UNARMABLE}: arm-failed" in l for l in lines), lines)
+        self.assertEqual(
+            [], [l for l in lines if l.startswith("::warning")], "no lenient warning"
+        )
+
+    def test_a_later_transient_cannot_discard_the_triggering_prs_failure(self) -> None:
+        # #3766's sticky precedence, INSIDE the narrower scope: the arm fails, then that
+        # same PR's race diagnostic exhausts its bounded retries. Exit 1 must stand.
+        module = self.auto
+        fake = module.FakeGh(
+            [module.fixture(number=UNARMABLE)],
+            mutation_errors={UNARMABLE: module.WORKFLOWS_DENIAL},
+        )
+        views: list[list[str]] = []
+
+        def diagnostic_exhausts(argv: list[str]) -> str:
+            if argv[:2] == ["pr", "view"] and argv[2] == str(UNARMABLE):
+                views.append(argv)
+                if len(views) >= 3:  # candidates(), pre-arm refresh, then the diagnostic
+                    raise module.gh_retry.GhTransientExhausted("HTTP 504 (3 attempts)")
+            return fake(argv)
+
+        lines: list[str] = []
+        code = module.run_sweep(
+            module.AutoArmer(
+                "sparq-org/sparq",
+                "main",
+                fake,
+                lines.append,
+                gh_read=diagnostic_exhausts,
+                scope_pr=UNARMABLE,
+            ),
+            log=lines.append,
+            mode="event",
+        )
+        self.assertEqual(1, code, "\n".join(lines))
+        self.assertEqual([], [l for l in lines if l.startswith("::warning")], lines)
+        self.assertTrue(
+            any("race diagnostic could not resolve" in l for l in lines), lines
+        )
+
+    def test_sweep_mode_still_covers_the_whole_repo(self) -> None:
+        # Without this, the scoping fix could silently become "event mode does nothing and
+        # nothing else covers the repository".
+        _fake, lines, code = arm_run(
+            self.auto, scope_pr=None, mode="sweep", failing=None
+        )
+        self.assertEqual(0, code, "\n".join(lines))
+        self.assertEqual(
+            2,
+            sum("armed head" in l for l in lines),
+            "the periodic sweep must still consider EVERY open review:pass PR\n"
+            + "\n".join(lines),
+        )
+        self.assertTrue(
+            any("considered=2" in l and "scope=all" in l for l in lines), lines
+        )
+        # ...and it stays ACCOUNTABLE for all of them: one failure still reds the sweep.
+        _fake, lines, code = arm_run(self.auto, scope_pr=None, mode="sweep")
+        self.assertEqual(1, code, "\n".join(lines))
+        self.assertTrue(any(f"PR #{ARMABLE}: armed head" in l for l in lines), lines)
+        self.assertTrue(any(f"PR #{UNARMABLE}: arm-failed" in l for l in lines), lines)
+
+    def test_the_workflow_passes_the_triggering_pr_number_to_the_arm_step(self) -> None:
+        """THE CALL SITE. Scoping the script is worthless if nothing supplies the number."""
+        steps = steps_of(load(AUTO_ARM_YML))
+        arm = [
+            step
+            for step in steps
+            if "scripts/auto-arm.py" in run_of(step)
+            and PROBE_FLAG not in run_of(step)
+            and "--self-test" not in run_of(step)
+        ]
+        self.assertEqual(1, len(arm), "auto-arm.yml must have exactly one arming step")
+        run, env = run_of(arm[0]), (arm[0].get("env") or {})
+        match = re.search(r'--pr\s+"\$\{?([A-Z_]+)\}?"', run)
+        self.assertIsNotNone(
+            match,
+            "the arming step must pass --pr \"$VAR\" — without it an event-mode run "
+            "cannot know which PR it is accountable for (#3776)\n" + run,
+        )
+        variable = match.group(1)
+        self.assertIn(variable, env, f"{variable} must be set in the step env")
+        self.assertEqual(
+            "${{ github.event.pull_request.number }}",
+            str(env[variable]).strip(),
+            f"{variable} must be EXACTLY the triggering PR's number: any fallback value "
+            "would scope the periodic sweep too, and the sweep is the whole-repo backstop",
+        )
+        # The mode axis must survive alongside it — scope answers 'whose failure is this
+        # run's business', mode answers 'how loud is a missed cycle' (#3759 finding 5).
+        mode_match = re.search(r'--mode\s+"\$\{?([A-Z_]+)\}?"', run)
+        self.assertIsNotNone(mode_match, run)
+        self.assertIn("event", str(env[mode_match.group(1)]))
+        self.assertIn("sweep", str(env[mode_match.group(1)]))
+
+    def test_the_script_alone_can_scope_a_stale_ref(self) -> None:
+        """The half that heals ALREADY-FROZEN PR refs.
+
+        `ARM_PR` above is snapshotted per PR ref exactly like the sparse-checkout manifest
+        that caused #3776, so a stale ref cannot pass it. The script always comes from the
+        default branch, so it must be able to derive the number from the RUNNER's
+        environment on its own — otherwise this fix would only reach rebased PRs.
+        """
+        resolve = self.auto.resolve_scope_pr
+        self.assertEqual(ARMABLE, resolve("", {"GITHUB_REF": f"refs/pull/{ARMABLE}/merge"}))
+        self.assertIsNone(resolve("", {"GITHUB_REF": "refs/heads/main"}))
+        with tempfile.TemporaryDirectory() as tmp:
+            payload = Path(tmp) / "event.json"
+            payload.write_text('{"pull_request": {"number": 909}}', encoding="utf-8")
+            self.assertEqual(
+                909,
+                resolve("", {"GITHUB_EVENT_PATH": str(payload)}),
+                "the event payload is the most specific environment source",
+            )
+        # An explicit --pr always wins, and a typo is loud rather than a whole-repo sweep.
+        self.assertEqual(42, resolve("42", {"GITHUB_REF": f"refs/pull/{ARMABLE}/merge"}))
+        with self.assertRaises(ValueError):
+            resolve("not-a-number", {})
+
+    def test_the_scoping_seam_is_documented_in_source(self) -> None:
+        source = AUTO_ARM_PY.read_text(encoding="utf-8")
+        for needle in (
+            "scope_pr",
+            "def candidates",
+            "def resolve_scope_pr",
+            # The distinction the maintainer asked to keep visible in the code: scoping is
+            # a CORRECTNESS fix; de-gating `arm reviewed PRs` is a POLICY decision (#3777).
+            "policy decision about what may block a merge",
+        ):
+            self.assertIn(needle, source, f"auto-arm.py must keep {needle!r}")
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -41,8 +41,13 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
+import shutil
+import subprocess
 import sys
+import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from types import ModuleType
@@ -417,6 +422,330 @@ class TestSelfTestsRunInCi(unittest.TestCase):
                 blob,
                 f"docs-quality.yml must run `{needle}` in a GATING job",
             )
+
+
+# --------------------------------------------------------------------------------------
+# [OPUS-5] #3776 — THE MISSING-SIBLING-IMPORT CLASS.
+#
+# auto-arm.yml runs on `pull_request`, so GitHub takes the WORKFLOW FILE — and therefore
+# its `sparse-checkout` manifest — from the PR's own ref, while the checkout step takes the
+# SCRIPT from `ref: default_branch`. #3766 added `import gh_retry` to scripts/auto-arm.py
+# and `scripts/gh_retry.py` to that manifest in ONE commit: atomic on main, not atomic
+# across refs. Every PR ref snapshotted earlier kept the one-entry manifest, so the runner
+# paired the NEW script with a checkout that never materialised gh_retry.py:
+#   ModuleNotFoundError: No module named 'gh_retry'  (#3434, run 30143852994)
+# `arm reviewed PRs` is GATING, so ci-summary fail-fasted and no reviewed PR on a stale ref
+# could merge — a missing RESILIENCE helper became a merge blocker.
+#
+# These suites pin BOTH halves of the fix:
+#   * SURVIVABILITY (heals the already-stale refs) — each script must import and pass its
+#     own self-test with gh_retry.py ABSENT, and the degraded path must still do the
+#     load-bearing work (mark ready + issue the arm mutation), never quietly no-op.
+#   * IMPOSSIBILITY (stops new skew) — no workflow may enumerate individual .py files whose
+#     sibling imports are not also enumerated, and the arm workflows must sparse-check out
+#     the whole `scripts` directory.
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+ARM_SCRIPTS = (REARM_PY, AUTO_ARM_PY)
+
+
+def run_without_gh_retry(script: Path, driver: str | None = None):
+    """Run ``script`` from a temp dir holding ONLY it, so `import gh_retry` cannot resolve.
+
+    This reproduces the runner's state exactly: sys.path[0] is the script's own directory,
+    and scripts/gh_retry.py was never checked out into it.
+    """
+    env = {k: v for k, v in __import__("os").environ.items() if k != "PYTHONPATH"}
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / script.name
+        shutil.copy2(script, target)
+        if (Path(tmp) / "gh_retry.py").exists():  # pragma: no cover - paranoia
+            raise AssertionError("the isolation dir must NOT contain gh_retry.py")
+        if driver is None:
+            argv = [sys.executable, str(target), "--self-test"]
+        else:
+            (Path(tmp) / "driver.py").write_text(driver, encoding="utf-8")
+            argv = [sys.executable, str(Path(tmp) / "driver.py"), target.name]
+        return subprocess.run(
+            argv, cwd=tmp, capture_output=True, text=True, check=False, env=env
+        )
+
+
+DRIVER_PRELUDE = textwrap.dedent(
+    '''
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    path = Path(sys.argv[1]).resolve()
+    spec = importlib.util.spec_from_file_location("under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["under_test"] = module
+    spec.loader.exec_module(module)
+
+    # The whole point: this driver must be running in the DEGRADED mode, not silently
+    # picking up the real helper from somewhere on sys.path.
+    assert module.GH_RETRY_DEGRADED is True, "expected degraded mode"
+    assert module.gh_retry is module._DegradedGhRetry, module.gh_retry
+    '''
+)
+
+# The degraded path must still MUTATE. "Gracefully degraded into doing nothing" is the
+# failure mode these two drivers exist to catch: they assert the draft->ready mutation AND
+# the arm mutation are really issued, and that the outcome counts the arm.
+AUTO_ARM_DRIVER = DRIVER_PRELUDE + textwrap.dedent(
+    """
+    # Draft in the list snapshot, ready on the live refresh: exercises BOTH mutations
+    # (gh pr ready, then the enablePullRequestAutoMerge CAS).
+    fake, messages, outcome = module.exercise(
+        module.fixture(draft=True), views=[module.fixture()]
+    )
+    assert outcome.armed == 1, (outcome, messages)
+    assert not outcome.arm_failures, outcome.arm_failures
+    assert any(call[:2] == ["pr", "ready"] for call in fake.calls), fake.calls
+    arm = module.graphql_calls(fake)
+    assert len(arm) == 1, fake.calls
+    assert any("enablePullRequestAutoMerge" in str(a) for a in arm[0]), arm
+    assert any("armed head" in m for m in messages), messages
+    print("DEGRADED-MUTATION-OK")
+    """
+)
+
+REARM_DRIVER = DRIVER_PRELUDE + textwrap.dedent(
+    """
+    fake, messages, outcome = module.exercise(module.fixture(4242))
+    assert outcome.armed == 1, (outcome, messages)
+    assert not outcome.arm_failures, outcome.arm_failures
+    arm = module.arm_calls(fake)
+    assert len(arm) == 1, fake.calls
+    assert "--auto" in arm[0], arm
+    print("DEGRADED-MUTATION-OK")
+    """
+)
+
+DEGRADED_DRIVERS = {REARM_PY: REARM_DRIVER, AUTO_ARM_PY: AUTO_ARM_DRIVER}
+
+
+class TestSurvivesMissingGhRetry(unittest.TestCase):
+    """#3776: a missing resilience helper must cost RETRIES, never the arm."""
+
+    def test_self_test_passes_with_gh_retry_absent(self) -> None:
+        # THE REGRESSION TEST. Before the import guard this reproduced the live
+        # ModuleNotFoundError from run 30143852994 verbatim.
+        for script in ARM_SCRIPTS:
+            with self.subTest(script=script.name):
+                result = run_without_gh_retry(script)
+                self.assertNotIn(
+                    "ModuleNotFoundError: No module named 'gh_retry'",
+                    result.stderr,
+                    f"{script.name} must not abort when gh_retry.py was not checked out "
+                    "(the #3434 outage); it must degrade to no-retry",
+                )
+                self.assertEqual(
+                    0,
+                    result.returncode,
+                    f"{script.name} --self-test must pass without gh_retry.py\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                )
+                self.assertIn("self-test: PASS", result.stdout, result.stdout)
+
+    def test_degraded_import_emits_exactly_one_loud_actionable_warning(self) -> None:
+        for script in ARM_SCRIPTS:
+            with self.subTest(script=script.name):
+                out = run_without_gh_retry(script).stdout
+                self.assertEqual(
+                    1,
+                    out.count("::warning title="),
+                    f"{script.name}: exactly ONE ::warning, never one per call\n{out}",
+                )
+                for needle in (
+                    "gh_retry.py",  # the missing file, by name
+                    "sparse-checkout",  # the mechanism
+                    "ONE-SHOT",  # what was actually lost
+                    "REMEDY",  # what to do about it
+                ):
+                    self.assertIn(needle, out, f"{script.name}: warning must name {needle!r}")
+
+    def test_degraded_path_still_performs_the_mutations(self) -> None:
+        # NOT-A-NO-OP. Degrading into silence would be worse than crashing: the check
+        # would go green while nothing was ever armed.
+        for script in ARM_SCRIPTS:
+            with self.subTest(script=script.name):
+                result = run_without_gh_retry(script, driver=DEGRADED_DRIVERS[script])
+                self.assertEqual(
+                    0,
+                    result.returncode,
+                    f"{script.name} degraded arm path\nstdout:\n{result.stdout}\n"
+                    f"stderr:\n{result.stderr}",
+                )
+                self.assertIn("DEGRADED-MUTATION-OK", result.stdout, result.stdout)
+
+
+class TestDegradedHelperContract(unittest.TestCase):
+    """The stand-in is exercised directly — it must not be a permissive stub."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rearm = load_module(REARM_PY, "rearm_sweeper_under_test")
+        cls.auto = load_module(AUTO_ARM_PY, "auto_arm_under_test")
+
+    def modules(self):
+        return ((self.rearm, "rearm-sweeper"), (self.auto, "auto-arm"))
+
+    def test_the_real_helper_is_used_when_it_is_importable(self) -> None:
+        # Non-vacuity in the OTHER direction: a guard that always degraded would silently
+        # delete #3759's transient tolerance from every scheduled run.
+        for module, name in self.modules():
+            self.assertFalse(module.GH_RETRY_DEGRADED, name)
+            self.assertEqual("gh_retry", module.gh_retry.__name__, name)
+
+    def test_degraded_read_only_guard_still_refuses_the_arm_mutation(self) -> None:
+        for module, name in self.modules():
+            degraded = module._DegradedGhRetry
+            with self.assertRaises(degraded.GhRetryUsageError, msg=name):
+                degraded.assert_read_only(
+                    ["api", "graphql", "-f", f"query={module.ENABLE_AUTO_MERGE}"]
+                    if hasattr(module, "ENABLE_AUTO_MERGE")
+                    else ["pr", "merge", "1", "--auto"]
+                )
+            # ...and refuses a mutation whichever shape it takes.
+            for refused in (
+                ["pr", "merge", "1", "--auto", "--squash"],
+                ["pr", "edit", "1", "--add-label", "review:pass"],
+                ["api", "-X", "POST", "repos/o/r/issues"],
+                ["api", "graphql", "--input", "body.json"],
+                ["api", "graphql", "-f", "query=mutation{enablePullRequestAutoMerge}"],
+            ):
+                with self.assertRaises(degraded.GhRetryUsageError, msg=(name, refused)):
+                    degraded.assert_read_only(refused)
+            # The reads the sweeps actually issue must still be accepted, or the degraded
+            # mode would be a different kind of brick.
+            for allowed in (
+                ["pr", "list", "--repo", "o/r", "--json", "number"],
+                ["pr", "view", "1", "--repo", "o/r", "--json", "number"],
+                ["api", "graphql", "-f", f"query={module.CAPABILITY_QUERY}"],
+            ):
+                degraded.assert_read_only(allowed)
+
+    def test_degraded_read_failure_is_fatal_never_lenient(self) -> None:
+        # GhTransientExhausted is what #3759 converts into ::warning + exit 0. With no
+        # retries there is nothing to exhaust, so synthesising it here would turn a 403
+        # into a false success. Fail closed instead.
+        class _Failed:
+            returncode = 1
+            stdout = ""
+            stderr = "HTTP 504: 504 Gateway Timeout"
+
+        for module, name in self.modules():
+            degraded = module._DegradedGhRetry
+            with self.assertRaises(degraded.GhFatalError, msg=name) as caught:
+                degraded.run_gh_read(
+                    ["pr", "list", "--repo", "o/r"], run=lambda *_a, **_k: _Failed()
+                )
+            self.assertNotIsInstance(
+                caught.exception, degraded.GhTransientExhausted, name
+            )
+            self.assertIn("NOT retried", str(caught.exception), name)
+
+    def test_degraded_stand_ins_do_not_drift_between_the_two_scripts(self) -> None:
+        # Same rule as the denial-marker pin: the workflows cannot share a helper, so the
+        # duplication is pinned rather than left to rot.
+        self.assertEqual(
+            tuple(sorted(self.rearm._DegradedGhRetry.READ_SUBCOMMANDS)),
+            tuple(sorted(self.auto._DegradedGhRetry.READ_SUBCOMMANDS)),
+        )
+        for name in ("assert_read_only", "run_gh_read"):
+            self.assertTrue(callable(getattr(self.rearm._DegradedGhRetry, name)), name)
+            self.assertTrue(callable(getattr(self.auto._DegradedGhRetry, name)), name)
+
+
+class TestSparseCheckoutManifest(unittest.TestCase):
+    """#3776 IMPOSSIBILITY half: a manifest that can go stale must not exist."""
+
+    def test_arm_workflows_check_out_the_whole_scripts_directory(self) -> None:
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            for step in steps_of(load(path)):
+                with_ = step.get("with") or {}
+                if "sparse-checkout" not in with_:
+                    continue
+                pattern = str(with_["sparse-checkout"]).split()
+                self.assertEqual(
+                    ["scripts"],
+                    pattern,
+                    f"{name}: enumerate the DIRECTORY, not files — a file list must be "
+                    "hand-updated for every new sibling import and is snapshotted per "
+                    "PR ref (#3776)",
+                )
+                self.assertNotIn(
+                    "sparse-checkout-cone-mode",
+                    with_,
+                    f"{name}: cone mode is what makes the bare `scripts` pattern "
+                    "recursive; non-cone would reinterpret it as a gitignore pattern",
+                )
+
+    def test_no_script_shadows_a_stdlib_module(self) -> None:
+        """The hazard the whole-directory checkout introduces, closed up front.
+
+        `python3 scripts/auto-arm.py` puts scripts/ FIRST on sys.path. While the manifest
+        listed two files that was harmless; now the entire directory is materialised, so a
+        file named e.g. scripts/types.py would shadow the stdlib for every script run from
+        there. Cheap to pin, silent and confusing to debug.
+        """
+        offenders = sorted(
+            str(p.relative_to(REPO_ROOT))
+            for p in SCRIPTS_DIR.rglob("*.py")
+            if p.stem in sys.stdlib_module_names
+        )
+        self.assertEqual(
+            [],
+            offenders,
+            "these scripts shadow a stdlib module and would break any sibling script "
+            f"importing it: {offenders}",
+        )
+
+    def test_no_workflow_enumerates_a_python_file_without_its_sibling_imports(
+        self,
+    ) -> None:
+        """The whole CLASS, over every workflow — not just the two arm ones.
+
+        A `sparse-checkout` list that names individual .py files silently encodes that
+        script's import graph. If a listed script imports a sibling under scripts/ that
+        the list omits, the runner gets a script it cannot import: #3434 exactly.
+        """
+        local_modules = {p.stem: p for p in SCRIPTS_DIR.rglob("*.py")}
+        offenders: list[str] = []
+        for workflow in sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml")):
+            document = load(workflow)
+            if not isinstance(document, dict):
+                continue
+            for step in steps_of(document):
+                with_ = step.get("with") or {}
+                raw = with_.get("sparse-checkout")
+                if not raw:
+                    continue
+                listed = [entry.strip() for entry in str(raw).split() if entry.strip()]
+                listed_stems = {Path(entry).stem for entry in listed}
+                for entry in listed:
+                    if not entry.endswith(".py"):
+                        continue
+                    script = REPO_ROOT / entry
+                    if not script.is_file():
+                        continue
+                    tree = ast.parse(script.read_text(encoding="utf-8"))
+                    imported: set[str] = set()
+                    for node in ast.walk(tree):
+                        if isinstance(node, ast.Import):
+                            imported.update(a.name.split(".")[0] for a in node.names)
+                        elif isinstance(node, ast.ImportFrom) and node.module:
+                            imported.add(node.module.split(".")[0])
+                    for sibling in sorted(imported & set(local_modules)):
+                        if sibling not in listed_stems:
+                            offenders.append(
+                                f"{workflow.name}: sparse-checkout lists {entry} which "
+                                f"imports sibling {sibling!r} "
+                                f"({local_modules[sibling].relative_to(REPO_ROOT)}) that "
+                                "the manifest omits — check out the directory instead"
+                            )
+        self.assertEqual([], offenders, "\n".join(offenders))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. Authored and reviewed by AI agents.

Fixes #3776. Follow-up decision: #3777.

**Two independent defects in the gating `arm reviewed PRs` check.** They share a root neighbourhood — the workflow file comes from the PR's ref while the script comes from the default branch — but they are separate bugs with separate fixes, tests and mutation checks:

* **Part A — a missing sibling import bricked the check on every stale branch.** `ModuleNotFoundError: No module named 'gh_retry'` on a GATING check (#3434, run 30143852994).
* **Part B — an event-triggered run judged every *other* PR too.** One permanently un-armable PR redded the gating check on every other PR's label event; measured `considered=2 armed=0 arm-failures=1` with exactly two `review:pass` PRs in the repo (run 30144214363).

**Deliberately NOT done: de-gating `arm reviewed PRs`.** That is a policy decision about what may block a merge, not a correctness fix. The ruleset is untouched — see the final section and #3777.

---

# PART A — a missing transient-retry helper must not brick a stale branch

## The defect: workflow-from-PR-ref vs script-from-default-branch

`arm reviewed PRs` is a **GATING** check. `auto-arm.yml` triggers on `pull_request`, and for a `pull_request` event GitHub resolves the **workflow file** from the PR's own ref — which means the workflow's `sparse-checkout` **manifest** is a per-PR snapshot. That same workflow's checkout step deliberately resolves the **script** from `ref: ${{ github.event.repository.default_branch }}` (run trusted policy, never PR-head code).

So the two halves of one dependency come from two different commits.

PR #3766 (`6137b7b3`, merged 2026-07-25T01:38:35Z) added `import gh_retry` to `scripts/auto-arm.py` **and** `scripts/gh_retry.py` to `auto-arm.yml`'s file-by-file sparse list **in the same commit**. That is atomic on `main`; it is not atomic across refs. Every PR ref whose workflow snapshot predates 01:38Z still enumerates `scripts/auto-arm.py` alone — so the runner pairs the *new* default-branch script with a checkout that never materialises `gh_retry.py`:

```
File "/home/runner/work/sparq/sparq/scripts/auto-arm.py", line 46, in <module>
    import gh_retry
ModuleNotFoundError: No module named 'gh_retry'
```

Live on **#3434**, run [`30143852994`](https://github.com/sparq-org/sparq/actions/runs/30143852994) (04:20Z; branch cut 2026-07-18). `ci-summary` fail-fasts on a failing gating check, so no reviewed PR on a stale ref could merge. **A missing *resilience* helper became a merge blocker.**

Two corrections to the original report, both verified:

* The stale-ref run's `Self-test policy` step ran only `python3 scripts/auto-arm.py --self-test` — no `gh_retry.py --self-test` line — confirming the workflow file itself came from an old snapshot. `refs/pull/3434/merge` is based on `a6250c48`, which predates `6137b7b3`; #3434's head tree carries no `.github/workflows/auto-arm.yml` at all, so the merge ref supplies the *base's* (older) copy. Either path gives the same skew: **manifest older than script.**
* Run [`30144214363`](https://github.com/sparq-org/sparq/actions/runs/30144214363) (04:32Z) is a **`schedule`** run on `main` and did **not** hit `ModuleNotFoundError` — main's manifest is correct. It failed for an unrelated reason, recorded at the bottom of this body.

## Why the fix has to live in the script, not the workflow

The stale PR refs cannot be rewritten. The manifest those runs use is **already frozen**: editing `auto-arm.yml`'s sparse list only heals refs snapshotted *after* the edit. The only code that reaches an already-stale PR is code fetched from the **default branch** — i.e. `scripts/auto-arm.py` itself.

That is why the guard is in the script. The workflow change below is the forward-looking half; **it is not the remedy for the ~71 open PRs.**

## What changed

**1. `scripts/auto-arm.py` — guarded import, explicit degradation.** `gh_retry` is a resilience helper (bounded, transient-only retry for idempotent reads). Losing it must cost *retries*, never the arm. On `ImportError` the script binds `gh_retry` to a `_DegradedGhRetry` stand-in and emits exactly **one** `::warning` naming the missing file, the mechanism, what was lost, and the remedy. The contract, decided and documented in-file:

| | degraded behaviour |
|---|---|
| idempotent reads | **one-shot** — no retry |
| read failure | `GhFatalError` → loud red. **Never** `GhTransientExhausted` — that type is exactly what #3759 converts into `::warning` + exit 0, so synthesising it here would turn a 403 into a *false success*. Degraded mode trades transient tolerance for loudness, which is the safe direction and strictly better than the guaranteed red it replaces. |
| `assert_read_only` | a **real** fail-closed guard, not a no-op, so the self-test's "every read this script issues IS a read" assertion cannot go vacuous when degraded |
| arm decision, `gh pr ready`, `enablePullRequestAutoMerge` CAS | **unchanged** — all still issued |

**2. `scripts/rearm-sweeper.py` — same treatment.** Same class, same fix. Being precise about exposure: `rearm-sweeper.yml` triggers only on `schedule`/`workflow_dispatch`, so its workflow file and its `ref: default_branch` checkout are always the same commit and it is **not** exposed to the ref skew today (and it is not a gate). The guard is there for the two ways that changes — adding any per-ref trigger, or adding a second sibling import without updating the manifest.

**3. Grepped the whole class.** AST-scanned every `scripts/**/*.py` for imports resolving to a sibling under `scripts/`, then cross-referenced against every workflow's `sparse-checkout` manifest. Only `auto-arm.py` and `rearm-sweeper.py` (both → `gh_retry`) are sparse-checked-out; `batch-merge.py → ci_select`, `retriage.py → triage` and `capture_baseline.py → metrics_row` run from full checkouts. `ci_summary_gate.py`, `pr-backlog.py` and `nightly/route_sweep_failures.py` are sparse-checked-out but currently import no sibling — the new class test (below) is what keeps that true.

**4. Made the skew impossible going forward.** Both arm workflows now sparse-check out the **whole directory**:

```yaml
sparse-checkout: scripts     # cone mode (the actions/checkout default)
```

`sparse-checkout-cone-mode: false` is **removed**, deliberately: cone mode is what makes a bare `scripts` recursive. Under non-cone the same word would be a gitignore pattern with different semantics, so the two must change together — and a test pins both halves. Verified empirically rather than assumed:

```
$ git clone --filter=blob:none --no-checkout --depth=1 … && git sparse-checkout init --cone \
    && git sparse-checkout set scripts && git checkout main
$ ls scripts/gh_retry.py scripts/auto-arm.py scripts/rearm-sweeper.py
scripts/auto-arm.py  scripts/gh_retry.py  scripts/rearm-sweeper.py
$ ls scripts/nightly/ | head -1        # recursive
route_sweep_failures.py
$ ls crates | head -3                  # nothing outside the cone
(empty)
```

`scripts/` is 4.8 MB, so a manifest that cannot go stale costs nothing measurable.

**5. Closed the hazard the whole-directory checkout introduces.** `python3 scripts/auto-arm.py` puts `scripts/` first on `sys.path`. With two files listed that was harmless; with the whole directory materialised, a file named e.g. `scripts/types.py` would shadow the stdlib for every script run from there. Pinned by a new test (currently 0 offenders across all 121 `scripts/**/*.py`).

## Verification

Tests added to `scripts/tests/test_arm_capability_wiring.py` (already run as a **gating** docs-quality step, and `TestSelfTestsRunInCi` keeps it that way). The isolation helper copies a script **alone** into a temp dir with `PYTHONPATH` stripped — reproducing the runner's state exactly, since `sys.path[0]` is then the script's own directory.

```
$ python3 scripts/gh_retry.py --self-test && python3 scripts/auto-arm.py --self-test \
    && python3 scripts/rearm-sweeper.py --self-test
gh-retry self-test: PASS
auto-arm self-test: PASS
rearm-sweeper self-test: PASS

$ python3 scripts/tests/test_arm_capability_wiring.py
Ran 29 tests in 2.002s
OK
```

Degraded mode, exercised directly (this is the state a stale-ref runner is in):

```
$ cd $(mktemp -d) && cp …/scripts/auto-arm.py . && python3 auto-arm.py --self-test
::warning title=auto-arm running WITHOUT transient-retry (scripts/gh_retry.py not checked
out)::No module named 'gh_retry' — this run's idempotent gh READS are ONE-SHOT: a GitHub
5xx blip will red it instead of being retried. Arming itself is UNAFFECTED and proceeds.
CAUSE: this script came from the default branch while the `sparse-checkout` manifest came
from an older workflow snapshot on the PR ref, which does not list scripts/gh_retry.py
(sparq #3776 / #3766). REMEDY: rebase the PR onto the default branch, or re-run once the PR
ref carries a workflow file that sparse-checks out the whole scripts/ directory.
auto-arm self-test: PASS
EXIT=0
```

Other CI gates over the touched surfaces, run the way CI does — all green:
`scripts/check-install-action-tool.py` (PASS), `scripts/check-terminology.py` (clean),
`test_path_ownership.py` (28 OK), `test_ci_select.py` (95 OK), `test_ci_select_wiring.py` (66 OK), `test_ci_summary_gate.py` (OK).
This PR touches only `.github/workflows/*.yml` and `scripts/*.py` — no Rust — so the Rust gate legs are unaffected by construction.

### Mutation checks

Snapshot-to-`/tmp` first, `cp`-restore, `cmp`-verified after each — never `git checkout`.

**M1 — remove the import guard** (plain `import gh_retry` in both scripts). The regression test goes RED with the real error:

```
FAIL: test_self_test_passes_with_gh_retry_absent (script='auto-arm.py')
AssertionError: "ModuleNotFoundError: No module named 'gh_retry'" unexpectedly found in
'Traceback (most recent call last):\n  File "/tmp/tmpmuu_mct6/auto-arm.py", line 197, in
<module>\n    import gh_retry\nModuleNotFoundError: No module named \'gh_retry\'\n' :
auto-arm.py must not abort when gh_retry.py was not checked out (the #3434 outage); it must
degrade to no-retry
Ran 28 tests … FAILED (failures=6)
```

**M2 — "gracefully degraded into doing nothing"** (`if GH_RETRY_DEGRADED: return` at the top of each `arm()`). The not-a-no-op test goes RED for both scripts, and the `fake.calls` dump in the failure shows the reads happening with the mutation absent:

```
FAIL: test_degraded_path_still_performs_the_mutations (script='auto-arm.py')
AssertionError: 0 != 1 : auto-arm.py degraded arm path
AssertionError: [['api','graphql',…capability probe…], ['pr','list',…],
                 ['pr','ready','447',…], ['pr','view','447',…]]      # no arm mutation
FAIL: test_degraded_path_still_performs_the_mutations (script='rearm-sweeper.py')
AssertionError: 0 != 1 : rearm-sweeper.py degraded arm path
Ran 28 tests … FAILED (failures=4)
```

**M3 — revert the manifest to the file list.** `AssertionError: Lists differ: ['scripts'] != ['scripts/auto-arm.py', 'scripts/gh_retry.py']`

**M4 — enumerate the script but omit its sibling (the exact #3766 mistake).** `auto-arm.yml: sparse-checkout lists scripts/auto-arm.py which imports sibling 'gh_retry' (scripts/gh_retry.py) that the manifest omits — check out the directory instead`

**M5 — add `scripts/types.py`.** `these scripts shadow a stdlib module and would break any sibling script importing it: ['scripts/types.py']`

Restore verified byte-identical, full suite re-run green:

```
$ cmp … (5 files)
ALL 5 FILES cmp-VERIFIED IDENTICAL TO SNAPSHOT
$ python3 scripts/tests/test_arm_capability_wiring.py
Ran 29 tests in 1.896s
OK
```

---

# PART B — an event-triggered run must judge the PR that triggered it

## The second defect

`AutoArmer.run()` swept **every** open `review:pass` PR in **both** modes. #3766 then made the exit status **sticky** over collected failures — correct, and load-bearing, for the cron sweep. Combined with whole-repo scope on a **GATING** check, the two are catastrophic together: one permanently un-armable PR reds `arm reviewed PRs` on **every other PR's** label event.

The blast radius was total, not theoretical. Measured on run [`30144214363`](https://github.com/sparq-org/sparq/actions/runs/30144214363) (2026-07-25T04:33:06Z), the last scheduled run before this change:

```
[auto-arm] arm-capability probe: can-arm — autoMergeAllowed=true (token=github-actions[bot], …)
PR #3434: draft -> marked ready
PR #3434: arm-failed (gh api graphql -f failed: gh: Pull request refusing to allow a GitHub App
  to create or update workflow `.github/workflows/zk-toolchain.yml` without `workflows` permission)
PR #2521: skipped security-surface (trust-surface)
[auto-arm] arm-failure summary: PR #3434 — …
[auto-arm] complete: considered=2 armed=0 arm-failures=1 transient-exhaustions=0 capability=can-arm
##[error]Process completed with exit code 1.
```

sparq had exactly **two** `review:pass` PRs at that moment, and #3434 cannot be armed **at all** until the `workflows: write` question is decided (#3777). So a label event on **any** PR ran this same sweep, collected #3434's failure, and redded the gating check on the PR being labelled. One PR taxed the whole queue.

Note what that error is **not**: it is not an `ARM_DENIAL_MARKER`, so it is correctly classified as a *per-PR* condition rather than a token-capability loss (which would latch `capability_lost` and skip every remaining candidate). A regression assertion pins that classification, because getting it wrong would swap one repo-wide failure mode for another.

## What changed (Part B)

**1. Scope is now a first-class axis, separate from mode.** `AutoArmer.scope_pr` answers *whose failure is this run's business*; `mode` still answers only *how loud is a missed cycle* (#3759 finding 5). The seam is one method:

```python
def candidates(self) -> list[PullRequest]:
    if self.scope_pr is not None:
        return [self.refresh(self.scope_pr)]     # event: the triggering PR, and nothing else
    return self.list_open()                      # sweep: the whole repository, unchanged
```

A bystander PR is not merely *excused* — it is never **read**, so nothing about it can reach this run's `ArmOutcome` or its exit status. Every run logs its own remit (`[auto-arm] scope: PR #N ONLY …` / `… whole-repo sweep`) and its `complete:` line now carries `scope=pr-N` / `scope=all`.

**2. #3766 is preserved exactly, inside the narrower scope.** This change narrows **which** PRs a run is accountable for; it does not weaken accountability for the one it answers for:

| | still true after Part B |
|---|---|
| triggering PR fails to arm, event mode | **hard exit 1** |
| …and a later transient exhausts | **still exit 1** — the collected verdict is untouchable |
| precedence | `collected-failure > transient-exhaustion > clean`, unchanged, both modes |
| transient alone, event mode | non-zero (no per-PR cron backstop) |
| transient alone, sweep mode | `::warning` + 0 (#3759) |
| sweep mode scope | **whole repository**, and still red on any PR's arm failure |

**3. The number reaches the script two ways, deliberately.** `auto-arm.yml`'s arm step gains `ARM_PR: ${{ github.event.pull_request.number }}` and passes `--pr "$ARM_PR"` (empty on `schedule`/`workflow_dispatch` ⇒ whole-repo sweep). But that expression lives in the **workflow file**, which on a `pull_request` event is snapshotted from the PR's own ref — *the exact skew Part A is about*. A frozen ref can never pass `--pr`. So `scripts/auto-arm.py` — which always comes from the default branch — also derives the number itself:

```
--pr  >  GITHUB_EVENT_PATH → pull_request.number  >  GITHUB_REF → refs/pull/<n>/…
```

That is the only half that can scope an already-stale ref, and it needs no rebase. If none of the three resolves in event mode, the run emits a loud `::warning` and falls back to whole-repo scope — the pre-#3776 behaviour — rather than exiting non-zero, because a hard failure there would brick the gating check for exactly the stale-ref population this issue is about. An explicitly supplied non-numeric `--pr` **is** fatal: a typo in the wiring must never read as a silent whole-repo sweep.

`rearm-sweeper.py` is deliberately **not** scoped: it triggers only on `schedule`/`workflow_dispatch`, it is not a gate, and it is the whole-repo re-arm backstop by design.

## Verification (Part B)

Same gating steps, run the way CI does:

```
$ python3 scripts/gh_retry.py --self-test && python3 scripts/auto-arm.py --self-test \
    && python3 scripts/rearm-sweeper.py --self-test
gh-retry self-test: PASS
auto-arm self-test: PASS
rearm-sweeper self-test: PASS

$ python3 scripts/tests/test_arm_capability_wiring.py
Ran 36 tests in 2.058s
OK
```

`auto-arm.py --self-test` gains sections (15)–(20); `TestEventModeIsPerPr` adds seven inspection/behaviour tests. Both replay the **live** shape — #2521 armable, #3434 permanently un-armable with the verbatim GitHub error text from run 30144214363.

Also green, unchanged by this diff: `actionlint` on both touched workflows (exit 0), `check-install-action-tool.py` (PASS), `check-fast-fix-ring-guard.py --self-test` + live (OK), `check-advisory-registry.py` (all clear), `check-terminology.py` (clean), `test_path_ownership.py` (28 OK), `test_ci_select.py` (95 OK), `test_ci_select_wiring.py` (66 OK), `test_ci_summary_gate.py` (OK), and the Part A degraded-isolation run (`::warning` + `self-test: PASS`, EXIT=0). No Rust is touched.

### Mutation checks (Part B)

Snapshot-to-`/tmp` first, `cp`-restore, `cmp`-verified after each — never `git checkout`.

**M-A — revert to whole-repo scope in event mode** (`candidates()` ignores `scope_pr`). The unrelated-PR test REDs, and the tail is the poisoning itself: a run that *claims* `scope=pr-2521` yet swept both.

```
FAIL: test_an_unarmable_unrelated_pr_does_not_fail_an_event_run
AssertionError: 0 != 1 : an event run for PR #2521 must not fail because a DIFFERENT PR
(#3434) cannot be armed — that is what poisoned the gating check for the whole repo (#3776)
Ran 36 tests … FAILED (failures=3)

$ python3 scripts/auto-arm.py --self-test
AssertionError: an event-mode run for PR #2521 must not fail because a DIFFERENT PR (#3434)
cannot be armed (code=1, [… 'PR #2521: armed head aaaaaaaaaaaa',
 'PR #3434: arm-failed (… without `workflows` permission)',
 '[auto-arm] complete: considered=2 armed=1 arm-failures=1 … scope=pr-2521'])
```

**M-B — make the triggering PR's own failure non-fatal** (a scoped run does not collect it). The *other* half REDs, and the sweep tests stay green — the discrimination is sharp in both directions:

```
FAIL: test_the_triggering_prs_own_failure_is_still_fatal
AssertionError: 1 != 0 : the TRIGGERING PR's own arm failure must still red the run
[auto-arm] scope: PR #3434 ONLY — …
PR #3434: arm-failed (… without `workflows` permission)
[auto-arm] complete: considered=1 armed=0 arm-failures=0 … scope=pr-3434
Ran 36 tests … FAILED (failures=3)      # test_sweep_mode_still_covers_the_whole_repo: ok
```

**M-C — scope sweep mode to one PR** (`list_open()[:1]`). The sweep test REDs:

```
FAIL: test_sweep_mode_still_covers_the_whole_repo
AssertionError: 2 != 1 : the periodic sweep must still consider EVERY open review:pass PR
[auto-arm] scope: EVERY open review:pass PR in the repository (whole-repo sweep)
PR #2521: armed head aaaaaaaaaaaa
[auto-arm] complete: considered=1 armed=1 arm-failures=0 … scope=all
Ran 36 tests … FAILED (failures=2)
```

**M-D — the WORKFLOW call site: drop `--pr "$ARM_PR"`.** The plumbing assertion REDs with the actual command line, which is precisely the "production call site / workflow step body" class a mutation harness measured as *uncaught* in these repos:

```
FAIL: test_the_workflow_passes_the_triggering_pr_number_to_the_arm_step
AssertionError: unexpectedly None : the arming step must pass --pr "$VAR" — without it an
event-mode run cannot know which PR it is accountable for (#3776)
python3 scripts/auto-arm.py --repo "$REPO" --default-branch "$DEFAULT_BRANCH" --mode "$ARM_MODE"
Ran 36 tests … FAILED (failures=1)
```

**M-E — the other call site: `main()` scopes SWEEP runs too**, silently (no `::warning`, so nothing else can catch it). The end-to-end-through-`main()` sweep assertion REDs:

```
AssertionError: (0, "[auto-arm] scope: PR #2521 ONLY — …\nPR #2521: armed head aaaaaaaaaaaa\n
[auto-arm] complete: considered=1 armed=1 arm-failures=0 … scope=pr-2521\n")
```

Restore verified byte-identical, full suite re-run green:

```
$ cmp …
cmp OK scripts/auto-arm.py
cmp OK scripts/rearm-sweeper.py
cmp OK scripts/gh_retry.py
cmp OK scripts/tests/test_arm_capability_wiring.py
cmp OK .github/workflows/auto-arm.yml
cmp OK .github/workflows/rearm-sweeper.yml
ALL 6 FILES cmp-VERIFIED IDENTICAL TO SNAPSHOT

$ python3 scripts/auto-arm.py --self-test && python3 scripts/tests/test_arm_capability_wiring.py
auto-arm self-test: PASS
Ran 36 tests in 2.058s
OK
```

## Does this actually unpoison the repo? Measured, not argued

The gating check still cannot be **observed** on this branch pre-merge (`auto-arm.yml` fetches the script from `ref: default_branch`, and this PR carries no labels so its own `pull_request: types: [labeled]` job never fires). The closest honest evidence is to drive **today's `main` script** and **this branch's script** over the **same real PR records** (`gh pr view --json id,number,state,isDraft,headRefOid,baseRefName,labels,autoMergeRequest,mergeStateStatus`) with the **same real GitHub error text**, in the mode a label event uses. Only the node-id field is rewritten, so the harness can target a PR's mutation.

```
SCENARIO: PR #3765 receives review:pass — does NOT touch .github/workflows/**

A) TODAY'S main script (whole-repo sweep on a label event for #3765)
   PR #3765: armed head dc92b4afe9f0
   PR #3434: draft -> marked ready
   PR #3434: arm-failed (… without `workflows` permission)
   PR #2521: skipped security-surface (trust-surface)
   [auto-arm] complete: considered=3 armed=1 arm-failures=1 …
   EXIT=1                                   ← #3765 is redded by #3434

B) THIS BRANCH's script, scoped to #3765
   [auto-arm] scope: PR #3765 ONLY — …
   PR #3765: armed head dc92b4afe9f0
   [auto-arm] complete: considered=1 armed=1 arm-failures=0 … scope=pr-3765
   EXIT=0                                   ← unpoisoned
```

**One honest limit, and it is not small.** A PR that itself modifies `.github/workflows/**` still reds its own arm check, because GitHub refuses `enablePullRequestAutoMerge` for an App token without `workflows: write` — the #3777 question. Evidence that this is the discriminating factor rather than something specific to #3434: across every `auto-arm` run in the retained window, the five PRs `github-actions[bot]` armed **successfully** (#3523, #3482, #3454, #3453 …) touch **no** workflow file, and the one workflow-touching PR it attempted (#3434) was refused. **This PR touches two workflow files, so it is in that set:**

```
SCENARIO: PR #3775 receives review:pass — DOES touch .github/workflows/** (this very PR)

A) TODAY'S main script            arm-failures=2 (#3775 AND #3434)   EXIT=1
B) THIS BRANCH's script           arm-failures=1 (#3775 only)        EXIT=1
```

So Part B converts a repo-wide tax into a correctly-attributed per-PR one. That is strictly better — a PR is now red for its own reasons, and `#3434`'s red no longer leaves the PR it lands on — but for the workflow-touching subset the gating arm check is still an unconditional merge blocker until #3777 is answered. Which is the whole argument below.

The control, from the same replay — the cron sweep is untouched and still whole-repo accountable:

```
C) THIS BRANCH's script, --mode sweep (no scope)
   [auto-arm] scope: EVERY open review:pass PR in the repository (whole-repo sweep)
   PR #3765: armed head …   PR #3434: arm-failed (…)   PR #2521: skipped security-surface
   [auto-arm] complete: considered=3 armed=1 arm-failures=1 … scope=all
   EXIT=1
```

One live observation worth recording because it changes how the poisoning should be read: while this work was in progress #3434's labels flipped from `review:pass` to `review:needs` and it returned to draft, so it is momentarily not a candidate at all and the sweep is momentarily clean. That does **not** retire the defect — it shows the poisoning is a **recurring** condition that any un-armable `review:pass` PR re-creates, not a one-off tied to #3434.

## Effect on #3434 — and two honest limits (Part A)

**LIMIT 1 — this cannot take effect on #3434, or on any PR, until it merges.** `auto-arm.yml`'s checkout step reads `ref: default_branch`, so every arm run — on #3434 or anywhere else — keeps fetching *today's* `main` copy of `scripts/auto-arm.py` regardless of what is on this branch. Re-running #3434 now would fail identically. There is also no way to observe the check on *this* PR: `auto-arm.yml`'s `pull_request` trigger is `types: [labeled]` and this PR carries no labels. Confirmed live at the time of writing — #3434's `arm reviewed PRs` is still `fail`, pinned to the 04:20Z `ModuleNotFoundError` run:

```
$ gh pr checks 3434 --repo sparq-org/sparq | grep -i 'arm reviewed'
arm reviewed PRs   fail   5s   …/actions/runs/30143852994/job/89641977396
```

So the heal is proven the only way it can be pre-merge: run **today's `main` script** and **this branch's script** under identical stale-manifest conditions — one directory, one file, nothing else, exactly what the runner sparse-checks out on a pre-01:38Z ref.

```
### A) TODAY'S main script under the frozen stale manifest (only auto-arm.py present):
Traceback (most recent call last):
  File "…/main-today/auto-arm.py", line 46, in <module>
    import gh_retry
ModuleNotFoundError: No module named 'gh_retry'
   EXIT=1

### B) THIS PR's script, identical conditions:
::warning title=auto-arm running WITHOUT transient-retry (scripts/gh_retry.py not checked out)::…
auto-arm self-test: PASS
   EXIT=0
```

Because the runner's only inputs are the default-branch script and the frozen manifest, B is exactly what every stale-ref PR gets the moment this lands. **That is the sense in which the guard heals stale branches** — and the reason the workflow edit alone could not.

**LIMIT 2 — after merge, #3434's arm check will still be red, for a second and unrelated reason.** The 04:32Z scheduled run got past the self-test and failed here:

```
PR #3434: draft -> marked ready
PR #3434: arm-failed (gh api graphql -f failed: gh: Pull request refusing to allow a
  GitHub App to create or update workflow `.github/workflows/zk-toolchain.yml` without
  `workflows` permission)
[auto-arm] complete: considered=2 armed=0 arm-failures=1 transient-exhaustions=0
```

#3434 modifies a workflow file, and `auto-arm.yml`'s token has no `workflows: write`, so GitHub refuses the arm. **Not fixed here, deliberately** — granting `workflows: write` to a job that arms arbitrary PRs is a privilege escalation that needs a maintainer decision, not a drive-by. Filed with three costed options as #3777.

That refusal is also what Part B's blast radius was made of — see the replay above.

## De-gating `arm reviewed PRs` — deliberately NOT done here, and why

Two things were on the table after the investigation. They are **different in kind**, and the distinction is preserved in the code, in the commit message, and here:

* **Per-PR scoping is a CORRECTNESS fix. Implemented (Part B).** An event-triggered run should judge the PR that triggered it. Judging unrelated PRs on someone else's label event is simply wrong — independently of whether the check gates, and independently of #3777. It needs no policy decision, so it did not wait for one.
* **De-gating `arm reviewed PRs` is a POLICY decision. NOT implemented.** What may block a merge is the maintainer's call, not a drive-by in a bugfix PR. The ruleset is untouched by this branch. The argument is recorded below and in #3777 so it can be decided on its merits rather than under outage pressure.

The argument, with the evidence this investigation produced:

1. **Arming is a convenience step.** It sets auto-merge. Its failure says nothing about whether the PR is correct, tested, or reviewed. Today the arm step's failure has **strictly more power than a failing test**: a red test reds one PR; a red arm blocks merges as a gating check.
2. **It is self-healing by design.** A ten-minute cron plus the re-arm sweeper re-attempt every arm. A missed arm costs latency, not correctness — exactly the reasoning #3759 already used to make *sweep* mode exit 0 on an exhausted transient. Gating contradicts that.
3. **The failure it protects against is better served by an alert.** A token that genuinely cannot arm should page loudly (the #3760 `::error` already does), not silently block every merge.
4. **Scoping shrinks the blast radius but does not remove the hazard.** Part B was the third argument in the original list ("it is not per-PR"), and it is now fixed — but the replay above shows what remains: a PR that touches `.github/workflows/**` still reds its own gating arm check, unconditionally, until #3777 is answered. **This PR is in that set.** A convenience step is currently able to block a correct, reviewed, fully-green change from merging at all.

Concretely, for the maintainer to accept or reject: keep the workflow, keep it red on real failures, and drop it from the `main` ruleset's required checks — leaving `gate` as the merge authority.

## Not armed

Per brief. No `--auto` set on this PR, and the ruleset is unchanged.
