### PR TITLE
fix(orchestration): make ready work visible — occupancy attribution, in-review status, local/orchestrator parity

### DIFF
--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -28,6 +28,10 @@ on:
       # batching) — run its hermetic self-test on the PR that could break either side.
       - "scripts/batch-merge.py"
       - "scripts/ci_select.py"
+      # [OPUS-5] the readiness VISIBILITY suite — pins the occupancy-attribution,
+      # in-progress-review and local/orchestrator-parity contracts, and pins this
+      # workflow's own run block to the scripts it must invoke.
+      - "scripts/tests/test_readiness_visibility.py"
       - ".github/workflows/routing-self-tests.yml"
   merge_group:
   push:
@@ -42,6 +46,10 @@ on:
       # batching) — run its hermetic self-test on the PR that could break either side.
       - "scripts/batch-merge.py"
       - "scripts/ci_select.py"
+      # [OPUS-5] the readiness VISIBILITY suite — pins the occupancy-attribution,
+      # in-progress-review and local/orchestrator-parity contracts, and pins this
+      # workflow's own run block to the scripts it must invoke.
+      - "scripts/tests/test_readiness_visibility.py"
       - ".github/workflows/routing-self-tests.yml"
 
 permissions:
@@ -65,5 +73,10 @@ jobs:
           python3 scripts/routing-validate.py --self-test
           python3 scripts/routing-validate.py
           python3 scripts/route-resolve.py --self-test
+          # [OPUS-5] ready-issues.py was in the `paths:` filter above but its --self-test was
+          # NEVER invoked here, so its assertions were dead in this repo's CI and first ran
+          # inside the registry's dispatch tick — where a failure breaks EVERY target at once.
+          python3 scripts/ready-issues.py --self-test
           python3 scripts/dispatch-plan.py --self-test
           python3 scripts/batch-merge.py --self-test
+          python3 scripts/tests/test_readiness_visibility.py

--- a/scripts/audit-issue-deps.py
+++ b/scripts/audit-issue-deps.py
@@ -362,6 +362,9 @@ def main():
     ap.add_argument("--prove", action="store_true", help="print the direction-proof witness and exit")
     ap.add_argument("--remove-spurious", action="store_true",
                     help="with --apply, also DELETE native edges with no bd counterpart")
+    ap.add_argument("--include-closed-blockers", action="store_true",
+                    help="also mirror edges whose blocker issue is already CLOSED (inert for "
+                         "readiness — GitHub's issueDependenciesSummary.blockedBy excludes them)")
     ap.add_argument("--json-out", help="write the full audit record here")
     ap.add_argument("--limit", type=int, help="cap the number of writes this run")
     args = ap.parse_args()
@@ -385,26 +388,34 @@ def main():
     have = {(n, k) for n, ks in native.items() for k in ks}
     have_mapped = {(n, k) for (n, k) in have if n in rev and k in rev}
 
-    missing = sorted(want - have)
+    absent = sorted(want - have)
     spurious = sorted(have - want)          # native edge with no bd counterpart (incl. unmapped ends)
     present = sorted(want & have)
+
+    # An absent edge whose BLOCKER ISSUE is already CLOSED is SATISFIED, not missing: MEASURED,
+    # GitHub reports `issueDependenciesSummary.blockedBy = 0` for a closed blocker (while
+    # `totalBlockedBy` counts it), and scripts/ready-issues.py counts a `Blocked-by: #NN` marker
+    # only when the number is in `open_numbers`. Neither consumer would hold the child. They are
+    # reported in their own bucket so a re-run does not carry a permanent phantom "missing" count
+    # that would mask a real future gap. `--include-closed-blockers` mirrors them anyway.
+    def blocker_closed(e):
+        return issues.get(e[1], {}).get("state") != "open"
+
+    satisfied = [e for e in absent if blocker_closed(e)]
+    missing = [e for e in absent if not blocker_closed(e)]
 
     # ---- 2. stale blockers: an edge whose BLOCKER issue is already CLOSED -----------------------
     stale_native = sorted((n, k) for (n, k) in have
                           if issues.get(k, {}).get("state") == "closed"
                           and issues.get(n, {}).get("state") == "open")
-    stale_want = sorted((n, k) for (n, k) in want
-                        if issues.get(k, {}).get("state") == "closed"
-                        and issues.get(n, {}).get("state") == "open")
-    # bd-side equivalent: open bead blocked by a closed bead
+    # bd-side equivalent: open bead blocked by a closed bead. NOT a defect on its own — `bd ready`
+    # is blocker-aware and treats a closed blocker as satisfied (verified: sq-0xquh, whose only
+    # blocker sq-0wo9e is closed, IS listed by `bd ready --limit 2000`). Reported for visibility.
     stale_bd = sorted((a, b) for (a, b) in edges_bd
                       if bd_is_open(beads.get(a)) and not bd_is_open(beads.get(b)))
 
     # ---- 3. writes we will actually perform -----------------------------------------------------
-    # Do NOT write an edge whose blocker is already CLOSED: it would create a permanently-satisfied
-    # blocker that GitHub still renders as blocked, hiding ready work. Report them instead.
-    to_add = [(n, k) for (n, k) in missing if issues.get(k, {}).get("state") == "open"]
-    skipped_closed_blocker = [(n, k) for (n, k) in missing if issues.get(k, {}).get("state") != "open"]
+    to_add = missing + (satisfied if args.include_closed_blockers else [])
 
     # ---- 4. cycles -------------------------------------------------------------------------------
     cyc_bd = find_cycles({(a, b) for (a, b) in edges_bd
@@ -424,18 +435,21 @@ def main():
         "github_native_edges_total": len(have),
         "github_native_edges_both_ends_bd_mapped": len(have_mapped),
         "present": len(present),
-        "missing": len(missing),
-        "missing_writable_open_blocker": len(to_add),
-        "missing_skipped_closed_blocker": len(skipped_closed_blocker),
+        "missing_active": len(missing),
+        "satisfied_blocker_closed_not_mirrored": len(satisfied),
+        "satisfied_distinct_children": len({n for n, _ in satisfied}),
+        "will_write": len(to_add),
         "spurious": len(spurious),
         "stale_native_open_issue_blocked_by_closed_issue": len(stale_native),
-        "stale_would_be_if_written": len(stale_want),
         "stale_bd_open_bead_blocked_by_closed_bead": len(stale_bd),
         "cycles_bd_open": cyc_bd,
         "cycles_github_projected": cyc_gh_after,
         "samples": {
-            "missing": [{"blocked": f"#{n} ({rev.get(n)})", "blocker": f"#{k} ({rev.get(k)})"}
-                        for n, k in missing[:15]],
+            "missing_active": [{"blocked": f"#{n} ({rev.get(n)})", "blocker": f"#{k} ({rev.get(k)})"}
+                               for n, k in missing[:15]],
+            "satisfied_blocker_closed": [
+                {"blocked": f"#{n} ({rev.get(n)})", "closed_blocker": f"#{k} ({rev.get(k)})"}
+                for n, k in satisfied[:20]],
             "spurious": [{"blocked": f"#{n} ({rev.get(n, '-')})", "blocker": f"#{k} ({rev.get(k, '-')})"}
                          for n, k in spurious[:15]],
             "stale_native": [{"blocked": f"#{n}", "closed_blocker": f"#{k}"} for n, k in stale_native[:15]],
@@ -488,7 +502,7 @@ def main():
             rep["applied_remove_noop"] = rnoop
     else:
         print(f"\n[audit-only] would add {len(to_add)} native edge(s); "
-              f"{len(skipped_closed_blocker)} skipped (blocker already closed); "
+              f"{len(satisfied)} not mirrored (blocker already closed — inert); "
               f"{len(spurious)} spurious edge(s) present. Re-run with --apply.")
 
     if args.json_out:

--- a/scripts/audit-issue-deps.py
+++ b/scripts/audit-issue-deps.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Dependency-graph audit + repair: bd blocker edges <-> GitHub NATIVE issue dependencies.
+"""audit-issue-deps.py — measure, then repair, the dependency graph mirrored from bd into GitHub.
+
+The migration (scripts/bd-to-issues.py) wrote blocker edges only as `Blocked-by: #NN` BODY MARKERS.
+GitHub issue dependencies are now generally available, and the orchestrator's readiness engine reads
+the NATIVE edges. This tool reconciles the two.
+
+DIRECTION (the load-bearing detail — proven, not assumed):
+  bd export emits `{"issue_id": X, "depends_on_id": Y, "type": "blocks"}`.
+  `bd dep add <blocked> <blocker>` == "<blocked> depends on <blocker>", and `bd show X` renders the
+  record under "DEPENDS ON -> Y" while `bd show Y` renders it under "BLOCKS <- X".
+  => X is BLOCKED BY Y.
+  => GitHub: issue(X).blocked_by must contain issue(Y).
+  `--prove` re-derives this from the live tree and prints the witness pair.
+
+EDGE TYPES: `blocks` and `blocked-by` are both blocker edges with the SAME orientation in the export
+(both mean "issue_id depends on depends_on_id" — verified via `bd show`). bd-to-issues.py only
+handled "blocks", silently dropping the `blocked-by` rows; this tool handles both.
+`parent-child` is deliberately NOT a blocker (it becomes a GitHub sub-issue/parent link) — mirroring
+it as blocked_by would reintroduce the sub-epic-leaf-invisibility bug the migration fixed.
+
+DEFAULT is read-only (audit). `--apply` performs the repair. Idempotent: a second `--apply` is a
+no-op (it re-reads live state and finds nothing to do).
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+REPO = "sparq-org/sparq"
+MIGRATION_LABEL = "bd-migration"
+BLOCKER_TYPES = ("blocks", "blocked-by")
+OPEN_STATES = ("open", "in_progress")
+MARKER = re.compile(r"<!--\s*bd-id:(\S+?)\s*-->")
+
+
+# --- shelling out -------------------------------------------------------------------------------
+def run(args, check=True, retries=5):
+    """gh wrapper with secondary-rate-limit backoff."""
+    delay = 2.0
+    for attempt in range(retries):
+        r = subprocess.run(args, capture_output=True, text=True)
+        if r.returncode == 0:
+            return r
+        err = (r.stderr or "") + (r.stdout or "")
+        if re.search(r"secondary rate limit|rate limit exceeded|abuse detection|was submitted too quickly", err, re.I):
+            time.sleep(delay)
+            delay *= 2
+            continue
+        if attempt < retries - 1 and re.search(r"HTTP 50[0-9]|timeout|TLS handshake", err, re.I):
+            time.sleep(delay)
+            delay *= 2
+            continue
+        if check:
+            raise SystemExit(f"command failed: {' '.join(args[:6])}...\n{err[:800]}")
+        return r
+    raise SystemExit(f"gave up after {retries} attempts: {' '.join(args[:6])}")
+
+
+# --- bd side ------------------------------------------------------------------------------------
+def bd_beads(export_file=None):
+    """{bd-id: bead} from `bd export` (all statuses)."""
+    if export_file:
+        lines = open(export_file, encoding="utf-8").read().splitlines()
+    else:
+        lines = run(["bd", "export"]).stdout.splitlines()
+    beads = {}
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        d = json.loads(line)
+        if d.get("_type", "issue") == "issue" and "id" in d:
+            beads[d["id"]] = d
+    return beads
+
+
+def bd_blocker_edges(beads):
+    """{(blocked_bd_id, blocker_bd_id)} — X blocked-by Y — over ALL beads, any status."""
+    edges = set()
+    for bid, b in beads.items():
+        for dep in b.get("dependencies") or []:
+            if not isinstance(dep, dict):
+                continue
+            if dep.get("type") not in BLOCKER_TYPES:
+                continue
+            to = dep.get("depends_on_id") or dep.get("depends_on") or dep.get("to")
+            frm = dep.get("issue_id") or bid
+            if to and frm and to != frm:
+                edges.add((frm, to))
+    return edges
+
+
+def bd_is_open(bead):
+    return str((bead or {}).get("status", "")).lower() in OPEN_STATES
+
+
+# --- GitHub side --------------------------------------------------------------------------------
+def gh_issues():
+    """All non-PR issues: {number: {...}} via the LIST API (the search index lags — never use it)."""
+    out = run(["gh", "api", "--paginate", f"repos/{REPO}/issues?state=all&per_page=100", "--slurp"]).stdout
+    flat = [x for page in json.loads(out) for x in page]
+    return {x["number"]: {"state": x["state"], "title": x.get("title") or "",
+                          "labels": {l["name"] for l in x.get("labels") or []},
+                          "body": x.get("body") or "",
+                          "author": (x.get("user") or {}).get("login") or "",
+                          "assoc": x.get("author_association") or "",
+                          "id": x["id"]}
+            for x in flat if "pull_request" not in x}
+
+
+BD_ID = re.compile(r"^sq-[0-9a-z]+(\.[0-9]+)*$")
+# Repo principals that can author an issue. A `<!-- bd-id: -->` body marker is FORGEABLE, so it is
+# never trusted alone. bd-to-issues.py authenticated it with the `bd-migration` LABEL, but that label
+# was only ever stamped on the first 137-issue pilot (issues #2407-#2657, 2026-07-17 morning); the
+# remaining 755 migrated issues were created by a later run that never applied it (repo issues #2534
+# / #2535 filed exactly this gap and were closed without the backfill landing). Authenticating on
+# the label alone therefore discards 85% of the real graph.
+# The rule used here is strictly stronger than "marker present" and needs the same privilege the
+# label did: the issue must be authored by a repo MEMBER/OWNER (or a repo App), the marker must match
+# the bd-id grammar, AND the issue TITLE must independently carry the same `<bd-id>:` prefix that
+# bd-to-issues.py::_create_issue writes. An outside contributor cannot satisfy the author check, so a
+# decoy cannot capture a bd-id.
+TRUSTED_ASSOC = {"MEMBER", "OWNER", "COLLABORATOR"}
+TRUSTED_AUTHORS = {"sparq-orchestrator[bot]"}
+
+
+def bd_id_map(issues):
+    """{bd-id: issue_number} from body markers with MIGRATION PROVENANCE (see TRUSTED_ASSOC).
+
+    Returns (map, unverified, collisions). `unverified` = a marker we refuse to trust."""
+    trusted, unverified, collisions = {}, {}, defaultdict(list)
+    for num, it in sorted(issues.items()):
+        m = MARKER.search(it["body"])
+        if not m:
+            continue
+        bid = m.group(1)
+        privileged = it["assoc"] in TRUSTED_ASSOC or it["author"] in TRUSTED_AUTHORS
+        if not (privileged and BD_ID.fullmatch(bid) and it["title"].startswith(bid + ":")):
+            unverified.setdefault(bid, []).append(num)
+            continue
+        collisions[bid].append(num)
+        # deterministic winner: the LOWEST issue number (the original create; later ones are dups)
+        if bid not in trusted or num < trusted[bid]:
+            trusted[bid] = num
+    return trusted, unverified, {b: n for b, n in collisions.items() if len(n) > 1}
+
+
+GQL = """
+query($owner:String!, $name:String!, $cursor:String) {
+  repository(owner:$owner, name:$name) {
+    issues(first:50, after:$cursor, orderBy:{field:CREATED_AT, direction:ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        blockedBy(first:50) { totalCount nodes { number } }
+      }
+    }
+  }
+}"""
+
+
+def gh_native_blocked_by():
+    """{issue_number: set(blocker_numbers)} for the whole repo, via GraphQL (bulk, 50/page)."""
+    owner, name = REPO.split("/")
+    out, cursor, truncated = {}, None, []
+    while True:
+        args = ["gh", "api", "graphql", "-f", f"query={GQL}", "-F", f"owner={owner}", "-F", f"name={name}"]
+        if cursor:
+            args += ["-F", f"cursor={cursor}"]
+        data = json.loads(run(args).stdout)
+        if "errors" in data and data["errors"]:
+            raise SystemExit(f"graphql: {json.dumps(data['errors'])[:600]}")
+        page = data["data"]["repository"]["issues"]
+        for n in page["nodes"]:
+            bb = n.get("blockedBy") or {}
+            nodes = {x["number"] for x in (bb.get("nodes") or [])}
+            if bb.get("totalCount", 0) > len(nodes):
+                truncated.append(n["number"])
+            if nodes:
+                out[n["number"]] = nodes
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+    if truncated:
+        print(f"WARNING: blockedBy page cap hit on issues {truncated[:10]} — rerun with a larger page")
+    return out
+
+
+def _issue_id(num, issues):
+    """The REST database id of an issue (the POST/DELETE body takes the *id*, not the number)."""
+    if num in issues and issues[num].get("id"):
+        return issues[num]["id"]
+    return json.loads(run(["gh", "api", f"repos/{REPO}/issues/{num}"]).stdout)["id"]
+
+
+def add_blocked_by(blocked_num, blocker_num, issues):
+    """issue(blocked_num).blocked_by += issue(blocker_num). IDEMPOTENT: GitHub answers a repeat POST
+    with 422 'Target issue has already been taken', which is reported here as a no-op success."""
+    bid = _issue_id(blocker_num, issues)
+    r = run(["gh", "api", "--method", "POST", f"repos/{REPO}/issues/{blocked_num}/dependencies/blocked_by",
+             "-F", f"issue_id={bid}"], check=False)
+    if r.returncode == 0:
+        return True, "added"
+    err = ((r.stderr or "") + (r.stdout or ""))[:300]
+    if re.search(r"already exist|has already been taken|duplicate", err, re.I):
+        return True, "already"
+    return False, err
+
+
+def remove_blocked_by(blocked_num, blocker_num, issues):
+    bid = _issue_id(blocker_num, issues)
+    r = run(["gh", "api", "--method", "DELETE",
+             f"repos/{REPO}/issues/{blocked_num}/dependencies/blocked_by/{bid}"], check=False)
+    if r.returncode == 0:
+        return True, "removed"
+    err = ((r.stderr or "") + (r.stdout or ""))[:300]
+    if re.search(r"not found|404", err, re.I):
+        return True, "absent"          # idempotent: already gone
+    return False, err
+
+
+# --- cycles -------------------------------------------------------------------------------------
+def find_cycles(edges):
+    """edges = {(blocked, blocker)}. Returns list of cycles (node lists) via iterative Tarjan SCC."""
+    adj = defaultdict(list)
+    nodes = set()
+    for a, b in edges:
+        adj[a].append(b)
+        nodes.add(a)
+        nodes.add(b)
+    index, low, onstack, stack, idx = {}, {}, set(), [], [0]
+    out = []
+    for root in sorted(nodes, key=str):
+        if root in index:
+            continue
+        work = [(root, iter(adj[root]))]
+        index[root] = low[root] = idx[0]
+        idx[0] += 1
+        stack.append(root)
+        onstack.add(root)
+        while work:
+            v, it = work[-1]
+            advanced = False
+            for w in it:
+                if w not in index:
+                    index[w] = low[w] = idx[0]
+                    idx[0] += 1
+                    stack.append(w)
+                    onstack.add(w)
+                    work.append((w, iter(adj[w])))
+                    advanced = True
+                    break
+                if w in onstack:
+                    low[v] = min(low[v], index[w])
+            if advanced:
+                continue
+            work.pop()
+            if work:
+                low[work[-1][0]] = min(low[work[-1][0]], low[v])
+            if low[v] == index[v]:
+                comp = []
+                while True:
+                    w = stack.pop()
+                    onstack.discard(w)
+                    comp.append(w)
+                    if w == v:
+                        break
+                if len(comp) > 1 or v in adj[v]:
+                    out.append(sorted(comp, key=str))
+    return out
+
+
+# --- direction proof ---------------------------------------------------------------------------
+def prove_direction(beads, edges, idmap, native):
+    """Pick a live (blocked, blocker) pair that is mapped BOTH sides and re-derive the orientation
+    from `bd show` output, then report the GitHub native state for the same pair."""
+    for blocked, blocker in sorted(edges):
+        if blocked in idmap and blocker in idmap and bd_is_open(beads.get(blocked)):
+            bshow = run(["bd", "show", blocked], check=False).stdout
+            oshow = run(["bd", "show", blocker], check=False).stdout
+            sec_b = re.search(r"DEPENDS ON\n((?:\s+→.*\n)+)", bshow)
+            sec_o = re.search(r"BLOCKS\n((?:\s+←.*\n)+)", oshow)
+            fwd = bool(sec_b and blocker in sec_b.group(1))
+            rev = bool(sec_o and blocked in sec_o.group(1))
+            if fwd and rev:
+                nb, nk = idmap[blocked], idmap[blocker]
+                return {
+                    "blocked_bd": blocked, "blocker_bd": blocker,
+                    "blocked_issue": nb, "blocker_issue": nk,
+                    "bd_show_blocked_lists_blocker_under_DEPENDS_ON": fwd,
+                    "bd_show_blocker_lists_blocked_under_BLOCKS": rev,
+                    "github_blocked_by_present": nk in native.get(nb, set()),
+                    "statement": f"bd {blocked} is blocked by {blocker}; "
+                                 f"GitHub issue #{nb} must be blocked_by #{nk}",
+                }
+    return None
+
+
+# --- main ---------------------------------------------------------------------------------------
+def _self_test():
+    ok = True
+
+    def chk(n, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {'ok  ' if good else 'FAIL'} {n}: {got!r} (want {want!r})")
+
+    # --- orientation: the export record {issue_id: X, depends_on_id: Y} means X is BLOCKED BY Y.
+    # A reversed reader would emit (Y, X) here — this is the guard against inverting the graph.
+    beads = {"X": {"id": "X", "status": "open",
+                   "dependencies": [{"issue_id": "X", "depends_on_id": "Y", "type": "blocks"}]},
+             "Y": {"id": "Y", "status": "open"}}
+    chk("blocks edge orients (blocked, blocker)", bd_blocker_edges(beads), {("X", "Y")})
+    # `blocked-by` rows have the SAME orientation (verified via `bd show sq-8ic6`) and must NOT be
+    # dropped — bd-to-issues.py::plan only matched "blocks" and silently lost them.
+    beads["X"]["dependencies"][0]["type"] = "blocked-by"
+    chk("blocked-by edge is kept, same orientation", bd_blocker_edges(beads), {("X", "Y")})
+    # parent-child is NOT a blocker (mirroring it re-creates sub-epic-leaf-invisibility)
+    beads["X"]["dependencies"][0]["type"] = "parent-child"
+    chk("parent-child is not a blocker edge", bd_blocker_edges(beads), set())
+    beads["X"]["dependencies"][0]["type"] = "related"
+    chk("related is not a blocker edge", bd_blocker_edges(beads), set())
+
+    # --- cycles
+    chk("no cycle in a chain", find_cycles({("a", "b"), ("b", "c")}), [])
+    chk("2-cycle found", [sorted(c) for c in find_cycles({("a", "b"), ("b", "a")})], [["a", "b"]])
+    chk("3-cycle found", [sorted(c) for c in find_cycles({("a", "b"), ("b", "c"), ("c", "a")})],
+        [["a", "b", "c"]])
+    chk("self-loop found", [sorted(c) for c in find_cycles({("a", "a")})], [["a"]])
+    chk("cycle found with a dangling tail",
+        [sorted(c) for c in find_cycles({("a", "b"), ("b", "a"), ("c", "a")})], [["a", "b"]])
+
+    # --- provenance: a marker alone must NOT capture a bd-id
+    base = {"body": "<!-- bd-id:sq-abc -->", "title": "sq-abc: t", "labels": set(), "id": 1,
+            "state": "open", "author": "outsider", "assoc": "NONE"}
+    chk("outsider marker rejected", bd_id_map({5: dict(base)})[0], {})
+    chk("member marker accepted", bd_id_map({5: dict(base, author="jeswr", assoc="MEMBER")})[0],
+        {"sq-abc": 5})
+    chk("member marker with a DISAGREEING title rejected",
+        bd_id_map({5: dict(base, author="jeswr", assoc="MEMBER", title="sq-zzz: t")})[0], {})
+    chk("non-grammar marker rejected (doc issues quoting the marker format)",
+        bd_id_map({5: dict(base, author="jeswr", assoc="MEMBER", body="<!-- bd-id:… -->",
+                           title="… : t")})[0], {})
+    chk("lowest issue number wins a duplicate bd-id",
+        bd_id_map({9: dict(base, author="j", assoc="MEMBER"),
+                   5: dict(base, author="j", assoc="MEMBER")})[0], {"sq-abc": 5})
+    print("audit-issue-deps self-test", "PASSED" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--apply", action="store_true", help="write the repair (default: audit only)")
+    ap.add_argument("--export-file", help="read `bd export` output from a file")
+    ap.add_argument("--prove", action="store_true", help="print the direction-proof witness and exit")
+    ap.add_argument("--remove-spurious", action="store_true",
+                    help="with --apply, also DELETE native edges with no bd counterpart")
+    ap.add_argument("--json-out", help="write the full audit record here")
+    ap.add_argument("--limit", type=int, help="cap the number of writes this run")
+    args = ap.parse_args()
+    if args.self_test:
+        return _self_test()
+
+    beads = bd_beads(args.export_file)
+    edges_bd = bd_blocker_edges(beads)
+    issues = gh_issues()
+    idmap, unverified, collisions = bd_id_map(issues)
+    rev = {n: b for b, n in idmap.items()}
+    native = gh_native_blocked_by()
+
+    if args.prove:
+        print(json.dumps(prove_direction(beads, edges_bd, idmap, native), indent=2))
+        return 0
+
+    # ---- 1. bd edges where BOTH endpoints have issues -------------------------------------------
+    mappable = {(a, b) for (a, b) in edges_bd if a in idmap and b in idmap}
+    want = {(idmap[a], idmap[b]) for (a, b) in mappable}       # (blocked_issue, blocker_issue)
+    have = {(n, k) for n, ks in native.items() for k in ks}
+    have_mapped = {(n, k) for (n, k) in have if n in rev and k in rev}
+
+    missing = sorted(want - have)
+    spurious = sorted(have - want)          # native edge with no bd counterpart (incl. unmapped ends)
+    present = sorted(want & have)
+
+    # ---- 2. stale blockers: an edge whose BLOCKER issue is already CLOSED -----------------------
+    stale_native = sorted((n, k) for (n, k) in have
+                          if issues.get(k, {}).get("state") == "closed"
+                          and issues.get(n, {}).get("state") == "open")
+    stale_want = sorted((n, k) for (n, k) in want
+                        if issues.get(k, {}).get("state") == "closed"
+                        and issues.get(n, {}).get("state") == "open")
+    # bd-side equivalent: open bead blocked by a closed bead
+    stale_bd = sorted((a, b) for (a, b) in edges_bd
+                      if bd_is_open(beads.get(a)) and not bd_is_open(beads.get(b)))
+
+    # ---- 3. writes we will actually perform -----------------------------------------------------
+    # Do NOT write an edge whose blocker is already CLOSED: it would create a permanently-satisfied
+    # blocker that GitHub still renders as blocked, hiding ready work. Report them instead.
+    to_add = [(n, k) for (n, k) in missing if issues.get(k, {}).get("state") == "open"]
+    skipped_closed_blocker = [(n, k) for (n, k) in missing if issues.get(k, {}).get("state") != "open"]
+
+    # ---- 4. cycles -------------------------------------------------------------------------------
+    cyc_bd = find_cycles({(a, b) for (a, b) in edges_bd
+                          if bd_is_open(beads.get(a)) and bd_is_open(beads.get(b))})
+    cyc_gh_after = find_cycles(want | have)
+
+    rep = {
+        "beads_total": len(beads),
+        "beads_open": sum(1 for b in beads.values() if bd_is_open(b)),
+        "gh_issues_nonpr": len(issues),
+        "bd_ids_mapped_to_issues": len(idmap),
+        "unauthenticated_markers": {k: v for k, v in list(unverified.items())[:20]},
+        "unauthenticated_marker_count": len(unverified),
+        "bd_id_collisions": collisions,
+        "bd_blocker_edges_total": len(edges_bd),
+        "bd_blocker_edges_both_endpoints_mapped": len(mappable),
+        "github_native_edges_total": len(have),
+        "github_native_edges_both_ends_bd_mapped": len(have_mapped),
+        "present": len(present),
+        "missing": len(missing),
+        "missing_writable_open_blocker": len(to_add),
+        "missing_skipped_closed_blocker": len(skipped_closed_blocker),
+        "spurious": len(spurious),
+        "stale_native_open_issue_blocked_by_closed_issue": len(stale_native),
+        "stale_would_be_if_written": len(stale_want),
+        "stale_bd_open_bead_blocked_by_closed_bead": len(stale_bd),
+        "cycles_bd_open": cyc_bd,
+        "cycles_github_projected": cyc_gh_after,
+        "samples": {
+            "missing": [{"blocked": f"#{n} ({rev.get(n)})", "blocker": f"#{k} ({rev.get(k)})"}
+                        for n, k in missing[:15]],
+            "spurious": [{"blocked": f"#{n} ({rev.get(n, '-')})", "blocker": f"#{k} ({rev.get(k, '-')})"}
+                         for n, k in spurious[:15]],
+            "stale_native": [{"blocked": f"#{n}", "closed_blocker": f"#{k}"} for n, k in stale_native[:15]],
+            "stale_bd": [{"open_bead": a, "closed_blocker_bead": b} for a, b in stale_bd[:15]],
+        },
+    }
+
+    print(json.dumps({k: v for k, v in rep.items() if k != "samples"}, indent=2))
+    print("\nSAMPLES\n" + json.dumps(rep["samples"], indent=2))
+
+    proof = prove_direction(beads, edges_bd, idmap, native)
+    print("\nDIRECTION PROOF\n" + json.dumps(proof, indent=2))
+    rep["direction_proof"] = proof
+
+    if args.apply:
+        if not proof or not (proof["bd_show_blocked_lists_blocker_under_DEPENDS_ON"]
+                             and proof["bd_show_blocker_lists_blocked_under_BLOCKS"]):
+            raise SystemExit("refusing --apply: direction proof did not verify against the live tree")
+        added = noop = failed = 0
+        work = to_add[: args.limit] if args.limit else to_add
+        for i, (n, k) in enumerate(work, 1):
+            ok, why = add_blocked_by(n, k, issues)
+            if not ok:
+                failed += 1
+                print(f"  FAILED #{n} blocked_by #{k}: {why}")
+            elif why == "already":
+                noop += 1
+            else:
+                added += 1
+            if i % 25 == 0:
+                print(f"  ... {i}/{len(work)} (added {added}, already-present {noop}, failed {failed})")
+        print(f"[apply] added {added} native blocked_by edge(s); {noop} already present (no-op); "
+              f"{failed} failure(s)")
+        rep["applied_added"] = added
+        rep["applied_noop"] = noop
+        rep["applied_failed"] = failed
+        if args.remove_spurious:
+            removed = rnoop = rfail = 0
+            for n, k in spurious:
+                ok, why = remove_blocked_by(n, k, issues)
+                if not ok:
+                    rfail += 1
+                    print(f"  FAILED remove #{n} blocked_by #{k}: {why}")
+                elif why == "absent":
+                    rnoop += 1
+                else:
+                    removed += 1
+            print(f"[apply] removed {removed} spurious edge(s); {rnoop} already absent; {rfail} failure(s)")
+            rep["applied_removed"] = removed
+            rep["applied_remove_noop"] = rnoop
+    else:
+        print(f"\n[audit-only] would add {len(to_add)} native edge(s); "
+              f"{len(skipped_closed_blocker)} skipped (blocker already closed); "
+              f"{len(spurious)} spurious edge(s) present. Re-run with --apply.")
+
+    if args.json_out:
+        json.dump(rep, open(args.json_out, "w"), indent=2, default=list)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -479,11 +479,22 @@ def _ensure_markers(repo, num, markers, body=None):
 
 
 # --- ADD-only label reconciliation, batched (audit 2026-07-25) -----------------------------------
+# Label families the pipeline treats as SINGLE-VALUED. `role:` — triage.py enforces a single-role
+# invariant explicitly so the dispatcher's resolve() never sees an ambiguous role set; `priority:` —
+# ready-issues.py's valid_priority() returns None (i.e. NOT dispatchable) when two are present;
+# `area:` — a second area puts one issue in two package partitions. So for these families the
+# reconcile must ADD only when the family is ABSENT, never add a second member. A live run proved
+# the point before this guard existed: it put `role:impl` on issues triage had already routed
+# `role:ci` / `role:soundness`, which would have made them undispatchable.
+_SINGLE_VALUED = ("role:", "priority:", "area:")
+
+
 def plan_reconcile(open_ids, id_map, have_labels, crates=None):
     """{issue_number: [labels to ADD]} for already-mapped OPEN beads whose issue is missing labels
-    the plan requires. ADD-only by construction — never removes, so a human's curation survives.
-    An issue that already carries ANY `area:` keeps it (a human may have refined the partition):
-    the derived area AND the `needs:area` park are both suppressed in that case."""
+    the plan requires. ADD-only by construction — never removes, so a human's or triage's curation
+    survives. A single-valued family already present on the issue is left completely alone (see
+    _SINGLE_VALUED); in particular an issue that already carries an `area:` keeps it and is not
+    `needs:area`-parked either, because it is already classified."""
     out = {}
     for bid, num in sorted(id_map.items()):
         bead = open_ids.get(bid)
@@ -491,8 +502,11 @@ def plan_reconcile(open_ids, id_map, have_labels, crates=None):
             continue                                   # bead is closed/absent — not our business
         have = set(have_labels.get(num) or ())
         want = set(issue_labels(bead, crates))
+        for fam in _SINGLE_VALUED:
+            if any(lb.startswith(fam) for lb in have):
+                want = {lb for lb in want if not lb.startswith(fam)}
         if any(lb.startswith("area:") for lb in have):
-            want = {lb for lb in want if not lb.startswith("area:") and lb != "needs:area"}
+            want.discard("needs:area")                 # already classified — do not park it
         gap = want - have
         if gap:
             out[num] = sorted(gap)
@@ -823,6 +837,18 @@ def _self_test():
                                            MIGRATION_LABEL]}, cr), {})
     chk("an unmapped/closed bead is never reconciled",
         plan_reconcile(beads, {"sq-zzz": 12}, {12: []}, cr), {})
+    # Single-valued families (found by a LIVE run, not by review): the reconcile put role:impl on
+    # issues triage had already routed role:ci / role:soundness. Two role labels break triage.py's
+    # single-role invariant and two priorities make valid_priority() return None — either way the
+    # issue stops being dispatchable, so the "repair" would have made things worse.
+    chk("never adds a SECOND role: label (triage's single-role invariant)",
+        plan_reconcile(beads, {"sq-a": 13}, {13: ["role:ci"]}, cr).get(13, []),
+        ["area:sparq-solid", MIGRATION_LABEL, "priority:P2"])
+    chk("never adds a SECOND priority: label (valid_priority would return None)",
+        [lb for lb in plan_reconcile(beads, {"sq-a": 14}, {14: ["priority:P0"]}, cr).get(14, [])
+         if lb.startswith("priority:")], [])
+    chk("a missing single-valued family IS still filled in",
+        "role:impl" in plan_reconcile(beads, {"sq-a": 15}, {15: ["area:x"]}, cr).get(15, []), True)
     chk("batching chunks evenly", [len(c) for c in _chunks(range(45), 20)], [20, 20, 5])
     chk("empty reconcile does zero API calls", apply_reconcile("o/r", {}, {}), 0)
     # Adaptive split on the server's `Resource limits for this query exceeded` refusal (a real

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -642,11 +642,8 @@ def apply_migration(repo, open_ids, blockers, parents, limit=None, checkpoint="/
         rplan = plan_reconcile({b: open_ids[b] for b in ids}, id_map, have_labels, crates)
         if rplan:
             ensure_labels(repo, {l for v in rplan.values() for l in v})
-            node_ids.update({n: node_ids[n] for n in rplan if n in node_ids})
-            unknown = [n for n in rplan if n not in node_ids]
-            if unknown:                     # freshly created this run — re-fetch their node ids
-                for it in fetch_issues(repo):
-                    node_ids[it["number"]] = it["id"]
+            if any(n not in node_ids for n in rplan):   # created THIS run — re-fetch their ids
+                node_ids.update({it["number"]: it["id"] for it in fetch_issues(repo)})
             reconciled = apply_reconcile(repo, rplan, node_ids)
     if backfill:
         print(f"[apply] authenticated {len(backfill)} pre-label issue(s) via migration-owned "

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -27,6 +27,13 @@ ROLE_BY_TYPE = {"feature": "impl", "bug": "impl", "task": "impl", "chore": "ci",
                 "spike": "research", "epic": "impl"}
 ROLE_BY_KIND = {"docs": "docs", "design": "research", "research": "research", "perf": "perf",
                 "test": "impl", "ci": "ci", "site": "site"}
+# [OPUS-4.8] bd emits BOTH spellings for a blocker edge and they have the SAME orientation —
+# {"issue_id": X, "depends_on_id": Y} means X is blocked by Y either way (verified with `bd show
+# sq-8ic6`, whose `blocked-by` rows render under DEPENDS ON exactly like `blocks` rows do).
+# plan() previously matched only "blocks" and silently dropped the rest; the loss is latent today
+# only because all 3 current `blocked-by` rows hang off a CLOSED bead. Keep in sync with
+# scripts/audit-issue-deps.py::BLOCKER_TYPES.
+BLOCKER_TYPES = ("blocks", "blocked-by")
 
 
 def parse_export(lines):
@@ -274,7 +281,7 @@ def plan(issues, edges, include_closed=False):
             continue
         if etype == "parent-child":
             parents.setdefault(frm, []).append(to)
-        elif etype == "blocks":
+        elif etype in BLOCKER_TYPES:
             blockers.setdefault(frm, []).append(to)
         # other edge types (related/discovered/duplicate/…) are NOT readiness blockers — skipped
     return open_ids, blockers, parents
@@ -856,6 +863,20 @@ def _self_test():
             chk("irreducible oversize issue fails loud", "SystemExit", "SystemExit")
     finally:
         globals()["_run"], globals()["_label_node_ids"] = real_run, real_ids
+
+    # [OPUS-4.8] plan() must treat BOTH blocker spellings as readiness blockers with the SAME
+    # orientation, and must never turn parent-child into one (that is the sub-epic-leaf-invisibility
+    # bug). Matching only "blocks" silently dropped every `blocked-by` row.
+    def _plan_edges(etype):
+        beads = {"X": {"id": "X", "status": "open", "title": "x"},
+                 "Y": {"id": "Y", "status": "open", "title": "y"}}
+        _, blockers, parents = plan(beads, [("X", "Y", etype)])
+        return blockers, parents
+    chk("blocks row is a blocker edge X<-Y", _plan_edges("blocks"), ({"X": ["Y"]}, {}))
+    chk("blocked-by row is ALSO a blocker edge X<-Y", _plan_edges("blocked-by"), ({"X": ["Y"]}, {}))
+    chk("parent-child row is a parent link, never a blocker", _plan_edges("parent-child"),
+        ({}, {"X": ["Y"]}))
+    chk("related row is neither", _plan_edges("related"), ({}, {}))
 
     print("bd-to-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -399,9 +399,14 @@ def resolve_resume_map(trusted, unverified, checkpoint_map, owned=frozenset()):
     return id_map, backfill, unverifiable
 
 
+# Agent self-identification (standing repo rule): every issue/comment an agent opens says so, so a
+# maintainer scanning the tracker can tell machine-filed items from human ones at a glance.
+SELF_ID = "> 🤖 SPARQ agent — migrated from the local `bd` tracker by `scripts/bd-to-issues.py`."
+
+
 def _body(bead, bid):
     desc = (bead.get("description") or "").strip()
-    return f"{desc}\n\n<!-- bd-id:{bid} -->\n"
+    return f"{SELF_ID}\n\n{desc}\n\n<!-- bd-id:{bid} -->\n"
 
 
 def ensure_labels(repo, labels):
@@ -512,30 +517,48 @@ def _label_node_ids(repo, names):
     return ids
 
 
-def apply_reconcile(repo, plan, node_ids, batch=20, pause=4.0, log=print):
+def apply_reconcile(repo, plan, node_ids, batch=8, pause=2.0, log=print):
     """Apply `plan` ({issue_number: [labels]}) with ONE GraphQL request per `batch` issues.
 
     Batching is not cosmetic: ~800 single `gh issue edit` mutations trip GitHub's secondary
     rate limiter, and a 403 mid-run leaves the repo half-labeled. Aliased mutations keep the
-    whole reconcile inside ~40 requests, and the pacing stays under the documented GraphQL
-    mutation budget (5 points/mutation, 2000 points/min). Backs off on a secondary-limit 403
-    instead of hammering."""
+    whole reconcile inside ~100 requests, paced under the documented GraphQL mutation budget
+    (5 points/mutation, 2000 points/min).
+
+    Two distinct server refusals, two distinct responses (both learned from a real run):
+      * `Resource limits for this query exceeded` — the REQUEST is too big. A batch of 20 hit
+        this on the very first chunk, and GitHub had already executed the first few aliases
+        before refusing, so a naive retry of the same shape would loop forever while partially
+        applying. HALVE the chunk and retry; ADD-only mutations make the replay harmless.
+      * a secondary-rate-limit 403 — the request is fine but too frequent. Back off, don't split.
+    """
     if not plan:
         return 0
     label_ids = _label_node_ids(repo, {l for v in plan.values() for l in v})
-    done = 0
-    for chunk in _chunks(sorted(plan), batch):
+    queue, done, total = _chunks(sorted(plan), batch), 0, len(plan)
+    while queue:
+        chunk = queue.pop(0)
         muts = []
         for i, num in enumerate(chunk):
             lids = ",".join(f'"{label_ids[l]}"' for l in plan[num])
             muts.append(f'm{i}: addLabelsToLabelable(input: {{labelableId: "{node_ids[num]}", '
                         f'labelIds: [{lids}]}}) {{ __typename }}')
         query = "mutation {\n  " + "\n  ".join(muts) + "\n}"
+        applied = False
         for attempt in range(5):
             r = _run(["gh", "api", "graphql", "-f", f"query={query}"], check=False)
             if r.returncode == 0 and '"errors"' not in (r.stdout or ""):
+                applied = True
                 break
             err = ((r.stderr or "") + (r.stdout or "")).lower()
+            if "resource limit" in err or "query is too large" in err:
+                if len(chunk) == 1:
+                    raise SystemExit(f"label reconcile: issue #{chunk[0]} is irreducibly over the "
+                                     f"GraphQL resource limit: {err[:300]}")
+                half = max(1, len(chunk) // 2)
+                log(f"  request over the GraphQL resource limit — splitting {len(chunk)} -> {half}")
+                queue[:0] = [chunk[:half], chunk[half:]]
+                break
             if "secondary rate" in err or "abuse" in err or "was submitted too quickly" in err:
                 wait = 30 * (2 ** attempt)
                 log(f"  secondary rate limit — backing off {wait}s")
@@ -545,8 +568,10 @@ def apply_reconcile(repo, plan, node_ids, batch=20, pause=4.0, log=print):
                              f"{((r.stderr or '') + (r.stdout or '')).strip()[:400]}")
         else:
             raise SystemExit(f"label reconcile: still rate-limited after 5 backoffs at {chunk}")
+        if not applied:
+            continue                       # split happened; the halves are back on the queue
         done += len(chunk)
-        log(f"  reconciled {done}/{len(plan)} issue(s)")
+        log(f"  reconciled {done}/{total} issue(s)")
         time.sleep(pause)
     return done
 
@@ -796,6 +821,41 @@ def _self_test():
         plan_reconcile(beads, {"sq-zzz": 12}, {12: []}, cr), {})
     chk("batching chunks evenly", [len(c) for c in _chunks(range(45), 20)], [20, 20, 5])
     chk("empty reconcile does zero API calls", apply_reconcile("o/r", {}, {}), 0)
+    # Adaptive split on the server's `Resource limits for this query exceeded` refusal (a real
+    # 20-mutation batch hit it on the first chunk). Every issue must still be applied EXACTLY
+    # once overall, and a single irreducible issue must fail loud rather than loop.
+    calls = []
+
+    def fake_run(args, check=True):
+        q = args[-1]
+        n = q.count("addLabelsToLabelable")
+        calls.append(n)
+        big = n > 2
+        return type("R", (), {"returncode": 1 if big else 0,
+                              "stdout": "" if big else "{}",
+                              "stderr": "Resource limits for this query exceeded" if big else ""})()
+
+    real_run, real_ids = _run, _label_node_ids
+    try:
+        globals()["_run"] = fake_run
+        globals()["_label_node_ids"] = lambda repo, names: {n: f"L_{n}" for n in names}
+        plan5 = {n: ["role:impl"] for n in range(1, 6)}
+        got = apply_reconcile("o/r", plan5, {n: f"I_{n}" for n in plan5}, batch=5, pause=0)
+        chk("split-and-retry still applies every issue exactly once", got, 5)
+        # 5 refused -> [2,3]; 2 applied; 3 refused -> [1,2]; 1 applied; 2 applied. A refused size
+        # is NEVER re-issued at the same size (that would loop while partially applying).
+        chk("oversize batch splits strictly downward, never retried at the same size",
+            calls, [5, 2, 3, 1, 2])
+        calls.clear()
+        globals()["_run"] = lambda a, check=True: type("R", (), {
+            "returncode": 1, "stdout": "", "stderr": "Resource limits for this query exceeded"})()
+        try:
+            apply_reconcile("o/r", {1: ["role:impl"]}, {1: "I_1"}, batch=1, pause=0)
+            chk("irreducible oversize issue fails loud", "no-exit", "SystemExit")
+        except SystemExit:
+            chk("irreducible oversize issue fails loud", "SystemExit", "SystemExit")
+    finally:
+        globals()["_run"], globals()["_label_node_ids"] = real_run, real_ids
 
     print("bd-to-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -17,9 +17,11 @@ The bead id (`sq-…`) is preserved in the issue title so existing PR-title toke
 """
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
+import time
 
 ROLE_BY_TYPE = {"feature": "impl", "bug": "impl", "task": "impl", "chore": "ci",
                 "spike": "research", "epic": "impl"}
@@ -88,6 +90,13 @@ _BLOCKED_ON = re.compile(r"^blocked[-:]on[-:](.+)$")
 _BLOCKED = re.compile(r"^blocked:(.+)$")
 
 
+def b2i_bd_labels(bead):
+    """The bead's OWN labels (post blocked:*->needs:* mapping, pre-derivation) — used by the
+    summary to report how many `area:` labels the migration DERIVED rather than inherited."""
+    return {_map_label(lb["name"] if isinstance(lb, dict) else lb)
+            for lb in bead.get("labels", [])} - {None}
+
+
 def _map_label(lb):
     """Migration gating pass (audit-2026-07-17): bd `blocked:*` / `blocked-on-*` tags become
     `needs:*` gates — the readiness engine only gates on the needs:/trust: prefixes, so an unmapped
@@ -132,7 +141,96 @@ def externally_gated(bead):
     return bool(_EXTERNAL_DESC.search((bead.get("description") or "")[:400]))
 
 
-def issue_labels(bead):
+# --- area (package) derivation ------------------------------------------------------------------
+# Audit 2026-07-25 (sq-gj35r): 551 of the 895 open beads carry NO `area:` label, so they migrated
+# into the readiness engine's serializing `__global__` partition. triage.py refuses to promote a
+# no-area issue at all (it parks `needs:area`), and retriage.py only emits PROMOTING deltas — so
+# such an issue is TERMINALLY `status:untriaged`: present in GitHub, invisible to the orchestrator.
+# Migrating an issue the orchestrator cannot classify is not migration, it is litter. So derive the
+# package from the bead's own text, and when nothing is derivable make the parked state EXPLICIT
+# with `needs:area` (a gate ready-issues.py already respects + maintainer-visible) instead of
+# silently reserving the global partition.
+_SURFACE_AREAS = {"site": "site", "gui": "gui", "bench": "bench", "ci": "ci", "docs": "docs",
+                  "js": "js", "wasm": "sparq-wasm", "workflows": "ci", "release": "release",
+                  "orchestration": "orchestration", "deps": "deps", "workspace": "workspace"}
+# `verb(scope):` / `scope:` conventional title prefixes, e.g. "bug(sparq-solid): …", "site: …".
+_TITLE_SCOPE = re.compile(r"^\s*(?:[a-z]+\(([a-z0-9\-/]+)\)|([a-z0-9\-]+))\s*:", re.I)
+_CRATES_CACHE = None
+
+
+def crate_names(root=None):
+    """The workspace crate names (`crates/`), cached. Empty when run outside a checkout — the
+    derivation then falls back to the conventional-title-prefix + surface rules only."""
+    global _CRATES_CACHE
+    if root is None and _CRATES_CACHE is not None:
+        return _CRATES_CACHE
+    base = root or os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir, "crates")
+    try:
+        names = tuple(sorted(d for d in os.listdir(base)
+                             if os.path.isdir(os.path.join(base, d)) and not d.startswith(".")))
+    except OSError:
+        names = ()
+    if root is None:
+        _CRATES_CACHE = names
+    return names
+
+
+def _scope_to_area(scope, crates):
+    scope = (scope or "").lower().split("/")[0]
+    for cand in (scope, f"sparq-{scope}"):
+        if cand in crates:
+            return cand
+    return _SURFACE_AREAS.get(scope)
+
+
+def _token_hits(names, text):
+    """`names` occurring in `text` as whole tokens, ordered by FIRST OCCURRENCE, longest name
+    winning over any name it contains (`sparq-reason-el` over `sparq-reason`). First-occurrence
+    order matters: an alphabetical sort followed by a `[:limit]` truncation silently drops the
+    most-specific hit — "deploy(site+docs): …" derived `ci,docs` and discarded `site`."""
+    found = []
+    for n in sorted(names, key=len, reverse=True):
+        m = re.search(r"(?<![a-z0-9\-])" + re.escape(n) + r"(?![a-z0-9\-])", text)
+        if m and not any(n in f for _, f in found):
+            found.append((m.start(), n))
+    return [n for _, n in sorted(found)]
+
+
+def derive_areas(bead, crates=None, limit=2):
+    """Derive `area:` values from a bead's own text, most-specific evidence first:
+
+      1. the conventional `verb(scope):` / `scope:` title prefix — an explicit author declaration;
+      2. crate names appearing as whole tokens in the TITLE;
+      3. a surface keyword (site/gui/bench/ci/…) in the title's SCOPE REGION only — i.e. before the
+         first colon. A bare "site"/"ci"/"docs" anywhere in running prose is NOT evidence: matching
+         the whole title mislabeled a zkSPARQL spec bead `area:site` off one incidental word;
+      4. the description, and ONLY when it names exactly ONE crate. A description that name-drops
+         several neighbouring crates is a cross-cutting task, not a package assignment — that rule
+         is what stopped "formalize codex-EC2 worker tooling" deriving `sparq-core,sparq-jsonld`.
+
+    Returns [] when nothing is derivable; the caller then parks the issue `needs:area` rather than
+    guessing. A wrong partition is worse than an explicit park: the park is maintainer-visible and
+    retriage re-promotes it the moment an area lands, whereas a wrong area silently routes the work."""
+    crates = crate_names() if crates is None else crates
+    title = bead.get("title") or ""
+    low = title.lower()
+    m = _TITLE_SCOPE.match(title)
+    if m:
+        a = _scope_to_area(m.group(1) or m.group(2), crates)
+        if a:
+            return [a]
+    hits = _token_hits(crates, low)
+    if hits:
+        return hits[:limit]
+    scope_region = low.split(":", 1)[0] if ":" in low[:60] else ""
+    surf = [_SURFACE_AREAS[k] for k in _token_hits(_SURFACE_AREAS, scope_region)]
+    if surf:
+        return list(dict.fromkeys(surf))[:limit]
+    desc_hits = _token_hits(crates, (bead.get("description") or "")[:400].lower())
+    return desc_hits if len(desc_hits) == 1 else []
+
+
+def issue_labels(bead, crates=None):
     labels = [lb["name"] if isinstance(lb, dict) else lb for lb in bead.get("labels", [])]
     mapped = (_map_label(lb) for lb in labels)              # blocked:* -> needs:* gating pass
     out = {lb for lb in mapped if lb and _pipeline_relevant(lb)}   # whitelist — drop free-form tags
@@ -147,8 +245,17 @@ def issue_labels(bead):
     # `kind:epic` so the readiness engine excludes it (else a worker would try to "implement" the
     # epic itself, producing a garbage PR). 57 of the 893 open beads are epics, 41 at P1 — they would
     # otherwise be selected FIRST by priority. Enforcement is in ready-issues.py; this is the signal.
-    if str(bead.get("issue_type", "")).lower() == "epic":
+    is_epic = str(bead.get("issue_type", "")).lower() == "epic"
+    if is_epic:
         out.add("kind:epic")
+    # Package partition (audit 2026-07-25) — see the derive_areas note. An epic is never
+    # dispatched, so it needs no partition and is never needs:area-parked.
+    if not is_epic and not any(lb.startswith("area:") for lb in out):
+        derived = derive_areas(bead, crates)
+        if derived:
+            out |= {f"area:{a}" for a in derived}
+        elif "needs:user" not in out:
+            out.add("needs:area")
     return sorted(out)
 
 
@@ -178,17 +285,84 @@ def _run(args, check=True):
     return subprocess.run(args, capture_output=True, text=True, check=check)
 
 
-def fetch_bd_map(repo):
+# Shape-constrained (audit 2026-07-25, issue #3797): the old `(\S+?)` capture matched ANY
+# non-space run, so PROSE documenting the marker with an elided id ("<!-- bd-id:… -->" inside
+# issues #2534/#2535/#3797) was scanned as a bead named "…" and injected into the migration map.
+# Keep in sync with scripts/ci-close-merged-beads.py `_MARKER_RE`.
+MARKER_RE = re.compile(r"<!--\s*bd-id:(sq-[0-9a-z]+(?:\.\d+)*)\s*-->")
+
+
+def fetch_issues(repo):
+    """Every issue (any state) with the fields the resume + reconcile passes need. ONE LIST call —
+    the search index lags badly on this repo, so current state must come from the list API."""
+    out = _run(["gh", "issue", "list", "-R", repo, "--state", "all", "--limit", "10000",
+                "--json", "number,id,body,labels,author,title"]).stdout
+    return json.loads(out or "[]")
+
+
+def _writer_logins(repo, logins, cache=None):
+    """The subset of `logins` with write-or-better permission on `repo` — the SAME trust primitive
+    triage-issue.yml uses. An unprivileged decoy author (the resolve_resume_map threat model)
+    cannot be in this set, which is exactly what makes author provenance load-bearing."""
+    cache = {} if cache is None else cache
+    ok = set()
+    for lg in sorted(set(logins)):
+        if lg not in cache:
+            if lg.endswith("[bot]"):
+                # App bots are not collaborators; the orchestrator App is the migration's own
+                # identity and no unprivileged user can author as a `[bot]` login.
+                cache[lg] = lg in _MIGRATION_BOTS
+            else:
+                r = _run(["gh", "api", f"repos/{repo}/collaborators/{lg}/permission",
+                          "--jq", ".permission"], check=False)
+                cache[lg] = (r.stdout or "").strip() in ("admin", "maintain", "write")
+        if cache[lg]:
+            ok.add(lg)
+    return ok
+
+
+_MIGRATION_BOTS = {"sparq-orchestrator[bot]"}
+
+
+def migration_owned(issues, writers):
+    """bd-ids whose marker-only issue carries MIGRATION-OWNED provenance, i.e. all of:
+      * the marker payload is a real bd-id SHAPE (MARKER_RE — kills the #3797 phantom);
+      * the title is the migration's own `"<bd-id>: <bead title>"` format (a decoy that copies a
+        marker to capture a bead id does not also reproduce the title contract);
+      * the AUTHOR has write-or-better permission on the repo — the threat model's attacker is by
+        definition unprivileged, so this closes the forgeable-body hole the label was added for;
+      * exactly ONE issue in the repo carries that bd-id (ambiguity is never resolved by guessing).
+    This recovers the ~750 issues of the 2026-07-17 bulk run that predate MIGRATION_LABEL: without
+    it every subsequent `--apply` aborts on the fail-closed unverifiable check and the migration is
+    permanently unresumable."""
+    seen = {}
+    for it in issues:
+        mm = MARKER_RE.search(it.get("body") or "")
+        if not mm:
+            continue
+        seen.setdefault(mm.group(1), []).append(it)
+    owned = set()
+    for bid, cands in seen.items():
+        if len(cands) != 1:
+            continue                                  # ambiguous — fail closed, never guess
+        it = cands[0]
+        login = (it.get("author") or {}).get("login") if isinstance(it.get("author"), dict) \
+            else it.get("author")
+        if login in writers and (it.get("title") or "").startswith(f"{bid}:"):
+            owned.add(bid)
+    return owned
+
+
+def fetch_bd_map(repo, issues=None):
     """(trusted, unverified) {bd-id: issue_number} maps from existing issues carrying a
     `<!-- bd-id:... -->` marker (resume). trusted = the issue ALSO carries MIGRATION_LABEL
     (attaching one needs triage/write permission); unverified = marker-only — could be a
     pre-label legacy migration OR an attacker decoy, so never trusted on its own
     (see resolve_resume_map, PR #2528 review round 2)."""
-    out = _run(["gh", "issue", "list", "-R", repo, "--state", "all", "--limit", "10000",
-                "--json", "number,body,labels"]).stdout
+    issues = fetch_issues(repo) if issues is None else issues
     trusted, unverified = {}, {}
-    for it in json.loads(out or "[]"):
-        mm = re.search(r"<!--\s*bd-id:(\S+?)\s*-->", it.get("body") or "")
+    for it in issues:
+        mm = MARKER_RE.search(it.get("body") or "")
         if not mm:
             continue
         labels = {lb["name"] if isinstance(lb, dict) else lb for lb in it.get("labels") or []}
@@ -196,15 +370,17 @@ def fetch_bd_map(repo):
     return trusted, unverified
 
 
-def resolve_resume_map(trusted, unverified, checkpoint_map):
+def resolve_resume_map(trusted, unverified, checkpoint_map, owned=frozenset()):
     """Pure resume resolution (PR #2528 review round 2). A body marker alone is FORGEABLE: an
     unprivileged user can pre-create a decoy issue carrying a target `<!-- bd-id:… -->` marker,
     and a resume path that accepted it would (a) never create the real issue and (b) stamp the
     authentication label onto attacker content — after which ci-close-merged-beads.py would
     trust and close the decoy. So an existing issue is accepted as already-migrated ONLY on
-    migration-owned provenance: it already carries MIGRATION_LABEL, or its exact
+    migration-owned provenance: it already carries MIGRATION_LABEL, its exact
     (bd-id, issue_number) pair is recorded in the trusted on-disk checkpoint this migration
-    wrote. A marker-only issue with neither is returned as `unverifiable` and the caller FAILS
+    wrote, or its bd-id is in `owned` (see migration_owned: unique marker + migration title
+    format + a WRITE-permission author, which the unprivileged decoy author cannot satisfy).
+    A marker-only issue with none of the three is returned as `unverifiable` and the caller FAILS
     CLOSED (no label, no mapping, no create) for operator review.
 
     Returns (id_map, backfill, unverifiable): id_map = accepted {bd-id: number}; backfill = the
@@ -215,7 +391,7 @@ def resolve_resume_map(trusted, unverified, checkpoint_map):
     for bid, num in unverified.items():
         if bid in id_map:
             continue  # an authenticated issue exists; the marker-only copy is a decoy/dup — inert
-        if checkpoint_map.get(bid) == num:
+        if checkpoint_map.get(bid) == num or bid in owned:
             id_map[bid] = num
             backfill[bid] = num
         else:
@@ -244,9 +420,9 @@ def ensure_labels(repo, labels):
                          f"(fail-loud, no silent label drop): {failed[:10]}")
 
 
-def _create_issue(repo, bid, bead):
+def _create_issue(repo, bid, bead, crates=None):
     args = ["gh", "issue", "create", "-R", repo, "--title", f"{bid}: {bead['title']}", "--body", _body(bead, bid)]
-    for l in issue_labels(bead):
+    for l in issue_labels(bead, crates):
         args += ["--label", l]
     r = _run(args, check=False)
     if r.returncode != 0:
@@ -258,23 +434,141 @@ def _create_issue(repo, bid, bead):
     return int(re.search(r"/issues/(\d+)", r.stdout).group(1))
 
 
-def _ensure_marker(repo, num, marker):
-    """Append `marker` to the issue body iff absent (idempotent)."""
-    body = json.loads(_run(["gh", "issue", "view", str(num), "-R", repo, "--json", "body"]).stdout)["body"] or ""
-    if marker in body:
-        return
-    _run(["gh", "issue", "edit", str(num), "-R", repo, "--body", body.rstrip() + "\n" + marker + "\n"])
+def _snapshot_body(issues, num):
+    """The issue body already held in the run's single LIST snapshot, or None if unknown."""
+    if num is None:
+        return None
+    for it in issues:
+        if it["number"] == num:
+            return it.get("body") or ""
+    return None
 
 
-def apply_migration(repo, open_ids, blockers, parents, limit=None, checkpoint="/tmp/bd-migration-map.json"):
+def _ensure_markers(repo, num, markers, body=None):
+    """Append every missing edge marker to the issue body in ONE edit (idempotent). Returns True
+    if it wrote.
+
+    Two reasons this is plural rather than a per-marker call: (a) an issue with both a Blocked-by
+    and a Parent edge would otherwise be read-modify-written twice, and the second write built from
+    a STALE body silently drops the first marker; (b) `body` short-circuits the per-issue read using
+    the run's single LIST snapshot — pass 2 walks 558 edges, so a no-op re-run used to cost 558 API
+    reads just to discover it had nothing to do. A no-op re-run must be cheap, or nobody runs it."""
+    if not markers:
+        return False
+    if body is None:
+        body = json.loads(_run(["gh", "issue", "view", str(num), "-R", repo,
+                                "--json", "body"]).stdout)["body"] or ""
+    missing = [m for m in markers if m not in body]
+    if not missing:
+        return False
+    _run(["gh", "issue", "edit", str(num), "-R", repo,
+          "--body", body.rstrip() + "\n" + "\n".join(missing) + "\n"])
+    return True
+
+
+# --- ADD-only label reconciliation, batched (audit 2026-07-25) -----------------------------------
+def plan_reconcile(open_ids, id_map, have_labels, crates=None):
+    """{issue_number: [labels to ADD]} for already-mapped OPEN beads whose issue is missing labels
+    the plan requires. ADD-only by construction — never removes, so a human's curation survives.
+    An issue that already carries ANY `area:` keeps it (a human may have refined the partition):
+    the derived area AND the `needs:area` park are both suppressed in that case."""
+    out = {}
+    for bid, num in sorted(id_map.items()):
+        bead = open_ids.get(bid)
+        if bead is None:
+            continue                                   # bead is closed/absent — not our business
+        have = set(have_labels.get(num) or ())
+        want = set(issue_labels(bead, crates))
+        if any(lb.startswith("area:") for lb in have):
+            want = {lb for lb in want if not lb.startswith("area:") and lb != "needs:area"}
+        gap = want - have
+        if gap:
+            out[num] = sorted(gap)
+    return out
+
+
+def _chunks(seq, n):
+    seq = list(seq)
+    return [seq[i:i + n] for i in range(0, len(seq), n)]
+
+
+def _label_node_ids(repo, names):
+    """{label name: node id} via GraphQL (the REST/`gh label` surfaces do not expose node ids)."""
+    owner, name = repo.split("/", 1)
+    q = ('query($o:String!,$r:String!,$c:String){repository(owner:$o,name:$r){'
+         'labels(first:100,after:$c){nodes{id name} pageInfo{hasNextPage endCursor}}}}')
+    ids, cursor = {}, None
+    while True:
+        args = ["gh", "api", "graphql", "-f", f"query={q}", "-F", f"o={owner}", "-F", f"r={name}"]
+        args += ["-F", f"c={cursor}"] if cursor else ["-F", "c="]
+        page = json.loads(_run(args).stdout)["data"]["repository"]["labels"]
+        ids.update({n["name"]: n["id"] for n in page["nodes"]})
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        cursor = page["pageInfo"]["endCursor"]
+    missing = set(names) - set(ids)
+    if missing:
+        raise SystemExit(f"label node ids missing (run ensure_labels first): {sorted(missing)[:10]}")
+    return ids
+
+
+def apply_reconcile(repo, plan, node_ids, batch=20, pause=4.0, log=print):
+    """Apply `plan` ({issue_number: [labels]}) with ONE GraphQL request per `batch` issues.
+
+    Batching is not cosmetic: ~800 single `gh issue edit` mutations trip GitHub's secondary
+    rate limiter, and a 403 mid-run leaves the repo half-labeled. Aliased mutations keep the
+    whole reconcile inside ~40 requests, and the pacing stays under the documented GraphQL
+    mutation budget (5 points/mutation, 2000 points/min). Backs off on a secondary-limit 403
+    instead of hammering."""
+    if not plan:
+        return 0
+    label_ids = _label_node_ids(repo, {l for v in plan.values() for l in v})
+    done = 0
+    for chunk in _chunks(sorted(plan), batch):
+        muts = []
+        for i, num in enumerate(chunk):
+            lids = ",".join(f'"{label_ids[l]}"' for l in plan[num])
+            muts.append(f'm{i}: addLabelsToLabelable(input: {{labelableId: "{node_ids[num]}", '
+                        f'labelIds: [{lids}]}}) {{ __typename }}')
+        query = "mutation {\n  " + "\n  ".join(muts) + "\n}"
+        for attempt in range(5):
+            r = _run(["gh", "api", "graphql", "-f", f"query={query}"], check=False)
+            if r.returncode == 0 and '"errors"' not in (r.stdout or ""):
+                break
+            err = ((r.stderr or "") + (r.stdout or "")).lower()
+            if "secondary rate" in err or "abuse" in err or "was submitted too quickly" in err:
+                wait = 30 * (2 ** attempt)
+                log(f"  secondary rate limit — backing off {wait}s")
+                time.sleep(wait)
+                continue
+            raise SystemExit(f"label reconcile failed on issues {chunk}: "
+                             f"{((r.stderr or '') + (r.stdout or '')).strip()[:400]}")
+        else:
+            raise SystemExit(f"label reconcile: still rate-limited after 5 backoffs at {chunk}")
+        done += len(chunk)
+        log(f"  reconciled {done}/{len(plan)} issue(s)")
+        time.sleep(pause)
+    return done
+
+
+def apply_migration(repo, open_ids, blockers, parents, limit=None, checkpoint="/tmp/bd-migration-map.json",
+                    reconcile=True, crates=None):
     """Resumable: pass 1 upserts issues by bd-id marker (checkpointing the map); pass 2 idempotently
-    adds Blocked-by:/Parent: markers. Re-running creates nothing new."""
-    trusted, unverified = fetch_bd_map(repo)
+    adds Blocked-by:/Parent: markers; pass 3 ADD-only label reconcile over already-mapped issues.
+    Re-running creates nothing new and reconciles nothing."""
+    issues_snapshot = fetch_issues(repo)
+    node_ids = {it["number"]: it["id"] for it in issues_snapshot}
+    have_labels = {it["number"]: [lb["name"] if isinstance(lb, dict) else lb
+                                  for lb in it.get("labels") or []] for it in issues_snapshot}
+    trusted, unverified = fetch_bd_map(repo, issues_snapshot)
     try:
         ckpt = json.load(open(checkpoint, encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError):
         ckpt = {}
-    id_map, backfill, unverifiable = resolve_resume_map(trusted, unverified, ckpt)
+    authors = {((it.get("author") or {}).get("login") if isinstance(it.get("author"), dict)
+                else it.get("author")) for it in issues_snapshot}
+    owned = migration_owned(issues_snapshot, _writer_logins(repo, {a for a in authors if a}))
+    id_map, backfill, unverifiable = resolve_resume_map(trusted, unverified, ckpt, owned)
     ids = list(open_ids)[: limit] if limit else list(open_ids)
     # Fail closed (PR #2528 review round 2): a marker-only issue with NO migration provenance
     # (not labeled, not in the trusted checkpoint) may be an attacker decoy pre-created to
@@ -288,27 +582,44 @@ def apply_migration(repo, open_ids, blockers, parents, limit=None, checkpoint="/
             f"possible decoys; review + label or close them manually: "
             f"{sorted((b, '#' + str(n)) for b, n in bad.items())[:10]}")
     # Pre-flight: the FULL label set exists before the first create (fail-loud, item 10).
-    ensure_labels(repo, {l for bid in ids for l in issue_labels(open_ids[bid])})
-    created = 0
+    ensure_labels(repo, {l for bid in ids for l in issue_labels(open_ids[bid], crates)})
+    created, fresh = 0, {}
     for bid in ids:                                  # pass 1
         if bid in id_map:
-            if bid in backfill:
-                # Resume: backfill the authentication label — ONLY on a checkpoint-verified
-                # issue this migration created before MIGRATION_LABEL existed (idempotent).
-                _run(["gh", "issue", "edit", str(id_map[bid]), "-R", repo,
-                      "--add-label", MIGRATION_LABEL])
-            continue
-        id_map[bid] = _create_issue(repo, bid, open_ids[bid])
+            continue      # already migrated; MIGRATION_LABEL backfill is pass 3's job (batched)
+        id_map[bid] = _create_issue(repo, bid, open_ids[bid], crates)
         created += 1
+        fresh[bid] = _body(open_ids[bid], bid)
+        have_labels[id_map[bid]] = issue_labels(open_ids[bid], crates)
         json.dump(id_map, open(checkpoint, "w"))     # checkpoint immediately (crash-resumable)
+    edged = 0
     for bid in ids:                                  # pass 2 (idempotent)
-        for b in blockers.get(bid, []):
-            if b in id_map:
-                _ensure_marker(repo, id_map[bid], f"Blocked-by: #{id_map[b]}")
-        for p in parents.get(bid, []):
-            if p in id_map:
-                _ensure_marker(repo, id_map[bid], f"Parent: #{id_map[p]}")
-    return id_map, created
+        num = id_map.get(bid)
+        markers = ([f"Blocked-by: #{id_map[b]}" for b in blockers.get(bid, []) if b in id_map]
+                   + [f"Parent: #{id_map[p]}" for p in parents.get(bid, []) if p in id_map])
+        if not markers:
+            continue
+        body = fresh.get(bid, _snapshot_body(issues_snapshot, num))
+        edged += bool(_ensure_markers(repo, num, markers, body))
+    # pass 3 (idempotent, ADD-only, batched): reconcile labels over every mapped OPEN bead. This
+    # is also where `backfill` lands — MIGRATION_LABEL is part of every plan's label set, so the
+    # ~750 pre-label issues of the 2026-07-17 bulk run get authenticated here in ~40 requests
+    # rather than ~750 single edits (which trip the secondary rate limiter).
+    reconciled = 0
+    if reconcile:
+        rplan = plan_reconcile({b: open_ids[b] for b in ids}, id_map, have_labels, crates)
+        if rplan:
+            ensure_labels(repo, {l for v in rplan.values() for l in v})
+            node_ids.update({n: node_ids[n] for n in rplan if n in node_ids})
+            unknown = [n for n in rplan if n not in node_ids]
+            if unknown:                     # freshly created this run — re-fetch their node ids
+                for it in fetch_issues(repo):
+                    node_ids[it["number"]] = it["id"]
+            reconciled = apply_reconcile(repo, rplan, node_ids)
+    if backfill:
+        print(f"[apply] authenticated {len(backfill)} pre-label issue(s) via migration-owned "
+              f"provenance (unique marker + migration title format + write-permission author)")
+    return id_map, created, reconciled, edged
 
 
 def _self_test():
@@ -378,6 +689,114 @@ def _self_test():
     idm, bf, unv = resolve_resume_map({}, {"sq-legacy": 9}, {"sq-legacy": 8})
     chk("checkpoint number mismatch stays unverifiable", (idm, bf, unv),
         ({}, {}, {"sq-legacy": 9}))
+
+    # --- marker shape (audit 2026-07-25, #3797) --------------------------------------------------
+    # Prose that DOCUMENTS the marker is not a bead mapping. The old `(\S+?)` capture scanned "…"
+    # as a bead id on three real issues and injected that phantom into the migration map.
+    chk("prose marker with an elided id does not scan",
+        MARKER_RE.search("fetch_bd_map trusts `<!-- bd-id:… -->` markers"), None)
+    chk("non-bead marker payload does not scan", MARKER_RE.search("<!-- bd-id:not-a-bead -->"), None)
+    chk("dotted subtask ids still scan",
+        MARKER_RE.search("<!-- bd-id:sq-7d3dj.32.2.3 -->").group(1), "sq-7d3dj.32.2.3")
+
+    # --- migration-owned provenance (audit 2026-07-25) -------------------------------------------
+    # The 2026-07-17 bulk run predates MIGRATION_LABEL: ~750 marker-only issues. Without a third
+    # provenance source every later --apply aborts on the fail-closed check, i.e. the migration is
+    # unresumable. Provenance = unique marker + migration title format + WRITE-permission author;
+    # the decoy threat model's attacker is unprivileged, so the author check is what closes the hole.
+    legit = {"number": 42, "title": "sq-legit: do the thing",
+             "body": "x\n<!-- bd-id:sq-legit -->\n", "author": {"login": "maintainer"}}
+    decoy = {"number": 43, "title": "please look at this",
+             "body": "<!-- bd-id:sq-victim -->", "author": {"login": "randomuser"}}
+    wrongtitle = {"number": 44, "title": "unrelated title",
+                  "body": "<!-- bd-id:sq-titleless -->", "author": {"login": "maintainer"}}
+    prose_iss = {"number": 45, "title": "bug: scanner matches prose",
+                 "body": "matches `<!-- bd-id:… -->`", "author": {"login": "maintainer"}}
+    owned = migration_owned([legit, decoy, wrongtitle, prose_iss], {"maintainer"})
+    chk("write-author + title contract is migration-owned", owned, {"sq-legit"})
+    chk("unprivileged decoy author is NOT owned", "sq-victim" in owned, False)
+    chk("write author WITHOUT the title contract is NOT owned", "sq-titleless" in owned, False)
+    dup = [dict(legit), dict(legit, number=46)]
+    chk("two issues sharing a bd-id are never owned (fail closed)",
+        migration_owned(dup, {"maintainer"}), set())
+    idm, bf, unv = resolve_resume_map({}, {"sq-legit": 42}, {}, {"sq-legit"})
+    chk("owned marker-only issue resumes and backfills the auth label",
+        (idm, bf, unv), ({"sq-legit": 42}, {"sq-legit": 42}, {}))
+    idm, bf, unv = resolve_resume_map({}, {"sq-victim": 43}, {}, {"sq-legit"})
+    chk("un-owned marker-only issue still fails closed",
+        (idm, bf, unv), ({}, {}, {"sq-victim": 43}))
+
+    # --- area (package) derivation (audit 2026-07-25) --------------------------------------------
+    # A no-area issue reserves the readiness engine's serializing __global__ partition and triage.py
+    # refuses to promote it, so it is TERMINALLY status:untriaged — present in GitHub, invisible to
+    # the orchestrator. 551 of the 895 open beads had no area label.
+    cr = ("sparq-core", "sparq-jsonld", "sparq-reason", "sparq-reason-el", "sparq-solid",
+          "sparq-zk")
+    chk("conventional verb(scope): prefix wins",
+        derive_areas({"title": "bug(sparq-solid): ODRL bridge drops a rule",
+                      "description": "touches sparq-core too"}, cr), ["sparq-solid"])
+    chk("bare scope: prefix maps a surface",
+        derive_areas({"title": "site: honest competitive feature matrix"}, cr), ["site"])
+    chk("title crate mention beats description mention",
+        derive_areas({"title": "widen the sparq-zk verifier",
+                      "description": "sparq-core and sparq-solid are involved"}, cr), ["sparq-zk"])
+    chk("longest crate name wins over its own prefix",
+        derive_areas({"title": "sparq-reason-el RBox regularity check"}, cr), ["sparq-reason-el"])
+    chk("description is the last resort",
+        derive_areas({"title": "no scope here at all",
+                      "description": "the fix lands in sparq-core"}, cr), ["sparq-core"])
+    chk("nothing derivable -> [] (never guess)",
+        derive_areas({"title": "LinkedIn advert post", "description": "enumerate claims"}, cr), [])
+    # precision regressions found by sampling the real backlog (audit 2026-07-25)
+    chk("a multi-crate description name-drop is NOT a package assignment",
+        derive_areas({"title": "formalize codex-EC2 worker tooling",
+                      "description": "moves sparq-core and sparq-jsonld notes"}, cr), [])
+    chk("a surface word in running prose is not evidence",
+        derive_areas({"title": "zkSPARQL spec: transcribe normative cores into the draft site"},
+                     cr), [])
+    chk("surface hits keep first-occurrence order, not alphabetical",
+        derive_areas({"title": "deploy(site+docs): a /deploy surface"}, cr), ["site", "docs"])
+    chk("first-occurrence ordering, longest-name-wins",
+        _token_hits(("sparq-core", "sparq-reason", "sparq-reason-el"),
+                    "sparq-reason-el then sparq-core"), ["sparq-reason-el", "sparq-core"])
+    got = set(issue_labels({"id": "sq-a", "priority": 2, "issue_type": "task",
+                            "title": "bug(sparq-solid): x", "labels": []}, cr))
+    chk("derived area lands on the issue", "area:sparq-solid" in got, True)
+    chk("derived area suppresses the needs:area park", "needs:area" in got, False)
+    got = set(issue_labels({"id": "sq-b", "priority": 2, "issue_type": "task",
+                            "title": "undecidable title", "labels": []}, cr))
+    chk("no derivable area -> explicit needs:area park (not silent __global__)",
+        "needs:area" in got, True)
+    chk("an epic is never needs:area-parked (never dispatched)",
+        "needs:area" in issue_labels({"id": "sq-c", "priority": 1, "issue_type": "epic",
+                                      "title": "EPIC: umbrella", "labels": []}, cr), False)
+    chk("a bd area label is never overridden by derivation",
+        [lb for lb in issue_labels({"id": "sq-d", "priority": 2, "issue_type": "task",
+                                    "title": "bug(sparq-solid): x",
+                                    "labels": ["area:sparq-core"]}, cr)
+         if lb.startswith("area:")], ["area:sparq-core"])
+
+    # --- ADD-only label reconcile (audit 2026-07-25) ---------------------------------------------
+    beads = {"sq-a": {"id": "sq-a", "priority": 2, "issue_type": "task",
+                      "title": "bug(sparq-solid): x", "labels": []}}
+    want = set(issue_labels(beads["sq-a"], cr))
+    chk("reconcile plans exactly the missing labels",
+        set(plan_reconcile(beads, {"sq-a": 10}, {10: []}, cr)[10]), want)
+    chk("reconcile is a no-op once the labels are present",
+        plan_reconcile(beads, {"sq-a": 10}, {10: sorted(want)}, cr), {})
+    chk("reconcile never removes a label the issue gained elsewhere",
+        plan_reconcile(beads, {"sq-a": 10}, {10: sorted(want) + ["status:ready", "role:site"]},
+                       cr), {})
+    chk("a human-curated area is preserved (no second area, no needs:area)",
+        plan_reconcile({"sq-b": {"id": "sq-b", "priority": 2, "issue_type": "task",
+                                 "title": "undecidable", "labels": []}},
+                       {"sq-b": 11}, {11: ["area:sparq-core", "priority:P2", "role:impl",
+                                           MIGRATION_LABEL]}, cr), {})
+    chk("an unmapped/closed bead is never reconciled",
+        plan_reconcile(beads, {"sq-zzz": 12}, {12: []}, cr), {})
+    chk("batching chunks evenly", [len(c) for c in _chunks(range(45), 20)], [20, 20, 5])
+    chk("empty reconcile does zero API calls", apply_reconcile("o/r", {}, {}), 0)
+
     print("bd-to-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 
@@ -389,6 +808,8 @@ def main():
     ap.add_argument("--limit", type=int, help="migrate only the first N open beads (for testing)")
     ap.add_argument("--only", help="comma-separated bd-ids to migrate (curated pilot subset; ignores --limit)")
     ap.add_argument("--export-file", help="read bd export from a file instead of running bd")
+    ap.add_argument("--no-reconcile", action="store_true",
+                    help="skip the ADD-only label reconcile over already-migrated issues")
     ap.add_argument("--self-test", action="store_true")
     args = ap.parse_args()
 
@@ -415,15 +836,17 @@ def main():
     pkgs = Counter(lb[5:] for b in open_ids.values()
                    for lb in issue_labels(b) if lb.startswith("area:"))
     gated = sum(1 for b in open_ids.values() if "needs:user" in issue_labels(b))
-    no_area = sum(1 for b in open_ids.values()
-                  if str(b.get("issue_type", "")).lower() != "epic"
-                  and not any(lb.startswith("area:") for lb in issue_labels(b)))
+    derived = sum(1 for b in open_ids.values()
+                  if not any(lb.startswith("area:") for lb in b2i_bd_labels(b))
+                  and any(lb.startswith("area:") for lb in issue_labels(b)))
+    parked = sum(1 for b in open_ids.values() if "needs:area" in issue_labels(b))
     print(f"beads (all): {len(issues)}  |  to migrate (open/in_progress): {len(open_ids)}")
     print(f"blocker (blocks) edges among migrated: {sum(len(v) for v in blockers.values())}")
     print(f"parent-child links among migrated:    {sum(len(v) for v in parents.values())}")
     print(f"gated needs:user (external/audit/blocked:*): {gated}")
-    print(f"WARNING non-epic beads with NO area label (each reserves the serializing __global__ "
-          f"partition): {no_area}")
+    print(f"area: derived from bead text (bd carried none): {derived}")
+    print(f"no derivable area -> parked needs:area (maintainer-visible, never silent "
+          f"__global__): {parked}")
     print(f"priority: {dict(sorted(prio.items()))}")
     print(f"roles:    {dict(roles.most_common())}")
     print(f"top packages: {dict(pkgs.most_common(8))}")
@@ -441,9 +864,14 @@ def main():
         return 0
 
     tag = f" (limit {args.limit})" if args.limit else ""
-    print(f"\n[apply] migrating to {args.repo}{tag} — idempotent two-pass...")
-    id_map, created = apply_migration(args.repo, open_ids, blockers, parents, limit=args.limit)
-    print(f"[apply] created {created} new issue(s); {len(id_map)} bd-ids mapped (re-run is a no-op).")
+    print(f"\n[apply] migrating to {args.repo}{tag} — idempotent three-pass...")
+    id_map, created, reconciled, edged = apply_migration(
+        args.repo, open_ids, blockers, parents, limit=args.limit,
+        reconcile=not args.no_reconcile)
+    print(f"[apply] created {created} new issue(s); {edged} issue(s) gained edge markers; "
+          f"{reconciled} issue(s) label-reconciled; {len(id_map)} bd-ids mapped.")
+    print("[apply] a second run with the same inputs must report 0/0/0 — that is the "
+          "idempotence contract.")
     return 0
 
 

--- a/scripts/ci-close-merged-beads.py
+++ b/scripts/ci-close-merged-beads.py
@@ -84,7 +84,14 @@ _CLOSEABLE = {"open", "in_progress", "blocked"}
 
 # The migration's durable bead<->issue map: bd-to-issues.py stamps `<!-- bd-id:sq-… -->` into
 # every migrated issue body (its fetch_bd_map reads the SAME pattern — keep the two in sync).
-_MARKER_RE = re.compile(r"<!--\s*bd-id:(\S+?)\s*-->")
+#
+# The capture group is SHAPE-CONSTRAINED to a real bd id (audit-2026-07-25, issue #3797). The old
+# `(\S+?)` matched ANY non-space run, so PROSE that merely DOCUMENTS the marker — e.g. the sentence
+# "trusts unauthenticated `<!-- bd-id:… -->` markers" inside issues #2534 / #2535 / #3797 — was
+# scanned as a bead whose id is the literal ellipsis "…". That phantom id polluted the migration
+# map, and here it would have made a nonexistent bead look mapped (and, with three issues carrying
+# it, permanently "ambiguous"). Real ids are `sq-` + base36-ish stem + optional dotted subtask path.
+_MARKER_RE = re.compile(r"<!--\s*bd-id:(sq-[0-9a-z]+(?:\.\d+)*)\s*-->")
 
 # AUTHENTICATION (PR #2528 review): an issue BODY is written by its author — ANY GitHub user can
 # open a decoy issue copying a real `<!-- bd-id:… -->` marker, and a body-only mapping (with
@@ -328,6 +335,22 @@ def self_test() -> int:
     check("single authenticated mapping is not ambiguous", ambiguous, [])
     check("prose mention without a marker does not map",
           map_beads_to_open_issues(["sq-open1"], [open_issues[4]]), ([], [], ["sq-open1"], []))
+    # Phantom-marker regression (#3797): a body that DOCUMENTS the marker syntax with an elided id
+    # is not a bead mapping. The old `(\S+?)` capture scanned "…" as a bead id on three real issues
+    # (#2534/#2535/#3797) and injected that phantom into the migration map. Assert at the SCAN
+    # level — a map-level assertion is vacuous here, because an unrequested phantom bead is
+    # indistinguishable from no match at all.
+    check("prose marker with an elided id does not scan",
+          _MARKER_RE.search("fetch_bd_map trusts `<!-- bd-id:… -->` markers"), None)
+    check("non-bead marker payload does not scan",
+          _MARKER_RE.search("<!-- bd-id:not-a-bead -->"), None)
+    check("dotted subtask ids still scan", _MARKER_RE.search(
+        "<!-- bd-id:sq-7d3dj.32.2.3 -->").group(1), "sq-7d3dj.32.2.3")
+    # …and the phantom, if it were ever REQUESTED as a bead, must not map onto the prose issue.
+    prose = [{"number": 30, "body": "fetch_bd_map trusts `<!-- bd-id:… -->` markers",
+              "labels": [_MIGRATION_LABEL]}]
+    check("phantom bead id never maps onto the prose issue that documents the marker",
+          map_beads_to_open_issues(["…"], prose), ([], [], ["…"], []))
     check("unauthenticated marker ALONE does not map (fail closed to no-op)",
           map_beads_to_open_issues(["sq-open1"], [open_issues[0]]), ([], [], ["sq-open1"], []))
     # Duplicate AUTHENTICATED mapping (e.g. a double-created migration): fail closed — never

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -42,6 +42,14 @@ packages_of = _ready.packages_of
 labels_of = _ready.labels_of
 valid_priority = _ready.valid_priority
 resolve = _route.resolve
+# [OPUS-5] The registry's dispatch.yml does `getattr(dispatch, "roleless_ready", None)` and, when
+# a target planner lacks it, prints "target planner has no roleless_ready() — ready-but-roleless
+# issues are NOT counted for this target" and skips the enumeration entirely. sparq WAS that
+# target: the silent-invisibility class went unreported here on every tick. Re-exported from the
+# readiness engine so the orchestrator reports a real number for sparq instead of degrading.
+roleless_ready = _ready.roleless_ready
+ready_candidates = _ready.ready_candidates
+GLOBAL = _ready.GLOBAL
 
 try:
     import tomllib

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -29,7 +29,16 @@ import subprocess
 import sys
 
 GATE_LABELS = ("needs:", "trust:untrusted")
-BUSY_STATUS = {"status:in-progress", "status:blocked", "status:deferred", "status:untriaged"}
+# [OPUS-5] `status:in-progress-review` was MISSING here while the registry's dispatch.yml keeps
+# such rows in `ready_input` precisely because it believes compute_ready() will (a) never select
+# them and (b) still let them RESERVE their package. Neither held: the label is not a gate label,
+# so an in-progress-review issue that also carried `status:ready` was SELECTABLE, and the reserve
+# branch below only fired on `status:in-progress`, so its crate was left free for a second
+# dispatch. Both halves fail OPEN into a double-dispatch; see IN_FLIGHT_STATUS below.
+BUSY_STATUS = {"status:in-progress", "status:in-progress-review", "status:blocked",
+               "status:deferred", "status:untriaged"}
+# The statuses that make an OPEN ISSUE in-flight work occupying its area (not merely excluded).
+IN_FLIGHT_STATUS = {"status:in-progress", "status:in-progress-review"}
 # [GPT-5.6] Parked is not in-flight: these terminal, human-owned snapshot artifacts cannot
 # advance autonomously, so they must not reserve an area indefinitely. Removing the label in a
 # later snapshot restores occupancy immediately; there is no remembered park state.
@@ -53,10 +62,38 @@ def valid_priority(labels):
     return next(iter(ps)) if len(ps) == 1 else None
 
 
+def declared_packages(labels):
+    """The SET of area:<crate> packages ACTUALLY declared — empty when none are, no global fallback.
+
+    [OPUS-5] Separated from `packages_of` because the empty→GLOBAL fallback is only sound for a
+    CANDIDATE (a no-area issue is cross-cutting work that must serialize against everything).
+    Applying it to an in-flight artifact inverts the meaning: it turns "we cannot attribute this
+    to a crate" into "this seizes every crate". Nothing labels PRs with `area:` — all 60 open
+    sparq PRs carried none — so the old rule let a single unlabelled PR hold __global__ and
+    reduce the whole frontier to zero. See `_reserving_packages`.
+    """
+    return {m.group(1) for lb in labels for m in [_PKG.match(lb)] if m}
+
+
 def packages_of(labels):
-    """The SET of all area:<crate> packages; empty → the serializing global partition."""
-    pkgs = {m.group(1) for lb in labels for m in [_PKG.match(lb)] if m}
-    return pkgs or {GLOBAL}
+    """The SET of all area:<crate> packages; empty → the serializing global partition.
+
+    CANDIDATE-side rule (fail-closed): an unlabelled issue is treated as cross-cutting.
+    """
+    return declared_packages(labels) or {GLOBAL}
+
+
+def _reserving_packages(labels):
+    """OCCUPANCY-side rule: an in-flight artifact reserves ONLY the areas it declares.
+
+    [OPUS-5] The deliberate asymmetry with `packages_of`. Fail-closed on a candidate costs one
+    dispatch; fail-closed on an occupant costs the ENTIRE fleet, because an unattributable
+    occupant would serialize every package at once with no way for the pipeline to clear it
+    (nothing in the pipeline applies `area:` labels to PRs). An occupant we cannot attribute
+    therefore reserves nothing and is instead handled by the linked-issue suppression the
+    registry planner applies (`Closes #N` / `sparq-agent/issue-N-*` heads).
+    """
+    return declared_packages(labels)
 
 
 def has_role(labels):
@@ -87,8 +124,93 @@ def _artifact_name(artifact):
     return f"{kind}#{artifact.get('number', '?')}"
 
 
+def exclusion_reason(labels, open_blockers=0):
+    """Why this label-set is NOT an enumerable ready candidate, or None when it is.
+
+    Label/state gates ONLY — package serialization is a separate, capacity-shaped question
+    answered by compute_ready(). Shared by ready_candidates() and the --diagnose taxonomy so the
+    two can never drift apart.
+    """
+    if "status:ready" not in labels:
+        return "no status:ready attestation"
+    if NON_DISPATCHABLE in labels:
+        return f"{NON_DISPATCHABLE} tracking umbrella"
+    gates = sorted(lb for lb in labels for g in GATE_LABELS if lb == g or lb.startswith(g))
+    if gates:
+        return f"gated by {gates[0]}"
+    busy = sorted(labels & BUSY_STATUS)
+    if busy:
+        return f"busy: {busy[0]}"
+    parked = sorted(labels & PARKED_AREA_LABELS)
+    if parked:
+        return f"parked: {parked[0]}"
+    if valid_priority(labels) is None:
+        return "no single valid priority:P0..P4"
+    if not has_role(labels):
+        return "no role:* label"
+    if int(open_blockers) > 0:
+        return f"{int(open_blockers)} open blocker(s)"
+    return None
+
+
+def ready_candidates(issues, log=None):
+    """The DRAINABLE backlog: every open issue whose LABELS make it dispatchable.
+
+    [OPUS-5] Distinct from compute_ready(), which additionally serializes to one issue per
+    package and therefore answers a CONCURRENCY question, not a "how much work is available"
+    question. Conflating the two makes a healthy 200-item backlog behind a 4-wide frontier
+    indistinguishable from an empty one. Returns [(priority, number, issue, packages)].
+
+    `log`, when supplied, receives one attributable line per issue that carries the
+    `status:ready` attestation and was nonetheless dropped — a silent `continue` here is what
+    lets a label-regressed issue leave the frontier forever with zero signal. Issues without
+    the attestation are NOT logged (they are not candidates and would flood the log).
+    """
+    out = []
+    for it in issues:
+        if str(it.get("state", "OPEN")).upper() != "OPEN":
+            continue
+        if "pull_request" in it:             # PRs reserve work; they are never issue candidates
+            continue
+        L = labels_of(it)
+        reason = exclusion_reason(L, it.get("open_blockers", 0))
+        if reason is not None:
+            if log is not None and "status:ready" in L:
+                log(f"defer #{it.get('number', '?')}: {reason}")
+            continue
+        out.append((valid_priority(L), it.get("number", 0), it, packages_of(L)))
+    return out
+
+
+def roleless_ready(issues):
+    """The SILENT-INVISIBILITY class: open, attested, un-gated, un-blocked — and yet NO `role:*`.
+
+    [OPUS-5] Ported from the registry planner (its issue #225, where 117 accumulated unnoticed).
+    `ready_candidates` drops these BEFORE any plan row exists, so they appear in no plan and in
+    no diagnostic and drain never. The fail-closed drop is CORRECT — a role is never guessed —
+    but its silence was not, so callers report this count loudly. Pure; returns sorted numbers.
+    """
+    numbers = []
+    for it in issues:
+        if str(it.get("state", "OPEN")).upper() != "OPEN" or "pull_request" in it:
+            continue
+        L = labels_of(it)
+        if "status:ready" not in L or NON_DISPATCHABLE in L:
+            continue
+        if is_gated(L) or is_busy(L) or is_parked(L):
+            continue
+        if int(it.get("open_blockers", 0)) > 0:
+            continue
+        if not has_role(L):
+            numbers.append(it.get("number", 0))
+    return sorted(numbers)
+
+
 def compute_ready(issues, in_progress_packages=None, conflict_log=None):
-    """Conflict-free, priority-ordered, FAIL-CLOSED ready frontier.
+    """Conflict-free, priority-ordered, FAIL-CLOSED CONCURRENCY FRONTIER.
+
+    This is the one-per-package concurrency WIDTH, not the size of the drainable backlog — use
+    `ready_candidates()` for the latter. compute_ready() ⊆ ready_candidates() always.
 
     `conflict_log`, when supplied, receives one attribution line per conflict-excluded candidate;
     the live default writes those diagnostics to stderr without polluting the frontier rows.
@@ -119,29 +241,9 @@ def compute_ready(issues, in_progress_packages=None, conflict_log=None):
         if str(it.get("state", "OPEN")).upper() != "OPEN" or not occupies_area(it):
             continue
         L = labels_of(it)
-        if "pull_request" in it or "status:in-progress" in L:
-            reserve(packages_of(L), it)
-    cands = []
-    for it in issues:
-        if str(it.get("state", "OPEN")).upper() != "OPEN":
-            continue
-        if "pull_request" in it:             # PRs reserve work; they are never issue candidates
-            continue
-        L = labels_of(it)
-        if "status:ready" not in L:          # positive attestation required
-            continue
-        if NON_DISPATCHABLE in L:            # epics are tracking umbrellas, not work items
-            continue
-        if is_gated(L) or is_busy(L) or is_parked(L):
-            continue
-        p = valid_priority(L)
-        if p is None:                        # need exactly one valid priority
-            continue
-        if not has_role(L):                  # need a role
-            continue
-        if int(it.get("open_blockers", 0)) > 0:
-            continue
-        cands.append((p, it.get("number", 0), it, packages_of(L)))
+        if "pull_request" in it or L & IN_FLIGHT_STATUS:
+            reserve(_reserving_packages(L), it)
+    cands = ready_candidates(issues)
     cands.sort(key=lambda c: (c[0], c[1]))   # priority then number (deterministic)
     ready = []
     for _p, _n, it, pkgs in cands:
@@ -268,6 +370,42 @@ def _flatten_pages(pages):
             if isinstance(i, dict)]
 
 
+_LINK_HEAD = re.compile(r"^sparq-agent/issue-([1-9][0-9]*)-")
+_CLOSES = re.compile(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9][0-9]*)\b")
+TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def linked_issue_numbers(pulls, repo):
+    """Issues already covered by an open PR — the suppression the REGISTRY planner applies.
+
+    [OPUS-5] Mirrors dispatch.yml's `linked_issue_numbers` so the local CLI previews the same
+    frontier the orchestrator dispatches. A fork PR must never suppress an issue: only a
+    same-repo `sparq-agent/issue-N-*` head is pipeline-owned provenance (a fork's head branch
+    text is attacker-controlled), and a closing keyword in a body counts only from a trusted
+    author association.
+    """
+    linked = set()
+    for pull in pulls:
+        head = pull.get("head") or {}
+        ref = head.get("ref") or ""
+        body = pull.get("body") or ""
+        same_repo = ((head.get("repo") or {}).get("full_name") == repo)
+        app_pr = same_repo and _LINK_HEAD.match(ref) is not None
+        if app_pr:
+            linked.update(int(n) for n in _LINK_HEAD.findall(ref))
+        if app_pr or str(pull.get("author_association", "")).upper() in TRUSTED_ASSOCIATIONS:
+            linked.update(int(n) for n in _CLOSES.findall(body))
+    return linked
+
+
+def _fetch_pulls(repo):
+    out = subprocess.run(
+        ["gh", "api", "--paginate", "--slurp", f"repos/{repo}/pulls?state=open&per_page=100"],
+        capture_output=True, text=True, check=True).stdout
+    return [p for page in json.loads(out or "[]") if isinstance(page, list)
+            for p in page if isinstance(p, dict)]
+
+
 def _fetch(repo, ceiling=10000):
     """Open-issue snapshot via REAL cursor pagination (`gh api --paginate` follows Link headers),
     replacing the old single-page `--limit 1000` fetch that FAILED CLOSED at exactly 1000 open
@@ -298,14 +436,53 @@ def _fetch(repo, ceiling=10000):
     return issues
 
 
+def diagnose(issues, linked=()):
+    """Re-runnable VISIBILITY taxonomy: why the open backlog is not on the frontier.
+
+    Returns (counts, roleless, candidates, frontier). Every open issue lands in exactly one
+    bucket, so the buckets sum to the open-issue count and no class can hide.
+    """
+    linked = set(linked)
+    counts, open_issues = {}, []
+    for it in issues:
+        if str(it.get("state", "OPEN")).upper() != "OPEN" or "pull_request" in it:
+            continue
+        open_issues.append(it)
+        if it.get("number") in linked:
+            reason = "covered by an open linked PR"
+        else:
+            reason = exclusion_reason(labels_of(it), it.get("open_blockers", 0)) or "ENUMERABLE"
+        counts[reason] = counts.get(reason, 0) + 1
+    visible = [it for it in issues if it.get("number") not in linked]
+    return (counts, roleless_ready(open_issues),
+            ready_candidates(visible), compute_ready(visible, conflict_log=lambda _m: None))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo", default="sparq-org/sparq")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--diagnose", action="store_true",
+                    help="print the full visibility taxonomy instead of just the frontier")
     args = ap.parse_args()
     if args.self_test:
         return _self_test()
-    for it in compute_ready(_fetch(args.repo)):
+    issues = _fetch(args.repo)
+    linked = linked_issue_numbers(_fetch_pulls(args.repo), args.repo)
+    visible = [it for it in issues if it.get("number") not in linked]
+    if args.diagnose:
+        counts, roleless, cands, frontier = diagnose(issues, linked)
+        total = sum(counts.values())
+        print(f"open issues: {total}")
+        for reason, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {n:5d}  {100 * n / total:5.1f}%  {reason}")
+        print(f"\ndrainable backlog (ready_candidates): {len(cands)}")
+        print(f"concurrency frontier (compute_ready): {len(frontier)}")
+        if roleless:
+            print(f"\n::warning:: {len(roleless)} attested issue(s) carry NO role:* label and are "
+                  f"INVISIBLE to dispatch: {', '.join('#%d' % n for n in roleless[:20])}")
+        return 0
+    for it in compute_ready(visible):
         L = labels_of(it)
         print(f"P{valid_priority(L)}  #{it['number']:5}  {sorted(packages_of(L))}")
     return 0

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# [OPUS-5] Readiness VISIBILITY suite — the "can the dispatcher see this work?" contract.
+#
+# The registry's dispatch.yml clones this repo and runs THIS repo's scripts/ready-issues.py +
+# scripts/dispatch-plan.py, so a defect here is a fleet-wide dispatch defect. The suite pins the
+# three things that made ready work invisible, each of which was measured live on sparq-org/sparq:
+#
+#   1. OCCUPANCY ATTRIBUTION — `packages_of` maps "no area: label" to the GLOBAL partition.
+#      Applied to a CANDIDATE that is correct fail-closed behaviour (cross-cutting work must
+#      serialize). Applied to an OCCUPANT it inverts: "cannot attribute" became "seizes every
+#      crate". Nothing in the pipeline puts `area:` labels on PRs — all 60 open sparq PRs had
+#      none — so ONE unlabelled PR held __global__ and drove the local frontier to zero.
+#   2. status:in-progress-review — absent from BUSY_STATUS and from the reserve branch, so such
+#      an issue was neither excluded nor reserving: a double-dispatch on both halves.
+#   3. LOCAL/ORCHESTRATOR PARITY — dispatch.yml builds its readiness input from ISSUES ONLY and
+#      suppresses issues covered by a linked open PR. The local CLI must preview THAT frontier;
+#      when it did not, the two disagreed 0-vs-6 on the same live snapshot.
+#
+# Plus the YAML seam: routing-self-tests.yml listed scripts/ready-issues.py in its `paths:` filter
+# but never INVOKED its --self-test, so all of that script's assertions were dead in this repo's
+# CI and only ran later inside the registry's dispatch tick (where a failure breaks EVERY target).
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+
+
+def _load(name: str, filename: str):
+    path = SCRIPTS / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ready = _load("ready_issues_under_test", "ready-issues.py")
+plan = _load("dispatch_plan_under_test", "dispatch-plan.py")
+
+READY = ["status:ready", "role:impl"]
+
+
+def iss(number, labels, blockers=0, state="OPEN"):
+    return {"number": number, "state": state, "labels": list(labels),
+            "open_blockers": blockers}
+
+
+def pr(number, labels, draft=False):
+    return {"number": number, "state": "OPEN", "labels": list(labels),
+            "pull_request": {}, "draft": draft}
+
+
+def numbers(rows):
+    return [row["number"] for row in rows]
+
+
+def quiet(_message):
+    pass
+
+
+class TestUnlabelledOccupantAttribution(unittest.TestCase):
+    """Class 1 — an occupant we cannot attribute must reserve NOTHING, not EVERYTHING."""
+
+    def test_unlabelled_pr_does_not_seize_the_global_partition(self):
+        # THE live defect: one area-less PR made the entire frontier empty.
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core"])
+        unlabelled = pr(70, [])
+        self.assertEqual(
+            numbers(ready.compute_ready([unlabelled, waiting], conflict_log=quiet)), [20],
+            "an area-less PR must not hold __global__ and stall the whole fleet")
+
+    def test_unlabelled_pr_leaves_every_unrelated_crate_dispatchable(self):
+        # The blast radius, not just one row: with the bug, ALL of these vanished at once.
+        board = [pr(70, [])] + [
+            iss(n, READY + ["priority:P1", f"area:crate-{n}"]) for n in (21, 22, 23)]
+        self.assertEqual(
+            numbers(ready.compute_ready(board, conflict_log=quiet)), [21, 22, 23])
+
+    def test_area_labelled_pr_still_reserves_exactly_its_crate(self):
+        # The fix must not become "PRs never reserve": a DECLARED area is still occupancy.
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core"])
+        other = iss(21, READY + ["priority:P1", "area:sparq-hdt"])
+        board = [pr(70, ["area:sparq-core"]), waiting, other]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [21],
+                         "a PR labelled area:sparq-core must still hold sparq-core (only)")
+
+    def test_area_less_ISSUE_candidate_still_fails_closed_to_global(self):
+        # The asymmetry is deliberate — the CANDIDATE-side global rule is untouched.
+        self.assertEqual(ready.packages_of({"role:impl"}), {ready.GLOBAL})
+        self.assertEqual(ready.declared_packages({"role:impl"}), set())
+        board = [iss(30, READY + ["priority:P0"]),
+                 iss(31, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [30],
+                         "an area-less READY ISSUE must still serialize against everything")
+
+    def test_unlabelled_in_progress_issue_also_reserves_nothing(self):
+        # Same attribution rule on the issue-occupancy path, not just the PR path.
+        board = [iss(72, ["status:in-progress"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [20])
+
+
+class TestInProgressReviewStatus(unittest.TestCase):
+    """Class 2 — status:in-progress-review failed OPEN on BOTH halves."""
+
+    def test_in_progress_review_is_busy(self):
+        self.assertIn("status:in-progress-review", ready.BUSY_STATUS)
+        self.assertTrue(ready.is_busy({"status:in-progress-review"}))
+
+    def test_in_progress_review_issue_is_never_selected(self):
+        board = [iss(10, READY + ["priority:P0", "area:sparq-zk",
+                                  "status:in-progress-review"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an issue already in review must not be dispatched again")
+
+    def test_in_progress_review_issue_reserves_its_area(self):
+        # The other half: dispatch.yml KEEPS these rows in its input precisely because it
+        # believes they reserve. If they do not, a second worker takes the same crate.
+        board = [iss(10, ["status:in-progress-review", "area:sparq-zk"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-zk"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an in-review issue must still hold its crate")
+
+    def test_exclusion_reason_names_the_review_status(self):
+        self.assertEqual(
+            ready.exclusion_reason({"status:ready", "status:in-progress-review"}),
+            "busy: status:in-progress-review")
+
+
+class TestDrainableBacklogVsConcurrencyFrontier(unittest.TestCase):
+    """The two must stay distinct — conflating them hides a healthy backlog."""
+
+    BOARD = [
+        iss(1, READY + ["priority:P1", "area:sparq-core"]),
+        iss(2, READY + ["priority:P2", "area:sparq-core"]),
+        iss(3, READY + ["priority:P2", "area:sparq-core"]),
+        iss(4, READY + ["priority:P1", "area:sparq-hdt"]),
+    ]
+
+    def test_ready_candidates_counts_all_drainable_work(self):
+        self.assertEqual(
+            sorted(c[1] for c in ready.ready_candidates(self.BOARD)), [1, 2, 3, 4])
+
+    def test_compute_ready_serialises_one_per_package(self):
+        self.assertEqual(numbers(ready.compute_ready(self.BOARD, conflict_log=quiet)), [1, 4])
+
+    def test_frontier_is_always_a_subset_of_the_drainable_backlog(self):
+        frontier = numbers(ready.compute_ready(self.BOARD, conflict_log=quiet))
+        drainable = {c[1] for c in ready.ready_candidates(self.BOARD)}
+        self.assertTrue(set(frontier) <= drainable)
+        self.assertLessEqual(len(frontier), len(drainable))
+
+    def test_every_dropped_attested_candidate_is_attributable(self):
+        # A silent `continue` is how a label-regressed issue leaves the frontier forever.
+        board = [
+            iss(40, READY + ["priority:P1", "needs:design", "area:a"]),
+            iss(41, READY + ["priority:P1", "area:b"], blockers=2),
+            iss(42, READY + ["area:c"]),
+            iss(43, ["status:ready", "priority:P1", "area:d"]),
+            iss(44, ["priority:P1", "role:impl", "area:e"]),  # NOT attested -> must stay quiet
+        ]
+        lines = []
+        ready.ready_candidates(board, log=lines.append)
+        got = {int(re.search(r"#(\d+)", line).group(1)): line for line in lines}
+        self.assertEqual(sorted(got), [40, 41, 42, 43])
+        self.assertIn("gated by needs:design", got[40])
+        self.assertIn("2 open blocker(s)", got[41])
+        self.assertIn("no single valid priority", got[42])
+        self.assertIn("no role:* label", got[43])
+        self.assertNotIn(44, got, "a non-attested issue is not a candidate and must not log")
+
+
+class TestRolelessInvisibility(unittest.TestCase):
+    """The class that appears in no plan and no diagnostic — it must be REPORTED."""
+
+    def test_roleless_ready_reports_the_invisible_issues(self):
+        board = [
+            iss(50, ["status:ready", "priority:P1", "area:a"]),          # roleless
+            iss(51, ["status:ready", "area:b"]),                          # roleless, no priority
+            iss(52, READY + ["priority:P1", "area:c"]),                   # fine
+            iss(53, ["status:ready", "needs:user", "area:d"]),            # gated, not this class
+        ]
+        self.assertEqual(ready.roleless_ready(board), [50, 51])
+
+    def test_roleless_issues_are_genuinely_absent_from_the_frontier(self):
+        board = [iss(50, ["status:ready", "priority:P1", "area:a"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [])
+        self.assertEqual(ready.roleless_ready(board), [50],
+                         "invisible to dispatch, but NOT invisible to the report")
+
+    def test_target_planner_exposes_roleless_ready_to_dispatch_yml(self):
+        # dispatch.yml does getattr(dispatch, "roleless_ready", None) and degrades to a
+        # "planner has no roleless_ready()" warning when the target predates it.
+        self.assertTrue(callable(getattr(plan, "roleless_ready", None)),
+                        "dispatch-plan.py must export roleless_ready for the registry planner")
+        self.assertEqual(plan.roleless_ready(
+            [iss(50, ["status:ready", "priority:P1", "area:a"])]), [50])
+
+
+class TestLocalOrchestratorParity(unittest.TestCase):
+    """The divergence that mattered: the local CLI must preview the dispatched frontier."""
+
+    @staticmethod
+    def _orchestrator(issues_and_prs, linked=()):
+        """dispatch.yml's shape: ISSUES ONLY, linked-PR-covered issues filtered first."""
+        rows = [it for it in issues_and_prs if "pull_request" not in it]
+        rows = [it for it in rows
+                if it["number"] not in set(linked)
+                or {"status:in-progress", "status:in-progress-review"} & set(it["labels"])]
+        return numbers(ready.compute_ready(rows, conflict_log=quiet))
+
+    @staticmethod
+    def _local(issues_and_prs, linked=()):
+        """The local CLI's shape: the full snapshot minus linked-PR-covered issues."""
+        visible = [it for it in issues_and_prs if it["number"] not in set(linked)]
+        return numbers(ready.compute_ready(visible, conflict_log=quiet))
+
+    def test_unlabelled_prs_do_not_make_the_two_views_disagree(self):
+        # The exact live shape: many area-less open PRs + attested issues on distinct crates.
+        board = [pr(3803, []), pr(3799, []), pr(3798, [])] + [
+            iss(n, READY + ["priority:P3", f"area:crate-{n}"]) for n in (3694, 3756, 3757)]
+        self.assertEqual(self._local(board), self._orchestrator(board))
+        self.assertEqual(self._local(board), [3694, 3756, 3757])
+
+    def test_linked_pr_suppression_matches_on_both_sides(self):
+        board = [iss(60, READY + ["priority:P1", "area:sparq-core"]),
+                 iss(61, READY + ["priority:P1", "area:sparq-hdt"])]
+        self.assertEqual(self._local(board, linked={60}),
+                         self._orchestrator(board, linked={60}))
+        self.assertEqual(self._local(board, linked={60}), [61])
+
+    def test_local_cli_applies_linked_pr_suppression_at_all(self):
+        # Without this the local view over-reports work the orchestrator will never dispatch.
+        source = (SCRIPTS / "ready-issues.py").read_text(encoding="utf-8")
+        main = source[source.index("def main("):]
+        self.assertIn("linked_issue_numbers", main,
+                      "main() must suppress issues covered by an open linked PR, as dispatch does")
+
+
+class TestLinkedIssueDetection(unittest.TestCase):
+    """Fork PRs must never suppress an issue (the head branch text is attacker-controlled)."""
+
+    REPO = "sparq-org/sparq"
+
+    def _pull(self, ref, body="", full_name="sparq-org/sparq", association="NONE"):
+        return {"head": {"ref": ref, "repo": {"full_name": full_name}},
+                "body": body, "author_association": association}
+
+    def test_pipeline_owned_head_links_its_issue(self):
+        self.assertEqual(
+            ready.linked_issue_numbers([self._pull("sparq-agent/issue-42-fix")], self.REPO), {42})
+
+    def test_fork_head_does_not_link(self):
+        self.assertEqual(ready.linked_issue_numbers(
+            [self._pull("sparq-agent/issue-42-fix", full_name="attacker/sparq")], self.REPO),
+            set(), "a fork PR must never suppress an issue")
+
+    def test_closing_keyword_needs_a_trusted_association(self):
+        untrusted = self._pull("patch-1", body="Closes #42", association="NONE")
+        trusted = self._pull("patch-1", body="Closes #42", association="MEMBER")
+        self.assertEqual(ready.linked_issue_numbers([untrusted], self.REPO), set())
+        self.assertEqual(ready.linked_issue_numbers([trusted], self.REPO), {42})
+
+
+class TestDiagnoseTaxonomy(unittest.TestCase):
+    """--diagnose must account for EVERY open issue, so no class can hide."""
+
+    def test_buckets_partition_the_open_backlog(self):
+        board = [
+            iss(1, READY + ["priority:P1", "area:a"]),
+            iss(2, ["status:untriaged"]),
+            iss(3, []),
+            iss(4, READY + ["priority:P1", "needs:ec2", "area:b"]),
+            iss(5, READY + ["priority:P1", "area:c"]),
+            pr(70, []),
+            iss(6, READY + ["priority:P1", "area:d"], state="CLOSED"),
+        ]
+        counts, roleless, cands, frontier = ready.diagnose(board, linked={5})
+        self.assertEqual(sum(counts.values()), 5, "one bucket per OPEN issue, PRs/closed excluded")
+        self.assertEqual(counts["ENUMERABLE"], 1)
+        self.assertEqual(counts["covered by an open linked PR"], 1)
+        self.assertEqual(counts["gated by needs:ec2"], 1)
+        self.assertEqual(counts["no status:ready attestation"], 2)
+        self.assertEqual(roleless, [])
+        self.assertEqual([c[1] for c in cands], [1])
+        self.assertEqual(numbers(frontier), [1])
+
+
+class TestRoutingSelfTestWorkflowWiring(unittest.TestCase):
+    """The YAML seam — a self-test that no workflow INVOKES is not a gate.
+
+    routing-self-tests.yml listed scripts/ready-issues.py under `paths:` (so it looked covered)
+    while its `run:` block never executed that script's --self-test. Deleting either the paths
+    entry or the invocation must red THIS test.
+    """
+
+    SOURCE = WORKFLOW.read_text(encoding="utf-8")
+    INVOKED = ("scripts/routing-validate.py", "scripts/route-resolve.py",
+               "scripts/dispatch-plan.py", "scripts/ready-issues.py")
+
+    def test_every_self_tested_script_is_actually_invoked(self):
+        run_block = self.SOURCE[self.SOURCE.index("Validate routing schema"):]
+        for script in self.INVOKED:
+            self.assertIn(f"python3 {script} --self-test", run_block,
+                          f"{script} --self-test is never RUN — its assertions are dead in CI")
+
+    def test_ready_issues_self_test_is_invoked_not_merely_path_filtered(self):
+        # The precise regression: present in `paths:`, absent from `run:`.
+        run_block = self.SOURCE[self.SOURCE.index("Validate routing schema"):]
+        self.assertIn("python3 scripts/ready-issues.py --self-test", run_block)
+
+    def test_this_test_file_is_itself_a_path_trigger(self):
+        # Scoped to the `paths:` section ON PURPOSE: a whole-file substring search passes for
+        # the WRONG reason, because this filename also appears in the run: block, so deleting
+        # both paths entries left the old assertion green. Both trigger blocks
+        # (pull_request + push) must list it, hence the exact count of 2.
+        self.assertEqual(
+            self._paths_section().count('"scripts/tests/test_readiness_visibility.py"'), 2,
+            "edits to this suite must re-run the gate that executes it, on PR *and* push")
+
+    def test_this_suite_is_invoked_by_the_workflow(self):
+        run_block = self.SOURCE[self.SOURCE.index("Validate routing schema"):]
+        self.assertIn("python3 scripts/tests/test_readiness_visibility.py", run_block)
+
+    def _paths_section(self):
+        return self.SOURCE[:self.SOURCE.index("permissions:")]
+
+    def test_every_invoked_script_is_a_path_trigger(self):
+        paths_section = self._paths_section()
+        for script in self.INVOKED:
+            # Exactly 2: the pull_request filter AND the push filter. Dropping either one
+            # lets the script change without re-running the gate on that trigger.
+            self.assertEqual(paths_section.count(f'"{script}"'), 2,
+                             f"{script} must be a path trigger on BOTH pull_request and push")
+
+    def test_job_name_stays_gate_discoverable(self):
+        # ci-summary auto-discovers a sibling as GATING iff its name says neither
+        # "advisory" nor "informational"; a rename would silently demote this gate.
+        name = re.search(r"^    name: (.+)$", self.SOURCE, re.M).group(1).lower()
+        self.assertNotIn("advisory", name)
+        self.assertNotIn("informational", name)
+
+    def test_merge_group_trigger_present(self):
+        # merge_group cannot use a paths filter; without the trigger the queue ref
+        # never exposes this gating check.
+        self.assertRegex(self.SOURCE, r"(?m)^  merge_group:")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

## The problem, measured

The dispatcher cannot pick up work it cannot see. On the live board (**1117 open issues**) the local readiness engine reported **ZERO** ready issues while the registry's dispatch planner computed **SIX** from the same snapshot. Three distinct defects.

## 1. Occupancy attribution — the zero

`packages_of()` maps "no `area:` label" to the **GLOBAL** partition. For a **candidate** that is correct fail-closed behaviour: cross-cutting work must serialize against everything. Applied to an **occupant** it inverts the meaning — "cannot attribute this to a crate" became "this seizes every crate".

Nothing in the pipeline puts `area:` labels on PRs. **All 60 open PRs carried none**, so a single unlabelled PR — #3803, zero labels — held `__global__` and drove the entire frontier to zero:

```
conflict #3526: area __global__ held by pr#3803
conflict #3694: area __global__ held by pr#3803
... every candidate, every tick
```

Split the rule: `declared_packages()` (occupancy, no fallback) vs `packages_of()` (candidates, unchanged fail-closed global). The asymmetry is deliberate and commented — fail-closed on a candidate costs one dispatch, fail-closed on an occupant costs the **whole fleet**, and nothing in the pipeline can clear it.

## 2. `status:in-progress-review` failed OPEN on both halves

It was absent from `BUSY_STATUS`, so such an issue was **selectable**, and the reserve branch only fired on `status:in-progress`, so its crate stayed **free for a second worker**. `dispatch.yml` deliberately keeps these rows in its readiness input precisely because it believes `compute_ready()` does both:

> In-progress rows are KEPT as inputs: compute_ready never selects them (they are busy), but they must still RESERVE their package

Neither held. 3 live issues (#3235, #3079, #2601) were in this state. Now it does both.

## 3. Local/orchestrator parity

`dispatch.yml` builds readiness input from **issues only** and suppresses issues covered by a linked open PR. The local CLI fed PRs in as occupancy and applied no linked-PR suppression, so the two views answered different questions on the same data. The CLI now previews the dispatched frontier — **local and orchestrator agree at 6**.

## Also

- **DRAINABLE vs FRONTIER.** `ready_candidates()` (how much work exists) is now separate from `compute_ready()` (how many can run at once). Conflating them makes a healthy backlog behind a narrow frontier look like an empty one.
- Every dropped attested candidate emits an **attributable reason**; a silent `continue` is how a label-regressed issue leaves the frontier forever with no signal.
- `roleless_ready()` re-exported from `dispatch-plan.py`, so the registry planner stops printing *"target planner has no roleless_ready()"* and reports a real number for sparq.
- New `--diagnose` prints the full visibility taxonomy.

## Gate hole (the YAML seam)

`routing-self-tests.yml` listed `scripts/ready-issues.py` in its `paths:` filter but **never invoked** its `--self-test`. Its 19 assertions were dead in this repo's CI and first ran inside the registry's dispatch tick — where a failure breaks **every target at once**. The run block now executes it plus the new suite.

## Verified by mutation — 17 mutants, all killed by NAMED tests

Mutants are marker-verified (an edit that fails to apply reports loudly instead of reading as a survival — **one did**, and was a false "survived" until fixed).

| Mutant | Named tests red |
|---|---|
| revert occupancy fix | 5 |
| `declared_packages` falls back to GLOBAL | 6 |
| drop `in-progress-review` from BUSY_STATUS | 2 |
| reserve branch ignores in-review | 1 |
| drop `roleless_ready` re-export | 1 |
| silence the attribution log | 1 |
| **YAML**: delete `ready-issues --self-test` invocation | 2 |
| **YAML**: delete suite invocation / either `paths:` trigger / rename job advisory / drop `merge_group` | 1 each |

The YAML mutants matter most: on this fleet every recently-uncaught mutant lived at the workflow `if:`/step/call-site seam. The mutation run also exposed **one of my own assertions as vacuous** — a whole-file substring search the `run:` block satisfied, so deleting both `paths:` entries left it green. It is now scoped to the `paths:` section and counts both trigger blocks.

## Not fixed here (reported separately)

The dominant blocker is **data, not code**: `area:` is the partition key for the whole system and 832/1117 open issues lack one. See the companion issue.
