### PR TITLE
fix(bench): re-derive the µs hard-zone noise floor — the 2x on main is runner noise, not #3755/#3679

### DIFF
--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -119,13 +119,35 @@ DISAPPEAR_FAIL_FRACTION = 0.30  # > 30% of gateable metrics missing from results
 # its unit appears here AND its median-of-window is below that unit's floor. Floors are
 # justified PER-UNIT by the measured honest run-to-run bands in the published benchmark-data
 # history (2026-07-23 replay):
-#   * "us" (micros, floor 20.0): µs-scale timing metrics have HONEST noise bands exceeding the
+#   * "us" (micros, floor 40.0): µs-scale timing metrics have HONEST noise bands exceeding the
 #     2.0x hard threshold. Within the honest pre-red-era oldest-10 points alone, max/min bands:
 #     sameas_size32_query_us 2.55x (values ~4-9µs), deeptax_d1000_query_us 3.25x (~4-13µs),
 #     lubm_q14_count_us 2.45x. Live replays: the honest head fails sameas_size32_query_us at
 #     2.14x (9 vs median 4.2); another honest entry fails deeptax_d1000_query_us at 2.00x
-#     (8 vs 4). Every observed false-fail metric has a median <~15 units; 20.0 covers them
-#     with margin while keeping every >= 20µs timing metric fully hard-gated.
+#     (8 vs 4).
+#     RE-DERIVED 2026-07-25 (the original 20.0 was set from the oldest-10 window and its
+#     "every false-fail has a median <~15" claim no longer holds). Replaying THIS gate's own
+#     methodology — worst current/median-of-trailing-5 per metric — over the full published
+#     `us` history, bucketed by metric magnitude, the honest band is:
+#         median  0-10µs : n=48  p90 1.84x  MAX 3.00x   (2 metrics >= 2.0x)
+#         median 10-20µs : n=40  p90 1.81x  MAX 2.09x   (1 metric  >= 2.0x)
+#         median 20-40µs : n=15  p90 1.84x  MAX 2.23x   (1 metric  >= 2.0x)
+#         median 40-80µs : n=30  p90 1.80x  MAX 1.88x   (none)
+#         median 80-200µs: n=25  p90 1.59x  MAX 1.76x   (none)
+#         median >=200µs : n=153 p90 1.52x  MAX 1.90x   (none)
+#     These buckets are a LOWER BOUND on the honest band, not an estimate of it: bench.yml's
+#     "Store + compare against history" step runs AFTER this gate and is skipped when the gate
+#     fails, so the published series contains only runs that already passed — every honest run
+#     whose noise exceeded the threshold is censored from the very history used to set the floor.
+#     The honest band only drops below the 2.0x hard threshold at >= 40µs, so 20.0 left the
+#     20-40µs band hard-gated INSIDE its own noise: honest history alone already reaches
+#     watdiv_sf1_L2_json_us 2.23x (43.7 vs trailing median 19.6) and watdiv_sf1_L2_materialize_us
+#     1.97x, and this floor's under-setting red main on run 30154655798 (a site-only commit —
+#     no Rust in the diff) via watdiv_sf1_L5_materialize_us 2.03x (median 20.6) and
+#     watdiv_sf1_S5_json_us 2.08x (median 39.5), both inside the measured band for their
+#     magnitude. 40.0 moves 15 metrics from hard-gated to watch-only — 6 of which had ALREADY
+#     reached >= 1.75x on honest history alone — and keeps every >= 40µs timing metric, where
+#     the measured band tops out at 1.88x, fully hard-gated.
 #   * "milli" (floor 20.0): the empirically-degenerate HNSW recall family —
 #     vectors_hnsw_recall_at10 honestly oscillates 1<->4 (4.0x band) at integer-milli
 #     resolution; its stable siblings (vectors_diskann_recall_at10 ~34,
@@ -136,7 +158,7 @@ DISAPPEAR_FAIL_FRACTION = 0.30  # > 30% of gateable metrics missing from results
 # exempted all of them), "ns_per_byte", "ratio", the `*_per_s` throughputs, every
 # deterministic unit, and any UNKNOWN/absent unit: unknown units FAIL TOWARD GATED.
 # DETERMINISTIC metrics are never floor-exempt even in an allow-listed unit.
-FLOOR_EXEMPT_UNITS: dict[str, float] = {"us": 20.0, "milli": 20.0}
+FLOOR_EXEMPT_UNITS: dict[str, float] = {"us": 40.0, "milli": 20.0}
 
 # Deterministic (byte/count/structural) metric classification. UNIT-first because the live metric
 # NAMES are trappy: bsbm_query01_count_us / lubm_*_count_us are TIMING metrics whose names contain
@@ -856,10 +878,34 @@ def self_test() -> int:
     # 15. The floor is the DISCRIMINATOR: the same 3.0x shape with its median ABOVE the floor
     #     hard-fails; and a sub-floor DETERMINISTIC metric at 2.0x still hard-fails (the floor
     #     never applies to deterministic outputs — a 2x on a count/bytes/gates value is real).
-    over = history_values(_series([[("big_query_us", 40.0)]] * 5))
-    code, rep = evaluate(_cur([("big_query_us", 120.0)]), over)
+    over = history_values(_series([[("big_query_us", 60.0)]] * 5))
+    code, rep = evaluate(_cur([("big_query_us", 180.0)]), over)
     check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
           "the same 3.0x shape with median above the floor hard-fails")
+
+    # 15a. The "us" floor SITS AT 40.0, not 20.0 — re-derived 2026-07-25 from the published
+    #      history (see FLOOR_EXEMPT_UNITS: the honest band only drops under 2.0x at >= 40µs;
+    #      the 20-40µs bucket honestly reaches 2.23x). This pair pins the boundary from BOTH
+    #      sides so neither a silent revert to 20.0 nor an open-ended raise passes:
+    #        - a 30µs-median metric at 2.0x is watch-only (would have RED main on run
+    #          30154655798, whose two hard failures had medians 20.6 and 39.5),
+    #        - a 45µs-median metric at the same 2.0x still hard-fails.
+    #      MUTATION CHECK: setting the "us" floor back to 20.0 turns the first check red;
+    #      raising it to >= 45.0 (or 90.0) turns the second red. The boundary is exclusive
+    #      (`med < floor`), so a metric whose median is EXACTLY the floor stays gated.
+    band = history_values(_series([[("midband_query_us", 30.0)]] * 5))
+    code, rep = evaluate(_cur([("midband_query_us", 60.0)]), band)
+    check(code == 0 and not rep["hard"] and len(rep["floor_exempt"]) == 1
+          and len(rep["floor_exempt_hard"]) == 1,
+          "20-40µs metric at 2.0x is watch-only under the re-derived 40µs floor (not a hard fail)")
+    above = history_values(_series([[("aboveband_query_us", 45.0)]] * 5))
+    code, rep = evaluate(_cur([("aboveband_query_us", 90.0)]), above)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
+          ">= 40µs metric at the SAME 2.0x still hard-fails — 40.0 is the discriminating floor")
+    exact = history_values(_series([[("exact_floor_query_us", 40.0)]] * 5))
+    code, rep = evaluate(_cur([("exact_floor_query_us", 80.0)]), exact)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
+          "a median EXACTLY at the floor stays gated (`med < floor` is exclusive)")
     det_small = history_values([{"date": i, "benches": [
         {"name": "solid_fixture_count", "value": 5.0, "unit": "count"}]} for i in range(5)])
     code, rep = evaluate([{"name": "solid_fixture_count", "value": 10.0, "unit": "count"}],


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous orchestration for sparq. Authored and reviewed by AI agents.

## TL;DR

The 2x on `main` is **not a code regression**, and it is **not #3755 or #3679**. Run
[30154655798](https://github.com/sparq-org/sparq/actions/runs/30154655798) red on two µs-scale
metrics whose "regression" is contradicted by their own sibling measurements *in the same run*.
The real defect is that the hard zone's `us` noise floor (20.0) was hard-gating metrics inside
their own measured noise band. **Nothing is reverted.** This PR re-derives the floor from the
published history using the gate's own methodology.

## Attribution evidence

**The head commit cannot be the cause.** Run 30154655798 is on `6775b4c2` (#3681) — four files,
all under `site/`, **zero Rust**. No engine code differs from its green parent `9f568f1b`.

**Both prime suspects are already inside the baseline they are accused of regressing.** The gate
compares against a median-of-5. `3ff8f4f3` (#3755) and `e8a41ab8` (#3679) merged 8s apart at
07:48Z; 4 of the 5 median points (`e8a41ab8`, `fc14f6c2`, `c38d3c78`, `9f568f1b`) contain **both**.
Post-merge measurements, in publish order:

| metric | pre-merge spread | post-merge (4 runs, both PRs in) | failing run |
|---|---|---|---|
| `watdiv_sf1_L5_materialize_us` | 12.8 – 32.8 | 23.6, 20.7, 20.6, 18.9 | 41.9 |
| `watdiv_sf1_S5_json_us` | 29.4 – 43.6 | 33.9, 42.2, 42.5, 38.1 | 82.1 |

There is **no step at either merge**. A regression cannot first appear four green runs later on a
site-only commit. (#3755's own commit `3ff8f4f3` has no history point — its bench run was cancelled
by the merge-queue batch — but `e8a41ab8`, which *contains* #3755, measured 23.6 / 33.9: normal.)

**The failing metrics are refuted by their siblings in the same run.** `count`, `materialize` and
`json` are three separate CLI invocations over the *same* query evaluation core
(`sparq_engine::count` / `query` / `query_json`, all via the same BGP + join + numeric-decode path).
Per-query ratios vs median:

| query | count | materialize | json |
|---|---|---|---|
| L2 | 1.07x | **1.80x** | 1.09x |
| L3 | 1.07x | **2.02x** | 1.17x |
| L4 | 1.12x | **1.80x** | 1.20x |
| L5 | 1.09x | **2.03x** | 1.09x |
| S4 | 1.07x | 1.12x | **1.90x** |
| S5 | 1.14x | 1.07x | **2.08x** |

For L2–L5 only `materialize` moved; for S4/S5 only `json` moved. A regression in numeric lookup or
join — the mechanisms #3755 and #3679 touch — must appear in **every** mode of the same query. It
appears in exactly one each. The strongest single fact: **`watdiv_sf1_L5_json_us` measured 21.5µs
while `watdiv_sf1_L5_materialize_us` measured 41.9µs** in the same run — json performs that same
evaluation *and* serializes the result. A work-superset cannot take half the time. The
`L5_materialize` number is a measurement artifact.

Positionally, the hits form **two contiguous runs of adjacent benchmarks** (execution indices
171–174 and 194–195 of 436), i.e. two transient scheduling stalls inside two windows of the run —
not a code path.

**The gate was right to reject the uniform-shift exemption.** This was genuinely not a whole-machine
slowdown: median timing-metric ratio 1.013, mean 1.035, 241 of 325 timing metrics within ±10%, and
all 103 non-timing metrics at exactly 1.0000. Condition (a) correctly did not hold.

## The actual defect, and the fix

`FLOOR_EXEMPT_UNITS["us"] = 20.0` was justified on the claim that *"every observed false-fail metric
has a median <~15 units"*. That claim no longer holds — this run false-failed at medians 20.6 and
39.5. Replaying **this gate's own methodology** (worst `current / median-of-trailing-5` per metric)
over the full published `us` history, bucketed by magnitude:

| median band | n | p90 band | MAX band | metrics ≥ 2.0x |
|---|---|---|---|---|
| 0–10µs | 48 | 1.84x | 3.00x | 2 |
| 10–20µs | 40 | 1.81x | 2.09x | 1 |
| **20–40µs** | **15** | **1.84x** | **2.23x** | **1** |
| 40–80µs | 30 | 1.80x | 1.88x | 0 |
| 80–200µs | 25 | 1.59x | 1.76x | 0 |
| ≥200µs | 153 | 1.52x | 1.90x | 0 |

The honest band does not fall under the 2.0x threshold until **≥ 40µs**. Honest history alone
already reaches `watdiv_sf1_L2_json_us` **2.23x** (43.7 vs trailing median 19.6). Both of this run's
failures (2.03x at median 20.6, 2.08x at median 39.5) sit **inside the measured band for their
magnitude**. So `us: 20.0` was hard-gating metrics inside their own noise.

`us: 20.0 → 40.0`. 15 metrics move from hard-gated to watch-only — 6 of which had already reached
≥1.75x on honest history alone — and every ≥40µs timing metric, where the measured band tops out at
1.88x, stays fully hard-gated. **Nothing is silently dropped:** downgraded rows still print flagged
`[under noise floor — watch only]`, still emit a `::warning`, and still route via `--report-out`
into the deduped bench-flake issue (the durable trail that survives median rebasing).

An honesty caveat now recorded in the code: these buckets are a **lower bound** on the honest band,
not an estimate of it. `bench.yml`'s "Store + compare against history" step runs *after* this gate
and is skipped when it fails, so every honest run whose noise exceeded the threshold is censored
from the very series used to justify the floor.

## Measured before/after

Replayed the failing run's real `bench-results.json` (extracted from the run log) against the real
published `prev-data.js`:

- **unpatched gate** — exit 1, reproducing both errors at the exact published numbers (2.03x / 2.08x).
- **patched gate** — exit 0; both rows correctly reported as watch-only and routed to the durable trail.
- **regression check** — replayed all 15 gateable published history points under both floors: 0 honest
  points red under either. The floor raise does not depend on loosening anything else.

## Non-vacuous tests

Self-test 59 → 62 checks, pinning the boundary from both sides. Mutation-verified:

| mutation | checks that go red |
|---|---|
| `us` floor → 20.0 (revert) | `20-40µs metric at 2.0x is watch-only` |
| `us` floor → 90.0 | the two ≥40µs hard-fail checks + the exact-boundary check |
| `us` floor → 41.0 | `a median EXACTLY at the floor stays gated` |

## What this PR does not do

- **Does not revert #3755 or #3679.** The data exonerates both. #3755 shipped no benchmark evidence
  and that remains a legitimate criticism — but "unevidenced" is not "responsible for this red", and
  reverting it would not have fixed a gate that reds on a site-only commit. If its claimed win is to
  be validated or removed, that is separate work on its own measurement, not a P0 revert.
- **Re-introduces nothing.** Only `scripts/bench_hardzone.py` changes; no Rust, so
  `bench/feature-off-declarations/3755.json` and the
  `numeric_cache_lookup_covers_outlined_storage_variants` coverage test both stay in place and no
  crate's coverage floor moves.
- **Does not weaken the deterministic zone.** Deterministic metrics are never floor-exempt at any
  magnitude, `s`/`ratio`/`ns_per_byte`/`*_per_s`/unknown units stay gated, and the separate strict
  byte-count ratchet is untouched.

`main`'s red was additionally cleared by re-running the bench job on `6775b4c2` — a re-measure of
the identical tree, which is itself the empirical test of the noise hypothesis.
