### PR TITLE
feat(orchestration): render the maintainer front door (#1135) from live state + a reviewable TOML

### DIFF
--- a/.github/workflows/refresh-start-here.yml
+++ b/.github/workflows/refresh-start-here.yml
@@ -1,0 +1,96 @@
+# refresh-start-here — keep the maintainer front door (#1135) honest, structurally.
+# [OPUS-5] sparq-org/sparq#4145.
+#
+# WHY. #1135 says "auto-maintained" and never was: it was refreshed by hand, and on 2026-07-26 it
+# was 13 days stale with SEVEN already-resolved entries still being presented to the maintainer as
+# work needing them. This workflow is the structural half of the fix — `scripts/render-start-here.py`
+# re-renders the body from `orchestration/start-here.toml` plus LIVE GitHub state, so a closed or
+# merged item drops out by construction rather than because somebody remembered.
+#
+# TRIGGERS.
+#   * schedule — four times a day, the backstop that catches everything (label counts, a PR that has
+#     newly rotted to CONFLICTING, an item closed while this workflow was failing).
+#   * issues/pull_request `closed` — prompt removal, so a resolved ask disappears within a minute
+#     instead of waiting for the next cron.
+#   * workflow_dispatch — manual re-render.
+#
+# COST. An on-close run passes `--if-ref`, so a close event for something the front door does not
+# list exits before making a single API call. That matters: at the 60-merges/hour target, a full
+# render per PR close would spend ~2400 requests/hour against GITHUB_TOKEN's 1000/hour/repository
+# budget, and the run that got rate-limited would be the one that mattered.
+#
+# LEAST PRIVILEGE. The workflow-level default is read-only; the one job adds `issues: write` (it
+# edits #1135) and `pull-requests: read` (it reads mergeable/mergeStateStatus). It never needs
+# `contents: write` — a downgrade of `issues` to `read`, or an escalation of `contents` to `write`,
+# reds scripts/tests/test_start_here_render.py::TestRefreshWorkflowWiring.
+#
+# NOT A GATE. This is a scheduled maintenance job, not a PR check; the renderer's own hermetic
+# `--self-test` plus scripts/tests/test_start_here_render.py run as part of the gating
+# `routing-self-tests` workflow, which is where a broken renderer must fail.
+name: refresh-start-here
+
+on:
+  schedule:
+    # 05:23 / 11:23 / 17:23 / 23:23 UTC — off the hour, so this never queues behind the top-of-hour
+    # cron pile-up.
+    - cron: "23 5,11,17,23 * * *"
+  issues:
+    types: [closed]
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # One renderer at a time. cancel-in-progress is ON deliberately: the render is idempotent and
+  # last-writer-wins, so under a merge burst the newest state should win rather than a queue of
+  # stale renders draining one by one. The `schedule` trigger above is what makes that safe — a
+  # cancelled run costs at most a few hours of staleness in the worst case, and the next close
+  # event re-triggers anyway.
+  group: refresh-start-here
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    name: Refresh START HERE (#1135)
+    runs-on: ubuntu-latest
+    # A `pull_request` close event from a FORK gets a read-only GITHUB_TOKEN, so `gh issue edit`
+    # could never succeed and the job would red on every external contributor's PR. Skip those;
+    # the cron still catches the state change. Deleting this guard turns every fork-PR close into
+    # a permanent red — TestRefreshWorkflowWiring::test_fork_pull_request_events_are_skipped.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      issues: write # it edits #1135 — the only write this job has
+      pull-requests: read # mergeable / mergeStateStatus for the gated-PR table
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Self-test the renderer (hermetic — no network, no writes)
+        # Runs BEFORE the live render: a malformed orchestration/start-here.toml or a broken drop
+        # rule must fail here, not half-way through rewriting the maintainer's front door.
+        run: python3 scripts/render-start-here.py --self-test
+
+      - name: Render #1135 from orchestration/start-here.toml + live state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Only the (integer) issue/PR number and the repository slug are interpolated.
+          ref=""
+          case "${{ github.event_name }}" in
+            issues) ref="${{ github.repository }}#${{ github.event.issue.number }}" ;;
+            pull_request) ref="${{ github.repository }}#${{ github.event.pull_request.number }}" ;;
+          esac
+          if [ -n "$ref" ]; then
+            # Cost guard: exits without a single API call when $ref is not on the front door.
+            python3 scripts/render-start-here.py --if-ref "$ref"
+          else
+            python3 scripts/render-start-here.py
+          fi

--- a/.github/workflows/refresh-start-here.yml
+++ b/.github/workflows/refresh-start-here.yml
@@ -24,6 +24,14 @@
 # `contents: write` — a downgrade of `issues` to `read`, or an escalation of `contents` to `write`,
 # reds scripts/tests/test_start_here_render.py::TestRefreshWorkflowWiring.
 #
+# TRUST NOTE on the `pull_request` trigger. For `pull_request` events GitHub runs the workflow file
+# as it exists on the PR, so a SAME-REPO PR that edits this file runs its own version on close with
+# `issues: write`. That blast radius is bounded to editing issues, which anyone who can push a
+# branch here can already do with their own token — and fork PRs (the untrusted case) are skipped by
+# the job `if` below AND get a read-only token regardless. If that ever stops being acceptable, drop
+# the `pull_request` trigger and rely on `issues: [closed]` plus the cron; prompt PR removal is a
+# latency nicety, not a correctness requirement.
+#
 # NOT A GATE. This is a scheduled maintenance job, not a PR check; the renderer's own hermetic
 # `--self-test` plus scripts/tests/test_start_here_render.py run as part of the gating
 # `routing-self-tests` workflow, which is where a broken renderer must fail.

--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -57,6 +57,13 @@ on:
       - "scripts/triage.py"
       - "scripts/retriage.py"
       - ".github/workflows/triage-issue.yml"
+      # [OPUS-5] the maintainer front door (#1135 / #4145) — the curated TOML, the renderer
+      # that drops resolved entries from it, and the suite that pins both plus the
+      # refresh-start-here.yml wiring.
+      - "orchestration/start-here.toml"
+      - "scripts/render-start-here.py"
+      - "scripts/tests/test_start_here_render.py"
+      - ".github/workflows/refresh-start-here.yml"
       - ".github/workflows/routing-self-tests.yml"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
@@ -108,6 +115,13 @@ on:
       - "scripts/triage.py"
       - "scripts/retriage.py"
       - ".github/workflows/triage-issue.yml"
+      # [OPUS-5] the maintainer front door (#1135 / #4145) — the curated TOML, the renderer
+      # that drops resolved entries from it, and the suite that pins both plus the
+      # refresh-start-here.yml wiring.
+      - "orchestration/start-here.toml"
+      - "scripts/render-start-here.py"
+      - "scripts/tests/test_start_here_render.py"
+      - ".github/workflows/refresh-start-here.yml"
       - ".github/workflows/routing-self-tests.yml"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
@@ -157,6 +171,12 @@ jobs:
           # runs cannot go red.
           python3 scripts/pr-area-labels.py --self-test
           python3 scripts/tests/test_pr_area_labels.py
+          # [OPUS-5] #4145: the front-door renderer. --self-test validates the SHIPPED
+          # orchestration/start-here.toml (a malformed curated file must fail on ITS PR, not at the
+          # next scheduled refresh of the maintainer's front door); the suite pins the drop /
+          # fail-closed / truncation rules and refresh-start-here.yml's own wiring.
+          python3 scripts/render-start-here.py --self-test
+          python3 scripts/tests/test_start_here_render.py
 
       # [OPUS-5] The bd->issues migration pair, previously ungated on a PR (see the `paths:`
       # note above). Both are hermetic: stdlib only, every subprocess boundary stubbed, no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -688,6 +688,30 @@ no network); the Python close-script carries a `--self-test`.
   fail-safe) is pinned by `scripts/tests/test_reconcile_merged_beads.sh`. The maintenance loop
   runs it (dry-run) each tick (step 0); the orchestrator reviews + applies the closes separately.
 
+- **`scripts/render-start-here.py [--dry-run | --self-test | --if-ref owner/repo#N]`** (#4145) —
+  renders the **maintainer front door**, issue
+  [#1135](https://github.com/sparq-org/sparq/issues/1135), from
+  **`orchestration/start-here.toml`** (the curated 🔴/🟡 copy — one `[[entry]]` per ask, with
+  `ref` / `bucket` / `ask` / `short`) **plus live GitHub state**. It exists because #1135 said
+  "auto-maintained" and never was: on 2026-07-26 it was 13 days stale and **seven of its entries
+  were already resolved** while still being shown to the maintainer as work needing them.
+  **The rule: the renderer may only DROP, ANNOTATE and ORDER what the TOML says — it never invents
+  an ask, so a new 🔴/🟡 item arrives as a PR to that file, and a hand edit of the issue is
+  overwritten by the next refresh.** It **drops any entry whose issue/PR is closed or merged**
+  (listing them under *Removed as resolved*), renders the maintainer-gated **PR table from live
+  `mergeable`/`mergeStateStatus`** so a PR that has rotted to `CONFLICTING` reads "needs rebase"
+  instead of "say arm it", and renders the `needs:user`/`needs:area`/`needs:ec2` populations and
+  the held-PR list from the **LIST API** (the search index lags label writes, so it under-reports).
+  **Fail-closed:** an entry is dropped only on positive evidence of resolution — an unreadable ref
+  is KEPT and marked *state unknown* while the process exits non-zero (sticky), and an **aggregate**
+  failure (a label count, the held-PR list) **aborts without publishing**. The issue is edited only
+  when the rendered text **differs** (no notification churn); 🟢 truncates before the
+  65 536-char body limit, 🔴 never does. `.github/workflows/refresh-start-here.yml` runs it on a
+  cron plus `issues`/`pull_request` **closed** (with `--if-ref` as the API-budget guard) and
+  `workflow_dispatch`; `routing-self-tests` runs `--self-test` +
+  `scripts/tests/test_start_here_render.py` so a broken renderer or a malformed TOML fails on ITS
+  PR.
+
 See `research/orchestration-automation-design.md` §1.3 (the five judgment behaviours that
 must stay with the orchestrator), §6 (failure modes + the guardrail behind each), and §5
 (the full phased stand-up plan with per-phase rollback).

--- a/orchestration/start-here.toml
+++ b/orchestration/start-here.toml
@@ -16,7 +16,10 @@
 #     (a hand edit is overwritten by the next refresh).
 #   * Every entry needs `ref` (or an explicit `untracked = true`), `bucket`, `ask`, `short`.
 #   * `ref` is the LIVE-STATE KEY only; it is never the source of the rendered prose (the 🔴 asks
-#     carry their own inline links). Cross-repo refs are allowed — "owner/repo#N".
+#     carry their own inline links). Cross-repo refs are allowed — "owner/repo#N" — but the refresh
+#     job runs on the repo-scoped GITHUB_TOKEN, so a ref in a PRIVATE repo reads as "state unknown":
+#     the entry is kept and marked (fail-closed), never dropped, and the job reds. Keep cross-repo
+#     refs public (jeswr/agent-account-registry is).
 #   * `ask` is free markdown on ONE logical line: the renderer collapses whitespace and re-wraps,
 #     so wrap it here for readability however you like. No blank lines inside a value.
 #   * `short` is the label used when the entry is dropped ("Removed as resolved").

--- a/orchestration/start-here.toml
+++ b/orchestration/start-here.toml
@@ -1,0 +1,467 @@
+# [OPUS-5] start-here.toml — the CURATED copy of the maintainer front door, issue #1135.
+#
+# WHY THIS FILE EXISTS (sparq-org/sparq#4145). #1135 is titled "auto-maintained" and never was:
+# it was refreshed by hand, and on 2026-07-26 it was 13 days stale with SEVEN entries already
+# resolved (#1848/#992/#1917 closed, #1084/#1973 closed-unmerged, #1791/#1155 merged) while still
+# being presented to the maintainer as work needing them. A front door that lists resolved work
+# burns the one resource the project cannot scale. So the de-staling is STRUCTURAL: this file holds
+# only the JUDGEMENT (which asks exist, how they are worded), and
+# `scripts/render-start-here.py` re-renders the issue body from it plus LIVE GitHub state, dropping
+# any entry whose issue/PR has closed or merged.
+#
+# CONTRACT (enforced by scripts/render-start-here.py --self-test and
+# scripts/tests/test_start_here_render.py):
+#   * The renderer may only DROP, ANNOTATE and ORDER what is written here. It NEVER invents an ask.
+#     A new 🔴/🟡 item therefore arrives as a PR to this file — not as a hand edit of the issue
+#     (a hand edit is overwritten by the next refresh).
+#   * Every entry needs `ref` (or an explicit `untracked = true`), `bucket`, `ask`, `short`.
+#   * `ref` is the LIVE-STATE KEY only; it is never the source of the rendered prose (the 🔴 asks
+#     carry their own inline links). Cross-repo refs are allowed — "owner/repo#N".
+#   * `ask` is free markdown on ONE logical line: the renderer collapses whitespace and re-wraps,
+#     so wrap it here for readability however you like. No blank lines inside a value.
+#   * `short` is the label used when the entry is dropped ("Removed as resolved").
+#   * `{placeholders}` in [[process]]/[[flight]]/[text] are substituted from LIVE counts; an
+#     unknown placeholder is a hard error, so a typo cannot ship a literal "{needs_user}".
+#
+# HOUSEKEEPING: entries that the renderer has dropped stay here (harmlessly re-listed under
+# "Removed as resolved") until a follow-up PR prunes them. Pruning is a copy edit; dropping is
+# automatic — that ordering is deliberate, because the automatic half is the one that must never
+# depend on anyone remembering.
+
+[meta]
+repo = "sparq-org/sparq"
+issue = 1135
+
+[text]
+header = '''
+🤖 **SPARQ agent** — your single front door. Decisions-first; only 🔴/🟡 need you.
+'''
+
+# Substituted: {date}, {dropped_sentence}.
+preamble = '''
+**Every item below was re-verified against the live GitHub API on {date}.** {dropped_sentence}
+This body is RENDERED by [`scripts/render-start-here.py`](https://github.com/sparq-org/sparq/blob/main/scripts/render-start-here.py)
+from [`orchestration/start-here.toml`](https://github.com/sparq-org/sparq/blob/main/orchestration/start-here.toml)
+on a schedule and whenever an issue or PR closes ([#4145](https://github.com/sparq-org/sparq/issues/4145)),
+so a closed or merged item drops out by construction and the PR table reads live conflict state.
+Changing what we ask you arrives as a PR to that TOML — a hand edit here is overwritten.
+'''
+
+blocked_intro = '''
+Each of these is human-only by nature — a credential, a licence, an external human, or your name on
+a public decision. No agent can close them.
+'''
+
+gated_intro = '''
+Protected paths and spec surfaces the fleet will not self-arm.
+'''
+
+process_intro = '''
+These cap everything else. Counts are live.
+'''
+
+# ---------------------------------------------------------------------------------------------
+# 🔴 Only you can unblock.
+# ---------------------------------------------------------------------------------------------
+
+[[entry]]
+ref = "sparq-org/sparq#53"
+bucket = "blocked"
+short = "npm bootstrap publish"
+ask = '''
+**npm bootstrap publish** — `@jeswr/sparq` is **still not live** (registry returns **404**).
+`publish.yml` (OIDC trusted publishing) is merged and ready; it needs your one-time `npm publish` +
+trusted-publisher registration. **Revoke the chat-sent token either way.**
+([#53](https://github.com/sparq-org/sparq/issues/53))
+'''
+
+[[entry]]
+# The ask is bead sq-qhy4, which has no GitHub issue of its own; #3274 (assurance promotion) is
+# GATED BY it, not equal to it, so #3274 closing must NOT drop this. Hence untracked: this entry
+# can only ever be removed by a human editing this file.
+untracked = true
+bucket = "blocked"
+short = "external cryptographer ZK audit (sq-qhy4)"
+ask = '''
+**External accredited-cryptographer ZK audit** (`sq-qhy4`, **P0**) — the bead says it plainly:
+*"agent-out-of-scope by definition."* sparq's ZK soundness claim currently rests entirely on
+internal single-model self-audits. Until an external cryptographer signs off, **no ZK
+security/privacy/integrity property may be relied on in production**, and `SECURITY.md` must keep
+its conservative "treat as untrusted" posture. This gates every production ZK claim and the
+assurance-promotion work ([#3274](https://github.com/sparq-org/sparq/issues/3274)).
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#3337"
+bucket = "blocked"
+short = "crates.io API token"
+ask = '''
+**[#3337](https://github.com/sparq-org/sparq/issues/3337) — crates.io API token / `cargo owner`.**
+Blocks Rust-side publication entirely.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1139"
+bucket = "blocked"
+short = "literature-DB API key"
+ask = '''
+**[#1139](https://github.com/sparq-org/sparq/issues/1139) — literature-DB API key** (Semantic
+Scholar): free key + signup, blocks the research-ingest lane.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#3382"
+bucket = "blocked"
+short = "RDFox licence"
+ask = '''
+**[#3382](https://github.com/sparq-org/sparq/issues/3382) — RDFox licence.** Needed to gather
+competitor numbers honestly; without it the performance-dominance tables cannot include RDFox and
+we must keep saying so.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1840"
+bucket = "blocked"
+short = "Noir upstream PR"
+ask = '''
+**[#1840](https://github.com/sparq-org/sparq/issues/1840) — Noir upstream PR**
+(noir-lang/noir#13314, BoundedVec capacity assert): review + flip from draft to ready. Upstream
+maintainers need a human author.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1615"
+bucket = "blocked"
+short = "LinkedIn post + profile pin"
+ask = '''
+**[#1615](https://github.com/sparq-org/sparq/issues/1615) — LinkedIn post + profile repo pin.**
+Text is drafted and ready; needs your click.
+'''
+
+[[entry]]
+# Cross-repo: the enrollment-template fix that carries this ask lives in the registry.
+ref = "jeswr/agent-account-registry#278"
+bucket = "blocked"
+short = "worker-account credentials"
+ask = '''
+**Worker-account credentials (agent-account-registry)** — `acct08` login and the missing
+`REGISTRY_SECRETS_PAT`. Enrollment cannot be automated because writing env secrets requires your
+auth. Directly limits fleet parallelism.
+'''
+
+[[entry]]
+# One ask, three drafted filings. The renderer drops the entry only when ALL THREE are resolved,
+# and annotates it when only some are — so a partial resolution can neither hide the remainder nor
+# keep claiming a filing that is already done.
+ref = [
+  "sparq-org/sparq#3338",
+  "sparq-org/sparq#3329",
+  "sparq-org/sparq#3385",
+]
+bucket = "blocked"
+short = "upstream filings needing your identity"
+ask = '''
+**Upstream filings that need your identity** —
+[#3338](https://github.com/sparq-org/sparq/issues/3338) (4 drafted `w3c/rdf-tests` issues),
+[#3329](https://github.com/sparq-org/sparq/issues/3329) (georust/geo feature request),
+[#3385](https://github.com/sparq-org/sparq/issues/3385) (offer the GML-SF parser as a standalone
+crate). All drafted; each wants a human to file it.
+'''
+
+# ---------------------------------------------------------------------------------------------
+# 🟡 Decisions — one line each. The Item cell is rendered from `ref`.
+# ---------------------------------------------------------------------------------------------
+
+[[entry]]
+ref = "sparq-org/sparq#3399"
+bucket = "decision"
+short = "final npm package name"
+ask = '''
+**final npm package name** (currently `@jeswr/sparq`). Blocks the npm bootstrap above and the JS
+docs surface — worth settling first.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1974"
+bucket = "decision"
+short = "ODRL JS API contract"
+ask = '''
+public JS API contract for ODRL policy evaluation; wasm32 probe works, +135 kB raw bundle. Pick the
+exposed surface.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1897"
+bucket = "decision"
+short = "merge-queue skip-push-CI soundness"
+ask = '''
+merge-queue skip-push-CI is **unsound** under SQUASH+ALLGREEN (squash mints a new SHA; the green
+gate lives on the ephemeral queue ref). Pick **A)** REBASE/MERGE + `max_entries:1`, **B)** leaner
+always-run push matrix *(recommended)*, **C)** drop.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1825"
+bucket = "decision"
+short = "SPQCPRM2 default emit"
+ask = '''
+default SPQCPRM2 (V2) on-disk emit **ON**? Reader ships; gated on a canonical EC2 measurement
+(`needs:ec2`).
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#3299"
+bucket = "decision"
+short = "GitHub Pages root owner"
+ask = '''
+reconcile the GitHub Pages **root** — which surface owns `/`.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1248"
+bucket = "decision"
+short = "tier-1 semver freeze"
+ask = '''
+ratify the tier-1 **semver freeze** — policy has landed, the declaration is yours.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1817"
+bucket = "decision"
+short = "/download alias contract"
+ask = '''
+`/download` alias contract + prerelease fallback.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1815"
+bucket = "decision"
+short = "CodeQL per-push end state"
+ask = '''
+⚠️ **premise now stale** — this asks whether to keep CodeQL per-push, but CodeQL was **disabled** on
+sparq (2026-07-18, merge latency) and the ruleset now requires only `gate`. Related PR
+[#3427](https://github.com/sparq-org/sparq/pull/3427) (CodeQL advisory-at-merge) is open. Decide the
+end state, then we close or rewrite both.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1690"
+bucket = "decision"
+short = "logo / brand pick"
+ask = '''
+logo / brand pick — concepts consolidated.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1587"
+bucket = "decision"
+short = "next-phase work-plan steer"
+ask = '''
+next-phase work-plan steer.
+'''
+
+# ---------------------------------------------------------------------------------------------
+# 🟡 Maintainer-gated PRs. `State` is rendered LIVE; `ask` is the CLEAN-state ask and is replaced
+# by the rebase ask whenever the PR has rotted to CONFLICTING.
+# ---------------------------------------------------------------------------------------------
+
+[[entry]]
+ref = "sparq-org/sparq#1712"
+bucket = "gated-pr"
+short = "zk-compose fail-closed coverage"
+what = "zk-compose fail-closed / determinism coverage"
+ask = '''
+cross-provider review in flight; I'll arm on a clean pair unless you object
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1607"
+bucket = "gated-pr"
+short = "Trust Expression proposal"
+what = "Trust Expression proposal draft"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1509"
+bucket = "gated-pr"
+short = "zkSPARQL proposal draft"
+what = "zkSPARQL proposal draft (restarted from the codebase)"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1658"
+bucket = "gated-pr"
+short = "zkSPARQL §7 extended fragment"
+what = "zkSPARQL §7 extended fragment + bounded-depth paths"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1621"
+bucket = "gated-pr"
+short = "ODRL core as stratified N3"
+what = "ODRL core as stratified N3 rules + Rust-vs-N3 differential"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1487"
+bucket = "gated-pr"
+short = "Kani harnesses for WAC/ACP"
+what = "Kani harnesses for the WAC/ACP decision core"
+ask = '''
+harness re-scoping decision
+'''
+
+# ---------------------------------------------------------------------------------------------
+# THE SEVEN STALE ENTRIES (#4145). These are the entries the hand-maintained revision was still
+# showing the maintainer on 2026-07-26 after they had already closed or merged. They are seeded
+# here DELIBERATELY and left for one cycle: the first automated render must drop all seven against
+# the live API and list them under "Removed as resolved", which is the end-to-end proof that the
+# drop is structural rather than a habit. The next housekeeping PR prunes this block.
+# ---------------------------------------------------------------------------------------------
+
+[[entry]]
+ref = "sparq-org/sparq#1848"
+bucket = "decision"
+short = "geo dict-pointer freshness"
+ask = '''
+geo dict-pointer freshness.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#992"
+bucket = "decision"
+short = "empty-container default flip"
+ask = '''
+empty-container default flip.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1917"
+bucket = "decision"
+short = "miri formal-alarm"
+ask = '''
+miri formal-alarm scope.
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1084"
+bucket = "gated-pr"
+short = "release v0.1.0"
+what = "release v0.1.0"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1791"
+bucket = "gated-pr"
+short = "agent-role refresh"
+what = "agent-role refresh"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1155"
+bucket = "gated-pr"
+short = "VC cryptosuite ingest bridge"
+what = "VC cryptosuite ingest bridge"
+ask = '''
+"arm it"
+'''
+
+[[entry]]
+ref = "sparq-org/sparq#1973"
+bucket = "gated-pr"
+short = "wasm policy feature probe"
+what = "wasm policy feature probe"
+ask = '''
+"arm it"
+'''
+
+# ---------------------------------------------------------------------------------------------
+# ⚠️ Process problems worth your steer. Counts are LIVE placeholders.
+# ---------------------------------------------------------------------------------------------
+
+[[process]]
+text = '''
+**`needs:user` has lost its meaning — {needs_user} open issues carry it.** Spot-checking, most are
+*not* decisions for you: e.g. [#3190](https://github.com/sparq-org/sparq/issues/3190) is a
+`bind_join` perf task, [#3211](https://github.com/sparq-org/sparq/issues/3211) an Elias-Fano codec.
+They were parked onto a **terminal human hold** when they should have been on a
+machine-recoverable class. **Ask:** may I run a re-triage pass that demotes every non-decision item
+off `needs:user`, leaving only the genuine asks (the 🔴 list above)? A front door with
+{needs_user} items behind it is not a front door.
+'''
+
+[[process]]
+text = '''
+**{needs_area} issues are blocked on `needs:area`** — they cannot be dispatched at all until an
+area label exists, and area classification is mechanical. Same ask: authorise the automated pass.
+'''
+
+[[process]]
+text = '''
+**{needs_ec2} issues sit on `needs:ec2`** — measurement runs that need a canonical box, not you
+personally, but they do need a spend decision.
+'''
+
+[[process]]
+text = '''
+**{held_prs} open PRs are held for you**
+([full list](https://github.com/sparq-org/sparq/pulls?q=is%3Apr+is%3Aopen+label%3A%22review%3Aneeds-user%22)),
+of which {held_prs_conflicting} are conflicted and decaying. Most are ZK/MPC drafts awaiting the
+`sq-qhy4` gate.
+'''
+
+[[process]]
+text = '''
+**Fleet throughput is capped by worker yield, not parallelism** — dominated by
+`EXIT_CLASS: no_change`, with the same hard issue retried 3× on the same model. Filed as
+[registry #701](https://github.com/jeswr/agent-account-registry/issues/701), with
+[#700](https://github.com/jeswr/agent-account-registry/issues/700) (PRs dead-ended with no exit
+from a `fail` verdict) and [#699](https://github.com/jeswr/agent-account-registry/issues/699) (park
+re-admission gated on a ledger window that closes above ~33 records/hour — i.e. closed at your
+60/hr target). **No action needed from you**; flagged because they explain why merge rate sits well
+below the 60/hr target.
+'''
+
+# ---------------------------------------------------------------------------------------------
+# 🟢 In flight — no action needed. TRUNCATED FIRST if the body approaches GitHub's 65 536-char
+# limit; the 🔴 section is never truncated.
+# ---------------------------------------------------------------------------------------------
+
+[[flight]]
+text = '''
+**Cross-provider review** is the sole arming gate and is holding: it rejected registry #681
+(forgeable body-marker evidence), caught a live self-merge, and a long run of consecutive reviews
+found substantive defects that green CI had missed.
+'''
+
+[[flight]]
+text = '''
+**solid-server-rs → sparq migration** (`sq-gg0qq`): `sparq-lws-core` landed; the WAC bypass closes
+in the P1 child with mandatory adversarial review.
+'''
+
+[[flight]]
+text = '''
+**Testing/correctness program** (`sq-3dyje`): substrate/core/engine proptests, 6 fuzz targets,
+UPDATE-differential vs Oxigraph, RDFC-1.0 determinism — all landed. Key finding retained: the
+nightly `cargo-mutants` matrix had been measuring **empty feature-gated crates**, so the
+"553 survivors" figure was a measurement artifact.
+'''
+
+[[flight]]
+text = '''
+**bd → GitHub issues migration** is live and driving the fleet; `bd` remains the local historical
+tracker.
+'''

--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -280,6 +280,17 @@ EVIDENCE_PATH = "site/src/data/paper-evidence.json"
 # Only these string fields are PROSE; every other string (and all numbers) is structured data.
 EVIDENCE_PROSE_FIELDS = frozenset({"note", "_comment"})
 
+# [OPUS-5] sparq-org/sparq#4145. PUBLISHED prose that does not live in a `*.md`/`*.typ` file.
+# `orchestration/start-here.toml` is the curated source of the maintainer front door (#1135):
+# every line of `ask`/`what`/`process`/`flight` in it is rendered VERBATIM into an issue body by
+# scripts/render-start-here.py, so it is exactly the surface this gate exists for — and it sat
+# outside SCAN_GLOBS (`*.md`, `*.typ`) entirely. Listed explicitly rather than by widening
+# SCAN_GLOBS to `*.toml`, which would sweep in every Cargo.toml / deny.toml in the workspace,
+# where a bare number is configuration and not a claim. Its content is line-shaped prose, so it
+# takes the ordinary markdown scan (fenced blocks and the ALLOW_LINE_SUBSTRINGS escape included).
+# Pinned by test_start_here_render.py::test_the_front_door_toml_is_inside_the_perf_number_gate.
+EXTRA_SCAN_PATHS = ("orchestration/start-here.toml",)
+
 
 def scan_evidence_json(path: str) -> list[tuple[int, str, str]]:
     """Scan the prose (`note`/`_comment`) fields of paper-evidence.json (bead sq-4hga).
@@ -344,6 +355,13 @@ def main() -> int:
         help="exit non-zero if any finding remains (use once a scope is clean to ratchet it HARD)",
     )
     ap.add_argument(
+        # [OPUS-5] #4145: print the RESOLVED default scan list and exit. Emitted from the same
+        # `files` variable the scan loop below consumes, so a coverage test cannot pass against
+        # a gate that has stopped scanning the file (which is the whole point of asking it).
+        "--list-scanned", action="store_true",
+        help="print the resolved default scan list (one path per line) and exit 0",
+    )
+    ap.add_argument(
         "paths", nargs="*",
         help="optional explicit paths to scan (default: all git-tracked markdown + the "
              "paper-factory .typ sources, minus the bench/research/changelog "
@@ -358,6 +376,17 @@ def main() -> int:
     # gets the same field-aware dispatch below.
     if not args.paths and os.path.exists(EVIDENCE_PATH) and EVIDENCE_PATH not in files:
         files = [*files, EVIDENCE_PATH]
+    # [OPUS-5] #4145: published prose outside SCAN_GLOBS — see EXTRA_SCAN_PATHS.
+    if not args.paths:
+        files = [*files, *(p for p in EXTRA_SCAN_PATHS
+                           if os.path.exists(p) and p not in files)]
+
+    if args.list_scanned:
+        for path in sorted(files):
+            if not args.paths and is_exempt_path(path):
+                continue
+            print(path)
+        return 0
 
     total = 0
     read_errors = 0  # [OPUS-4.8] unreadable files — never silently skipped

--- a/scripts/render-start-here.py
+++ b/scripts/render-start-here.py
@@ -148,7 +148,20 @@ class RefState:
         return self.error is not None or not self.state
 
     def is_resolved(self) -> bool:
-        """True ONLY on positive evidence of resolution. Unknown is never resolved (rule 1)."""
+        """True ONLY on positive evidence of resolution. Unknown is never resolved (rule 1).
+
+        THE `unknown` GUARD IS DEFENCE IN DEPTH, AND IT NEEDS A CONSTRUCTED FIXTURE TO PIN.
+        No `live_ref_state` exit produces `error` set alongside a resolved-looking `state`
+        today: every error path leaves `state` at ''/'open', and the merged/closed paths
+        early-return before `error` can be set. So a fixture like
+        `RefState(error="HTTP 403")` does NOT discriminate this branch — it returns False via
+        `state.lower() != "closed"` even with the branch deleted. The branch only becomes
+        load-bearing when a ref LOOKS resolved and the read failed, which is the shape
+        `_self_test` and `test_a_resolved_looking_ref_whose_read_failed_is_not_resolved`
+        assert on. Keep both: the branch is what stops a future caller (a cached payload, a
+        partial GraphQL read, a second data source) from turning a 403 into "resolved, drop
+        the maintainer's P0".
+        """
         if self.unknown:
             return False
         return self.merged or self.state.lower() == "closed"
@@ -877,8 +890,27 @@ def _self_test(config_path: Path) -> int:
         merge_state_status="DIRTY",
     )
     broken = RefState(ref="sparq-org/sparq#5", error="HTTP 403")
+    # A ref that LOOKS resolved but whose read failed. This — not `broken` — is what pins
+    # `if self.unknown: return False` in is_resolved(); see that method's docstring. `broken`
+    # has no state at all, so it returns False via the empty-state fallback whether the guard
+    # is there or not, and an assertion on it alone would pass for the wrong reason on the most
+    # important invariant in the file.
+    half_closed = RefState(ref="sparq-org/sparq#6", state="closed", error="HTTP 403")
+    half_merged = RefState(
+        ref="sparq-org/sparq#7", is_pr=True, state="open", merged=True, error="HTTP 403"
+    )
     assert not open_i.is_resolved() and closed_i.is_resolved() and merged_pr.is_resolved()
-    assert not broken.is_resolved(), "an unreadable ref must NEVER count as resolved"
+    assert not broken.is_resolved(), "a ref with NO readable state must never count as resolved"
+    assert not half_closed.is_resolved(), (
+        "a ref that reads `closed` from a FAILED read must never count as resolved — "
+        "dropping it would delete an ask on the strength of an error"
+    )
+    assert not half_merged.is_resolved(), (
+        "a ref that reads `merged` from a FAILED read must never count as resolved"
+    )
+    assert broken.unknown and RefState(ref="sparq-org/sparq#8").unknown, (
+        "both clauses of `unknown` must hold: an error, and a state that never arrived"
+    )
     assert _pr_state_cell(conflicting).endswith("CONFLICTING")
     assert _pr_state_cell(broken) == "⚠️ state unknown"
 

--- a/scripts/render-start-here.py
+++ b/scripts/render-start-here.py
@@ -1,0 +1,917 @@
+#!/usr/bin/env python3
+# [OPUS-5] render-start-here.py — render the maintainer front door (#1135) from
+# orchestration/start-here.toml plus LIVE GitHub state. Issue sparq-org/sparq#4145.
+"""render-start-here.py — regenerate issue #1135 ("START HERE — what needs @jeswr").
+
+THE BUG THIS EXISTS TO KILL. #1135 was titled "auto-maintained" and never was. On 2026-07-26 it
+was 13 days stale and SEVEN of its entries were already resolved (#1848/#992/#1917 closed,
+#1084/#1973 closed-unmerged, #1791/#1155 merged) while still being shown to the maintainer as work
+needing them. A front door that lists resolved work is worse than no front door: it burns the one
+resource the project cannot scale. So the de-staling must be STRUCTURAL — a closed or merged entry
+drops out because the renderer reads live state, not because someone remembered.
+
+SPLIT OF RESPONSIBILITY
+  orchestration/start-here.toml  the JUDGEMENT: which asks exist and how they are worded.
+  this script                    the STATE: what is still open, which PR has rotted to CONFLICTING,
+                                 how many issues carry needs:user / needs:area / needs:ec2, how many
+                                 PRs are held.
+The renderer may only DROP, ANNOTATE and ORDER entries from the TOML. It NEVER invents an ask —
+a new 🔴/🟡 item arrives as a PR to the TOML.
+
+FAIL-CLOSED RULES (the reason this script is longer than it looks)
+  1. An entry is dropped ONLY on positive evidence of resolution (state == closed, or a PR with
+     merged == true). Missing, malformed or unreadable state KEEPS the entry and marks it
+     "state unknown". Quietly dropping a P0 because of a transient 403 is the worst available
+     failure, so the unknown path is biased all the way to keep.
+  2. A per-ref failure still publishes (keeping is loss-free) but the process exits NON-ZERO so the
+     workflow reds and a human sees the degradation. The exit status is STICKY: a later success can
+     never clear an earlier failure (this repo has been bitten three times by exit-zero swallowing
+     an earned failure).
+  3. An AGGREGATE failure (a label count or the held-PR list) ABORTS the whole render without
+     touching the issue: those numbers are rendered as prose with no per-item marker to hang an
+     "unknown" on, so publishing them wrong is not an option.
+  4. GitHub's issue-body limit is 65 536 characters. If the body exceeds it, the 🟢 "in flight"
+     section is truncated first, then the removed-as-resolved list, then the process notes. The
+     🔴 / 🟡 sections are NEVER truncated; if the body still does not fit, the render aborts.
+  5. The issue is edited ONLY when the rendered text differs from the current body — no no-op
+     churn, no notification spam.
+
+LIVE COUNTS USE THE LIST API, NOT THE SEARCH INDEX. GitHub's search index lags label writes by
+minutes to hours, so `search/issues?q=label:...` under-reports (measured 2026-07-26: search said 34
+issues carried needs:ec2 while the list API said 35). Counts here come from `gh issue list --label`.
+
+USAGE
+  python3 scripts/render-start-here.py --dry-run   # print the markdown, touch nothing
+  python3 scripts/render-start-here.py --self-test # hermetic assertions, no network
+  python3 scripts/render-start-here.py             # render + `gh issue edit` iff the body differs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - py<3.11
+    import tomli as tomllib  # type: ignore[no-redef]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "orchestration" / "start-here.toml"
+
+# GitHub's hard limit on an issue body. Rule 4 above.
+BODY_LIMIT = 65_536
+WRAP = 100
+
+BUCKETS = ("blocked", "decision", "gated-pr")
+REF_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#[1-9][0-9]*$")
+# Placeholder names contain DIGITS (needs_ec2). An earlier `[a-z_]+` class silently failed to
+# recognise `{needs_ec2}` at all, so parse-time validation passed and the maintainer was shown a
+# literal "{needs_ec2} issues sit on needs:ec2". Hence both the digit-tolerant class here AND the
+# LEFTOVER_PLACEHOLDER_RE sweep of the finished body below: a name this regex cannot see is still
+# caught before publication.
+PLACEHOLDER_RE = re.compile(r"\{([a-z_][a-z0-9_]*)\}")
+LEFTOVER_PLACEHOLDER_RE = re.compile(r"\{[A-Za-z_][A-Za-z0-9_]*\}")
+
+# Exit codes. 0 clean; 2 aborted without publishing; 3 published but degraded.
+EXIT_OK = 0
+EXIT_ABORT = 2
+EXIT_DEGRADED = 3
+
+# The ask shown for a PR that has rotted to CONFLICTING. Rendered INSTEAD of the TOML's
+# clean-state ask, so the front door can never say "arm it" about a PR that cannot be armed.
+REBASE_ASK = "needs rebase before it can arm — say the word and the fleet rebases"
+UNKNOWN_MARK = "⚠️ **state unknown** — live state could not be read, so this entry is KEPT"
+TRUNCATED_MARK = (
+    "- *(this section was truncated to fit GitHub's 65 536-character issue-body limit; "
+    "the 🔴 and 🟡 sections above are never truncated)*"
+)
+
+
+class RenderAborted(Exception):
+    """Raised when publishing would be lossy or impossible. Nothing is written."""
+
+
+class Status:
+    """Sticky exit status: severity only ever escalates.
+
+    A later successful step must never downgrade an earlier earned failure — this repo has shipped
+    that bug three times (a later transient discarding a hard failure). `code` is therefore a
+    monotone maximum and there is deliberately no way to lower it.
+    """
+
+    def __init__(self) -> None:
+        self._code = EXIT_OK
+        self.notes: list[str] = []
+
+    @property
+    def code(self) -> int:
+        return self._code
+
+    def degrade(self, note: str, code: int = EXIT_DEGRADED) -> None:
+        self.notes.append(note)
+        self._code = max(self._code, code)
+
+    @property
+    def degraded(self) -> bool:
+        return self._code != EXIT_OK
+
+
+# --------------------------------------------------------------------------------------------
+# Live state
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass
+class RefState:
+    """Live state of one issue/PR ref. `error` set => nothing about it is trusted."""
+
+    ref: str
+    is_pr: bool = False
+    state: str = ""  # "open" / "closed" / "" when unknown
+    merged: bool = False
+    draft: bool = False
+    mergeable: str = ""  # MERGEABLE / CONFLICTING / UNKNOWN
+    merge_state_status: str = ""  # CLEAN / BLOCKED / DIRTY / BEHIND / UNSTABLE / UNKNOWN
+    error: str | None = None
+
+    @property
+    def unknown(self) -> bool:
+        return self.error is not None or not self.state
+
+    def is_resolved(self) -> bool:
+        """True ONLY on positive evidence of resolution. Unknown is never resolved (rule 1)."""
+        if self.unknown:
+            return False
+        return self.merged or self.state.lower() == "closed"
+
+    def resolution_word(self) -> str:
+        return "merged" if self.merged else "closed"
+
+
+@dataclass
+class Counts:
+    needs_user: int
+    needs_area: int
+    needs_ec2: int
+    held_prs: int
+    held_prs_conflicting: int
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "needs_user": self.needs_user,
+            "needs_area": self.needs_area,
+            "needs_ec2": self.needs_ec2,
+            "held_prs": self.held_prs,
+            "held_prs_conflicting": self.held_prs_conflicting,
+        }
+
+
+def _gh(args: list[str]) -> str:
+    proc = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False, timeout=120
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh {' '.join(args)} -> exit {proc.returncode}: "
+            f"{(proc.stderr or proc.stdout).strip()[:400]}"
+        )
+    return proc.stdout
+
+
+def live_ref_state(ref: str) -> RefState:
+    """Read one ref. Any failure is reported as `error`, never as "not closed"."""
+    repo, _, number = ref.partition("#")
+    try:
+        raw = _gh(["api", f"repos/{repo}/issues/{number}"])
+        payload = json.loads(raw)
+    except Exception as exc:  # noqa: BLE001 - every failure mode is the same: unknown
+        return RefState(ref=ref, error=str(exc))
+    state = payload.get("state")
+    if not isinstance(state, str) or state.lower() not in ("open", "closed"):
+        # Malformed payload is UNKNOWN, not "open" and not "closed" (rule 1).
+        return RefState(ref=ref, error=f"no usable state field in payload for {ref}")
+    pull = payload.get("pull_request")
+    if not isinstance(pull, dict):
+        return RefState(ref=ref, is_pr=False, state=state)
+    merged = bool(pull.get("merged_at"))
+    out = RefState(ref=ref, is_pr=True, state=state, merged=merged)
+    if merged or state.lower() == "closed":
+        return out  # resolved: the mergeability detail below is irrelevant
+    try:
+        detail = json.loads(
+            _gh(
+                [
+                    "pr",
+                    "view",
+                    number,
+                    "--repo",
+                    repo,
+                    "--json",
+                    "isDraft,mergeable,mergeStateStatus",
+                ]
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        out.error = str(exc)
+        return out
+    out.draft = bool(detail.get("isDraft"))
+    out.mergeable = str(detail.get("mergeable") or "")
+    out.merge_state_status = str(detail.get("mergeStateStatus") or "")
+    if not out.mergeable:
+        out.error = f"no mergeable field for {ref}"
+    return out
+
+
+def live_counts(repo: str) -> Counts:
+    """Label populations + the held-PR list, from the LIST API (never the lagging search index)."""
+
+    def label_count(label: str) -> int:
+        raw = _gh(
+            [
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--label",
+                label,
+                "--state",
+                "open",
+                "--limit",
+                "1000",
+                "--json",
+                "number",
+            ]
+        )
+        return len(json.loads(raw))
+
+    held = json.loads(
+        _gh(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--label",
+                "review:needs-user",
+                "--limit",
+                "300",
+                "--json",
+                "number,mergeable",
+            ]
+        )
+    )
+    return Counts(
+        needs_user=label_count("needs:user"),
+        needs_area=label_count("needs:area"),
+        needs_ec2=label_count("needs:ec2"),
+        held_prs=len(held),
+        held_prs_conflicting=sum(1 for p in held if p.get("mergeable") == "CONFLICTING"),
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass
+class Entry:
+    refs: list[str]
+    bucket: str
+    ask: str
+    short: str
+    what: str = ""
+    untracked: bool = False
+
+
+@dataclass
+class Config:
+    repo: str
+    issue: int
+    text: dict[str, str]
+    entries: list[Entry] = field(default_factory=list)
+    process: list[str] = field(default_factory=list)
+    flight: list[str] = field(default_factory=list)
+
+    def bucket(self, name: str) -> list[Entry]:
+        return [e for e in self.entries if e.bucket == name]
+
+
+REQUIRED_TEXT = ("header", "preamble", "blocked_intro", "gated_intro", "process_intro")
+
+
+def parse_config(doc: dict) -> Config:
+    """Parse + VALIDATE. A malformed curated file must fail loudly, never render half a door."""
+    errs: list[str] = []
+    meta = doc.get("meta") or {}
+    repo = str(meta.get("repo") or "")
+    issue = meta.get("issue")
+    if not REF_RE.match(f"{repo}#1"):
+        errs.append("meta.repo must be 'owner/repo'")
+    if not isinstance(issue, int) or issue <= 0:
+        errs.append("meta.issue must be a positive integer")
+    text = doc.get("text") or {}
+    for key in REQUIRED_TEXT:
+        if not str(text.get(key) or "").strip():
+            errs.append(f"text.{key} is required")
+
+    entries: list[Entry] = []
+    for i, raw in enumerate(doc.get("entry") or []):
+        where = f"entry[{i}]"
+        bucket = str(raw.get("bucket") or "")
+        if bucket not in BUCKETS:
+            errs.append(f"{where}: bucket must be one of {BUCKETS}, got {bucket!r}")
+        ask = _one_line(raw.get("ask") or "")
+        short = _one_line(raw.get("short") or "")
+        if not ask:
+            errs.append(f"{where}: ask is required")
+        if not short:
+            errs.append(f"{where}: short is required (it labels the entry when it is dropped)")
+        untracked = bool(raw.get("untracked"))
+        ref_field = raw.get("ref")
+        refs: list[str] = []
+        if isinstance(ref_field, str):
+            refs = [ref_field.strip()] if ref_field.strip() else []
+        elif isinstance(ref_field, list):
+            refs = [str(r).strip() for r in ref_field if str(r).strip()]
+        elif ref_field is not None:
+            errs.append(f"{where}: ref must be a string or a list of strings")
+        for ref in refs:
+            if not REF_RE.match(ref):
+                errs.append(f"{where}: ref {ref!r} must look like 'owner/repo#123'")
+        # An entry with no ref can never be auto-dropped. That is the SAFE direction, so it is
+        # allowed — but only when declared, so a typo'd/empty ref cannot silently become
+        # undroppable-and-unnoticed.
+        if not refs and not untracked:
+            errs.append(f"{where}: no ref — set `untracked = true` to declare that on purpose")
+        if refs and untracked:
+            errs.append(f"{where}: `untracked = true` contradicts ref {refs}")
+        if bucket == "gated-pr":
+            if len(refs) != 1:
+                errs.append(f"{where}: a gated-pr entry needs exactly one PR ref")
+            if not str(raw.get("what") or "").strip():
+                errs.append(f"{where}: a gated-pr entry needs `what`")
+        if bucket == "decision" and len(refs) != 1:
+            errs.append(f"{where}: a decision entry needs exactly one ref (it renders the Item cell)")
+        for cell_field in ("ask", "what") if bucket in ("decision", "gated-pr") else ():
+            if "|" in _one_line(raw.get(cell_field) or ""):
+                errs.append(f"{where}: {cell_field} renders into a table cell — escape the '|'")
+        entries.append(
+            Entry(
+                refs=refs,
+                bucket=bucket,
+                ask=ask,
+                short=short,
+                what=_one_line(raw.get("what") or ""),
+                untracked=untracked,
+            )
+        )
+
+    process = [_one_line(p.get("text") or "") for p in (doc.get("process") or [])]
+    flight = [_one_line(f.get("text") or "") for f in (doc.get("flight") or [])]
+    for i, t in enumerate(process):
+        if not t:
+            errs.append(f"process[{i}]: text is required")
+    for i, t in enumerate(flight):
+        if not t:
+            errs.append(f"flight[{i}]: text is required")
+    if not entries:
+        errs.append("no [[entry]] blocks — refusing to render an empty front door")
+
+    # Placeholders are checked against the live-count key set at PARSE time so a typo fails the
+    # PR's self-test rather than shipping a literal "{needs_user}" to the maintainer.
+    known = set(Counts(0, 0, 0, 0, 0).as_dict()) | {"date", "dropped_sentence"}
+    for label, values in (("text", list(text.values())), ("process", process), ("flight", flight)):
+        for value in values:
+            for name in PLACEHOLDER_RE.findall(str(value)):
+                if name not in known:
+                    errs.append(f"{label}: unknown placeholder {{{name}}}")
+    if errs:
+        raise RenderAborted("invalid orchestration/start-here.toml:\n  - " + "\n  - ".join(errs))
+    return Config(
+        repo=repo,
+        issue=int(issue),
+        text={k: _one_line(v) if k != "header" else str(v).strip() for k, v in text.items()},
+        entries=entries,
+        process=process,
+        flight=flight,
+    )
+
+
+def load_config(path: Path) -> Config:
+    with path.open("rb") as fh:
+        return parse_config(tomllib.load(fh))
+
+
+def _one_line(value: object) -> str:
+    """Collapse a curated multi-line TOML value to one logical line (the renderer owns wrapping)."""
+    return " ".join(str(value).split())
+
+
+# --------------------------------------------------------------------------------------------
+# Rendering
+# --------------------------------------------------------------------------------------------
+
+
+def _ref_url(ref: str, is_pr: bool) -> str:
+    repo, _, number = ref.partition("#")
+    kind = "pull" if is_pr else "issues"
+    return f"https://github.com/{repo}/{kind}/{number}"
+
+
+def _ref_label(ref: str) -> str:
+    repo, _, number = ref.partition("#")
+    return f"#{number}" if repo == "sparq-org/sparq" else f"{repo}#{number}"
+
+
+def _substitute(text: str, values: dict[str, object]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        if name not in values:
+            raise RenderAborted(f"unknown placeholder {{{name}}} in curated text")
+        return str(values[name])
+
+    return PLACEHOLDER_RE.sub(repl, text)
+
+
+def _fill(text: str, width: int = WRAP, initial: str = "", subsequent: str = "") -> str:
+    """Wrap for readability WITHOUT ever breaking a token.
+
+    `break_on_hyphens`/`break_long_words` must stay off: the default settings split
+    `https://github.com/sparq-org/...` after the hyphen, and a newline inside a markdown link
+    destination silently un-links it — which on this issue means the maintainer loses the link to
+    the very thing they are being asked about.
+    """
+    return textwrap.fill(
+        text,
+        width=width,
+        initial_indent=initial,
+        subsequent_indent=subsequent,
+        break_on_hyphens=False,
+        break_long_words=False,
+    )
+
+
+def _bullet(text: str, marker: str = "- ") -> str:
+    return _fill(text, initial=marker, subsequent=" " * len(marker))
+
+
+def _quote(text: str) -> str:
+    return _fill(text, width=WRAP - 2, initial="> ", subsequent="> ")
+
+
+def _pr_state_cell(state: RefState) -> str:
+    bits: list[str] = []
+    if state.unknown:
+        return "⚠️ state unknown"
+    if state.draft:
+        bits.append("draft")
+    if state.mergeable == "CONFLICTING":
+        bits.append("⚠️ CONFLICTING")
+    elif state.merge_state_status in ("BLOCKED", "BEHIND", "DIRTY"):
+        bits.append(state.merge_state_status)
+    elif state.mergeable == "MERGEABLE":
+        bits.append("MERGEABLE")
+    else:
+        # mergeable == UNKNOWN (GitHub still computing, or we could not read it). Saying
+        # "MERGEABLE" here would invite the maintainer to arm a PR that cannot merge.
+        bits.append("⚠️ state unknown")
+    return ", ".join(bits)
+
+
+@dataclass
+class Rendered:
+    body: str
+    dropped: list[tuple[Entry, RefState]]
+    unknown: list[tuple[Entry, RefState]]
+
+
+def render(
+    config: Config,
+    states: dict[str, RefState],
+    counts: Counts,
+    *,
+    date: str,
+    limit: int = BODY_LIMIT,
+) -> Rendered:
+    """Pure render. `states` must cover every ref in the config (missing => unknown => kept)."""
+    kept: list[tuple[Entry, list[RefState]]] = []
+    dropped: list[tuple[Entry, RefState]] = []
+    unknown: list[tuple[Entry, RefState]] = []
+    for entry in config.entries:
+        entry_states = [
+            states.get(ref, RefState(ref=ref, error="no state was fetched for this ref"))
+            for ref in entry.refs
+        ]
+        for st in entry_states:
+            if st.unknown:
+                unknown.append((entry, st))
+        if entry_states and all(st.is_resolved() for st in entry_states):
+            dropped.append((entry, entry_states[0]))
+            continue
+        kept.append((entry, entry_states))
+
+    values: dict[str, object] = dict(counts.as_dict())
+    values["date"] = date
+    values["dropped_sentence"] = _dropped_sentence(len(dropped))
+
+    head = [config.text["header"], "", _quote(_substitute(config.text["preamble"], values))]
+    red = _render_blocked(config, kept)
+    decisions = _render_decisions(config, kept, states)
+    gated = _render_gated(config, kept, states)
+    process = _render_process(config, values)
+    flight_items = [_bullet(_substitute(t, values)) for t in config.flight]
+    removed = _render_removed(dropped)
+    footer = _render_footer(date, unknown)
+
+    def assemble(flight_kept: list[str], removed_text: str, process_text: str) -> str:
+        flight = ["## 🟢 In flight — no action needed", ""]
+        flight.extend(flight_kept)
+        # Say so whenever ANY 🟢 item was sacrificed, not only when the section is emptied: a
+        # silently shortened list reads as a complete one.
+        if len(flight_kept) < len(flight_items):
+            flight.append(TRUNCATED_MARK)
+        chunks = ["\n".join(head), red, decisions, gated, process_text, "\n".join(flight)]
+        if removed_text:
+            chunks.append(removed_text)
+        chunks.append(footer)
+        return "\n\n".join(c for c in chunks if c).strip() + "\n"
+
+    # Truncation ladder (rule 4): sacrifice 🟢 items, then the whole 🟢 section, then the
+    # removed-as-resolved list, then the process notes. 🔴 / 🟡 are never touched.
+    flight_kept = list(flight_items)
+    body = assemble(flight_kept, removed, process)
+    while len(body) > limit and flight_kept:
+        flight_kept.pop()
+        body = assemble(flight_kept, removed, process)
+    if len(body) > limit and removed:
+        removed = _removed_placeholder(len(dropped))
+        body = assemble(flight_kept, removed, process)
+    if len(body) > limit:
+        body = assemble(flight_kept, removed, _render_process(config, values, truncate=True))
+    if len(body) > limit:
+        raise RenderAborted(
+            f"rendered body is {len(body)} chars, over GitHub's {limit} limit, and only the "
+            "🔴/🟡 sections are left — refusing to truncate the sections that need a human. "
+            "Shorten orchestration/start-here.toml."
+        )
+    # Nothing that looks like a placeholder may survive into the published body. This caught the
+    # real `{needs_ec2}` escape (a name the substitution regex could not even see) and it catches
+    # every future one regardless of which regex missed it.
+    leftover = LEFTOVER_PLACEHOLDER_RE.search(body)
+    if leftover:
+        raise RenderAborted(
+            f"unsubstituted placeholder {leftover.group(0)} survived into the rendered body — "
+            "refusing to publish it. Fix the placeholder name in orchestration/start-here.toml "
+            "(known names: " + ", ".join(sorted(values)) + ")."
+        )
+    return Rendered(body=body, dropped=dropped, unknown=unknown)
+
+
+def _dropped_sentence(count: int) -> str:
+    if count == 0:
+        return "Nothing needed dropping this pass."
+    plural = "entry was" if count == 1 else "entries were"
+    return (
+        f"{count} {plural} already resolved and {'has' if count == 1 else 'have'} been dropped "
+        "automatically (see *Removed as resolved* at the bottom)."
+    )
+
+
+def _render_blocked(config: Config, kept: list[tuple[Entry, list[RefState]]]) -> str:
+    out = ["## 🔴 Only you can unblock", "", _wrap_para(config.text["blocked_intro"]), ""]
+    n = 0
+    for entry, states in kept:
+        if entry.bucket != "blocked":
+            continue
+        n += 1
+        marker = f"{n}. "
+        out.append(_fill(_annotate(entry.ask, entry, states), initial=marker,
+                         subsequent=" " * len(marker)))
+    if n == 0:
+        out.append("*(nothing — every human-only blocker is resolved.)*")
+    return "\n".join(out)
+
+
+def _render_decisions(
+    config: Config, kept: list[tuple[Entry, list[RefState]]], states: dict[str, RefState]
+) -> str:
+    rows = []
+    for entry, entry_states in kept:
+        if entry.bucket != "decision":
+            continue
+        ref = entry.refs[0]
+        st = states.get(ref)
+        link = f"**[{_ref_label(ref)}]({_ref_url(ref, bool(st and st.is_pr))})**"
+        rows.append(f"| {link} | {_annotate(entry.ask, entry, entry_states)} |")
+    if not rows:
+        return ""
+    return "\n".join(["## 🟡 Decisions — one line from you each", "", "| Item | Ask |", "|---|---|", *rows])
+
+
+def _render_gated(
+    config: Config, kept: list[tuple[Entry, list[RefState]]], states: dict[str, RefState]
+) -> str:
+    rows = []
+    for entry, entry_states in kept:
+        if entry.bucket != "gated-pr":
+            continue
+        ref = entry.refs[0]
+        st = states.get(ref) or RefState(ref=ref, error="no state was fetched for this ref")
+        link = f"**[{_ref_label(ref)}]({_ref_url(ref, True)})**"
+        # A CONFLICTING PR cannot be armed, so the live state REPLACES the curated "arm it" ask.
+        ask = REBASE_ASK if st.mergeable == "CONFLICTING" else _annotate(entry.ask, entry, entry_states)
+        rows.append(f"| {link} | {_pr_state_cell(st)} | {entry.what} | {ask} |")
+    if not rows:
+        return ""
+    return "\n".join(
+        [
+            "## 🟡 Maintainer-gated PRs — a word from you arms each",
+            "",
+            _wrap_para(config.text["gated_intro"]),
+            "",
+            "| PR | State | What | Ask |",
+            "|---|---|---|---|",
+            *rows,
+        ]
+    )
+
+
+def _render_process(config: Config, values: dict[str, object], *, truncate: bool = False) -> str:
+    out = ["## ⚠️ Process problems worth your steer", "", _wrap_para(config.text["process_intro"]), ""]
+    if truncate:
+        out.append(TRUNCATED_MARK)
+    else:
+        out.extend(_bullet(_substitute(t, values)) for t in config.process)
+    return "\n".join(out)
+
+
+def _render_removed(dropped: list[tuple[Entry, RefState]]) -> str:
+    if not dropped:
+        return ""
+    items = [
+        f"`{_ref_label(st.ref)}` {entry.short} (**{st.resolution_word()}**)"
+        for entry, st in dropped
+    ]
+    return "\n".join(
+        [
+            "---",
+            "",
+            "### Removed as resolved (dropped automatically by this render)",
+            "",
+            _fill(" · ".join(items)),
+        ]
+    )
+
+
+def _removed_placeholder(count: int) -> str:
+    return "\n".join(
+        [
+            "---",
+            "",
+            "### Removed as resolved (dropped automatically by this render)",
+            "",
+            f"*{count} resolved entries were dropped; the list was truncated to fit the "
+            "issue-body limit.*",
+        ]
+    )
+
+
+def _render_footer(date: str, unknown: list[tuple[Entry, RefState]]) -> str:
+    lines = [
+        _wrap_para(
+            "*Rendered by the SPARQ agent 🤖 from `orchestration/start-here.toml` via "
+            "`scripts/render-start-here.py` — last refresh "
+            f"**{date}**. Closed and merged items drop out by construction; the PR table reads "
+            "live conflict state. Add or reword an ask by PR to that TOML.*"
+        )
+    ]
+    if unknown:
+        refs = ", ".join(sorted({_ref_label(st.ref) for _e, st in unknown}))
+        lines += [
+            "",
+            _wrap_para(
+                f"*⚠️ This refresh ran DEGRADED: live state for {refs} could not be read, so "
+                "those entries were kept unverified rather than dropped. The refresh job is red "
+                "until the next clean run.*"
+            ),
+        ]
+    return "\n".join(lines)
+
+
+def _annotate(ask: str, entry: Entry, states: list[RefState]) -> str:
+    """Add the only annotations the renderer is allowed to add: unknown, and partly-resolved."""
+    out = ask
+    resolved = [st for st in states if st.is_resolved()]
+    if resolved and len(resolved) < len(states):
+        done = ", ".join(f"{_ref_label(st.ref)} {st.resolution_word()}" for st in resolved)
+        out += f" *(partly resolved: {done} — the rest of this ask still stands.)*"
+    if any(st.unknown for st in states):
+        out += f" {UNKNOWN_MARK}."
+    return out
+
+
+def _wrap_para(text: str) -> str:
+    return _fill(text)
+
+
+# --------------------------------------------------------------------------------------------
+# Live run
+# --------------------------------------------------------------------------------------------
+
+
+def collect_states(config: Config, status: Status, fetch=live_ref_state) -> dict[str, RefState]:
+    states: dict[str, RefState] = {}
+    for entry in config.entries:
+        for ref in entry.refs:
+            if ref in states:
+                continue
+            st = fetch(ref)
+            states[ref] = st
+            if st.unknown:
+                status.degrade(f"{ref}: {st.error or 'no state'} (kept, never dropped)")
+    return states
+
+
+def current_body(repo: str, issue: int, runner=None) -> str:
+    # Resolved at CALL time, not bound as a default: the tests patch the module's `_gh` to
+    # intercept every subprocess, and a default-bound reference would slip past that seam.
+    runner = runner or _gh
+    raw = runner(["issue", "view", str(issue), "--repo", repo, "--json", "body"])
+    return str(json.loads(raw).get("body") or "")
+
+
+def publish(repo: str, issue: int, body: str, runner=None) -> None:
+    runner = runner or _gh
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
+        fh.write(body)
+        path = fh.name
+    runner(["issue", "edit", str(issue), "--repo", repo, "--body-file", path])
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    ap.add_argument("--dry-run", action="store_true", help="print the markdown; touch nothing")
+    ap.add_argument("--self-test", action="store_true", help="hermetic assertions; no network")
+    ap.add_argument("--issue", type=int, default=None)
+    ap.add_argument("--repo", default=None)
+    ap.add_argument(
+        "--if-ref",
+        default=None,
+        metavar="owner/repo#N",
+        help=(
+            "COST GUARD for the on-close triggers: do nothing unless this ref is one the front "
+            "door actually lists. At the 60-merges/hour target a full render per PR close would "
+            "spend ~2400 API calls/hour against GITHUB_TOKEN's 1000/hour/repository budget, and "
+            "the render that mattered would be the one that got rate-limited."
+        ),
+    )
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test(args.config)
+
+    status = Status()
+    try:
+        config = load_config(args.config)
+        if args.if_ref:
+            known = {ref for entry in config.entries for ref in entry.refs}
+            if args.if_ref not in known:
+                print(
+                    f"{args.if_ref} is not listed on the front door — nothing to re-render "
+                    "(no API calls made).",
+                    file=sys.stderr,
+                )
+                return EXIT_OK
+        repo = args.repo or config.repo
+        issue = args.issue or config.issue
+        counts = live_counts(repo)  # rule 3: a failure here aborts before anything is written
+        states = collect_states(config, status)
+        rendered = render(
+            config,
+            states,
+            counts,
+            date=datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+        )
+    except RenderAborted as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        return EXIT_ABORT
+    except Exception as exc:  # noqa: BLE001 - aggregate/live failure: abort, publish nothing
+        print(f"ABORT: could not read live state: {exc}", file=sys.stderr)
+        return EXIT_ABORT
+
+    if args.dry_run:
+        print(rendered.body, end="")
+        _report(rendered, status, published=False)
+        return status.code
+
+    try:
+        existing = current_body(repo, issue)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ABORT: could not read the current body of {repo}#{issue}: {exc}", file=sys.stderr)
+        return EXIT_ABORT
+
+    if existing.strip() == rendered.body.strip():
+        print(f"{repo}#{issue}: already up to date ({len(rendered.body)} chars) — no edit.", file=sys.stderr)
+        _report(rendered, status, published=False)
+        return status.code
+
+    try:
+        publish(repo, issue, rendered.body)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ABORT: gh issue edit failed: {exc}", file=sys.stderr)
+        return EXIT_ABORT
+    print(f"{repo}#{issue}: updated ({len(rendered.body)} chars).", file=sys.stderr)
+    _report(rendered, status, published=True)
+    return status.code
+
+
+def _report(rendered: Rendered, status: Status, *, published: bool) -> None:
+    for entry, st in rendered.dropped:
+        print(f"  dropped {st.ref} ({st.resolution_word()}): {entry.short}", file=sys.stderr)
+    for note in status.notes:
+        print(f"  DEGRADED {note}", file=sys.stderr)
+    if status.degraded:
+        print(
+            "  exiting non-zero: some refs could not be verified. Nothing was dropped on their "
+            f"account{' and the body was still published' if published else ''}.",
+            file=sys.stderr,
+        )
+
+
+# --------------------------------------------------------------------------------------------
+# Hermetic self-test (no network). The exhaustive suite is scripts/tests/test_start_here_render.py.
+# --------------------------------------------------------------------------------------------
+
+
+def _self_test(config_path: Path) -> int:
+    config = load_config(config_path)  # the SHIPPED file must validate
+    assert config.repo and config.issue, "meta must resolve"
+    assert config.bucket("blocked"), "the shipped TOML must carry the 🔴 asks"
+
+    open_i = RefState(ref="sparq-org/sparq#1", state="open")
+    closed_i = RefState(ref="sparq-org/sparq#2", state="closed")
+    merged_pr = RefState(ref="sparq-org/sparq#3", is_pr=True, state="closed", merged=True)
+    conflicting = RefState(
+        ref="sparq-org/sparq#4",
+        is_pr=True,
+        state="open",
+        mergeable="CONFLICTING",
+        merge_state_status="DIRTY",
+    )
+    broken = RefState(ref="sparq-org/sparq#5", error="HTTP 403")
+    assert not open_i.is_resolved() and closed_i.is_resolved() and merged_pr.is_resolved()
+    assert not broken.is_resolved(), "an unreadable ref must NEVER count as resolved"
+    assert _pr_state_cell(conflicting).endswith("CONFLICTING")
+    assert _pr_state_cell(broken) == "⚠️ state unknown"
+
+    cfg = Config(
+        repo="sparq-org/sparq",
+        issue=1135,
+        text={k: f"{k} text" for k in REQUIRED_TEXT},
+        entries=[
+            Entry(refs=[open_i.ref], bucket="blocked", ask="keep me", short="keep"),
+            Entry(refs=[closed_i.ref], bucket="blocked", ask="drop me", short="closed one"),
+            Entry(refs=[merged_pr.ref], bucket="decision", ask="drop me too", short="merged one"),
+            Entry(
+                refs=[conflicting.ref],
+                bucket="gated-pr",
+                ask='"arm it"',
+                short="rotted",
+                what="a rotted PR",
+            ),
+            Entry(refs=[broken.ref], bucket="blocked", ask="unverifiable", short="unknown one"),
+        ],
+        process=["{needs_user} on needs:user"],
+        flight=["in flight"],
+    )
+    states = {s.ref: s for s in (open_i, closed_i, merged_pr, conflicting, broken)}
+    out = render(cfg, states, Counts(1, 2, 3, 4, 5), date="2026-01-01")
+    assert "keep me" in out.body and "unverifiable" in out.body
+    assert "drop me" not in out.body and "drop me too" not in out.body
+    assert REBASE_ASK in out.body and '"arm it"' not in out.body
+    assert "1 on needs:user" in out.body
+    assert len(out.dropped) == 2 and len(out.unknown) == 1
+
+    status = Status()
+    status.degrade("boom")
+    status.notes.append("a later success")
+    assert status.code == EXIT_DEGRADED, "the exit status must be sticky"
+    print("render-start-here.py --self-test: OK")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render-start-here.py
+++ b/scripts/render-start-here.py
@@ -25,7 +25,7 @@ FAIL-CLOSED RULES (the reason this script is longer than it looks)
      failure, so the unknown path is biased all the way to keep.
   2. A per-ref failure still publishes (keeping is loss-free) but the process exits NON-ZERO so the
      workflow reds and a human sees the degradation. The exit status is STICKY: a later success can
-     never clear an earlier failure (this repo has been bitten three times by exit-zero swallowing
+     never clear an earlier failure (this repo has been bitten repeatedly by exit-zero swallowing
      an earned failure).
   3. An AGGREGATE failure (a label count or the held-PR list) ABORTS the whole render without
      touching the issue: those numbers are rendered as prose with no per-item marker to hang an
@@ -104,7 +104,7 @@ class Status:
     """Sticky exit status: severity only ever escalates.
 
     A later successful step must never downgrade an earlier earned failure — this repo has shipped
-    that bug three times (a later transient discarding a hard failure). `code` is therefore a
+    that bug repeatedly (a later transient discarding a hard failure). `code` is therefore a
     monotone maximum and there is deliberately no way to lower it.
     """
 

--- a/scripts/render-start-here.py
+++ b/scripts/render-start-here.py
@@ -753,11 +753,16 @@ def current_body(repo: str, issue: int, runner=None) -> str:
 
 
 def publish(repo: str, issue: int, body: str, runner=None) -> None:
+    # `--body-file` rather than `--body`: the body carries newlines, backticks and emoji, and an
+    # argv round-trip through a shell is where those get mangled.
     runner = runner or _gh
     with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as fh:
         fh.write(body)
         path = fh.name
-    runner(["issue", "edit", str(issue), "--repo", repo, "--body-file", path])
+    try:
+        runner(["issue", "edit", str(issue), "--repo", repo, "--body-file", path])
+    finally:
+        Path(path).unlink(missing_ok=True)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/tests/fixtures/start-here-1135-2026-07-26.md
+++ b/scripts/tests/fixtures/start-here-1135-2026-07-26.md
@@ -1,0 +1,128 @@
+🤖 **SPARQ agent** — your single front door. Decisions-first; only 🔴/🟡 need you.
+
+> **Every item below was re-verified live on 2026-07-26.** Seven entries carried by the previous
+> revision were already resolved and have been removed (see *Removed as resolved* at the bottom).
+> This issue was never actually auto-maintained despite its title — it was refreshed by hand, which is
+> why it went 13 days stale. That is being fixed at the source in
+> [#4145](https://github.com/sparq-org/sparq/issues/4145): a cron-driven renderer that drops any
+> closed/merged item automatically and reads PR conflict state live, driven by a reviewable TOML so
+> changes to what we ask you arrive as a PR.
+
+## 🔴 Only you can unblock
+
+Each of these is human-only by nature — a credential, a licence, an external human, or your name on
+a public decision. No agent can close them.
+
+1. **npm bootstrap publish** — `@jeswr/sparq` is **still not live** (registry returns **404**, verified
+   today). `publish.yml` (OIDC trusted publishing) is merged and ready; it needs your one-time
+   `npm publish` + trusted-publisher registration. **Revoke the chat-sent token either way.**
+   ([#53](https://github.com/sparq-org/sparq/issues/53))
+2. **External accredited-cryptographer ZK audit** (`sq-qhy4`, **P0**) — the bead says it plainly:
+   *"agent-out-of-scope by definition."* sparq's ZK soundness claim currently rests entirely on
+   internal single-model self-audits. Until an external cryptographer signs off, **no ZK
+   security/privacy/integrity property may be relied on in production**, and `SECURITY.md` must keep
+   its conservative "treat as untrusted" posture. This gates every production ZK claim and the
+   assurance-promotion work ([#3274](https://github.com/sparq-org/sparq/issues/3274)).
+3. **[#3337](https://github.com/sparq-org/sparq/issues/3337) — crates.io API token / `cargo owner`.**
+   Blocks Rust-side publication entirely.
+4. **[#1139](https://github.com/sparq-org/sparq/issues/1139) — literature-DB API key** (Semantic
+   Scholar): free key + signup, blocks the research-ingest lane.
+5. **[#3382](https://github.com/sparq-org/sparq/issues/3382) — RDFox licence.** Needed to gather
+   competitor numbers honestly; without it the performance-dominance tables cannot include RDFox and
+   we must keep saying so.
+6. **[#1840](https://github.com/sparq-org/sparq/issues/1840) — Noir upstream PR**
+   (noir-lang/noir#13314, BoundedVec capacity assert): review + flip from draft to ready. Upstream
+   maintainers need a human author.
+7. **[#1615](https://github.com/sparq-org/sparq/issues/1615) — LinkedIn post + profile repo pin.**
+   Text is drafted and ready; needs your click.
+8. **Worker-account credentials (agent-account-registry)** — `acct08` login and the missing
+   `REGISTRY_SECRETS_PAT`. Enrollment cannot be automated because writing env secrets requires your
+   auth. Directly limits fleet parallelism.
+9. **Upstream filings that need your identity** —
+   [#3338](https://github.com/sparq-org/sparq/issues/3338) (4 drafted `w3c/rdf-tests` issues),
+   [#3329](https://github.com/sparq-org/sparq/issues/3329) (georust/geo feature request),
+   [#3385](https://github.com/sparq-org/sparq/issues/3385) (offer the GML-SF parser as a standalone
+   crate). All drafted; each wants a human to file it.
+
+## 🟡 Decisions — one line from you each
+
+| Item | Ask |
+|---|---|
+| **[#3399](https://github.com/sparq-org/sparq/issues/3399)** | **final npm package name** (currently `@jeswr/sparq`). Blocks 1️⃣ above and the JS docs surface — worth settling first. |
+| **[#1974](https://github.com/sparq-org/sparq/issues/1974)** | public JS API contract for ODRL policy evaluation; wasm32 probe works, +135 kB raw bundle. Pick the exposed surface. |
+| **[#1897](https://github.com/sparq-org/sparq/issues/1897)** | merge-queue skip-push-CI is **unsound** under SQUASH+ALLGREEN (squash mints a new SHA; the green gate lives on the ephemeral queue ref). Pick **A)** REBASE/MERGE + `max_entries:1`, **B)** leaner always-run push matrix *(recommended)*, **C)** drop. |
+| **[#1825](https://github.com/sparq-org/sparq/issues/1825)** | default SPQCPRM2 (V2) on-disk emit **ON**? Reader ships; gated on a canonical EC2 measurement (`needs:ec2`). |
+| **[#3299](https://github.com/sparq-org/sparq/issues/3299)** | reconcile the GitHub Pages **root** — which surface owns `/`. |
+| **[#1248](https://github.com/sparq-org/sparq/issues/1248)** | ratify the tier-1 **semver freeze** — policy has landed, the declaration is yours. |
+| **[#1817](https://github.com/sparq-org/sparq/issues/1817)** | `/download` alias contract + prerelease fallback. |
+| **[#1815](https://github.com/sparq-org/sparq/issues/1815)** | ⚠️ **premise now stale** — this asks whether to keep CodeQL per-push, but CodeQL was **disabled** on sparq (2026-07-18, merge latency) and the ruleset now requires only `gate`. Related PR [#3427](https://github.com/sparq-org/sparq/pull/3427) (CodeQL advisory-at-merge) is open and conflicted. Decide the end state, then we close or rewrite both. |
+| **[#1690](https://github.com/sparq-org/sparq/issues/1690)** | logo / brand pick — concepts consolidated. |
+| **[#1587](https://github.com/sparq-org/sparq/issues/1587)** | next-phase work-plan steer. |
+
+## 🟡 Maintainer-gated PRs — a word from you arms each
+
+Protected paths and spec surfaces the fleet will not self-arm.
+
+| PR | State | What | Ask |
+|---|---|---|---|
+| **[#1712](https://github.com/sparq-org/sparq/pull/1712)** | MERGEABLE | zk-compose fail-closed / determinism coverage | cross-provider review **in flight now**; I'll arm on a clean pair unless you object |
+| **[#1607](https://github.com/sparq-org/sparq/pull/1607)** | MERGEABLE | Trust Expression proposal draft | "arm it" |
+| **[#1509](https://github.com/sparq-org/sparq/pull/1509)** | MERGEABLE | zkSPARQL proposal draft (restarted from the codebase) | "arm it" |
+| **[#1658](https://github.com/sparq-org/sparq/pull/1658)** | ⚠️ CONFLICTING | zkSPARQL §7 extended fragment + bounded-depth paths | needs rebase before it can arm — say the word and the fleet rebases |
+| **[#1621](https://github.com/sparq-org/sparq/pull/1621)** | ⚠️ CONFLICTING | ODRL core as stratified N3 rules + Rust-vs-N3 differential | same — rebase then arm |
+| **[#1487](https://github.com/sparq-org/sparq/pull/1487)** | draft, BLOCKED | Kani harnesses for the WAC/ACP decision core | harness re-scoping decision |
+
+## ⚠️ Process problems worth your steer
+
+These are new since the last revision and they cap everything else.
+
+- **`needs:user` has lost its meaning — 111 open issues carry it.** Spot-checking, most are *not*
+  decisions for you: e.g. [#3190](https://github.com/sparq-org/sparq/issues/3190) is a `bind_join`
+  perf task, [#3211](https://github.com/sparq-org/sparq/issues/3211) an Elias-Fano codec. They were
+  parked onto a **terminal human hold** when they should have been on a machine-recoverable class.
+  **Ask:** may I run a re-triage pass that demotes every non-decision item off `needs:user`, leaving
+  only genuine asks (the ~9 in 🔴 above)? A front door with 111 items behind it is not a front door.
+- **257 issues are blocked on `needs:area`** (20 of them P1) — they cannot be dispatched at all until
+  an area label exists, and area classification is mechanical. Same ask: authorise the automated pass.
+- **34 issues sit on `needs:ec2`** — measurement runs that need a canonical box, not you personally,
+  but they do need a spend decision.
+- **21 open PRs are held for you** ([full list](https://github.com/sparq-org/sparq/pulls?q=is%3Apr+is%3Aopen+label%3A%22review%3Aneeds-user%22)),
+  of which 6 are conflicted and decaying. Most are ZK/MPC drafts awaiting the `sq-qhy4` gate.
+- **Fleet throughput is capped by worker yield, not parallelism** — measured today: **70 success /
+  126 failure (36%)** across 196 worker runs, dominated by `EXIT_CLASS: no_change`, and the same hard
+  issue is retried **3×** with the same model. Filed as
+  [registry #701](https://github.com/jeswr/agent-account-registry/issues/701). Also
+  [#700](https://github.com/jeswr/agent-account-registry/issues/700) (11 PRs dead-ended: no exit from
+  a `fail` verdict) and [#699](https://github.com/jeswr/agent-account-registry/issues/699) (park
+  re-admission is gated on a ledger window that closes above ~33 records/hour — i.e. it is closed at
+  your 60/hr target). **No action needed from you**; flagged because they explain why merge rate sits
+  at ~5/hr rather than 60/hr.
+
+## 🟢 In flight — no action needed
+
+- **Today:** 73 commits / 73 merged PRs on `main`, main green.
+- **Cross-provider review** is the sole arming gate and is holding: it rejected #681 (forgeable
+  body-marker evidence) and caught a live self-merge, and 18+ consecutive reviews found substantive
+  defects that green CI had missed.
+- **solid-server-rs → sparq migration** (`sq-gg0qq`): `sparq-lws-core` landed; WAC bypass closes in
+  the P1 child with mandatory adversarial review.
+- **Testing/correctness program** (`sq-3dyje`): substrate/core/engine proptests, 6 fuzz targets,
+  UPDATE-differential vs Oxigraph, RDFC-1.0 determinism — all landed. Key finding retained: the
+  nightly `cargo-mutants` matrix had been measuring **empty feature-gated crates**, so the "553
+  survivors" figure was a measurement artifact.
+- **bd → GitHub issues migration** is live and driving the fleet; `bd` remains the local historical
+  tracker.
+
+---
+
+### Removed as resolved (were still listed as needing you)
+
+`#1848` geo dict-pointer freshness (**closed**) · `#992` empty-container default flip (**closed**) ·
+`#1084` release v0.1.0 (**closed**) · `#1791` agent-role refresh (**merged**) · `#1155` VC cryptosuite
+ingest bridge (**merged**) · `#1973` wasm policy feature probe (**closed**) · `#1917` miri formal-alarm
+(**closed**).
+
+*Maintained by the SPARQ agent 🤖 — last refresh **2026-07-26**, verified item-by-item against live
+API state. Automated regeneration (cron + on-close/on-merge, closed items dropping out by
+construction) is tracked in [#4145](https://github.com/sparq-org/sparq/issues/4145); until that lands,
+refreshes are manual and this issue can drift again.*

--- a/scripts/tests/test_start_here_render.py
+++ b/scripts/tests/test_start_here_render.py
@@ -1130,6 +1130,22 @@ class TestSeedFidelity(unittest.TestCase):
         for number in (1848, 992, 1917, 1084, 1791, 1155, 1973):
             self.assertIn(f"sparq-org/sparq#{number}", refs)
 
+    def test_the_external_audit_ask_stays_structurally_undroppable(self):
+        """The one entry a live ref would silently DELETE, pinned in the SHIPPED file.
+
+        `test_untracked_entry_is_never_dropped` pins the renderer MECHANISM; nothing pinned the
+        curated declaration. Found by mutation: giving the sq-qhy4 entry
+        `ref = "sparq-org/sparq#3274"` (the assurance-promotion issue, which sq-qhy4 GATES but is
+        not equal to) survived the whole suite — and the day #3274 closes, the P0 "no production
+        ZK claim without an external cryptographer" ask leaves the maintainer's front door on its
+        own. sq-qhy4 has no GitHub issue of its own, so `untracked` is the only correct encoding
+        and it may only be removed by a human editing the TOML.
+        """
+        audit = [e for e in rsh.load_config(CONFIG).bucket("blocked") if "sq-qhy4" in e.short]
+        self.assertEqual(len(audit), 1, "the external cryptographer ZK audit ask has gone missing")
+        self.assertTrue(audit[0].untracked, "sq-qhy4 must not be droppable by any live ref")
+        self.assertEqual(audit[0].refs, [])
+
     def test_the_curated_gated_pr_asks_never_hard_code_a_state(self):
         # The State column is LIVE. A hand-written "CONFLICTING"/"MERGEABLE" in the curated copy is
         # exactly the decay this issue is about.
@@ -1137,6 +1153,38 @@ class TestSeedFidelity(unittest.TestCase):
         for e in config.bucket("gated-pr"):
             for token in ("CONFLICTING", "MERGEABLE", "BLOCKED"):
                 self.assertNotIn(token, e.ask + e.what, f"{e.short}: state belongs to live data")
+
+
+class TestTheCuratedFileIsInsideTheHonestyGates(unittest.TestCase):
+    """The TOML is PUBLISHED prose. It has to be covered by the gates that police prose.
+
+    `check-no-perf-numbers.py`'s SCAN_GLOBS is `*.md` / `*.typ`, so before #4145 the one file
+    whose content is copied verbatim into an issue body sat entirely outside the
+    no-hard-coded-performance-numbers gate. Zero findings today is not the same as covered.
+    """
+
+    PERF_GATE = REPO_ROOT / "scripts" / "check-no-perf-numbers.py"
+
+    def _default_scan_list(self) -> str:
+        # Ask the gate itself which files it scans, rather than re-deriving its globs here: the
+        # question is what the SHIPPED gate covers, and a re-derivation would agree with a
+        # broken gate. `--advisory` always exits 0; the listing is what matters.
+        proc = subprocess.run(
+            [sys.executable, str(self.PERF_GATE), "--advisory", "--list-scanned"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr[-2000:])
+        return proc.stdout
+
+    def test_the_front_door_toml_is_inside_the_perf_number_gate(self):
+        self.assertIn("orchestration/start-here.toml", self._default_scan_list().splitlines())
+
+    def test_the_shipped_toml_carries_no_hard_coded_performance_number(self):
+        proc = subprocess.run(
+            [sys.executable, str(self.PERF_GATE), "--enforce", str(CONFIG.relative_to(REPO_ROOT))],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stdout[-3000:] + proc.stderr[-2000:])
 
 
 class TestRefreshWorkflowWiring(unittest.TestCase):

--- a/scripts/tests/test_start_here_render.py
+++ b/scripts/tests/test_start_here_render.py
@@ -413,7 +413,24 @@ class TestGatedPrTable(unittest.TestCase):
 class TestNeverInvents(unittest.TestCase):
     """The renderer may DROP, ANNOTATE and ORDER. It may not author an ask."""
 
-    def test_every_rendered_blocked_item_comes_from_the_toml(self):
+    @staticmethod
+    def _blocked_items(body: str) -> list[str]:
+        """Reassemble each 🔴 item from its wrapped lines, whitespace-normalised.
+
+        Deliberately NOT a first-line-prefix check: comparing only the first rendered line lets
+        anything appended to the tail of an ask through, which is exactly the "invents an ask"
+        failure this test is named after.
+        """
+        section = body.split("## 🔴 Only you can unblock", 1)[1].split("\n## ", 1)[0]
+        items: list[str] = []
+        for line in section.splitlines():
+            if re.match(r"^\d+\. ", line):
+                items.append(line.split(". ", 1)[1])
+            elif items and line.startswith("   "):
+                items[-1] += " " + line.strip()
+        return [" ".join(i.split()) for i in items]
+
+    def test_every_rendered_blocked_item_is_verbatim_from_the_toml(self):
         config = rsh.load_config(CONFIG)
         states = {
             ref: rsh.RefState(ref=ref, state="open", is_pr=True, mergeable="MERGEABLE",
@@ -423,15 +440,26 @@ class TestNeverInvents(unittest.TestCase):
         }
         body = rsh.render(config, states, COUNTS, date="2026-07-26").body
         curated = {" ".join(e.ask.split()) for e in config.entries}
-        for line in body.splitlines():
-            m = re.match(r"^\d+\. (.*)$", line)
-            if not m:
-                continue
-            item = m.group(1)
-            self.assertTrue(
-                any(ask.startswith(item) or item.startswith(ask[:60]) for ask in curated),
-                f"rendered 🔴 item is not traceable to the TOML: {item[:80]}",
-            )
+        items = self._blocked_items(body)
+        self.assertEqual(len(items), len(config.bucket("blocked")))
+        for item in items:
+            # EXACT equality: with every ref open and mergeable, no annotation applies, so any
+            # difference at all is the renderer authoring copy.
+            self.assertIn(item, curated, f"rendered 🔴 item is not verbatim TOML: {item[:90]}")
+
+    def test_the_only_additions_are_the_declared_annotations(self):
+        # And when an annotation DOES apply, it must be exactly one of the two declared ones.
+        config = rsh.load_config(CONFIG)
+        states = {
+            ref: rsh.RefState(ref=ref, error="HTTP 502")
+            for e in config.entries
+            for ref in e.refs
+        }
+        body = rsh.render(config, states, COUNTS, date="2026-07-26").body
+        curated = {" ".join(e.ask.split()) for e in config.entries}
+        for item in self._blocked_items(body):
+            stripped = item.replace(f" {rsh.UNKNOWN_MARK}.", "")
+            self.assertIn(stripped, curated, f"unexpected addition: {item[-90:]}")
 
     def test_every_table_ask_cell_is_a_curated_ask_or_the_rebase_annotation(self):
         config = rsh.load_config(CONFIG)

--- a/scripts/tests/test_start_here_render.py
+++ b/scripts/tests/test_start_here_render.py
@@ -1,0 +1,988 @@
+#!/usr/bin/env python3
+# [OPUS-5] sparq-org/sparq#4145 — the maintainer-front-door contract (#1135).
+#
+# THE FAILURE THIS SUITE EXISTS TO PREVENT. #1135 is titled "auto-maintained" and never was. On
+# 2026-07-26 it was 13 days stale and SEVEN of its entries were already resolved (#1848/#992/#1917
+# closed, #1084/#1973 closed-unmerged, #1791/#1155 merged) while still being presented to the
+# maintainer as work needing them. A front door that lists resolved work is worse than no front
+# door, so every rule below is pinned by a test that goes RED when the rule is deleted:
+#
+#   drop-when-resolved      a closed issue / merged PR disappears .............. TestDropRules
+#   FAIL CLOSED             an unreadable ref is KEPT + marked, never dropped .. TestFailClosed
+#   live PR state           a CONFLICTING PR reads "needs rebase", not "arm it"  TestGatedPrTable
+#   never invent an ask     every rendered ask traces to the TOML ............. TestNeverInvents
+#   65 536-char limit       🟢 truncates, 🔴 never does ....................... TestTruncation
+#   no no-op churn          identical body => no `gh issue edit` ............... TestPublishPath
+#   sticky exit             a later success cannot clear a failure ............. TestStickyStatus
+#   list API, not search    label counts come from the un-lagged API ........... TestLiveQueries
+#   THE YAML SEAM           triggers/permissions/steps/inputs, parsed as YAML .. TestRefreshWorkflowWiring
+#
+# THE YAML SEAM IS DELIBERATELY STRUCTURAL. Measured in this repo: 18/18 Python mutants died while
+# every single uncaught mutant lived in a workflow `if:`, a deleted step, or a wrong call-site
+# input. A substring or `count(...) == N` assertion over workflow TEXT cannot see `if: false`, a
+# removed step, or `--dry-run` quietly added to the live invocation, so this suite parses the
+# workflow with PyYAML and asserts on the parsed job/step/permission/trigger objects.
+#
+# Run: python3 scripts/tests/test_start_here_render.py   (also run by routing-self-tests.yml)
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import re
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import ModuleType
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "render-start-here.py"
+CONFIG = REPO_ROOT / "orchestration" / "start-here.toml"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "refresh-start-here.yml"
+SELF_TEST_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+# The live body of #1135 as it stood on 2026-07-26, the revision this TOML was seeded from. It is
+# an INDEPENDENT artifact (fetched from the API, not generated here), which is what makes the
+# seed-fidelity test below able to detect an ask lost in the migration.
+FIXTURE = REPO_ROOT / "scripts" / "tests" / "fixtures" / "start-here-1135-2026-07-26.md"
+
+SHA_PINNED = re.compile(r"^[^@]+@[0-9a-f]{40}$")
+
+
+def _load(path: Path, name: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, path
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+rsh = _load(SCRIPT, "render_start_here_under_test")
+
+
+def workflow(path: Path = WORKFLOW) -> dict:
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict), f"{path} must parse as a mapping"
+    return doc
+
+
+def triggers(doc: dict) -> dict:
+    # PyYAML resolves the bare key `on` to the boolean True (YAML 1.1). Read both spellings so a
+    # quoted "on:" cannot make these assertions silently vacuous.
+    got = doc.get("on", doc.get(True))
+    assert isinstance(got, dict), "the workflow must declare a mapping of triggers"
+    return got
+
+
+def steps_of(doc: dict) -> list[dict]:
+    out: list[dict] = []
+    for job in (doc.get("jobs") or {}).values():
+        out.extend(job.get("steps") or [])
+    return out
+
+
+# --------------------------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------------------------
+
+OPEN_ISSUE = "sparq-org/sparq#100"
+CLOSED_ISSUE = "sparq-org/sparq#101"
+MERGED_PR = "sparq-org/sparq#102"
+CLOSED_PR = "sparq-org/sparq#103"
+CLEAN_PR = "sparq-org/sparq#104"
+CONFLICTING_PR = "sparq-org/sparq#105"
+DRAFT_PR = "sparq-org/sparq#106"
+BROKEN = "sparq-org/sparq#107"
+UNKNOWN_MERGEABLE_PR = "sparq-org/sparq#108"
+
+STATES = {
+    OPEN_ISSUE: rsh.RefState(ref=OPEN_ISSUE, state="open"),
+    CLOSED_ISSUE: rsh.RefState(ref=CLOSED_ISSUE, state="closed"),
+    MERGED_PR: rsh.RefState(ref=MERGED_PR, is_pr=True, state="closed", merged=True),
+    CLOSED_PR: rsh.RefState(ref=CLOSED_PR, is_pr=True, state="closed"),
+    CLEAN_PR: rsh.RefState(
+        ref=CLEAN_PR, is_pr=True, state="open", mergeable="MERGEABLE", merge_state_status="CLEAN"
+    ),
+    CONFLICTING_PR: rsh.RefState(
+        ref=CONFLICTING_PR,
+        is_pr=True,
+        state="open",
+        mergeable="CONFLICTING",
+        merge_state_status="DIRTY",
+    ),
+    DRAFT_PR: rsh.RefState(
+        ref=DRAFT_PR,
+        is_pr=True,
+        state="open",
+        draft=True,
+        mergeable="MERGEABLE",
+        merge_state_status="BLOCKED",
+    ),
+    BROKEN: rsh.RefState(ref=BROKEN, error="HTTP 403: rate limited"),
+    UNKNOWN_MERGEABLE_PR: rsh.RefState(
+        ref=UNKNOWN_MERGEABLE_PR,
+        is_pr=True,
+        state="open",
+        mergeable="UNKNOWN",
+        merge_state_status="UNKNOWN",
+    ),
+}
+
+TEXT = {
+    "header": "🤖 header",
+    "preamble": "verified {date}. {dropped_sentence}",
+    "blocked_intro": "human-only",
+    "gated_intro": "protected paths",
+    "process_intro": "counts are live",
+}
+
+
+def cfg(entries, *, process=("{needs_user} on needs:user",), flight=("in flight",)) -> rsh.Config:
+    return rsh.Config(
+        repo="sparq-org/sparq",
+        issue=1135,
+        text=dict(TEXT),
+        entries=list(entries),
+        process=list(process),
+        flight=list(flight),
+    )
+
+
+def entry(ref, bucket="blocked", ask="THE ASK", short="short", what="what", untracked=False):
+    refs = [ref] if isinstance(ref, str) else list(ref)
+    return rsh.Entry(
+        refs=refs, bucket=bucket, ask=ask, short=short, what=what, untracked=untracked
+    )
+
+
+COUNTS = rsh.Counts(11, 22, 33, 44, 5)
+
+
+def render(entries, **kw):
+    return rsh.render(cfg(entries, **kw), STATES, COUNTS, date="2026-07-26")
+
+
+# --------------------------------------------------------------------------------------------
+
+
+class TestDropRules(unittest.TestCase):
+    """The core bug: resolved work must LEAVE the front door by construction."""
+
+    def test_open_entry_is_kept(self):
+        # Discriminating baseline: without this, "everything is dropped" would pass every
+        # drop test below.
+        out = render([entry(OPEN_ISSUE, ask="STILL OPEN")])
+        self.assertIn("STILL OPEN", out.body)
+        self.assertEqual(out.dropped, [])
+        self.assertNotIn("Removed as resolved", out.body)
+
+    def test_closed_issue_is_dropped_and_listed_as_removed(self):
+        out = render([entry(OPEN_ISSUE, ask="KEEP"), entry(CLOSED_ISSUE, ask="GONE", short="c")])
+        self.assertNotIn("GONE", out.body)
+        self.assertIn("KEEP", out.body)
+        self.assertIn("Removed as resolved", out.body)
+        self.assertIn("`#101` c (**closed**)", out.body)
+        self.assertEqual([e.short for e, _ in out.dropped], ["c"])
+
+    def test_merged_pr_is_dropped_and_reported_as_merged(self):
+        out = render(
+            [
+                entry(OPEN_ISSUE, ask="KEEP"),
+                entry(MERGED_PR, bucket="gated-pr", ask="GONE", short="m", what="w"),
+            ]
+        )
+        self.assertNotIn("GONE", out.body)
+        self.assertIn("`#102` m (**merged**)", out.body)
+
+    def test_closed_but_unmerged_pr_is_dropped_as_closed(self):
+        # #1084/#1973 were exactly this shape: PRs closed without merging. Reporting them as
+        # "merged" would be a false claim about what happened to the work.
+        out = render(
+            [entry(OPEN_ISSUE), entry(CLOSED_PR, bucket="gated-pr", short="cp", what="w")]
+        )
+        self.assertIn("`#103` cp (**closed**)", out.body)
+        self.assertNotIn("`#103` cp (**merged**)", out.body)
+
+    def test_the_seven_stale_shapes_all_drop(self):
+        # The literal 2026-07-26 stale set, by shape: 3 closed issues, 2 closed PRs, 2 merged PRs.
+        entries = [
+            entry(OPEN_ISSUE, ask="ONLY SURVIVOR"),
+            entry(CLOSED_ISSUE, ask="A", short="a"),
+            entry(CLOSED_PR, bucket="gated-pr", ask="B", short="b", what="w"),
+            entry(MERGED_PR, bucket="gated-pr", ask="C", short="c", what="w"),
+        ]
+        out = render(entries)
+        self.assertEqual(len(out.dropped), 3)
+        for gone in ("A", "B", "C"):
+            self.assertNotIn(f"| {gone} |", out.body)
+        self.assertIn("ONLY SURVIVOR", out.body)
+        self.assertIn("3 entries were already resolved", out.body)
+
+    def test_untracked_entry_is_never_dropped(self):
+        # sq-qhy4 (the external cryptographer audit) has no GitHub ref; it may only leave by hand.
+        out = render([entry([], ask="EXTERNAL AUDIT", untracked=True)])
+        self.assertIn("EXTERNAL AUDIT", out.body)
+        self.assertEqual(out.dropped, [])
+
+    def test_multi_ref_entry_drops_only_when_every_ref_is_resolved(self):
+        both_open = render([entry([OPEN_ISSUE, CLEAN_PR], ask="THREE FILINGS")])
+        self.assertIn("THREE FILINGS", both_open.body)
+        all_done = render([entry(OPEN_ISSUE), entry([CLOSED_ISSUE, MERGED_PR], ask="ALL FILED")])
+        self.assertNotIn("ALL FILED", all_done.body)
+
+    def test_partly_resolved_multi_ref_entry_is_kept_and_annotated(self):
+        out = render([entry([OPEN_ISSUE, CLOSED_ISSUE], ask="THREE FILINGS")])
+        self.assertIn("THREE FILINGS", out.body)
+        self.assertIn("partly resolved: #101 closed", out.body)
+
+
+class TestFailClosed(unittest.TestCase):
+    """A transient API error must never look like "resolved". Keeping is the safe direction."""
+
+    def test_unreadable_ref_is_kept_and_marked_state_unknown(self):
+        out = render([entry(BROKEN, ask="A P0 NOBODY ELSE CAN DO")])
+        self.assertIn("A P0 NOBODY ELSE CAN DO", out.body)
+        self.assertIn("state unknown", out.body)
+        self.assertEqual(out.dropped, [])
+        self.assertEqual(len(out.unknown), 1)
+
+    def test_missing_state_for_a_ref_is_unknown_not_open(self):
+        # `states` simply not containing the ref (a fetch that never happened) must land in the
+        # SAME fail-closed branch as an error, and be reported as degraded rather than silently OK.
+        out = rsh.render(
+            cfg([entry("sparq-org/sparq#999", ask="UNFETCHED")]),
+            {},
+            COUNTS,
+            date="2026-07-26",
+        )
+        self.assertIn("UNFETCHED", out.body)
+        self.assertEqual(out.dropped, [])
+        self.assertEqual(len(out.unknown), 1)
+
+    def test_refstate_is_resolved_requires_positive_evidence(self):
+        self.assertFalse(rsh.RefState(ref="r", error="boom").is_resolved())
+        self.assertFalse(rsh.RefState(ref="r", state="").is_resolved())
+        self.assertFalse(rsh.RefState(ref="r", state="open").is_resolved())
+        self.assertTrue(rsh.RefState(ref="r", state="closed").is_resolved())
+        self.assertTrue(rsh.RefState(ref="r", state="open", merged=True).is_resolved())
+
+    def test_malformed_payload_is_unknown_not_open(self):
+        # A 200 with a payload that has no usable `state` (a proxy error page, a schema change)
+        # must be UNKNOWN. Treating it as "not closed" would be luck, not a rule.
+        original = rsh._gh
+        try:
+            rsh._gh = lambda args: json.dumps({"nonsense": True})
+            state = rsh.live_ref_state("sparq-org/sparq#7")
+        finally:
+            rsh._gh = original
+        self.assertTrue(state.unknown)
+        self.assertFalse(state.is_resolved())
+
+    def test_pr_detail_failure_leaves_the_entry_unknown_not_mergeable(self):
+        original = rsh._gh
+
+        def fake(args):
+            if args[0] == "api":
+                return json.dumps({"state": "open", "pull_request": {"merged_at": None}})
+            raise RuntimeError("gh pr view exploded")
+
+        try:
+            rsh._gh = fake
+            state = rsh.live_ref_state("sparq-org/sparq#8")
+        finally:
+            rsh._gh = original
+        self.assertTrue(state.unknown)
+        self.assertEqual(rsh._pr_state_cell(state), "⚠️ state unknown")
+
+    def test_degradation_is_recorded_for_every_unreadable_ref(self):
+        status = rsh.Status()
+        states = rsh.collect_states(
+            cfg([entry(BROKEN), entry(OPEN_ISSUE)]),
+            status,
+            fetch=lambda ref: STATES[ref],
+        )
+        self.assertEqual(status.code, rsh.EXIT_DEGRADED)
+        self.assertTrue(any(BROKEN in n for n in status.notes))
+        self.assertEqual(len(states), 2)
+
+
+class TestStickyStatus(unittest.TestCase):
+    """A later transient must never discard an earlier earned failure (three prior outages)."""
+
+    def test_status_escalates_and_never_downgrades(self):
+        status = rsh.Status()
+        self.assertEqual(status.code, rsh.EXIT_OK)
+        status.degrade("first failure")
+        self.assertEqual(status.code, rsh.EXIT_DEGRADED)
+
+    def test_interleaved_sequence_keeps_the_failure(self):
+        # failure -> successes -> failure -> successes must still exit non-zero.
+        status = rsh.Status()
+        status.degrade("ref A unreadable")
+        for _ in range(5):
+            rsh.collect_states(cfg([entry(OPEN_ISSUE)]), status, fetch=lambda ref: STATES[ref])
+        self.assertEqual(status.code, rsh.EXIT_DEGRADED)
+        self.assertTrue(status.degraded)
+
+
+class TestGatedPrTable(unittest.TestCase):
+    """The table must describe the PR that exists NOW, not the one we last looked at."""
+
+    def _row(self, body: str, number: str) -> str:
+        rows = [ln for ln in body.splitlines() if ln.startswith(f"| **[#{number}]")]
+        self.assertEqual(len(rows), 1, f"expected exactly one row for #{number}")
+        return rows[0]
+
+    def test_clean_pr_keeps_the_curated_ask(self):
+        body = render([entry(CLEAN_PR, bucket="gated-pr", ask='"arm it"', what="w")]).body
+        row = self._row(body, "104")
+        self.assertIn("MERGEABLE", row)
+        self.assertIn('"arm it"', row)
+
+    def test_conflicting_pr_is_annotated_and_never_says_arm_it(self):
+        body = render([entry(CONFLICTING_PR, bucket="gated-pr", ask='"arm it"', what="w")]).body
+        row = self._row(body, "105")
+        self.assertIn("⚠️ CONFLICTING", row)
+        self.assertIn(rsh.REBASE_ASK, row)
+        self.assertNotIn('"arm it"', row)
+
+    def test_draft_blocked_pr_reports_both_facts(self):
+        body = render([entry(DRAFT_PR, bucket="gated-pr", ask="decide the scope", what="w")]).body
+        self.assertIn("draft, BLOCKED", self._row(body, "106"))
+
+    def test_unknown_mergeability_is_not_reported_as_mergeable(self):
+        # GitHub returns mergeable=UNKNOWN while it recomputes. Printing "MERGEABLE" there invites
+        # the maintainer to arm a PR that cannot merge.
+        body = render(
+            [entry(UNKNOWN_MERGEABLE_PR, bucket="gated-pr", ask='"arm it"', what="w")]
+        ).body
+        row = self._row(body, "108")
+        self.assertIn("state unknown", row)
+        self.assertNotIn("MERGEABLE", row)
+
+    def test_pr_links_point_at_pull_not_issues(self):
+        body = render([entry(CLEAN_PR, bucket="gated-pr", what="w")]).body
+        self.assertIn("https://github.com/sparq-org/sparq/pull/104", body)
+
+
+class TestNeverInvents(unittest.TestCase):
+    """The renderer may DROP, ANNOTATE and ORDER. It may not author an ask."""
+
+    def test_every_rendered_blocked_item_comes_from_the_toml(self):
+        config = rsh.load_config(CONFIG)
+        states = {
+            ref: rsh.RefState(ref=ref, state="open", is_pr=True, mergeable="MERGEABLE",
+                              merge_state_status="CLEAN")
+            for e in config.entries
+            for ref in e.refs
+        }
+        body = rsh.render(config, states, COUNTS, date="2026-07-26").body
+        curated = {" ".join(e.ask.split()) for e in config.entries}
+        for line in body.splitlines():
+            m = re.match(r"^\d+\. (.*)$", line)
+            if not m:
+                continue
+            item = m.group(1)
+            self.assertTrue(
+                any(ask.startswith(item) or item.startswith(ask[:60]) for ask in curated),
+                f"rendered 🔴 item is not traceable to the TOML: {item[:80]}",
+            )
+
+    def test_every_table_ask_cell_is_a_curated_ask_or_the_rebase_annotation(self):
+        config = rsh.load_config(CONFIG)
+        states = {
+            ref: rsh.RefState(ref=ref, is_pr=True, state="open", mergeable="CONFLICTING",
+                              merge_state_status="DIRTY")
+            for e in config.entries
+            for ref in e.refs
+        }
+        body = rsh.render(config, states, COUNTS, date="2026-07-26").body
+        curated = {" ".join(e.ask.split()) for e in config.entries} | {rsh.REBASE_ASK}
+        for line in body.splitlines():
+            if not line.startswith("| **[#"):
+                continue
+            cells = [c.strip() for c in line.strip("|").split("|")]
+            self.assertIn(cells[-1], curated, f"invented ask cell: {cells[-1][:80]}")
+
+    def test_a_ref_absent_from_the_toml_never_appears(self):
+        body = render([entry(OPEN_ISSUE)]).body
+        self.assertNotIn("#404", body)
+
+    def test_unsubstituted_placeholder_is_refused(self):
+        # The real defect: `{needs_ec2}` (a digit in the name) slipped past the substitution regex
+        # and shipped literally to the maintainer. Nothing placeholder-shaped may reach the body.
+        with self.assertRaises(rsh.RenderAborted):
+            render([entry(OPEN_ISSUE)], process=("{needs_EC2} issues",))
+
+    def test_unknown_placeholder_name_fails_validation(self):
+        doc = self._minimal_doc()
+        doc["process"] = [{"text": "{needs_ec3} issues"}]
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(doc)
+
+    def test_known_placeholders_are_substituted(self):
+        body = render([entry(OPEN_ISSUE)], process=("{needs_user}/{needs_area}/{needs_ec2}",)).body
+        self.assertIn("11/22/33", body)
+
+    @staticmethod
+    def _minimal_doc() -> dict:
+        return {
+            "meta": {"repo": "sparq-org/sparq", "issue": 1135},
+            "text": dict(TEXT),
+            "entry": [
+                {"ref": OPEN_ISSUE, "bucket": "blocked", "ask": "a", "short": "s"},
+            ],
+        }
+
+
+class TestMarkdownIntegrity(unittest.TestCase):
+    """A wrapped link is a dead link — and the link IS the ask."""
+
+    def _live_body(self) -> str:
+        config = rsh.load_config(CONFIG)
+        states = {
+            ref: rsh.RefState(ref=ref, is_pr=True, state="open", mergeable="MERGEABLE",
+                              merge_state_status="CLEAN")
+            for e in config.entries
+            for ref in e.refs
+        }
+        return rsh.render(config, states, COUNTS, date="2026-07-26").body
+
+    def test_no_link_destination_is_broken_across_a_line(self):
+        # textwrap's defaults split `https://github.com/sparq-org/...` at the hyphen, and a newline
+        # inside a markdown link destination silently un-links it — so the maintainer loses the link
+        # to the very thing they are being asked about. Measured on the first render of this file.
+        body = self._live_body()
+        for target in re.findall(r"\]\(([^)]*)\)", body):
+            self.assertNotIn("\n", target, f"wrapped link destination: {target[:60]}")
+            self.assertNotRegex(target, r"\s", f"whitespace in link destination: {target[:60]}")
+
+    def test_every_markdown_link_is_closed(self):
+        body = self._live_body()
+        self.assertEqual(body.count("]("), len(re.findall(r"\]\([^)\s]+\)", body)))
+
+    def test_table_rows_have_the_declared_column_count(self):
+        # An unescaped pipe in curated copy shifts every later cell, which is how a "State" column
+        # ends up displaying half an ask. Checked per SECTION, since the two tables differ in width.
+        body = self._live_body()
+        for header, width in (
+            ("## 🟡 Decisions", 2),
+            ("## 🟡 Maintainer-gated PRs", 4),
+        ):
+            section = body.split(header, 1)[1].split("\n## ", 1)[0]
+            rows = [ln for ln in section.splitlines() if ln.startswith("| **[#")]
+            self.assertTrue(rows, f"no rows rendered under {header}")
+            for row in rows:
+                self.assertEqual(len(row.strip("|").split("|")), width, row[:80])
+
+
+class TestConfigValidation(unittest.TestCase):
+    """A malformed curated file must fail loudly rather than render half a door."""
+
+    def doc(self, **entry_overrides) -> dict:
+        base = {"ref": OPEN_ISSUE, "bucket": "blocked", "ask": "a", "short": "s"}
+        base.update(entry_overrides)
+        return {
+            "meta": {"repo": "sparq-org/sparq", "issue": 1135},
+            "text": dict(TEXT),
+            "entry": [base],
+        }
+
+    def test_the_shipped_toml_validates(self):
+        config = rsh.load_config(CONFIG)
+        self.assertEqual(config.repo, "sparq-org/sparq")
+        self.assertEqual(config.issue, 1135)
+        self.assertTrue(config.bucket("blocked"))
+        self.assertTrue(config.bucket("decision"))
+        self.assertTrue(config.bucket("gated-pr"))
+
+    def test_unknown_bucket_is_rejected(self):
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(bucket="urgent"))
+
+    def test_missing_short_is_rejected(self):
+        # `short` is what the removed-as-resolved line prints; without it a dropped entry becomes
+        # an unattributed number.
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(short=""))
+
+    def test_a_refless_entry_must_declare_untracked(self):
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(ref=""))
+        rsh.parse_config(self.doc(ref="", untracked=True))  # declared => fine
+
+    def test_untracked_contradicting_a_ref_is_rejected(self):
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(untracked=True))
+
+    def test_malformed_ref_is_rejected(self):
+        for bad in ("#123", "sparq-org/sparq", "sparq-org/sparq#0", "https://…/issues/1"):
+            with self.assertRaises(rsh.RenderAborted):
+                rsh.parse_config(self.doc(ref=bad))
+
+    def test_cross_repo_ref_is_accepted_and_labelled_with_its_repo(self):
+        config = rsh.parse_config(self.doc(ref="jeswr/agent-account-registry#278"))
+        self.assertEqual(config.entries[0].refs, ["jeswr/agent-account-registry#278"])
+        self.assertEqual(rsh._ref_label("jeswr/agent-account-registry#278"),
+                         "jeswr/agent-account-registry#278")
+
+    def test_gated_pr_entry_needs_what_and_exactly_one_ref(self):
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(bucket="gated-pr", what=""))
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(bucket="gated-pr", what="w", ref=[OPEN_ISSUE, CLEAN_PR]))
+
+    def test_a_pipe_in_a_table_cell_is_rejected(self):
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(self.doc(bucket="decision", ask="A | B"))
+
+    def test_an_empty_entry_list_is_rejected(self):
+        doc = self.doc()
+        doc["entry"] = []
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.parse_config(doc)
+
+
+class TestTruncation(unittest.TestCase):
+    """65 536 chars is a hard GitHub limit. 🟢 gives way; 🔴 never does."""
+
+    RED = "THE UNPUBLISHED NPM PACKAGE — ONLY THE MAINTAINER CAN DO THIS"
+
+    def _oversized(self, limit=6000, flight_items=40):
+        entries = [entry(OPEN_ISSUE, ask=self.RED), entry(CLEAN_PR, bucket="decision", ask="DECIDE")]
+        config = cfg(entries, flight=[f"flight item {i} " + "x" * 400 for i in range(flight_items)])
+        return rsh.render(config, STATES, COUNTS, date="2026-07-26", limit=limit)
+
+    def test_oversized_body_truncates_green_and_keeps_red(self):
+        out = self._oversized()
+        self.assertLessEqual(len(out.body), 6000)
+        self.assertIn(self.RED, out.body)
+        self.assertIn("DECIDE", out.body)
+        self.assertIn("truncated to fit", out.body)
+
+    def test_untruncated_body_keeps_every_green_item(self):
+        # Discrimination: the truncation path must be entered only when needed.
+        out = self._oversized(limit=rsh.BODY_LIMIT)
+        self.assertIn("flight item 39", out.body)
+        self.assertNotIn("truncated to fit", out.body)
+
+    def test_green_items_are_dropped_from_the_tail_first(self):
+        out = self._oversized(limit=4000)
+        self.assertIn("flight item 0", out.body)
+        self.assertNotIn("flight item 39", out.body)
+
+    def test_removed_list_gives_way_before_the_process_notes(self):
+        entries = [entry(OPEN_ISSUE, ask=self.RED)] + [
+            rsh.Entry(refs=[CLOSED_ISSUE], bucket="blocked", ask="gone", short=f"resolved-{i}")
+            for i in range(200)
+        ]
+        config = cfg(entries, process=("PROCESS NOTE {needs_user}",), flight=("green",))
+        out = rsh.render(config, STATES, COUNTS, date="2026-07-26", limit=2600)
+        self.assertLessEqual(len(out.body), 2600)
+        self.assertIn(self.RED, out.body)
+        self.assertIn("resolved entries were dropped", out.body)
+        self.assertNotIn("resolved-199", out.body)
+
+    def test_a_red_section_that_cannot_fit_aborts_instead_of_being_cut(self):
+        entries = [
+            rsh.Entry(refs=[OPEN_ISSUE], bucket="blocked", ask="RED " + "y" * 900, short=f"r{i}")
+            for i in range(20)
+        ]
+        with self.assertRaises(rsh.RenderAborted):
+            rsh.render(cfg(entries), STATES, COUNTS, date="2026-07-26", limit=3000)
+
+    def test_the_live_body_fits_with_room_to_spare(self):
+        config = rsh.load_config(CONFIG)
+        states = {
+            ref: rsh.RefState(ref=ref, state="open", is_pr=True, mergeable="MERGEABLE",
+                              merge_state_status="CLEAN")
+            for e in config.entries
+            for ref in e.refs
+        }
+        body = rsh.render(config, states, COUNTS, date="2026-07-26").body
+        self.assertLess(len(body), rsh.BODY_LIMIT)
+        self.assertNotIn("truncated to fit", body)
+
+
+class FakeGh:
+    """Intercepts every `gh` invocation the renderer makes, and records it."""
+
+    def __init__(self, *, body="stale body", fail=(), counts=3):
+        self.calls: list[list[str]] = []
+        self.published: list[str] = []
+        self.body = body
+        self.fail = tuple(fail)
+        self.counts = counts
+
+    def __call__(self, args: list[str]) -> str:
+        self.calls.append(list(args))
+        joined = " ".join(args)
+        for token in self.fail:
+            if token in joined:
+                raise RuntimeError(f"simulated failure for {token}")
+        if args[:1] == ["api"]:
+            return json.dumps({"state": "open"})
+        if args[:2] == ["pr", "view"]:
+            return json.dumps(
+                {"isDraft": False, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}
+            )
+        if args[:2] == ["issue", "list"]:
+            return json.dumps([{"number": i} for i in range(self.counts)])
+        if args[:2] == ["pr", "list"]:
+            return json.dumps([{"number": 1, "mergeable": "CONFLICTING"}])
+        if args[:2] == ["issue", "view"]:
+            return json.dumps({"body": self.body})
+        if args[:2] == ["issue", "edit"]:
+            path = args[args.index("--body-file") + 1]
+            self.published.append(Path(path).read_text(encoding="utf-8"))
+            return ""
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    def edits(self) -> list[list[str]]:
+        return [c for c in self.calls if c[:2] == ["issue", "edit"]]
+
+
+class MainHarness(unittest.TestCase):
+    def run_main(self, argv, fake: FakeGh):
+        original = rsh._gh
+        rsh._gh = fake
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf):
+                code = rsh.main(argv)
+        finally:
+            rsh._gh = original
+        return code, buf.getvalue()
+
+
+class TestPublishPath(MainHarness):
+    """No no-op churn; a degraded run still publishes but still reds; an aggregate failure aborts."""
+
+    ARGV = ["--config", str(CONFIG)]
+
+    def test_edit_happens_when_the_body_differs(self):
+        fake = FakeGh(body="a stale hand-written body")
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(code, rsh.EXIT_OK)
+        self.assertEqual(len(fake.edits()), 1)
+        self.assertIn("🔴 Only you can unblock", fake.published[0])
+
+    def test_identical_body_is_not_re_published(self):
+        # Notification spam is how a front door gets muted, so an unchanged render must not edit.
+        fake = FakeGh(body="whatever")
+        self.run_main(self.ARGV, fake)
+        rendered = fake.published[0]
+        again = FakeGh(body=rendered)
+        code, _ = self.run_main(self.ARGV, again)
+        self.assertEqual(code, rsh.EXIT_OK)
+        self.assertEqual(again.edits(), [], "an identical body must not be re-published")
+
+    def test_dry_run_touches_nothing_and_prints_the_body(self):
+        fake = FakeGh(body="stale")
+        code, printed = self.run_main([*self.ARGV, "--dry-run"], fake)
+        self.assertEqual(code, rsh.EXIT_OK)
+        self.assertEqual(fake.edits(), [])
+        self.assertNotIn(["issue", "view"], [c[:2] for c in fake.calls])
+        self.assertIn("🔴 Only you can unblock", printed)
+
+    def test_a_label_count_failure_aborts_without_publishing(self):
+        # Aggregate numbers have no per-item "unknown" marker to hang on, so a body built from a
+        # failed count would be a confident lie. Abort, publish nothing.
+        fake = FakeGh(body="stale", fail=("issue list",))
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(code, rsh.EXIT_ABORT)
+        self.assertEqual(fake.edits(), [])
+
+    def test_a_held_pr_list_failure_aborts_without_publishing(self):
+        fake = FakeGh(body="stale", fail=("pr list",))
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(code, rsh.EXIT_ABORT)
+        self.assertEqual(fake.edits(), [])
+
+    def test_a_per_ref_failure_publishes_everything_but_still_exits_non_zero(self):
+        # THE WORST FAILURE would be silently omitting a P0 because of a transient 403. So the
+        # entry stays, marked, and the process exits non-zero so the job reds.
+        fake = FakeGh(body="stale", fail=("repos/sparq-org/sparq/issues/53",))
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(code, rsh.EXIT_DEGRADED)
+        self.assertEqual(len(fake.edits()), 1)
+        published = fake.published[0]
+        self.assertIn("npm bootstrap publish", published)
+        self.assertIn("state unknown", published)
+        self.assertIn("ran DEGRADED", published)
+
+    def test_an_edit_failure_aborts_non_zero(self):
+        fake = FakeGh(body="stale", fail=("issue edit",))
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(code, rsh.EXIT_ABORT)
+
+    def test_if_ref_for_an_unlisted_ref_costs_nothing(self):
+        # The cost guard: at 60 merges/hour a full render per close would exceed GITHUB_TOKEN's
+        # 1000 requests/hour/repository budget.
+        fake = FakeGh(body="stale")
+        code, _ = self.run_main([*self.ARGV, "--if-ref", "sparq-org/sparq#999999"], fake)
+        self.assertEqual(code, rsh.EXIT_OK)
+        self.assertEqual(fake.calls, [], "an unlisted ref must not cost a single API call")
+
+    def test_if_ref_for_a_listed_ref_renders(self):
+        fake = FakeGh(body="stale")
+        code, _ = self.run_main([*self.ARGV, "--if-ref", "sparq-org/sparq#53"], fake)
+        self.assertEqual(code, rsh.EXIT_OK)
+        self.assertEqual(len(fake.edits()), 1)
+
+    def test_a_broken_toml_aborts_before_any_api_call(self):
+        fake = FakeGh(body="stale")
+        code, _ = self.run_main(["--config", str(FIXTURE)], fake)  # markdown, not TOML
+        self.assertEqual(code, rsh.EXIT_ABORT)
+        self.assertEqual(fake.calls, [])
+
+
+class TestLiveQueries(MainHarness):
+    """Which API the counts come from is a correctness question, not a style one."""
+
+    def test_counts_use_the_list_api_not_the_lagging_search_index(self):
+        # MEASURED 2026-07-26: search/issues reported 34 issues on needs:ec2 while the list API
+        # reported 35. Rendering a stale number as "live" is the same class of dishonesty this
+        # whole issue is about.
+        fake = FakeGh(body="stale")
+        self.run_main(["--config", str(CONFIG), "--dry-run"], fake)
+        joined = [" ".join(c) for c in fake.calls]
+        self.assertTrue(any(c.startswith("issue list") for c in joined))
+        self.assertFalse(
+            any("search/issues" in c or "--search" in c for c in joined),
+            "label populations must not be read from the search index",
+        )
+
+    def test_every_needs_label_population_is_queried(self):
+        fake = FakeGh(body="stale")
+        self.run_main(["--config", str(CONFIG), "--dry-run"], fake)
+        joined = " || ".join(" ".join(c) for c in fake.calls)
+        for label in ("needs:user", "needs:area", "needs:ec2"):
+            self.assertIn(f"--label {label}", joined)
+        self.assertIn("--label review:needs-user", joined)
+
+    def test_held_pr_conflict_count_is_derived_from_the_live_list(self):
+        counts = rsh.live_counts.__wrapped__ if hasattr(rsh.live_counts, "__wrapped__") else None
+        self.assertIsNone(counts)  # no caching decorator may hide a stale count
+        fake = FakeGh(body="stale")
+        original = rsh._gh
+        rsh._gh = fake
+        try:
+            got = rsh.live_counts("sparq-org/sparq")
+        finally:
+            rsh._gh = original
+        self.assertEqual(got.held_prs, 1)
+        self.assertEqual(got.held_prs_conflicting, 1)
+
+
+class TestSeedFidelity(unittest.TestCase):
+    """The migration from the hand-written body must not have silently lost an ask."""
+
+    def test_every_ref_in_the_2026_07_26_body_survives_the_migration(self):
+        fixture = FIXTURE.read_text(encoding="utf-8")
+        config = rsh.load_config(CONFIG)
+        states = {
+            ref: rsh.RefState(ref=ref, is_pr=True, state="open", mergeable="MERGEABLE",
+                              merge_state_status="CLEAN")
+            for e in config.entries
+            for ref in e.refs
+        }
+        body = rsh.render(config, states, COUNTS, date="2026-07-26").body
+        wanted = set(re.findall(r"#(\d{2,5})\b", fixture))
+        got = set(re.findall(r"#(\d{2,5})\b", body))
+        self.assertEqual(
+            wanted - got,
+            set(),
+            "these refs were on the maintainer's front door on 2026-07-26 and are not in the "
+            "rendered output — an ask was lost in the migration to the TOML",
+        )
+
+    def test_the_seven_stale_entries_are_seeded_so_the_first_render_drops_them(self):
+        config = rsh.load_config(CONFIG)
+        refs = {ref for e in config.entries for ref in e.refs}
+        for number in (1848, 992, 1917, 1084, 1791, 1155, 1973):
+            self.assertIn(f"sparq-org/sparq#{number}", refs)
+
+    def test_the_curated_gated_pr_asks_never_hard_code_a_state(self):
+        # The State column is LIVE. A hand-written "CONFLICTING"/"MERGEABLE" in the curated copy is
+        # exactly the decay this issue is about.
+        config = rsh.load_config(CONFIG)
+        for e in config.bucket("gated-pr"):
+            for token in ("CONFLICTING", "MERGEABLE", "BLOCKED"):
+                self.assertNotIn(token, e.ask + e.what, f"{e.short}: state belongs to live data")
+
+
+class TestRefreshWorkflowWiring(unittest.TestCase):
+    """THE YAML SEAM — parsed structurally, because text assertions cannot see `if: false`."""
+
+    def setUp(self):
+        self.doc = workflow()
+        self.jobs = self.doc.get("jobs") or {}
+        self.job = self.jobs.get("refresh") or {}
+        self.steps = self.job.get("steps") or []
+
+    # --- triggers -----------------------------------------------------------------------------
+    def test_schedule_trigger_exists(self):
+        crons = [c.get("cron") for c in triggers(self.doc).get("schedule") or []]
+        self.assertTrue(crons, "without a cron the front door only refreshes on close events")
+        for cron in crons:
+            self.assertRegex(str(cron), r"^\S+( \S+){4}$")
+
+    def test_schedule_runs_several_times_a_day(self):
+        crons = [str(c["cron"]) for c in triggers(self.doc)["schedule"]]
+        hours = set()
+        for cron in crons:
+            hour_field = cron.split()[1]
+            hours.update(hour_field.split(",")) if hour_field != "*" else hours.add("*")
+        self.assertGreaterEqual(len(hours), 2, "#4145 asks for a few refreshes a day")
+
+    def test_close_events_are_wired_for_prompt_removal(self):
+        got = triggers(self.doc)
+        self.assertEqual((got.get("issues") or {}).get("types"), ["closed"])
+        self.assertEqual((got.get("pull_request") or {}).get("types"), ["closed"])
+
+    def test_workflow_dispatch_exists(self):
+        self.assertIn("workflow_dispatch", triggers(self.doc))
+
+    # --- permissions --------------------------------------------------------------------------
+    def test_workflow_level_permissions_are_read_only(self):
+        self.assertEqual(self.doc.get("permissions"), {"contents": "read"})
+
+    def test_the_job_has_exactly_the_writes_it_needs(self):
+        perms = self.job.get("permissions")
+        self.assertIsInstance(perms, dict, "the job must declare explicit permissions")
+        self.assertEqual(perms.get("issues"), "write", "it edits #1135")
+        self.assertEqual(perms.get("pull-requests"), "read")
+        self.assertEqual(perms.get("contents"), "read", "no contents:write — it pushes nothing")
+        self.assertNotIn("actions", perms)
+
+    # --- steps --------------------------------------------------------------------------------
+    def test_every_action_is_sha_pinned(self):
+        for step in self.steps:
+            if "uses" in step:
+                self.assertRegex(str(step["uses"]).split(" #")[0], SHA_PINNED.pattern)
+
+    def test_checkout_does_not_persist_credentials(self):
+        checkout = [s for s in self.steps if str(s.get("uses", "")).startswith("actions/checkout@")]
+        self.assertEqual(len(checkout), 1)
+        self.assertIs((checkout[0].get("with") or {}).get("persist-credentials"), False)
+
+    def _render_steps(self) -> list[dict]:
+        return [s for s in self.steps if "render-start-here.py" in str(s.get("run", ""))]
+
+    def test_the_renderer_is_actually_invoked(self):
+        self.assertTrue(self._render_steps(), "a workflow that never runs the renderer is theatre")
+
+    def test_the_self_test_runs_before_the_live_render(self):
+        runs = [str(s.get("run", "")) for s in self.steps]
+        self_test = [i for i, r in enumerate(runs) if "--self-test" in r]
+        live = [i for i, r in enumerate(runs) if self._is_live_invocation(r)]
+        self.assertTrue(self_test, "the hermetic self-test step is missing")
+        self.assertTrue(live, "the live render step is missing")
+        self.assertLess(min(self_test), min(live), "validate the TOML before rewriting the issue")
+
+    @staticmethod
+    def _is_live_invocation(run: str) -> bool:
+        for line in run.splitlines():
+            line = line.strip()
+            if not line.startswith("python3 scripts/render-start-here.py"):
+                continue
+            if "--self-test" in line:
+                continue
+            return True
+        return False
+
+    def test_the_live_step_is_not_secretly_a_dry_run(self):
+        # The classic wrong-input mutant: `--dry-run` on the live step makes the workflow green
+        # forever while the front door never changes.
+        live = [s for s in self.steps if self._is_live_invocation(str(s.get("run", "")))]
+        self.assertTrue(live)
+        for step in live:
+            self.assertNotIn("--dry-run", str(step["run"]))
+
+    def test_the_live_step_has_a_token(self):
+        for step in self.steps:
+            if self._is_live_invocation(str(step.get("run", ""))):
+                self.assertIn("GH_TOKEN", (step.get("env") or {}))
+
+    def test_close_events_pass_the_if_ref_cost_guard(self):
+        run = "\n".join(str(s.get("run", "")) for s in self.steps)
+        self.assertIn("--if-ref", run, "an on-close run must not cost a full render")
+        self.assertIn("github.event.issue.number", run)
+        self.assertIn("github.event.pull_request.number", run)
+
+    def test_the_scripts_the_workflow_names_exist(self):
+        run = "\n".join(str(s.get("run", "")) for s in self.steps)
+        for path in re.findall(r"python3 (scripts/[\w./-]+)", run):
+            self.assertTrue((REPO_ROOT / path).is_file(), f"{path} does not exist")
+
+    # --- disabling ----------------------------------------------------------------------------
+    def test_no_job_or_step_is_disabled(self):
+        # `if: false` is invisible to a substring assertion and turns the whole fix into a no-op.
+        falsey = (False, "false", "${{ false }}", "0", None)
+        for name, job in self.jobs.items():
+            if "if" in job:
+                self.assertNotIn(job["if"], falsey, f"job {name} is disabled")
+            for i, step in enumerate(job.get("steps") or []):
+                if "if" in step:
+                    self.assertNotIn(step["if"], falsey, f"{name} step {i} is disabled")
+
+    def test_fork_pull_request_events_are_skipped(self):
+        # A fork PR close gets a read-only token, so the edit can only fail. Without this guard the
+        # job reds on every external contributor's PR and the real failures get ignored.
+        guard = " ".join(str(self.job.get("if", "")).split())
+        self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", guard)
+        self.assertIn("github.event_name != 'pull_request'", guard)
+
+    def test_concurrency_is_serialised_with_a_cron_backstop(self):
+        concurrency = self.doc.get("concurrency")
+        self.assertIsInstance(concurrency, dict)
+        self.assertTrue(concurrency.get("group"))
+        # cancel-in-progress is only safe BECAUSE a schedule re-renders unconditionally.
+        if concurrency.get("cancel-in-progress"):
+            self.assertTrue(triggers(self.doc).get("schedule"))
+
+
+class TestSelfTestWorkflowWiring(unittest.TestCase):
+    """A suite no workflow runs is not a gate (the ready-issues.py regression, #3423)."""
+
+    def setUp(self):
+        self.doc = workflow(SELF_TEST_WORKFLOW)
+
+    def test_this_suite_and_the_renderer_self_test_are_invoked(self):
+        runs = [
+            str(step.get("run", ""))
+            for job in (self.doc.get("jobs") or {}).values()
+            for step in (job.get("steps") or [])
+        ]
+        joined = "\n".join(runs)
+        self.assertIn("python3 scripts/render-start-here.py --self-test", joined)
+        self.assertIn("python3 scripts/tests/test_start_here_render.py", joined)
+
+    def test_every_front_door_file_is_a_path_trigger_on_both_events(self):
+        got = triggers(self.doc)
+        for event in ("pull_request", "push"):
+            paths = (got.get(event) or {}).get("paths") or []
+            for needed in (
+                "orchestration/start-here.toml",
+                "scripts/render-start-here.py",
+                "scripts/tests/test_start_here_render.py",
+                ".github/workflows/refresh-start-here.yml",
+            ):
+                self.assertIn(needed, paths, f"{needed} must re-run this gate on {event}")
+
+    def test_the_gate_job_is_not_disabled_and_stays_gate_discoverable(self):
+        for name, job in (self.doc.get("jobs") or {}).items():
+            self.assertNotIn(job.get("if", "unset"), (False, "false"), f"job {name} disabled")
+            job_name = str(job.get("name", "")).lower()
+            # ci-summary treats a sibling as GATING iff its name says neither of these.
+            self.assertNotIn("advisory", job_name)
+            self.assertNotIn("informational", job_name)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_start_here_render.py
+++ b/scripts/tests/test_start_here_render.py
@@ -298,6 +298,37 @@ class TestFailClosed(unittest.TestCase):
         self.assertTrue(state.unknown)
         self.assertEqual(rsh._pr_state_cell(state), "⚠️ state unknown")
 
+    def test_a_partially_read_pr_is_unknown_even_though_it_looks_mergeable(self):
+        # DISCRIMINATING case for the `state.unknown` short-circuit in _pr_state_cell: a ref whose
+        # error is set but whose mergeable field happens to be populated (a read that failed
+        # half-way, a cached value). Falling through to the mergeable branch would print
+        # "MERGEABLE" about a PR we did not actually manage to read.
+        half_read = rsh.RefState(
+            ref="sparq-org/sparq#9",
+            is_pr=True,
+            state="open",
+            mergeable="MERGEABLE",
+            merge_state_status="CLEAN",
+            error="connection reset after the first read",
+        )
+        self.assertEqual(rsh._pr_state_cell(half_read), "⚠️ state unknown")
+        self.assertFalse(half_read.is_resolved())
+
+    def test_an_unexpected_state_string_is_unknown_not_trusted(self):
+        # `{"state": "reopened"}` / a non-string state must land in the UNKNOWN branch. Without the
+        # payload check the value is trusted verbatim, and `42.lower()` raises deep inside the
+        # render instead of being reported as an unreadable ref.
+        original = rsh._gh
+        try:
+            for payload in ({"state": "reopened"}, {"state": 42}, {"state": None}, {}):
+                rsh._gh = lambda args, p=payload: json.dumps(p)
+                state = rsh.live_ref_state("sparq-org/sparq#7")
+                self.assertTrue(state.unknown, f"{payload} must be UNKNOWN")
+                self.assertFalse(state.is_resolved())
+                self.assertEqual(rsh._pr_state_cell(state), "⚠️ state unknown")
+        finally:
+            rsh._gh = original
+
     def test_degradation_is_recorded_for_every_unreadable_ref(self):
         status = rsh.Status()
         states = rsh.collect_states(
@@ -318,6 +349,16 @@ class TestStickyStatus(unittest.TestCase):
         self.assertEqual(status.code, rsh.EXIT_OK)
         status.degrade("first failure")
         self.assertEqual(status.code, rsh.EXIT_DEGRADED)
+
+    def test_a_later_lower_severity_report_cannot_clear_an_earlier_failure(self):
+        # The exact shape of the three prior outages: a LATER transient (reported at a lower
+        # severity) overwriting an EARLIER earned hard failure. `degrade` must be a monotone
+        # maximum, not an assignment.
+        status = rsh.Status()
+        status.degrade("a ref could not be read", code=rsh.EXIT_DEGRADED)
+        status.degrade("something benign happened afterwards", code=rsh.EXIT_OK)
+        self.assertEqual(status.code, rsh.EXIT_DEGRADED)
+        self.assertTrue(status.degraded)
 
     def test_interleaved_sequence_keeps_the_failure(self):
         # failure -> successes -> failure -> successes must still exit non-zero.

--- a/scripts/tests/test_start_here_render.py
+++ b/scripts/tests/test_start_here_render.py
@@ -27,10 +27,12 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import io
 import json
 import re
+import subprocess
 import sys
 import unittest
 from contextlib import redirect_stdout
@@ -269,6 +271,86 @@ class TestFailClosed(unittest.TestCase):
         self.assertFalse(rsh.RefState(ref="r", state="open").is_resolved())
         self.assertTrue(rsh.RefState(ref="r", state="closed").is_resolved())
         self.assertTrue(rsh.RefState(ref="r", state="open", merged=True).is_resolved())
+
+    def test_a_resolved_looking_ref_whose_read_failed_is_not_resolved(self):
+        """The `if self.unknown: return False` guard in is_resolved(), pinned for ITS reason.
+
+        `RefState(error="boom")` above does NOT discriminate that guard: with the guard deleted
+        it still returns False, via `state.lower() != "closed"`. So an assertion on that fixture
+        passes because the state is empty, not because unknown-is-never-resolved — a
+        non-discriminating fixture on the single most important invariant in the file. The guard
+        only becomes load-bearing when a ref LOOKS resolved and the read failed, which is what
+        this asserts. No live `live_ref_state` exit produces that combination today (every error
+        path leaves `state` at ''/'open'; the merged/closed paths early-return before `error`
+        can be set), which is precisely why it takes a constructed fixture: the guard is what
+        stops a future caller — a cached payload, a partial GraphQL read, a second data source —
+        from turning a 403 into "resolved, drop the maintainer's P0".
+        """
+        self.assertFalse(rsh.RefState(ref="r", state="closed", error="HTTP 403").is_resolved())
+        self.assertFalse(
+            rsh.RefState(ref="r", is_pr=True, state="open", merged=True, error="HTTP 403")
+            .is_resolved()
+        )
+        # ...and end to end: kept, marked, counted as degraded, never in the removed list.
+        ref = "sparq-org/sparq#111"
+        out = rsh.render(
+            cfg([entry(ref, ask="LOOKS DONE, READ FAILED")]),
+            {ref: rsh.RefState(ref=ref, state="closed", error="HTTP 403")},
+            COUNTS,
+            date="2026-07-26",
+        )
+        self.assertIn("LOOKS DONE, READ FAILED", out.body)
+        self.assertEqual(out.dropped, [])
+        self.assertEqual(len(out.unknown), 1)
+        self.assertNotIn("Removed as resolved", out.body)
+
+    def test_a_ref_whose_state_never_arrived_is_unknown_even_with_no_error(self):
+        """The `not self.state` clause of `unknown` — the other half of the same guard.
+
+        Deleting it leaves every `is_resolved()` assertion green (an empty state is still not
+        "closed"), so nothing above can see it go. What it actually controls is whether the ref
+        is REPORTED: without it a state-less ref renders with no `state unknown` marker and the
+        run exits 0.
+        """
+        empty = rsh.RefState(ref="sparq-org/sparq#112")
+        self.assertTrue(empty.unknown)
+        status = rsh.Status()
+        rsh.collect_states(cfg([entry(empty.ref)]), status, fetch=lambda ref: empty)
+        self.assertEqual(status.code, rsh.EXIT_DEGRADED)
+        out = rsh.render(
+            cfg([entry(empty.ref, ask="NO STATE AT ALL")]), {empty.ref: empty}, COUNTS,
+            date="2026-07-26",
+        )
+        self.assertIn("state unknown", out.body)
+        self.assertEqual(out.dropped, [])
+
+    def test_a_pr_whose_mergeable_field_never_arrived_is_recorded_as_an_error(self):
+        """`if not out.mergeable: out.error = ...` in live_ref_state.
+
+        Deleting it turns exit 3 into exit 0 AND reverts the ask to the curated "arm it" for a
+        PR whose mergeability was never read. `test_pr_detail_failure_leaves_the_entry_unknown`
+        covers the EXCEPTION path; `test_unknown_mergeability_is_not_reported_as_mergeable` uses
+        `mergeable="UNKNOWN"`, which is non-empty and never reaches this branch. So this is the
+        one that sees it.
+        """
+        original = rsh._gh
+
+        def fake(args):
+            if args[0] == "api":
+                return json.dumps({"state": "open", "pull_request": {"merged_at": None}})
+            # A 200 with the mergeability field simply absent (a partial GraphQL response, a
+            # schema change, a permissions-trimmed payload).
+            return json.dumps({"isDraft": False, "mergeStateStatus": "CLEAN"})
+
+        try:
+            rsh._gh = fake
+            state = rsh.live_ref_state("sparq-org/sparq#10")
+        finally:
+            rsh._gh = original
+        self.assertEqual(state.mergeable, "")
+        self.assertIsNotNone(state.error, "an absent mergeable field must be recorded as unread")
+        self.assertTrue(state.unknown)
+        self.assertFalse(state.is_resolved())
 
     def test_malformed_payload_is_unknown_not_open(self):
         # A 200 with a payload that has no usable `state` (a proxy error page, a schema change)
@@ -680,12 +762,19 @@ class TestTruncation(unittest.TestCase):
 class FakeGh:
     """Intercepts every `gh` invocation the renderer makes, and records it."""
 
-    def __init__(self, *, body="stale body", fail=(), counts=3):
+    CLEAN_DETAIL = {"isDraft": False, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}
+
+    def __init__(self, *, body="stale body", fail=(), counts=3, pr_numbers=(), pr_view=None):
         self.calls: list[list[str]] = []
         self.published: list[str] = []
         self.body = body
         self.fail = tuple(fail)
         self.counts = counts
+        # Refs the `issues` API should report as PULL REQUESTS (so the renderer goes on to read
+        # `gh pr view`), and the detail payload it gets back. Default: no ref is a PR, and the
+        # detail is a clean mergeable one — i.e. exactly the previous behaviour.
+        self.pr_numbers = {str(n).rpartition("#")[2] for n in pr_numbers}
+        self.pr_view = dict(self.CLEAN_DETAIL) if pr_view is None else dict(pr_view)
 
     def __call__(self, args: list[str]) -> str:
         self.calls.append(list(args))
@@ -694,11 +783,11 @@ class FakeGh:
             if token in joined:
                 raise RuntimeError(f"simulated failure for {token}")
         if args[:1] == ["api"]:
+            if args[1].rpartition("/")[2] in self.pr_numbers:
+                return json.dumps({"state": "open", "pull_request": {"merged_at": None}})
             return json.dumps({"state": "open"})
         if args[:2] == ["pr", "view"]:
-            return json.dumps(
-                {"isDraft": False, "mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"}
-            )
+            return json.dumps(self.pr_view)
         if args[:2] == ["issue", "list"]:
             return json.dumps([{"number": i} for i in range(self.counts)])
         if args[:2] == ["pr", "list"]:
@@ -808,6 +897,171 @@ class TestPublishPath(MainHarness):
         code, _ = self.run_main(["--config", str(FIXTURE)], fake)  # markdown, not TOML
         self.assertEqual(code, rsh.EXIT_ABORT)
         self.assertEqual(fake.calls, [])
+
+
+class TestEveryExitPathIsSticky(MainHarness):
+    """`return status.code` at EVERY return path of main(), not only the publish one.
+
+    Exit-zero-swallowing is the class this repo has now been bitten by EIGHT times, and this is
+    the PR that advertises sticky exit as a headline guard — so "the publish path is pinned" is
+    not good enough. `return status.code` -> `return EXIT_OK` survived at both the `--dry-run`
+    branch and the `already up to date` branch when only
+    `test_a_per_ref_failure_publishes_everything_but_still_exits_non_zero` existed.
+
+    The `already up to date` branch is REACHABLE and is where a swallowed non-zero costs most: a
+    persistent 403 on a 🔴 ref renders an IDENTICAL degraded body next pass, so no edit happens
+    and main falls through that branch. Because it reads "already up to date", `return EXIT_OK`
+    there is a natural-looking cleanup — and it would leave the cron green while the front door
+    carries an unverified P0 indefinitely with nobody alerted.
+    """
+
+    ARGV = ["--config", str(CONFIG)]
+    # The npm-bootstrap credential ask: P0, and something only the maintainer can do.
+    P0 = "repos/sparq-org/sparq/issues/53"
+
+    @staticmethod
+    def _refs_in_read_order() -> list[str]:
+        seen: list[str] = []
+        for e in rsh.load_config(CONFIG).entries:
+            for ref in e.refs:
+                if ref not in seen:
+                    seen.append(ref)
+        return seen
+
+    def _steady_state(self, fail) -> FakeGh:
+        """Publish once, then hand back a FakeGh primed with that EXACT body.
+
+        This is the real steady state of a persistent per-ref failure, so the second run takes
+        the `already up to date` branch for the same reason production does.
+        """
+        first = FakeGh(body="a stale hand-written body", fail=fail)
+        code, _ = self.run_main(self.ARGV, first)
+        self.assertEqual(code, rsh.EXIT_DEGRADED)
+        self.assertEqual(len(first.published), 1)
+        return FakeGh(body=first.published[0], fail=fail)
+
+    def test_dry_run_with_a_degraded_ref_still_exits_non_zero(self):
+        fake = FakeGh(body="stale", fail=(self.P0,))
+        code, printed = self.run_main([*self.ARGV, "--dry-run"], fake)
+        self.assertEqual(code, rsh.EXIT_DEGRADED, "--dry-run must not swallow the degradation")
+        self.assertEqual(fake.edits(), [])
+        self.assertIn("state unknown", printed)
+
+    def test_an_already_up_to_date_body_still_exits_non_zero_when_degraded(self):
+        again = self._steady_state((self.P0,))
+        code, _ = self.run_main(self.ARGV, again)
+        self.assertEqual(again.edits(), [], "an identical body must not be re-published")
+        self.assertEqual(
+            code, rsh.EXIT_DEGRADED,
+            "'already up to date' must not clear the 403 — the P0 is still unverified",
+        )
+
+    def test_a_failure_on_the_FIRST_ref_survives_every_later_success(self):
+        # Interleaving, order A: degrade first, then dozens of clean reads, then the up-to-date
+        # branch. A last-write-wins status, or a literal 0 on that branch, both go red here.
+        first_ref = self._refs_in_read_order()[0]
+        token = "issues/" + first_ref.rpartition("#")[2]
+        again = self._steady_state((token,))
+        code, _ = self.run_main(self.ARGV, again)
+        self.assertEqual(again.edits(), [])
+        self.assertEqual(code, rsh.EXIT_DEGRADED)
+
+    def test_a_failure_on_the_LAST_ref_survives_every_earlier_success(self):
+        # Interleaving, order B: the successes come FIRST. Neither order may return 0.
+        last_ref = self._refs_in_read_order()[-1]
+        token = "issues/" + last_ref.rpartition("#")[2]
+        again = self._steady_state((token,))
+        code, _ = self.run_main(self.ARGV, again)
+        self.assertEqual(again.edits(), [])
+        self.assertEqual(code, rsh.EXIT_DEGRADED)
+        # ...and on the --dry-run path too, in that same order.
+        dry = FakeGh(body="stale", fail=(token,))
+        self.assertEqual(self.run_main([*self.ARGV, "--dry-run"], dry)[0], rsh.EXIT_DEGRADED)
+
+    def test_no_return_after_the_live_read_hard_codes_an_exit_code(self):
+        """Structural backstop, so the NEXT branch added to main() inherits the rule.
+
+        The three behavioural tests above pin the three return paths that exist today. This one
+        pins the SHAPE: below the point where live state is read, a return may only be
+        `status.code` (sticky) or `EXIT_ABORT` (strictly worse than degraded, published nothing).
+        A literal `EXIT_OK` there is the bug by construction. The `--if-ref` cost guard returns
+        `EXIT_OK` legitimately — it sits ABOVE the live read and cannot be degraded yet, which
+        is why the boundary is a line number and not a whitelist of branches.
+        """
+        fn = next(
+            node for node in ast.parse(SCRIPT.read_text(encoding="utf-8")).body
+            if isinstance(node, ast.FunctionDef) and node.name == "main"
+        )
+        live_read = min(
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call)
+            and getattr(node.func, "id", "") in ("live_counts", "collect_states")
+        )
+        offenders = []
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Return) or node.lineno < live_read:
+                continue
+            value = node.value
+            sticky = isinstance(value, ast.Attribute) and value.attr == "code"
+            abort = isinstance(value, ast.Name) and value.id == "EXIT_ABORT"
+            if not (sticky or abort):
+                offenders.append(f"line {node.lineno}: return {ast.unparse(value)}")
+        self.assertEqual(
+            offenders, [],
+            "every return below the live read must be `status.code` (or EXIT_ABORT); a literal "
+            "exit code there discards an earned failure",
+        )
+
+
+class TestUnreadPrIsNeverPresentedAsArmable(MainHarness):
+    """A PR whose mergeability was never read must not be handed to the maintainer as "arm it"."""
+
+    ARGV = ["--config", str(CONFIG)]
+
+    def test_a_pr_view_missing_mergeable_degrades_and_drops_the_arm_it_ask(self):
+        # The State column does NOT discriminate here — `_pr_state_cell`'s else-branch prints
+        # "state unknown" for an empty `mergeable` whether or not the error was recorded. What
+        # discriminates is the ASK (curated `"arm it"` vs the unknown annotation) and the EXIT
+        # CODE (0 vs 3). Deleting `if not out.mergeable: out.error = ...` reds both assertions.
+        gated = rsh.load_config(CONFIG).bucket("gated-pr")
+        refs = [ref for e in gated for ref in e.refs]
+        self.assertTrue(refs, "the shipped TOML must carry the gated-PR table")
+        fake = FakeGh(
+            body="stale",
+            pr_numbers=refs,
+            pr_view={"isDraft": False, "mergeStateStatus": "CLEAN"},  # no `mergeable` key
+        )
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(
+            code, rsh.EXIT_DEGRADED,
+            "a PR whose mergeability never arrived must red the refresh job",
+        )
+        published = fake.published[0]
+        rows = [ln for ln in published.splitlines() if ln.startswith("| **[#") and ln.count("|") == 5]
+        self.assertEqual(len(rows), len(refs), "every gated PR must render exactly one row")
+        for row in rows:
+            ask = row.strip("|").split("|")[-1].strip()
+            self.assertIn(
+                "state unknown", ask,
+                f"an unread PR is presented as actionable: {ask[:80]}",
+            )
+
+    def test_a_clean_pr_read_is_not_degraded(self):
+        # Discrimination in the other direction: with the mergeability actually present, the
+        # same wiring must exit 0 and keep the curated ask. Without this, "everything is
+        # degraded" would satisfy the test above.
+        gated = rsh.load_config(CONFIG).bucket("gated-pr")
+        refs = [ref for e in gated for ref in e.refs]
+        fake = FakeGh(body="stale", pr_numbers=refs)
+        code, _ = self.run_main(self.ARGV, fake)
+        self.assertEqual(code, rsh.EXIT_OK)
+        published = fake.published[0]
+        rows = [ln for ln in published.splitlines() if ln.startswith("| **[#") and ln.count("|") == 5]
+        self.assertEqual(len(rows), len(refs))
+        for row in rows:
+            self.assertIn("MERGEABLE", row)
+            self.assertNotIn("state unknown", row)
 
 
 class TestLiveQueries(MainHarness):

--- a/scripts/tests/test_start_here_render.py
+++ b/scripts/tests/test_start_here_render.py
@@ -424,7 +424,7 @@ class TestFailClosed(unittest.TestCase):
 
 
 class TestStickyStatus(unittest.TestCase):
-    """A later transient must never discard an earlier earned failure (three prior outages)."""
+    """A later transient must never discard an earlier earned failure (a recurring outage class)."""
 
     def test_status_escalates_and_never_downgrades(self):
         status = rsh.Status()
@@ -433,7 +433,7 @@ class TestStickyStatus(unittest.TestCase):
         self.assertEqual(status.code, rsh.EXIT_DEGRADED)
 
     def test_a_later_lower_severity_report_cannot_clear_an_earlier_failure(self):
-        # The exact shape of the three prior outages: a LATER transient (reported at a lower
+        # The exact shape of every prior outage in the class: a LATER transient (reported at a lower
         # severity) overwriting an EARLIER earned hard failure. `degrade` must be a monotone
         # maximum, not an assignment.
         status = rsh.Status()


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Closes #4145.

## The failure this prevents

#1135 is titled *"auto-maintained"* and never was. On 2026-07-26 it was **13 days stale and seven of
its entries were already resolved** — #1848/#992/#1917 closed, #1084/#1973 closed-unmerged,
#1791/#1155 merged — while still being presented to the maintainer as work needing them. A front
door that lists resolved work is worse than no front door: it burns the one resource we cannot
scale. So the de-staling is **structural**, not a habit.

## What lands

| File | Role |
|---|---|
| `orchestration/start-here.toml` | the **curated judgement** — one `[[entry]]` per ask (`ref`/`bucket`/`ask`/`short`), seeded from today's #1135 body. Changing what we ask the maintainer now arrives as a **PR**. |
| `scripts/render-start-here.py` | the **live state** — drops resolved entries, reads PR conflict state, renders live label populations, edits the issue only when the text differs. |
| `.github/workflows/refresh-start-here.yml` | cron (4×/day) + `issues`/`pull_request` **closed** + `workflow_dispatch`; SHA-pinned checkout, `issues: write` and nothing else. |
| `scripts/tests/test_start_here_render.py` | 99 tests; wired into the gating `routing-self-tests` workflow. |

**The renderer may only DROP, ANNOTATE and ORDER what the TOML says — it never invents an ask.**
A hand edit of the issue is overwritten by the next refresh; new 🔴/🟡 items arrive by PR.

## Fail-closed design (where this class of script usually goes wrong)

- **An entry is dropped only on positive evidence of resolution.** Missing, malformed or unreadable
  state **keeps** the entry and marks it *state unknown*. Quietly dropping a P0 because of a
  transient 403 is the worst available failure, so the unknown path is biased all the way to keep.
- A **per-ref** failure still publishes (keeping is loss-free) but exits **non-zero**, and the exit
  status is **sticky** — a later success cannot clear an earlier failure.
- An **aggregate** failure (a label count, the held-PR list) **aborts without touching the issue**:
  those numbers render as prose with no per-item marker to hang an "unknown" on.
- **65 536-char limit:** 🟢 truncates (from the tail, and it says so), then the removed-list, then
  the process notes. 🔴/🟡 are never truncated — if the body still does not fit, the render aborts.
- **Live counts come from the LIST API, not the search index.** Measured today: search reported 34
  issues on `needs:ec2`, the list API 35. Rendering a lagging number as "live" is the same class of
  dishonesty this issue is about.
- **API budget:** an on-close run passes `--if-ref` and exits **before any API call** when the closed
  item is not on the front door. At the 60-merges/hour target a full render per close would spend
  ~2400 requests/hour against `GITHUB_TOKEN`'s 1000/hour/repository budget.

## Two real defects found in my own first render (both now pinned)

1. `{needs_ec2}` shipped **literally** to the maintainer: the placeholder regex was `[a-z_]+`, which
   cannot match a digit, so parse-time validation saw no placeholder at all. Fixed, plus a
   belt-and-braces sweep of the finished body for anything placeholder-shaped.
2. `textwrap` split `https://github.com/sparq-org/…` at the hyphen, and a newline inside a markdown
   link destination silently **un-links** it — i.e. the maintainer loses the link to the very thing
   they are being asked about.

## Verification

`--dry-run` against the live API reproduces today's #1135 content:

- **all 9 🔴 asks, 10 🟡 decisions, 6 gated PRs, 5 process notes and 4 🟢 items**, with **zero refs
  added and zero refs lost** (set-equal on every `#N` in the body);
- the **seven stale entries are seeded on purpose** and the first render **drops all seven against
  the live API**, reproducing the *Removed as resolved* footer verbatim (`closed` vs `merged` words
  included). A follow-up housekeeping PR prunes them from the TOML; dropping is automatic, pruning
  is a copy edit — that ordering is the point.

Deliberate deltas from the hand-written revision, all of them the fix working:

- live numbers moved since this morning — `needs:ec2` 34 → **35** (search-index lag), held PRs
  21 → **14**, conflicted 6 → **3**;
- #1621's ask changes from *"same — rebase then arm"* to the live-derived rebase sentence (its
  `CONFLICTING` state is now read, not remembered);
- the preamble/footer now describe the automation, and decaying hand-recorded figures ("verified
  today", "20 of them P1", "70 success / 126 failure across 196 runs", "73 commits today", "~5/hr")
  are gone — they were never part of an ask and are exactly the hard-coded-number class the repo
  bans;
- *"Blocks 1️⃣ above"* → *"Blocks the npm bootstrap above"*, because 🔴 numbering is now derived and
  an ordinal would rot the moment an item drops.

## Non-vacuous tests — measured, not asserted

### The earlier universal claim was FALSE, and is withdrawn

An earlier revision of this body said *"No guard is left without a red test."* An independent
71-mutant sweep during review refuted it with 4 counterexamples, one of them a reachable live-path
exit-code guard. A mutation campaign establishes a **lower bound** on coverage — it can only speak
about the mutants it actually ran — so it can never support a universal. The numbers below are the
run, not a claim about everything the run did not try.

### The four review findings, and what closed each one

All four were **missing regression tests, not live defects**: the reviewer independently confirmed
against the live API that an ask cannot be dropped (two 🔴 refs pointed at 404s, including the P0
npm-credential ask — both kept, marked *state unknown*, excluded from the removed list, exit 3),
cannot be invented or reworded, and that 🔴 aborts rather than truncating.

| Finding | What survived | Test that now goes red |
|---|---|---|
| **F1** sticky exit unpinned at 2 of its 3 delivery points | `return status.code` → `return EXIT_OK` at the `--dry-run` **and** `already up to date` branches of `main()` | `test_dry_run_with_a_degraded_ref_still_exits_non_zero`, `test_an_already_up_to_date_body_still_exits_non_zero_when_degraded`, `test_a_failure_on_the_FIRST_ref_survives_every_later_success`, `test_a_failure_on_the_LAST_ref_survives_every_earlier_success`, `test_no_return_after_the_live_read_hard_codes_an_exit_code` |
| **F2** an unread `mergeable` field | deleting `if not out.mergeable: out.error = …` turns exit 3 → **0** and reverts the ask to the curated `"arm it"` | `test_a_pr_whose_mergeable_field_never_arrived_is_recorded_as_an_error`, `test_a_pr_view_missing_mergeable_degrades_and_drops_the_arm_it_ask` |
| **F3** `if self.unknown: return False` pinned by a fixture that passed for the wrong reason | `RefState(error=…)` has an EMPTY state, so it returns False with the guard deleted; the `not self.state` clause is likewise invisible to every `is_resolved` assertion | `test_a_resolved_looking_ref_whose_read_failed_is_not_resolved`, `test_a_ref_whose_state_never_arrived_is_unknown_even_with_no_error`, and reworded `_self_test` assertions naming the mechanism they actually exercise |
| **T3** (found while re-running) the sq-qhy4 audit entry's `untracked` declaration | pointing it at `ref = sparq-org/sparq#3274` — the issue it **gates** but is not equal to — survived the whole suite; the day #3274 closes, that P0 ask leaves the front door on its own | `test_the_external_audit_ask_stays_structurally_undroppable` |

F1 is the load-bearing one. The `already up to date` branch is genuinely reachable — a persistent
403 on a 🔴 ref re-renders an **identical** body, so no edit happens and `main()` falls through it —
and because the branch reads "already up to date", `return EXIT_OK` there is a natural-looking
cleanup. This is the exit-zero-swallowing class the repo has been bitten by **eight** times, in the
PR that advertises sticky exit as a headline guard. It is now pinned three ways: behaviourally at
each branch, by the interleaved sequence in **both** orders (failure-on-the-first-ref-then-only-
successes, and only-successes-then-failure-on-the-last-ref), and by an AST backstop
(`test_no_return_after_the_live_read_hard_codes_an_exit_code`) asserting that **every** return
below the live read is `status.code` or `EXIT_ABORT` — so the next branch added to `main()`
inherits the rule instead of needing to be remembered.

### The run

**51/51 mutants killed** in the campaign below, at head `f57a823ab`, harness output verbatim in the
PR discussion. Each mutation is a single exact textual edit applied to a fresh copy of the tree,
after which `scripts/tests/test_start_here_render.py` + `render-start-here.py --self-test` are
re-run; a mutant nothing reds is a survivor. Breakdown: **9** on the three review findings (F1a–e,
F2a, F3a–c), **16** re-checking the guards the previous campaign claimed (R1–R16), **3** on the
new perf-gate coverage (G1–G3), **20** at the YAML seam across both workflows (Y1–Y19 incl. Y1b/Y2b),
**3** on the shipped TOML (T1–T3). Two mutants in an earlier pass did not apply cleanly and were
rewritten rather than counted as kills (a duplicate-key `if: false`, which PyYAML silently discards,
and an ambiguous `contents: read` anchor).

Suite: **99 tests** (was 85 at first review, 86 after the first hardening round).

What the number does **not** say: no campaign of this kind proves the absence of an unpinned guard.
It says these 51 specific defects are caught. The honest summary is *every guard I could name and
mutate has a named red test* — and the review that produced F1–F3 is direct evidence that the way
to find the rest is another adversarial sweep, not a stronger adjective here.

**The YAML seam is parsed structurally**, never substring-matched. Measured in this repo, every
uncaught mutant historically lived in a workflow `if:`, a deleted step, or a wrong call-site input,
which a text assertion cannot see — so the suite parses both workflows with PyYAML and asserts on
the parsed job/step/permission/trigger objects. All 20 seam mutants died, including the two that
only a structural check can catch: `if: false` on the job (`test_no_job_or_step_is_disabled`) and
`--dry-run` quietly added to **either** branch of the live invocation
(`test_the_live_step_is_not_secretly_a_dry_run`).

## The curated TOML is now inside the honesty gate (review advisory)

`check-no-perf-numbers.py`'s `SCAN_GLOBS` is `*.md` / `*.typ`, so `orchestration/start-here.toml` —
the one file whose content is copied **verbatim** into an issue body — sat outside the gate
entirely. Zero findings today is not the same as covered, so I **added the coverage** rather than
filing a follow-up bead.

It is listed explicitly (`EXTRA_SCAN_PATHS`, the same shape as the existing `paper-evidence.json`
entry) rather than by widening `SCAN_GLOBS` to `*.toml`, which would sweep in every `Cargo.toml` /
`deny.toml` in the workspace, where a bare number is configuration and not a claim. A new
`--list-scanned` flag prints the resolved default scan list from the **same** `files` variable the
scan loop consumes, so the coverage test asks the gate what it scans instead of re-deriving its
globs — a re-derivation would agree with a broken gate. `--enforce` stays clean: 0 findings across
267 scanned files.

## Gate run (local, on what this PR touches)

All green at head `f57a823ab`:

- the full `routing-self-tests` run block — `routing-validate.py --self-test` + full run,
  `route-resolve.py`, `ready-issues.py`, `dispatch-plan.py`, `batch-merge.py`,
  `test_readiness_visibility.py`, `render-start-here.py --self-test`,
  `test_start_here_render.py` (**99 tests, OK**), `bd-to-issues.py --self-test`,
  `ci-close-merged-beads.py --self-test`;
- `check-terminology.py` (+ `--self-test`, + `test_banned_terminology.py`),
  `check-no-perf-numbers.py --enforce` (**0 findings / 267 files**), `check-advisory-registry.py`,
  `check-fast-fix-ring-guard.py`, `check-install-action-tool.py`, `check-skill-frontmatter.py`,
  `check-privacy-claims.sh`, `check-readme-template.py --enforce`;
- `markdownlint-cli2` (419 files, 0 errors), `typos` over the gate's own docs scope
  (249 files, clean) + `test_typos_allowlist.sh` (16 passed).

Not armed, not labelled, and I am **not** the reviewer of my own fix — the orchestrator routes a
fresh verdict.
