### PR TITLE
fix(ci): a mid-gate re-draft must not re-dispatch draft-tier select onto a head with full-tier legs (#3781)

### DIFF
--- a/.github/workflows/ci-select.yml
+++ b/.github/workflows/ci-select.yml
@@ -49,6 +49,14 @@
 # detection contract with scripts/ci_summary_gate.py (SELECT_RE); the wiring test
 # scripts/tests/test_ci_select_wiring.py pins the two together. Do NOT add the words
 # "advisory"/"informational" to any name here (they would un-gate the check).
+#
+# THREE NAME SPELLINGS, ONE LEG IDENTITY. The job name carries the TIER as a
+# suffix marker: bare (full tier), ", draft-tier" (a draft-assembled reduced leg
+# set), or ", no-leg" (a guarded label-flip no-op run that assembled nothing at
+# all — [OPUS-5] #3781, see the job comment). scripts/ci_summary_gate.py strips
+# every marker to one normalized leg identity, so the three spellings are the
+# SAME leg across tiers; only the marker decides what the gate may conclude from
+# the run.
 name: ci-select
 
 on:
@@ -82,9 +90,30 @@ jobs:
     # one workflow's full-tier select must never release the hold for the
     # others), so a draft-tier leg set can never admit a non-draft PR to the
     # merge queue. The stable phrase "change-based test selection" (the SELECT_RE
-    # detection contract) is a prefix of BOTH spellings, and neither contains the
+    # detection contract) is a prefix of ALL THREE spellings, and none contains the
     # words "advisory"/"informational".
-    name: select (change-based test selection${{ github.event.pull_request.draft == true && ', draft-tier' || '' }})
+    #
+    # [OPUS-5] #3781 — THE ", no-leg" MARKER TAKES PRECEDENCE OVER ", draft-tier".
+    # A `labeled`/`unlabeled` pull_request event whose label is NOT one of
+    # ci-full / bench-full / fuzz-full is a GUARDED NO-OP for every caller: the
+    # #2546 label-trigger guard `if:`s off every root job of ci.yml, bench.yml,
+    # feature-matrix.yml and fuzz.yml, so the run assembles ZERO legs and THIS
+    # unconditional pre-job is its only non-skipped job (measured on sparq #3472:
+    # 8 label-flip runs at 07:28:57, each with exactly one non-skipped job — this
+    # select). Marking such a run ", draft-tier" (which is what happened, because
+    # the review pipeline re-drafts the PR in the same breath as the label flip)
+    # manufactured a hold NOTHING could ever discharge: a full-tier successor is
+    # only produced by a NON-draft payload, so the gate burned all 155 polls and
+    # fail-closed-refused a leg set with zero failing legs. The tier of a run that
+    # assembled no legs is not "draft" — it is NOT EVIDENCE AT ALL, and the gate
+    # ignores such a run entirely (scripts/ci_summary_gate.py NO_LEG_MARKER /
+    # no_leg_run_ids), which leaves the PREVIOUS real run authoritative instead of
+    # letting a vacuous all-skipped run supersede it. CONSERVATIVE BY DESIGN: on a
+    # ci-full/bench-full/fuzz-full flip at least one caller DOES do real work, so
+    # no marker is claimed and the pre-#3781 behaviour stands unchanged (a
+    # bench-full flip therefore still lets ci.yml's no-op run supersede — today's
+    # behaviour, not a regression; the review pipeline never flips those labels).
+    name: select (change-based test selection${{ (github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action) && !contains(fromJSON('["ci-full","bench-full","fuzz-full"]'), github.event.label.name)) && ', no-leg' || (github.event.pull_request.draft == true && ', draft-tier' || '') }})
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci-select.yml
+++ b/.github/workflows/ci-select.yml
@@ -155,9 +155,16 @@ jobs:
           # the run sees which tier this selection was assembled for (the machine
           # contract is the job NAME marker above).
           IS_DRAFT_PR: ${{ github.event.pull_request.draft == true }}
+          # [OPUS-5] #3781: the same no-leg condition as the job name above, surfaced
+          # for the human reader. A no-leg run's step summary must NOT claim "Tier:
+          # draft" — it assembled nothing, and saying "draft" is exactly the confusion
+          # that cost a full drain pass to unpick.
+          IS_NO_LEG_RUN: ${{ github.event_name == 'pull_request' && contains(fromJSON('["labeled","unlabeled"]'), github.event.action) && !contains(fromJSON('["ci-full","bench-full","fuzz-full"]'), github.event.label.name) }}
         run: |
           set -euo pipefail
-          if [ "${IS_DRAFT_PR:-}" = "true" ]; then
+          if [ "${IS_NO_LEG_RUN:-}" = "true" ]; then
+            echo "**Tier: no-leg** — this run was started by a \`${EVENT}\` label flip that the label-trigger guard turns into a NO-OP: every leg is skipped and this selection pre-job is the run's only real job. The ci-summary gate therefore IGNORES this whole run and keeps the previous real run of this workflow authoritative (#3781)." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "${IS_DRAFT_PR:-}" = "true" ]; then
             echo "**Tier: draft** — draft-tier CI (reduced sibling set; the full matrix re-runs at ready_for_review and its fresh gate supersedes this head's draft-tier results)." >> "$GITHUB_STEP_SUMMARY"
           fi
           args=(--event "$EVENT")

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -223,7 +223,7 @@ no check-run there either — not a byte-identical copy of the PR check-set.)
 | `artifact-exact-equality` (wasm feature-OFF byte identity) | `vectorized-feature-off.yml` | kept iff `sparq-wasm` is in the affected closure (in-step `ci_select.py` verdict; ci-full label / selector error / full mode ⇒ run) |
 
 **The integrity invariant — a draft-tier gate result must NEVER admit a PR to the
-merge queue.** The load-bearing mechanism is rule 1 (structural); rules 2–6 are
+merge queue.** The load-bearing mechanism is rule 1 (structural); rules 2–8 are
 belts (all in `scripts/ci_summary_gate.py`, unit-tested in
 `scripts/tests/test_ci_summary_gate.py`; the name/trigger wiring pinned by
 `scripts/tests/test_ci_select_wiring.py`):
@@ -280,6 +280,44 @@ belts (all in `scripts/ci_summary_gate.py`, unit-tested in
    Attempt-scoped job listing supplies the completed leg inventory and prevents
    an old attempt that reused the run id from leaking into the verdict; the
    workflow-run conclusion supplies the verdict when an entire job evaporates.
+7. **A run that assembled NO LEGS is not evidence (#3781).** [OPUS-5] A
+   `labeled`/`unlabeled` `pull_request` event whose label is not
+   `ci-full`/`bench-full`/`fuzz-full` is a guarded no-op for every `ci-select`
+   caller: the #2546 label-trigger guard skips every root job of `ci.yml`,
+   `bench.yml`, `feature-matrix.yml` and `fuzz.yml`, so the run's ONLY non-skipped
+   job is the deliberately-unconditional `select` pre-job. `ci-select.yml`
+   therefore names that job **`…, no-leg`**, never `…, draft-tier`, and the gate
+   treats the whole run as **non-authoritative**: it is excluded from newest-run
+   candidacy (rule 6) and every check-run it produced is a non-event, so the
+   PREVIOUS real run of that workflow stays authoritative. Two things this fixes,
+   both measured on 2026-07-25 (#3472/#3468/#3681):
+   * **the deadlock.** The review pipeline re-drafts a freshly-readied worker PR
+     ~13 min after the ready and flips `review:needs` in the same breath. Before
+     this rule, each of the resulting no-op runs' selects came out draft-marked
+     (the PR was a draft again), so the head acquired four draft-marked instances
+     whose full-tier successor could never exist — only a NON-draft payload
+     produces one. Rule 4 then held for all 155 polls and refused a leg set with
+     **zero failing legs**, three times in one drain pass.
+   * **evidence erasure.** Newest-run resolution is per-workflow, so a vacuous
+     all-`skipped` run used to *become* authoritative — discarding a real run that
+     was still in flight (#3472's real CI matrix ran until 07:34:08, six minutes
+     after the flip runs completed) or even a real `failure`. Ignoring the run is
+     therefore strictly MORE fail-closed than the behaviour it replaces.
+   Conservative by construction: on a `ci-full`/`bench-full`/`fuzz-full` flip at
+   least one caller does real work, so no `no-leg` claim is made and the previous
+   behaviour stands. `scripts/tests/test_ci_select_wiring.py::TestNoLegMarkerWiring`
+   EVALUATES the marker expression against synthetic payloads and proves, by
+   `needs:`-graph reachability, that every caller job really is inert on such a
+   flip — the claim, not just the string.
+8. **An unsatisfiable hold REDs immediately, with the diagnosis (#3781).**
+   [OPUS-5] Rule 4's hold is a WAIT for the `ready_for_review` full-tier re-runs.
+   When every sibling has CONCLUDED, a draft-marked select still lacks a successor,
+   and the PR reads as CURRENTLY A DRAFT, that wait is unsatisfiable on arrival, so
+   the gate fails fast naming exactly that instead of burning the remaining budget
+   (measured: 155 polls / ~37 min per occurrence). It is the same refusal rule 4
+   reaches at budget exhaustion — never a new pass — and it stands down whenever the
+   set is still settling, the PR reads non-draft, or the draft state is unreadable
+   (then the pre-#3781 budget-exhaustion path renders the verdict unchanged).
 
 **Why the queue can never latch a draft-tier result.** Rule 1 is structural: the
 queue and branch protection admit a PR only on a successful check-run of the
@@ -287,7 +325,7 @@ exact context `gate`, and no draft-tier run ever emits one. This matters more
 than it may look, because the `merge_group` run deliberately omits two lanes
 (`bench.yml`'s deterministic byte ratchet and the heavy recall shards,
 sq-6vshe.6) on the premise that their full form already ran on the PR head —
-a premise a draft-built head would otherwise break. Rules 2–6 alone would NOT
+a premise a draft-built head would otherwise break. Rules 2–8 alone would NOT
 close that: a concluded draft-tier `gate` success would remain the *latest* run
 of the required context from the un-draft moment until the ready_for_review
 `ci-summary` run registers its check-run (seconds of event latency; indefinitely

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -173,6 +173,33 @@
 #     cannot merge anyway, so a false RED here is cheap; a false PASS is the
 #     invariant violation).
 #
+# NO-LEG RUNS AND THE UNSATISFIABLE HOLD (#3781). [OPUS-5] The two rules "a worker PR
+# stays DRAFT until reviewed" and "a full-tier gate refuses a draft-tier leg set" are
+# each correct and composed into a deadlock with no exit. Measured 3-for-3 on
+# 2026-07-25 (#3472/#3468/#3681): `sparq-orchestrator[bot]` re-drafts a freshly-readied
+# worker PR ~13 min after the ready, flipping `review:needs` in the same breath; the
+# label flip re-triggers ci.yml / bench.yml / feature-matrix.yml / fuzz.yml, whose
+# #2546 label-trigger guard skips EVERY root job — so each run's only non-skipped job
+# is the unconditional select pre-job, which (the PR now being a draft) came out named
+# `…, draft-tier`. Four fresh draft-marked select instances therefore appeared on a
+# head with no possible full-tier successor, and the gate burned all 155 polls before
+# fail-closed-refusing a leg set with ZERO failing legs. Two additions close it:
+#   * NO-LEG RUNS ARE NOT EVIDENCE — ci-select.yml names its job `…, no-leg` (never
+#     `…, draft-tier`) on a guarded label-flip no-op, and the gate treats such a run as
+#     NON-AUTHORITATIVE: it is excluded from newest-run candidacy and every check-run
+#     it produced is a non-event (no_leg_run_ids / resolve_newest_workflow_runs). The
+#     previous REAL run of that workflow therefore stays authoritative. This is
+#     strictly MORE fail-closed than the pre-#3781 behaviour, where newest-run
+#     resolution let a vacuous all-skipped run supersede a real one — erasing a
+#     still-in-flight matrix (measured: #3472's real CI run finished at 07:34:08, six
+#     minutes AFTER the flip runs completed) or even a real FAILURE.
+#   * THE HOLD IS DETECTED WHEN IT IS UNSATISFIABLE — a full-tier PR gate whose
+#     siblings have ALL concluded, which still holds on a draft-marked select with no
+#     successor, and whose PR reads as CURRENTLY A DRAFT, is waiting for something that
+#     cannot happen (only a non-draft payload produces a full-tier select). It REDs
+#     immediately with that diagnosis instead of burning ~67 minutes of budget on a
+#     refusal already decided. Same verdict, named honestly, ~1 minute in.
+#
 # Exit-0 paths, exhaustively (fail-fast adds NO exit-0 path — it only ever
 # returns 1): (1) render_verdict over a stable-empty set;
 # (2) render_verdict over an all-terminal set with zero non-passing GATING checks
@@ -266,6 +293,28 @@ _PASSING = ("success", "skipped", "neutral")
 # advisory rule uses — so the gate can partition draft-assembled from full-assembled
 # selection check-runs on a head SHA without any extra API surface.
 DRAFT_TIER_MARKER = ", draft-tier"
+# [OPUS-5] #3781: the marker ci-select.yml appends INSTEAD of ", draft-tier" when the
+# calling run is a GUARDED LABEL-FLIP NO-OP — a labeled/unlabeled pull_request event
+# whose label is none of ci-full/bench-full/fuzz-full. The #2546 label-trigger guard
+# `if:`s off every root job of ci.yml / bench.yml / feature-matrix.yml / fuzz.yml on
+# such an event, so the run assembles ZERO legs and that workflow's unconditional
+# select pre-job is its ONLY non-skipped job. Such a run is NOT draft-tier evidence and
+# NOT full-tier evidence — it is not evidence at all — so the gate treats it as
+# NON-AUTHORITATIVE (no_leg_run_ids + resolve_newest_workflow_runs) and it can neither
+# create nor discharge a draft-tier hold (draft_selects_unsuperseded).
+#
+# WHY A WHOLE-RUN EXCLUSION, NOT MERELY A TIER-NEUTRAL SELECT NAME. Measured on sparq
+# #3472: the PR was readied at 07:15:37 (full-tier runs dispatched; CI's real matrix ran
+# until 07:34:08), re-drafted with `review:needs` at 07:28:50, and the resulting 8
+# label-flip runs completed within ~90s with every job skipped. Newest-run resolution
+# (#3505) is per-workflow, so those vacuous runs BECOME the authoritative run for CI /
+# Benchmarks / feature-matrix / fuzz and their all-`skipped` leg sets REPLACE the real,
+# still-in-flight ones. Neutralising only the select NAME would therefore have swapped a
+# 155-poll deadlock for a GREEN gate rendered over legs that had not finished. Ignoring
+# the RUN instead keeps the previous real run authoritative — strictly more fail-closed:
+# a mid-flight run keeps the gate polling, and a FAILED run keeps failing it instead of
+# being erased by a label flip.
+NO_LEG_MARKER = ", no-leg"
 # [FABLE-5] Draft-tier CI: THIS aggregator's own job name is tiered the same way
 # (ci-summary.yml `gate` job): a draft-payload run emits the check-run
 # `gate, draft-tier` and NEVER the required `gate` context — the structural half
@@ -333,6 +382,11 @@ class Config:
     max_total_polls: int = 155  # absolute cap: 45 extension polls x 40s = +30 min
     sat_queue_min: int = 5      # queued workflow-runs in the repo => saturation
     progress_window: int = 15   # polls over which a completed-count rise = progress
+    # [OPUS-5] #3781: consecutive polls the UNSATISFIABLE-HOLD state must persist before
+    # the gate fails fast on it (see run_gate). Small on purpose — the state is already
+    # all-terminal, so the only thing this window buys is tolerance for check-run
+    # registration lag; 3 polls x 20s replaces a ~67-minute burn with ~1 minute.
+    unsat_confirm_polls: int = 3
     max_consec_fetch_failures: int = 5
     summary_path: str = field(default_factory=lambda: os.environ.get("GITHUB_STEP_SUMMARY", ""))
 
@@ -465,6 +519,7 @@ def resolve_newest_workflow_runs(
     *,
     attempt_jobs: dict[int, list[dict]] | None = None,
     redispatch_pending_ids: set[int] | None = None,
+    no_leg_ids: set[int] | None = None,
 ) -> tuple[list[dict], int]:
     """Resolve Actions checks through newest workflow runs, preserving external checks.
 
@@ -476,10 +531,20 @@ def resolve_newest_workflow_runs(
     preserved: manually-posted checks (notably ``feature-matrix report``) may link
     to a workflow_run whose own head SHA differs from the commit on which it posts
     the check.
+
+    ``no_leg_ids`` ([OPUS-5] #3781, computed by no_leg_run_ids over the SAME check
+    list): runs that declared themselves EVIDENCE-FREE via the ", no-leg" select
+    marker. They are excluded from newest-run candidacy — so a vacuous label-flip
+    run can never supersede the previous real run of its workflow — and every
+    check-run of theirs is counted as superseded. Defaults to the empty set, which
+    makes this function byte-identical to its pre-#3781 behaviour.
     """
     attempt_jobs = attempt_jobs or {}
     redispatch_pending_ids = redispatch_pending_ids or set()
-    newest = newest_workflow_runs(workflow_runs)
+    no_leg_ids = no_leg_ids or set()
+    newest = newest_workflow_runs(
+        [r for r in workflow_runs if _as_int(r.get("id")) not in no_leg_ids]
+    )
     all_by_id = {_as_int(r.get("id")): r for r in workflow_runs if _as_int(r.get("id"))}
     self_id = _as_int(self_run_id)
     self_workflow = ""
@@ -498,6 +563,14 @@ def resolve_newest_workflow_runs(
         latest = newest.get(key)
         if key == self_workflow:
             continue
+        # [OPUS-5] #3781: a run that assembled NO legs (a guarded label-flip no-op) was
+        # already removed from `newest` above, so every check-run it produced — its own
+        # select plus the whole skipped needs-graph behind it — falls out below as a
+        # NON-EVENT: either `run_id != latest_id` (a real predecessor stayed
+        # authoritative) or `latest is None` (the vacuous run was that workflow's only
+        # one). Deliberately NOT an extra `run_id in no_leg_ids` branch here: it would
+        # be unreachable, and a guard that no input can distinguish is a guard no test
+        # can pin (it survived every mutant).
         if latest is None:
             superseded += 1
             continue
@@ -611,11 +684,33 @@ class WorkflowRunResolver:
         # bound, preventing repeated POSTs while the list API still shows attempt 1.
         self._redispatch_seen: dict[tuple[str, int, int], int] = {}
         self._terminal_jobs_cache: dict[tuple[int, int], list[dict]] = {}
+        # [OPUS-5] #3781: run ids already announced as NO-LEG (log once, not per poll).
+        self._no_leg_reported: set[int] = set()
 
     def __call__(self) -> list[dict]:
         checks = self.fetch_checks()
         workflows = self.fetch_workflows()
-        newest = newest_workflow_runs(workflows)
+        # [OPUS-5] #3781: drop the EVIDENCE-FREE runs (", no-leg" select marker) from
+        # newest-run candidacy BEFORE anything downstream keys off `newest` — the
+        # redispatch decision, the attempt-jobs inventory and the resolver must all
+        # agree on which run is authoritative, or a vacuous label-flip run could still
+        # supersede a real predecessor through one of the other two paths.
+        no_leg_ids = no_leg_run_ids(checks)
+        authoritative = [
+            r for r in workflows if _as_int(r.get("id")) not in no_leg_ids
+        ]
+        fresh_no_leg = sorted(no_leg_ids - self._no_leg_reported)
+        if fresh_no_leg:
+            # Announced ONCE per run id, not once per poll: the gate can poll 155 times
+            # and this line is a standing fact about the head, not a per-poll event.
+            self._no_leg_reported |= set(fresh_no_leg)
+            print(
+                f"  workflow-run resolver: {len(fresh_no_leg)} run(s) declared NO LEGS "
+                f"(guarded label-flip no-op, #3781) — ignored, so the previous real run "
+                f"of each workflow stays authoritative: "
+                f"{', '.join(str(i) for i in fresh_no_leg)}"
+            )
+        newest = newest_workflow_runs(authoritative)
         self_id = _as_int(self.self_run_id)
         self_workflow = ""
         for run in workflows:
@@ -686,6 +781,7 @@ class WorkflowRunResolver:
             self.self_run_id,
             attempt_jobs=attempt_jobs,
             redispatch_pending_ids=redispatch_pending,
+            no_leg_ids=no_leg_ids,
         )
         if superseded:
             print(
@@ -696,9 +792,10 @@ class WorkflowRunResolver:
 
 
 def normalized_name(name: str) -> str:
-    """A check-run name with the draft-tier marker stripped — the identity under
-    which a draft-assembled select and its full-tier successor are the SAME leg."""
-    return name.replace(DRAFT_TIER_MARKER, "")
+    """A check-run name with every TIER marker stripped — the identity under which a
+    draft-assembled select, a no-leg label-flip select ([OPUS-5] #3781) and their
+    full-tier successor are all the SAME leg."""
+    return name.replace(DRAFT_TIER_MARKER, "").replace(NO_LEG_MARKER, "")
 
 
 def _leg_identity(run: dict) -> tuple[str, str]:
@@ -709,6 +806,47 @@ def _leg_identity(run: dict) -> tuple[str, str]:
 def is_draft_tier(name: str) -> bool:
     """Was this check-run produced by a draft-tier-assembled run (name marker)?"""
     return DRAFT_TIER_MARKER in name
+
+
+def is_no_leg_select(name: str) -> bool:
+    """[OPUS-5] #3781: is this the PURE selection pre-job of a run that assembled NO
+    LEGS (a guarded label-flip no-op — see NO_LEG_MARKER)? Deliberately conjoined with
+    is_pure_select: only the bare reusable ci-select pre-job may declare its run
+    evidence-free. A COMPOUND job that merely contains the selection phrase while
+    carrying additional gating evidence (`fv-select (change-based test selection) +
+    fv-manifest (proof inventory)`) can never make its run non-authoritative, so a
+    marker that drifted onto an evidence-bearing job name fails CLOSED (the run stays
+    authoritative and keeps gating)."""
+    return NO_LEG_MARKER in name and is_pure_select(name)
+
+
+def select_tier(name: str) -> str:
+    """[OPUS-5] #3781: the TIER a selection check-run was assembled at — "draft",
+    "no-leg" or "full". Three-valued so cross-tier supersession stays explicit:
+    no-leg evidence must no more stand in for a full-tier selection than draft
+    evidence may (forgive_superseded)."""
+    if is_draft_tier(name):
+        return "draft"
+    if NO_LEG_MARKER in name:
+        return "no-leg"
+    return "full"
+
+
+def no_leg_run_ids(check_runs: list[dict]) -> set[int]:
+    """[OPUS-5] #3781: the Actions run ids that DECLARED THEMSELVES evidence-free by
+    naming their pure select check-run with NO_LEG_MARKER. Such a run assembled zero
+    legs (the #2546 label-trigger guard skipped every root job), so it must not become
+    the authoritative newest run for its workflow and erase the previous real run's
+    legs. Run ids come from the check-run's own details/html url — the same
+    server-supplied locator the newest-run resolver already trusts."""
+    out: set[int] = set()
+    for r in check_runs:
+        if not is_no_leg_select(r.get("name", "")):
+            continue
+        rid = _workflow_run_id_of_check(r)
+        if rid:
+            out.add(rid)
+    return out
 
 
 def is_draft_gate_artifact(name: str) -> bool:
@@ -780,11 +918,20 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
             key = _leg_identity(r)
             mine = _order_key(r)
             pure_select = is_pure_select(r_name)
-            r_tier = is_draft_tier(r_name)
+            r_tier = select_tier(r_name)
             if any(
                 o is not r
                 and _leg_identity(o) == key
                 and o.get("conclusion") not in _SUPERSEDABLE
+                # [OPUS-5] #3781: a NO-LEG select proves nothing about any tier's
+                # selection, so it may only ever supersede another no-leg select.
+                # Without this the strictly-later disjunct below would let a vacuous
+                # label-flip select forgive a cancelled REAL-tier select and thereby
+                # release a draft-tier hold. Pure narrowing (fewer forgivenesses =>
+                # more REDs), and unreachable in production because the no-leg run's
+                # checks never survive resolve_newest_workflow_runs — defence in depth
+                # for any caller that renders a verdict over a raw check list.
+                and (select_tier(o.get("name", "")) == "no-leg") == (r_tier == "no-leg")
                 and (
                     # pure select: any SAME-TIER same-name success proves a
                     # sound selection; everything else (non-select legs,
@@ -793,7 +940,7 @@ def forgive_superseded(runs: list[dict]) -> tuple[list[dict], list[dict]]:
                     (
                         pure_select
                         and o.get("conclusion") == "success"
-                        and is_draft_tier(o.get("name", "")) == r_tier
+                        and select_tier(o.get("name", "")) == r_tier
                     )
                     or _order_key(o) > mine
                 )
@@ -834,11 +981,21 @@ def draft_selects_unsuperseded(runs: list[dict]) -> list[str]:
     that each demand a successor; a hold that cannot be satisfied REDs at budget
     exhaustion ("stale draft-tier run, full run pending") rather than ever
     passing over draft-assembled legs. Re-running the selecting workflows (or
-    pushing a new head) clears it."""
+    pushing a new head) clears it.
+
+    [OPUS-5] #3781: a NO-LEG select (a guarded label-flip no-op run — see
+    NO_LEG_MARKER) belongs to NEITHER pool. It cannot CREATE a hold, because its run
+    assembled no legs at all and a full-tier successor for it can never exist while
+    the PR is a draft — that composition is the #3781 deadlock, which burned all 155
+    polls on three PRs with zero failing legs. And it cannot DISCHARGE one either: an
+    evidence-free selection must never stand in for the full-tier re-run a genuinely
+    draft-assembled leg set is waiting on. In production such a check never reaches
+    here (its whole run is dropped by resolve_newest_workflow_runs); this is the
+    predicate-level belt for any path that renders a verdict over a raw check list."""
     groups: dict[tuple[str, str], tuple[list[dict], list[dict]]] = {}
     for r in runs:
         name = r.get("name", "")
-        if not is_select(name):
+        if not is_select(name) or is_no_leg_select(name):
             continue
         marked, unmarked = groups.setdefault(_leg_identity(r), ([], []))
         (marked if is_draft_tier(name) else unmarked).append(r)
@@ -1244,6 +1401,26 @@ def _emit(line: str, summary_path: str = "") -> None:
             fh.write(line + "\n")
 
 
+def _bounded_draft_read(
+    tier_ctx: TierContext | None,
+) -> tuple[bool | None, Exception | None]:
+    """The PR's LIVE draft state via tier_ctx.fetch_pr_draft, bounded-retried on
+    transient FetchError. Returns (state, last_error); state is None when there is no
+    fetcher wired or every attempt failed. Shared by the conclusion-time re-check
+    (_draft_recheck) and the #3781 unsatisfiable-hold detector so both read the state
+    exactly the same way — the CALLERS decide what an unreadable state means."""
+    still_draft: bool | None = None
+    last_err: Exception | None = None
+    if tier_ctx is not None and tier_ctx.fetch_pr_draft is not None:
+        for _ in range(max(1, tier_ctx.draft_check_retries)):
+            try:
+                still_draft = tier_ctx.fetch_pr_draft()
+                break
+            except FetchError as exc:  # transient API blip: bounded retry
+                last_err = exc
+    return still_draft, last_err
+
+
 def _draft_recheck(tier_ctx: TierContext | None, summary_path: str = "") -> int:
     """[FABLE-5] Draft-tier conclusion-time re-check, applied on EVERY would-be-
     SUCCESS path (including the stable-empty set): a DRAFT-tier run confirms the
@@ -1256,15 +1433,7 @@ def _draft_recheck(tier_ctx: TierContext | None, summary_path: str = "") -> int:
     violation. Returns 0 (ok to pass) or 1 (fail). Full-tier runs: always 0."""
     if not tier_ctx or tier_ctx.run_tier != "draft":
         return 0
-    still_draft = None
-    last_err: Exception | None = None
-    if tier_ctx.fetch_pr_draft is not None:
-        for _ in range(max(1, tier_ctx.draft_check_retries)):
-            try:
-                still_draft = tier_ctx.fetch_pr_draft()
-                break
-            except FetchError as exc:  # transient API blip: bounded retry
-                last_err = exc
+    still_draft, last_err = _bounded_draft_read(tier_ctx)
     if still_draft is None:
         _emit(
             "### ci-summary: FAILED — draft-tier run could not confirm the PR's "
@@ -1521,6 +1690,8 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     # observed on the PREVIOUS poll — the red fires only when a fresh re-poll
     # re-observes the identical set (header §FAIL-FAST).
     ff_suspect: tuple | None = None
+    # [OPUS-5] #3781: consecutive polls the UNSATISFIABLE-HOLD state has persisted.
+    unsat_polls = 0
 
     attempt = 0
     while attempt < cfg.max_total_polls:
@@ -1645,6 +1816,79 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 )
                 continue  # no sleep: the grace re-poll is deliberately immediate
             ff_suspect = None
+
+        # [OPUS-5] #3781 — UNSATISFIABLE HOLD: detect it, do not wait it out.
+        # The draft-tier hold (awaiting_full) is a WAIT for the ready_for_review
+        # full-tier re-runs to register. That wait is only meaningful while such a
+        # re-run can still happen. When ALL THREE hold —
+        #   (1) every awaited sibling has CONCLUDED (pending == 0: nothing is coming),
+        #   (2) a draft-marked select instance still lacks a full-tier successor, and
+        #   (3) the PR is CURRENTLY A DRAFT (live API read),
+        # — the hold is unsatisfiable ON ARRIVAL: a full-tier select is produced ONLY
+        # by a non-draft pull_request payload, so while the PR stays a draft no
+        # successor can ever register on this SHA. Measured on #3472/#3468/#3681: the
+        # gate spent all 155 polls (~67 min of wall-clock budget) in exactly this state
+        # and then emitted the refusal it could have emitted at poll 3, on PRs with
+        # ZERO failing legs. This is a `return 1` — the SAME refusal render_verdict's
+        # stale-draft-tier belt reaches at budget exhaustion, arrived at sooner and
+        # named honestly; it never turns a would-be RED green.
+        # NOT fired while anything is still settling (pending / awaiting_report), before
+        # the startup-race floor, or on a state that has not persisted for
+        # unsat_confirm_polls — that window is the discrimination against check-run
+        # registration lag. An UNREADABLE draft state does NOT fire either: the gate
+        # keeps polling exactly as before (a false RED here would be a new failure mode,
+        # while the pre-#3781 behaviour of burning the budget is merely slow).
+        if (
+            awaiting_full
+            and pending == 0
+            and not awaiting_report
+            and attempt >= cfg.min_polls
+        ):
+            unsat_polls += 1
+            if unsat_polls >= cfg.unsat_confirm_polls:
+                still_draft, draft_err = _bounded_draft_read(tier_ctx)
+                if still_draft is True:
+                    stale = draft_selects_unsuperseded(runs)
+                    _emit(
+                        "### ci-summary: FAILED (fail-fast) — UNSATISFIABLE draft-tier "
+                        "hold, not a slow run. Every sibling check-run on this head SHA "
+                        f"has CONCLUDED, {len(stale)} draft-marked select instance(s) "
+                        "still have no full-tier successor, and the PR is CURRENTLY A "
+                        "DRAFT — so no full-tier select can ever register on this SHA "
+                        "(only a non-draft pull_request payload produces one). The hold "
+                        "is unsatisfiable on arrival, so the gate REDs NOW with the "
+                        f"diagnosis instead of burning the remaining "
+                        f"{cfg.max_total_polls - attempt} poll(s) on a refusal that is "
+                        "already decided (#3781). REMEDY: re-ready the PR (`gh pr "
+                        "ready` fires ready_for_review, which re-runs every selecting "
+                        "workflow at FULL tier), or push a new head. A worker PR that "
+                        "the review pipeline re-drafts mid-gate hits this whenever the "
+                        "re-draft lands inside the gate's polling window.",
+                        cfg.summary_path,
+                    )
+                    for n in sorted(set(stale)):
+                        _emit(
+                            f"- ✗ {n}: draft-tier selection with no full-tier successor",
+                            cfg.summary_path,
+                        )
+                    print(
+                        "::error::ci-summary failed fast — unsatisfiable draft-tier hold "
+                        "(all siblings terminal, PR still a draft, no full-tier select "
+                        "possible)."
+                    )
+                    return 1
+                # Not unsatisfiable (PR is ready, or the state is unreadable): keep
+                # polling and re-arm the window, so the live draft state is re-read at
+                # most once every unsat_confirm_polls polls rather than on every poll.
+                unsat_polls = 0
+                print(
+                    "  unsatisfiable-hold check: the draft-tier hold is all-terminal but "
+                    f"the PR draft state read as {still_draft!r}"
+                    + (f" (last error: {draft_err})" if draft_err else "")
+                    + " — not declaring it unsatisfiable; continuing to poll."
+                )
+        else:
+            unsat_polls = 0
 
         # Clean convergence: everything terminal, held for the settle, past the floor.
         if attempt >= cfg.min_polls and pending == 0 and stable >= cfg.settle_polls:

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -1585,6 +1585,34 @@ class TestNoLegMarkerWiring(unittest.TestCase):
                 f"condition must exclude those labels, or a run that produced real "
                 f"legs would be declared evidence-free and then IGNORED")
 
+    def test_the_step_summary_agrees_with_the_job_name(self):
+        """The human-facing step summary and the machine-facing job name must decide
+        `no-leg` from the SAME condition. A summary that said "Tier: draft" for a run
+        the gate is ignoring is exactly the misreading that cost a full drain pass to
+        unpick, so both expressions are evaluated side by side on every payload."""
+        step = next(s for s in self.sel["jobs"]["select"]["steps"]
+                    if "ci_select.py" in str(s.get("run", "")))
+        expr = str(step["env"]["IS_NO_LEG_RUN"])
+        cases = [
+            dict(draft=True, action="labeled", label="review:needs"),
+            dict(draft=True, action="unlabeled", label="review:pass"),
+            dict(draft=False, action="labeled", label="review:needs"),
+            dict(draft=True, action="labeled", label="ci-full"),
+            dict(draft=True, action="synchronize"),
+            dict(draft=False, action="ready_for_review"),
+            dict(event="push"),
+            dict(event="merge_group"),
+        ]
+        for case in cases:
+            ctx = pr_event(**case)
+            summary_says = _truthy(_GhExpr(expr[3:-2], ctx).parse())
+            name_says = self.gate.is_no_leg_select(render_job_name(self.name, ctx))
+            self.assertEqual(
+                summary_says, name_says,
+                f"{case}: the step summary and the job name disagree about whether "
+                f"this run assembled no legs (summary={summary_says}, "
+                f"name={name_says}) — one of the two conditions has drifted (#3781)")
+
     def test_the_evaluator_itself_is_not_vacuous(self):
         """A wiring test whose evaluator silently returns '' for everything would
         pass every assertion above. Prove the evaluator discriminates."""

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -109,6 +109,196 @@ def _workspace_members() -> set[str]:
     return members
 
 
+# ---------------------------------------------------------------------------------
+# [OPUS-5] #3781 — A TINY GITHUB-EXPRESSION EVALUATOR, so a workflow expression can
+# be MUTATION-TESTED instead of merely string-matched.
+#
+# WHY THIS EXISTS. A mutation sweep over these repos' CI guards found that every
+# UNCAUGHT mutant lived in a workflow `if:`, a step body, or a production call site —
+# never in a Python predicate. String-equality inspection tests (`assertEqual(name,
+# "gate" + MARKER_EXPR)`) catch a DELETED expression but say nothing about what it
+# EVALUATES to, so dropping a `!`, widening a label list, or swapping the two branches
+# of a ternary passes them. The #3781 defect was exactly of that shape: an expression
+# that was individually correct and composed into a deadlock. So the marker expression
+# is EVALUATED here, against synthetic event payloads, and the rendered check-run name
+# is fed to the real gate predicates — end to end, YAML → name → verdict.
+#
+# The grammar is deliberately the SMALLEST one that covers the live expression:
+# parenthesised `&&`/`||`/`!`/`==`, single-quoted literals, `true`/`false`, dotted
+# `github.…` context paths, and the two functions used (`contains`, `fromJSON`).
+# Anything outside it raises — an expression that outgrows this evaluator FAILS THE
+# TEST LOUDLY rather than silently going unchecked (fail-closed).
+_TOKEN_RE = re.compile(
+    r"""\s*(?:
+        (?P<str>'(?:[^']|'')*')
+      | (?P<op>&&|\|\||==|!=|!|\(|\)|,)
+      | (?P<word>[A-Za-z_][A-Za-z0-9_.\-]*)
+    )""",
+    re.VERBOSE,
+)
+
+
+class GhExprError(AssertionError):
+    """The expression used syntax outside the evaluator's supported grammar."""
+
+
+def _tokenize(src: str) -> list[tuple[str, str]]:
+    pos, out = 0, []
+    while pos < len(src):
+        if src[pos].isspace():
+            pos += 1
+            continue
+        m = _TOKEN_RE.match(src, pos)
+        if not m or m.end() == pos:
+            raise GhExprError(f"unsupported syntax at offset {pos}: {src[pos:pos + 30]!r}")
+        pos = m.end()
+        for kind in ("str", "op", "word"):
+            if m.group(kind) is not None:
+                out.append((kind, m.group(kind)))
+                break
+    return out
+
+
+def _truthy(value) -> bool:
+    """GitHub-expression truthiness: '' / false / null are falsy."""
+    if value is None or value is False:
+        return False
+    if value == "":
+        return False
+    return True
+
+
+class _GhExpr:
+    """Recursive-descent evaluator for the supported grammar (precedence:
+    ! > == > && > ||, matching GitHub's documented order)."""
+
+    def __init__(self, src: str, ctx: dict):
+        self.toks = _tokenize(src)
+        self.i = 0
+        self.ctx = ctx
+
+    def parse(self):
+        value = self._or()
+        if self.i != len(self.toks):
+            raise GhExprError(f"trailing tokens at {self.toks[self.i:]}")
+        return value
+
+    def _peek(self):
+        return self.toks[self.i] if self.i < len(self.toks) else (None, None)
+
+    def _eat(self, text):
+        if self._peek()[1] == text:
+            self.i += 1
+            return True
+        return False
+
+    def _or(self):
+        value = self._and()
+        while self._eat("||"):
+            right = self._and()
+            value = value if _truthy(value) else right
+        return value
+
+    def _and(self):
+        value = self._cmp()
+        while self._eat("&&"):
+            right = self._cmp()
+            value = right if _truthy(value) else value
+        return value
+
+    def _cmp(self):
+        left = self._unary()
+        for op in ("==", "!="):
+            if self._eat(op):
+                right = self._unary()
+                eq = left == right
+                return eq if op == "==" else not eq
+        return left
+
+    def _unary(self):
+        if self._eat("!"):
+            return not _truthy(self._unary())
+        return self._primary()
+
+    def _primary(self):
+        kind, text = self._peek()
+        if text == "(":
+            self.i += 1
+            value = self._or()
+            if not self._eat(")"):
+                raise GhExprError("unbalanced parenthesis")
+            return value
+        if kind == "str":
+            self.i += 1
+            return text[1:-1].replace("''", "'")
+        if kind == "word":
+            self.i += 1
+            if text == "true":
+                return True
+            if text == "false":
+                return False
+            if text in ("contains", "fromJSON") or self._peek()[1] == "(":
+                return self._call(text)
+            return self._lookup(text)
+        raise GhExprError(f"unexpected token {text!r}")
+
+    def _call(self, fn):
+        if not self._eat("("):
+            raise GhExprError(f"{fn}: expected '('")
+        args = []
+        if self._peek()[1] != ")":
+            args.append(self._or())
+            while self._eat(","):
+                args.append(self._or())
+        if not self._eat(")"):
+            raise GhExprError(f"{fn}: expected ')'")
+        if fn == "fromJSON":
+            return json.loads(args[0])
+        if fn == "contains":
+            haystack, needle = args
+            if isinstance(haystack, list):
+                return needle in haystack
+            return str(needle) in str(haystack or "")
+        raise GhExprError(f"unsupported function {fn}()")
+
+    def _lookup(self, path):
+        node = self.ctx
+        for part in path.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return None  # an absent context value is null (falsy), as in GitHub
+            node = node[part]
+        return node
+
+
+def _marker_expr_of(name: str) -> str:
+    """The single `${{ … }}` substitution in a job `name:` (verbatim, braces included)."""
+    matches = re.findall(r"\$\{\{.*?\}\}", name)
+    assert len(matches) == 1, f"expected exactly one expression in {name!r}"
+    return matches[0]
+
+
+def render_job_name(name: str, ctx: dict) -> str:
+    """Render a job `name:` for a synthetic event payload by EVALUATING its
+    expression — the check-run name the gate would actually receive."""
+    expr = _marker_expr_of(name)
+    value = _GhExpr(expr[3:-2], ctx).parse()
+    if value is True:
+        value = "true"
+    elif value is False or value is None:
+        value = ""
+    return name.replace(expr, str(value))
+
+
+def pr_event(*, draft=False, action="synchronize", label=None, event="pull_request"):
+    """A synthetic `github` context for a pull_request (or other) event."""
+    ctx = {"event_name": event, "event": {}}
+    if event == "pull_request":
+        ctx["event"] = {"action": action, "pull_request": {"draft": draft}}
+        if label is not None:
+            ctx["event"]["label"] = {"name": label}
+    return {"github": ctx}
+
+
 class TestWiring(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -988,6 +1178,11 @@ class TestDraftTierWiring(unittest.TestCase):
     # disjunct => RUN; only a genuinely-draft PR head can skip.
     DRAFT_GUARD = "github.event_name != 'pull_request' || github.event.pull_request.draft != true"
     MARKER_EXPR = "${{ github.event.pull_request.draft == true && ', draft-tier' || '' }}"
+    # [OPUS-5] #3781: ci-select's own marker expression is now THREE-valued (", no-leg"
+    # takes precedence over ", draft-tier" on a guarded label-flip no-op run), so it is
+    # no longer the same literal as the ci-summary gate's. Its BEHAVIOUR — not its text
+    # — is pinned by TestNoLegMarkerWiring, which evaluates the live expression.
+    DRAFT_MARKER_LITERAL = ", draft-tier"
 
     # Every gate-feeding workflow with a pull_request trigger. Advisory-only
     # workflows (pr-title, deploy-lint, deploy-terraform-lint) are deliberately
@@ -1019,22 +1214,29 @@ class TestDraftTierWiring(unittest.TestCase):
     # ---- the tier marker (the gate's detection contract) ---------------------
     def test_select_job_name_carries_the_draft_tier_marker(self):
         name = self.sel["jobs"]["select"]["name"]
-        self.assertIn(self.MARKER_EXPR, name,
-                      "ci-select's job name must append the draft-tier marker on "
-                      "draft PR payloads (the gate's tier detection contract)")
         marker = self.gate.DRAFT_TIER_MARKER
-        self.assertIn(marker, self.MARKER_EXPR,
-                      "the YAML marker literal must be the gate's DRAFT_TIER_MARKER")
-        # Both RENDERED spellings must satisfy the SELECT_RE contract, carry no
-        # advisory token, and normalize to the same identity.
-        full = name.replace(self.MARKER_EXPR, "")
-        draft = name.replace(self.MARKER_EXPR, marker)
-        for rendered in (full, draft, f"select / {full}", f"select / {draft}"):
+        self.assertEqual(marker, self.DRAFT_MARKER_LITERAL)
+        self.assertIn(f"&& '{marker}'", name,
+                      "ci-select's job name must still append the draft-tier marker on "
+                      "draft PR payloads (the gate's tier detection contract)")
+        # Every RENDERED spelling must satisfy the SELECT_RE contract, carry no
+        # advisory token, and normalize to the same identity. ([OPUS-5] #3781 adds the
+        # third spelling, ", no-leg".)
+        expr = _marker_expr_of(name)
+        full = name.replace(expr, "")
+        draft = name.replace(expr, marker)
+        no_leg = name.replace(expr, self.gate.NO_LEG_MARKER)
+        for rendered in (full, draft, no_leg,
+                         f"select / {full}", f"select / {draft}", f"select / {no_leg}"):
             self.assertTrue(self.gate.is_select(rendered), rendered)
             self.assertFalse(self.gate.is_advisory(rendered), rendered)
         self.assertTrue(self.gate.is_draft_tier(draft))
         self.assertFalse(self.gate.is_draft_tier(full))
+        self.assertFalse(self.gate.is_draft_tier(no_leg),
+                         "a no-leg run must NOT be read as draft-tier — that is the "
+                         "#3781 deadlock")
         self.assertEqual(self.gate.normalized_name(draft), full)
+        self.assertEqual(self.gate.normalized_name(no_leg), full)
 
     # ---- draft skip guards ---------------------------------------------------
     def test_coverage_jobs_skip_on_draft_heads(self):
@@ -1199,6 +1401,201 @@ class TestDraftTierWiring(unittest.TestCase):
         self.assertIn("github.event.pull_request.number", str(conc.get("group", "")))
         self.assertTrue(conc.get("cancel-in-progress"),
                         "js.yml must cancel superseded PR runs")
+
+
+class TestNoLegMarkerWiring(unittest.TestCase):
+    """[OPUS-5] #3781 — the ", no-leg" marker, EVALUATED not string-matched.
+
+    THE DEFECT. `sparq-orchestrator[bot]` re-drafts a freshly-readied worker PR ~13
+    min after the ready and flips `review:needs` in the same breath. That label event
+    re-triggers ci.yml / bench.yml / feature-matrix.yml / fuzz.yml, whose #2546
+    label-trigger guard skips EVERY root job — measured on sparq #3472: 8 such runs,
+    each with exactly ONE non-skipped job (the unconditional select). Because the PR
+    was now a draft, each of those selects came out `…, draft-tier`, so the head
+    acquired four fresh draft-marked select instances whose full-tier successor could
+    never exist (only a NON-draft payload produces one). The gate burned all 155 polls
+    and refused a leg set with zero failing legs, three times in one pass.
+
+    THE CONTRACT PINNED HERE. ci-select.yml must name that job `…, no-leg` — never
+    `…, draft-tier` — on a guarded label-flip no-op, and must keep naming it
+    `…, draft-tier` on a genuinely draft-assembled run. Every case is checked by
+    EVALUATING the live expression (see the evaluator above) and feeding the rendered
+    name to the real gate predicates, so a mutated expression (a dropped `!`, a
+    widened label list, swapped ternary branches) REDs on behaviour."""
+
+    # The escape labels: on one of these at least one caller DOES do real work, so no
+    # no-leg claim may be made. Derived from the callers' own guards below.
+    ESCAPE_LABELS = ("ci-full", "bench-full", "fuzz-full")
+
+    @classmethod
+    def setUpClass(cls):
+        cls.sel = _load(SELECT_YML)
+        cls.gate = _gate_module()
+        cls.name = cls.sel["jobs"]["select"]["name"]
+
+    def _render(self, **kwargs) -> str:
+        return render_job_name(self.name, pr_event(**kwargs))
+
+    # ---- the load-bearing discrimination -------------------------------------
+    def test_guarded_label_flip_on_a_draft_pr_renders_no_leg_not_draft_tier(self):
+        """(a) THE FIX. A `review:needs` flip on a DRAFT PR — the exact #3472 event —
+        must render the no-leg marker. If it renders ", draft-tier" the run
+        manufactures an unsatisfiable hold and the whole parked backlog deadlocks."""
+        for action in ("labeled", "unlabeled"):
+            rendered = self._render(draft=True, action=action, label="review:needs")
+            self.assertIn(self.gate.NO_LEG_MARKER, rendered,
+                          f"{action} review:needs on a draft PR must render the "
+                          f"no-leg marker, got {rendered!r}")
+            self.assertFalse(
+                self.gate.is_draft_tier(rendered),
+                f"{action} review:needs on a draft PR must NOT be marked draft-tier: "
+                f"its run assembles ZERO legs, so the hold it would create can never "
+                f"be discharged while the PR stays a draft (#3781) — got {rendered!r}")
+            self.assertTrue(self.gate.is_no_leg_select(rendered), rendered)
+            self.assertTrue(self.gate.is_select(rendered), rendered)
+            self.assertFalse(self.gate.is_advisory(rendered), rendered)
+
+    def test_a_genuine_draft_run_still_renders_the_draft_tier_marker(self):
+        """(b) THE OTHER HALF OF THE DISCRIMINATION — the fix must not blind
+        draft-tier CI. An `opened`/`synchronize`/`reopened` run on a draft PR
+        assembles a REAL reduced leg set, so it must still be marked draft-tier and
+        still create the hold that keeps its legs out of the merge queue."""
+        for action in ("opened", "synchronize", "reopened"):
+            rendered = self._render(draft=True, action=action)
+            self.assertTrue(
+                self.gate.is_draft_tier(rendered),
+                f"a draft {action} run assembles real (reduced) legs and MUST stay "
+                f"draft-tier-marked — got {rendered!r}")
+            self.assertFalse(self.gate.is_no_leg_select(rendered), rendered)
+
+    def test_escape_label_flips_make_no_no_leg_claim(self):
+        """A ci-full/bench-full/fuzz-full flip DOES do real work in at least one
+        caller, so it must not claim to be evidence-free (conservative: the
+        pre-#3781 behaviour stands)."""
+        for label in self.ESCAPE_LABELS:
+            for draft in (True, False):
+                rendered = self._render(draft=draft, action="labeled", label=label)
+                self.assertFalse(
+                    self.gate.is_no_leg_select(rendered),
+                    f"{label} triggers real work — no no-leg claim allowed "
+                    f"(got {rendered!r})")
+                self.assertEqual(self.gate.is_draft_tier(rendered), draft, rendered)
+
+    def test_non_draft_and_non_pr_events_are_unchanged(self):
+        """push / merge_group / schedule and a non-draft synchronize must render the
+        BARE full-tier name, byte-identical to the pre-#3781 behaviour."""
+        bare = self.name.replace(_marker_expr_of(self.name), "")
+        self.assertEqual(self._render(draft=False, action="synchronize"), bare)
+        self.assertEqual(self._render(event="push"), bare)
+        self.assertEqual(self._render(event="merge_group"), bare)
+        self.assertEqual(self._render(event="schedule"), bare)
+        self.assertFalse(self.gate.is_draft_tier(bare))
+        self.assertFalse(self.gate.is_no_leg_select(bare))
+
+    def test_ready_for_review_renders_full_tier(self):
+        """The un-draft moment is the ONLY thing that can discharge a draft-tier
+        hold, so it must render the bare full-tier name."""
+        rendered = self._render(draft=False, action="ready_for_review")
+        self.assertFalse(self.gate.is_draft_tier(rendered))
+        self.assertFalse(self.gate.is_no_leg_select(rendered))
+
+    # ---- cross-file drift guards --------------------------------------------
+    def test_every_job_of_every_caller_is_inert_on_a_non_escape_label_flip(self):
+        """THE CLAIM BEHIND THE MARKER, checked by REACHABILITY, not by grep.
+
+        `…, no-leg` asserts the run assembled ZERO legs. That is true only because
+        every job of every ci-select caller is skipped on a non-escape label flip —
+        either by carrying the #2546 label-trigger guard itself, or by `needs:`-ing a
+        job that does, or by being restricted to a non-pull_request event. If any job
+        ever becomes reachable on such a flip, the shared select would claim `no-leg`
+        for a run that DID produce evidence, and the gate would then ignore that
+        evidence. Only the ci-select caller job is exempt — it is deliberately
+        unconditional, because a skipped select poisons the gate."""
+        guard = "contains(fromJSON('[\"labeled\",\"unlabeled\"]'), github.event.action)"
+        for wf_name in ("ci.yml", "feature-matrix.yml", "bench.yml", "fuzz.yml"):
+            wf = _load(REPO_ROOT / ".github" / "workflows" / wf_name)
+            jobs = wf["jobs"]
+
+            def needs_of(job_id):
+                raw = jobs[job_id].get("needs") or []
+                return [raw] if isinstance(raw, str) else list(raw)
+
+            def cond(job_id):
+                return " ".join(str(jobs[job_id].get("if", "")).split())
+
+            def event_restricted(job_id):
+                """`if:` pins the event to something that is not pull_request."""
+                text = cond(job_id)
+                return "github.event_name" in text and "pull_request" not in text
+
+            memo = {}
+
+            def inert(job_id):
+                if job_id in memo:
+                    return memo[job_id]
+                memo[job_id] = False  # a cycle can never prove inertness
+                text = cond(job_id)
+                alwaysish = "always()" in text or "!cancelled()" in text
+                memo[job_id] = (
+                    guard in text
+                    or event_restricted(job_id)
+                    or (bool(needs_of(job_id)) and not alwaysish
+                        and any(inert(n) for n in needs_of(job_id)))
+                )
+                return memo[job_id]
+
+            callers = [j for j, spec in jobs.items()
+                       if "ci-select.yml" in str(spec.get("uses", ""))]
+            self.assertEqual(len(callers), 1, f"{wf_name}: exactly one select caller")
+            live = sorted(j for j in jobs if j not in callers and not inert(j))
+            self.assertFalse(
+                live,
+                f"{wf_name}: {live} would still RUN on a non-escape label flip, so "
+                f"such a run does NOT assemble zero legs and the shared ci-select job "
+                f"must not claim `no-leg` for it — the gate would then ignore a run "
+                f"that produced real evidence (#3781 / the #2546 guard)")
+
+    def test_no_leg_condition_covers_every_caller_escape_label(self):
+        """Drift guard in the other direction: every label a caller treats as
+        'do real work' must be EXCLUDED from the no-leg condition, or a run that
+        does real work would be declared evidence-free and then IGNORED."""
+        expr = _marker_expr_of(self.name)
+        excluded = set()
+        for group in re.findall(
+            r"!contains\(fromJSON\('(\[[^']*\])'\), github\.event\.label\.name\)", expr
+        ):
+            excluded |= set(json.loads(group))
+        self.assertTrue(excluded, "the no-leg condition must exclude the escape labels")
+        self.assertEqual(excluded, set(self.ESCAPE_LABELS))
+        for wf_name in ("ci.yml", "feature-matrix.yml", "bench.yml", "fuzz.yml"):
+            text = (REPO_ROOT / ".github" / "workflows" / wf_name).read_text(
+                encoding="utf-8")
+            work_labels = set(
+                re.findall(r"github\.event\.label\.name == '([^']+)'", text)
+            )
+            for group in re.findall(
+                r"contains\(fromJSON\('(\[[^']*\])'\), github\.event\.label\.name\)",
+                text,
+            ):
+                work_labels |= set(json.loads(group))
+            missing = work_labels - excluded
+            self.assertFalse(
+                missing,
+                f"{wf_name} does real work on {sorted(missing)} — the no-leg "
+                f"condition must exclude those labels, or a run that produced real "
+                f"legs would be declared evidence-free and then IGNORED")
+
+    def test_the_evaluator_itself_is_not_vacuous(self):
+        """A wiring test whose evaluator silently returns '' for everything would
+        pass every assertion above. Prove the evaluator discriminates."""
+        self.assertTrue(_GhExpr("true && 'x'", {}).parse())
+        self.assertEqual(_GhExpr("false && 'x' || 'y'", {}).parse(), "y")
+        self.assertEqual(_GhExpr("!false && 'x' || 'y'", {}).parse(), "x")
+        self.assertTrue(_GhExpr("contains(fromJSON('[\"a\"]'), 'a')", {}).parse())
+        self.assertFalse(_GhExpr("contains(fromJSON('[\"a\"]'), 'b')", {}).parse())
+        self.assertIsNone(_GhExpr("github.missing.path", {"github": {}}).parse())
+        with self.assertRaises(GhExprError):
+            _GhExpr("a $$ b", {}).parse()
 
 
 class TestContainerScanMergeGroupGate(unittest.TestCase):

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import re
 import sys
 import unittest
 from contextlib import redirect_stdout
@@ -1555,14 +1556,20 @@ class TestDraftTierIntegrity(unittest.TestCase):
     # ---- stale draft-tier leg-set belt (full-tier pull_request runs) --------
     def test_full_tier_holds_then_reds_on_unsuperseded_draft_select(self):
         """A full-tier pull_request gate over a draft-tier-assembled leg set must
-        WAIT (the ready_for_review re-run is expected), and at budget exhaustion
-        must RED — never conclude success over draft-tier legs."""
+        WAIT (the ready_for_review re-run is expected) and must RED — never
+        conclude success over draft-tier legs.
+
+        [OPUS-5] #3781: with the PR STILL A DRAFT the hold is unsatisfiable, so the
+        refusal now arrives via the fast path instead of at budget exhaustion. The
+        verdict (exit 1) and the hold itself are unchanged; the budget-exhaustion
+        belt is pinned by TestUnsatisfiableHoldFastFail
+        ::test_unreadable_draft_state_falls_back_to_the_budget_belt."""
         polls = [[R(SELECT_DRAFT, started="2026-07-17T10:00:00Z", rid=1), GREEN]]
         code, out = run(tiny_cfg(), polls,
                         tier_ctx=draft_ctx(counting(True), run_tier="full"))
         self.assertEqual(code, 1)
         self.assertIn("awaiting the full-tier re-run", out)
-        self.assertIn("stale draft-tier run, full run pending", out)
+        self.assertIn("UNSATISFIABLE draft-tier hold", out)
 
     def test_full_tier_passes_once_full_select_supersedes(self):
         draft_sel = R(SELECT_DRAFT, started="2026-07-17T10:00:00Z", rid=1)
@@ -1607,8 +1614,10 @@ class TestDraftTierIntegrity(unittest.TestCase):
     def test_first_full_select_must_not_release_all_draft_instances(self):
         """REGRESSION (critic finding 2): with four draft-marked selects and only
         ONE later full-tier select ever registering, the gate must hold and then
-        RED at budget exhaustion — never conclude success over the three
-        workflows whose full-tier runs never registered any check-runs."""
+        RED — never conclude success over the three workflows whose full-tier runs
+        never registered any check-runs. ([OPUS-5] #3781: the PR is still a draft, so
+        the RED now arrives on the unsatisfiable-hold fast path; the COUNT — the
+        load-bearing part of this regression — is asserted either way.)"""
         drafts = [R(SELECT_DRAFT, started=f"2026-07-17T10:00:0{i}Z", rid=i)
                   for i in range(1, 5)]
         one_full = R(SELECT_FULL, started="2026-07-17T10:05:00Z", rid=99)
@@ -1617,7 +1626,6 @@ class TestDraftTierIntegrity(unittest.TestCase):
                         tier_ctx=draft_ctx(counting(True), run_tier="full"))
         self.assertEqual(code, 1)
         self.assertIn("awaiting the full-tier re-run", out)
-        self.assertIn("stale draft-tier run, full run pending", out)
         self.assertIn("3 draft-marked select instance(s)", out)
 
     def test_full_tier_non_pr_event_ignores_draft_selects(self):
@@ -1765,6 +1773,498 @@ class TestDraftTierIntegrity(unittest.TestCase):
                 url="https://github.com/o/r/actions/runs/111/job/5")
         code, out = run(tiny_cfg(), [[art, GREEN]])
         self.assertEqual(code, 0, out)
+
+
+SELECT_NO_LEG = "select / select (change-based test selection, no-leg)"
+
+
+def _job(name, *, run_id, status="completed", conclusion="success", jid=0,
+         started="2026-07-25T07:15:40Z"):
+    """An Actions Jobs-API payload as make_fetch_attempt_jobs returns it."""
+    return {"id": jid or run_id * 10, "name": name, "status": status,
+            "conclusion": conclusion, "started_at": started,
+            "html_url": f"https://github.test/o/r/actions/runs/{run_id}/job/{jid or 1}"}
+
+
+def _check(name, *, run_id, status="completed", conclusion="success", rid=0,
+           started="2026-07-25T07:15:40Z"):
+    """A commit check-run whose details_url locates its Actions run (the locator
+    no_leg_run_ids + the newest-run resolver both key off)."""
+    return R(name, status=status, conclusion=conclusion, rid=rid or run_id,
+             started=started,
+             url=f"https://github.test/o/r/actions/runs/{run_id}/job/{rid or 1}")
+
+
+class TestNoLegRunExclusion(unittest.TestCase):
+    """[OPUS-5] #3781 — a run that assembled NO LEGS is not evidence, so it must
+    never become the authoritative newest run for its workflow.
+
+    THE MEASURED SHAPE (sparq #3472, 2026-07-25). The PR was readied at 07:15:37 and
+    four full-tier runs started (CI's real matrix ran until 07:34:08). At 07:28:50 the
+    review pipeline re-drafted it and flipped `review:needs`; that label event started
+    8 more runs which completed within ~90s with EVERY job skipped except the
+    unconditional `select` — named `…, draft-tier`, because the PR was a draft again.
+    Two independent harms followed, and both are pinned here:
+      (1) four draft-marked select instances appeared with no possible full-tier
+          successor, so the gate burned all 155 polls and refused (the #3781 deadlock);
+      (2) newest-run resolution is per-workflow, so those vacuous runs BECAME
+          authoritative for CI/Benchmarks/feature-matrix/fuzz — meaning the real,
+          still-in-flight legs were discarded and replaced by `skipped` ones.
+
+    Harm (2) is why the fix ignores the RUN rather than merely neutralising the select
+    NAME: neutralising the name alone would have turned the deadlock into a GREEN gate
+    rendered over legs that had not finished. Every test below drives the PRODUCTION
+    call site (WorkflowRunResolver.__call__), not resolve_newest_workflow_runs
+    directly, so dropping the `no_leg_ids=` argument there is caught."""
+
+    def _resolver(self, checks_by_poll, workflows_by_poll):
+        """A WorkflowRunResolver over scripted (checks, workflows) polls."""
+        state = {"i": 0}
+
+        def nth(seq):
+            i = min(state["i"], len(seq) - 1)
+            return [dict(x) for x in seq[i]]
+
+        def fetch_checks():
+            return nth(checks_by_poll)
+
+        def fetch_workflows():
+            out = nth(workflows_by_poll)
+            state["i"] += 1
+            return out
+
+        jobs = {}
+        posts = []
+
+        def fetch_attempt_jobs(run_id, attempt):
+            return [dict(j) for j in jobs.get(run_id, [])]
+
+        resolver = g.WorkflowRunResolver(
+            self_run_id="999",
+            fetch_checks=fetch_checks,
+            fetch_workflows=fetch_workflows,
+            fetch_attempt_jobs=fetch_attempt_jobs,
+            redispatch=posts.append,
+        )
+        resolver.jobs = jobs
+        resolver.posts = posts
+        return resolver
+
+    def _drive(self, resolver, cfg=None, tier_ctx=None, depth=0):
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = g.run_gate(cfg or tiny_cfg(), resolver, lambda: depth,
+                              sleep_fn=lambda s: None, tier_ctx=tier_ctx)
+        return code, out.getvalue()
+
+    # ---- (a) the suppression -------------------------------------------------
+    def test_a_label_flip_no_op_run_cannot_erase_a_real_runs_FAILURE(self):
+        """(a) THE SHARPEST FORM. The real full-tier run FAILED. A later label-flip
+        no-op run of the same workflow must NOT supersede it — a red must survive a
+        label flip. Mutating the suppression away (dropping `no_leg_ids=` at the call
+        site, or making no_leg_run_ids return an empty set) makes the vacuous run
+        newest, its `skipped` legs satisfy the gate, and this GREENS."""
+        real = W(101, 7, name="CI", conclusion="failure",
+                 created="2026-07-25T07:15:37Z")
+        flip = W(102, 7, name="CI", conclusion="success",
+                 created="2026-07-25T07:28:57Z")
+        checks = [
+            _check("test shard", run_id=101, conclusion="failure", rid=1),
+            _check(SELECT_FULL, run_id=101, rid=2),
+            _check("test shard", run_id=102, conclusion="skipped", rid=3,
+                   started="2026-07-25T07:29:23Z"),
+            _check(SELECT_NO_LEG, run_id=102, rid=4,
+                   started="2026-07-25T07:29:23Z"),
+        ]
+        resolver = self._resolver([checks], [[real, flip]])
+        resolver.jobs[101] = [_job("test shard", run_id=101, conclusion="failure"),
+                              _job("select / select (change-based test selection)",
+                                   run_id=101, jid=2)]
+        resolver.jobs[102] = [_job("test shard", run_id=102, conclusion="skipped"),
+                              _job(SELECT_NO_LEG, run_id=102, jid=2)]
+        code, out = self._drive(resolver)
+        self.assertEqual(
+            code, 1,
+            "a guarded label-flip no-op run must NOT supersede the real run and erase "
+            "its FAILURE — the gate went GREEN over a vacuous all-skipped run "
+            f"(#3781). Output:\n{out}")
+        self.assertIn("declared NO LEGS", out)
+
+    def test_a_label_flip_no_op_run_cannot_discard_an_inflight_real_run(self):
+        """(a, second harm) The real run is STILL RUNNING when the flip lands (the
+        measured #3472 timing: real CI finished 07:34:08, the flip runs completed by
+        07:29:47). The gate must keep WAITING on the real legs and conclude on them —
+        not conclude immediately over the flip run's skipped ones."""
+        inflight = W(101, 7, name="CI", status="in_progress", conclusion=None,
+                     created="2026-07-25T07:15:37Z")
+        done = W(101, 7, name="CI", conclusion="success",
+                 created="2026-07-25T07:15:37Z")
+        flip = W(102, 7, name="CI", conclusion="success",
+                 created="2026-07-25T07:28:57Z")
+        pending_checks = [
+            _check("test shard", run_id=101, status="in_progress", conclusion=None,
+                   rid=1),
+            _check(SELECT_FULL, run_id=101, rid=2),
+            _check(SELECT_NO_LEG, run_id=102, rid=4,
+                   started="2026-07-25T07:29:23Z"),
+        ]
+        done_checks = [
+            _check("test shard", run_id=101, rid=1),
+            _check(SELECT_FULL, run_id=101, rid=2),
+            _check(SELECT_NO_LEG, run_id=102, rid=4,
+                   started="2026-07-25T07:29:23Z"),
+        ]
+        resolver = self._resolver(
+            [pending_checks, pending_checks, done_checks],
+            [[inflight, flip], [inflight, flip], [done, flip]],
+        )
+        resolver.jobs[101] = [_job("test shard", run_id=101),
+                              _job(SELECT_FULL, run_id=101, jid=2)]
+        code, out = self._drive(resolver)
+        self.assertEqual(code, 0, out)
+        self.assertIn(
+            "attempt 1: 3 check-run(s), 2 running", out,
+            "the in-flight real leg must still be counted as PENDING — a vacuous "
+            "label-flip run superseded it, so the gate stopped waiting for the real "
+            f"matrix (#3781). Output:\n{out}")
+
+    def test_the_no_leg_select_creates_no_draft_tier_hold(self):
+        """(a, the deadlock itself) The exact #3472 head: a completed real full-tier
+        run plus a later label-flip no-op run, gate at FULL tier, PR currently a
+        DRAFT. The no-leg select must create NO hold — with the pre-fix
+        `, draft-tier` name this is precisely the state that burned 155 polls."""
+        real = W(101, 7, name="CI", created="2026-07-25T07:15:37Z")
+        flip = W(102, 7, name="CI", created="2026-07-25T07:28:57Z")
+        checks = [
+            _check("test shard", run_id=101, rid=1),
+            _check(SELECT_FULL, run_id=101, rid=2),
+            _check(SELECT_NO_LEG, run_id=102, rid=4,
+                   started="2026-07-25T07:29:23Z"),
+        ]
+        resolver = self._resolver([checks], [[real, flip]])
+        resolver.jobs[101] = [_job("test shard", run_id=101),
+                              _job(SELECT_FULL, run_id=101, jid=2)]
+        code, out = self._drive(
+            resolver, tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 0, out)
+        self.assertNotIn(
+            "awaiting the full-tier re-run", out,
+            "a no-leg select must not manufacture a draft-tier hold: its run "
+            "assembled zero legs and no full-tier successor can ever exist while "
+            f"the PR is a draft (#3781). Output:\n{out}")
+        self.assertIn("PASSED", out)
+
+    def test_a_cancelled_no_leg_run_is_never_redispatched(self):
+        """(a) The exclusion must reach the #3505 REDISPATCH decision too, not only the
+        check-resolution pass. A cancelled label-flip no-op run would otherwise look
+        like `the newest run of this workflow was cancelled`, burning the once-only
+        `actions: write` re-run POST on a vacuous run and then REDding the gate with
+        `superseded-legs, re-run required`. All three consumers of `newest` (redispatch,
+        the attempt-jobs inventory, resolution) must agree on who is authoritative."""
+        real = W(101, 7, name="CI", created="2026-07-25T07:15:37Z")
+        cancelled_flip = W(102, 7, name="CI", conclusion="cancelled",
+                           created="2026-07-25T07:28:57Z")
+        checks = [
+            _check("test shard", run_id=101, rid=1),
+            _check(SELECT_FULL, run_id=101, rid=2),
+            _check(SELECT_NO_LEG, run_id=102, conclusion="cancelled", rid=4,
+                   started="2026-07-25T07:29:23Z"),
+        ]
+        resolver = self._resolver([checks], [[real, cancelled_flip]])
+        resolver.jobs[101] = [_job("test shard", run_id=101),
+                              _job(SELECT_FULL, run_id=101, jid=2)]
+        code, out = self._drive(resolver)
+        self.assertFalse(
+            resolver.posts,
+            "a cancelled label-flip NO-OP run must never be re-dispatched — it "
+            "assembled no legs, so re-running it produces no evidence and its "
+            f"cancellation is not a superseded-legs event (#3781). Output:\n{out}")
+        self.assertEqual(code, 0, out)
+        self.assertNotIn("superseded-legs, re-run required", out)
+
+    # ---- (b) the discrimination: draft-tier CI must NOT be blinded -----------
+    def test_a_genuine_draft_tier_run_stays_authoritative_and_still_holds(self):
+        """(b) THE OTHER HALF. A real DRAFT-TIER run (a draft `synchronize`, which
+        assembles a genuinely reduced leg set) must NOT be ignored: it stays the
+        authoritative newest run AND its draft-marked select still creates the hold
+        that keeps draft-assembled legs out of the merge queue. A fix that ignored
+        draft-tier runs too would blind draft-tier CI completely."""
+        draft_run = W(201, 7, name="CI", created="2026-07-25T06:00:00Z")
+        checks = [
+            _check("test shard", run_id=201, rid=1, started="2026-07-25T06:00:10Z"),
+            _check(SELECT_DRAFT, run_id=201, rid=2, started="2026-07-25T06:00:10Z"),
+        ]
+        resolver = self._resolver([checks], [[draft_run]])
+        resolver.jobs[201] = [_job("test shard", run_id=201,
+                                   started="2026-07-25T06:00:10Z"),
+                              _job(SELECT_DRAFT, run_id=201, jid=2,
+                                   started="2026-07-25T06:00:10Z")]
+        code, out = self._drive(
+            resolver, tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1, out)
+        self.assertNotIn(
+            "declared NO LEGS", out,
+            "a genuinely draft-tier run assembles REAL (reduced) legs and must stay "
+            f"authoritative — the fix must not blind draft-tier CI. Output:\n{out}")
+        self.assertIn("awaiting the full-tier re-run", out,
+                      "the draft-tier hold must still be created for a real "
+                      "draft-assembled leg set")
+        self.assertIn("test shard", [r.get("name") for r in resolver()],
+                      "the draft-tier run's own legs must still be judged")
+
+    # ---- predicate-level belts ----------------------------------------------
+    def test_marker_predicates_discriminate_all_three_tiers(self):
+        self.assertEqual(g.NO_LEG_MARKER, ", no-leg")
+        self.assertEqual(g.select_tier(SELECT_FULL), "full")
+        self.assertEqual(g.select_tier(SELECT_DRAFT), "draft")
+        self.assertEqual(g.select_tier(SELECT_NO_LEG), "no-leg")
+        self.assertTrue(g.is_no_leg_select(SELECT_NO_LEG))
+        self.assertFalse(g.is_no_leg_select(SELECT_DRAFT))
+        self.assertFalse(g.is_no_leg_select(SELECT_FULL))
+        self.assertFalse(g.is_draft_tier(SELECT_NO_LEG),
+                         "a no-leg select must never read as draft-tier")
+        self.assertTrue(g.is_select(SELECT_NO_LEG))
+        self.assertFalse(g.is_advisory(SELECT_NO_LEG))
+        self.assertEqual(g.normalized_name(SELECT_NO_LEG), SELECT_FULL)
+
+    def test_a_compound_select_can_never_declare_its_run_evidence_free(self):
+        """FAIL-CLOSED hardening: only the PURE ci-select pre-job may make its run
+        non-authoritative. A compound job that carries additional gating evidence
+        (fv-select + fv-manifest) keeps its run authoritative even if the marker
+        drifted onto its name."""
+        compound = ("fv-select (change-based test selection, no-leg) + "
+                    "fv-manifest (proof inventory)")
+        self.assertFalse(g.is_no_leg_select(compound))
+        self.assertEqual(
+            g.no_leg_run_ids([_check(compound, run_id=303, rid=1)]), set(),
+            "an evidence-bearing compound job must not be able to make its whole "
+            "run a non-event")
+
+    def test_no_leg_run_ids_reads_the_run_locator(self):
+        self.assertEqual(
+            g.no_leg_run_ids([_check(SELECT_NO_LEG, run_id=102, rid=4)]), {102})
+        self.assertEqual(g.no_leg_run_ids([_check(SELECT_FULL, run_id=101, rid=1)]),
+                         set())
+        # No parseable run id => nothing to exclude (fail back to the old behaviour).
+        self.assertEqual(g.no_leg_run_ids([R(SELECT_NO_LEG)]), set())
+
+    def test_a_no_leg_select_can_neither_create_nor_discharge_a_hold(self):
+        """The predicate-level belt (defence in depth: in production the whole run is
+        already dropped upstream). A no-leg instance is in NEITHER pool."""
+        no_leg = R(SELECT_NO_LEG, started="2026-07-25T07:29:23Z", rid=4)
+        draft = R(SELECT_DRAFT, started="2026-07-25T06:00:00Z", rid=1)
+        self.assertEqual(g.draft_selects_unsuperseded([no_leg]), [],
+                         "a no-leg select must not CREATE a hold (#3781)")
+        self.assertEqual(
+            g.draft_selects_unsuperseded([draft, no_leg]), [SELECT_DRAFT],
+            "a no-leg select must not DISCHARGE a real draft-tier hold — "
+            "evidence-free selection can never stand in for the full-tier re-run")
+
+    def test_a_no_leg_success_does_not_forgive_a_cancelled_real_select(self):
+        """forgive_superseded is tier-aware in THREE values now: a later no-leg
+        success must not excuse a cancelled draft-tier select (which would release
+        the hold by deleting the instance that demands a successor)."""
+        cancelled_draft = R(SELECT_DRAFT, conclusion="cancelled",
+                            started="2026-07-25T06:00:00Z", rid=1)
+        later_no_leg = R(SELECT_NO_LEG, started="2026-07-25T07:29:23Z", rid=4)
+        kept, forgiven = g.forgive_superseded([cancelled_draft, later_no_leg])
+        self.assertEqual(forgiven, [],
+                         "a no-leg select must not forgive a cancelled real-tier "
+                         "select")
+        self.assertIn(cancelled_draft, kept)
+        # The intended un-draft flow is untouched: a later FULL-tier select still does.
+        later_full = R(SELECT_FULL, started="2026-07-25T07:29:23Z", rid=5)
+        _, forgiven2 = g.forgive_superseded([cancelled_draft, later_full])
+        self.assertEqual(forgiven2, [cancelled_draft])
+
+
+class TestUnsatisfiableHoldFastFail(unittest.TestCase):
+    """[OPUS-5] #3781 ask 2 — the gate can DETECT an unsatisfiable hold, so it must
+    say so instead of burning the budget.
+
+    Measured on #3472/#3468/#3681: the gate spent all 155 poll attempts printing
+    `awaiting the full-tier re-run (draft-tier selection present)` and then emitted
+    the refusal it could have emitted at poll 3 — ~37 minutes of silent burn per
+    occurrence, on PRs with ZERO failing legs. The hold is a WAIT for the
+    ready_for_review full-tier re-runs; when every sibling has concluded, a
+    draft-marked select still lacks a successor, AND the PR is currently a draft, no
+    such re-run can happen (only a non-draft payload produces a full-tier select), so
+    the wait is unsatisfiable on arrival.
+
+    This is a `return 1` — the same verdict the budget-exhaustion belt reaches, named
+    honestly and ~1 minute in. It NEVER turns a would-be RED green."""
+
+    def _stuck(self):
+        """All-terminal set holding on one draft-marked select with no successor."""
+        return [[R(SELECT_DRAFT, started="2026-07-25T07:29:23Z", rid=1), GREEN]]
+
+    # ---- (c) detection + the naming diagnosis --------------------------------
+    def test_unsatisfiable_hold_fails_fast_with_the_naming_diagnosis(self):
+        cfg = tiny_cfg()
+        fetch = scripted(self._stuck())
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = g.run_gate(cfg, fetch, lambda: 0, sleep_fn=lambda s: None,
+                              tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        text = out.getvalue()
+        self.assertEqual(code, 1, text)
+        self.assertIn("UNSATISFIABLE draft-tier hold", text)
+        self.assertIn("PR is CURRENTLY A DRAFT", text)
+        self.assertIn("1 draft-marked select instance(s)", text)
+        self.assertIn("gh pr ready", text, "the diagnosis must name the remedy")
+        self.assertLess(
+            fetch.state["calls"], cfg.max_total_polls,
+            "the unsatisfiable hold must be DETECTED, not waited out: the gate "
+            f"burned all {cfg.max_total_polls} polls on a refusal that was already "
+            "decided at poll 3 (#3781 — measured 155 polls / ~37 min per "
+            "occurrence, 3-for-3)")
+        self.assertLessEqual(
+            fetch.state["calls"], cfg.unsat_confirm_polls + cfg.min_polls,
+            f"detection must fire within the confirm window; took "
+            f"{fetch.state['calls']} polls")
+
+    def test_the_fast_path_only_ever_reds(self):
+        """No new exit-0 path: the detector's only outcome is the refusal."""
+        source = (REPO_ROOT / "scripts" / "ci_summary_gate.py").read_text(
+            encoding="utf-8")
+        self.assertEqual(
+            len(re.findall(r"^\s*return 0\b", source, re.M)), 5,
+            "the #3781 detector must add only `return 1` paths — the gate's exit-0 "
+            "surface is FIXED and enumerated in the module header (_draft_recheck's "
+            "two, render_verdict's empty-set + PASS, and _self_test's)")
+
+    # ---- (d) the discrimination: a still-settling set is NOT unsatisfiable ---
+    def test_a_still_settling_set_is_not_declared_unsatisfiable(self):
+        """(d) The hold with legs STILL RUNNING is exactly what the wait is for. It
+        must not be called unsatisfiable, and once the full-tier select lands the
+        gate must PASS."""
+        draft_sel = R(SELECT_DRAFT, started="2026-07-25T07:29:23Z", rid=1)
+        full_sel = R(SELECT_FULL, started="2026-07-25T07:35:00Z", rid=2)
+        # The pending phase deliberately outlasts min_polls + unsat_confirm_polls, so a
+        # detector that ignored `pending` WOULD fire here (and RED) before the re-run
+        # registers. That is the whole discrimination.
+        cfg = tiny_cfg(max_total_polls=12, base_polls=10)
+        polls = [
+            [draft_sel, PENDING],                    # legs still running: settling
+            [draft_sel, PENDING],
+            [draft_sel, PENDING],
+            [draft_sel, PENDING],
+            [draft_sel, PENDING],
+            [draft_sel, PENDING],
+            [draft_sel, full_sel, GREEN],            # the full-tier re-run registers
+            [draft_sel, full_sel, GREEN],
+            [draft_sel, full_sel, GREEN],
+        ]
+        code, out = run(cfg, polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertNotIn(
+            "UNSATISFIABLE", out,
+            "a set with siblings STILL RUNNING is genuinely settling — the hold is a "
+            "WAIT for those legs, so declaring it unsatisfiable is a false RED "
+            f"(#3781). Output:\n{out}")
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+
+    def test_a_hold_about_to_be_discharged_is_not_declared_unsatisfiable(self):
+        """(d) The confirm window's REASON. The set is all-terminal and the hold looks
+        stuck, but the full-tier select is merely a poll or two behind (check-run
+        registration lag at the un-draft moment). Firing on the FIRST observation would
+        RED a PR whose successor lands immediately afterwards; the state must persist
+        for unsat_confirm_polls first."""
+        draft_sel = R(SELECT_DRAFT, started="2026-07-25T07:29:23Z", rid=1)
+        full_sel = R(SELECT_FULL, started="2026-07-25T07:35:00Z", rid=2)
+        polls = [
+            [draft_sel, GREEN],                      # all-terminal, hold looks stuck
+            [draft_sel, GREEN],
+            [draft_sel, full_sel, GREEN],            # lag over: the successor lands
+            [draft_sel, full_sel, GREEN],
+            [draft_sel, full_sel, GREEN],
+        ]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertNotIn(
+            "UNSATISFIABLE", out,
+            "the confirm window exists so a successor that is merely LATE is not "
+            f"mistaken for one that can never come (#3781). Output:\n{out}")
+        self.assertEqual(code, 0, out)
+        self.assertIn("PASSED", out)
+
+    def test_a_readied_pr_is_not_declared_unsatisfiable(self):
+        """(d) The PR reads NON-draft: the ready_for_review full-tier re-runs may
+        still be registering, so the hold is satisfiable and the detector must stand
+        down. The pre-#3781 budget-exhaustion belt then renders the refusal."""
+        fetch_draft = counting(False)
+        code, out = run(tiny_cfg(), self._stuck(),
+                        tier_ctx=draft_ctx(fetch_draft, run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertNotIn("UNSATISFIABLE", out)
+        self.assertIn("stale draft-tier run, full run pending", out)
+        self.assertGreater(fetch_draft.state["calls"], 0,
+                           "the detector must actually READ the live draft state")
+
+    def test_unreadable_draft_state_falls_back_to_the_budget_belt(self):
+        """An API failure must not manufacture a NEW failure mode: the detector
+        stands down and the gate behaves exactly as it did pre-#3781 (hold, then RED
+        at budget exhaustion via render_verdict's stale-draft-tier belt)."""
+        cfg = tiny_cfg()
+        fetch = scripted(self._stuck())
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = g.run_gate(
+                cfg, fetch, lambda: 0, sleep_fn=lambda s: None,
+                tier_ctx=draft_ctx(counting(g.FetchError("api down")),
+                                   run_tier="full"))
+        text = out.getvalue()
+        self.assertEqual(code, 1, text)
+        self.assertNotIn("UNSATISFIABLE", text)
+        self.assertIn("stale draft-tier run, full run pending", text)
+        self.assertEqual(fetch.state["calls"], cfg.max_total_polls,
+                         "an unreadable draft state must fall back to the full "
+                         "pre-#3781 budget, never to a fast RED")
+
+    def test_no_hold_means_the_draft_api_is_never_touched(self):
+        """Cost + blast-radius discipline: a full-tier run with no draft-tier hold
+        must not read the PR's draft state at all (the pre-#3781 invariant)."""
+        fetch_draft = counting(True)
+        code, out = run(tiny_cfg(), [[GREEN, GREEN2]],
+                        tier_ctx=draft_ctx(fetch_draft, run_tier="full"))
+        self.assertEqual(code, 0, out)
+        self.assertEqual(fetch_draft.state["calls"], 0)
+
+    def test_the_startup_floor_is_respected(self):
+        """min_polls guards a startup race: no verdict — including this one — before
+        the floor, so a check set that has barely begun registering cannot be
+        declared unsatisfiable."""
+        cfg = tiny_cfg(min_polls=6, unsat_confirm_polls=1, max_total_polls=8)
+        fetch = scripted(self._stuck())
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = g.run_gate(cfg, fetch, lambda: 0, sleep_fn=lambda s: None,
+                              tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1, out.getvalue())
+        self.assertGreaterEqual(fetch.state["calls"], 6,
+                                "the detector must not fire before min_polls")
+
+    def test_a_failing_leg_still_fails_FAST_ahead_of_the_hold_diagnosis(self):
+        """Precedence: a genuine failing leg is the better diagnosis, and the
+        existing fail-fast path must still win."""
+        polls = [[R(SELECT_DRAFT, started="2026-07-25T07:29:23Z", rid=1), RED,
+                  PENDING]]
+        code, out = run(tiny_cfg(), polls,
+                        tier_ctx=draft_ctx(counting(True), run_tier="full"))
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED (fail-fast)", out)
+        self.assertIn("- ✗ clippy: failure", out)
+        self.assertNotIn("UNSATISFIABLE", out)
+
+    def test_a_non_pr_event_never_reaches_the_detector(self):
+        """merge_group/push run on a fresh ref and have no PR to read."""
+        fetch_draft = counting(True)
+        ctx = g.TierContext(run_tier="full", event_name="merge_group",
+                            fetch_pr_draft=fetch_draft)
+        code, out = run(tiny_cfg(), [[R(SELECT_DRAFT), GREEN]], tier_ctx=ctx)
+        self.assertEqual(code, 0, out)
+        self.assertEqual(fetch_draft.state["calls"], 0)
 
 
 class TestMergeGroupChangeClassAccounting(unittest.TestCase):


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. Authored and reviewed by AI agents.

Fixes #3781.

## The defect, in one screenful of API output

`sparq-orchestrator[bot]` re-drafts a freshly-readied worker PR ~13 min after the ready (07:28:50 #3472, 07:28:54 #3468, 07:01:21 #3681) and flips `review:needs` in the same breath. That label event re-triggers `ci.yml` / `bench.yml` / `feature-matrix.yml` / `fuzz.yml`. The #2546 label-trigger guard does its job — every root job is skipped — so the run contributes nothing. Here is what each of #3472's **eight** label-flip runs actually contained (non-skipped jobs only):

```
30149378802 feature-matrix  select / select (change-based test selection, draft-tier)=success
30149378811 fuzz            select / select (change-based test selection, draft-tier)=success
30149378812 Benchmarks      select / select (change-based test selection, draft-tier)=success
30149379023 Benchmarks      select / select (change-based test selection, draft-tier)=success
30149379034 CI              select / select (change-based test selection, draft-tier)=success
30149379039 fuzz            select / select (change-based test selection, draft-tier)=success
30149379052 feature-matrix  select / select (change-based test selection, draft-tier)=success
30148989669 CI (07:15:37, the REAL ready_for_review run)  ... completed 07:34:08
```

One non-skipped job per run — the unconditional `select` pre-job — and because the PR was a draft again, each came out named **`…, draft-tier`**. Four draft-marked select instances (after newest-run resolution) now sat on a head whose full-tier successor **can never exist**: only a NON-draft `pull_request` payload produces a full-tier select. The gate burned all **155 poll attempts** on `awaiting the full-tier re-run (draft-tier selection present)` and then correctly fail-closed-refused.

**All three PRs had ZERO failing legs** — #3468: 422 runs / 0 failures; #3681: 196 / 0; #3472: `clippy (gate)` success, no failing leg at all. The only red was `gate`, and only because of the mixed leg set the race created. **Measured cost per occurrence: a full CI matrix wasted plus 155 wasted polls (~37 min) producing a guaranteed refusal — 3-for-3 in one drain pass.**

## Which option, and why

**Option (A)** — suppress the draft-tier `select` re-dispatch — *plus the run-level half that (A) alone gets wrong.*

**(B) is not implementable in this repo.** The re-draft actor is `sparq-orchestrator[bot]`, driven from the registry-side review pipeline; nothing in sparq converts a PR *to* draft (`scripts/auto-arm.py` and `scripts/rearm-sweeper.py` only ever mark drafts *ready*). "Defer the re-draft until the gate concludes" would have to land in the private orchestration repo, i.e. it cannot be shipped or tested here.

**(A) as literally worded has a hole, and it is a bad one.** "Suppress the draft-tier marker on the flip run" leaves the vacuous run *authoritative*: newest-run resolution (#3505) is per-workflow, so the flip run **becomes** the newest run for CI / Benchmarks / feature-matrix / fuzz and its all-`skipped` leg set **replaces** the real one. #3472's real CI matrix ran until **07:34:08**, six minutes *after* the flip runs completed (07:29:47) — so a name-only fix would have turned the 155-poll deadlock into a **GREEN gate rendered over legs that had not finished**. Worse, the same path erases a real `failure`.

So the fix keeps (A)'s framing — change no policy, no timing, only what the gate concludes from a run that assembled nothing — and applies it to the **run**, not just the name:

1. **`ci-select.yml`** names its job `…, no-leg` (never `…, draft-tier`) when the caller's event is a `labeled`/`unlabeled` `pull_request` whose label is not `ci-full`/`bench-full`/`fuzz-full` — exactly the condition under which every caller's root jobs are already `if:`-skipped. On an escape label at least one caller *does* real work, so no claim is made and the pre-#3781 behaviour stands unchanged (conservative; the review pipeline never flips those labels).
2. **The gate treats a no-leg run as NON-AUTHORITATIVE** — excluded from newest-run candidacy, so every check-run it produced (its select plus the whole skipped `needs:` graph) is a non-event and the **previous real run stays authoritative**. This is *strictly more fail-closed* than what it replaces: a mid-flight run keeps the gate polling, and a FAILED run keeps failing it, instead of being erased by a label flip. The exclusion is applied once, before anything downstream keys off `newest`, so the redispatch decision, the attempt-jobs inventory and check resolution cannot disagree about who is authoritative.
3. **Belts.** A no-leg select can neither create nor discharge a draft-tier hold, and can never forgive a cancelled real-tier select (`select_tier` is three-valued now). Only the **pure** ci-select pre-job may declare its run evidence-free — a compound `fv-select … + fv-manifest …` job carrying the marker fails CLOSED and keeps gating.

**Ask 2, the fail-fast half.** A full-tier PR gate whose siblings have **all** concluded, which still holds on a draft-marked select with no successor, and whose PR reads as **currently a draft**, is waiting for something that cannot happen. It now REDs immediately naming exactly that (with the remedy) instead of burning the remaining budget. It is the *same* refusal the budget-exhaustion belt reaches: **`return 0` count unchanged (5), only `return 1` added.** It stands down when the set is still settling, when the PR reads non-draft, or when the draft state is unreadable — that last one matters, because a false RED there would be a *new* failure mode whereas burning the budget is merely slow.

## Verification — 22 mutations of the LIVE files, zero survivors

Full harness output in the task report. The wiring is tested, not just the predicates: a ~120-line GitHub-expression evaluator **evaluates the live `name:` expression** against synthetic event payloads and feeds the rendered check-run name to the real gate predicates (YAML → name → verdict), and the "assembles zero legs" claim is proved by **`needs:`-graph reachability** over all four callers rather than by grep. Representative naming assertions:

| Mutation (of the live file) | Naming assertion that fired |
|---|---|
| gate call site drops `no_leg_ids=` | `a guarded label-flip no-op run must NOT supersede the real run and erase its FAILURE — the gate went GREEN over a vacuous all-skipped run (#3781)` |
| `newest_workflow_runs(authoritative)` → `(workflows)` | `[102] is not false : a cancelled label-flip NO-OP run must never be re-dispatched — it assembled no legs, so re-running it produces no evidence` |
| YAML drops the no-leg branch | `', no-leg' not found in 'select (change-based test selection, draft-tier)' : labeled review:needs on a draft PR must render the no-leg marker` |
| YAML drops the `!` before the escape-label list | `ci-full triggers real work — no no-leg claim allowed (got '… , no-leg')` |
| YAML marks every draft run no-leg | `a draft opened run assembles real (reduced) legs and MUST stay draft-tier-marked` |
| `is_no_leg_select` swallows draft-tier too | `a genuinely draft-tier run assembles REAL (reduced) legs and must stay authoritative — the fix must not blind draft-tier CI` |
| `ci.yml` drops its label guard | `ci.yml: ['build-archive', 'changes', 'conformance', …, 'wasm'] would still RUN on a non-escape label flip, so such a run does NOT assemble zero legs` |
| detector removed / never REDs / text gutted | `'UNSATISFIABLE draft-tier hold' not found in "attempt 1 … attempt 8 …"` (the run burns the whole budget again) |
| detector ignores `pending` | `a set with siblings STILL RUNNING is genuinely settling — the hold is a WAIT for those legs, so declaring it unsatisfiable is a false RED` |
| confirm window removed | `the confirm window exists so a successor that is merely LATE is not mistaken for one that can never come` |
| detector ignores the live draft state | `'UNSATISFIABLE' unexpectedly found …` (a readied PR / unreadable API state must fall back to the budget belt) |

Real tails, run the way CI does: `test_ci_summary_gate.py` **167 tests OK**, `test_ci_select_wiring.py` **74 OK**, `ci_summary_gate.py --self-test` OK, plus `test_ci_select.py` / `test_path_ownership.py` / `test_ci_selection_alarm.py` / `test_arm_capability_wiring.py` / `test_cone_coverage.py` / `test_feature_matrix_assemble.py` / `test_gates.py` OK, `actionlint` clean on the changed workflows, `check-no-perf-numbers --enforce` / `check-terminology` / `check-advisory-registry` clean.

## Notes for review

* **One dead branch removed rather than tested.** An explicit `run_id in no_leg_ids` early-return in `resolve_newest_workflow_runs` survived every mutant, because excluding the run from `newest` already drops its checks via `run_id != latest_id` or `latest is None`. A guard no input can distinguish is a guard no test can pin, so it is gone and the reasoning is in a comment.
* **Reasoned but not separately tested:** the same exclusion should also restore the `feature-matrix report` requirement after a label flip (the flip run's placeholder `opt-in group (…)` checks no longer win `fm_group_run_id`, so the CURRENT group run is the real one again). Same fail-closed direction; called out rather than claimed as verified.
* **Residual, deliberately not fixed:** on a `bench-full`/`fuzz-full` flip, the *other* callers' runs are no-ops but make no no-leg claim, so they still supersede — today's behaviour exactly, and not the reported defect.
* A sibling gate-budget fix is in flight on `fable/main-green-hang-detector-and-descoped-ec2-lane` (#3783). Both touch `scripts/ci_summary_gate.py`; this diff is scoped to the draft-tier / unsatisfiable-hold path, so **a trivial rebase may be needed** depending on merge order.
* **NOT armed.**
