### PR TITLE
ci: pin the Rust toolchain to 1.97.1 (rust-toolchain.toml) and reconcile every lane that needs a different one

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -102,6 +102,18 @@ jobs:
     # then run instrumented. Generous ceiling so a hung run fails with a clear timeout rather
     # than running away (matches miri.yml's posture).
     timeout-minutes: 90
+    # [OPUS-5] PINNED-TOOLCHAIN ESCAPE. The repo root carries a `rust-toolchain.toml`
+    # pinning STABLE, and rustup resolves that file (precedence 4) ABOVE the `rustup
+    # default <toolchain>` that `dtolnay/rust-toolchain` performs (precedence 5). The
+    # `cargo +nightly-2026-06-11 test -Zbuild-std …` calls below are precedence 1 and were
+    # already immune; this env var (precedence 2) restores the pre-pin behaviour for every
+    # other cargo/rustc invocation in the job, including the `rustc -vV` that
+    # Swatinem/rust-cache keys its cache on. `-Zbuild-std` requires nightly, so a silent
+    # fallback to stable here would be a hard failure rather than a quiet one — but it
+    # would still be caused by the pin, not by the sanitizer. Keep in sync with the
+    # `toolchain:` input below.
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2026-06-11
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # [OPUS-4.8] sq-czlh: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1309,7 +1309,48 @@ jobs:
       - name: cargo check on the declared MSRV
         # [SONNET-4.6] Test targets must compile at the declared floor too; they can
         # otherwise hide newer temporary-lifetime-extension behavior from this gate.
-        run: cargo check --workspace --all-targets --exclude sparq-py --exclude sparq-hdt
+        #
+        # [OPUS-5] NON-VACUITY ASSERTION, deliberately in the SAME `run:` block as the
+        # compile it guards. This lane's entire meaning is the VERSION, so "which
+        # compiler ran" must be a CHECKED fact, not a logged one. Before this, the only
+        # thing standing between the gate and silent vacuity was the job-level
+        # `RUSTUP_TOOLCHAIN` above: delete that one line and the root
+        # `rust-toolchain.toml` (precedence 4) outranks the `rustup default 1.88`
+        # (precedence 5) in the step above, the lane compiles the workspace on pinned
+        # stable, `rustup show active-toolchain` dutifully PRINTS the wrong answer, and
+        # CI stays GREEN — re-arming exactly the vacuity PR #3511 finding 4 fixed.
+        #
+        # Two design choices, both load-bearing:
+        #  * The floor is DERIVED from the root `Cargo.toml` `rust-version` rather than
+        #    hardcoded a fourth time, so this also gates the "keep this == root
+        #    rust-version" invariant that three comments in this job ask humans to
+        #    maintain by hand and nothing enforced. Drift in EITHER direction reds.
+        #  * `cargo` is asserted as well as `rustc`: `cargo check` is what actually
+        #    resolves the `rust-version` floor, and asserting only `rustc` would miss a
+        #    split resolution between the two proxies.
+        # Fail-closed throughout: an unreadable/renamed `rust-version`, a missing
+        # toolchain, or a `--version` that does not parse all exit non-zero.
+        # Same-block placement means no `if:`/step boundary can skip the assertion
+        # while still running the compile.
+        run: |
+          floor="$(sed -n 's/^[[:space:]]*rust-version[[:space:]]*=[[:space:]]*"\([0-9][0-9]*\.[0-9][0-9]*\).*/\1/p' Cargo.toml | head -n1)"
+          if [ -z "$floor" ]; then
+            echo "::error::could not read [workspace.package] rust-version from the root Cargo.toml"
+            exit 1
+          fi
+          echo "declared MSRV floor (root Cargo.toml rust-version) = $floor"
+          for tool in rustc cargo; do
+            ver="$("$tool" --version)" || { echo "::error::$tool --version failed"; exit 1; }
+            echo "$tool --version -> $ver"
+            case "$ver" in
+              "$tool $floor."*|"$tool $floor "*) ;;
+              *)
+                echo "::error::MSRV gate is NOT on the declared floor $floor — $tool reports '$ver'. This lane must compile ON the floor toolchain or it proves nothing; check the job-level RUSTUP_TOOLCHAIN and the root rust-toolchain.toml pin."
+                exit 1
+                ;;
+            esac
+          done
+          cargo check --workspace --all-targets --exclude sparq-py --exclude sparq-hdt
 
   conformance:
     # W3C SPARQL conformance RATCHET (roadmap T13/38). The full 1229-test scope is at

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1269,6 +1269,20 @@ jobs:
       # ld is fine here: this lane is `cargo check` (only build scripts and
       # proc-macros link) and its meaning is the VERSION floor, not link speed.
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: ""
+      # [OPUS-5] KEEPS THIS GATE NON-VACUOUS UNDER THE ROOT `rust-toolchain.toml`
+      # PIN. rustup resolves the toolchain file (precedence 4) ABOVE `rustup
+      # default` (precedence 5), so the `rustup default 1.88` below — which was
+      # the whole fix for the vacuity described in the step comment — would be
+      # SILENTLY OVERRIDDEN by the root pin and this lane would go back to
+      # compiling on pinned stable, i.e. vacuous again in exactly the way PR
+      # #3511 finding 4 called out. `RUSTUP_TOOLCHAIN` is precedence 2, so it
+      # beats the file; setting it at JOB level (rather than `cargo +1.88` at
+      # one call site) makes every cargo/rustc in the job — including anything
+      # nested — use the floor, and makes `rustup show active-toolchain` print
+      # "overridden by environment variable RUSTUP_TOOLCHAIN" so the log states
+      # which compiler actually ran. Keep this == the pin below == root
+      # Cargo.toml `rust-version`.
+      RUSTUP_TOOLCHAIN: "1.88"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Rust (pinned MSRV toolchain 1.88)
@@ -2836,6 +2850,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
+      # [OPUS-5] REQUIRED once the root `rust-toolchain.toml` pin exists. The action
+      # above installs `llvm-tools-preview` onto the toolchain IT manages (`stable`)
+      # and then calls `rustup default` — precedence 5, which the toolchain file
+      # (precedence 4) outranks. So cargo here resolves to the PINNED toolchain, on
+      # which the component would be absent, and `cargo llvm-cov` fails with the
+      # llvm-tools missing rather than measuring anything. This adds the component to
+      # the ACTIVE (pinned) toolchain. Idempotent, and a no-op if it is already there.
+      - name: Ensure llvm-tools-preview on the pinned toolchain
+        run: rustup component add llvm-tools-preview
       # Per-shard cache key: each shard builds a DIFFERENT crate subset (different
       # instrumented objects), so keying the cache by shard keeps them from clobbering /
       # thrashing one another's saved target dir.
@@ -2985,6 +3008,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
+      # [OPUS-5] REQUIRED once the root `rust-toolchain.toml` pin exists. The action
+      # above installs `llvm-tools-preview` onto the toolchain IT manages (`stable`)
+      # and then calls `rustup default` — precedence 5, which the toolchain file
+      # (precedence 4) outranks. So cargo here resolves to the PINNED toolchain, on
+      # which the component would be absent, and `cargo llvm-cov` fails with the
+      # llvm-tools missing rather than measuring anything. This adds the component to
+      # the ACTIVE (pinned) toolchain. Idempotent, and a no-op if it is already there.
+      - name: Ensure llvm-tools-preview on the pinned toolchain
+        run: rustup component add llvm-tools-preview
       # Per-partition dep cache: each partition compiles the same instrumented engine, so a
       # shared-key cache warms the deps; keying by part avoids save-race clobbering.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -3036,6 +3068,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
+      # [OPUS-5] REQUIRED once the root `rust-toolchain.toml` pin exists. The action
+      # above installs `llvm-tools-preview` onto the toolchain IT manages (`stable`)
+      # and then calls `rustup default` — precedence 5, which the toolchain file
+      # (precedence 4) outranks. So cargo here resolves to the PINNED toolchain, on
+      # which the component would be absent, and `cargo llvm-cov` fails with the
+      # llvm-tools missing rather than measuring anything. This adds the component to
+      # the ACTIVE (pinned) toolchain. Idempotent, and a no-op if it is already there.
+      - name: Ensure llvm-tools-preview on the pinned toolchain
+        run: rustup component add llvm-tools-preview
       # Reuse a run partition's dep cache to warm the merge job's object compile.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -3246,6 +3287,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
+      # [OPUS-5] REQUIRED once the root `rust-toolchain.toml` pin exists. The action
+      # above installs `llvm-tools-preview` onto the toolchain IT manages (`stable`)
+      # and then calls `rustup default` — precedence 5, which the toolchain file
+      # (precedence 4) outranks. So cargo here resolves to the PINNED toolchain, on
+      # which the component would be absent, and `cargo llvm-cov` fails with the
+      # llvm-tools missing rather than measuring anything. This adds the component to
+      # the ACTIVE (pinned) toolchain. Idempotent, and a no-op if it is already there.
+      - name: Ensure llvm-tools-preview on the pinned toolchain
+        run: rustup component add llvm-tools-preview
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
         # [OPUS-4.8] sq-tool-pin: explicit `with: tool:` is MANDATORY when SHA-pinning

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -170,6 +170,18 @@ jobs:
       fail-fast: false
       matrix:
         suite: ${{ fromJSON(needs.fv-select.outputs.suites) }}
+    # [OPUS-5] PINNED-TOOLCHAIN ESCAPE — REQUIRED here, not belt-and-braces, and this lane
+    # GATES the merge. The repo root carries a `rust-toolchain.toml` pinning STABLE, and
+    # rustup resolves that file (precedence 4) ABOVE the `rustup default <toolchain>` that
+    # `dtolnay/rust-toolchain` performs (precedence 5). Every cargo call in this job
+    # (`cargo install --locked kani-verifier`, `cargo kani setup`, `cargo kani --harness`)
+    # is a plain invocation with no `+<toolchain>`, so without this env var they would all
+    # silently move off the declared nightly onto pinned stable. `RUSTUP_TOOLCHAIN` is
+    # precedence 2 and beats the file, preserving exactly the toolchain this lane resolved
+    # to before the pin existed. Keep in sync with the `toolchain:` input below and with
+    # kani.yml's identical escape.
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2026-06-11
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -197,9 +197,17 @@ jobs:
     # default <toolchain>` that `dtolnay/rust-toolchain` performs (precedence 5). The
     # `cargo +nightly-2026-06-11 fuzz …` calls below are precedence 1 and were already
     # immune; this env var (precedence 2) restores the pre-pin behaviour for the rest of
-    # the job. It matters most for `cargo fuzz`, which re-invokes cargo itself for the
-    # `fuzz/` sub-workspace: that nested invocation would otherwise resolve the ROOT pin
-    # (rustup searches upward from the cwd) and lose the nightly the lane declares. Note
+    # the job. [OPUS-5] CORRECTION, measured on rustup 1.29.0: this env var is NOT what
+    # protects the nested cargo that `cargo fuzz` spawns for the `fuzz/` sub-workspace.
+    # rustup EXPORTS the resolved toolchain to child processes — `cargo +nightly-2026-06-11
+    # <subcmd>` hands the child `RUSTUP_TOOLCHAIN=nightly-2026-06-11-<host>` (and
+    # `RUSTUP_TOOLCHAIN_SOURCE=cli`), which is precedence 2 and so still outranks the root
+    # file even when the nested cargo runs from `fuzz/`. Verified directly: with a root pin
+    # in place, a `cargo +nightly-2026-06-11` subcommand invoked from a sub-directory saw
+    # the nightly, while the same subcommand invoked as a PLAIN `cargo` saw the pin. So the
+    # nested call was already safe; what this env var actually buys is the invocations that
+    # carry NO `+toolchain` at all — `cargo install cargo-fuzz` and the `rustc -vV` that
+    # Swatinem/rust-cache keys its cache on, which would otherwise re-key onto the pin. Note
     # this env is scoped to THIS job only — the `differential-smoke` job below is a
     # deliberate stable lane and correctly inherits the pin. Keep in sync with the
     # `toolchain:` input below.

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -192,6 +192,19 @@ jobs:
     # Generous ceiling above the worst case (nightly: 4 targets × 600s + build) so a
     # hung target fails with a clear timeout rather than running away.
     timeout-minutes: 60
+    # [OPUS-5] PINNED-TOOLCHAIN ESCAPE. The repo root carries a `rust-toolchain.toml`
+    # pinning STABLE, and rustup resolves that file (precedence 4) ABOVE the `rustup
+    # default <toolchain>` that `dtolnay/rust-toolchain` performs (precedence 5). The
+    # `cargo +nightly-2026-06-11 fuzz …` calls below are precedence 1 and were already
+    # immune; this env var (precedence 2) restores the pre-pin behaviour for the rest of
+    # the job. It matters most for `cargo fuzz`, which re-invokes cargo itself for the
+    # `fuzz/` sub-workspace: that nested invocation would otherwise resolve the ROOT pin
+    # (rustup searches upward from the cwd) and lose the nightly the lane declares. Note
+    # this env is scoped to THIS job only — the `differential-smoke` job below is a
+    # deliberate stable lane and correctly inherits the pin. Keep in sync with the
+    # `toolchain:` input below.
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2026-06-11
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # [OPUS-4.8] sq-czlh: reclaim ~20-30 GB of pre-installed SDKs/toolchains BEFORE the

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -264,6 +264,19 @@ jobs:
             features: ""
             harnesses: >-
               domain_corpus_exhibits_a_surviving_escalation
+    # [OPUS-5] PINNED-TOOLCHAIN ESCAPE — REQUIRED here, not belt-and-braces. The repo root
+    # carries a `rust-toolchain.toml` pinning STABLE, and rustup resolves that file
+    # (precedence 4) ABOVE the `rustup default <toolchain>` that `dtolnay/rust-toolchain`
+    # performs (precedence 5). Unlike the miri/asan/fuzz lanes, NOTHING in this job uses
+    # `cargo +<toolchain>`: `cargo install --locked kani-verifier`, `cargo kani setup` and
+    # every `cargo kani --harness` invocation are plain cargo calls, so without this env
+    # var they would all silently move from the declared nightly onto pinned stable —
+    # changing which compiler builds the driver and which host toolchain Kani's codegen
+    # sits on. `RUSTUP_TOOLCHAIN` is precedence 2 and beats the file, preserving exactly
+    # the toolchain this lane resolved to before the pin existed. Keep in sync with the
+    # `toolchain:` input below.
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2026-06-11
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Kani pins its own internal toolchain via `cargo kani setup`, but it still needs a host

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -164,6 +164,17 @@ jobs:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+    # [OPUS-5] PINNED-TOOLCHAIN ESCAPE. The repo root carries a `rust-toolchain.toml`
+    # pinning STABLE. rustup resolves that file (precedence 4) ABOVE the `rustup default
+    # <toolchain>` that `dtolnay/rust-toolchain` performs (precedence 5), so with the pin
+    # in place a plain `cargo`/`rustc` in this job resolves to pinned stable, NOT the
+    # nightly this lane declares. The `cargo +nightly-2026-06-11 miri …` calls below are
+    # precedence 1 and were already immune; this env var (precedence 2) restores the
+    # pre-pin behaviour for everything else in the job — notably the `rustc -vV` that
+    # Swatinem/rust-cache derives its cache key from, which would otherwise silently
+    # re-key the Miri cache onto stable. Keep in sync with the `toolchain:` input below.
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2026-06-11
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -244,6 +255,9 @@ jobs:
     name: miri doctests (sparq-core)
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # [OPUS-5] PINNED-TOOLCHAIN ESCAPE — see the identical note on the `miri` job above.
+    env:
+      RUSTUP_TOOLCHAIN: nightly-2026-06-11
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -80,9 +80,13 @@
 #   3. a `rustup override set` directory override
 #   4. THIS FILE
 #   5. `rustup default`
-# So this file BEATS every `rustup default stable` in the workflow tree (those
-# ~40 lines are now no-ops for toolchain selection; they still usefully add
-# components), and is in turn BEATEN by `+toolchain` and `RUSTUP_TOOLCHAIN`.
+# So this file BEATS every `rustup default stable` in the workflow tree — all 40
+# of those lines are now COMPLETE no-ops, and is in turn BEATEN by `+toolchain`
+# and `RUSTUP_TOOLCHAIN`.
+# [OPUS-5] They add no components either: `rustup default stable` only selects.
+# Measured: of the 40 `run:` blocks containing `rustup default stable`, 7 also
+# contain a separate `rustup component add` — it is THAT command (which applies
+# to the active, i.e. pinned, toolchain) that adds anything, not the `default`.
 # The lanes that deliberately need a different compiler — the MSRV floor check
 # and the nightly Miri/ASan/fuzz/Kani lanes — assert themselves through those
 # two higher-precedence mechanisms, so they keep the compiler they declare.
@@ -130,9 +134,18 @@
 # the newest that exists.
 channel = "1.97.1"
 
-# `minimal` = rustc + cargo + rust-std only; every component this repo actually
-# needs is listed explicitly below rather than pulled in by the `default`
+# `minimal` = rustc + cargo + rust-std only; every component the PINNED-STABLE
+# lanes need is listed explicitly below rather than pulled in by the `default`
 # profile (which would also fetch rust-docs).
+#
+# [OPUS-5] Deliberately NOT the set of every component the repo uses. Three
+# more are needed elsewhere and are correctly NOT listed here:
+#   * `llvm-tools-preview` — the four ci.yml coverage jobs, added to the ACTIVE
+#     (pinned) toolchain by an explicit `rustup component add` step in each.
+#   * `miri`, `rust-src` — miri.yml / asan.yml / fuzz.yml, installed by their
+#     own `dtolnay/rust-toolchain` step onto the NIGHTLY those lanes escape to.
+# Listing any of them here would make every job that activates the pin fetch a
+# component it does not use.
 profile = "minimal"
 
 # clippy  — the `-D warnings` gate in ci.yml's `lint` job and in the registry's

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,160 @@
+# =============================================================================
+# PINNED RUST TOOLCHAIN — read this before changing the version.
+# =============================================================================
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# Until this file landed, NOTHING in sparq pinned a Rust version. Every stable
+# lane in `.github/workflows/` resolves its compiler with either
+#
+#     rustup default stable          (~40 sites, "use the runner image's Rust")
+#
+# or the SHA-pinned `dtolnay/rust-toolchain` action with no `toolchain:` input
+# (which also means "stable"). Both spellings mean "whatever Rust this machine
+# happens to carry" — they do NOT mean "a specific compiler". The registry's
+# review-fix gate (jeswr/agent-account-registry, `review-fix.yml`, the
+# "Ensure a Rust toolchain for the crate-scoped gate" step) inherits the same
+# property: it runs `rustup show active-toolchain || rustup default stable`
+# and then clippies THIS repository with `-D warnings`.
+#
+# So two independent consumers linted the same source with `-D warnings` on two
+# different compilers, and `-D warnings` turns any lint-set difference into a
+# hard build failure on unchanged code.
+#
+# THE MEASUREMENT (registry issue jeswr/agent-account-registry#664)
+# ----------------------------------------------------------------
+# `clippy::uninlined_format_args` is warn-by-default on clippy 1.88.0 and is
+# allow-by-default on every other version measured. Reproduced directly, on a
+# small crate containing the exact shape of `crates/sparq-core/src/nt.rs:411`
+# plus a field-access and a two-argument `format!`, `cargo clippy -- -D warnings`:
+#
+#     clippy 1.88.0  -> FAIL  (error: variables can be used directly in the
+#                              `format!` string ... `-D clippy::uninlined-format-args`
+#                              implied by `-D warnings`)
+#     clippy 1.89.0  -> pass
+#     clippy 1.97.0  -> pass
+#     clippy 1.97.1  -> pass   (the pin below)
+#
+# Measured versions only — 1.89.0/1.97.0/1.97.1 were tested, the versions
+# between them were not. On 1.97.1 the lint still EXISTS and fires under an
+# explicit `-W clippy::uninlined_format_args`; it is simply not on by default.
+# NOTE for anyone reading sparq issue #3575, which asserts the opposite ("on
+# Rust stable 1.97.1 `clippy::uninlined_format_args` is warn-by-default … once
+# the runner bumps to 1.97+ that lane fails repo-wide"): that claim does not
+# hold. sparq CI has been drawing 1.97.1 and the workspace `-D warnings` lane is
+# green, and the direct measurement above agrees. The hazard demonstrated here
+# runs the other way — a LAGGING toolchain, not a new one.
+#
+# On the live lanes, same source, same `-D warnings`:
+#
+#   * sparq's own `lint` job (ci.yml, `clippy (deny warnings)`) drew
+#     rustc 1.97.1 (8bab26f4f 2026-07-14) on three consecutive green runs
+#     and passes.
+#   * the registry fix gate drew rustc 1.88.0 (6b00bc388 2025-06-23) and failed
+#     on `crates/sparq-core/src/nt.rs:411` — a file the PR under test did not
+#     touch, that is unchanged on `main`, and that sparq CI is green on.
+#     Every registry fix run that actually reached the clippy gate failed this
+#     way; the one run recorded as a "success" never executed the gate step at
+#     all (it is conditional on `fix_made_changes == 'true'`), so it is not
+#     evidence that the same command sometimes passes.
+#
+# The exposure is NOT one lint. The codebase is written throughout in the
+# pre-inline `format!("{}", x)` style — an estimated 666+ sites across 41
+# crates — so a consumer that lands on the strict clippy does not fail on one
+# line, it fails on hundreds. Sweeping that is a scheduled project, not
+# something to do under a red `main`; see the FOLLOW-UP section.
+#
+# WHAT THIS FILE BUYS
+# -------------------
+# `rustup` honours a `rust-toolchain.toml` for EVERY consumer that runs cargo
+# anywhere inside this checkout — sparq's own CI, the registry's fix-lane gate
+# (its step `cd`s into the target checkout precisely so a target pin is
+# honoured), and a developer's laptop. One file makes them agree by
+# construction instead of by coincidence. It also removes the standing risk the
+# `lint` job's own comment already names — "a Rust-stable bump that adds a lint
+# fails CI" — because the compiler no longer moves without a commit.
+#
+# Precedence matters and is easy to get wrong. rustup resolves, highest first:
+#   1. `cargo +<toolchain>` / `rustc +<toolchain>`
+#   2. the `RUSTUP_TOOLCHAIN` environment variable
+#   3. a `rustup override set` directory override
+#   4. THIS FILE
+#   5. `rustup default`
+# So this file BEATS every `rustup default stable` in the workflow tree (those
+# ~40 lines are now no-ops for toolchain selection; they still usefully add
+# components), and is in turn BEATEN by `+toolchain` and `RUSTUP_TOOLCHAIN`.
+# The lanes that deliberately need a different compiler — the MSRV floor check
+# and the nightly Miri/ASan/fuzz/Kani lanes — assert themselves through those
+# two higher-precedence mechanisms, so they keep the compiler they declare.
+# If you add a lane that needs a non-pinned toolchain, it MUST use one of them;
+# `rustup default <x>` will silently lose to this file.
+#
+# COST, STATED HONESTLY
+# ---------------------
+# The repo carries an explicit CI-economy directive to use the runner image's
+# preinstalled toolchain and never trigger a toolchain download. This pin
+# partly gives that up: the image's toolchain is installed under the name
+# `stable`, and `1.97.1` is a DIFFERENT rustup toolchain directory even when it
+# is byte-identical, so jobs now fetch it once. `profile = "minimal"` plus an
+# explicit component/target list keeps that download as small as it can be.
+# That is the price of a reproducible lint gate and it was accepted knowingly.
+#
+# FOLLOW-UP (the deliberate exit from this pin)
+# ---------------------------------------------
+# Maintainer decision, 2026-07-25: PIN THE TOOLCHAIN NOW, SWEEP THE LINT LATER.
+# This file is deliberately only half the fix. The other half:
+#   1. Either sweep `uninlined_format_args` workspace-wide (mechanical via
+#      `cargo clippy --fix`, but a ~666-site diff across 41 crates needing a
+#      full workspace verification, and it would collide with most open PRs), or
+#      — smaller and more reviewable — state the project's position on the lint
+#      explicitly via `[workspace.lints.clippy]`. Note the convention conflict
+#      recorded in sparq issue #3575: positional `format!("{}", x)` args are
+#      mandated elsewhere to dodge a CodeQL `rust/unused-variable` false
+#      positive, so "just inline them" is not obviously the right answer.
+#   2. THEN bump the `channel` below deliberately, as its own reviewed change.
+#
+# The reason to do (1) before (2) is not that this specific lint is about to be
+# re-promoted — as measured above it is allow-by-default on 1.97.1. It is that
+# the workspace is written entirely in a style ONE lint-group decision away
+# from a repo-wide `-D warnings` failure, and this pin is currently the only
+# thing standing between that and `main`. Until (1) lands, treat a `channel`
+# bump as a change that can red the whole workspace, and verify it as one.
+#
+# =============================================================================
+
+[toolchain]
+# The exact compiler sparq CI is currently GREEN on: `rustup show
+# active-toolchain` in the `lint` job reported
+# `stable-x86_64-unknown-linux-gnu unchanged - rustc 1.97.1 (8bab26f4f 2026-07-14)`
+# on three consecutive successful runs. Pinning the version that passes, not
+# the newest that exists.
+channel = "1.97.1"
+
+# `minimal` = rustc + cargo + rust-std only; every component this repo actually
+# needs is listed explicitly below rather than pulled in by the `default`
+# profile (which would also fetch rust-docs).
+profile = "minimal"
+
+# clippy  — the `-D warnings` gate in ci.yml's `lint` job and in the registry's
+#           crate-scoped fix gate. This is the component the whole file is for.
+# rustfmt — `cargo fmt --all --check` (currently informational in `lint`).
+#
+# The ~40 `rustup component add rustfmt clippy` lines in the workflows remain
+# correct — with this file active they add to the pinned toolchain — but they
+# are now redundant, because rustup installs these when it materialises the
+# pin.
+components = ["clippy", "rustfmt"]
+
+# REQUIRED, not cosmetic. Roughly nineteen jobs across ci.yml, js.yml,
+# pages.yml, publish.yml, release.yml, gui.yml, bench.yml, site-visual.yml,
+# site-e2e-hero.yml, vectorized-feature-off.yml and nightly-full-sweep.yml
+# build for wasm32 after `dtolnay/rust-toolchain` installs the target `with:
+# targets: wasm32-unknown-unknown`. That action installs the target onto the
+# toolchain it manages (`stable`) and then calls `rustup default` — which this
+# file outranks. Without this line those jobs would resolve to `1.97.1`, find
+# no wasm32 `std`, and fail with "can't find crate for `core`". Declaring the
+# target here makes rustup materialise it on the pinned toolchain instead.
+# Verified locally: adding a `targets` entry for an ALREADY-INSTALLED toolchain
+# makes the next rustup invocation in the directory download the missing
+# `rust-std` before running.
+targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -139,10 +139,15 @@ profile = "minimal"
 #           crate-scoped fix gate. This is the component the whole file is for.
 # rustfmt — `cargo fmt --all --check` (currently informational in `lint`).
 #
-# The ~40 `rustup component add rustfmt clippy` lines in the workflows remain
-# correct — with this file active they add to the pinned toolchain — but they
-# are now redundant, because rustup installs these when it materialises the
-# pin.
+# The 11 `rustup component add` lines in the workflows remain correct — with
+# this file active they add to the pinned toolchain — but the 7 that add only
+# `clippy`/`rustfmt clippy` are now redundant, because rustup installs those
+# when it materialises the pin. The other 4 add `llvm-tools-preview`, which is
+# NOT listed here and so is still required (see the coverage jobs in ci.yml).
+# [OPUS-5] Counted, not estimated: `grep -c 'rustup component add'` over
+# .github/workflows = 11 (6 x `clippy`, 1 x `rustfmt clippy`, 4 x
+# `llvm-tools-preview`). The "~40" figure this comment previously carried was
+# the `rustup default stable` count copied to the wrong line.
 components = ["clippy", "rustfmt"]
 
 # REQUIRED, not cosmetic. Roughly nineteen jobs across ci.yml, js.yml,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/supply-chain lane, running on Claude Opus 5. Implements registry issue [jeswr/agent-account-registry#664](https://github.com/jeswr/agent-account-registry/issues/664) under the maintainer decision of 2026-07-25: **pin the toolchain now, sweep the lint later.** No `crates/` source is touched.

## The problem

Nothing in sparq pinned a Rust version. The ~40 `rustup default stable` sites and every `dtolnay/rust-toolchain` use without a `toolchain:` input both mean *"whatever Rust this machine happens to carry"* — not *"a specific compiler"*. The registry's review-fix gate (`review-fix.yml`, step *Ensure a Rust toolchain for the crate-scoped gate*) inherits the same property and then clippies **this** repository with `-D warnings`.

So two independent consumers linted identical source on different compilers, and `-D warnings` turns any lint-set difference into a hard failure on unchanged code.

### Measured

| Consumer | Compiler drawn | Result |
| --- | --- | --- |
| sparq CI `lint` job | `rustc 1.97.1 (8bab26f4f 2026-07-14)` | green |
| registry review-fix gate | `rustc 1.88.0 (6b00bc388 2025-06-23)` | fails on `crates/sparq-core/src/nt.rs:411` |

`nt.rs:411` is untouched by the PR under test and unchanged on `main`. Reproduced the mechanism directly on a small crate carrying that exact shape (plus a field-access and a two-argument `format!`), plain `cargo clippy -- -D warnings`:

```
clippy 1.88.0  -> FAIL   error: variables can be used directly in the `format!` string
                         = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
clippy 1.89.0  -> pass
clippy 1.97.0  -> pass
clippy 1.97.1  -> pass   (the pin)
```

## Two corrections to the diagnosis in #664

Both from evidence, and both change what the fix defends against.

**1. The intermittency is not a coin flip.** #664 reads "1 of 4 runs succeeded on identical source" as the signature of a heterogeneous runner fleet. It is not: the run recorded as a success (`review-fix fix sparq-org/sparq#3436`, 17:27Z) **never executed the clippy gate at all** — that step is conditional on `fix_made_changes == 'true'`, and its log contains no toolchain step and no gate step. Every run that actually reached the gate failed, deterministically, on 1.88.0.

**2. The strict clippy is the OLD one.** #664 warns that sparq `main` is "green only because the runners it has drawn carry the permissive clippy", implying a newer image would break it. The measurement runs the other way: 1.97.1 is the permissive one, 1.88.0 is strict. The demonstrated hazard is a **lagging** toolchain.

That also falsifies open issue **#3575**, which asserts `uninlined_format_args` is warn-by-default on stable 1.97.1 and predicts a repo-wide `-D warnings` failure "once the ubuntu-latest runner's preinstalled stable bumps to 1.97+". Runners are on 1.97.1 *now*, the workspace lane is green, and direct measurement agrees — on 1.97.1 the lint fires only under an explicit `-W clippy::uninlined_format_args`. Commented there rather than editing that issue.

## The fix, and the part that was easy to get wrong

`rust-toolchain.toml` at the repo root pinning **1.97.1**, with `profile = "minimal"`, `components = ["clippy", "rustfmt"]` and `targets = ["wasm32-unknown-unknown"]`. rustup honours it for every consumer inside the checkout — sparq CI, the registry gate (whose step `cd`s into the target checkout precisely so a target pin is honoured), and local builds.

But a root pin **outranks `rustup default`**, so it silently hijacks every lane that deliberately uses a different compiler. Verified precedence, empirically, in this worktree:

```
1  cargo +<toolchain>          2  RUSTUP_TOOLCHAIN
3  rustup override             4  rust-toolchain.toml        5  rustup default
```

Every lane was audited against that:

| Lane | Would the pin have broken it? | Fix |
| --- | --- | --- |
| `ci.yml` **msrv** (gating) | **Yes — silently vacuous.** `rustup default 1.88` loses to the file, so the floor check would compile on pinned stable again — the exact regression PR #3511 finding 4 fixed. | job-level `RUSTUP_TOOLCHAIN: "1.88"` |
| `formal-verification.yml` **kani** (gating) | **Yes.** Every cargo call is plain (`cargo install kani-verifier`, `cargo kani setup`, `cargo kani --harness`) — all would move onto pinned stable. | job-level `RUSTUP_TOOLCHAIN: nightly-2026-06-11` |
| `kani.yml` (informational) | **Yes**, same shape. | same |
| `miri.yml` x2, `asan.yml`, `fuzz.yml` | Partly. Their `cargo +nightly-2026-06-11` calls are precedence 1 and were already immune, but plain cargo / the `rustc -vV` that rust-cache keys on / `cargo fuzz`'s nested cargo invocation were not. | same env var, restoring pre-pin behaviour |
| ~19 wasm32 jobs across 11 workflows | **Yes.** `dtolnay/rust-toolchain … targets: wasm32-unknown-unknown` installs the target onto the `stable` toolchain *it* manages; the pin outranks it, so those builds would fail with no wasm32 `std`. | `targets` declared in the toolchain file |
| 4 coverage jobs in `ci.yml` | **Yes.** Same shape for `components: llvm-tools-preview`; `cargo llvm-cov` would find no llvm-tools. | explicit `rustup component add llvm-tools-preview` per job |
| `build-matrix.yml` | No. Its `rustup target add` applies to the **active** toolchain, which is now the pinned one. | none |

The ~40 `rustup default stable` lines are left alone: under the pin they are no-ops for *selection* but still usefully add components, and rewriting them all would be large churn colliding with open PRs. (Their comments claiming "never trigger a toolchain download" are now inaccurate — real doc drift, but it overlaps existing issue #3720's 71-copy toolchain-preamble dedup, so I did not file a duplicate.)

## Verified vs not verified

**Verified locally** (work box, `aarch64-unknown-linux-gnu`):

- `rust-toolchain.toml` parses; `rustup show active-toolchain` in the worktree reports `1.97.1-… (overridden by '<repo>/rust-toolchain.toml')`; rustc/cargo/clippy all report 1.97.1.
- Precedence, all three directions: the file overrides `rustup default`; `RUSTUP_TOOLCHAIN=1.88` overrides the file; `+<toolchain>` overrides the file.
- rustup **does** install a toolchain-file `targets` entry on demand — observed it fetch wasm32 `rust-std` onto an already-installed toolchain.
- `rustup component add llvm-tools-preview` resolves onto the pinned toolchain.
- `cargo clippy -p sparq-core --all-targets -- -D warnings` → **exit 0** under the pin. That is the exact crate and lint the registry gate died on.
- `cargo clippy --workspace --all-targets -- -D warnings` → **exit 0, zero warnings**, the full workspace clean on 1.97.1 (13m05s cold on this box).
- All 63 workflow files parse as YAML; `actionlint` clean on all six changed files.
- `scripts/check-privacy-claims.sh` passes.

**Not verified — stated plainly:**

- This box is **aarch64**; CI is **x86_64**. Clippy lint sets are not target-specific, but no local run proves the CI host.
- The workspace clippy above was **default features only**. The gating `--all-features` sibling step was not run locally (RAM).
- The nightly lanes (**miri / asan / fuzz / kani / formal-verification**) were **not executed here** — Kani/CBMC and `-Zbuild-std` sanitizer builds are not runnable on this box in reasonable time. Their `RUSTUP_TOOLCHAIN` escapes follow the precedence rule verified above and are built to preserve each lane's pre-pin resolution exactly, but they are **documented-untested; validate on the first CI run of each lane.** `miri` / `asan` / `kani` are scheduled lanes, so their first real exercise may not be on this PR.
- No wasm32 crate was compiled end-to-end here; only the presence of the target on the pinned toolchain was verified.
- **CI cost, not measured.** The pin partly gives up the repo's explicit use-the-preinstalled-toolchain economy directive: the image installs its Rust under the name `stable`, and `1.97.1` is a separate rustup toolchain directory even when byte-identical, so Rust jobs now fetch it once. `profile = "minimal"` plus an explicit component/target list keeps that as small as possible. An accepted tradeoff, not a measured one.

No tests were added: this change has no runtime behaviour to assert, and a test that only re-stated the file's contents would be vacuous. The claims above rest on the reproductions listed, not on a new assertion.

## Gate impact

No job was renamed, added or removed — only job-level `env:` blocks and one new step in four coverage jobs. The `ci-summary / gate` aggregator is unaffected; it resolves advisory status from `.github/advisory-registry.json`, which this PR does not touch. The path filter is preserved: no `changes` / `rust_changed` condition was altered.

## Follow-up (deliberately not done here)

Per the maintainer decision the 666-site `uninlined_format_args` sweep is **not** attempted. The exit path from this pin is documented in the file itself: either sweep the lint or declare the project's position via `[workspace.lints.clippy]` — noting the convention conflict in #3575, where positional args are mandated elsewhere to dodge a CodeQL false positive — and only then bump `channel` as its own reviewed change.
