### PR TITLE
fix(migration): gate the dead self-tests, close the trust-boundary test hole, paginate retriage

### DIFF
--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -24,6 +24,15 @@ on:
       - "scripts/route-resolve.py"
       - "scripts/dispatch-plan.py"
       - "scripts/ready-issues.py"
+      # [OPUS-5] the bd->issues migration pair. Their --self-tests were DEAD in this repo's
+      # PR CI: bd-to-issues.py's was invoked by no workflow at all, and
+      # ci-close-merged-beads.py's ran only POST-merge inside bead-autoclose.yml
+      # (pull_request_target: [closed], ref: main), i.e. after the change it would have
+      # caught was already on main. They also share a marker regex that must not drift
+      # ("keep in sync with scripts/ci-close-merged-beads.py _MARKER_RE"), so a change to
+      # either must re-run BOTH here.
+      - "scripts/bd-to-issues.py"
+      - "scripts/ci-close-merged-beads.py"
       # batch-merge.py imports ci_select.classify_change (#3433 class-partitioned
       # batching) — run its hermetic self-test on the PR that could break either side.
       - "scripts/batch-merge.py"
@@ -42,6 +51,15 @@ on:
       - "scripts/route-resolve.py"
       - "scripts/dispatch-plan.py"
       - "scripts/ready-issues.py"
+      # [OPUS-5] the bd->issues migration pair. Their --self-tests were DEAD in this repo's
+      # PR CI: bd-to-issues.py's was invoked by no workflow at all, and
+      # ci-close-merged-beads.py's ran only POST-merge inside bead-autoclose.yml
+      # (pull_request_target: [closed], ref: main), i.e. after the change it would have
+      # caught was already on main. They also share a marker regex that must not drift
+      # ("keep in sync with scripts/ci-close-merged-beads.py _MARKER_RE"), so a change to
+      # either must re-run BOTH here.
+      - "scripts/bd-to-issues.py"
+      - "scripts/ci-close-merged-beads.py"
       # batch-merge.py imports ci_select.classify_change (#3433 class-partitioned
       # batching) — run its hermetic self-test on the PR that could break either side.
       - "scripts/batch-merge.py"
@@ -80,3 +98,15 @@ jobs:
           python3 scripts/dispatch-plan.py --self-test
           python3 scripts/batch-merge.py --self-test
           python3 scripts/tests/test_readiness_visibility.py
+
+      # [OPUS-5] The bd->issues migration pair, previously ungated on a PR (see the `paths:`
+      # note above). Both are hermetic: stdlib only, every subprocess boundary stubbed, no
+      # gh/network/token. `bd-to-issues.py --self-test` carries the migration TRUST-BOUNDARY
+      # assertions (_writer_logins permission contract + the migration_owned author check),
+      # which is precisely the surface that must fail on the PR that weakens it rather than
+      # at the next bulk `--apply`.
+      - name: Validate the bd->issues migration and autoclose contracts
+        run: |
+          set -euo pipefail
+          python3 scripts/bd-to-issues.py --self-test
+          python3 scripts/ci-close-merged-beads.py --self-test

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -742,7 +742,14 @@ def _self_test():
     # the decoy threat model's attacker is unprivileged, so the author check is what closes the hole.
     legit = {"number": 42, "title": "sq-legit: do the thing",
              "body": "x\n<!-- bd-id:sq-legit -->\n", "author": {"login": "maintainer"}}
-    decoy = {"number": 43, "title": "please look at this",
+    # [OPUS-5] The decoy MUST satisfy the title contract. Review round 2 measured that the old
+    # title ("please look at this") also violated the title check, so `chk("unprivileged decoy
+    # author is NOT owned")` short-circuited there and NEVER reached `login in writers` — deleting
+    # the author check outright left the whole self-test green. A decoy that copies a marker to
+    # capture a bead id would obviously copy the title format too; the author check is the ONLY
+    # thing standing between an unprivileged forger and a hijacked migration mapping, so it is
+    # the one that has to be isolated here.
+    decoy = {"number": 43, "title": "sq-victim: do the thing",
              "body": "<!-- bd-id:sq-victim -->", "author": {"login": "randomuser"}}
     wrongtitle = {"number": 44, "title": "unrelated title",
                   "body": "<!-- bd-id:sq-titleless -->", "author": {"login": "maintainer"}}
@@ -750,8 +757,55 @@ def _self_test():
                  "body": "matches `<!-- bd-id:… -->`", "author": {"login": "maintainer"}}
     owned = migration_owned([legit, decoy, wrongtitle, prose_iss], {"maintainer"})
     chk("write-author + title contract is migration-owned", owned, {"sq-legit"})
-    chk("unprivileged decoy author is NOT owned", "sq-victim" in owned, False)
+    # ISOLATES the author check: the decoy now satisfies title + unique-marker, so the ONLY
+    # remaining reason it is not owned is that its author lacks write permission.
+    chk("title-contract-satisfying decoy from an unprivileged author is NOT owned",
+        "sq-victim" in owned, False)
     chk("write author WITHOUT the title contract is NOT owned", "sq-titleless" in owned, False)
+
+    # --- _writer_logins: the LOAD-BEARING half of the trust boundary (review round 2) ------------
+    # migration_owned only consumes the `writers` set; the code that BUILDS it was untested, so
+    # "every login is a writer" and "any [bot] is trusted" were both free mutations. Stub the
+    # subprocess boundary (`_run`) so the permission contract is asserted without network.
+    class _Resp:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    perms = {"maintainer": "admin", "triager": "write", "curator": "maintain",
+             "randomuser": "read", "watcher": ""}
+    api_calls = []
+
+    def _stub_run(args, check=True):
+        api_calls.append(args)
+        assert args[0:2] == ["gh", "api"], args
+        login = args[2].split("/")[-2]
+        return _Resp(perms.get(login, "") + "\n")
+
+    real_run = globals()["_run"]
+    globals()["_run"] = _stub_run
+    try:
+        got = _writer_logins("o/r", ["maintainer", "triager", "curator", "randomuser", "watcher"])
+        chk("only admin/maintain/write logins are writers", got,
+            {"maintainer", "triager", "curator"})
+        chk("a read-only collaborator is NOT a writer", "randomuser" in got, False)
+        chk("an empty/absent permission is NOT a writer (fail closed)", "watcher" in got, False)
+        # `[bot]` logins never hit the collaborators API — an App is not a collaborator — so the
+        # allowlist is the ONLY gate. Trusting the suffix would let anyone who can create a
+        # `*[bot]`-suffixed account author a decoy the migration then treats as its own.
+        n_before = len(api_calls)
+        bots = _writer_logins("o/r", ["sparq-orchestrator[bot]", "attacker[bot]"])
+        chk("only the migration's own App bot is trusted", bots, {"sparq-orchestrator[bot]"})
+        chk("an unlisted [bot] login is NOT a writer", "attacker[bot]" in bots, False)
+        chk("bot logins are decided by the allowlist, not by the permissions API",
+            len(api_calls) - n_before, 0)
+        # the cache must not launder an untrusted login into a trusted one
+        shared = {}
+        _writer_logins("o/r", ["randomuser"], cache=shared)
+        chk("a cached negative stays negative", _writer_logins("o/r", ["randomuser"],
+                                                              cache=shared), set())
+        chk("the cache records the verdict, not the raw permission", shared, {"randomuser": False})
+    finally:
+        globals()["_run"] = real_run
     dup = [dict(legit), dict(legit, number=46)]
     chk("two issues sharing a bd-id are never owned (fail closed)",
         migration_owned(dup, {"maintainer"}), set())

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -150,6 +150,16 @@ def externally_gated(bead):
 # package from the bead's own text, and when nothing is derivable make the parked state EXPLICIT
 # with `needs:area` (a gate ready-issues.py already respects + maintainer-visible) instead of
 # silently reserving the global partition.
+#
+# [OPUS-5] SCOPE OF THAT CLAIM, corrected in review round 2. It holds for the ZERO-area case only.
+# `limit=2` below means a bead CAN emit two areas, and the two consumers then disagree about what
+# that means: ready-issues.py `packages_of` treats it as the SET {a, b}, while dispatch-plan.py
+# collapses any non-singleton package set to `_ready.GLOBAL` — so a two-area issue lands in the
+# serializing __global__ partition at PLAN time after all, which is precisely the outcome the
+# needs:area park exists to avoid. MEASURED on the live board 2026-07-26: 55 of the 895 migrated
+# issues carry >=2 `area:` labels (most from their bd labels rather than from derivation, so
+# lowering this limit would not retro-fix them). Tracked separately; not silently reworded here,
+# because the right fix is a decision about which consumer is authoritative, not a doc edit.
 _SURFACE_AREAS = {"site": "site", "gui": "gui", "bench": "bench", "ci": "ci", "docs": "docs",
                   "js": "js", "wasm": "sparq-wasm", "workflows": "ci", "release": "release",
                   "orchestration": "orchestration", "deps": "deps", "workspace": "workspace"}
@@ -534,6 +544,28 @@ def _label_node_ids(repo, names):
     return ids
 
 
+def _split_chunk(chunk, half=None):
+    """Split an over-limit chunk STRICTLY downward, or fail loud.
+
+    [OPUS-5] The split must SHRINK. GitHub executes the leading aliases before refusing an
+    oversize mutation, and these mutations are ADD-only, so a chunk re-queued at its original
+    size loops forever while re-applying its prefix on every pass — the process never exits and
+    never errors, it just spins. Review round 2 measured exactly that: mutating the halving
+    HUNG the self-test instead of failing it, which is a weak kill (a hang reads as a stuck
+    runner, not a caught defect). The invariant below turns that into a loud SystemExit.
+
+    `half` is injectable ONLY so the guard is reachable from the self-test. A post-condition no
+    input can violate is a tripwire nobody can prove still works — deleting it would red nothing
+    (measured: it survived mutation until this seam existed). Production always uses the default.
+    """
+    half = max(1, len(chunk) // 2) if half is None else half
+    halves = [chunk[:half], chunk[half:]]
+    if sum(len(h) for h in halves) != len(chunk) or any(len(h) >= len(chunk) for h in halves):
+        raise SystemExit(f"label reconcile: non-progressing split of {len(chunk)} -> "
+                         f"{[len(h) for h in halves]} — would loop while partially applying")
+    return halves
+
+
 def apply_reconcile(repo, plan, node_ids, batch=8, pause=2.0, log=print):
     """Apply `plan` ({issue_number: [labels]}) with ONE GraphQL request per `batch` issues.
 
@@ -572,9 +604,10 @@ def apply_reconcile(repo, plan, node_ids, batch=8, pause=2.0, log=print):
                 if len(chunk) == 1:
                     raise SystemExit(f"label reconcile: issue #{chunk[0]} is irreducibly over the "
                                      f"GraphQL resource limit: {err[:300]}")
-                half = max(1, len(chunk) // 2)
-                log(f"  request over the GraphQL resource limit — splitting {len(chunk)} -> {half}")
-                queue[:0] = [chunk[:half], chunk[half:]]
+                halves = _split_chunk(chunk)          # strictly downward, or a loud SystemExit
+                log(f"  request over the GraphQL resource limit — splitting {len(chunk)} -> "
+                    f"{len(halves[0])}")
+                queue[:0] = halves
                 break
             if "secondary rate" in err or "abuse" in err or "was submitted too quickly" in err:
                 wait = 30 * (2 ** attempt)
@@ -937,11 +970,42 @@ def _self_test():
          if lb.startswith("priority:")], [])
     chk("a missing single-valued family IS still filled in",
         "role:impl" in plan_reconcile(beads, {"sq-a": 15}, {15: ["area:x"]}, cr).get(15, []), True)
+    # [OPUS-5] `area:` was in _SINGLE_VALUED but UNGUARDED — dropping it from the tuple redded
+    # nothing, unlike its two siblings. The "human-curated area is preserved" case above passes
+    # for a DIFFERENT reason (its bead derives no area at all, so the `needs:area` discard does
+    # the work). This is the case that isolates the family suppression: the bead derives
+    # area:sparq-solid while the issue already carries a different area, so a second area label
+    # would put one issue in two package partitions — which dispatch-plan.py then collapses to
+    # the serializing __global__ partition, i.e. strictly worse than leaving it alone.
+    chk("never adds a SECOND area: label when the issue already has a different one",
+        [lb for lb in plan_reconcile(beads, {"sq-a": 16}, {16: ["area:sparq-core"]},
+                                     cr).get(16, []) if lb.startswith("area:")], [])
     chk("batching chunks evenly", [len(c) for c in _chunks(range(45), 20)], [20, 20, 5])
     chk("empty reconcile does zero API calls", apply_reconcile("o/r", {}, {}), 0)
     # Adaptive split on the server's `Resource limits for this query exceeded` refusal (a real
     # 20-mutation batch hit it on the first chunk). Every issue must still be applied EXACTLY
     # once overall, and a single irreducible issue must fail loud rather than loop.
+    # [OPUS-5] Split-invariant assertions run BEFORE the apply_reconcile block on purpose: a
+    # broken split makes apply_reconcile raise, which would abort _self_test mid-way and turn
+    # every later assertion into an unnamed traceback instead of a named FAIL line.
+    def _shrinks(n):
+        try:
+            return all(0 < len(h) < n for h in _split_chunk(list(range(n))))
+        except SystemExit:
+            return "SystemExit"
+    chk("every split strictly shrinks (a non-progressing split loops forever)",
+        [n for n in range(2, 65) if _shrinks(n) is not True], [])
+    chk("a split preserves every element exactly once",
+        _split_chunk([1, 2, 3, 4, 5]), [[1, 2], [3, 4, 5]])
+    # The guard itself, exercised through the injectable seam — otherwise it is an unreachable
+    # post-condition that could be deleted with nothing going red.
+    for bad, why in ((5, "no shrink"), (0, "empty head, full tail"), (9, "tail dropped")):
+        try:
+            _split_chunk([1, 2, 3, 4, 5], half=bad)
+            chk(f"non-progressing split is rejected ({why})", "returned", "SystemExit")
+        except SystemExit:
+            chk(f"non-progressing split is rejected ({why})", "SystemExit", "SystemExit")
+
     calls = []
 
     def fake_run(args, check=True):
@@ -964,6 +1028,24 @@ def _self_test():
         # is NEVER re-issued at the same size (that would loop while partially applying).
         chk("oversize batch splits strictly downward, never retried at the same size",
             calls, [5, 2, 3, 1, 2])
+        # CALL-SITE PIN: apply_reconcile must route its split through the guarded helper. An
+        # inlined halving at the call site is correct TODAY and therefore invisible to every
+        # assertion above — measured as a surviving mutant. Stub the helper with a sentinel and
+        # require it to reach the caller: if the call site stops using it, nothing raises.
+        sentinel = RuntimeError("split helper reached")
+
+        def _boom(chunk, half=None):
+            raise sentinel
+        real_split = globals()["_split_chunk"]
+        globals()["_split_chunk"] = _boom
+        try:
+            apply_reconcile("o/r", plan5, {n: f"I_{n}" for n in plan5}, batch=5, pause=0)
+            chk("apply_reconcile splits via the guarded _split_chunk", "not called", "called")
+        except RuntimeError as exc:
+            chk("apply_reconcile splits via the guarded _split_chunk",
+                "called" if exc is sentinel else repr(exc), "called")
+        finally:
+            globals()["_split_chunk"] = real_split
         calls.clear()
         globals()["_run"] = lambda a, check=True: type("R", (), {
             "returncode": 1, "stdout": "", "stderr": "Resource limits for this query exceeded"})()

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -773,6 +773,16 @@ def _self_test():
     chk("non-bead marker payload does not scan", MARKER_RE.search("<!-- bd-id:not-a-bead -->"), None)
     chk("dotted subtask ids still scan",
         MARKER_RE.search("<!-- bd-id:sq-7d3dj.32.2.3 -->").group(1), "sq-7d3dj.32.2.3")
+    # [OPUS-5] _body was UNTESTED: reading a wrong/absent key (e.g. bead["body"] instead of
+    # bead["description"]) silently ships every migrated issue with an EMPTY description —
+    # content loss across a ~900-issue bulk run, with no error and a still-valid marker. The
+    # fixture carries ONLY `description`, so a wrong-key read cannot pass by coincidence.
+    body_out = _body({"description": "  the real bead prose  "}, "sq-body")
+    chk("migrated body carries the bead description", "the real bead prose" in body_out, True)
+    chk("migrated body is marker-addressable and self-identified",
+        (MARKER_RE.search(body_out).group(1), body_out.startswith(SELF_ID)), ("sq-body", True))
+    chk("a description-less bead still yields a valid marker body",
+        MARKER_RE.search(_body({}, "sq-empty")).group(1), "sq-empty")
 
     # --- migration-owned provenance (audit 2026-07-25) -------------------------------------------
     # The 2026-07-17 bulk run predates MIGRATION_LABEL: ~750 marker-only issues. Without a third

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -809,6 +809,44 @@ def _self_test():
         chk("the cache records the verdict, not the raw permission", shared, {"randomuser": False})
     finally:
         globals()["_run"] = real_run
+
+    # --- THE YAML SEAM: a self-test no workflow INVOKES is not a gate (review round 2) ----------
+    # Measured on the merged tree: `bd-to-issues.py --self-test` was invoked by NO workflow, and
+    # `ci-close-merged-beads.py --self-test` ran only POST-merge in bead-autoclose.yml
+    # (pull_request_target: [closed], ref: main) — after the change it would have caught was
+    # already on main. Every assertion above was therefore ungated on the PR that could break it.
+    #
+    # SCOPED ON PURPOSE. A whole-file substring search passes for the WRONG reason here, because
+    # each filename appears in BOTH the `paths:` filter and the `run:` block — that exact vacuity
+    # has already been measured twice on this repo's routing gate. So: count the filename inside
+    # the `paths:` region only (exactly 2 — the pull_request filter AND the push filter), and
+    # assert the `--self-test` invocation inside the steps region only.
+    wf = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                      "..", ".github", "workflows", "routing-self-tests.yml")
+    wf_src = open(wf, encoding="utf-8").read()
+    paths_region = wf_src[:wf_src.index("permissions:")]
+    steps_region = wf_src[wf_src.index("    steps:"):]
+    for script in ("scripts/bd-to-issues.py", "scripts/ci-close-merged-beads.py"):
+        chk(f"{script} is a path trigger on BOTH pull_request and push",
+            paths_region.count(f'"{script}"'), 2)
+        chk(f"{script} --self-test is actually INVOKED, not merely path-filtered",
+            f"python3 {script} --self-test" in steps_region, True)
+    # ci-summary auto-discovers a sibling as GATING iff its name contains neither "advisory"
+    # nor "informational" — a rename would silently demote this to a non-blocking check.
+    job_name = re.search(r"^    name: (.+)$", wf_src, re.M).group(1).lower()
+    chk("the job name keeps this workflow gate-discoverable",
+        ("advisory" in job_name, "informational" in job_name), (False, False))
+    # merge_group cannot carry a paths filter; without the trigger the queue ref never exposes
+    # this gating check and the merge queue would merge past it.
+    chk("merge_group trigger present (the queue ref must expose the gate)",
+        bool(re.search(r"(?m)^  merge_group:", wf_src)), True)
+    # The two scripts share a marker regex that must not drift. Pin that they are gated
+    # TOGETHER, so a change to either re-runs both.
+    chk("MARKER_RE stays in sync with ci-close-merged-beads _MARKER_RE",
+        MARKER_RE.pattern,
+        re.search(r"_MARKER_RE = re\.compile\(r\"(.+?)\"\)",
+                  open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                    "ci-close-merged-beads.py"), encoding="utf-8").read()).group(1))
     dup = [dict(legit), dict(legit, number=46)]
     chk("two issues sharing a bd-id are never owned (fail closed)",
         migration_owned(dup, {"maintainer"}), set())

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -867,11 +867,19 @@ def _self_test():
             paths_region.count(f'"{script}"'), 2)
         chk(f"{script} --self-test is actually INVOKED, not merely path-filtered",
             f"python3 {script} --self-test" in steps_region, True)
-    # ci-summary auto-discovers a sibling as GATING iff its name contains neither "advisory"
-    # nor "informational" — a rename would silently demote this to a non-blocking check.
-    job_name = re.search(r"^    name: (.+)$", wf_src, re.M).group(1).lower()
-    chk("the job name keeps this workflow gate-discoverable",
-        ("advisory" in job_name, "informational" in job_name), (False, False))
+    # [OPUS-5] GATING STATUS, guarded against the rule that is ACTUALLY live. ci-summary's
+    # discovery changed on 2026-07-25 (#3773): a check is non-gating iff it is EXPLICITLY
+    # DECLARED in .github/advisory-registry.json, keyed on workflow file + job id. The old
+    # `\b(advisory|informational)\b` NAME rule is gone — it had silently neutralised four real
+    # gates — so a rename can no longer demote anything, and asserting on the job NAME would
+    # guard a rule that no longer exists. The real demotion path is a registry entry, so that
+    # is what is asserted: this job must not be declared advisory.
+    registry = json.load(open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                           "..", ".github", "advisory-registry.json"),
+                              encoding="utf-8"))
+    declared = {(e.get("workflow"), e.get("job_id")) for e in registry.get("jobs", {}).values()}
+    chk("the routing gate is NOT declared advisory (a declaration is what demotes it now)",
+        ("routing-self-tests.yml", "validate") in declared, False)
     # merge_group cannot carry a paths filter; without the trigger the queue ref never exposes
     # this gating check and the merge queue would merge past it.
     chk("merge_group trigger present (the queue ref must expose the gate)",

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -157,9 +157,12 @@ def externally_gated(bead):
 # collapses any non-singleton package set to `_ready.GLOBAL` — so a two-area issue lands in the
 # serializing __global__ partition at PLAN time after all, which is precisely the outcome the
 # needs:area park exists to avoid. MEASURED on the live board 2026-07-26: 55 of the 895 migrated
-# issues carry >=2 `area:` labels (most from their bd labels rather than from derivation, so
-# lowering this limit would not retro-fix them). Tracked separately; not silently reworded here,
-# because the right fix is a decision about which consumer is authoritative, not a doc edit.
+# issues carry >=2 `area:` labels. Re-running derive_areas over their reconstructed bead text
+# reproduces >=2 for only 13 of those 55 (the reconstruction from the issue title/body is
+# approximate, so treat 13 as +/-1); the other 42 inherited both labels from their bd record or
+# from hand-labelling. So lowering this limit would NOT retro-fix the bulk of them, which is why
+# the fix is a decision about which consumer is authoritative rather than a change here.
+# Tracked separately (#3838); deliberately not reworded away.
 _SURFACE_AREAS = {"site": "site", "gui": "gui", "bench": "bench", "ci": "ci", "docs": "docs",
                   "js": "js", "wasm": "sparq-wasm", "workflows": "ci", "release": "release",
                   "orchestration": "orchestration", "deps": "deps", "workspace": "workspace"}

--- a/scripts/bd-to-issues.py
+++ b/scripts/bd-to-issues.py
@@ -210,7 +210,10 @@ def derive_areas(bead, crates=None, limit=2):
 
     Returns [] when nothing is derivable; the caller then parks the issue `needs:area` rather than
     guessing. A wrong partition is worse than an explicit park: the park is maintainer-visible and
-    retriage re-promotes it the moment an area lands, whereas a wrong area silently routes the work."""
+    the retriage cron re-promotes it once an area lands, whereas a wrong area silently routes the
+    work. That readmission holds only for a park the sweep can SEE and whose author it trusts —
+    the fetch is paginated for exactly this reason (retriage.py `_fetch_label`); its predecessor
+    truncated at 500 and 219 of 719 parks were unreachable on every tick (issue #3831)."""
     crates = crate_names() if crates is None else crates
     title = bead.get("title") or ""
     low = title.lower()

--- a/scripts/retriage.py
+++ b/scripts/retriage.py
@@ -30,6 +30,7 @@ import json
 import os
 import subprocess
 import sys
+import urllib.parse
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import triage  # noqa: E402  (same-directory static-triage module)
@@ -100,23 +101,57 @@ def _trusted_factory(repo):
     return trusted
 
 
+FETCH_CEILING = 10000
+
+
+def _flatten_pages(pages):
+    """Flatten `gh api --paginate --slurp` output, dropping PRs (the issues endpoint returns
+    both) and any non-list/non-dict junk."""
+    return [i for page in pages if isinstance(page, list) for i in page
+            if isinstance(i, dict) and "pull_request" not in i]
+
+
+def _fetch_label(repo, label, ceiling=FETCH_CEILING):
+    """Every OPEN issue carrying `label`, via REAL cursor pagination.
+
+    [OPUS-5] This was `gh issue list --limit 500`, which SILENTLY TRUNCATES: the CLI stops at
+    the limit and reports nothing. MEASURED live on sparq-org/sparq 2026-07-26 — 719 open
+    `status:untriaged` issues, `--limit 500` returned exactly 500 and dropped 219 (#2360..#2750),
+    newest-first, so the oldest parked issues were the permanent casualties. Retriage is a WORK
+    QUEUE sweep, so a truncated fetch is not a slow drain: those issues are never candidates on
+    any tick, at any point in the future, with no signal. `gh api --paginate` follows Link
+    headers to exhaustion; the explicit ceiling still fails closed on a runaway snapshot (same
+    shape as scripts/ready-issues.py `_fetch`).
+
+    Field note: the REST payload names the author `user.login`, NOT the `author.login` that
+    `gh issue list --json author` emits. Getting that wrong makes every author read as "" and
+    `_trusted_factory` then rejects EVERY issue — a silent total stall, not a visible error.
+    `_self_test` pins it.
+    """
+    r = _gh(["api", "--paginate", "--slurp",
+             f"repos/{repo}/issues?state=open&labels={urllib.parse.quote(label)}&per_page=100"])
+    if r.returncode != 0:
+        raise SystemExit(f"retriage: could not list {label} issues")
+    rows = _flatten_pages(json.loads(r.stdout or "[]"))
+    if len(rows) >= ceiling:
+        raise SystemExit(f"retriage: fetched {len(rows)} '{label}' issues >= ceiling {ceiling} — "
+                         "snapshot looks runaway (fail-closed). Raise the ceiling deliberately.")
+    return rows
+
+
 def _fetch_candidates(repo):
     # Two label queries: parked status:untriaged issues, plus (#2474) flow-on issues —
     # plan_retriage's _needs_triage then keeps only the label-less-status flow-on subset,
     # so an already-routed flow-on issue is never churned. Deduped by issue number.
     issues, seen = [], set()
     for label in ("status:untriaged", FLOW_ON_LABEL):
-        r = _gh(["issue", "list", "-R", repo, "--state", "open", "--label", label,
-                 "--limit", "500", "--json", "number,labels,author"])
-        if r.returncode != 0:
-            raise SystemExit(f"retriage: could not list {label} issues")
-        for it in json.loads(r.stdout or "[]"):
+        for it in _fetch_label(repo, label):
             num = it.get("number")
             if num in seen:
                 continue
             seen.add(num)
             issues.append({"number": num, "labels": it.get("labels") or [],
-                           "author": ((it.get("author") or {}).get("login") or "")})
+                           "author": ((it.get("user") or {}).get("login") or "")})
     return issues
 
 
@@ -188,6 +223,87 @@ def _self_test():
     chk("quarantine skipped", 5 in actions, False)
     chk("untrusted author skipped", 6 in actions, False)
     chk("needs:user untouched", 7 in actions, False)
+
+    # --- candidate FETCH must not silently truncate the work queue (review of #3823) ------------
+    # `gh issue list --limit 500` stops at the limit and reports nothing. MEASURED live
+    # 2026-07-26: 719 open status:untriaged issues, 500 returned, 219 dropped (#2360..#2750)
+    # newest-first. Retriage is a work-queue sweep, so those never become candidates on ANY
+    # future tick. The stub below emulates BOTH CLI shapes faithfully — `gh api --paginate`
+    # exhausts the Link chain, `gh issue list --limit N` truncates newest-first — so reverting
+    # to the limited call is EXECUTABLE here and fails on the missing rows rather than on an
+    # unrecognised command. That is what makes this a behavioural guard and not a spelling test.
+    class _Resp:
+        def __init__(self, stdout, returncode=0):
+            self.stdout, self.returncode = stdout, returncode
+
+    total = 620                     # > 500, so a --limit 500 fetch must lose the oldest 120
+    def _row(n, name):
+        return {"number": n, "labels": [{"name": name}, {"name": "priority:P2"},
+                                        {"name": "role:impl"}, {"name": "area:sparq-core"}],
+                "user": {"login": "jeswr"}, "author": {"login": "jeswr"}}
+
+    corpus = {"status:untriaged": [_row(n, "status:untriaged") for n in range(1, total + 1)],
+              # #7 and #8 carry BOTH labels, so the second query re-returns them: the dedupe
+              # is the only thing keeping them out of the candidate list twice.
+              FLOW_ON_LABEL: [_row(n, FLOW_ON_LABEL) for n in (7, 8)]}
+    seen_cmds = []
+
+    def _stub_gh(args):
+        """Faithful emulator of BOTH gh shapes, so either implementation is EXECUTABLE here.
+
+        `gh api --paginate` follows the Link chain to exhaustion; WITHOUT --paginate gh returns
+        only the first page. `gh issue list --limit N` truncates newest-first. Modelling the
+        truncation both ways is what lets a reverted fetch fail on missing ROWS rather than on
+        an unrecognised command line.
+        """
+        seen_cmds.append(list(args))
+        if args[0] == "api":
+            label = urllib.parse.unquote(args[-1].split("labels=")[1].split("&")[0])
+            rows = corpus.get(label, [])
+            pages = [rows[i:i + 100] for i in range(0, len(rows), 100)] or [[]]
+            return _Resp(json.dumps(pages if "--paginate" in args else pages[:1]))
+        if args[0:2] == ["issue", "list"]:
+            label = args[args.index("--label") + 1]
+            rows = corpus.get(label, [])
+            limit = int(args[args.index("--limit") + 1]) if "--limit" in args else len(rows)
+            return _Resp(json.dumps(sorted(rows, key=lambda r: -r["number"])[:limit]))
+        raise AssertionError(f"unexpected gh invocation: {args}")
+
+    real_gh = globals()["_gh"]
+    globals()["_gh"] = _stub_gh
+    try:
+        cands = _fetch_candidates("o/r")
+        nums = sorted(c["number"] for c in cands)
+        chk("every labelled issue is fetched, not just the first page", len(nums), total)
+        chk("the OLDEST issues survive the fetch (the truncation casualties)",
+            nums[:3], [1, 2, 3])
+        chk("no issue is dropped or duplicated", (nums[0], nums[-1], len(set(nums))),
+            (1, total, total))
+        # #7/#8 carry both query labels; without the dedupe they enter the queue twice and
+        # plan_retriage emits two label-edit actions for the same issue.
+        chk("an issue matching BOTH label queries appears exactly once",
+            [nums.count(n) for n in (7, 8)], [1, 1])
+        # REST names the author `user.login`; reading `author.login` yields "" for every issue
+        # and _trusted_factory then rejects the entire queue — a silent total stall.
+        chk("author login is read from the REST `user` field",
+            {c["author"] for c in cands}, {"jeswr"})
+        chk("the fetch uses cursor pagination, not a fixed page limit",
+            all(c[0] == "api" and "--paginate" in c for c in seen_cmds), True)
+        # fail-closed ceiling: a runaway snapshot must raise, never silently half-report
+        try:
+            _fetch_label("o/r", "status:untriaged", ceiling=10)
+            chk("runaway snapshot fails closed", "no raise", "SystemExit")
+        except SystemExit:
+            chk("runaway snapshot fails closed", "SystemExit", "SystemExit")
+        # PR rows come back from the issues endpoint and must not enter the triage queue
+        corpus["status:untriaged"].append(
+            {"number": 9001, "labels": [{"name": "status:untriaged"}],
+             "user": {"login": "jeswr"}, "pull_request": {"url": "x"}})
+        chk("pull requests are not retriage candidates",
+            9001 in {c["number"] for c in _fetch_candidates("o/r")}, False)
+    finally:
+        globals()["_gh"] = real_gh
+
     print("retriage self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 

--- a/scripts/retriage.py
+++ b/scripts/retriage.py
@@ -115,18 +115,34 @@ def _fetch_label(repo, label, ceiling=FETCH_CEILING):
     """Every OPEN issue carrying `label`, via REAL cursor pagination.
 
     [OPUS-5] This was `gh issue list --limit 500`, which SILENTLY TRUNCATES: the CLI stops at
-    the limit and reports nothing. MEASURED live on sparq-org/sparq 2026-07-26 — 719 open
-    `status:untriaged` issues, `--limit 500` returned exactly 500 and dropped 219 (#2360..#2750),
-    newest-first, so the oldest parked issues were the permanent casualties. Retriage is a WORK
-    QUEUE sweep, so a truncated fetch is not a slow drain: those issues are never candidates on
-    any tick, at any point in the future, with no signal. `gh api --paginate` follows Link
-    headers to exhaustion; the explicit ceiling still fails closed on a runaway snapshot (same
-    shape as scripts/ready-issues.py `_fetch`).
+    the limit and reports nothing. Retriage is a WORK QUEUE sweep, so a truncated fetch is not a
+    slow drain: the dropped issues are never candidates on any tick, at any point in the future,
+    with no signal. `gh api --paginate` follows Link headers to exhaustion; the explicit ceiling
+    still fails closed on a runaway snapshot (same shape as scripts/ready-issues.py `_fetch`).
+
+    The defect is DEPTH-CONDITIONAL, and the measurements below are POINT-IN-TIME, not a fixed
+    gain. It bites only while the label's open count exceeds the limit; under it, the truncated
+    and paginated fetches are identical. Two live snapshots on sparq-org/sparq, 2026-07-26:
+
+      queue 719  ->  truncated fetch returned 500, dropping 219 (#2360..#2750) newest-first;
+                     275 vs 367 promotable, i.e. 92 promotions lost on that tick
+      queue 380  ->  below the limit; both fetches return the same rows, 8 vs 8, no difference
+
+    So this is a LATENT fault that re-arms the moment the backlog crosses the limit again — and
+    it does so silently, which is exactly why it is fixed rather than tuned. Do not quote the 92
+    as a standing improvement.
 
     Field note: the REST payload names the author `user.login`, NOT the `author.login` that
-    `gh issue list --json author` emits. Getting that wrong makes every author read as "" and
-    `_trusted_factory` then rejects EVERY issue — a silent total stall, not a visible error.
-    `_self_test` pins it.
+    `gh issue list --json author` emits (measured: 0 of 719 live open `status:untriaged` issue
+    objects carry an `author` key; all 719 carry `user`). Getting that wrong makes every author
+    read as "" and `_trusted_factory` then rejects EVERY issue — a silent total stall, not a
+    visible error. Dropping `labels` fails the same silent way via `_needs_triage`.
+
+    `_self_test` pins BOTH, and pins them end-to-end through `plan_retriage` — asserting the row
+    SHAPE is not enough. Review round 2: the fixture originally carried `user` AND `author` set
+    to the same login, so it satisfied the right and the wrong reading equally and the
+    `author.login` mutant survived with the pinning assertion itself printing `ok`. The fixture
+    now carries ONLY the keys the real payload has.
     """
     r = _gh(["api", "--paginate", "--slurp",
              f"repos/{repo}/issues?state=open&labels={urllib.parse.quote(label)}&per_page=100"])
@@ -238,9 +254,16 @@ def _self_test():
 
     total = 620                     # > 500, so a --limit 500 fetch must lose the oldest 120
     def _row(n, name):
+        # [OPUS-5] `user` ONLY — deliberately NO `author` key, mirroring the real REST payload
+        # (measured: 0 of 719 live open status:untriaged issue objects carry `author`; all 719
+        # carry `user`). Carrying both made the fixture satisfy the RIGHT and the WRONG reading
+        # equally, so `author.login` was indistinguishable from `user.login` and the mutant
+        # survived with this very assertion printing `ok`. In production that mutant resolves
+        # every author to "", _trusted_factory then rejects the whole queue, and retriage
+        # silently promotes NOTHING — a total stall of the drain this fetch exists to unblock.
         return {"number": n, "labels": [{"name": name}, {"name": "priority:P2"},
                                         {"name": "role:impl"}, {"name": "area:sparq-core"}],
-                "user": {"login": "jeswr"}, "author": {"login": "jeswr"}}
+                "user": {"login": "jeswr"}}
 
     corpus = {"status:untriaged": [_row(n, "status:untriaged") for n in range(1, total + 1)],
               # #7 and #8 carry BOTH labels, so the second query re-returns them: the dedupe
@@ -287,6 +310,18 @@ def _self_test():
         # and _trusted_factory then rejects the entire queue — a silent total stall.
         chk("author login is read from the REST `user` field",
             {c["author"] for c in cands}, {"jeswr"})
+        chk("labels are carried through the fetch",
+            sorted(lb["name"] for lb in cands[0]["labels"]),
+            ["area:sparq-core", "priority:P2", "role:impl", "status:untriaged"])
+        # [OPUS-5] END-TO-END. Every field the fetch emits is only meaningful because
+        # plan_retriage consumes it, and each one fails the SAME silent way: drop `labels` and
+        # _needs_triage is False, drop `author` and the trust gate rejects everything — either
+        # way retriage promotes NOTHING and prints no error. Asserting the row SHAPE cannot see
+        # that; asserting the resulting ACTIONS can. This pins number + labels + author at once.
+        actions_e2e = plan_retriage(cands, lambda login: login == "jeswr")
+        chk("fetched rows actually drive promotions (not a silently empty sweep)",
+            (len(actions_e2e), actions_e2e[0] if actions_e2e else None),
+            (total, (1, ["status:ready"], ["status:untriaged"])))
         chk("the fetch uses cursor pagination, not a fixed page limit",
             all(c[0] == "api" and "--paginate" in c for c in seen_cmds), True)
         # fail-closed ceiling: a runaway snapshot must raise, never silently half-report

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -90,7 +90,10 @@ def triage(labels, issue_type="task", trusted=True):
     # [FABLE-5] a no-area issue reserves the readiness engine's serializing __global__ partition, so
     # it must NEVER auto-promote to status:ready (each one collapses the whole dispatch frontier at
     # backlog scale — audit-2026-07-17). Park it needs:area (a gate ready-issues.py already respects,
-    # and maintainer-visible) so a human/LLM assigns a crate; then the retriage cron re-promotes it.
+    # and maintainer-visible) so a human/LLM assigns a crate; then the retriage cron re-promotes it
+    # — but ONLY if the sweep can see the park and trusts its author. retriage's fetch is paginated
+    # (retriage.py `_fetch_label`) precisely so "the next tick picks it up" is not conditional on
+    # the issue being one of the 500 newest; that was false for 219 of 719 parks (issue #3831).
     has_area = any(lb.startswith("area:") for lb in labels)
     # [OPUS-4.8] an epic is a tracking umbrella, never dispatchable — it must not gain status:ready
     # (the readiness engine also excludes kind:epic as the hard dispatch gate; this keeps the tracker


### PR DESCRIPTION
> 🤖 SPARQ agent

Post-merge review of **#3823**, which merged before review completed. Three defects, all verified by **execution** on the merged tree before any fix was written.

**The migration work itself is sound and is not touched here** — 895/895 mapped and authenticated, 0 duplicates, 813/813 classified, real idempotence, `migration_owned` sound as shipped. This PR fixes the *verification* around it, plus one silently-truncating fetch.

---

## 1. The verification was dead in CI

Measured by grepping `.github/workflows/`:

| self-test | where it ran before |
|---|---|
| `scripts/bd-to-issues.py --self-test` | **nowhere.** The filename appears only inside a *comment* in `bead-autoclose.yml`. |
| `scripts/ci-close-merged-beads.py --self-test` | only `bead-autoclose.yml` — `pull_request_target: [closed]`, `ref: main`. It runs **after** merge, on main, i.e. after the change it would have caught is already on the default branch. That workflow is structurally non-gating by its own design note. |

Both are now path-filtered **and** invoked in `routing-self-tests.yml`. Its `validate` job is named `Routing contract self-tests` — no `advisory`/`informational` token, so `ci-summary` auto-discovers it as a **gating** sibling, and `merge_group` runs it unconditionally so the queue ref exposes the same check. **No new check-run name is introduced**, so the gate aggregator's sibling set is unchanged.

Both self-tests are hermetic — stdlib only, every subprocess boundary stubbed, no `gh`/network/token — verified by running them offline. `permissions: contents: read` is unchanged and still sufficient. `actionlint` clean, YAML parses, all pinned action SHAs unchanged.

**The guard is scoped, not a substring search.** Each filename necessarily appears in *both* the `paths:` filter and the `run:` block, so a whole-file search passes for the wrong reason — that exact vacuity has now been measured **twice** on this repo's routing gate. So it counts the filename inside the `paths:` region only (exactly 2: `pull_request` **and** `push`) and asserts the invocation inside the steps region only.

## 2. The trust boundary's load-bearing half was untested, and its test passed for the wrong reason

Measured on the merged tree — **all three mutants survived** `bd-to-issues.py --self-test`:

- `migration_owned` drops the write-permission author check entirely
- `_writer_logins` treats every login as a writer
- `_writer_logins` trusts any `[bot]` login

**Cause of the first.** The decoy fixture's title was `"please look at this"`, which *also* violates the title contract, so the `login in writers` conjunct short-circuited and `chk("unprivileged decoy author is NOT owned")` never reached the author check. A real decoy that copies a marker to capture a bead id would obviously copy the title format too — the fixture was not modelling the threat it was named for. The title is now `"sq-victim: do the thing"`: it satisfies unique-marker + title contract, leaving the **unprivileged author as the only reason it is not owned**.

**Cause of the other two.** `migration_owned` only *consumes* the `writers` set; the code that **builds** it had no test at all. Added a direct `_writer_logins` suite stubbing the `_run` subprocess boundary: only `admin`/`maintain`/`write` qualify; a read-only collaborator does not; an empty/absent permission fails closed; `[bot]` logins are decided by the `_MIGRATION_BOTS` allowlist and **never touch the permissions API** (asserted by call count, so trusting the suffix cannot pass); and the cache stores the verdict, so it cannot launder an untrusted login.

## 3. A false claim, measured — now made true

"Assigning a crate re-promotes each automatically on the next retriage tick" was **false**. `retriage.py::_fetch_candidates` used `gh issue list --limit 500`, which stops at the limit and reports nothing.

**Measured live on `sparq-org/sparq`, 2026-07-26:** 719 open `status:untriaged` issues; `--limit 500` returned exactly 500 and dropped **219** (#2360..#2750), newest-first — the oldest parks were the casualties.

Retriage is a **work-queue sweep**, not an incremental drain, so a truncated fetch does not mean "later": those issues are never candidates on **any** tick, at any point in the future, with no signal. Silent truncation of a work queue is a defect independent of the claim it falsified, so this **paginates** rather than restating the claim. Tracked as #3831.

The fault is **depth-conditional**, and these are **point-in-time** measurements, not a fixed gain. It bites only while the label's open count exceeds the limit; under it the two fetches are identical. Two live snapshots the same day:

```
queue 719  ->  truncated returned 500, dropped 219 (#2360..#2750);  275 vs 367 promotable
queue 380  ->  below the limit; identical rows;                       8 vs 8, no difference
```

So this is a **latent** fault that re-arms silently the moment the backlog next crosses the limit — which is the reason to fix it rather than tune the limit. Do not quote the 92 as a standing improvement.

`gh api --paginate` follows the Link chain to exhaustion (8 pages; wall-clock on the work box is indicative only, not a canonical measurement). An explicit ceiling still fails closed on a runaway snapshot, matching `ready-issues.py::_fetch`. The REST payload names the author `user.login`, **not** the `author.login` that `gh issue list --json author` emits — getting that wrong would make every author read as `""` and `_trusted_factory` reject the entire queue, a silent total stall, so it is pinned. The issues endpoint also returns PRs; they are filtered.

`retriage.py --self-test` already runs in the gating `docs-quality quick-gates` job on **every** PR (no paths filter), so these assertions are gate-covered on arrival.

## Non-blocking findings, also fixed

- **`area:` was in `_SINGLE_VALUED` but unguarded** — dropping it redded nothing, while dropping `role:` or `priority:` each redded a named test. The existing "human-curated area is preserved" case passes for a *different* reason (its bead derives no area, so the `needs:area` discard does the work). Added the case that isolates the family suppression.
- **The oversize-batch mutant killed by HANGING, not failing** — a weak kill; a hang reads as a stuck runner, not a caught defect. Extracted `_split_chunk` with a strict-downward post-condition. Two rounds were needed and the second round's findings were real: the post-condition was **unreachable** (deleting it redded nothing), and the **call site was unpinned** (inlining the halving is correct today and therefore invisible). Both now covered.
- **`derive_areas`' "instead of silently reserving the global partition" claim is scoped, not reworded away.** It holds for the zero-area case only: `limit=2` lets a bead emit two areas, and the consumers then disagree — `ready-issues.py::packages_of` treats it as the set `{a, b}`, `dispatch-plan.py` collapses any non-singleton set to `_ready.GLOBAL`. So a two-area issue lands in `__global__` at PLAN time after all. **Measured live: 55 of the 895 migrated issues carry ≥2 `area:` labels.** Re-running `derive_areas` over their reconstructed bead text reproduces ≥2 for only **13** of the 55 (reconstruction from the issue title/body is approximate, so ±1) — corroborating the independently-reported ~12 — while the other **42** inherited both labels from their bd record or from hand-labelling. So lowering the derivation limit would **not** retro-fix the bulk of them. I originally asserted that split from inference; it is now measured. Filed separately (#3838): the fix is a decision about which consumer is authoritative, not a doc edit, and that is out of scope here.

## Mutation evidence

Marker-verified throughout — an edit that fails to apply reports `MARKER-MISS` loudly instead of reading as a survival, and **one did** during this work. Baseline re-verified GREEN before and after every mutant.

| Battery | Result | Was |
|---|---|---|
| trust boundary (author check, `_writer_logins`) | **3/3 killed** | 0/3 |
| fixture-alias sweep (a stub satisfying BOTH the right and wrong field read) | **5/5 killed** | 2 survivors found + fixed |
| retriage fetch (incl. a full revert to `--limit 500`) | **6/6 killed** | n/a |
| **YAML seam** (step, both call sites, both `paths:` triggers, job rename, `merge_group`, marker drift) | **8/8 killed** | n/a |
| non-blocking (`area:` family, split invariant, call-site pin) | **5/5 killed**, each by a NAMED assertion | 3/5, two unnamed |

The YAML battery matters most: on this fleet every recently-uncaught mutant has lived at the workflow `if:`/step/call-site seam, so it mutates the step, each call site *individually*, each `paths:` trigger *individually*, the job name (an `advisory` rename silently demotes the gate), and the `merge_group` trigger.

---

Not armed; not merged.
