### PR TITLE
fix(orchestration): make ready work visible — occupancy attribution, in-review status, local/orchestrator parity

### DIFF
--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -28,6 +28,10 @@ on:
       # batching) — run its hermetic self-test on the PR that could break either side.
       - "scripts/batch-merge.py"
       - "scripts/ci_select.py"
+      # [OPUS-5] the readiness VISIBILITY suite — pins the occupancy-attribution,
+      # in-progress-review and local/orchestrator-parity contracts, and pins this
+      # workflow's own run block to the scripts it must invoke.
+      - "scripts/tests/test_readiness_visibility.py"
       - ".github/workflows/routing-self-tests.yml"
   merge_group:
   push:
@@ -42,6 +46,10 @@ on:
       # batching) — run its hermetic self-test on the PR that could break either side.
       - "scripts/batch-merge.py"
       - "scripts/ci_select.py"
+      # [OPUS-5] the readiness VISIBILITY suite — pins the occupancy-attribution,
+      # in-progress-review and local/orchestrator-parity contracts, and pins this
+      # workflow's own run block to the scripts it must invoke.
+      - "scripts/tests/test_readiness_visibility.py"
       - ".github/workflows/routing-self-tests.yml"
 
 permissions:
@@ -65,5 +73,10 @@ jobs:
           python3 scripts/routing-validate.py --self-test
           python3 scripts/routing-validate.py
           python3 scripts/route-resolve.py --self-test
+          # [OPUS-5] ready-issues.py was in the `paths:` filter above but its --self-test was
+          # NEVER invoked here, so its assertions were dead in this repo's CI and first ran
+          # inside the registry's dispatch tick — where a failure breaks EVERY target at once.
+          python3 scripts/ready-issues.py --self-test
           python3 scripts/dispatch-plan.py --self-test
           python3 scripts/batch-merge.py --self-test
+          python3 scripts/tests/test_readiness_visibility.py

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -42,6 +42,14 @@ packages_of = _ready.packages_of
 labels_of = _ready.labels_of
 valid_priority = _ready.valid_priority
 resolve = _route.resolve
+# [OPUS-5] The registry's dispatch.yml does `getattr(dispatch, "roleless_ready", None)` and, when
+# a target planner lacks it, prints "target planner has no roleless_ready() — ready-but-roleless
+# issues are NOT counted for this target" and skips the enumeration entirely. sparq WAS that
+# target: the silent-invisibility class went unreported here on every tick. Re-exported from the
+# readiness engine so the orchestrator reports a real number for sparq instead of degrading.
+roleless_ready = _ready.roleless_ready
+ready_candidates = _ready.ready_candidates
+GLOBAL = _ready.GLOBAL
 
 try:
     import tomllib

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -29,7 +29,16 @@ import subprocess
 import sys
 
 GATE_LABELS = ("needs:", "trust:untrusted")
-BUSY_STATUS = {"status:in-progress", "status:blocked", "status:deferred", "status:untriaged"}
+# [OPUS-5] `status:in-progress-review` was MISSING here while the registry's dispatch.yml keeps
+# such rows in `ready_input` precisely because it believes compute_ready() will (a) never select
+# them and (b) still let them RESERVE their package. Neither held: the label is not a gate label,
+# so an in-progress-review issue that also carried `status:ready` was SELECTABLE, and the reserve
+# branch below only fired on `status:in-progress`, so its crate was left free for a second
+# dispatch. Both halves fail OPEN into a double-dispatch; see IN_FLIGHT_STATUS below.
+BUSY_STATUS = {"status:in-progress", "status:in-progress-review", "status:blocked",
+               "status:deferred", "status:untriaged"}
+# The statuses that make an OPEN ISSUE in-flight work occupying its area (not merely excluded).
+IN_FLIGHT_STATUS = {"status:in-progress", "status:in-progress-review"}
 # [GPT-5.6] Parked is not in-flight: these terminal, human-owned snapshot artifacts cannot
 # advance autonomously, so they must not reserve an area indefinitely. Removing the label in a
 # later snapshot restores occupancy immediately; there is no remembered park state.
@@ -53,10 +62,38 @@ def valid_priority(labels):
     return next(iter(ps)) if len(ps) == 1 else None
 
 
+def declared_packages(labels):
+    """The SET of area:<crate> packages ACTUALLY declared — empty when none are, no global fallback.
+
+    [OPUS-5] Separated from `packages_of` because the empty→GLOBAL fallback is only sound for a
+    CANDIDATE (a no-area issue is cross-cutting work that must serialize against everything).
+    Applying it to an in-flight artifact inverts the meaning: it turns "we cannot attribute this
+    to a crate" into "this seizes every crate". Nothing labels PRs with `area:` — all 60 open
+    sparq PRs carried none — so the old rule let a single unlabelled PR hold __global__ and
+    reduce the whole frontier to zero. See `_reserving_packages`.
+    """
+    return {m.group(1) for lb in labels for m in [_PKG.match(lb)] if m}
+
+
 def packages_of(labels):
-    """The SET of all area:<crate> packages; empty → the serializing global partition."""
-    pkgs = {m.group(1) for lb in labels for m in [_PKG.match(lb)] if m}
-    return pkgs or {GLOBAL}
+    """The SET of all area:<crate> packages; empty → the serializing global partition.
+
+    CANDIDATE-side rule (fail-closed): an unlabelled issue is treated as cross-cutting.
+    """
+    return declared_packages(labels) or {GLOBAL}
+
+
+def _reserving_packages(labels):
+    """OCCUPANCY-side rule: an in-flight artifact reserves ONLY the areas it declares.
+
+    [OPUS-5] The deliberate asymmetry with `packages_of`. Fail-closed on a candidate costs one
+    dispatch; fail-closed on an occupant costs the ENTIRE fleet, because an unattributable
+    occupant would serialize every package at once with no way for the pipeline to clear it
+    (nothing in the pipeline applies `area:` labels to PRs). An occupant we cannot attribute
+    therefore reserves nothing and is instead handled by the linked-issue suppression the
+    registry planner applies (`Closes #N` / `sparq-agent/issue-N-*` heads).
+    """
+    return declared_packages(labels)
 
 
 def has_role(labels):
@@ -87,8 +124,93 @@ def _artifact_name(artifact):
     return f"{kind}#{artifact.get('number', '?')}"
 
 
+def exclusion_reason(labels, open_blockers=0):
+    """Why this label-set is NOT an enumerable ready candidate, or None when it is.
+
+    Label/state gates ONLY — package serialization is a separate, capacity-shaped question
+    answered by compute_ready(). Shared by ready_candidates() and the --diagnose taxonomy so the
+    two can never drift apart.
+    """
+    if "status:ready" not in labels:
+        return "no status:ready attestation"
+    if NON_DISPATCHABLE in labels:
+        return f"{NON_DISPATCHABLE} tracking umbrella"
+    gates = sorted(lb for lb in labels for g in GATE_LABELS if lb == g or lb.startswith(g))
+    if gates:
+        return f"gated by {gates[0]}"
+    busy = sorted(labels & BUSY_STATUS)
+    if busy:
+        return f"busy: {busy[0]}"
+    parked = sorted(labels & PARKED_AREA_LABELS)
+    if parked:
+        return f"parked: {parked[0]}"
+    if valid_priority(labels) is None:
+        return "no single valid priority:P0..P4"
+    if not has_role(labels):
+        return "no role:* label"
+    if int(open_blockers) > 0:
+        return f"{int(open_blockers)} open blocker(s)"
+    return None
+
+
+def ready_candidates(issues, log=None):
+    """The DRAINABLE backlog: every open issue whose LABELS make it dispatchable.
+
+    [OPUS-5] Distinct from compute_ready(), which additionally serializes to one issue per
+    package and therefore answers a CONCURRENCY question, not a "how much work is available"
+    question. Conflating the two makes a healthy 200-item backlog behind a 4-wide frontier
+    indistinguishable from an empty one. Returns [(priority, number, issue, packages)].
+
+    `log`, when supplied, receives one attributable line per issue that carries the
+    `status:ready` attestation and was nonetheless dropped — a silent `continue` here is what
+    lets a label-regressed issue leave the frontier forever with zero signal. Issues without
+    the attestation are NOT logged (they are not candidates and would flood the log).
+    """
+    out = []
+    for it in issues:
+        if str(it.get("state", "OPEN")).upper() != "OPEN":
+            continue
+        if "pull_request" in it:             # PRs reserve work; they are never issue candidates
+            continue
+        L = labels_of(it)
+        reason = exclusion_reason(L, it.get("open_blockers", 0))
+        if reason is not None:
+            if log is not None and "status:ready" in L:
+                log(f"defer #{it.get('number', '?')}: {reason}")
+            continue
+        out.append((valid_priority(L), it.get("number", 0), it, packages_of(L)))
+    return out
+
+
+def roleless_ready(issues):
+    """The SILENT-INVISIBILITY class: open, attested, un-gated, un-blocked — and yet NO `role:*`.
+
+    [OPUS-5] Ported from the registry planner (its issue #225, where 117 accumulated unnoticed).
+    `ready_candidates` drops these BEFORE any plan row exists, so they appear in no plan and in
+    no diagnostic and drain never. The fail-closed drop is CORRECT — a role is never guessed —
+    but its silence was not, so callers report this count loudly. Pure; returns sorted numbers.
+    """
+    numbers = []
+    for it in issues:
+        if str(it.get("state", "OPEN")).upper() != "OPEN" or "pull_request" in it:
+            continue
+        L = labels_of(it)
+        if "status:ready" not in L or NON_DISPATCHABLE in L:
+            continue
+        if is_gated(L) or is_busy(L) or is_parked(L):
+            continue
+        if int(it.get("open_blockers", 0)) > 0:
+            continue
+        if not has_role(L):
+            numbers.append(it.get("number", 0))
+    return sorted(numbers)
+
+
 def compute_ready(issues, in_progress_packages=None, conflict_log=None):
-    """Conflict-free, priority-ordered, FAIL-CLOSED ready frontier.
+    """Conflict-free, priority-ordered, FAIL-CLOSED CONCURRENCY FRONTIER.
+
+    This is the one-per-package concurrency WIDTH, not the size of the drainable backlog — use
+    `ready_candidates()` for the latter. compute_ready() ⊆ ready_candidates() always.
 
     `conflict_log`, when supplied, receives one attribution line per conflict-excluded candidate;
     the live default writes those diagnostics to stderr without polluting the frontier rows.
@@ -119,29 +241,9 @@ def compute_ready(issues, in_progress_packages=None, conflict_log=None):
         if str(it.get("state", "OPEN")).upper() != "OPEN" or not occupies_area(it):
             continue
         L = labels_of(it)
-        if "pull_request" in it or "status:in-progress" in L:
-            reserve(packages_of(L), it)
-    cands = []
-    for it in issues:
-        if str(it.get("state", "OPEN")).upper() != "OPEN":
-            continue
-        if "pull_request" in it:             # PRs reserve work; they are never issue candidates
-            continue
-        L = labels_of(it)
-        if "status:ready" not in L:          # positive attestation required
-            continue
-        if NON_DISPATCHABLE in L:            # epics are tracking umbrellas, not work items
-            continue
-        if is_gated(L) or is_busy(L) or is_parked(L):
-            continue
-        p = valid_priority(L)
-        if p is None:                        # need exactly one valid priority
-            continue
-        if not has_role(L):                  # need a role
-            continue
-        if int(it.get("open_blockers", 0)) > 0:
-            continue
-        cands.append((p, it.get("number", 0), it, packages_of(L)))
+        if "pull_request" in it or L & IN_FLIGHT_STATUS:
+            reserve(_reserving_packages(L), it)
+    cands = ready_candidates(issues)
     cands.sort(key=lambda c: (c[0], c[1]))   # priority then number (deterministic)
     ready = []
     for _p, _n, it, pkgs in cands:
@@ -268,6 +370,42 @@ def _flatten_pages(pages):
             if isinstance(i, dict)]
 
 
+_LINK_HEAD = re.compile(r"^sparq-agent/issue-([1-9][0-9]*)-")
+_CLOSES = re.compile(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9][0-9]*)\b")
+TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def linked_issue_numbers(pulls, repo):
+    """Issues already covered by an open PR — the suppression the REGISTRY planner applies.
+
+    [OPUS-5] Mirrors dispatch.yml's `linked_issue_numbers` so the local CLI previews the same
+    frontier the orchestrator dispatches. A fork PR must never suppress an issue: only a
+    same-repo `sparq-agent/issue-N-*` head is pipeline-owned provenance (a fork's head branch
+    text is attacker-controlled), and a closing keyword in a body counts only from a trusted
+    author association.
+    """
+    linked = set()
+    for pull in pulls:
+        head = pull.get("head") or {}
+        ref = head.get("ref") or ""
+        body = pull.get("body") or ""
+        same_repo = ((head.get("repo") or {}).get("full_name") == repo)
+        app_pr = same_repo and _LINK_HEAD.match(ref) is not None
+        if app_pr:
+            linked.update(int(n) for n in _LINK_HEAD.findall(ref))
+        if app_pr or str(pull.get("author_association", "")).upper() in TRUSTED_ASSOCIATIONS:
+            linked.update(int(n) for n in _CLOSES.findall(body))
+    return linked
+
+
+def _fetch_pulls(repo):
+    out = subprocess.run(
+        ["gh", "api", "--paginate", "--slurp", f"repos/{repo}/pulls?state=open&per_page=100"],
+        capture_output=True, text=True, check=True).stdout
+    return [p for page in json.loads(out or "[]") if isinstance(page, list)
+            for p in page if isinstance(p, dict)]
+
+
 def _fetch(repo, ceiling=10000):
     """Open-issue snapshot via REAL cursor pagination (`gh api --paginate` follows Link headers),
     replacing the old single-page `--limit 1000` fetch that FAILED CLOSED at exactly 1000 open
@@ -298,14 +436,53 @@ def _fetch(repo, ceiling=10000):
     return issues
 
 
+def diagnose(issues, linked=()):
+    """Re-runnable VISIBILITY taxonomy: why the open backlog is not on the frontier.
+
+    Returns (counts, roleless, candidates, frontier). Every open issue lands in exactly one
+    bucket, so the buckets sum to the open-issue count and no class can hide.
+    """
+    linked = set(linked)
+    counts, open_issues = {}, []
+    for it in issues:
+        if str(it.get("state", "OPEN")).upper() != "OPEN" or "pull_request" in it:
+            continue
+        open_issues.append(it)
+        if it.get("number") in linked:
+            reason = "covered by an open linked PR"
+        else:
+            reason = exclusion_reason(labels_of(it), it.get("open_blockers", 0)) or "ENUMERABLE"
+        counts[reason] = counts.get(reason, 0) + 1
+    visible = [it for it in issues if it.get("number") not in linked]
+    return (counts, roleless_ready(open_issues),
+            ready_candidates(visible), compute_ready(visible, conflict_log=lambda _m: None))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo", default="sparq-org/sparq")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--diagnose", action="store_true",
+                    help="print the full visibility taxonomy instead of just the frontier")
     args = ap.parse_args()
     if args.self_test:
         return _self_test()
-    for it in compute_ready(_fetch(args.repo)):
+    issues = _fetch(args.repo)
+    linked = linked_issue_numbers(_fetch_pulls(args.repo), args.repo)
+    visible = [it for it in issues if it.get("number") not in linked]
+    if args.diagnose:
+        counts, roleless, cands, frontier = diagnose(issues, linked)
+        total = sum(counts.values())
+        print(f"open issues: {total}")
+        for reason, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+            print(f"  {n:5d}  {100 * n / total:5.1f}%  {reason}")
+        print(f"\ndrainable backlog (ready_candidates): {len(cands)}")
+        print(f"concurrency frontier (compute_ready): {len(frontier)}")
+        if roleless:
+            print(f"\n::warning:: {len(roleless)} attested issue(s) carry NO role:* label and are "
+                  f"INVISIBLE to dispatch: {', '.join('#%d' % n for n in roleless[:20])}")
+        return 0
+    for it in compute_ready(visible):
         L = labels_of(it)
         print(f"P{valid_priority(L)}  #{it['number']:5}  {sorted(packages_of(L))}")
     return 0

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -436,6 +436,37 @@ def _fetch(repo, ceiling=10000):
     return issues
 
 
+def dispatchable_view(issues, linked=()):
+    """The rows the ORCHESTRATOR feeds to compute_ready — the single source of the local preview.
+
+    [OPUS-5] Mirrors dispatch.yml's `ready_input` comprehension exactly:
+
+        ready_input = [row for row in readiness_input
+                       if "status:in-progress" in row["labels"]
+                       or "status:in-progress-review" in row["labels"]
+                       or (row["number"] not in linked and trusted(...))]
+
+    The `or` matters and a plain `number not in linked` is WRONG for the dominant live shape.
+    A `status:in-progress-review` issue is normally covered by its OWN worker PR, so it is
+    always in `linked`; dropping it frees the crate it is actively occupying and the next tick
+    dispatches a SECOND worker onto it. dispatch.yml keeps those rows deliberately — "In-progress
+    rows are KEPT as inputs: compute_ready never selects them (they are busy), but they must
+    still RESERVE their package in its taken-seeding". Executed counterexample, in-review #100 on
+    sparq-core covered by its own PR plus attested #200 on sparq-core: the `not in linked` rule
+    yields [200], the orchestrator yields [].
+
+    Residual, deliberate divergence: dispatch.yml ALSO requires `trusted(issue, bots)`, which
+    needs the issue AUTHOR and the registry's per-repo trusted-bot list. The local snapshot
+    carries neither, so the local preview is an UPPER BOUND on the orchestrator frontier — it
+    may show a row the registry will drop as untrusted. `trust:untrusted` (the label the triage
+    pipeline applies) is still excluded here via GATE_LABELS. Parity is claimed on the
+    linked/in-flight axis only.
+    """
+    linked = set(linked)
+    return [it for it in issues
+            if it.get("number") not in linked or labels_of(it) & IN_FLIGHT_STATUS]
+
+
 def diagnose(issues, linked=()):
     """Re-runnable VISIBILITY taxonomy: why the open backlog is not on the frontier.
 
@@ -448,12 +479,12 @@ def diagnose(issues, linked=()):
         if str(it.get("state", "OPEN")).upper() != "OPEN" or "pull_request" in it:
             continue
         open_issues.append(it)
-        if it.get("number") in linked:
+        if it.get("number") in linked and not (labels_of(it) & IN_FLIGHT_STATUS):
             reason = "covered by an open linked PR"
         else:
             reason = exclusion_reason(labels_of(it), it.get("open_blockers", 0)) or "ENUMERABLE"
         counts[reason] = counts.get(reason, 0) + 1
-    visible = [it for it in issues if it.get("number") not in linked]
+    visible = dispatchable_view(issues, linked)
     return (counts, roleless_ready(open_issues),
             ready_candidates(visible), compute_ready(visible, conflict_log=lambda _m: None))
 
@@ -469,7 +500,7 @@ def main():
         return _self_test()
     issues = _fetch(args.repo)
     linked = linked_issue_numbers(_fetch_pulls(args.repo), args.repo)
-    visible = [it for it in issues if it.get("number") not in linked]
+    visible = dispatchable_view(issues, linked)
     if args.diagnose:
         counts, roleless, cands, frontier = diagnose(issues, linked)
         total = sum(counts.values())

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -13,15 +13,22 @@
 #   2. status:in-progress-review — absent from BUSY_STATUS and from the reserve branch, so such
 #      an issue was neither excluded nor reserving: a double-dispatch on both halves.
 #   3. LOCAL/ORCHESTRATOR PARITY — dispatch.yml builds its readiness input from ISSUES ONLY and
-#      suppresses issues covered by a linked open PR. The local CLI must preview THAT frontier;
-#      when it did not, the two disagreed 0-vs-6 on the same live snapshot.
+#      suppresses issues covered by a linked open PR EXCEPT the in-flight ones, which it keeps
+#      so they still reserve their package. The local CLI must preview THAT frontier; when it
+#      did not, the two disagreed 0-vs-6 on the same live snapshot. Review round 2 found the
+#      first fix still wrong for the dominant live shape (it dropped EVERY linked row, freeing
+#      the crate an in-review issue is actively occupying) and the parity claim guarded only by
+#      a source-substring assertion, so the regression survived mutation. The parity tests below
+#      therefore run the REAL main()/--diagnose, stubbing only the two network calls.
 #
 # Plus the YAML seam: routing-self-tests.yml listed scripts/ready-issues.py in its `paths:` filter
 # but never INVOKED its --self-test, so all of that script's assertions were dead in this repo's
 # CI and only ran later inside the registry's dispatch tick (where a failure breaks EVERY target).
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import re
 import sys
 import unittest
@@ -205,24 +212,104 @@ class TestRolelessInvisibility(unittest.TestCase):
             [iss(50, ["status:ready", "priority:P1", "area:a"])]), [50])
 
 
+def worker_pr(number, issue_number):
+    """A pipeline-owned worker PR whose head branch links `issue_number` (dispatch.yml's rule)."""
+    return {"number": number, "state": "OPEN", "labels": [], "pull_request": {}, "draft": False,
+            "head": {"ref": f"sparq-agent/issue-{issue_number}-fix",
+                     "repo": {"full_name": "sparq-org/sparq"}},
+            "body": "", "author_association": "NONE"}
+
+
 class TestLocalOrchestratorParity(unittest.TestCase):
-    """The divergence that mattered: the local CLI must preview the dispatched frontier."""
+    """The divergence that mattered: the local CLI must preview the dispatched frontier.
+
+    [OPUS-5] The parity claim used to rest on a SOURCE-SUBSTRING assertion plus two test-local
+    reimplementations of both sides — so `compute_ready(visible)` -> `compute_ready(issues)` in
+    the real main() restored the whole bug with the suite green. Every assertion below now runs
+    the REAL main()/--diagnose over a stubbed snapshot, stubbing ONLY the two network calls, and
+    compares its printed frontier against a mirror of dispatch.yml's comprehension.
+    """
 
     @staticmethod
-    def _orchestrator(issues_and_prs, linked=()):
-        """dispatch.yml's shape: ISSUES ONLY, linked-PR-covered issues filtered first."""
+    def _orchestrator(issues_and_prs, pulls=()):
+        """Mirror of dispatch.yml `ready_input`: ISSUES ONLY; a linked row survives iff in-flight.
+
+        Copied shape (agent-account-registry .github/workflows/dispatch.yml):
+            ready_input = [row for row in readiness_input
+                           if "status:in-progress" in row["labels"]
+                           or "status:in-progress-review" in row["labels"]
+                           or (row["number"] not in linked and trusted(...))]
+        The `trusted(...)` conjunct is registry-side (needs the issue author + the per-repo
+        trusted-bot list) and is out of scope for the local preview; see dispatchable_view's
+        docstring for that documented residual divergence.
+        """
+        linked = ready.linked_issue_numbers(list(pulls), "sparq-org/sparq")
         rows = [it for it in issues_and_prs if "pull_request" not in it]
         rows = [it for it in rows
-                if it["number"] not in set(linked)
+                if it["number"] not in linked
                 or {"status:in-progress", "status:in-progress-review"} & set(it["labels"])]
         return numbers(ready.compute_ready(rows, conflict_log=quiet))
 
     @staticmethod
-    def _local(issues_and_prs, linked=()):
-        """The local CLI's shape: the full snapshot minus linked-PR-covered issues."""
-        visible = [it for it in issues_and_prs if it["number"] not in set(linked)]
-        return numbers(ready.compute_ready(visible, conflict_log=quiet))
+    def _run_cli(issues_and_prs, pulls=(), argv=()):
+        """Execute the REAL main() end-to-end; only `_fetch`/`_fetch_pulls` are stubbed."""
+        real_fetch, real_pulls, real_argv = ready._fetch, ready._fetch_pulls, sys.argv
+        ready._fetch = lambda repo, ceiling=10000: [dict(it) for it in issues_and_prs]
+        ready._fetch_pulls = lambda repo: [dict(p) for p in pulls]
+        sys.argv = ["ready-issues.py", *argv]
+        out, err = io.StringIO(), io.StringIO()
+        try:
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                rc = ready.main()
+        finally:
+            ready._fetch, ready._fetch_pulls, sys.argv = real_fetch, real_pulls, real_argv
+        assert rc == 0, f"main() exited {rc}"
+        return out.getvalue()
 
+    @classmethod
+    def _local(cls, issues_and_prs, pulls=()):
+        """The frontier the REAL CLI prints, parsed from its `P<n>  #<num>  [...]` rows."""
+        return [int(n) for n in re.findall(
+            r"^P\d+\s+#\s*(\d+)\s", cls._run_cli(issues_and_prs, pulls), re.M)]
+
+    # -- the executed counterexample -------------------------------------------------------
+    # in-review #100 on sparq-core, covered by its OWN worker PR, + attested #200 on sparq-core.
+    COUNTEREXAMPLE_PULLS = (worker_pr(101, 100),)
+    COUNTEREXAMPLE_BOARD = (
+        iss(100, READY + ["priority:P1", "area:sparq-core", "status:in-progress-review"]),
+        iss(200, READY + ["priority:P1", "area:sparq-core"]),
+    )
+
+    def test_in_flight_issue_covered_by_its_own_pr_still_reserves_its_crate(self):
+        # THE regression. Dropping every linked row frees sparq-core while #100 is actively
+        # being worked, and the next tick dispatches a SECOND worker onto the same crate.
+        board, pulls = list(self.COUNTEREXAMPLE_BOARD), list(self.COUNTEREXAMPLE_PULLS)
+        self.assertEqual(self._orchestrator(board, pulls), [],
+                         "sanity: the orchestrator keeps #100 as an occupant, so #200 conflicts")
+        self.assertEqual(self._local(board, pulls), [],
+                         "local CLI dispatched #200 onto a crate the orchestrator sees as busy")
+
+    def test_cli_frontier_equals_orchestrator_frontier_on_the_counterexample(self):
+        board, pulls = list(self.COUNTEREXAMPLE_BOARD), list(self.COUNTEREXAMPLE_PULLS)
+        self.assertEqual(self._local(board, pulls), self._orchestrator(board, pulls))
+
+    def test_diagnose_frontier_equals_orchestrator_frontier_on_the_counterexample(self):
+        # --diagnose reads its own `visible`; it regressed independently of the default path.
+        out = self._run_cli(list(self.COUNTEREXAMPLE_BOARD), list(self.COUNTEREXAMPLE_PULLS),
+                            argv=("--diagnose",))
+        self.assertIn("concurrency frontier (compute_ready): 0", out)
+        self.assertIn("drainable backlog (ready_candidates): 1", out)
+
+    def test_diagnose_does_not_call_an_in_flight_row_merely_pr_covered(self):
+        # The bucket must agree with the view: a row dispatchable_view KEEPS is reported as
+        # busy, not as suppressed. Otherwise the taxonomy explains a drop that never happened.
+        counts, _roleless, _cands, frontier = ready.diagnose(
+            list(self.COUNTEREXAMPLE_BOARD), linked={100})
+        self.assertEqual(counts.get("busy: status:in-progress-review"), 1)
+        self.assertIsNone(counts.get("covered by an open linked PR"))
+        self.assertEqual(numbers(frontier), [])
+
+    # -- the previously-covered shapes, now through the real CLI ---------------------------
     def test_unlabelled_prs_do_not_make_the_two_views_disagree(self):
         # The exact live shape: many area-less open PRs + attested issues on distinct crates.
         board = [pr(3803, []), pr(3799, []), pr(3798, [])] + [
@@ -231,18 +318,20 @@ class TestLocalOrchestratorParity(unittest.TestCase):
         self.assertEqual(self._local(board), [3694, 3756, 3757])
 
     def test_linked_pr_suppression_matches_on_both_sides(self):
+        # A linked row with NO in-flight status is still suppressed on both sides.
         board = [iss(60, READY + ["priority:P1", "area:sparq-core"]),
                  iss(61, READY + ["priority:P1", "area:sparq-hdt"])]
-        self.assertEqual(self._local(board, linked={60}),
-                         self._orchestrator(board, linked={60}))
-        self.assertEqual(self._local(board, linked={60}), [61])
+        pulls = [worker_pr(62, 60)]
+        self.assertEqual(self._local(board, pulls), self._orchestrator(board, pulls))
+        self.assertEqual(self._local(board, pulls), [61])
 
     def test_local_cli_applies_linked_pr_suppression_at_all(self):
-        # Without this the local view over-reports work the orchestrator will never dispatch.
-        source = (SCRIPTS / "ready-issues.py").read_text(encoding="utf-8")
-        main = source[source.index("def main("):]
-        self.assertIn("linked_issue_numbers", main,
-                      "main() must suppress issues covered by an open linked PR, as dispatch does")
+        # Behavioural, not a substring: deleting the linked_issue_numbers call in main() must
+        # let #60 back onto the frontier ahead of the crate it is already covered on.
+        board = [iss(60, READY + ["priority:P0", "area:sparq-core"]),
+                 iss(61, READY + ["priority:P1", "area:sparq-hdt"])]
+        self.assertEqual(self._local(board, [worker_pr(62, 60)]), [61],
+                         "main() must suppress issues covered by an open linked PR, as dispatch does")
 
 
 class TestLinkedIssueDetection(unittest.TestCase):

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+# [OPUS-5] Readiness VISIBILITY suite — the "can the dispatcher see this work?" contract.
+#
+# The registry's dispatch.yml clones this repo and runs THIS repo's scripts/ready-issues.py +
+# scripts/dispatch-plan.py, so a defect here is a fleet-wide dispatch defect. The suite pins the
+# three things that made ready work invisible, each of which was measured live on sparq-org/sparq:
+#
+#   1. OCCUPANCY ATTRIBUTION — `packages_of` maps "no area: label" to the GLOBAL partition.
+#      Applied to a CANDIDATE that is correct fail-closed behaviour (cross-cutting work must
+#      serialize). Applied to an OCCUPANT it inverts: "cannot attribute" became "seizes every
+#      crate". Nothing in the pipeline puts `area:` labels on PRs — all 60 open sparq PRs had
+#      none — so ONE unlabelled PR held __global__ and drove the local frontier to zero.
+#   2. status:in-progress-review — absent from BUSY_STATUS and from the reserve branch, so such
+#      an issue was neither excluded nor reserving: a double-dispatch on both halves.
+#   3. LOCAL/ORCHESTRATOR PARITY — dispatch.yml builds its readiness input from ISSUES ONLY and
+#      suppresses issues covered by a linked open PR. The local CLI must preview THAT frontier;
+#      when it did not, the two disagreed 0-vs-6 on the same live snapshot.
+#
+# Plus the YAML seam: routing-self-tests.yml listed scripts/ready-issues.py in its `paths:` filter
+# but never INVOKED its --self-test, so all of that script's assertions were dead in this repo's
+# CI and only ran later inside the registry's dispatch tick (where a failure breaks EVERY target).
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+
+
+def _load(name: str, filename: str):
+    path = SCRIPTS / filename
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, f"cannot load {path}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ready = _load("ready_issues_under_test", "ready-issues.py")
+plan = _load("dispatch_plan_under_test", "dispatch-plan.py")
+
+READY = ["status:ready", "role:impl"]
+
+
+def iss(number, labels, blockers=0, state="OPEN"):
+    return {"number": number, "state": state, "labels": list(labels),
+            "open_blockers": blockers}
+
+
+def pr(number, labels, draft=False):
+    return {"number": number, "state": "OPEN", "labels": list(labels),
+            "pull_request": {}, "draft": draft}
+
+
+def numbers(rows):
+    return [row["number"] for row in rows]
+
+
+def quiet(_message):
+    pass
+
+
+class TestUnlabelledOccupantAttribution(unittest.TestCase):
+    """Class 1 — an occupant we cannot attribute must reserve NOTHING, not EVERYTHING."""
+
+    def test_unlabelled_pr_does_not_seize_the_global_partition(self):
+        # THE live defect: one area-less PR made the entire frontier empty.
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core"])
+        unlabelled = pr(70, [])
+        self.assertEqual(
+            numbers(ready.compute_ready([unlabelled, waiting], conflict_log=quiet)), [20],
+            "an area-less PR must not hold __global__ and stall the whole fleet")
+
+    def test_unlabelled_pr_leaves_every_unrelated_crate_dispatchable(self):
+        # The blast radius, not just one row: with the bug, ALL of these vanished at once.
+        board = [pr(70, [])] + [
+            iss(n, READY + ["priority:P1", f"area:crate-{n}"]) for n in (21, 22, 23)]
+        self.assertEqual(
+            numbers(ready.compute_ready(board, conflict_log=quiet)), [21, 22, 23])
+
+    def test_area_labelled_pr_still_reserves_exactly_its_crate(self):
+        # The fix must not become "PRs never reserve": a DECLARED area is still occupancy.
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core"])
+        other = iss(21, READY + ["priority:P1", "area:sparq-hdt"])
+        board = [pr(70, ["area:sparq-core"]), waiting, other]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [21],
+                         "a PR labelled area:sparq-core must still hold sparq-core (only)")
+
+    def test_area_less_ISSUE_candidate_still_fails_closed_to_global(self):
+        # The asymmetry is deliberate — the CANDIDATE-side global rule is untouched.
+        self.assertEqual(ready.packages_of({"role:impl"}), {ready.GLOBAL})
+        self.assertEqual(ready.declared_packages({"role:impl"}), set())
+        board = [iss(30, READY + ["priority:P0"]),
+                 iss(31, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [30],
+                         "an area-less READY ISSUE must still serialize against everything")
+
+    def test_unlabelled_in_progress_issue_also_reserves_nothing(self):
+        # Same attribution rule on the issue-occupancy path, not just the PR path.
+        board = [iss(72, ["status:in-progress"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [20])
+
+
+class TestInProgressReviewStatus(unittest.TestCase):
+    """Class 2 — status:in-progress-review failed OPEN on BOTH halves."""
+
+    def test_in_progress_review_is_busy(self):
+        self.assertIn("status:in-progress-review", ready.BUSY_STATUS)
+        self.assertTrue(ready.is_busy({"status:in-progress-review"}))
+
+    def test_in_progress_review_issue_is_never_selected(self):
+        board = [iss(10, READY + ["priority:P0", "area:sparq-zk",
+                                  "status:in-progress-review"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an issue already in review must not be dispatched again")
+
+    def test_in_progress_review_issue_reserves_its_area(self):
+        # The other half: dispatch.yml KEEPS these rows in its input precisely because it
+        # believes they reserve. If they do not, a second worker takes the same crate.
+        board = [iss(10, ["status:in-progress-review", "area:sparq-zk"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-zk"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an in-review issue must still hold its crate")
+
+    def test_exclusion_reason_names_the_review_status(self):
+        self.assertEqual(
+            ready.exclusion_reason({"status:ready", "status:in-progress-review"}),
+            "busy: status:in-progress-review")
+
+
+class TestDrainableBacklogVsConcurrencyFrontier(unittest.TestCase):
+    """The two must stay distinct — conflating them hides a healthy backlog."""
+
+    BOARD = [
+        iss(1, READY + ["priority:P1", "area:sparq-core"]),
+        iss(2, READY + ["priority:P2", "area:sparq-core"]),
+        iss(3, READY + ["priority:P2", "area:sparq-core"]),
+        iss(4, READY + ["priority:P1", "area:sparq-hdt"]),
+    ]
+
+    def test_ready_candidates_counts_all_drainable_work(self):
+        self.assertEqual(
+            sorted(c[1] for c in ready.ready_candidates(self.BOARD)), [1, 2, 3, 4])
+
+    def test_compute_ready_serialises_one_per_package(self):
+        self.assertEqual(numbers(ready.compute_ready(self.BOARD, conflict_log=quiet)), [1, 4])
+
+    def test_frontier_is_always_a_subset_of_the_drainable_backlog(self):
+        frontier = numbers(ready.compute_ready(self.BOARD, conflict_log=quiet))
+        drainable = {c[1] for c in ready.ready_candidates(self.BOARD)}
+        self.assertTrue(set(frontier) <= drainable)
+        self.assertLessEqual(len(frontier), len(drainable))
+
+    def test_every_dropped_attested_candidate_is_attributable(self):
+        # A silent `continue` is how a label-regressed issue leaves the frontier forever.
+        board = [
+            iss(40, READY + ["priority:P1", "needs:design", "area:a"]),
+            iss(41, READY + ["priority:P1", "area:b"], blockers=2),
+            iss(42, READY + ["area:c"]),
+            iss(43, ["status:ready", "priority:P1", "area:d"]),
+            iss(44, ["priority:P1", "role:impl", "area:e"]),  # NOT attested -> must stay quiet
+        ]
+        lines = []
+        ready.ready_candidates(board, log=lines.append)
+        got = {int(re.search(r"#(\d+)", line).group(1)): line for line in lines}
+        self.assertEqual(sorted(got), [40, 41, 42, 43])
+        self.assertIn("gated by needs:design", got[40])
+        self.assertIn("2 open blocker(s)", got[41])
+        self.assertIn("no single valid priority", got[42])
+        self.assertIn("no role:* label", got[43])
+        self.assertNotIn(44, got, "a non-attested issue is not a candidate and must not log")
+
+
+class TestRolelessInvisibility(unittest.TestCase):
+    """The class that appears in no plan and no diagnostic — it must be REPORTED."""
+
+    def test_roleless_ready_reports_the_invisible_issues(self):
+        board = [
+            iss(50, ["status:ready", "priority:P1", "area:a"]),          # roleless
+            iss(51, ["status:ready", "area:b"]),                          # roleless, no priority
+            iss(52, READY + ["priority:P1", "area:c"]),                   # fine
+            iss(53, ["status:ready", "needs:user", "area:d"]),            # gated, not this class
+        ]
+        self.assertEqual(ready.roleless_ready(board), [50, 51])
+
+    def test_roleless_issues_are_genuinely_absent_from_the_frontier(self):
+        board = [iss(50, ["status:ready", "priority:P1", "area:a"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [])
+        self.assertEqual(ready.roleless_ready(board), [50],
+                         "invisible to dispatch, but NOT invisible to the report")
+
+    def test_target_planner_exposes_roleless_ready_to_dispatch_yml(self):
+        # dispatch.yml does getattr(dispatch, "roleless_ready", None) and degrades to a
+        # "planner has no roleless_ready()" warning when the target predates it.
+        self.assertTrue(callable(getattr(plan, "roleless_ready", None)),
+                        "dispatch-plan.py must export roleless_ready for the registry planner")
+        self.assertEqual(plan.roleless_ready(
+            [iss(50, ["status:ready", "priority:P1", "area:a"])]), [50])
+
+
+class TestLocalOrchestratorParity(unittest.TestCase):
+    """The divergence that mattered: the local CLI must preview the dispatched frontier."""
+
+    @staticmethod
+    def _orchestrator(issues_and_prs, linked=()):
+        """dispatch.yml's shape: ISSUES ONLY, linked-PR-covered issues filtered first."""
+        rows = [it for it in issues_and_prs if "pull_request" not in it]
+        rows = [it for it in rows
+                if it["number"] not in set(linked)
+                or {"status:in-progress", "status:in-progress-review"} & set(it["labels"])]
+        return numbers(ready.compute_ready(rows, conflict_log=quiet))
+
+    @staticmethod
+    def _local(issues_and_prs, linked=()):
+        """The local CLI's shape: the full snapshot minus linked-PR-covered issues."""
+        visible = [it for it in issues_and_prs if it["number"] not in set(linked)]
+        return numbers(ready.compute_ready(visible, conflict_log=quiet))
+
+    def test_unlabelled_prs_do_not_make_the_two_views_disagree(self):
+        # The exact live shape: many area-less open PRs + attested issues on distinct crates.
+        board = [pr(3803, []), pr(3799, []), pr(3798, [])] + [
+            iss(n, READY + ["priority:P3", f"area:crate-{n}"]) for n in (3694, 3756, 3757)]
+        self.assertEqual(self._local(board), self._orchestrator(board))
+        self.assertEqual(self._local(board), [3694, 3756, 3757])
+
+    def test_linked_pr_suppression_matches_on_both_sides(self):
+        board = [iss(60, READY + ["priority:P1", "area:sparq-core"]),
+                 iss(61, READY + ["priority:P1", "area:sparq-hdt"])]
+        self.assertEqual(self._local(board, linked={60}),
+                         self._orchestrator(board, linked={60}))
+        self.assertEqual(self._local(board, linked={60}), [61])
+
+    def test_local_cli_applies_linked_pr_suppression_at_all(self):
+        # Without this the local view over-reports work the orchestrator will never dispatch.
+        source = (SCRIPTS / "ready-issues.py").read_text(encoding="utf-8")
+        main = source[source.index("def main("):]
+        self.assertIn("linked_issue_numbers", main,
+                      "main() must suppress issues covered by an open linked PR, as dispatch does")
+
+
+class TestLinkedIssueDetection(unittest.TestCase):
+    """Fork PRs must never suppress an issue (the head branch text is attacker-controlled)."""
+
+    REPO = "sparq-org/sparq"
+
+    def _pull(self, ref, body="", full_name="sparq-org/sparq", association="NONE"):
+        return {"head": {"ref": ref, "repo": {"full_name": full_name}},
+                "body": body, "author_association": association}
+
+    def test_pipeline_owned_head_links_its_issue(self):
+        self.assertEqual(
+            ready.linked_issue_numbers([self._pull("sparq-agent/issue-42-fix")], self.REPO), {42})
+
+    def test_fork_head_does_not_link(self):
+        self.assertEqual(ready.linked_issue_numbers(
+            [self._pull("sparq-agent/issue-42-fix", full_name="attacker/sparq")], self.REPO),
+            set(), "a fork PR must never suppress an issue")
+
+    def test_closing_keyword_needs_a_trusted_association(self):
+        untrusted = self._pull("patch-1", body="Closes #42", association="NONE")
+        trusted = self._pull("patch-1", body="Closes #42", association="MEMBER")
+        self.assertEqual(ready.linked_issue_numbers([untrusted], self.REPO), set())
+        self.assertEqual(ready.linked_issue_numbers([trusted], self.REPO), {42})
+
+
+class TestDiagnoseTaxonomy(unittest.TestCase):
+    """--diagnose must account for EVERY open issue, so no class can hide."""
+
+    def test_buckets_partition_the_open_backlog(self):
+        board = [
+            iss(1, READY + ["priority:P1", "area:a"]),
+            iss(2, ["status:untriaged"]),
+            iss(3, []),
+            iss(4, READY + ["priority:P1", "needs:ec2", "area:b"]),
+            iss(5, READY + ["priority:P1", "area:c"]),
+            pr(70, []),
+            iss(6, READY + ["priority:P1", "area:d"], state="CLOSED"),
+        ]
+        counts, roleless, cands, frontier = ready.diagnose(board, linked={5})
+        self.assertEqual(sum(counts.values()), 5, "one bucket per OPEN issue, PRs/closed excluded")
+        self.assertEqual(counts["ENUMERABLE"], 1)
+        self.assertEqual(counts["covered by an open linked PR"], 1)
+        self.assertEqual(counts["gated by needs:ec2"], 1)
+        self.assertEqual(counts["no status:ready attestation"], 2)
+        self.assertEqual(roleless, [])
+        self.assertEqual([c[1] for c in cands], [1])
+        self.assertEqual(numbers(frontier), [1])
+
+
+class TestRoutingSelfTestWorkflowWiring(unittest.TestCase):
+    """The YAML seam — a self-test that no workflow INVOKES is not a gate.
+
+    routing-self-tests.yml listed scripts/ready-issues.py under `paths:` (so it looked covered)
+    while its `run:` block never executed that script's --self-test. Deleting either the paths
+    entry or the invocation must red THIS test.
+    """
+
+    SOURCE = WORKFLOW.read_text(encoding="utf-8")
+    INVOKED = ("scripts/routing-validate.py", "scripts/route-resolve.py",
+               "scripts/dispatch-plan.py", "scripts/ready-issues.py")
+
+    def test_every_self_tested_script_is_actually_invoked(self):
+        run_block = self.SOURCE[self.SOURCE.index("Validate routing schema"):]
+        for script in self.INVOKED:
+            self.assertIn(f"python3 {script} --self-test", run_block,
+                          f"{script} --self-test is never RUN — its assertions are dead in CI")
+
+    def test_ready_issues_self_test_is_invoked_not_merely_path_filtered(self):
+        # The precise regression: present in `paths:`, absent from `run:`.
+        run_block = self.SOURCE[self.SOURCE.index("Validate routing schema"):]
+        self.assertIn("python3 scripts/ready-issues.py --self-test", run_block)
+
+    def test_this_test_file_is_itself_a_path_trigger(self):
+        # Scoped to the `paths:` section ON PURPOSE: a whole-file substring search passes for
+        # the WRONG reason, because this filename also appears in the run: block, so deleting
+        # both paths entries left the old assertion green. Both trigger blocks
+        # (pull_request + push) must list it, hence the exact count of 2.
+        self.assertEqual(
+            self._paths_section().count('"scripts/tests/test_readiness_visibility.py"'), 2,
+            "edits to this suite must re-run the gate that executes it, on PR *and* push")
+
+    def test_this_suite_is_invoked_by_the_workflow(self):
+        run_block = self.SOURCE[self.SOURCE.index("Validate routing schema"):]
+        self.assertIn("python3 scripts/tests/test_readiness_visibility.py", run_block)
+
+    def _paths_section(self):
+        return self.SOURCE[:self.SOURCE.index("permissions:")]
+
+    def test_every_invoked_script_is_a_path_trigger(self):
+        paths_section = self._paths_section()
+        for script in self.INVOKED:
+            # Exactly 2: the pull_request filter AND the push filter. Dropping either one
+            # lets the script change without re-running the gate on that trigger.
+            self.assertEqual(paths_section.count(f'"{script}"'), 2,
+                             f"{script} must be a path trigger on BOTH pull_request and push")
+
+    def test_job_name_stays_gate_discoverable(self):
+        # ci-summary auto-discovers a sibling as GATING iff its name says neither
+        # "advisory" nor "informational"; a rename would silently demote this gate.
+        name = re.search(r"^    name: (.+)$", self.SOURCE, re.M).group(1).lower()
+        self.assertNotIn("advisory", name)
+        self.assertNotIn("informational", name)
+
+    def test_merge_group_trigger_present(self):
+        # merge_group cannot use a paths filter; without the trigger the queue ref
+        # never exposes this gating check.
+        self.assertRegex(self.SOURCE, r"(?m)^  merge_group:")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import contextlib
 import importlib.util
 import io
+import json
 import re
 import sys
 import unittest
@@ -430,12 +431,22 @@ class TestRoutingSelfTestWorkflowWiring(unittest.TestCase):
             self.assertEqual(paths_section.count(f'"{script}"'), 2,
                              f"{script} must be a path trigger on BOTH pull_request and push")
 
-    def test_job_name_stays_gate_discoverable(self):
-        # ci-summary auto-discovers a sibling as GATING iff its name says neither
-        # "advisory" nor "informational"; a rename would silently demote this gate.
-        name = re.search(r"^    name: (.+)$", self.SOURCE, re.M).group(1).lower()
-        self.assertNotIn("advisory", name)
-        self.assertNotIn("informational", name)
+    def test_gate_is_not_declared_advisory(self):
+        # [OPUS-5] Guards the rule that is LIVE. ci-summary's discovery changed on
+        # 2026-07-25 (#3773): a check is non-gating iff it is EXPLICITLY DECLARED in
+        # .github/advisory-registry.json, keyed on workflow file + job id. The old
+        # `\b(advisory|informational)\b` NAME rule is gone — it had silently neutralised
+        # four real gates, two of them documented in-repo as HARD — so a rename can no
+        # longer demote anything (declarations bind to job identity and
+        # check-advisory-registry.py C4 reds on a rename). Asserting on the job NAME would
+        # therefore guard a rule that no longer exists; the real demotion path is a
+        # registry entry, so that is what is asserted.
+        registry = json.loads(
+            (REPO_ROOT / ".github" / "advisory-registry.json").read_text(encoding="utf-8"))
+        declared = {(e.get("workflow"), e.get("job_id"))
+                    for e in registry.get("jobs", {}).values()}
+        self.assertNotIn(("routing-self-tests.yml", "validate"), declared,
+                         "declaring this job advisory stops ci-summary gating on it")
 
     def test_merge_group_trigger_present(self):
         # merge_group cannot use a paths filter; without the trigger the queue ref


### PR DESCRIPTION
> 🤖 SPARQ agent

## The problem, measured

The dispatcher cannot pick up work it cannot see. On the live board (**1117 open issues**) the local readiness engine reported **ZERO** ready issues while the registry's dispatch planner computed **SIX** from the same snapshot. Three distinct defects.

**Scope, corrected in review round 2.** Those are *this repo's* readiness engine and the registry's *PLAN* stage. Merging this does **NOT** clear the separately-observed production zero `crate __global__ busy via pr#3628`. That line is printed by `scripts/dispatch-claim.py::filter_busy_area_items` in **`jeswr/agent-account-registry`** — a different repo and a later layer (CLAIM, not PLAN) — where `busy_packages_of_pulls` deliberately fails closed to `__global__` for a PR whose provenance linkage is missing or whose source issue carries no `area:`. Nothing in this PR touches that rule, and the asymmetry argument below does **not** transfer to it unexamined: that fallback guards against a *latched arm* merging into an unknowable crate, which is a different threat from the one `_reserving_packages` addresses. The registry-side half needs its own change, on its own evidence.

## 1. Occupancy attribution — the zero

`packages_of()` maps "no `area:` label" to the **GLOBAL** partition. For a **candidate** that is correct fail-closed behaviour: cross-cutting work must serialize against everything. Applied to an **occupant** it inverts the meaning — "cannot attribute this to a crate" became "this seizes every crate".

Nothing in the pipeline puts `area:` labels on PRs. **All 60 open PRs carried none**, so a single unlabelled PR — #3803, zero labels — held `__global__` and drove the entire frontier to zero:

```
conflict #3526: area __global__ held by pr#3803
conflict #3694: area __global__ held by pr#3803
... every candidate, every tick
```

Split the rule: `declared_packages()` (occupancy, no fallback) vs `packages_of()` (candidates, unchanged fail-closed global). The asymmetry is deliberate and commented — fail-closed on a candidate costs one dispatch, fail-closed on an occupant costs the **whole fleet**, and nothing in the pipeline can clear it.

## 2. `status:in-progress-review` failed OPEN on both halves

It was absent from `BUSY_STATUS`, so such an issue was **selectable**, and the reserve branch only fired on `status:in-progress`, so its crate stayed **free for a second worker**. `dispatch.yml` deliberately keeps these rows in its readiness input precisely because it believes `compute_ready()` does both:

> In-progress rows are KEPT as inputs: compute_ready never selects them (they are busy), but they must still RESERVE their package

Neither held. 3 live issues (#3235, #3079, #2601) were in this state. Now it does both.

## 3. Local/orchestrator parity

`dispatch.yml` builds readiness input from **issues only** and suppresses issues covered by a linked open PR — **except the in-flight ones, which it keeps so they still reserve their package**. The local CLI fed PRs in as occupancy and applied no linked-PR suppression, so the two views answered different questions on the same data.

Review round 2 found the first fix still wrong for the dominant live shape: it dropped **every** linked row. A `status:in-progress-review` issue is normally covered by its *own* worker PR, so it is always linked, and dropping it frees the crate it is actively occupying — a double-dispatch, i.e. defect 2 above reintroduced one layer up. Executed counterexample — in-review #100 on `sparq-core` covered by its own PR, plus attested #200 on `sparq-core`: the shipped rule yielded `[200]`, the orchestrator yields `[]`.

The rule now lives in one place, `dispatchable_view(issues, linked)`, mirroring dispatch.yml's comprehension, and is used by `main()` **and** `diagnose()`. The taxonomy bucket follows it: a row the view KEEPS is reported `busy: ...`, never "covered by an open linked PR", so the diagnostic can no longer explain a drop that never happened.

**Documented residual divergence:** dispatch.yml *also* requires `trusted(issue, bots)`, which needs the issue author and the registry's per-repo trusted-bot list. The local snapshot carries neither, so the local preview is an **upper bound** on the orchestrator frontier. Parity is claimed on the linked/in-flight axis only.

## Also

- **DRAINABLE vs FRONTIER.** `ready_candidates()` (how much work exists) is now separate from `compute_ready()` (how many can run at once). Conflating them makes a healthy backlog behind a narrow frontier look like an empty one.
- Every dropped attested candidate emits an **attributable reason**; a silent `continue` is how a label-regressed issue leaves the frontier forever with no signal.
- `roleless_ready()` re-exported from `dispatch-plan.py`, so the registry planner stops printing *"target planner has no roleless_ready()"* and reports a real number for sparq.
- New `--diagnose` prints the full visibility taxonomy.

## Gate hole (the YAML seam)

`routing-self-tests.yml` listed `scripts/ready-issues.py` in its `paths:` filter but **never invoked** its `--self-test`. Its 19 assertions were dead in this repo's CI and first ran inside the registry's dispatch tick — where a failure breaks **every target at once**. The run block now executes it plus the new suite.

## Verified by mutation

Mutants are marker-verified (an edit that fails to apply reports loudly instead of reading as a survival — **one did**, and was a false "survived" until fixed).

**Round 1 — 17 mutants, all killed by NAMED tests**

| Mutant | Named tests red |
|---|---|
| revert occupancy fix | 5 |
| `declared_packages` falls back to GLOBAL | 6 |
| drop `in-progress-review` from BUSY_STATUS | 2 |
| reserve branch ignores in-review | 1 |
| drop `roleless_ready` re-export | 1 |
| silence the attribution log | 1 |
| **YAML**: delete `ready-issues --self-test` invocation | 2 |
| **YAML**: delete suite invocation / either `paths:` trigger / rename job advisory / drop `merge_group` | 1 each |

**Round 2 — the reviewer's survivor, and the battery that now kills it.** Cross-provider review showed claim 3 was guarded only by a **source-substring** assertion plus two test-local reimplementations of both sides, so mutating `main()`'s `compute_ready(visible)` → `compute_ready(issues)` restored the entire bug with the suite green. The parity tests now execute the **real** `main()` and `--diagnose` over a stubbed snapshot — only `_fetch`/`_fetch_pulls` are stubbed — and parse the printed frontier.

| # | Mutant | Named tests red |
|---|---|---|
| M1 | `main()` `compute_ready(visible)` → `compute_ready(issues)` — **the reported survivor** | 2 |
| M2 | `dispatchable_view` drops the in-flight exception (the shipped rule) | 4 |
| M3 | keeps only `status:in-progress`, not `-review` | 4 |
| M4 | `main()` drops linked suppression entirely | 2 |
| M5 | `diagnose()` reverts to the plain not-in-linked view | 2 |
| M6 | `diagnose()` bucket ignores the in-flight exception | 1 |
| M7 | reserve branch stops honouring `IN_FLIGHT_STATUS` | 4 |
| M8 | `_reserving_packages` falls back to GLOBAL | 5 |

**8/8 killed** (was 7/8). The YAML mutants matter most: on this fleet every recently-uncaught mutant lived at the workflow `if:`/step/call-site seam. The round-1 run also exposed one of my own assertions as vacuous — a whole-file substring search the `run:` block satisfied, so deleting both `paths:` entries left it green; it is now scoped to the `paths:` section and counts both trigger blocks. Round 2 found the *same class* of defect a second time in this PR, which is the honest reading: substring assertions on this suite have now failed twice, and the parity guards are behavioural for that reason.

## Not fixed here (reported separately)

The dominant blocker is **data, not code**: `area:` is the partition key for the whole system and 832/1117 open issues lack one. See the companion issue.

---

**Note:** this supersedes #3815 for *these* changes. #3815 was opened from a branch in the shared checkout that two other agents subsequently committed onto, so it now bundles bd-migration and dependency-graph work as well. This PR is the same commit, isolated onto `origin/main`, so it can be reviewed and merged on its own. #3815 is left open for the other agents' commits.
