### PR TITLE
fix(ci): the hang detector must not fire on live bounded proofs, and a descoped OIDC lane must not gate main

### DIFF
--- a/.github/workflows/bench-ec2.yml
+++ b/.github/workflows/bench-ec2.yml
@@ -1,8 +1,38 @@
 name: Benchmarks (EC2)
 
-# Cost-capped EC2-deferred benchmark (roadmap G3). The cost PROTECTIONS live here:
-#   * rate limit  — runs ONLY on cron (weekly heavy + nightly full-suite) + manual dispatch; NEVER on
-#                   push or pull_request, so no per-commit and no fork-PR triggers.
+# Cost-capped EC2-deferred benchmark (roadmap G3).
+#
+# ═══ RETIRED AS AN AUTOMATED LANE — MANUAL DISPATCH ONLY ([OPUS-5] #3784) ═══
+# The AWS OIDC role this workflow assumes (`vars.AWS_BENCH_ROLE_ARN`) was DELIBERATELY
+# DESCOPED by the orchestration design ("NO EC2, and NO billable runners… the EC2
+# build-farm, EC2 codex worker, LOCAL-vs-EC2 tiering, and the AWS OIDC role are all out
+# of scope"). So `Configure AWS credentials (OIDC)` can no longer authenticate: run
+# 30151339208 / job 89662120793 burned 12 retries of "Could not load credentials from
+# any providers" BEFORE any benchmark ran, and it did so on EVERY scheduled tick.
+# A check-run named without an advisory token and with no `.github/advisory-registry.json`
+# declaration GATES (#3773/#3774), so a permanently-failing cron lane made `main`
+# permanently and uninformatively red.
+# THE FIX IMPLEMENTS THE DESCOPING DECISION rather than muting a live signal:
+#   * the `schedule:` triggers are GONE — both of them. The weekly heavy cron carried the
+#     identical dead-OIDC defect and would have redded `main` every Monday, so retiring
+#     only the nightly would have left the same bug on a slower clock.
+#   * NOT declared advisory. Muting a permanently-broken gate to green a dashboard is
+#     exactly what #3774's declared-not-inferred rule exists to prevent; a registry entry
+#     here would have been the easy path, not the honest one. Pinned by a test
+#     (scripts/tests/test_ci_summary_gate.py::TestDescopedEc2Lane).
+#   * MAINTAINER-RUN EC2 BENCHMARKING IS NOT DESCOPED and is NOT removed. Both campaigns
+#     stay reachable via `workflow_dispatch` (pick the lane with the `lane` input), and
+#     every EC2 bench script + doc is untouched — notably scripts/ec2-bench.sh and the
+#     orphan-proof scripts/bench/canonical-beir-gather-instance.sh rails (#3488).
+#   * ROLE-PRESENT GUARD: each job now requires `vars.AWS_BENCH_ROLE_ARN != ''`, so a
+#     dispatch while the role is descoped SKIPS visibly instead of failing at the OIDC
+#     step. Re-provision the repo variable and the lane revives unchanged; re-add a
+#     `schedule:` block in the same commit if the automated cadence is wanted back, and
+#     restate the cost basis below when you do.
+#
+# The cost PROTECTIONS (unchanged, and still the reason this design is safe to revive):
+#   * rate limit  — manual dispatch only; NEVER on push or pull_request, so no per-commit
+#                   and no fork-PR triggers.
 #   * fork guard  — the jobs are skipped unless it's the canonical repo.
 #   * OIDC        — assumes a short-lived, tag-scoped IAM role (no long-lived AWS keys); see
 #                   research/ci-ec2-design.md for the trust + permissions policies to create.
@@ -11,34 +41,41 @@ name: Benchmarks (EC2)
 #
 # TWO LANES (both on the SAME cost-capped EC2 rails — spot + tag purpose=sparq-ci-bench + the
 # always-run terminate/delete cleanup trap; NEVER touch prod i-090531b4ede8f2d3f / dev
-# i-00f76802f345b6b77):
-#   * ec2-bench (WEEKLY, Mondays 06:00 UTC) — the HEAVY campaign at the ~2M-triple scale (the
-#     roadmap-G3 large-hardware run). Publishes to dev/bench-ec2. UNCHANGED.
-#   * nightly-full-bench (NIGHTLY, 06:41 UTC) — [FABLE-5] sq-6vshe.6, MAINTAINER-DIRECTED. Runs the
+# i-00f76802f345b6b77). Select with the `lane` dispatch input:
+#   * ec2-bench (`lane: heavy`) — the HEAVY campaign at the ~2M-triple scale (the
+#     roadmap-G3 large-hardware run). Publishes to dev/bench-ec2.
+#   * nightly-full-bench (`lane: full-suite`) — [FABLE-5] sq-6vshe.6, MAINTAINER-DIRECTED. Runs the
 #     FULL NOISY TIMING SUITE (query latencies + well-known sp2b/dbpsb/watdiv/bsbm/lubm + the cargo-only
 #     fts/geo/vector/rsp/hdt/solid/nlq/zk hooks) at the SAME 200k CI scale the per-commit series used, on
 #     a quiet dedicated spot instance (contention-free wall-clock, unlike a shared GitHub runner). This is
 #     the lane the flaky/slow benchmark timing was MOVED TO: it was dragging the merge queue + flapping
-#     the gate on shared runners, so the per-PR bench lane now runs ONLY the fast deterministic byte-count
-#     ratchet (bench.yml `--deterministic-only`) and this nightly EC2 lane carries the full perf-tracking
-#     series. Publishes to dev/bench-nightly (a distinct dashboard dir, so it collides with neither the
-#     per-commit dev/bench nor the weekly heavy dev/bench-ec2). The perf-tracking is NOT lost — only moved.
+#     the gate on shared runners, so the per-PR bench lane runs ONLY the fast deterministic byte-count
+#     ratchet (bench.yml `--deterministic-only`). Publishes to dev/bench-nightly (a distinct dashboard
+#     dir, so it collides with neither the per-commit dev/bench nor the heavy dev/bench-ec2). The job id
+#     and the `sparq engine (nightly full suite)` series name are KEPT so the published dashboard history
+#     stays continuous; its DISPLAY name no longer claims a nightly cadence it does not have.
+#     HONEST STATUS ([OPUS-5] #3784): with the cron retired and the OIDC role descoped, the at-scale
+#     timing series is NOT being collected — it is dispatch-on-demand, not automated. Saying otherwise
+#     would be the doc drift this change exists to remove.
 #
-# COST BASIS (why NIGHTLY is affordable):
-#   * The nightly runs the full suite at the 200k CI scale (NOT the 2M heavy scale), so a run is a short
-#     spot session on a c7g.4xlarge (arm64, spot ~$0.30-0.40/hr): build + full suite ~10-20 min ≈
-#     ~$0.07-0.14/run. 30 nights/month ≈ $2-4/month. Together with the weekly heavy (~$0.80/month) the
-#     EC2 bench total stays UNDER the $5/month cap. Back it with an AWS Budgets alarm on the
-#     purpose=sparq-ci-bench tag. If a future scale-up pushes over budget, drop the nightly cron to
-#     `weekly` (state the new cost basis in this header) — the design does not depend on the cadence.
-#
-# NOT LIVE until `AWS_BENCH_ROLE_ARN` (repo variable) points at the IAM role; until then the runs
-# fail harmlessly at the OIDC step (no instance launched, no cost).
+# COST BASIS (per manual run, for whoever revives the cadence): the full-suite lane runs at the 200k CI
+# scale (NOT the 2M heavy scale) — a short spot session on a c7g.4xlarge (arm64), build + full suite well
+# inside the job timeout. The heavy lane is the 2M-scale campaign. Both stay under the documented
+# $5/month EC2 bench cap at their original weekly+nightly cadence; back any revived cadence with an AWS
+# Budgets alarm on the purpose=sparq-ci-bench tag.
 on:
-  schedule:
-    - cron: '0 6 * * 1'      # ec2-bench: Mondays 06:00 UTC (weekly heavy)
-    - cron: '41 6 * * *'     # nightly-full-bench: 06:41 UTC daily (offset off other nightly lanes)
+  # [OPUS-5] #3784: NO `schedule:` — see the RETIRED note above. A cron tick against a
+  # descoped OIDC role is a guaranteed gating failure on `main`, every night.
   workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Which EC2 campaign to run (both require vars.AWS_BENCH_ROLE_ARN)'
+        type: choice
+        required: false
+        default: heavy
+        options:
+          - heavy
+          - full-suite
 
 # [OPUS-4.8] Least-privilege default (Scorecard TokenPermissions): top-level read-only;
 # the single ec2-bench job opts into the writes it genuinely needs (per-job below).
@@ -51,13 +88,17 @@ concurrency:
 
 jobs:
   ec2-bench:
-    name: heavy benchmark on EC2 (spot)
-    # [FABLE-5] sq-6vshe.6: the WEEKLY heavy campaign. Runs on the Monday cron OR a manual dispatch
-    # (unchanged manual behavior); the nightly '41 6 * * *' cron routes to nightly-full-bench instead,
-    # so a nightly tick never launches this heavy 2M-scale instance.
+    name: heavy benchmark on EC2 (spot, manual dispatch)
+    # [FABLE-5] sq-6vshe.6: the HEAVY campaign, now maintainer-dispatched (`lane: heavy`, the
+    # default). [OPUS-5] #3784: the `vars.AWS_BENCH_ROLE_ARN != ''` clause is the ROLE-PRESENT
+    # GUARD — while the AWS OIDC role is descoped this job SKIPS visibly instead of burning 12
+    # credential retries and posting a gating failure. It is not a mute: `skipped` here means
+    # "the descoped infrastructure was not there", the guard is one reviewable clause naming the
+    # variable, and provisioning the variable revives the lane with no further edit.
     if: >-
       github.repository == 'sparq-org/sparq' &&
-      (github.event_name != 'schedule' || github.event.schedule == '0 6 * * 1')
+      github.event.inputs.lane == 'heavy' &&
+      vars.AWS_BENCH_ROLE_ARN != ''
     runs-on: ubuntu-latest
     # [OPUS-4.8] Job-scoped writes (least privilege):
     #   id-token: write — assume the short-lived, tag-scoped IAM role via OIDC
@@ -121,20 +162,29 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
 
-  # [FABLE-5] (sq-6vshe.6 heavy-lane placement, MAINTAINER-DIRECTED) The NIGHTLY FULL-SUITE lane —
+  # [FABLE-5] (sq-6vshe.6 heavy-lane placement, MAINTAINER-DIRECTED) The FULL-SUITE lane —
   # the destination for the noisy timing benchmarks moved OFF the per-PR / merge_group bench gate. It
   # runs ci-bench.sh's FULL suite (query latencies + all well-known + cargo-only latency suites) at the
   # 200k CI scale on a QUIET dedicated spot instance (contention-free wall-clock, unlike a shared GitHub
   # runner), reusing the SAME cost-capped EC2 rails as ec2-bench (spot + purpose=sparq-ci-bench tag + the
   # always-run terminate/delete cleanup trap in scripts/ec2-bench.sh). Publishes the full series to
-  # dev/bench-nightly so the perf-tracking dashboard keeps its trend — the tracking is MOVED, not lost.
+  # dev/bench-nightly.
+  # [OPUS-5] #3784 HONEST STATUS: this lane's cron is RETIRED and its OIDC role is descoped, so the
+  # at-scale timing series is collected ONLY when a maintainer dispatches `lane: full-suite` with
+  # vars.AWS_BENCH_ROLE_ARN provisioned. The dashboard trend is therefore NOT currently being
+  # maintained — the previous "the tracking is MOVED, not lost" claim no longer holds and has been
+  # removed rather than left to rot. Reviving the cadence = re-adding a `schedule:` block AND the role.
   nightly-full-bench:
-    name: nightly full-suite benchmark on EC2 (spot)
-    # Nightly cron only (the '41 6 * * *' tick). A weekly-cron tick or a manual dispatch routes to the
-    # heavy ec2-bench job above instead, so this job never double-launches alongside it.
+    name: full-suite benchmark on EC2 (spot, manual dispatch)
+    # [OPUS-5] #3784: dispatched with `lane: full-suite`. The old check name — `nightly full-suite
+    # benchmark on EC2 (spot)` — is deliberately gone: it was the permanently-failing GATING
+    # check-run that made `main` unable to go green, and it named a nightly cadence this lane no
+    # longer has. `lane: heavy` routes to ec2-bench above instead, so the two never double-launch.
+    # Same ROLE-PRESENT GUARD: no OIDC role => skip, never a gating failure.
     if: >-
       github.repository == 'sparq-org/sparq' &&
-      github.event_name == 'schedule' && github.event.schedule == '41 6 * * *'
+      github.event.inputs.lane == 'full-suite' &&
+      vars.AWS_BENCH_ROLE_ARN != ''
     runs-on: ubuntu-latest
     # Job-scoped writes (least privilege):
     #   id-token: write — assume the short-lived, tag-scoped IAM role via OIDC
@@ -265,13 +315,15 @@ jobs:
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             || echo "::warning::nightly attribution filer failed (non-fatal)"
       # [FABLE-5] DEMOTION AUTO-BEAD PROTOCOL (research/ci-structural-speedup.md §7; mirrors fuzz.yml +
-      # differential.yml). The full noisy timing suite was DEMOTED off per-PR/merge_group to this nightly
-      # lane. If the nightly run FAILS (a suite correctness diff regressed, or the run itself broke) that
+      # differential.yml). The full noisy timing suite was DEMOTED off per-PR/merge_group to this
+      # lane. If a dispatched run FAILS (a suite correctness diff regressed, or the run itself broke) that
       # failure must not silently rot — it auto-files a standing P1 bead + a GitHub issue naming the lane
       # + run, so a finding the fast per-PR deterministic slice could not have caught is tracked to
       # closure. gh failures degrade to warnings (the lane is already red); the JSONL append is
       # best-effort (protected-main GH013 push may decline — the issue is the reliable channel).
-      - name: File a demoted-lane bead + issue on nightly failure
+      # [OPUS-5] #3784: unreachable while the OIDC role is descoped — the role-present guard skips the
+      # whole job, so a credentials failure can no longer manufacture a demoted-lane bead every night.
+      - name: File a demoted-lane bead + issue on a full-suite run failure
         if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,10 +37,14 @@ on:
   # hard-gates the byte-count / memory-layout ratchet (store/dict/wasm bytes; a pure
   # function of the code, immune to shared-runner noise) but SKIPS every wall-clock timing
   # loop + well-known / crate-example latency suite. Those NOISY, FLAKY timing benchmarks
-  # were dragging the merge queue and flapping the gate; they are RELOCATED to the nightly
-  # EC2 lane (bench-ec2.yml `nightly-full-bench`, cron), which publishes the full at-scale
+  # were dragging the merge queue and flapping the gate; they are RELOCATED to the EC2
+  # full-suite lane (bench-ec2.yml `nightly-full-bench`), which publishes the full at-scale
   # series to the benchmark-data branch the Pages dashboard reads. See the "Run benchmarks"
   # step guard below and bench-ec2.yml.
+  # [OPUS-5] #3784 HONEST STATUS: that EC2 lane is MANUAL-DISPATCH ONLY — its cron is retired
+  # because the AWS OIDC role it assumes was descoped, so the at-scale timing series is NOT
+  # being collected automatically. The per-commit deterministic ratchet and the push-to-main
+  # full run below are unaffected; only the AT-SCALE EC2 trend is on hold until the role returns.
   #
   # [FABLE-5] LABEL-TRIGGER GUARD (full rationale: ci.yml's pull_request note): only
   # the `ci-full` / `bench-full` toggles start real work off a label event. The
@@ -290,7 +294,8 @@ jobs:
       # metrics (`--deterministic-only`): the hard-gated store/dict/wasm bytes ratchet — a pure
       # function of the code, seconds not minutes, immune to shared-runner noise. The full noisy
       # timing suite (query latencies + well-known / crate-example suites + the parse timing metric)
-      # is RELOCATED to the nightly EC2 lane (bench-ec2.yml) so it no longer drags the merge queue or
+      # is RELOCATED to the EC2 full-suite lane (bench-ec2.yml — MANUAL DISPATCH ONLY since #3784
+      # retired its cron) so it no longer drags the merge queue or
       # flaps the gate. On push-to-main / schedule / workflow_dispatch (NOT a PR) the FULL suite runs,
       # so the auto-ratchet floor + the benchmark-data history (main-only steps below) stay continuous
       # exactly as before — the per-commit trend on the Pages dashboard is unaffected. The two-line

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -374,7 +374,8 @@ jobs:
             echo "::error::dev/bench/data.js is missing or EMPTY in the assembled artifact"; fail=1
           fi
           # EC2 dashboard (dev/bench-ec2): assert presence-in-artifact IFF it exists on the
-          # benchmark-data branch. bench-ec2.yml is not live until AWS_BENCH_ROLE_ARN is set, so
+          # benchmark-data branch. bench-ec2.yml is not live until AWS_BENCH_ROLE_ARN is set AND a
+          # maintainer dispatches it ([OPUS-5] #3784 retired its crons with the descoped OIDC role), so
           # dev/bench-ec2 may not exist on the branch yet — hard-failing on its absence would
           # brick every deploy and regress sq-iigf. But once the EC2 lane HAS pushed, a missing
           # out/dev/bench-ec2/index.html means the overlay dropped a subtree → hard fail.

--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -104,8 +104,9 @@ Notes on a few that need care:
   `-O2` not `-O3`) and runs 14 sub-second queries on a fixed 250k-triple corpus, emitting
   `sp2b_<query>_<mode>_us` (trend-only) plus a HARD expected-rows correctness diff. Three
   intentionally-pathological queries (q05a/q06/q12a, tens of seconds at 250k) sit in
-  `queries-heavy/` for the EC2/nightly tier; the **full 5M-100M scale** belongs to
-  `bench-ec2.yml`/nightly (`bench/sp2b/gen.sh <triples>` at a larger `-t`).
+  `queries-heavy/` for the EC2 tier; the **full 5M-100M scale** belongs to
+  `bench-ec2.yml` (`bench/sp2b/gen.sh <triples>` at a larger `-t`) — which is
+  **manual dispatch only**, see the CI-tracking bullet below.
 - **`dbpsb` (DBPSB/FEASIBLE) is tiered + fetch-and-cache (real DBpedia)** — see
   [`bench/dbpsb/README.md`](./dbpsb/README.md). Per-commit, `fetch.sh` downloads ONE
   sha256-pinned DBpedia Databus slice (CC-BY-SA; `mappingbased-objects_lang=en` 2019.09.01,
@@ -304,9 +305,13 @@ Notes on a few that need care:
   and `STATUS.md`. Do not launch without the budget + gate checks.
 - **CI tracking**: `bench.yml` runs `ci-bench` on every push to main (free
   runners, trend + large-regression alert, no hard-fail); `bench-ec2.yml` runs
-  the heavier version weekly on spot (NOT live until `AWS_BENCH_ROLE_ARN` is set
-  — fails harmlessly at OIDC, no cost). Both push to the orphan **`benchmark-data`**
-  branch via github-action-benchmark.
+  the heavier version on spot. **`bench-ec2.yml` is MANUAL DISPATCH ONLY** — its
+  crons were retired in [#3784](https://github.com/sparq-org/sparq/issues/3784)
+  because the AWS OIDC role it assumes was descoped, so every scheduled tick
+  failed at the credentials step *before any benchmark ran* and gated `main`. Its
+  EC2 series is therefore collected only when a maintainer dispatches the workflow
+  with `AWS_BENCH_ROLE_ARN` provisioned. Both push to the orphan
+  **`benchmark-data`** branch via github-action-benchmark.
 - **`competitor-gather` is the versioned external-engine comparison** — see the
   registry [`competitors.json`](./competitors.json) (Oxigraph embedded Rust dep /
   QLever Docker image / eye N3 binary: pinned version, install+run recipe, and the

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -120,10 +120,24 @@ From the binding/packaging workflows (when those surfaces are exercised):
 > it (the required set is the single `gate` context, not this job by name). The NOISY wall-clock timing
 > suites (query latencies + the well-known sp2b/dbpsb/watdiv/bsbm/lubm + cargo-only latency suites)
 > were dragging the merge queue and flapping the gate on shared runners, so they are RELOCATED to the
-> nightly EC2 lane (`bench-ec2.yml` `nightly-full-bench`, cron, quiet dedicated spot instance) which
-> publishes the full at-scale series to the `benchmark-data` branch the Pages dashboard reads — the
-> perf-tracking is moved, not lost. The weekly heavy EC2 campaign (`bench-ec2.yml` `ec2-bench`) and
-> release/dist workflows remain non-gating (release/dist fire only on tags). The **Scorecard** workflow
+> EC2 full-suite lane (`bench-ec2.yml` `nightly-full-bench`, quiet dedicated spot instance) which
+> publishes the full at-scale series to the `benchmark-data` branch the Pages dashboard reads.
+>
+> **[OPUS-5] #3784 — `bench-ec2.yml` is MANUAL DISPATCH ONLY, and the at-scale trend is on hold.**
+> Both of that workflow's crons are RETIRED. It authenticates through an AWS OIDC role
+> (`vars.AWS_BENCH_ROLE_ARN`) that the orchestration design deliberately descoped, so every scheduled
+> tick failed in `Configure AWS credentials (OIDC)` *before any benchmark ran* — and because the check
+> name carries no advisory token and no `.github/advisory-registry.json` declaration, that failure
+> **GATED** (see §ADVISORY MUST BE DECLARED in `scripts/ci_summary_gate.py`), which is why `main` could
+> not go green. The lane was RETIRED rather than declared advisory: muting a permanently-broken gate to
+> green a dashboard is exactly what the declared-not-inferred rule exists to prevent. Consequences to
+> read honestly: the at-scale timing series is **not** being collected on a cadence (the earlier
+> "perf-tracking is moved, not lost" claim no longer holds), and maintainer-run EC2 benchmarking is
+> unaffected — both campaigns stay dispatchable via the `lane` input, and every EC2 bench script stays
+> in the tree. Reviving the cadence means re-provisioning the role AND re-adding a `schedule:` block in
+> the same change. A cron-less workflow posts no check-runs on a `main` head SHA, so neither EC2
+> campaign can gate anything today; release/dist workflows likewise remain non-gating (they fire only
+> on tags). The **Scorecard** workflow
 > (`scorecard.yml`) re-scores posture on push to `main` and feeds the public OpenSSF
 > dashboard/badge (its SARIF upload to GitHub code-scanning is disabled and the job has
 > no `security-events: write` — see the Scorecard note later in this document); with

--- a/docs/pages-cutover-runbook.md
+++ b/docs/pages-cutover-runbook.md
@@ -75,11 +75,15 @@ different workflows:
   `200`.
 - `dev/bench-ec2` — the **heavy EC2 series**, written by `bench-ec2.yml`
   (`benchmark-data-dir-path: dev/bench-ec2`). This is the easy-to-miss one. Note
-  `bench-ec2.yml` is **not live yet** (it fails harmlessly at the OIDC step until
-  the repo variable `AWS_BENCH_ROLE_ARN` is set), so `dev/bench-ec2` may be empty
-  or absent on the served snapshot today — hence its `404` above. It is still a
-  declared, scheduled producer of a **second** Pages directory, so any unified
-  producer must account for it or the EC2 dashboard `404`s after cutover.
+  `bench-ec2.yml` is **not live**: it authenticates through an AWS OIDC role
+  (`vars.AWS_BENCH_ROLE_ARN`) that was deliberately descoped, and its crons were
+  **retired** in [#3784](https://github.com/sparq-org/sparq/issues/3784) because
+  each scheduled tick failed at the credentials step and — carrying no advisory
+  declaration — gated `main`. It is now **manual dispatch only** (pick `lane:
+  heavy` or `lane: full-suite`), so `dev/bench-ec2` may be empty or absent on the
+  served snapshot today — hence its `404` above. It is still a declared producer of
+  a **second** Pages directory, so any unified producer must account for it or the
+  EC2 dashboard `404`s after cutover.
 
 ### Chart.js is loaded from a CDN
 
@@ -186,7 +190,9 @@ gh api -X PUT repos/jeswr/sparq/pages \
 Within a minute or so, `https://jeswr.github.io/sparq/dev/bench/` is served from
 the branch again — and, unlike the frozen snapshot, it **resumes updating** as
 `bench.yml` pushes new points to `benchmark-data`. (`dev/bench-ec2` will appear
-once `bench-ec2.yml` is live and has pushed at least one point.)
+once `bench-ec2.yml` is live and has pushed at least one point — which now requires
+both re-provisioning `AWS_BENCH_ROLE_ARN` and a manual dispatch, since #3784 retired
+its crons.)
 
 This rollback is the **recommended interim state** until the unified producer is
 ready: it is the only configuration in which the dashboard both serves *and*

--- a/research/ci-ec2-design.md
+++ b/research/ci-ec2-design.md
@@ -4,6 +4,18 @@ The heavy benchmarks (many-core/NUMA scaling, large-scale ingestion) can't run o
 runners. They run on EC2, but a **public** repo with EC2-triggering CI is dangerous if done wrong,
 and must stay **under $5/month**. This is the security + cost design.
 
+> **STATUS ([OPUS-5], #3784) — the automated lane is RETIRED; this record is now the revival spec.**
+> The AWS OIDC role this design depends on was deliberately descoped, so `bench-ec2.yml`'s crons
+> were removed: every scheduled tick failed in `Configure AWS credentials (OIDC)` before any
+> benchmark ran and — carrying no advisory declaration — that failure **gated** `main`. The workflow
+> is now **manual dispatch only** (`lane: heavy` / `lane: full-suite`), guarded by
+> `vars.AWS_BENCH_ROLE_ARN != ''` so a dispatch without the role skips instead of failing.
+> Everything below still describes what to create to bring the lane back, so the `schedule:` block
+> quoted later is **aspirational, not current** — re-add it in the same change that re-provisions the
+> role. Maintainer-run EC2 benchmarking outside this CI lane is NOT descoped.
+
+<!-- separate blockquotes (MD028) -->
+
 > **G2 — free per-commit perf CI (Pages toggle).** `.github/workflows/bench.yml` runs
 > `scripts/ci-bench.sh` on every push to `main` and on `pull_request` (PRs compute + comment but
 > do **not** auto-push, so the published series isn't polluted), storing points via

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -39,7 +39,8 @@ cd "$(dirname "$0")/.."
 # geo/fts/vector/rsp/hdt/solid/nlq/zk). This is the FAST, DETERMINISTIC form of the per-PR / merge_group
 # bench gate (bench.yml): the deterministic byte-count RATCHET (scripts/perf-gate.py) still hard-gates
 # every PR against bench/perf-baseline.json — a pure function of the code, seconds not minutes, immune to
-# shared-runner noise — while the noisy latency suites are RELOCATED to the nightly EC2 lane (bench-ec2.yml)
+# shared-runner noise — while the noisy latency suites are RELOCATED to the EC2 full-suite lane
+# (bench-ec2.yml; [OPUS-5] #3784: MANUAL DISPATCH ONLY, cron retired with the descoped AWS OIDC role)
 # so they no longer drag the merge queue or flap the gate. The stanzas below are the EXACT same load/wasm
 # commands the full run uses (single source of truth), just without the timing/suite blocks.
 PARSE_ONLY=0

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -74,12 +74,48 @@
 #     rose over the last PROGRESS_WINDOW polls). Keep polling, at the slower
 #     SAT_INTERVAL to cut API pressure, re-checking the signal each poll, up to the
 #     ABSOLUTE cap MAX_TOTAL_POLLS.
-#   * GENUINE HANG — pending work with an idle queue AND no recent completions.
-#     RED immediately (the old behaviour, now correctly scoped to real hangs).
+#   * GENUINE HANG — pending work with an idle queue AND no recent completions
+#     AND nothing executing (see §LIVENESS VETO). RED immediately (the old
+#     behaviour, now correctly scoped to real hangs).
 # The extension NEVER changes what a verdict says: exit 0 still happens ONLY via
 # render_verdict over an all-terminal set (or the stable-empty set), so a genuinely
 # failing leg still fails and nothing green is synthesised. The absolute cap +
 # the workflow-level timeout-minutes bound the wait — no infinite gate.
+#
+# LIVENESS VETO (#3783). [OPUS-5] The hang heuristic above shipped with TWO
+# signals — "the Actions queue is idle" AND "no completions in the last
+# PROGRESS_WINDOW polls" — and both are satisfied by a PERFECTLY HEALTHY long
+# bounded proof. On 2026-07-25 `gate` run 30149978128 on `main` declared a
+# "genuine hang" while three `kani` legs had been `in_progress` for 11 minutes:
+# the queue was idle precisely BECAUSE those jobs had dequeued and started, and a
+# `kani` harness emits no completion for tens of minutes by design. The two
+# signals meant to PROVE a hang are exactly what a live proof looks like.
+# THE RULE NOW: an awaited sibling in `in_progress` is POSITIVE LIVENESS EVIDENCE
+# and VETOES the genuine-hang verdict (live_siblings()). Queue depth may only
+# count toward "hang" when the awaited siblings are `queued` or absent — i.e.
+# genuinely not running. The veto is exit-1-only in effect: it can only POSTPONE
+# a red to the absolute cap, never synthesise a pass, and the absolute cap plus
+# ci-summary.yml's own `timeout-minutes` still bound the wait.
+# The #3677 case the detector exists for is UNTOUCHED: an evaporated check-run is
+# represented by _workflow_summary_check(force_pending=True), whose status is
+# `queued`, so a lost leg still REDs at the base budget. That discrimination
+# (in_progress => not a hang; queued/absent => still a hang) is the property the
+# tests pin, and it is deliberately name-INDEPENDENT: a hard-coded slow-lane list
+# (`kani`, `cargo-fuzz`, coverage shards) would re-introduce exactly the
+# rename-fragility #3773 removed from the advisory rule, so liveness is read from
+# the platform's own status field instead.
+#
+# VERDICT TAXONOMY (#3783 ask 3). [OPUS-5] "The gate could not determine an
+# answer" and "a gating check failed" are different events and must not read
+# identically — conflating them cost repeated wasted diagnosis (#3758/#3765
+# unsatisfiable hold, #3781 ready->re-draft race, #3783 this). So the two
+# ABSOLUTE-budget exits are now reported as `UNDETERMINED (not a test failure)`,
+# naming WHICH could-not-determine it was (siblings still EXECUTING vs the runner
+# pool never draining) and stating explicitly that nothing has been shown to be
+# broken. Both still exit 1 — an unobserved leg is never assumed green — so the
+# fail-closed posture is byte-for-byte unchanged; only the words changed. A
+# base-budget GENUINE HANG stays a FAILURE, because nothing executing plus an idle
+# queue plus no completions really is a broken pipeline.
 #
 # FETCH-FAILURE TOLERANCE: the bash `set -e` turned ONE transient `gh api` blip
 # into a gate RED. A failed poll is now skipped (state untouched) and only
@@ -1502,6 +1538,40 @@ def failfast_failures(runs: list[dict]) -> list[dict]:
     return out
 
 
+# [OPUS-5] #3783 — the LIVENESS VETO's single source of truth.
+LIVE_STATUS = "in_progress"
+
+
+def live_siblings(runs: list[dict]) -> list[dict]:
+    """[OPUS-5] #3783: the awaited siblings that are DEMONSTRABLY EXECUTING now.
+
+    GitHub gives a check-run exactly ONE non-terminal status once a runner has
+    picked the job up: `in_progress`. Every other non-terminal status a check-run
+    or an Actions job can carry — `queued`, `waiting`, `requested`, `pending` —
+    means the leg has NOT started, and *that* is the state an idle Actions queue
+    is evidence about.
+
+    So `in_progress` is POSITIVE LIVENESS EVIDENCE and vetoes the genuine-hang
+    verdict (header §LIVENESS VETO): the two hang signals (idle queue + no recent
+    completions) are both NORMAL for a healthy long bounded proof — the queue is
+    idle precisely BECAUSE the job dequeued and started, and a `kani` harness
+    emits no completion for tens of minutes by design.
+
+    The #3677 case the detector was built for is untouched: an EVAPORATED
+    check-run is represented by `_workflow_summary_check(..., force_pending=True)`,
+    whose status is `queued` — never `in_progress` — so a lost leg still REDs at
+    the base budget exactly as before.
+    """
+    return [r for r in runs if r.get("status") == LIVE_STATUS]
+
+
+def _name_list(runs: list[dict], limit: int = 6) -> str:
+    """Comma-joined check-run names for a diagnostic line (bounded, deterministic)."""
+    names = sorted({(r.get("name") or "<unnamed>") for r in runs})
+    shown = ", ".join(f"`{n}`" for n in names[:limit])
+    return shown + (f", +{len(names) - limit} more" if len(names) > limit else "")
+
+
 def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
              tier_ctx: TierContext | None = None) -> int:
     """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url,
@@ -1668,29 +1738,42 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 print(f"  (queue-depth fetch raised {exc!r} — treating depth as unknown)")
                 depth = None
             saturated = depth is not None and depth >= cfg.sat_queue_min
-            if not (saturated or progressing):
+            # [OPUS-5] #3783 LIVENESS VETO (header §LIVENESS VETO). An awaited
+            # sibling in `in_progress` is POSITIVE evidence the work is alive, and
+            # it invalidates BOTH hang signals at once: the queue is idle because
+            # that job already dequeued, and a long bounded proof emits no
+            # completion for tens of minutes by design. Queue depth may therefore
+            # only count toward "hang" when the awaited siblings are `queued` or
+            # absent — i.e. genuinely NOT running.
+            live = live_siblings(runs)
+            if not (saturated or progressing or live):
                 print(
                     f"::error::ci-summary timed out — {pending} sibling check-run(s) never "
-                    f"finished within the base budget, the Actions queue is idle "
+                    f"finished within the base budget, NO awaited sibling is `in_progress` "
+                    f"(nothing is executing), the Actions queue is idle "
                     f"(depth={depth if depth is not None else 'unknown'} < {cfg.sat_queue_min}) "
                     f"and no completions landed in the last {cfg.progress_window} poll(s): "
                     f"genuine hang, not a still-settling set. See the per-poll log above."
                 )
                 return 1
+            live_note = (
+                f", {len(live)} sibling(s) EXECUTING ({_name_list(live)})" if live else ""
+            )
             if not extension_started:
                 extension_started = True
                 print(
                     f"::notice::ci-summary base budget reached with {pending} sibling(s) still "
-                    f"pending, but the runner pool shows saturation/progress "
+                    f"pending, but the runner pool shows saturation/progress/liveness "
                     f"(queued runs={depth if depth is not None else 'unknown'}, "
-                    f"progressing={progressing}) — this is a throughput signal, not a hang. "
+                    f"progressing={progressing}{live_note}) — this is a throughput/liveness "
+                    f"signal, not a hang. "
                     f"Extending the wait (adaptive budget, sq-90cv4) up to poll "
                     f"{cfg.max_total_polls}."
                 )
             else:
                 print(
                     f"  extension: queued runs={depth if depth is not None else 'unknown'}, "
-                    f"progressing={progressing} — still settling."
+                    f"progressing={progressing}{live_note} — still settling."
                 )
             if attempt < cfg.max_total_polls:
                 sleep_fn(cfg.sat_interval)
@@ -1709,6 +1792,41 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             "the verdict on the final all-terminal set."
         )
         return render_verdict(runs, cfg.summary_path, tier_ctx)
+    # [OPUS-5] #3783 VERDICT TAXONOMY (header §VERDICT TAXONOMY). Exhausting the
+    # ABSOLUTE budget with work still outstanding is NOT the same event as a gating
+    # leg failing: nothing in the tree has been shown to be broken, the gate simply
+    # ran out of wall-clock before the answer existed. Both branches below still
+    # exit 1 (fail-closed — an unobserved leg can never be assumed green), but they
+    # must not READ like a test failure, because reading them that way is what
+    # burned repeated diagnosis on #3758/#3765/#3781/#3783.
+    live = live_siblings(runs)
+    if live:
+        _emit(
+            f"### ci-summary: UNDETERMINED (not a test failure) — the wait budget "
+            f"expired while {len(live)} awaited sibling(s) were STILL EXECUTING: "
+            f"{_name_list(live)}. Nothing has been shown to be broken; these legs are "
+            f"alive and governed by their own workflow `timeout-minutes`. This gate "
+            f"exits non-zero because an unobserved leg is never assumed green "
+            f"(fail-closed), NOT because a check failed — re-run this gate once the "
+            f"long-running legs conclude. ABSOLUTE budget (base + saturation "
+            f"extension, sq-90cv4) reached at poll {cfg.max_total_polls}.",
+            cfg.summary_path,
+        )
+        print(
+            "::error::ci-summary UNDETERMINED — budget expired with siblings still "
+            "executing (see the step summary); this is a could-not-determine, not a "
+            "failing check. See the per-poll log above."
+        )
+        return 1
+    _emit(
+        f"### ci-summary: UNDETERMINED (not a test failure) — {pending} sibling "
+        f"check-run(s) never finished within the ABSOLUTE budget (base + saturation "
+        f"extension, sq-90cv4). The runner pool stayed saturated longer than the "
+        f"extension allows, so the sibling set never resolved; no gating check has "
+        f"been shown to fail. Fail-closed exit — re-run this gate once the queue "
+        f"drains.",
+        cfg.summary_path,
+    )
     print(
         f"::error::ci-summary timed out — {pending} sibling check-run(s) never finished "
         f"within the ABSOLUTE budget (base + saturation extension, sq-90cv4). The runner "

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -353,8 +353,12 @@ class TestAdaptiveSaturationBudget(unittest.TestCase):
         self.assertNotIn("::error::", out)
 
     def test_genuine_hang_fails(self):
-        # Pending forever, idle queue, zero progress => RED at the base budget.
-        polls = [[GREEN, IN_PROGRESS]]
+        # QUEUED forever, idle queue, zero progress => RED at the base budget.
+        # [OPUS-5] #3783: this fixture used to await an `in_progress` sibling, which
+        # is precisely the misfire the liveness veto fixes — a leg that is EXECUTING
+        # is not hung. The genuine-hang shape is a leg that never STARTED (queued,
+        # which is also what an evaporated check-run resolves to — #3677).
+        polls = [[GREEN, PENDING]]
         code, out = run(tiny_cfg(), polls, depth=0)
         self.assertEqual(code, 1)
         self.assertIn("genuine hang", out)
@@ -393,12 +397,283 @@ class TestAdaptiveSaturationBudget(unittest.TestCase):
         self.assertIn("PASSED", out)
 
     def test_no_progress_and_depth_unknown_is_a_hang(self):
-        # Unknown depth + flat completions must NOT extend forever: it REDs at the
-        # base budget exactly like the old behaviour (fail-closed on no evidence).
-        polls = [[GREEN, IN_PROGRESS]]
+        # Unknown depth + flat completions + nothing EXECUTING must NOT extend
+        # forever: it REDs at the base budget exactly like the old behaviour
+        # (fail-closed on no evidence). [OPUS-5] #3783: queued, not in_progress.
+        polls = [[GREEN, PENDING]]
         code, out = run(tiny_cfg(), polls, depth=None)
         self.assertEqual(code, 1)
         self.assertIn("genuine hang", out)
+
+
+# [OPUS-5] The live #3783 shape: `gate` run 30149978128 on main (e8a41ab8c) declared a
+# "genuine hang" while these three legs had been executing for 11 minutes.
+KANI_LIVE = [
+    R("kani sparq-core (dict mmap validator totality) (bounded proofs, informational)",
+      status="in_progress", conclusion=None, started="2026-07-25T08:20:50Z", rid=1),
+    R("kani sparq-engine (vectorized reducer kernels) (bounded proofs, informational)",
+      status="in_progress", conclusion=None, started="2026-07-25T08:20:49Z", rid=2),
+    R("kani sparq-vectors (.spqv validator) (bounded proofs, informational)",
+      status="in_progress", conclusion=None, started="2026-07-25T08:20:50Z", rid=3),
+]
+
+
+class TestLivenessVeto(unittest.TestCase):
+    """[OPUS-5] #3783 — an EXECUTING sibling is positive liveness evidence and must
+    veto the genuine-hang verdict; a sibling that never STARTED must still be
+    detected as a hang. That discrimination is the whole fix, so both directions are
+    pinned here (deleting the veto REDs the first group; broadening it past
+    `in_progress` REDs the second)."""
+
+    def test_in_progress_siblings_are_not_a_hang(self):
+        # The exact incident: idle queue (depth=0) + zero completions + three kani
+        # legs EXECUTING. Both hang signals are satisfied by a healthy bounded proof.
+        code, out = run(tiny_cfg(), [[GREEN] + KANI_LIVE], depth=0)
+        self.assertNotIn(
+            "genuine hang", out,
+            "#3783 REGRESSION: the hang detector fired while awaited siblings were "
+            "`in_progress` — an executing kani bounded proof was declared a hang. An "
+            "idle Actions queue means those jobs DEQUEUED and STARTED, and kani emits "
+            "no completion for tens of minutes by design, so neither signal is "
+            "evidence of a hang. The liveness veto (live_siblings) is missing.",
+        )
+        self.assertIn("sibling(s) EXECUTING", out)
+        # Bounded, and never green: the veto only postpones the red to the cap.
+        self.assertEqual(code, 1, out)
+
+    def test_one_live_sibling_among_queued_ones_vetoes(self):
+        # The real set was mixed (some queued, some running). ONE executing sibling
+        # is enough liveness evidence: nothing is demonstrably lost.
+        code, out = run(tiny_cfg(), [[GREEN, PENDING, KANI_LIVE[0]]], depth=0)
+        self.assertNotIn(
+            "genuine hang", out,
+            "#3783 REGRESSION: a mixed queued+in_progress sibling set was declared a "
+            "hang; one executing leg proves the pipeline is alive.",
+        )
+        self.assertEqual(code, 1, out)
+
+    def test_all_queued_siblings_are_still_a_hang(self):
+        # THE DISCRIMINATION: nothing executing, idle queue, no completions => the
+        # detector must still fire. This is what keeps the veto from blinding it.
+        code, out = run(tiny_cfg(), [[GREEN, PENDING,
+                                      R("shard-2", status="queued", conclusion=None)]],
+                        depth=0)
+        self.assertEqual(code, 1)
+        self.assertIn(
+            "genuine hang", out,
+            "#3783 OVER-CORRECTION: awaited siblings that never STARTED (all `queued`, "
+            "idle queue, no completions) are the genuine-hang case the detector exists "
+            "for (#3677 evaporated check-runs resolve to `queued` too). The veto must "
+            "key on `in_progress` ONLY — it has been broadened to swallow non-running "
+            "legs, so a real hang now waits out the whole budget instead of REDing.",
+        )
+
+    def test_evaporated_check_run_resolves_to_queued_not_live(self):
+        # #3677: an evaporated/pending leg is represented by the run-level synthetic
+        # with force_pending=True. Its status MUST NOT read as liveness, or the hang
+        # detector loses the only case it was built for.
+        synthetic = g._workflow_summary_check(W(700, 7, status="in_progress",
+                                                conclusion=None), force_pending=True)
+        self.assertEqual(
+            synthetic["status"], "queued",
+            "#3677/#3783 REGRESSION: the force_pending run-level synthetic (how an "
+            "EVAPORATED check-run is represented) no longer reports `queued`. If it "
+            "reports `in_progress` it looks EXECUTING to the liveness veto, so a lost "
+            "leg vetoes its own hang detection and the gate waits out the whole budget "
+            "instead of REDing — the exact case the detector was built for.",
+        )
+        self.assertEqual(
+            g.live_siblings([synthetic]), [],
+            "#3677 REGRESSION: the force_pending run-level synthetic (an evaporated "
+            "check-run) is being counted as an EXECUTING sibling, so a lost leg would "
+            "veto its own hang detection and never RED.",
+        )
+
+    def test_live_siblings_counts_in_progress_only(self):
+        # The predicate itself: only `in_progress` is liveness. `queued`/`waiting`/
+        # `requested`/`pending` all mean the leg has not started.
+        rows = [R("a", status="in_progress", conclusion=None),
+                R("b", status="queued", conclusion=None),
+                R("c", status="waiting", conclusion=None),
+                R("d", status="requested", conclusion=None),
+                R("e", status="pending", conclusion=None),
+                R("f")]
+        self.assertEqual(
+            [r["name"] for r in g.live_siblings(rows)], ["a"],
+            "#3783: live_siblings must select EXACTLY the `in_progress` rows — a "
+            "`queued`/`waiting`/`requested`/`pending` leg has not started and is what "
+            "an idle Actions queue is evidence about.",
+        )
+
+    def test_veto_never_turns_a_verdict_green(self):
+        # Exit-0 invariant: the veto is a POSTPONEMENT, never a pass. Siblings that
+        # execute forever exhaust the absolute cap and still exit non-zero.
+        code, _ = run(tiny_cfg(), [[GREEN] + KANI_LIVE], depth=0)
+        self.assertEqual(code, 1, "the liveness veto must never synthesise a pass")
+
+    def test_real_failure_beside_a_live_sibling_still_reds(self):
+        # The veto must not delay a real red: fail-fast still fires while a kani
+        # proof runs.
+        polls = [[RED] + KANI_LIVE, [RED] + KANI_LIVE]
+        code, out = run(tiny_cfg(), polls, depth=0)
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED (fail-fast)", out)
+
+
+class TestVerdictTaxonomy(unittest.TestCase):
+    """[OPUS-5] #3783 ask 3 — "the gate could not determine an answer" must not read
+    like "a gating check failed". Both still exit 1 (fail-closed); only the words
+    differ, and that difference is what stops a budget expiry being diagnosed as a
+    broken tree (#3758/#3765/#3781/#3783)."""
+
+    def test_budget_expiry_with_live_siblings_reads_undetermined(self):
+        code, out = run(tiny_cfg(), [[GREEN] + KANI_LIVE], depth=0)
+        self.assertEqual(code, 1, "fail-closed: an unobserved leg is never assumed green")
+        self.assertIn(
+            "UNDETERMINED (not a test failure)", out,
+            "#3783 ask 3 REGRESSION: a budget expiry with siblings STILL EXECUTING is "
+            "reported identically to a real gating failure. Nothing was shown to be "
+            "broken — this outcome must say 'could not determine', not 'FAILED'.",
+        )
+        self.assertNotIn("### ci-summary: FAILED", out)
+        # It must name WHICH legs were alive, so the reader is not sent hunting.
+        self.assertIn("kani sparq-core", out)
+
+    def test_saturation_absolute_budget_reads_undetermined(self):
+        # The other could-not-determine: the runner pool never drained.
+        code, out = run(tiny_cfg(), [[GREEN, PENDING]], depth=20)
+        self.assertEqual(code, 1)
+        self.assertIn("ABSOLUTE budget", out)
+        self.assertIn(
+            "UNDETERMINED (not a test failure)", out,
+            "#3783 ask 3 REGRESSION: absolute-budget exhaustion under runner "
+            "saturation reports as a failure though no gating check was shown to "
+            "fail; it is a could-not-determine.",
+        )
+
+    def test_genuine_hang_still_reads_as_a_failure(self):
+        # The taxonomy discriminates in BOTH directions: nothing executing + idle
+        # queue + no completions IS a broken pipeline and keeps failing loudly.
+        code, out = run(tiny_cfg(), [[GREEN, PENDING]], depth=0)
+        self.assertEqual(code, 1)
+        self.assertIn("genuine hang", out)
+        self.assertNotIn(
+            "UNDETERMINED", out,
+            "#3783: a genuine hang must NOT be softened to 'could not determine' — "
+            "nothing running with an idle queue and no completions is a real defect.",
+        )
+
+    def test_a_real_gating_failure_is_never_called_undetermined(self):
+        code, out = run(tiny_cfg(), [[GREEN, RED]])
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED", out)
+        self.assertNotIn(
+            "UNDETERMINED", out,
+            "#3783: a genuinely failing gating check must keep reading as FAILED — the "
+            "taxonomy must not launder a real defect into 'could not determine'.",
+        )
+
+
+class TestDescopedEc2Lane(unittest.TestCase):
+    """[OPUS-5] #3784 — the AWS OIDC role `bench-ec2.yml` assumes was DELIBERATELY
+    DESCOPED, so every automated tick of that workflow was a guaranteed GATING failure
+    on `main` (12 credential retries, before any benchmark ran). The chosen fix is
+    RETIREMENT of the automated lane, NOT an advisory-registry mute: #3774 landed the
+    rule that advisory status is declared deliberately, and muting a permanently-broken
+    gate to green a dashboard is the behaviour that rule exists to prevent. These tests
+    pin BOTH halves — the lane cannot fire automatically, AND it was not muted."""
+
+    WORKFLOW = REPO_ROOT / ".github" / "workflows" / "bench-ec2.yml"
+    REGISTRY = REPO_ROOT / ".github" / "advisory-registry.json"
+
+    def _wf(self) -> dict:
+        # PyYAML is installed in the job that runs this file (docs-quality quick-gates);
+        # the raw-text guards in test_the_permanently_failing_check_name_is_gone hold
+        # unconditionally, so the two load-bearing properties gate even without it.
+        try:
+            import yaml
+        except ImportError:  # pragma: no cover - PyYAML is present in CI
+            self.skipTest("PyYAML unavailable")
+        # `on:` is parsed by PyYAML 1.1 as the boolean True.
+        doc = yaml.safe_load(self.WORKFLOW.read_text(encoding="utf-8"))
+        doc["_on"] = doc.get(True, doc.get("on"))
+        return doc
+
+    def test_no_schedule_trigger(self):
+        doc = self._wf()
+        self.assertNotIn(
+            "schedule", doc["_on"],
+            "#3784 REGRESSION: bench-ec2.yml runs on a `schedule:` again. Its AWS OIDC "
+            "role is DESCOPED, so every cron tick fails in `Configure AWS credentials "
+            "(OIDC)` before any benchmark runs, posts a GATING check-run on main's head "
+            "SHA (no advisory token, no registry entry => it GATES per #3773/#3774), and "
+            "makes `main` permanently and uninformatively red. Re-adding a cadence "
+            "requires re-provisioning vars.AWS_BENCH_ROLE_ARN in the same change.",
+        )
+        self.assertIn("workflow_dispatch", doc["_on"],
+                      "maintainer-run EC2 benchmarking is NOT descoped and must stay dispatchable")
+
+    def test_both_campaigns_stay_reachable_by_dispatch(self):
+        # Retiring the cron must not delete a capability: BOTH lanes stay selectable,
+        # so #3488's maintainer-run EC2 benchmarking keeps working once the role exists.
+        doc = self._wf()
+        options = doc["_on"]["workflow_dispatch"]["inputs"]["lane"]["options"]
+        self.assertEqual(sorted(options), ["full-suite", "heavy"])
+        conds = {jid: " ".join(job["if"].split()) for jid, job in doc["jobs"].items()}
+        self.assertIn("github.event.inputs.lane == 'heavy'", conds["ec2-bench"])
+        self.assertIn("github.event.inputs.lane == 'full-suite'", conds["nightly-full-bench"])
+
+    def test_every_oidc_job_carries_the_role_present_guard(self):
+        doc = self._wf()
+        for jid, job in doc["jobs"].items():
+            uses = [s.get("uses", "") for s in job.get("steps", [])]
+            if not any("configure-aws-credentials" in u for u in uses):
+                continue
+            self.assertIn(
+                "vars.AWS_BENCH_ROLE_ARN != ''", " ".join(job.get("if", "").split()),
+                f"#3784 REGRESSION: job `{jid}` assumes the DESCOPED AWS OIDC role with "
+                f"no role-present guard, so a dispatch while the role is absent burns 12 "
+                f"credential retries and posts a gating failure instead of skipping.",
+            )
+
+    def test_the_lane_was_not_muted_via_the_advisory_registry(self):
+        # The easy path we deliberately did NOT take. If a future change wants advisory
+        # status for this lane it must DELETE this assertion with a written justification
+        # — which is exactly the deliberate declaration #3774 demands.
+        declared = json.loads(self.REGISTRY.read_text(encoding="utf-8"))["jobs"]
+        for key, entry in declared.items():
+            self.assertNotEqual(
+                entry.get("workflow"), "bench-ec2.yml",
+                f"#3784: `{key}` declares a bench-ec2.yml job advisory. The descoped "
+                f"OIDC lane was RETIRED, not muted — declaring a permanently-failing "
+                f"gate advisory to green the dashboard is precisely what #3774's "
+                f"declared-not-inferred rule exists to prevent.",
+            )
+
+    def test_the_permanently_failing_check_name_is_gone(self):
+        # The gate has no name-based escape hatch (#3773), so the ONLY way this check-run
+        # stops gating `main` is for it to stop being produced.
+        text = self.WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn(
+            "name: nightly full-suite benchmark on EC2 (spot)", text,
+            "#3784 REGRESSION: the check-run name that could never pass is back. It "
+            "carries no advisory token and no registry declaration, so it GATES.",
+        )
+        # And the retirement is a behaviour change, not a rename: no automated trigger
+        # can produce the check-run at all. (Raw text, so this holds without PyYAML.)
+        self.assertNotIn(
+            "cron:", text,
+            "#3784 REGRESSION: a cron re-appeared in bench-ec2.yml — an automated tick "
+            "against the descoped AWS OIDC role is a guaranteed gating failure on main.",
+        )
+        guard_lines = [ln for ln in text.splitlines()
+                       if ln.strip() == "vars.AWS_BENCH_ROLE_ARN != ''"]
+        self.assertEqual(
+            len(guard_lines), 2,
+            "#3784 REGRESSION: both EC2 jobs must carry the role-present guard, so a "
+            "dispatch while the AWS OIDC role is descoped SKIPS instead of failing at "
+            "`Configure AWS credentials (OIDC)` and posting a gating check-run.",
+        )
 
 
 class TestSelfExclusionAndFetch(unittest.TestCase):
@@ -1433,7 +1708,11 @@ class TestSubprocessRobustness(unittest.TestCase):
         Mutation check: remove the try/except in run_gate → RuntimeError propagates
         instead of being caught → this test goes RED."""
         out = io.StringIO()
-        fetch = scripted([[GREEN, IN_PROGRESS]])
+        # [OPUS-5] #3783: the awaited sibling must be QUEUED, not `in_progress` —
+        # an executing sibling is positive liveness evidence and now VETOES the hang
+        # verdict (see TestLivenessVeto). The property under test here is the
+        # try/except around fetch_queue_depth, not the hang shape.
+        fetch = scripted([[GREEN, PENDING]])
 
         def raising_depth():
             raise RuntimeError("subprocess.run raised: gh not found")


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. Authored and reviewed by AI agents.

Fixes both causes of `main` being red. Neither is a code defect in the tree; both are CI-infrastructure defects on the same surface (`scripts/ci_summary_gate.py` + workflow wiring), so they ship together.

Closes #3783. Closes #3784.

---

## Defect 1 (#3783) — the hang detector misfired on live `kani` bounded proofs

The genuine-hang heuristic had two signals: **the Actions queue is idle** AND **no completions in the last `PROGRESS_WINDOW` polls**. Both are satisfied by a *perfectly healthy* long bounded proof — the queue is idle *precisely because* the job dequeued and started, and a `kani` harness emits no completion for tens of minutes by design. The two signals meant to prove a hang are exactly what a live proof looks like. Live evidence: `gate` run `30149978128` on `main` (`e8a41ab8c`) concluded "genuine hang" while `kani sparq-core` / `sparq-engine` / `sparq-vectors` had been `in_progress` for 11 minutes.

**Fix — LIVENESS VETO.** An awaited sibling in `in_progress` is positive liveness evidence and vetoes the hang verdict (`live_siblings()`). Queue depth may only count toward "hang" when the awaited siblings are `queued` or absent, i.e. genuinely not running.

**The #3677 case is deliberately preserved.** An evaporated check-run is represented by `_workflow_summary_check(..., force_pending=True)`, whose status is **`queued`** — never `in_progress` — so a lost leg still REDs at the base budget. That discrimination (`in_progress` ⇒ not a hang; `queued`/absent ⇒ still a hang) is the property the tests pin.

**On the optional slow-lane exemption — judgement: rejected, and the veto subsumes it.** A hard-coded `kani`/`cargo-fuzz`/coverage-shard list would re-introduce exactly the rename fragility #3773 removed from the advisory rule (rename the job, silently change the semantics). Reading liveness from the platform's own status field is name-independent and covers every slow lane, present and future, for free.

**On budget headroom — judgement: declined, with the arithmetic.** `kani` on `main` runs ~41 min wall-clock (`30150937647`: 08:20:47 → 09:01:36, and the four prior nightlies are within a minute of that). The gate's absolute cap is `110×20s + 45×40s` ≈ 67 min against `ci-summary.yml`'s own `timeout-minutes: 80` — so raising the cap enough to cover last night's shape (the `kani` cron fired 32 min after the gate began polling, putting completion at ~73 min) would leave under 5 min of margin, and going further means raising the gate job's timeout too. The gate is a **waiter occupying a runner slot**; making every gate hold a slot longer under congestion worsens the very congestion that delayed `kani` (memory: `reference-ci-congestion-collapse`). Declined as a band-aid. The real lever is in "What still remains" below.

### Reporting (#3783 ask 3) — "could not determine" ≠ "the tree is broken"

Three separate times in one night the gate spent its whole budget and then reported the wrong thing (#3758/#3765 unsatisfiable hold; #3781 ready→re-draft race burning 155 polls; #3783 this). Both `ABSOLUTE`-budget exits now report **`UNDETERMINED (not a test failure)`**, naming *which* could-not-determine it was — siblings still **EXECUTING** (listed by name, so the reader is not sent hunting) vs the runner pool never draining — and stating explicitly that nothing has been shown to be broken. A base-budget **genuine hang stays a FAILURE**, because nothing executing + an idle queue + no completions really is a broken pipeline.

**Fail-closed posture is unchanged.** Both new branches still `exit 1` — an unobserved leg is never assumed green. Mechanically: `return 0` count **6 → 6**, `return render_verdict(...)` call sites **2 → 2**, `return 1` count **15 → 16**. Exactly one `return 1` added; no exit-0 path added or widened.

---

## Defect 2 (#3784) — a GATING check that can never pass

`nightly full-suite benchmark on EC2 (spot)` failed in `Configure AWS credentials (OIDC)` after 12 retries — *before any benchmark ran* (run `30151339208`, job `89662120793`) — because the orchestration design deliberately descoped EC2 and the AWS OIDC role. Carrying no advisory token and no `.github/advisory-registry.json` entry, post-#3774 it **GATED**, so `main` could not be green while it existed.

### Chosen: option 1 — RETIRE the automated lane. Not option 3.

**Why.** The registry entry was available and would have been the fastest route to green. It would also have been the first violation of a rule merged four hours earlier: #3774 landed the principle that advisory status is *declared deliberately*, and muting a **permanently broken** gate to green a dashboard is precisely the behaviour that rule exists to prevent. There is a real distinction here — the `nightly-full-sweep.yml` lanes in the registry are declared advisory because a nightly *that runs* must not block a merge; this lane **cannot run at all**. Declaring it advisory would record "we accept this lane's verdict as informational", which is false: there is no verdict. Retirement records the truth: the lane is dead code the moment its role was descoped.

**What changed.**

1. **Both `schedule:` crons removed.** Not just the nightly — the weekly heavy campaign authenticates through the same dead role and would have redded `main` every Monday. Retiring only the nightly would have left the same bug on a slower clock.
2. **Maintainer-run EC2 benchmarking preserved** — it is *not* descoped and is actively used. Both campaigns stay reachable via `workflow_dispatch` with a `lane` input (`heavy` | `full-suite`), and **no EC2 bench tooling or documentation is deleted**: `scripts/ec2-bench.sh`, `scripts/bench/canonical-beir-gather-instance.sh` and its orphan-proof rails (#3488), and `research/ci-ec2-design.md` all stay. Only the CI lane that authenticates via the dead role is retired.
3. **Role-present guard** on both jobs (`vars.AWS_BENCH_ROLE_ARN != ''`), so a dispatch while the role is descoped **skips visibly** instead of burning 12 credential retries and posting a gating failure. Provisioning the repo variable revives the lane with no further edit. This is not a mute: it is one reviewable clause naming the variable, `skipped` honestly means "the descoped infrastructure was not there", and a test asserts no `bench-ec2.yml` job is ever declared advisory.
4. **`nightly-full-bench`'s display name no longer claims a cadence it does not have** (`full-suite benchmark on EC2 (spot, manual dispatch)`). Its **job id and the `sparq engine (nightly full suite)` series name are kept** so the published `dev/bench-nightly` dashboard history stays continuous.
5. **Docs corrected where they were now false** — `docs/branch-protection.md`, `docs/pages-cutover-runbook.md`, `bench/CATALOG.md`, `research/ci-ec2-design.md` (status banner: it is now the *revival spec*, its `schedule:` block is aspirational), plus the `bench.yml` / `pages.yml` / `ci-bench.sh` headers. Notably the claim that the at-scale perf-tracking was *"moved, not lost"* **no longer holds** and has been retracted rather than left to rot: with the cron retired, that series is collected only on demand.

---

## Verification — mutations applied to the LIVE files, never a fixture

`163` hermetic tests green (`python3 scripts/tests/test_ci_summary_gate.py`), plus `ci_summary_gate.py --self-test`, `check-advisory-registry.py` (all clear C2+C3+C4), `check-no-perf-numbers.py --enforce`, `check-readme-template.py --enforce`, `markdownlint-cli2` (0 errors), `typos`, all 25 `scripts/tests/test_*.py`.

Nine mutants, each applied by rewriting the real `scripts/ci_summary_gate.py` / `.github/workflows/bench-ec2.yml` / `.github/advisory-registry.json`, snapshot-restored by `cp` with marker verification. **Zero survivors.** Each redded because a guard fired, not because a search string vanished:

| # | Mutation (on the live file) | Test that REDs |
|---|---|---|
| M1 | delete the veto: `if not (saturated or progressing or live)` → `(saturated or progressing)` | `test_in_progress_siblings_are_not_a_hang` |
| M2 | flip the comparison: `LIVE_STATUS = "in_progress"` → `"queued"` | `test_all_queued_siblings_are_still_a_hang` |
| M3 | broaden the veto: `status == LIVE_STATUS` → `status != "completed"` | `test_all_queued_siblings_are_still_a_hang` |
| M4 | delete the taxonomy: report a live-sibling expiry as `FAILED` | `test_budget_expiry_with_live_siblings_reads_undetermined` |
| M5 | collapse the taxonomy the other way: launder a genuine hang as `UNDETERMINED` | `test_genuine_hang_still_reads_as_a_failure` |
| M6 | `force_pending` synthetic claims liveness: `"queued"` → `"in_progress"` | `test_evaporated_check_run_resolves_to_queued_not_live` |
| M7 | re-add the retired cron to `bench-ec2.yml` | `test_no_schedule_trigger` |
| M8 | delete the role-present guard from the full-suite OIDC job | `test_every_oidc_job_carries_the_role_present_guard` |
| M9 | take the easy path: add a `bench-ec2.yml` advisory-registry entry | `test_the_lane_was_not_muted_via_the_advisory_registry` |

Naming assertions, as emitted:

**M1** (`'genuine hang' unexpectedly found in …`)
> `#3783 REGRESSION: the hang detector fired while awaited siblings were `in_progress` — an executing kani bounded proof was declared a hang. An idle Actions queue means those jobs DEQUEUED and STARTED, and kani emits no completion for tens of minutes by design, so neither signal is evidence of a hang. The liveness veto (live_siblings) is missing.`

**M2 / M3** (`'genuine hang' not found in …`) — the discrimination, in the other direction
> `#3783 OVER-CORRECTION: awaited siblings that never STARTED (all `queued`, idle queue, no completions) are the genuine-hang case the detector exists for (#3677 evaporated check-runs resolve to `queued` too). The veto must key on `in_progress` ONLY — it has been broadened to swallow non-running legs, so a real hang now waits out the whole budget instead of REDing.`

**M4** (`'UNDETERMINED (not a test failure)' not found in …`)
> `#3783 ask 3 REGRESSION: a budget expiry with siblings STILL EXECUTING is reported identically to a real gating failure. Nothing was shown to be broken — this outcome must say 'could not determine', not 'FAILED'.`

**M5** (`'UNDETERMINED' unexpectedly found in …`)
> `#3783: a genuine hang must NOT be softened to 'could not determine' — nothing running with an idle queue and no completions is a real defect.`

**M6** (`'in_progress' != 'queued'`)
> `#3677/#3783 REGRESSION: the force_pending run-level synthetic (how an EVAPORATED check-run is represented) no longer reports `queued`. If it reports `in_progress` it looks EXECUTING to the liveness veto, so a lost leg vetoes its own hang detection and the gate waits out the whole budget instead of REDing — the exact case the detector was built for.`

**M7** (`'schedule' unexpectedly found in {'schedule': [{'cron': '41 6 * * *'}], …}`)
> `#3784 REGRESSION: bench-ec2.yml runs on a `schedule:` again. Its AWS OIDC role is DESCOPED, so every cron tick fails in `Configure AWS credentials (OIDC)` before any benchmark runs, posts a GATING check-run on main's head SHA (no advisory token, no registry entry => it GATES per #3773/#3774), and makes `main` permanently and uninformatively red. Re-adding a cadence requires re-provisioning vars.AWS_BENCH_ROLE_ARN in the same change.`

**M8** (`"vars.AWS_BENCH_ROLE_ARN != ''" not found in "github.repository == 'sparq-org/sparq' && github.event.inputs.lane == 'full-suite'"`)
> `#3784 REGRESSION: job `nightly-full-bench` assumes the DESCOPED AWS OIDC role with no role-present guard, so a dispatch while the role is absent burns 12 credential retries and posts a gating failure instead of skipping.`

**M9** (`'bench-ec2.yml' == 'bench-ec2.yml'`)
> `#3784: `full-suite benchmark on EC2 (spot, manual dispatch)` declares a bench-ec2.yml job advisory. The descoped OIDC lane was RETIRED, not muted — declaring a permanently-failing gate advisory to green the dashboard is precisely what #3774's declared-not-inferred rule exists to prevent.`

Two existing tests had to be **re-fixtured, because their fixtures encoded the defect**: `test_genuine_hang_fails` and `test_no_progress_and_depth_unknown_is_a_hang` both awaited an **`in_progress`** sibling and asserted "genuine hang" — i.e. the suite pinned the misfire. They now await a `queued` sibling, which is the real genuine-hang shape (and the shape an evaporated check-run resolves to). Same for `test_fetch_queue_depth_raises_treated_as_unknown_no_extension`, whose subject is the `try/except`, not the hang shape.

---

## Will `main` be green once this lands?

**#3784: yes, definitively.** A cron-less workflow posts no check-runs on a `main` head SHA, so the permanently-failing gating check disappears rather than being reclassified.

**#3783: the false RED is fixed, but a residual UNDETERMINED red remains reachable.** With the veto, live `kani` proofs no longer produce a "genuine hang" FAILURE. Whether the gate then goes *green* depends on whether `kani` finishes inside the ~67-min absolute budget:

- `kani` cron fires near its scheduled time ⇒ ~41 min ⇒ gate converges **green**.
- `kani`'s cron is delayed more than ~26 min (last night: the 06:11 cron fired at 08:20) ⇒ the budget expires and the gate exits 1 as **`UNDETERMINED (not a test failure)`**, naming the live legs. Honest and diagnosable, but still not green.

### What still remains — the actual root cause, deliberately left for its own review

Verified after opening: the three legs in the incident were `kani.yml`'s **`schedule`-triggered** jobs (run `30150937647`, `event: schedule`, path `.github/workflows/kani.yml`, names ending `(bounded proofs, informational)`), and that job **is declared advisory** in `.github/advisory-registry.json`. `kani.yml` has no `push` or `pull_request` trigger at all.

So the precise shape is: a **cron lane fired 2h09m late** (06:11 cron, ran 08:20), landed its check-runs on `main`'s head SHA while the push `gate` was mid-poll, re-armed the settle window, and the gate then waited 43 minutes on legs whose conclusion **it excludes from the verdict by construction** — before reporting a hang. (Note this is *not* true of `formal-verification.yml`'s `kani … (change-coupled proofs)` legs, which are deliberately **gating** and fire on the same `push`/`pull_request` as the gate, so they start together and their measured runtime fits inside the budget. Those must keep being waited on.)

The fix is one narrow change — stop counting **declared-advisory** siblings as work the gate must wait for. The set of check-runs whose outcome the gate ignores would be unchanged; we would merely stop *blocking* on the ones already ignored. It would have made run `30149978128` conclude green in about five polls, and it *reduces* gate runner occupancy, unlike any budget increase.

I did not do it here, for a stated reason: it **widens an exit-0 path** (the existing clean-convergence `render_verdict` would fire earlier, so a set with no registered gating legs could pass sooner). This PR's acceptance constraint was that the aggregator's fail-closed behaviour stay unchanged with only `return 1` added, and widening the success path of the one check that authorises every merge deserves its own diff and its own adversarial review, not a rider on a red-main fix. Filed as a follow-up.

## Not a real defect

- **The `kani` legs themselves.** They completed `success` (~41 min, run `30150937647`), and the four preceding nightlies are within a minute of that runtime. Nothing about `kani` needs fixing; every other check on `e8a41ab8c` was green with zero gating failures.
- **`scripts/ec2-bench.sh` and the EC2 bench tooling.** The failure was pre-benchmark authentication, not the scripts. Untouched.
- **The `#3677` hang detection.** It was correctly built and is correctly scoped by this change, not removed — verified by M6 and `test_all_queued_siblings_are_still_a_hang`.
- **The pre-existing `if: failure()` demoted-lane bead filer in `bench-ec2.yml`.** It behaved as designed; it was firing on a credentials failure only because the lane was firing at all. The role-present guard makes it unreachable while the role is descoped.

Not armed.
