### PR TITLE
ci(arm): arm on the sparq-orchestrator App token, and pin the EFFECTIVE permission set (#3777)

### DIFF
--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -15,7 +15,8 @@ on:
 # (enablePullRequestAutoMerge)" — the #3760 outage, which the re-arm sweeper hit with
 # exactly that misconfiguration while THIS workflow armed fine (runs 30033315483 vs
 # 30027010495). Pinned by scripts/tests/test_arm_capability_wiring.py.
-# [OPUS-5] #3777 — `workflows` is NOT settable here. MEASURED 2026-07-25.
+# [OPUS-5] #3777 — `workflows` is NOT settable here, and the fix is the TOKEN, not this
+# block. MEASURED 2026-07-25.
 #
 # GitHub refuses `enablePullRequestAutoMerge` on a PR touching `.github/workflows/**`
 # unless the acting identity holds the `workflows` permission. The obvious fix — adding
@@ -23,15 +24,33 @@ on:
 # GITHUB_TOKEN permission scopes, and adding it makes the workflow fail to start at all
 # (run 30176307537: conclusion=failure, ZERO jobs, a startup failure — while the same
 # workflow succeeded on `main` thirteen minutes earlier). yaml.safe_load accepts the key;
-# GitHub does not.
+# GitHub does not. So GITHUB_TOKEN can NEVER arm a workflow-touching PR, at any setting.
 #
-# `workflows` is a GitHub APP INSTALLATION permission. It has to be granted in the App's
-# settings and the installation must then accept the updated permission — a maintainer
-# action, not a repository change. Until that happens, workflow-touching PRs stay unarmable
-# and must be merged by hand.
+# `workflows` is a GitHub APP INSTALLATION permission, and the App already holds it:
+#     gh api /apps/sparq-orchestrator          -> permissions.workflows = write
+#     gh api /orgs/sparq-org/installations     -> id 146840030, workflows = write (accepted)
+# An earlier revision of this comment claimed a maintainer still had to grant it in the
+# App's settings. That was wrong — it was never verified against the API. The grant is done.
 #
-# The set below is PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py, so it
-# cannot widen unnoticed — including by a future attempt to add `workflows` here.
+# What was actually missing here is that this workflow did not USE the App. It ran the arm
+# on `github.token`, while its siblings (rearm-sweeper.yml, batch-merge.yml) mint the
+# sparq-orchestrator App token first and fall back to `github.token`. That asymmetry is
+# fixed below.
+#
+# HONEST RESIDUAL: minting is fail-soft on `ORCHESTRATOR_APP_ID`, and that secret is NOT
+# configured in this repository — every App-token step in the repo is currently `skipped`
+# (batch-merge runs 30163981782..30177204603, 15/15 skipped; same for rearm-sweeper). So
+# today this still falls back to `github.token` and workflow-touching PRs still are not
+# armed. The remaining maintainer action is the SECRETS (ORCHESTRATOR_APP_ID +
+# ORCHESTRATOR_APP_PRIVATE_KEY), not the App permission. When they land, this lane starts
+# arming workflow-touching PRs with no further change.
+#
+# The set below is PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py — and the
+# pin is on the EFFECTIVE set (this block, or a job's own block where one is declared, since
+# a job-level `permissions:` REPLACES rather than merges). An earlier revision pinned only
+# this workflow-level block and claimed that "a fourth permission fails the suite"; that was
+# FALSE — a job-level block adding `workflows: write` + `actions: write` was measured to
+# leave the whole suite green. Widening at EITHER level now fails a named test.
 permissions:
   contents: write
   pull-requests: write
@@ -50,7 +69,25 @@ jobs:
     # 10s+30s per idempotent READ during a platform blip) without hitting the
     # job ceiling; the sweep itself is unchanged.
     timeout-minutes: 10
+    env:
+      # Secrets are not readable from step `if:` expressions — mirror the id into env
+      # so the mint step can be skipped fail-soft when the App is not configured.
+      ORCHESTRATOR_APP_ID: ${{ secrets.ORCHESTRATOR_APP_ID }}
     steps:
+      # [OPUS-5] #3777 — the ONLY identity that can arm a workflow-touching PR. GITHUB_TOKEN
+      # structurally cannot (see the header): `workflows` is not one of its scopes. The
+      # sparq-orchestrator App installation holds `workflows: write`, so a minted App token
+      # can. Same action + SHA + fail-soft `if:` as rearm-sweeper.yml and batch-merge.yml —
+      # when the secret is absent this is `skipped` and every consumer falls back to
+      # `github.token`, i.e. exactly today's behaviour, so this cannot regress the lane.
+      - name: Mint the sparq-orchestrator App token (arms must fire merge events)
+        id: app-token
+        if: env.ORCHESTRATOR_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ORCHESTRATOR_APP_ID }}
+          private-key: ${{ secrets.ORCHESTRATOR_APP_PRIVATE_KEY }}
+
       # Run the trusted default-branch policy, never code from the candidate PR head.
       - name: Checkout auto-arm policy
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -83,7 +120,7 @@ jobs:
       # expression as the arm step below (pinned by the wiring test).
       - name: Probe arm capability (one loud error, never per-PR)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           REPO: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: >-
@@ -97,7 +134,7 @@ jobs:
       # are collected, summarised, and the run exits non-zero.
       - name: Arm eligible PRs
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           REPO: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           # [FABLE-5] #3759 finding 5: the label-triggered (pull_request) invocation is

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -15,31 +15,26 @@ on:
 # (enablePullRequestAutoMerge)" — the #3760 outage, which the re-arm sweeper hit with
 # exactly that misconfiguration while THIS workflow armed fine (runs 30033315483 vs
 # 30027010495). Pinned by scripts/tests/test_arm_capability_wiring.py.
-# [OPUS-5] #3777 — `workflows: write`, granted by the maintainer 2026-07-25.
+# [OPUS-5] #3777 — `workflows` is NOT settable here. MEASURED 2026-07-25.
 #
-# WHY IT IS NEEDED. GitHub refuses `enablePullRequestAutoMerge` on a PR touching
-# `.github/workflows/**` unless the token carries `workflows: write`:
-#   "refusing to allow a GitHub App to create or update workflow
-#    `.github/workflows/zk-toolchain.yml` without `workflows` permission"
-# Without it EVERY workflow-touching PR is unarmable forever while the sweep logs an
-# arm-failure each cycle — #3434 sat exactly that way.
+# GitHub refuses `enablePullRequestAutoMerge` on a PR touching `.github/workflows/**`
+# unless the acting identity holds the `workflows` permission. The obvious fix — adding
+# `workflows: write` to this block — DOES NOT WORK: `workflows` is not one of the
+# GITHUB_TOKEN permission scopes, and adding it makes the workflow fail to start at all
+# (run 30176307537: conclusion=failure, ZERO jobs, a startup failure — while the same
+# workflow succeeded on `main` thirteen minutes earlier). yaml.safe_load accepts the key;
+# GitHub does not.
 #
-# WHY IT IS SAFE HERE, AND ONLY HERE. This is a genuine privilege escalation — the arming
-# token can now approve merges of workflow changes — so it is bounded by the shape of this
-# job, not by good intentions:
-#   * it checks out ONLY its own policy script(s), `ref:` the DEFAULT BRANCH, never the
-#     candidate PR head, with `persist-credentials: false`;
-#   * it runs no target code and no model — nothing PR-supplied executes here;
-#   * what it does run is gated by the required `gate` check on the default branch.
-# A job that ran PR-head code under this permission WOULD be an escalation path. This one
-# cannot be: the permission and the untrusted input never share a job.
+# `workflows` is a GitHub APP INSTALLATION permission. It has to be granted in the App's
+# settings and the installation must then accept the updated permission — a maintainer
+# action, not a repository change. Until that happens, workflow-touching PRs stay unarmable
+# and must be merged by hand.
 #
-# PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py — a fourth permission fails
-# the suite, so this escalation cannot widen unnoticed.
+# The set below is PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py, so it
+# cannot widen unnoticed — including by a future attempt to add `workflows` here.
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 # A label event and the sweep must never race each other into a double arm.
 concurrency:

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -15,9 +15,31 @@ on:
 # (enablePullRequestAutoMerge)" — the #3760 outage, which the re-arm sweeper hit with
 # exactly that misconfiguration while THIS workflow armed fine (runs 30033315483 vs
 # 30027010495). Pinned by scripts/tests/test_arm_capability_wiring.py.
+# [OPUS-5] #3777 — `workflows: write`, granted by the maintainer 2026-07-25.
+#
+# WHY IT IS NEEDED. GitHub refuses `enablePullRequestAutoMerge` on a PR touching
+# `.github/workflows/**` unless the token carries `workflows: write`:
+#   "refusing to allow a GitHub App to create or update workflow
+#    `.github/workflows/zk-toolchain.yml` without `workflows` permission"
+# Without it EVERY workflow-touching PR is unarmable forever while the sweep logs an
+# arm-failure each cycle — #3434 sat exactly that way.
+#
+# WHY IT IS SAFE HERE, AND ONLY HERE. This is a genuine privilege escalation — the arming
+# token can now approve merges of workflow changes — so it is bounded by the shape of this
+# job, not by good intentions:
+#   * it checks out ONLY its own policy script(s), `ref:` the DEFAULT BRANCH, never the
+#     candidate PR head, with `persist-credentials: false`;
+#   * it runs no target code and no model — nothing PR-supplied executes here;
+#   * what it does run is gated by the required `gate` check on the default branch.
+# A job that ran PR-head code under this permission WOULD be an escalation path. This one
+# cannot be: the permission and the untrusted input never share a job.
+#
+# PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py — a fourth permission fails
+# the suite, so this escalation cannot widen unnoticed.
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 # A label event and the sweep must never race each other into a double arm.
 concurrency:

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -28,31 +28,26 @@ on:
 # The App token is still PREFERRED when configured (same identity batch-merge.yml uses,
 # so a merge it triggers is attributed to the App rather than github-actions[bot]); the
 # workflow token is the fallback and, with write, is sufficient to arm.
-# [OPUS-5] #3777 — `workflows: write`, granted by the maintainer 2026-07-25.
+# [OPUS-5] #3777 — `workflows` is NOT settable here. MEASURED 2026-07-25.
 #
-# WHY IT IS NEEDED. GitHub refuses `enablePullRequestAutoMerge` on a PR touching
-# `.github/workflows/**` unless the token carries `workflows: write`:
-#   "refusing to allow a GitHub App to create or update workflow
-#    `.github/workflows/zk-toolchain.yml` without `workflows` permission"
-# Without it EVERY workflow-touching PR is unarmable forever while the sweep logs an
-# arm-failure each cycle — #3434 sat exactly that way.
+# GitHub refuses `enablePullRequestAutoMerge` on a PR touching `.github/workflows/**`
+# unless the acting identity holds the `workflows` permission. The obvious fix — adding
+# `workflows: write` to this block — DOES NOT WORK: `workflows` is not one of the
+# GITHUB_TOKEN permission scopes, and adding it makes the workflow fail to start at all
+# (run 30176307537: conclusion=failure, ZERO jobs, a startup failure — while the same
+# workflow succeeded on `main` thirteen minutes earlier). yaml.safe_load accepts the key;
+# GitHub does not.
 #
-# WHY IT IS SAFE HERE, AND ONLY HERE. This is a genuine privilege escalation — the arming
-# token can now approve merges of workflow changes — so it is bounded by the shape of this
-# job, not by good intentions:
-#   * it checks out ONLY its own policy script(s), `ref:` the DEFAULT BRANCH, never the
-#     candidate PR head, with `persist-credentials: false`;
-#   * it runs no target code and no model — nothing PR-supplied executes here;
-#   * what it does run is gated by the required `gate` check on the default branch.
-# A job that ran PR-head code under this permission WOULD be an escalation path. This one
-# cannot be: the permission and the untrusted input never share a job.
+# `workflows` is a GitHub APP INSTALLATION permission. It has to be granted in the App's
+# settings and the installation must then accept the updated permission — a maintainer
+# action, not a repository change. Until that happens, workflow-touching PRs stay unarmable
+# and must be merged by hand.
 #
-# PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py — a fourth permission fails
-# the suite, so this escalation cannot widen unnoticed.
+# The set below is PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py, so it
+# cannot widen unnoticed — including by a future attempt to add `workflows` here.
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 concurrency:
   group: re-arm-sweeper

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -38,13 +38,24 @@ on:
 # workflow succeeded on `main` thirteen minutes earlier). yaml.safe_load accepts the key;
 # GitHub does not.
 #
-# `workflows` is a GitHub APP INSTALLATION permission. It has to be granted in the App's
-# settings and the installation must then accept the updated permission — a maintainer
-# action, not a repository change. Until that happens, workflow-touching PRs stay unarmable
-# and must be merged by hand.
+# `workflows` is a GitHub APP INSTALLATION permission, and the App already holds it —
+# verified against the API, not assumed:
+#     gh api /apps/sparq-orchestrator          -> permissions.workflows = write
+#     gh api /orgs/sparq-org/installations     -> id 146840030, workflows = write (accepted)
+# An earlier revision of this comment claimed a maintainer still had to grant it. That was
+# wrong. This workflow already prefers the App token (below), so it needs no change.
 #
-# The set below is PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py, so it
-# cannot widen unnoticed — including by a future attempt to add `workflows` here.
+# HONEST RESIDUAL: `ORCHESTRATOR_APP_ID` is not configured in this repository, so the mint
+# step is `skipped` on every run to date and the sweep falls back to `github.token` — which
+# can never arm a workflow-touching PR. The remaining maintainer action is the SECRETS
+# (ORCHESTRATOR_APP_ID + ORCHESTRATOR_APP_PRIVATE_KEY), not the App permission.
+#
+# The set below is PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py — and the
+# pin is on the EFFECTIVE set (this block, or a job's own block where one is declared, since
+# a job-level `permissions:` REPLACES rather than merges). An earlier revision pinned only
+# this workflow-level block and claimed that "a fourth permission fails the suite"; that was
+# FALSE — a job-level block adding `workflows: write` + `actions: write` was measured to
+# leave the whole suite green. Widening at EITHER level now fails a named test.
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -28,9 +28,31 @@ on:
 # The App token is still PREFERRED when configured (same identity batch-merge.yml uses,
 # so a merge it triggers is attributed to the App rather than github-actions[bot]); the
 # workflow token is the fallback and, with write, is sufficient to arm.
+# [OPUS-5] #3777 — `workflows: write`, granted by the maintainer 2026-07-25.
+#
+# WHY IT IS NEEDED. GitHub refuses `enablePullRequestAutoMerge` on a PR touching
+# `.github/workflows/**` unless the token carries `workflows: write`:
+#   "refusing to allow a GitHub App to create or update workflow
+#    `.github/workflows/zk-toolchain.yml` without `workflows` permission"
+# Without it EVERY workflow-touching PR is unarmable forever while the sweep logs an
+# arm-failure each cycle — #3434 sat exactly that way.
+#
+# WHY IT IS SAFE HERE, AND ONLY HERE. This is a genuine privilege escalation — the arming
+# token can now approve merges of workflow changes — so it is bounded by the shape of this
+# job, not by good intentions:
+#   * it checks out ONLY its own policy script(s), `ref:` the DEFAULT BRANCH, never the
+#     candidate PR head, with `persist-credentials: false`;
+#   * it runs no target code and no model — nothing PR-supplied executes here;
+#   * what it does run is gated by the required `gate` check on the default branch.
+# A job that ran PR-head code under this permission WOULD be an escalation path. This one
+# cannot be: the permission and the untrusted input never share a job.
+#
+# PINNED EXACTLY by scripts/tests/test_arm_capability_wiring.py — a fourth permission fails
+# the suite, so this escalation cannot widen unnoticed.
 permissions:
   contents: write
   pull-requests: write
+  workflows: write
 
 concurrency:
   group: re-arm-sweeper

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -137,37 +137,19 @@ class TestPermissionPin(unittest.TestCase):
                 f"{name} must keep `pull-requests: write`",
             )
 
-    def test_both_arm_workflows_declare_workflows_write(self) -> None:
-        """#3777: GitHub refuses `enablePullRequestAutoMerge` on a PR touching
-        `.github/workflows/**` without `workflows: write` — "refusing to allow a GitHub App
-        to create or update workflow ... without `workflows` permission". Without it EVERY
-        workflow-touching PR is unarmable forever while the sweep logs an arm-failure per
-        cycle (#3434 sat exactly that way). Granted by the maintainer 2026-07-25."""
-        for name, (path, _script) in ARM_WORKFLOWS.items():
-            permissions = load(path).get("permissions") or {}
-            self.assertEqual(
-                permissions.get("workflows"),
-                "write",
-                f"{name}: a workflow-touching PR cannot be armed without `workflows: write` "
-                f"(#3777). Removing it silently strands every such PR — the sweep keeps "
-                f"reporting arm-failures and nothing ever merges.",
-            )
-
     def test_arm_workflow_permissions_are_EXACTLY_the_approved_set(self) -> None:
         """The compensating control for #3777's escalation.
 
-        `workflows: write` lets the arming token approve merges of WORKFLOW changes. That is a
-        real privilege escalation, approved deliberately and bounded by this job's shape (it
-        checks out only its own policy script from the DEFAULT BRANCH, never the candidate PR
-        head, and runs no target code or model — so the permission and the untrusted input
-        never share a job).
+        The tests above assert that specific keys are PRESENT. Nothing asserted that others
+        were ABSENT, so any permission could be added to a token that arms ARBITRARY PRs
+        without the widening itself being reviewed. This pins the whole set.
 
-        That bound is only meaningful while the permission set stays exactly what was
-        approved. A FOURTH permission — `id-token`, `packages`, `actions: write` — would widen
-        the escalation with no review of the widening, because the two tests above only assert
-        that specific keys are present, never that others are absent. This pins the whole set,
-        so any addition fails here and has to be argued for on its own merits."""
-        approved = {"contents": "write", "pull-requests": "write", "workflows": "write"}
+        It also pins the #3777 finding: `workflows` cannot be added here. It is a GitHub APP
+        INSTALLATION permission, not a GITHUB_TOKEN scope — adding it makes the workflow fail
+        to START (run 30176307537: conclusion=failure, zero jobs, while the same workflow
+        succeeded on `main` minutes earlier). `yaml.safe_load` accepts the key and GitHub does
+        not, so a YAML-level check would not have caught it; this test does."""
+        approved = {"contents": "write", "pull-requests": "write"}
         for name, (path, _script) in ARM_WORKFLOWS.items():
             permissions = load(path).get("permissions")
             self.assertEqual(

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -137,6 +137,47 @@ class TestPermissionPin(unittest.TestCase):
                 f"{name} must keep `pull-requests: write`",
             )
 
+    def test_both_arm_workflows_declare_workflows_write(self) -> None:
+        """#3777: GitHub refuses `enablePullRequestAutoMerge` on a PR touching
+        `.github/workflows/**` without `workflows: write` — "refusing to allow a GitHub App
+        to create or update workflow ... without `workflows` permission". Without it EVERY
+        workflow-touching PR is unarmable forever while the sweep logs an arm-failure per
+        cycle (#3434 sat exactly that way). Granted by the maintainer 2026-07-25."""
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            permissions = load(path).get("permissions") or {}
+            self.assertEqual(
+                permissions.get("workflows"),
+                "write",
+                f"{name}: a workflow-touching PR cannot be armed without `workflows: write` "
+                f"(#3777). Removing it silently strands every such PR — the sweep keeps "
+                f"reporting arm-failures and nothing ever merges.",
+            )
+
+    def test_arm_workflow_permissions_are_EXACTLY_the_approved_set(self) -> None:
+        """The compensating control for #3777's escalation.
+
+        `workflows: write` lets the arming token approve merges of WORKFLOW changes. That is a
+        real privilege escalation, approved deliberately and bounded by this job's shape (it
+        checks out only its own policy script from the DEFAULT BRANCH, never the candidate PR
+        head, and runs no target code or model — so the permission and the untrusted input
+        never share a job).
+
+        That bound is only meaningful while the permission set stays exactly what was
+        approved. A FOURTH permission — `id-token`, `packages`, `actions: write` — would widen
+        the escalation with no review of the widening, because the two tests above only assert
+        that specific keys are present, never that others are absent. This pins the whole set,
+        so any addition fails here and has to be argued for on its own merits."""
+        approved = {"contents": "write", "pull-requests": "write", "workflows": "write"}
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            permissions = load(path).get("permissions")
+            self.assertEqual(
+                dict(permissions or {}),
+                approved,
+                f"{name}: the arming token's permission set changed. It is pinned to exactly "
+                f"{approved} (#3777). Adding a permission here widens what a token that arms "
+                f"ARBITRARY PRs can do — justify it explicitly rather than extending this set.",
+            )
+
     def test_arm_workflows_do_not_narrow_permissions_at_the_job_level(self) -> None:
         # A job-level `permissions:` REPLACES the workflow-level block, so a job-level
         # narrowing would silently reintroduce the outage.

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -160,6 +160,53 @@ class TestPermissionPin(unittest.TestCase):
                 f"ARBITRARY PRs can do — justify it explicitly rather than extending this set.",
             )
 
+    def test_every_arm_job_EFFECTIVE_permission_set_is_exactly_the_approved_set(
+        self,
+    ) -> None:
+        """The level that actually takes effect — closes the bypass in the test above.
+
+        `test_arm_workflow_permissions_are_EXACTLY_the_approved_set` reads only the
+        WORKFLOW-level block. A job-level `permissions:` block REPLACES it wholesale (the
+        very fact the next test exists to defend), so the exact-set pin was reading the
+        level that does NOT decide. MEASURED bypass: injecting
+
+            arm:
+              permissions:
+                contents: write
+                pull-requests: write
+                workflows: write
+                actions: write
+
+        into auto-arm.yml left the entire suite GREEN. That is doubly bad here — a job-level
+        `workflows: write` also reintroduces the run-30176307537 STARTUP failure, and nothing
+        caught it.
+
+        So: compute each job's EFFECTIVE set (its own block if present, else the
+        workflow-level block) and pin that. Widening at either level now fails.
+        """
+        approved = {"contents": "write", "pull-requests": "write"}
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            document = load(path)
+            workflow_level = document.get("permissions")
+            for job_id, job in (document.get("jobs") or {}).items():
+                # A job-level block REPLACES the workflow-level one; it does not merge.
+                effective = job["permissions"] if "permissions" in job else workflow_level
+                self.assertEqual(
+                    dict(effective or {}),
+                    approved,
+                    f"{name}:{job_id}: the EFFECTIVE permission set of this arming job is "
+                    f"pinned to exactly {approved} (#3777). This job "
+                    + (
+                        "declares its own `permissions:` block, which REPLACES the "
+                        "workflow-level one"
+                        if "permissions" in job
+                        else "inherits the workflow-level block"
+                    )
+                    + ". Adding a permission widens what a token that arms ARBITRARY PRs "
+                    "can do; adding `workflows` additionally makes the workflow fail to "
+                    "START. Justify any change explicitly rather than extending this set.",
+                )
+
     def test_arm_workflows_do_not_narrow_permissions_at_the_job_level(self) -> None:
         # A job-level `permissions:` REPLACES the workflow-level block, so a job-level
         # narrowing would silently reintroduce the outage.
@@ -229,6 +276,101 @@ class TestProbeWiring(unittest.TestCase):
                 f"{name}: a probe on a DIFFERENT token than the arm step would attest "
                 "capability the sweep does not have",
             )
+
+    # ---- [OPUS-5] #3777: the SAME TOKEN pin above is RELATIVE, and that is a real hole.
+    #
+    # `test_probe_and_arm_steps_use_the_identical_token_expression` asserts only that the
+    # probe and the arm consume the SAME expression. It never asserts WHICH. Both steps
+    # holding a bare `${{ github.token }}` satisfies it perfectly — which is exactly the
+    # state auto-arm.yml shipped in while rearm-sweeper.yml and batch-merge.yml used the
+    # App token, and the relative pin reported green on both. The pin covered auto-arm
+    # (ARM_WORKFLOWS has always held both files) but was VACUOUS for this class of bug.
+    #
+    # The two tests below are the absolute pin: they name the expression itself, so a
+    # silent revert to `github.token` is a NAMED failure rather than an invisible one.
+
+    APP_TOKEN_EXPRESSION = "${{ steps.app-token.outputs.token || github.token }}"
+    APP_TOKEN_ACTION = (
+        "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1"
+    )
+
+    def test_arm_workflows_prefer_the_orchestrator_app_token_over_github_token(
+        self,
+    ) -> None:
+        """#3777: GITHUB_TOKEN can NEVER arm a PR that touches `.github/workflows/**`.
+
+        `workflows` is not one of the GITHUB_TOKEN permission scopes — adding it to a
+        `permissions:` block makes the workflow fail to START (run 30176307537:
+        conclusion=failure, zero jobs). It is a GitHub APP INSTALLATION permission, and the
+        sparq-orchestrator installation holds it (`gh api /orgs/sparq-org/installations` ->
+        146840030, workflows=write). So the ONLY identity that can arm those PRs is a minted
+        App token, and every token-consuming step on the arm path must prefer it.
+
+        Falling back to `github.token` is deliberate and fail-soft (the App secrets may be
+        absent), but the App token must come FIRST in the expression.
+        """
+        for name, (path, script) in ARM_WORKFLOWS.items():
+            steps = steps_of(load(path))
+            consumers = [
+                step
+                for step in steps
+                if script in run_of(step) and "--self-test" not in run_of(step)
+            ]
+            self.assertTrue(consumers, f"{name}: expected probe + arm steps")
+            for step in consumers:
+                self.assertEqual(
+                    (step.get("env") or {}).get("GH_TOKEN"),
+                    self.APP_TOKEN_EXPRESSION,
+                    f"{name}: step {step.get('name')!r} must consume "
+                    f"{self.APP_TOKEN_EXPRESSION!r}. A bare `github.token` structurally "
+                    "cannot hold `workflows`, so every PR touching .github/workflows/** "
+                    "becomes permanently un-armable (#3777).",
+                )
+
+    def test_arm_workflows_mint_the_app_token_fail_soft_with_the_pinned_action(
+        self,
+    ) -> None:
+        """The `steps.app-token.outputs.token` half of the expression must be real.
+
+        Without the mint step the preferred half is always empty and the expression silently
+        degrades to `github.token` — green tests, dead capability. Pins the step id (which the
+        expression references by name), the SHA-pinned action (repo-wide supply-chain
+        posture), and the fail-soft `if:` reading the JOB-LEVEL env mirror, because secrets
+        are not readable from a step `if:`.
+        """
+        for name, (path, _script) in ARM_WORKFLOWS.items():
+            document = load(path)
+            for job_id, job in (document.get("jobs") or {}).items():
+                mint = [
+                    step
+                    for step in (job.get("steps") or [])
+                    if step.get("id") == "app-token"
+                ]
+                self.assertEqual(
+                    len(mint),
+                    1,
+                    f"{name}:{job_id} must mint the App token exactly once with "
+                    "id `app-token` (the token expression references it by that id)",
+                )
+                step = mint[0]
+                self.assertEqual(
+                    step.get("uses"),
+                    self.APP_TOKEN_ACTION,
+                    f"{name}:{job_id}: the App-token action stays SHA-pinned",
+                )
+                self.assertEqual(
+                    step.get("if"),
+                    "env.ORCHESTRATOR_APP_ID != ''",
+                    f"{name}:{job_id}: minting must be fail-soft on the env mirror, so an "
+                    "unconfigured App skips the step instead of failing the lane",
+                )
+                self.assertEqual(
+                    (job.get("env") or {}).get("ORCHESTRATOR_APP_ID"),
+                    "${{ secrets.ORCHESTRATOR_APP_ID }}",
+                    f"{name}:{job_id}: the job must mirror ORCHESTRATOR_APP_ID into env — "
+                    "secrets are not readable from a step `if:` expression, so without the "
+                    "mirror the fail-soft guard is always false and the App is never used",
+                )
 
     def test_self_test_step_survives(self) -> None:
         for name, (path, script) in ARM_WORKFLOWS.items():


### PR DESCRIPTION
> 🤖 **SPARQ agent** — authored by Claude Opus 5. **Scope changed twice; the current fix is the third section.**

## #3777's diagnosis was wrong, and so was my correction of it

I twice told the maintainer that a manual GitHub App action was required. Both times I asserted it without checking the API. Verified now:

```
gh api /apps/sparq-orchestrator
  owner: sparq-org (Organization)
  permissions: { ..., workflows: write }        <-- ALREADY GRANTED

gh api /orgs/sparq-org/installations
  installation 146840030, app_slug sparq-orchestrator
  permissions: { ..., workflows: write }        <-- ALREADY ACCEPTED
```

The App **and** its installation already carry `workflows: write`. **No App permission grant is outstanding.**

## The real defect: `auto-arm.yml` never used the App

Its probe and arm steps both ran on `${{ github.token }}`. Its siblings `rearm-sweeper.yml` and `batch-merge.yml` mint the `sparq-orchestrator` App token and fall back to `github.token`.

That asymmetry is fatal, because `GITHUB_TOKEN` **structurally cannot** hold `workflows` — it is not one of its permission scopes, and adding it makes the workflow fail to *start* (run `30176307537`: conclusion=failure, **zero jobs**; the same workflow succeeded on `main` thirteen minutes earlier). So the arm lane could never arm a PR touching `.github/workflows/**` at any `permissions:` setting.

`auto-arm.yml` now mirrors `rearm-sweeper.yml` exactly — same SHA-pinned `actions/create-github-app-token@bcd2ba49…` (v3.2.0), same fail-soft `if: env.ORCHESTRATOR_APP_ID != ''` on a job-level env mirror, same `${{ steps.app-token.outputs.token || github.token }}` on **both** the probe and the arm step.

## Two pins were vacuous — both measured, not argued

| Pin | Why it did not hold |
|---|---|
| **SAME TOKEN** | Asserted probe == arm, never **which** token. Both steps holding bare `github.token` satisfied it perfectly — precisely the state `auto-arm.yml` shipped in, reported green throughout. |
| **EXACT-SET** (the control I added in the previous revision) | Read the **workflow-level** `permissions:` block. A **job-level** block *replaces* it — the very fact the neighbouring test exists to defend. A job-level `workflows: write` + `actions: write` left the whole suite green, while also reintroducing the startup failure. |

The header comment I wrote claiming *"a fourth permission fails the suite, so this escalation cannot widen unnoticed"* was false as written. It is corrected in both workflow files to describe what is actually enforced.

Both holes are now pinned absolutely: the token expression **by name**, and the **EFFECTIVE** per-job permission set (a job's own block if present, else the workflow-level one).

> On the probe: `auto-arm.yml` **has always had** a `--probe-arm-capability` step, and `ARM_WORKFLOWS` has always covered both files. The pin's weakness was the *expression it compared*, not a missing step or a missing workflow.

## Mutation table — 11/11 mutants die on a named test

| Mutation | Result | Named test |
|---|---|---|
| auto-arm ARM step reverted to bare `github.token` | RED | `test_arm_workflows_prefer_the_orchestrator_app_token_over_github_token` |
| auto-arm probe+arm **both** reverted (silent full revert) | RED | `test_arm_workflows_prefer_the_orchestrator_app_token_over_github_token` |
| mint step deleted | RED | `test_arm_workflows_mint_the_app_token_fail_soft_with_the_pinned_action` |
| job-level `ORCHESTRATOR_APP_ID` env mirror deleted | RED | `test_arm_workflows_mint_the_app_token_fail_soft_with_the_pinned_action` |
| mint step's fail-soft `if:` removed | RED | `test_arm_workflows_mint_the_app_token_fail_soft_with_the_pinned_action` |
| App-token action unpinned to floating `@v3` | RED | `test_arm_workflows_mint_the_app_token_fail_soft_with_the_pinned_action` |
| **job-level** block adds `workflows: write` | RED | `test_every_arm_job_EFFECTIVE_permission_set_is_exactly_the_approved_set` |
| **job-level** block adds `actions: write` | RED | `test_every_arm_job_EFFECTIVE_permission_set_is_exactly_the_approved_set` |
| **job-level** block drops `pull-requests` (narrowing, reopens #3760) | RED | `test_arm_workflows_do_not_narrow_permissions_at_the_job_level` + effective-set |
| workflow-level widening `actions: write` (no regression) | RED | `test_arm_workflow_permissions_are_EXACTLY_the_approved_set` + effective-set |
| `workflows: write` re-added at workflow level | RED | both exact-set tests |

**Vacuity control** — the same two decisive mutants judged by the *pre-change* test file:

| Mutation | Under the old test file |
|---|---|
| probe+arm both reverted to `github.token` | **GREEN — survived** |
| job-level `workflows: write` + `actions: write` | **GREEN — survived** |

37 → 40 tests, 6 subtests. Both workflows parse; `actionlint` exit 0; all three policy self-tests pass.

## Honest residual — this does NOT arm workflow-touching PRs today

Minting is fail-soft on `ORCHESTRATOR_APP_ID`, and **that secret is not configured in this repository**. Measured, not inferred:

```
repo secrets: OPENALEX_API_KEY only
batch-merge   runs 30163981782..30177204603 — mint step "skipped", 15/15
rearm-sweeper run 30177022784               — mint step "skipped"
```

Already documented in `release-plz.yml`'s header for the same reason. So every arm still falls back to `github.token`, and workflow-touching PRs remain un-armable **until the secrets land**.

**The outstanding maintainer action is the SECRETS (`ORCHESTRATOR_APP_ID` + `ORCHESTRATOR_APP_PRIVATE_KEY`), not the App permission.** When they are configured this lane starts arming workflow-touching PRs with no further change — and so do `rearm-sweeper` and `batch-merge`, which have been silently degraded all along.

This PR is a strict no-op on today's runtime behaviour (skipped mint → same token as before), so it cannot regress the lane. It does not close #3777.
