### PR TITLE
feat(ci): derive PR `area:` labels from changed paths — the __global__ starvation fix (reg#677)

### DIFF
--- a/.github/workflows/pr-area-label.yml
+++ b/.github/workflows/pr-area-label.yml
@@ -80,8 +80,15 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Derive and apply area labels
+        # Every `github.*` value reaches the shell through `env:`, never interpolated
+        # into the `run:` body — the standard expression-injection precaution. The
+        # mapping below is pinned by EQUALITY in the seam test, so swapping a field
+        # (e.g. `github.event.number` for the pull-request number) cannot ship.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || 0 }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
         run: |
           set -euo pipefail
           # BOOTSTRAP / REVERT GUARD. The checkout above is the DEFAULT BRANCH, so on the
@@ -99,7 +106,7 @@ jobs:
             exit 0
           fi
           python3 scripts/pr-area-labels.py \
-            --repo "${{ github.repository }}" \
-            --pr "${{ github.event.pull_request.number || 0 }}" \
-            --head-repo "${{ github.event.pull_request.head.repo.full_name || '' }}" \
+            --repo "$TARGET_REPO" \
+            --pr "$PR_NUMBER" \
+            --head-repo "$PR_HEAD_REPO" \
             --apply

--- a/.github/workflows/pr-area-label.yml
+++ b/.github/workflows/pr-area-label.yml
@@ -84,6 +84,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # BOOTSTRAP / REVERT GUARD. The checkout above is the DEFAULT BRANCH, so on the
+          # PR that INTRODUCES the deriver — and on any ref taken after it is deleted or
+          # reverted — the file is simply not there (measured: this job failed exactly
+          # this way on its own PR, #4170). Report LOUDLY and exit 0 rather than reddening
+          # `gate` for every open PR over a condition no PR author can fix. It is a
+          # ::warning, not a ::notice, so a genuine disappearance is visible in the run
+          # summary instead of looking like a healthy no-op. The guarded path and the
+          # invoked path are asserted EQUAL by
+          # test_pr_area_labels.py::TestWorkflowSeam::test_the_run_block_guards_the_bootstrap_case,
+          # so guarding one file while running another cannot ship.
+          if [ ! -f scripts/pr-area-labels.py ]; then
+            echo "::warning title=pr-area-label inert::scripts/pr-area-labels.py is absent from the default branch, so NO area: label was derived and this PR keeps the serializing __global__ partition. Expected ONLY on the PR that adds the deriver; otherwise it has been deleted or reverted on the default branch."
+            exit 0
+          fi
           python3 scripts/pr-area-labels.py \
             --repo "${{ github.repository }}" \
             --pr "${{ github.event.pull_request.number || 0 }}" \

--- a/.github/workflows/pr-area-label.yml
+++ b/.github/workflows/pr-area-label.yml
@@ -1,0 +1,91 @@
+# pr-area-label — derive a PR's `area:` conflict-partition labels from its changed paths.
+# [OPUS-5] 🤖 SPARQ agent. Registry issue jeswr/agent-account-registry#677.
+#
+# WHY THIS EXISTS (measured 2026-07-26 14:45Z, reg#677): the fleet scheduler partitions
+# work by `area:<name>`. An in-flight PR RESERVES its areas; a ready issue defers while
+# any of its areas is reserved; and a PR with NO `area:` label maps to the SERIALIZING
+# `__global__` partition, so ONE unlabelled PR defers EVERY issue whatever crate it names.
+# 84 of 87 open PRs carried no `area:` label because nothing in the pipeline ever applied
+# one. Live layer chain that tick: candidates 12 -> frontier 3 -> lease 3 ->
+# max_concurrent 8 -> account pool 28, so min = 3 — 28 account slots idle while 3 workers
+# ran, and raising max_concurrent/package_width measured net +0 workers (reg#689). This
+# workflow closes the layer that actually binds.
+#
+# WHY NOT actions/labeler: it cannot express the three properties this needs — (a) the
+# label must ALREADY EXIST (labeler's add-label call silently CREATES an unknown label,
+# which is how a typo becomes permanent repo state), (b) a >max_areas fan-out must fall
+# BACK to `__global__` rather than acquiring many labels, and (c) the same code must drive
+# the one-pass backfill of the existing open PRs. The policy lives in reviewable TOML
+# (ci/area-labels.toml), not inline YAML.
+#
+# TRUSTED-CODE POSTURE. The job holds `pull-requests: write`, so it must NOT execute code
+# from the pull request. `actions/checkout` is therefore pinned to the repository's
+# DEFAULT BRANCH, not to the PR head or merge ref: the deriver and its policy table are
+# always the reviewed on-main versions. A PR that edits either is validated by the
+# hermetic self-tests (scripts/tests/test_pr_area_labels.py, run by routing-self-tests.yml)
+# and takes effect once merged. Pinned by
+# test_pr_area_labels.py::TestWorkflowSeam::test_checkout_uses_default_branch_not_pr_head.
+#
+# FORK PRs. `pull_request` (deliberately NOT `pull_request_target`) hands a fork PR a
+# READ-ONLY token, so no label write can succeed. That path is handled EXPLICITLY inside
+# the deriver: the `--head-repo` argument below carries the PR's head repo, and when it is
+# not this repository the run prints a `::notice` and exits 0 instead of failing on a
+# confusing 403.
+#
+# NO `if:` ANYWHERE, BY DESIGN. Every skip decision (fork PR, no pull-request context on
+# the merge_group ref) is made in Python, where a mutation dies against a named test.
+# Measured in this project: 18/18 Python mutants died while EVERY surviving mutant lived
+# in a workflow `if:` / step / call-site. The structural seam tests assert that this
+# workflow has no job-level or step-level `if:` at all, so re-introducing one — including
+# `if: false` — turns a named test red.
+#
+# GATING POSTURE: gating. The job name carries no advisory/informational token and has no
+# .github/advisory-registry.json entry, so ci-summary auto-discovers it as a required
+# sibling. It cannot break already-open PRs: `pull_request` runs the workflow file from
+# the PR's own merge ref, so a PR that predates this file produces no check-run at all,
+# and a missing leg is not a failing leg.
+name: pr-area-label
+
+on:
+  # Every PR event that can change the changed-path set or make a draft reviewable.
+  # NO `paths:` filter, deliberately: every PR must be attributed, and a path filter
+  # would silently re-open the starvation hole for whatever it excluded.
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  # The queue ref exposes the same gating check name (repo convention, cf.
+  # routing-self-tests.yml). There is no pull request in a merge_group payload, so the
+  # deriver receives `--pr 0` and no-ops — see the Python no-pull-request-context path.
+  merge_group:
+
+# Least privilege. `pull-requests: write` is the ONLY write scope, and it is the exact
+# scope the "add labels to a pull request" call needs. `contents: read` is required by
+# actions/checkout to read the deriver + ci/area-labels.toml; it grants no write.
+# NO `issues: write`, no `contents: write`, no secrets are referenced anywhere.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-area-label-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: derive area labels
+    runs-on: ubuntu-latest
+    steps:
+      # Checked out at the DEFAULT BRANCH on purpose — see TRUSTED-CODE POSTURE above.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Derive and apply area labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python3 scripts/pr-area-labels.py \
+            --repo "${{ github.repository }}" \
+            --pr "${{ github.event.pull_request.number || 0 }}" \
+            --head-repo "${{ github.event.pull_request.head.repo.full_name || '' }}" \
+            --apply

--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -42,6 +42,14 @@ on:
       # workflow's own run block to the scripts it must invoke.
       - "scripts/tests/test_readiness_visibility.py"
       - ".github/workflows/routing-self-tests.yml"
+      # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
+      # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
+      # and defers EVERY issue, so a drift in the deriver, its declared table, or the
+      # labelling workflow must fail on ITS OWN PR, not at the next dispatch tick.
+      - "scripts/pr-area-labels.py"
+      - "ci/area-labels.toml"
+      - "scripts/tests/test_pr_area_labels.py"
+      - ".github/workflows/pr-area-label.yml"
   merge_group:
   push:
     branches: [main]
@@ -69,6 +77,14 @@ on:
       # workflow's own run block to the scripts it must invoke.
       - "scripts/tests/test_readiness_visibility.py"
       - ".github/workflows/routing-self-tests.yml"
+      # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
+      # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
+      # and defers EVERY issue, so a drift in the deriver, its declared table, or the
+      # labelling workflow must fail on ITS OWN PR, not at the next dispatch tick.
+      - "scripts/pr-area-labels.py"
+      - "ci/area-labels.toml"
+      - "scripts/tests/test_pr_area_labels.py"
+      - ".github/workflows/pr-area-label.yml"
 
 permissions:
   contents: read
@@ -98,6 +114,12 @@ jobs:
           python3 scripts/dispatch-plan.py --self-test
           python3 scripts/batch-merge.py --self-test
           python3 scripts/tests/test_readiness_visibility.py
+          # [OPUS-5] reg#677: the PR `area:` deriver + its YAML seam. The suite is
+          # invoked HERE and that invocation is itself pinned by
+          # test_pr_area_labels.py::TestSelfTestIsActuallyInvoked — a suite nobody
+          # runs cannot go red.
+          python3 scripts/pr-area-labels.py --self-test
+          python3 scripts/tests/test_pr_area_labels.py
 
       # [OPUS-5] The bd->issues migration pair, previously ungated on a PR (see the `paths:`
       # note above). Both are hermetic: stdlib only, every subprocess boundary stubbed, no

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,15 @@ no network); the Python close-script carries a `--self-test`.
   add-labels REST call silently would, so a typo'd area is dropped with a `::warning`
   instead), and **fail-closed**: unresolvable paths or more than `[policy] max_areas`
   distinct areas keep the PR on `__global__` — *unclassified* and *genuinely cross-cutting*
-  are now distinguishable, which is the actual bug. `--dry-run` is the default; `--apply`
+  are now distinguishable, which is the actual bug. The changed-file list is the one input
+  attribution cannot check for itself, so it is enumerated with the **paginated REST**
+  endpoint *and* cross-checked against `changedFiles`; any disagreement is
+  `incomplete-paths` → `__global__`. (`gh pr view --json files` is GraphQL
+  `files(first: 100)` and **silently truncates** — measured on PR #3581: `changedFiles`
+  646, `--json files` 100. A truncated list derives a proper **subset** of the true areas,
+  and a too-narrow reservation puts two workers on one crate, where a too-broad one merely
+  delays. Renames consume `previous_filename`, so a cross-crate move implicates both
+  ends.) `--dry-run` is the default; `--apply`
   mutates; `--backfill` sweeps every open PR (use `--pace` — each label add fires a
   `pull_request: labeled` event that ci/bench/fuzz/feature-matrix all react to). Wired to
   every PR by `.github/workflows/pr-area-label.yml` (least-privilege

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -551,6 +551,33 @@ no network); the Python close-script carries a `--self-test`.
   two beads on the same crate launch and conflict (this gap once dispatched two
   sparq-server beads at once — sq-8rpq). Carries an `--explain` (per-bead keep/drop
   reasons) and a hermetic `--dry-run-self-test`.
+- **`scripts/pr-area-labels.py`** + **`ci/area-labels.toml`** — the thing that makes the
+  conflict-partition *work on PRs*. <!-- [OPUS-5] reg#677 --> The scheduler partitions by
+  `area:<name>`: an in-flight PR **reserves** its areas and a ready issue **defers** while
+  any of its areas is reserved — so a PR with **no `area:` label** maps to the serializing
+  `__global__` partition and defers **every** issue, whatever crate it names. Measured
+  2026-07-26 (registry #677): **84 of 87 open PRs carried no `area:` label**, because
+  nothing in the pipeline ever applied one; the live chain was candidates 12 → frontier 3
+  → lease 3 → max_concurrent 8 → account pool 28, i.e. **28 account slots idle while 3
+  workers ran**, and raising `max_concurrent`/`package_width` measured **net +0** workers
+  (registry #689). This deriver reads a PR's changed paths and applies the `area:` labels
+  the paths imply — `crates/<name>/…` → `area:<name>` implicitly, everything else from the
+  reviewable `[[map]]` table in `ci/area-labels.toml`. It is **additive only** (a
+  human-applied `area:` is never removed), **idempotent**, **never creates a label** (the
+  add-labels REST call silently would, so a typo'd area is dropped with a `::warning`
+  instead), and **fail-closed**: unresolvable paths or more than `[policy] max_areas`
+  distinct areas keep the PR on `__global__` — *unclassified* and *genuinely cross-cutting*
+  are now distinguishable, which is the actual bug. `--dry-run` is the default; `--apply`
+  mutates; `--backfill` sweeps every open PR (use `--pace` — each label add fires a
+  `pull_request: labeled` event that ci/bench/fuzz/feature-matrix all react to). Wired to
+  every PR by `.github/workflows/pr-area-label.yml` (least-privilege
+  `pull-requests: write`, checkout pinned to the **default branch** so a privileged token
+  never runs PR-authored code, explicit fork read-only-token path, and **no `if:` at any
+  level** — every skip decision is in Python, where a mutant dies). Guards:
+  `scripts/tests/test_pr_area_labels.py`, run by `routing-self-tests.yml`.
+  **When you add a top-level directory, add a `[[map]]` row** or every PR touching it
+  silently starves the frontier again — the totality test over `git ls-files` is what
+  catches this.
 - **`.claude/workflows/autonomous-scheduler.js`** (epic sq-sgu1) — the **self-driving
   bead-frontier loop**, MATERIALISED as a committed, re-runnable harness Workflow so it
   survives a session restart. <!-- [OPUS-4.8] durable scheduler --> Each wave it reads the

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -29,8 +29,20 @@
 # THE FAIL-CLOSED RULE (do not weaken it)
 # ===========================================================================
 # `__global__` is expressed as "the PR carries NO `area:` label". The deriver emits
-# NO labels — i.e. leaves the PR on `__global__` — in exactly three cases:
+# NO labels — i.e. leaves the PR on `__global__` — in exactly four cases:
 #
+#   0. `incomplete-paths` — the changed-file enumeration disagreed with GitHub's
+#                        authoritative `changedFiles` count, so the list is PARTIAL.
+#                        This is the input-boundary case and the only one that is not
+#                        about the table: attribution is a pure function of the path
+#                        string, so within a COMPLETE list under-reservation is
+#                        impossible — but a TRUNCATED list derives a proper SUBSET of
+#                        the true areas, which is the CORRUPTING direction (a wrong
+#                        narrow reservation puts two workers on one crate; a wrong
+#                        broad one only delays). Measured 2026-07-26: PR #3581 reports
+#                        `changedFiles = 646` while `gh pr view --json files` — GraphQL
+#                        `files(first: 100)` — returns 100. The deriver therefore uses
+#                        the PAGINATED REST endpoint AND cross-checks the count.
 #   1. `no-paths`      — the changed-file list is empty/unavailable.
 #   2. `unresolved`    — ANY changed path has no rule here, or resolves to an
 #                        `area:` label that does not exist in the repo. STRICT on

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -103,10 +103,14 @@ max_areas = 4
 # test can stay STRICT for every other row (a dead row is a silent hole that looks like
 # coverage). Two legitimate kinds: a FETCHED/GENERATED tree, and a file an in-flight PR
 # adds. Keep this list short and justified — it is the one place a typo can hide.
+# An entry is DROPPED once its path lands (the strict dead-row check then covers the
+# row automatically, so nothing is lost). That housekeeping is reported as DRIFT rather
+# than gated: in a continuously-merging repo a path landing on `main` must not red an
+# unrelated PR's `Routing contract self-tests` — it has no runtime consequence, whereas
+# `test_every_tracked_file_in_the_repo_resolves` does and stays a hard gate.
 anticipated_roots = [
   "tests/**",             # W3C/RDF conformance corpora, FETCHED by scripts/fetch-*.sh (gitignored)
-  "rust-toolchain.toml",  # toolchain pin; added by an in-flight PR, mapped ahead of it
-  "rust-toolchain",       # the legacy filename form of the same pin
+  "rust-toolchain",       # the legacy filename form of the toolchain pin (never landed)
 ]
 
 [lanes]
@@ -443,6 +447,10 @@ pattern = "skills/data-formats/**"
 area = "sparq-core"
 
 [[map]]
+pattern = "skills/e2ee-ng/**"
+area = "sparq-e2ee-ng"
+
+[[map]]
 pattern = "skills/federated-planning/**"
 area = "sparq-fedplan"
 
@@ -523,6 +531,10 @@ pattern = "skills/shacl-validation/**"
 area = "sparq-shacl"
 
 [[map]]
+pattern = "skills/solid-lws-server/**"
+area = "sparq-lws-core"
+
+[[map]]
 pattern = "skills/sparql-query/**"
 area = "sparq-engine"
 
@@ -563,8 +575,11 @@ area = "sparq-zk"
 # and take `__global__`, which is the starvation this file exists to remove. `docs` is
 # the deliberately conservative choice: it over-serializes against other prose work
 # rather than guessing a crate. Rows above win, and
-# test_every_skill_surface_has_a_map_row keeps pressure to add the specific row once the
-# surface lands on the default branch.
+# test_every_skill_surface_has_a_map_row REPORTS (does not gate on) a surface with no
+# specific row, so adding one stays visible without a new skill on `main` reding an
+# unrelated PR. It is safe to demote precisely BECAUSE of this catch-all: attribution
+# stays total either way, and a missing row costs only a coarser (`docs`) lane, never
+# a wrong crate.
 [[map]]
 pattern = "skills/**"
 area = "docs"

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -57,10 +57,15 @@
 # ===========================================================================
 # RESOLUTION ORDER (normative)
 # ===========================================================================
-#   1. `crates/<name>/...`  ->  area `<name>`, when `<name>` is a live workspace
-#      member (read from the root Cargo.toml `[workspace] members`). This rule is
-#      IMPLICIT — it is code, not a row below, so a new crate needs no edit here.
-#      A `crates/` path whose `<name>` is not a member is UNRESOLVED (fail closed).
+#   1. `crates/<name>/<something>`  ->  area `<name>`. IMPLICIT — it is code, not a row
+#      below, so a new crate needs no edit here. Deliberately NOT gated on workspace
+#      membership: the workflow evaluates a PR against the DEFAULT BRANCH's manifest (a
+#      `pull-requests: write` job must not execute PR-authored code), so a PR that ADDS
+#      a crate would otherwise be unresolvable forever — and those PRs collide with
+#      nothing, so they are the ones that most deserve a narrow partition. The guard
+#      against inventing an area is the live-`area:`-label check, which no non-crate
+#      name can pass. A file sitting DIRECTLY in `crates/` (two segments, e.g.
+#      `crates/README.md`) is not a crate and is UNRESOLVED (fail closed).
 #   2. the first matching `[[map]]` row below, in file order.
 #   3. otherwise UNRESOLVED -> the whole PR falls back to `__global__`.
 #
@@ -76,7 +81,7 @@
 # ===========================================================================
 # MAINTENANCE
 # ===========================================================================
-# * Adding a crate: nothing to do here (rule 1 is implicit) — but the repo must
+# * Adding a crate: nothing to do here (rule 1 is implicit) — but the repo MUST
 #   have an `area:<crate>` label, or the deriver drops it and the PR stays
 #   `__global__` with a `::warning`. It NEVER auto-creates a label: the workflow
 #   holds `pull-requests: write` only, and the "add labels" REST call silently

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -557,3 +557,14 @@ area = "sparq-vc"
 [[map]]
 pattern = "skills/zk-query-proofs/**"
 area = "sparq-zk"
+
+# CATCH-ALL for a skills surface that does not yet have its own row above — a PR that
+# ADDS a skill (live case: #3464 adding skills/e2ee-ng/) would otherwise be unresolved
+# and take `__global__`, which is the starvation this file exists to remove. `docs` is
+# the deliberately conservative choice: it over-serializes against other prose work
+# rather than guessing a crate. Rows above win, and
+# test_every_skill_surface_has_a_map_row keeps pressure to add the specific row once the
+# surface lands on the default branch.
+[[map]]
+pattern = "skills/**"
+area = "docs"

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -588,8 +588,8 @@ area = "sparq-zk"
 # the deliberately conservative choice: it over-serializes against other prose work
 # rather than guessing a crate. Rows above win, and
 # test_every_skill_surface_has_a_map_row REPORTS (does not gate on) a surface with no
-# specific row, so adding one stays visible without a new skill on `main` reding an
-# unrelated PR. It is safe to demote precisely BECAUSE of this catch-all: attribution
+# specific row, so adding one stays visible without a new skill on `main` turning an
+# unrelated PR red. It is safe to demote precisely BECAUSE of this catch-all: attribution
 # stays total either way, and a missing row costs only a coarser (`docs`) lane, never
 # a wrong crate.
 [[map]]

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -94,6 +94,15 @@
 # in practice a workspace-wide refactor. Raising it trades scheduler safety for
 # throughput; lowering it trades throughput for safety.
 max_areas = 4
+# Patterns whose root does not exist on disk TODAY. Declared here so the map-validity
+# test can stay STRICT for every other row (a dead row is a silent hole that looks like
+# coverage). Two legitimate kinds: a FETCHED/GENERATED tree, and a file an in-flight PR
+# adds. Keep this list short and justified — it is the one place a typo can hide.
+anticipated_roots = [
+  "tests/**",             # W3C/RDF conformance corpora, FETCHED by scripts/fetch-*.sh (gitignored)
+  "rust-toolchain.toml",  # toolchain pin; added by an in-flight PR, mapped ahead of it
+  "rust-toolchain",       # the legacy filename form of the same pin
+]
 
 [lanes]
 # The `area:` names that are NOT workspace crates. Every one of these is an
@@ -156,10 +165,6 @@ pattern = ".gitignore"
 area = "ci"
 
 [[map]]
-pattern = ".gitattributes"
-area = "ci"
-
-[[map]]
 pattern = "rustfmt.toml"
 area = "ci"
 
@@ -169,6 +174,46 @@ area = "ci"
 
 [[map]]
 pattern = "advisory.markdownlint-cli2.jsonc"
+area = "ci"
+
+[[map]]
+pattern = ".markdownlint-cli2.jsonc"
+area = "ci"
+
+# Prose/lint/scan/test-runner tool configs. Each redefines what a CI leg checks, so the
+# lane on which two concurrent editors collide is `ci`.
+[[map]]
+pattern = ".vale.ini"
+area = "ci"
+
+[[map]]
+pattern = ".vale/**"
+area = "ci"
+
+[[map]]
+pattern = ".hadolint.yaml"
+area = "ci"
+
+[[map]]
+pattern = ".trivyignore"
+area = "ci"
+
+[[map]]
+pattern = ".roborev.toml"
+area = "ci"
+
+[[map]]
+pattern = ".config/**"
+area = "ci"
+
+[[map]]
+pattern = ".claude-plugin/**"
+area = "ci"
+
+# A stray committed `du` dump. Mapped only so it cannot silently send a PR to
+# `__global__`; it should be deleted from the tree, not curated here.
+[[map]]
+pattern = ".du.txt"
 area = "ci"
 
 # ---------------------------------------------------------------------------
@@ -215,6 +260,11 @@ area = "site"
 
 [[map]]
 pattern = "assets/**"
+area = "site"
+
+# The published security.txt — served by the site.
+[[map]]
+pattern = ".well-known/**"
 area = "site"
 
 [[map]]
@@ -280,6 +330,10 @@ area = "release"
 
 [[map]]
 pattern = "Dockerfile"
+area = "release"
+
+[[map]]
+pattern = ".dockerignore"
 area = "release"
 
 [[map]]

--- a/ci/area-labels.toml
+++ b/ci/area-labels.toml
@@ -1,0 +1,500 @@
+# [OPUS-5] PR `area:` attribution — the changed-path -> conflict-partition map.
+# 🤖 SPARQ agent. Registry issue jeswr/agent-account-registry#677.
+#
+# WHO CONSUMES THIS: scripts/pr-area-labels.py (the deriver + the backfill), which
+# is invoked by .github/workflows/pr-area-label.yml on every pull_request event and
+# by hand for the one-pass backfill. Validated by scripts/tests/test_pr_area_labels.py.
+#
+# WHY THIS FILE EXISTS — the measured problem (reg#677, 2026-07-26 14:45Z).
+# The fleet scheduler (`dispatch-claim.py` / `scripts/ready-issues.py`) partitions work
+# by `area:<name>`: an in-flight PR RESERVES its areas, and a ready issue is deferred
+# while any of ITS areas is reserved. A PR with NO `area:` label maps to the
+# SERIALIZING `__global__` partition, so while it is in flight EVERY issue defers,
+# whatever crate it names. Measured: 84 of 87 open PRs carried no `area:` label,
+# because NOTHING in the pipeline ever applied one. Live layer chain that tick:
+# candidates 12 -> frontier 3 -> lease 3 -> max_concurrent 8 -> account pool 28,
+# i.e. min = 3 — 28 account slots idle while 3 workers ran. Raising max_concurrent or
+# package_width was measured at net +0 concurrent workers (reg#689), because this
+# layer, not the caps, is the binding limiter.
+#
+# WHAT THIS FILE IS *NOT*. It is NOT ci/path-ownership.toml. That map answers "which
+# crates must be TESTED when this path changes" (a soundness question — under-listing
+# a reader is an unsound CI skip). THIS map answers "which lane would two concurrent
+# workers COLLIDE on if both touched this path" (a capacity question — a wrong narrow
+# lane costs duplicated work, a too-wide lane costs throughput). The two answers
+# legitimately differ: `.github/**` is an unconditional FULL-MATRIX trigger in
+# path-ownership.toml, yet its collision lane is just `ci`. Keep them separate.
+#
+# ===========================================================================
+# THE FAIL-CLOSED RULE (do not weaken it)
+# ===========================================================================
+# `__global__` is expressed as "the PR carries NO `area:` label". The deriver emits
+# NO labels — i.e. leaves the PR on `__global__` — in exactly three cases:
+#
+#   1. `no-paths`      — the changed-file list is empty/unavailable.
+#   2. `unresolved`    — ANY changed path has no rule here, or resolves to an
+#                        `area:` label that does not exist in the repo. STRICT on
+#                        purpose: one unattributable path means the PR's blast
+#                        radius is unknown, and unknown must serialize. The fix is
+#                        to ADD the missing row below, not to relax the rule.
+#   3. `cross-cutting` — more than `[policy] max_areas` distinct areas. A PR that
+#                        genuinely spans the workspace IS repo-wide work.
+#
+# The bug reg#677 describes is NOT the fail-closed rule. It is that *unclassified*
+# was indistinguishable from *genuinely cross-cutting*. Narrowing everything would
+# be the opposite error: a WRONG narrow label lets two workers collide on one crate,
+# which is worse than a stalled frontier because it wastes both workers AND produces
+# conflicting diffs. When in doubt, leave the path unmapped (=> `__global__`), or map
+# it to a deliberately SHARED lane (below) — never guess a crate.
+#
+# SHARED LANES ARE THE PREFERRED CONSERVATIVE ANSWER. For a path that is a
+# repo-wide *shared file* rather than crate source — `Cargo.lock`, `deny.toml`,
+# `scripts/**` — the honest collision partition is the shared file's own lane
+# (`deps`, `ci`), not `__global__`: two lockfile PRs really do collide with each
+# other, and really do NOT collide with a docs PR. Over-serializing a lane is
+# always safe; mis-attributing to a crate is not.
+#
+# ===========================================================================
+# RESOLUTION ORDER (normative)
+# ===========================================================================
+#   1. `crates/<name>/...`  ->  area `<name>`, when `<name>` is a live workspace
+#      member (read from the root Cargo.toml `[workspace] members`). This rule is
+#      IMPLICIT — it is code, not a row below, so a new crate needs no edit here.
+#      A `crates/` path whose `<name>` is not a member is UNRESOLVED (fail closed).
+#   2. the first matching `[[map]]` row below, in file order.
+#   3. otherwise UNRESOLVED -> the whole PR falls back to `__global__`.
+#
+# PATTERN GRAMMAR (close to ci/path-ownership.toml, with ONE deliberate difference):
+#   * repo-relative POSIX path, no leading `./`;
+#   * `dir/**` matches `dir` itself and anything beneath it;
+#   * anything else is a glob in which `*` matches within ONE path segment only —
+#     it does NOT cross `/`. This is the deliberate difference: path-ownership.toml
+#     uses `fnmatch`, whose `*` DOES cross `/`, so a row like `*.md` there would
+#     also swallow `skills/inference/SKILL.md` and make the whole map order-fragile.
+#     Here `*.md` means "a markdown file at the repo ROOT" and nothing else.
+#
+# ===========================================================================
+# MAINTENANCE
+# ===========================================================================
+# * Adding a crate: nothing to do here (rule 1 is implicit) — but the repo must
+#   have an `area:<crate>` label, or the deriver drops it and the PR stays
+#   `__global__` with a `::warning`. It NEVER auto-creates a label: the workflow
+#   holds `pull-requests: write` only, and the "add labels" REST call silently
+#   CREATES an unknown label, which is how a typo becomes permanent repo state.
+# * Adding a top-level directory: add a `[[map]]` row, or every PR touching it
+#   silently falls back to `__global__` and starves the frontier again.
+# * `scripts/tests/test_pr_area_labels.py` asserts every row's pattern root exists
+#   on disk and every row's `area` is either a live workspace member or a declared
+#   `[lanes] non_crate` name — so a typo'd row cannot ship.
+
+[policy]
+# More than this many distinct areas on one PR => genuinely cross-cutting =>
+# `__global__` (no labels). 4 is a judgment call: a 2-4 crate change is ordinary
+# fan-out work whose real collision set IS those crates, while a 5+ crate change is
+# in practice a workspace-wide refactor. Raising it trades scheduler safety for
+# throughput; lowering it trades throughput for safety.
+max_areas = 4
+
+[lanes]
+# The `area:` names that are NOT workspace crates. Every one of these is an
+# EXISTING label in sparq-org/sparq (verified 2026-07-26); the test pins that
+# every `[[map]] area` value is either a live crate or a name in this list, so a
+# typo in a row below fails the hermetic self-test rather than the live pipeline.
+non_crate = [
+  "bench",        # measurement harness + recorded results
+  "ci",           # the pipeline itself: workflows, gate scripts, CI policy
+  "deploy-demo",  # deployment recipes / the public demo
+  "deps",         # dependency + supply-chain lane (lockfile, deny.toml, vet)
+  "docs",         # prose surfaces: docs/, research/, book/, compliance/, charters
+  "gui",          # the Tauri desktop app
+  "js",           # the JS/TS packages + bindings
+  "release",      # packaging + release plumbing
+  "site",         # the Next.js marketing/docs site
+  "testing",      # test scaffolding not owned by one crate (fuzz/, fetched suites)
+  "upstream",     # vendored forks we contribute back to
+  "workspace",    # root manifest / toolchain pin / cargo config
+  "zk",           # the out-of-workspace Noir circuit tree
+]
+
+# ---------------------------------------------------------------------------
+# THE PIPELINE ITSELF -> `ci`.
+# These are shared, highly conflict-prone files edited by many concurrent agents,
+# and `ci` is exactly the lane on which those edits collide with each other. Note
+# this is a much NARROWER claim than path-ownership.toml's `.github/` trigger:
+# there, a workflow edit forces the full test matrix; here it merely says "another
+# CI-editing worker must not run concurrently".
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = ".github/**"
+area = "ci"
+
+[[map]]
+pattern = "scripts/**"
+area = "ci"
+
+[[map]]
+pattern = "ci/**"
+area = "ci"
+
+[[map]]
+pattern = "orchestration/**"
+area = "ci"
+
+[[map]]
+pattern = ".claude/**"
+area = "ci"
+
+# The bd tracker database. `.beads/issues.jsonl` is the single most merge-conflict-
+# prone file in the repo (every agent appends to it), so serializing it against the
+# other pipeline work is the deliberately conservative call.
+[[map]]
+pattern = ".beads/**"
+area = "ci"
+
+[[map]]
+pattern = ".gitignore"
+area = "ci"
+
+[[map]]
+pattern = ".gitattributes"
+area = "ci"
+
+[[map]]
+pattern = "rustfmt.toml"
+area = "ci"
+
+[[map]]
+pattern = "_typos.toml"
+area = "ci"
+
+[[map]]
+pattern = "advisory.markdownlint-cli2.jsonc"
+area = "ci"
+
+# ---------------------------------------------------------------------------
+# WORKSPACE + DEPENDENCY SHARED LANES.
+# `Cargo.lock` deliberately does NOT go to `__global__`: two dependency PRs collide
+# with each other (and on cargo-vet attestations — see the repo's own
+# "same-new-dep beads collide on cargo-vet" finding), while a lockfile PR does not
+# collide with a docs PR at all. The lockfile's lane IS the collision surface.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "Cargo.toml"
+area = "workspace"
+
+[[map]]
+pattern = "Cargo.lock"
+area = "deps"
+
+[[map]]
+pattern = "rust-toolchain.toml"
+area = "workspace"
+
+[[map]]
+pattern = "rust-toolchain"
+area = "workspace"
+
+[[map]]
+pattern = ".cargo/**"
+area = "workspace"
+
+[[map]]
+pattern = "deny.toml"
+area = "deps"
+
+[[map]]
+pattern = "supply-chain/**"
+area = "deps"
+
+# ---------------------------------------------------------------------------
+# FRONT ENDS + BINDINGS.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "site/**"
+area = "site"
+
+[[map]]
+pattern = "assets/**"
+area = "site"
+
+[[map]]
+pattern = "gui/**"
+area = "gui"
+
+[[map]]
+pattern = "js/**"
+area = "js"
+
+[[map]]
+pattern = "packages/**"
+area = "js"
+
+[[map]]
+pattern = "package.json"
+area = "js"
+
+[[map]]
+pattern = "package-lock.json"
+area = "js"
+
+# ---------------------------------------------------------------------------
+# MEASUREMENT.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "bench/**"
+area = "bench"
+
+[[map]]
+pattern = "hwrun/**"
+area = "bench"
+
+[[map]]
+pattern = "metrics/**"
+area = "bench"
+
+[[map]]
+pattern = "gen_highcard.py"
+area = "bench"
+
+# ---------------------------------------------------------------------------
+# TEST SCAFFOLDING owned by no single crate.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "fuzz/**"
+area = "testing"
+
+[[map]]
+pattern = "tests/**"
+area = "testing"
+
+# ---------------------------------------------------------------------------
+# PACKAGING / RELEASE / DEPLOY.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "packaging/**"
+area = "release"
+
+[[map]]
+pattern = "release-plz.toml"
+area = "release"
+
+[[map]]
+pattern = "Dockerfile"
+area = "release"
+
+[[map]]
+pattern = "deploy/**"
+area = "deploy-demo"
+
+# ---------------------------------------------------------------------------
+# VENDORED FORKS -> `upstream` (the lane for work we contribute back).
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "vendor/**"
+area = "upstream"
+
+# ---------------------------------------------------------------------------
+# THE NOIR CIRCUIT TREE (out of the cargo workspace).
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "zk/**"
+area = "zk"
+
+# ---------------------------------------------------------------------------
+# PROSE SURFACES -> `docs`.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "docs/**"
+area = "docs"
+
+[[map]]
+pattern = "book/**"
+area = "docs"
+
+[[map]]
+pattern = "research/**"
+area = "docs"
+
+[[map]]
+pattern = "compliance/**"
+area = "docs"
+
+[[map]]
+pattern = "examples/**"
+area = "docs"
+
+# ROOT-level markdown only — `*` does not cross `/` (see PATTERN GRAMMAR above), so
+# this covers README.md / AGENTS.md / CLAUDE.md / SECURITY.md / CHANGELOG.md / ... and
+# never reaches `skills/**/SKILL.md` or a crate README.
+[[map]]
+pattern = "*.md"
+area = "docs"
+
+[[map]]
+pattern = "llms.txt"
+area = "docs"
+
+[[map]]
+pattern = "LICENSE"
+area = "docs"
+
+[[map]]
+pattern = "CODEOWNERS"
+area = "docs"
+
+# ---------------------------------------------------------------------------
+# `skills/<surface>/**` -> THE OWNING SURFACE.
+# Each row is the crate whose public API the skill documents (derived from the
+# crate the SKILL.md actually names, then hand-checked). A skill edit is doc work
+# on that crate's surface, so it collides with impl work on the same crate — which
+# is the desired serialization: the repo's public-API -> SKILL.md maintenance rule
+# means the same worker usually touches both.
+# `skills/SKILL.md` (the index) and the two non-crate surfaces go to `docs`.
+# ---------------------------------------------------------------------------
+[[map]]
+pattern = "skills/SKILL.md"
+area = "docs"
+
+[[map]]
+pattern = "skills/academic-paper/**"
+area = "docs"
+
+[[map]]
+pattern = "skills/terminology/**"
+area = "docs"
+
+[[map]]
+pattern = "skills/access-control/**"
+area = "sparq-solid"
+
+[[map]]
+pattern = "skills/agent-tools/**"
+area = "sparq-mcp"
+
+[[map]]
+pattern = "skills/arrow-columnar/**"
+area = "sparq-arrow"
+
+[[map]]
+pattern = "skills/cli/**"
+area = "sparq-cli"
+
+[[map]]
+pattern = "skills/data-formats/**"
+area = "sparq-core"
+
+[[map]]
+pattern = "skills/federated-planning/**"
+area = "sparq-fedplan"
+
+[[map]]
+pattern = "skills/full-text-search/**"
+area = "sparq-text"
+
+[[map]]
+pattern = "skills/genai-retrieval/**"
+area = "sparq-nlq"
+
+[[map]]
+pattern = "skills/geosparql/**"
+area = "sparq-geo"
+
+[[map]]
+pattern = "skills/gpu-kernels/**"
+area = "sparq-gpu"
+
+[[map]]
+pattern = "skills/graph-analytics/**"
+area = "sparq-algos"
+
+[[map]]
+pattern = "skills/helm-deploy/**"
+area = "sparq-server"
+
+[[map]]
+pattern = "skills/http-server/**"
+area = "sparq-server"
+
+[[map]]
+pattern = "skills/http3-server/**"
+area = "sparq-http3"
+
+[[map]]
+pattern = "skills/inference/**"
+area = "sparq-reason"
+
+[[map]]
+pattern = "skills/javascript-wasm/**"
+area = "sparq-wasm"
+
+[[map]]
+pattern = "skills/jsonld/**"
+area = "sparq-jsonld"
+
+[[map]]
+pattern = "skills/mpc/**"
+area = "sparq-mpc"
+
+[[map]]
+pattern = "skills/prov-lineage/**"
+area = "sparq-prov"
+
+[[map]]
+pattern = "skills/python/**"
+area = "sparq-py"
+
+[[map]]
+pattern = "skills/rdf-canon/**"
+area = "sparq-canon"
+
+[[map]]
+pattern = "skills/rdf-wrapper/**"
+area = "sparq-wrapper"
+
+[[map]]
+pattern = "skills/shacl-compact-syntax/**"
+area = "sparq-shaclc"
+
+[[map]]
+pattern = "skills/shacl-forms/**"
+area = "sparq-forms"
+
+[[map]]
+pattern = "skills/shacl-validation/**"
+area = "sparq-shacl"
+
+[[map]]
+pattern = "skills/sparql-query/**"
+area = "sparq-engine"
+
+[[map]]
+pattern = "skills/streaming-rsp/**"
+area = "sparq-rsp"
+
+[[map]]
+pattern = "skills/structural-similarity/**"
+area = "sparq-sim"
+
+[[map]]
+pattern = "skills/substrate/**"
+area = "sparq-substrate"
+
+[[map]]
+pattern = "skills/trust-graph/**"
+area = "sparq-trust"
+
+[[map]]
+pattern = "skills/usage-control-policy/**"
+area = "sparq-policy"
+
+[[map]]
+pattern = "skills/vector-search/**"
+area = "sparq-vectors"
+
+[[map]]
+pattern = "skills/verifiable-credentials/**"
+area = "sparq-vc"
+
+[[map]]
+pattern = "skills/zk-query-proofs/**"
+area = "sparq-zk"

--- a/scripts/pr-area-labels.py
+++ b/scripts/pr-area-labels.py
@@ -16,9 +16,21 @@ THE CONTRACT
     can never be dropped (`apply_areas` records every request; the test asserts no
     DELETE is ever issued).
   * FAIL CLOSED: it emits NO labels — leaving the PR on `__global__` — when the changed
-    paths are unavailable (`no-paths`), when ANY path is unattributable (`unresolved`),
-    or when more than `[policy] max_areas` distinct areas are implicated
-    (`cross-cutting`). Unknown blast radius must serialize. See ci/area-labels.toml.
+    paths are unavailable (`no-paths`), only PARTIALLY available (`incomplete-paths`),
+    when ANY path is unattributable (`unresolved`), or when more than
+    `[policy] max_areas` distinct areas are implicated (`cross-cutting`). Unknown blast
+    radius must serialize. See ci/area-labels.toml.
+  * THE INPUT BOUNDARY IS THE PROOF OBLIGATION. Attribution is a pure function of the
+    path string, so within a COMPLETE list under-reservation is impossible. It is the
+    list itself that cannot be trusted: `gh pr view --json files` is GraphQL
+    `files(first: 100)` and SILENTLY TRUNCATES (measured on this repo: PR #3581 reports
+    `changedFiles = 646` and `--json files` returns 100). A truncated list derives a
+    PROPER SUBSET of the true areas — the CORRUPTING direction, because a too-narrow
+    reservation puts two workers on one crate, while a too-broad one only delays. So the
+    file list is enumerated with the PAGINATED REST endpoint AND cross-checked against
+    the authoritative `changedFiles` count; any disagreement is `incomplete-paths`.
+    Renames are consumed via `previous_filename` (REST-only), so a cross-crate move
+    implicates BOTH the source and the destination crate.
   * It NEVER creates a label. GitHub's "add labels to an issue" REST call SILENTLY
     CREATES an unknown label, so a typo'd area would become permanent repo state; every
     candidate area is therefore checked against the repo's live label set first and
@@ -182,18 +194,25 @@ def attribute(path, policy):
     return None
 
 
-def derive_areas(paths, policy, known_areas):
+def derive_areas(paths, policy, known_areas, complete=True):
     """(areas, reason) for a changed-path list. EMPTY areas == stay on `__global__`.
 
     `known_areas` is the set of area names for which an `area:<name>` label ACTUALLY
     exists in the repo; an area outside it is treated as unresolved, because applying
     it would silently create a label (see module docstring).
 
-    The reason vocabulary is exactly {"resolved", "no-paths", "unresolved",
-    "cross-cutting"}; the latter three all mean "emit nothing, stay on `__global__`" and
-    are distinguished only so the log says WHY. Callers branch on `== "resolved"`, so a
-    future reason is fail-closed by construction.
+    `complete` is the verdict of `paths_are_complete` — whether `paths` is KNOWN to be
+    the whole changed-file list. A partial list derives a proper SUBSET of the true
+    areas, which is the corrupting direction, so it emits nothing.
+
+    The reason vocabulary is exactly {"resolved", "no-paths", "incomplete-paths",
+    "unresolved", "cross-cutting"}; the latter four all mean "emit nothing, stay on
+    `__global__`" and are distinguished only so the log says WHY. Callers branch on
+    `== "resolved"`, so a future reason is fail-closed by construction.
     """
+    if not complete:
+        # TRUNCATED / partial enumeration. See `paths_are_complete`.
+        return frozenset(), "incomplete-paths"
     if not paths:
         return frozenset(), "no-paths"
     areas, unresolved = set(), []
@@ -213,15 +232,38 @@ def derive_areas(paths, policy, known_areas):
     return frozenset(areas), "resolved"
 
 
+def paths_are_complete(enumerated, changed):
+    """Is an enumeration of `enumerated` changed-file ENTRIES the WHOLE changed set?
+
+    `changed` is GitHub's authoritative `changedFiles` count for the PR, fetched
+    independently of the file list. They disagree exactly when the enumeration was
+    capped — GraphQL's `files(first: 100)`, or the REST endpoint's 3000-file ceiling.
+
+    Fail closed on anything that is not a confident, exact agreement: a missing or
+    non-integer `changed` means we could not establish completeness at all, which is
+    NOT the same as having established it.
+    """
+    if not isinstance(enumerated, int) or isinstance(enumerated, bool) or enumerated < 0:
+        return False
+    if not isinstance(changed, int) or isinstance(changed, bool) or changed < 0:
+        return False
+    return enumerated == changed
+
+
 def plan_for_pr(pr, policy, known_areas):
-    """The full decision for one PR dict {number, labels:[str], files:[str]}.
+    """The full decision for one PR dict {number, labels:[str], files:[str], complete:bool}.
 
     Returns a dict with the derived areas, the labels to ADD (never to remove), and the
     reason. `partition` is what the scheduler will see AFTER the add.
+
+    `complete` must be EXACTLY `True` for any label to be emitted. A record that omits it
+    — a fetcher that never established that its file list is whole — therefore fails
+    CLOSED rather than deriving from a possibly-truncated list.
     """
     existing = {lb[len(AREA_PREFIX):] for lb in pr.get("labels") or []
                 if isinstance(lb, str) and lb.startswith(AREA_PREFIX)}
-    areas, reason = derive_areas(pr.get("files") or [], policy, known_areas)
+    areas, reason = derive_areas(pr.get("files") or [], policy, known_areas,
+                                 complete=pr.get("complete") is True)
     add = sorted(areas - existing)
     after = existing | areas
     return {
@@ -281,29 +323,68 @@ def known_area_labels(repo, runner=None):
             if ln.startswith(AREA_PREFIX) and len(ln) > len(AREA_PREFIX)}
 
 
+def fetch_changed_files(repo, number, runner=None):
+    """(paths, entry_count) for a PR, enumerated with the PAGINATED REST endpoint.
+
+    `gh pr view --json files` is GraphQL `files(first: 100)` and is NOT used anywhere in
+    this module: it silently truncates, and a truncated list derives a proper SUBSET of
+    the true areas (module docstring). `gh api --paginate` walks every page.
+
+    `paths` contains, for each entry, the file's CURRENT path and — for a rename — its
+    `previous_filename` as well, so a move out of `crates/A/` into `crates/B/` implicates
+    BOTH crates. `entry_count` counts ENTRIES, not paths, because that is the number
+    `changedFiles` is comparable with.
+    """
+    raw = _gh(["api", "--paginate", f"repos/{repo}/pulls/{number}/files?per_page=100",
+               "--jq", r'.[] | [.filename, (.previous_filename // "")] | @tsv'],
+              runner=runner)
+    paths, entries = [], 0
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        entries += 1
+        current, _, previous = line.partition("\t")
+        for p in (current.strip(), previous.strip()):
+            if p and p not in paths:
+                paths.append(p)
+    return paths, entries
+
+
+def _with_changed_files(repo, record, changed, runner=None):
+    """Attach the enumerated paths + the completeness verdict to a PR record."""
+    paths, entries = fetch_changed_files(repo, record["number"], runner=runner)
+    record["files"] = paths
+    record["complete"] = paths_are_complete(entries, changed)
+    return record
+
+
 def fetch_pr(repo, number, runner=None):
+    # `changedFiles` is the authoritative count and is fetched INDEPENDENTLY of the file
+    # list, so the two can be cross-checked. `files` is deliberately NOT requested here.
     raw = _gh(["pr", "view", str(number), "--repo", repo,
-               "--json", "number,labels,files"], runner=runner)
+               "--json", "number,labels,changedFiles"], runner=runner)
     data = json.loads(raw)
-    return {
+    return _with_changed_files(repo, {
         "number": data.get("number", number),
         "labels": [lb.get("name") for lb in data.get("labels") or []],
-        "files": [f.get("path") for f in data.get("files") or []],
-    }
+    }, data.get("changedFiles"), runner=runner)
 
 
 def fetch_open_prs(repo, limit=300, runner=None):
+    # Same rule as fetch_pr: the list call carries metadata + the authoritative count,
+    # never the capped GraphQL `files` connection. The per-PR REST enumeration costs one
+    # extra call per open PR; a backfill is a hand-run, dry-run-by-default operation, and
+    # a wrong narrow label is not worth saving ~90 requests.
     raw = _gh(["pr", "list", "--repo", repo, "--state", "open", "--limit", str(limit),
-               "--json", "number,labels,files,isDraft,title"], runner=runner)
+               "--json", "number,labels,changedFiles,isDraft,title"], runner=runner)
     out = []
     for data in json.loads(raw):
-        out.append({
+        out.append(_with_changed_files(repo, {
             "number": data.get("number"),
             "labels": [lb.get("name") for lb in data.get("labels") or []],
-            "files": [f.get("path") for f in data.get("files") or []],
             "title": data.get("title") or "",
             "isDraft": bool(data.get("isDraft")),
-        })
+        }, data.get("changedFiles"), runner=runner))
     return out
 
 
@@ -331,6 +412,9 @@ def _emit(plan, pr, policy, known_areas, apply, out):
                 detail += f" (+{len(blockers) - 8} more)"
         elif plan["reason"] == "cross-cutting":
             detail = f"  spans >{policy.max_areas} areas"
+        elif plan["reason"] == "incomplete-paths":
+            detail = ("  changed-file enumeration disagreed with `changedFiles` — the "
+                      "list is partial, so any narrowing would be a proper SUBSET")
         print(f"#{n} KEEP {GLOBAL} [{plan['reason']}]{detail}", file=out)
         return 0
     if plan["noop"]:
@@ -462,6 +546,15 @@ def _self_test():
     assert areas(ok)[1] == "resolved" and len(areas(ok)[0]) == policy.max_areas
     # No paths at all => global.
     assert areas([]) == (frozenset(), "no-paths")
+    # A PARTIAL changed-file list => global. This is the truncation boundary: the same
+    # paths derive a real (but SUBSET) answer when the list is known whole.
+    partial = ["crates/sparq-core/src/lib.rs"]
+    assert derive_areas(partial, policy, known, complete=False) == (
+        frozenset(), "incomplete-paths")
+    assert derive_areas(partial, policy, known, complete=True)[1] == "resolved"
+    assert paths_are_complete(100, 646) is False
+    assert paths_are_complete(646, 646) is True
+    assert paths_are_complete(0, None) is False
     # An area with no live label is unresolved, never auto-created.
     assert derive_areas(["crates/sparq-core/src/lib.rs"], policy, set()) == (
         frozenset(), "unresolved")
@@ -475,17 +568,23 @@ def _self_test():
     assert attribute("scripts/pr-area-labels.py", policy) == "ci"
     # Additive only: derivation never proposes removing a human label.
     plan = plan_for_pr({"number": 1, "labels": ["area:sparq-core", "review:parked"],
-                        "files": ["crates/sparq-engine/src/lib.rs"]}, policy, known)
+                        "files": ["crates/sparq-engine/src/lib.rs"],
+                        "complete": True}, policy, known)
     assert plan["add"] == ["area:sparq-engine"], plan
     assert plan["partition"] == ["sparq-core", "sparq-engine"], plan
     # Idempotent: nothing to add when the derived area is already there.
     assert plan_for_pr({"number": 2, "labels": ["area:sparq-engine"],
-                        "files": ["crates/sparq-engine/src/lib.rs"]},
+                        "files": ["crates/sparq-engine/src/lib.rs"], "complete": True},
                        policy, known)["noop"] is True
     # A fail-closed PR that already carries a HUMAN area keeps it (not global).
     keep = plan_for_pr({"number": 3, "labels": ["area:sparq-zk"],
-                        "files": ["no/such/dir/x.txt"]}, policy, known)
+                        "files": ["no/such/dir/x.txt"], "complete": True}, policy, known)
     assert keep["add"] == [] and keep["partition"] == ["sparq-zk"], keep
+    # A record with NO completeness verdict fails CLOSED — a fetcher that never
+    # established that its list is whole must not narrow anything.
+    blind = plan_for_pr({"number": 4, "labels": [],
+                         "files": ["crates/sparq-engine/src/lib.rs"]}, policy, known)
+    assert blind["add"] == [] and blind["reason"] == "incomplete-paths", blind
     print("pr-area-labels self-test OK")
     return 0
 

--- a/scripts/pr-area-labels.py
+++ b/scripts/pr-area-labels.py
@@ -57,9 +57,6 @@ WORKSPACE_MANIFEST = REPO_ROOT / "Cargo.toml"
 GLOBAL = "__global__"          # mirrors ready-issues.py / dispatch-claim.py
 AREA_PREFIX = "area:"
 CRATES_DIR = "crates"
-# Reasons the deriver declines to narrow a PR. Every one of these means "stay on
-# __global__"; they are distinguished only so the log says WHY.
-FAIL_CLOSED = ("no-paths", "unresolved", "cross-cutting")
 
 
 class PolicyError(RuntimeError):
@@ -191,6 +188,11 @@ def derive_areas(paths, policy, known_areas):
     `known_areas` is the set of area names for which an `area:<name>` label ACTUALLY
     exists in the repo; an area outside it is treated as unresolved, because applying
     it would silently create a label (see module docstring).
+
+    The reason vocabulary is exactly {"resolved", "no-paths", "unresolved",
+    "cross-cutting"}; the latter three all mean "emit nothing, stay on `__global__`" and
+    are distinguished only so the log says WHY. Callers branch on `== "resolved"`, so a
+    future reason is fail-closed by construction.
     """
     if not paths:
         return frozenset(), "no-paths"

--- a/scripts/pr-area-labels.py
+++ b/scripts/pr-area-labels.py
@@ -83,12 +83,12 @@ class Policy:
 
 
 def load_members(manifest=WORKSPACE_MANIFEST):
-    """The workspace crate directory names — the domain of the implicit `crates/<name>` rule.
+    """The workspace crate directory names, read from the root manifest (hermetic — no
+    `cargo metadata`, no toolchain).
 
-    Read from the root manifest rather than `cargo metadata` so this stays hermetic and
-    needs no toolchain. A `crates/<x>/...` path whose `<x>` is not a member is
-    UNRESOLVED (fail closed), which is what stops `crates/README.md` or a stale
-    directory from inventing an area.
+    NOT a gate on attribution: see `attribute` for why a PR that ADDS a crate must still
+    resolve. Membership is used for the hermetic table-validity assertions and for the
+    `::warning` about declared areas that have no label.
     """
     data = tomllib.loads(Path(manifest).read_text(encoding="utf-8"))
     members = ((data.get("workspace") or {}).get("members") or [])
@@ -160,16 +160,25 @@ def attribute(path, policy):
     """The single area a changed path implicates, or None when nothing claims it.
 
     Resolution order is normative (ci/area-labels.toml): the implicit
-    `crates/<member>/...` rule first, then the first matching `[[map]]` row.
+    `crates/<name>/...` rule first, then the first matching `[[map]]` row.
     """
     if not isinstance(path, str) or not path:
         return None
     path = path[2:] if path.startswith("./") else path
     parts = path.split("/")
-    if len(parts) >= 2 and parts[0] == CRATES_DIR:
-        # A `crates/` path is claimed ONLY by a live workspace member. Anything else
-        # (a stale dir, `crates/README.md`) is unresolved => fail closed.
-        return parts[1] if parts[1] in policy.members else None
+    if parts[0] == CRATES_DIR:
+        # A CRATE DIRECTORY is `crates/<name>/<something>` — at least three segments.
+        # A file sitting directly in `crates/` (two segments, e.g. `crates/README.md`)
+        # is NOT a crate and resolves to nothing => fail closed.
+        if len(parts) < 3:
+            return None
+        # Deliberately NOT gated on workspace membership. The workflow evaluates a PR
+        # against the DEFAULT BRANCH's manifest (a `pull-requests: write` job must not
+        # run PR-authored code), so a PR that ADDS a crate would be permanently
+        # unresolvable — and those are exactly the PRs that collide with nothing and
+        # most deserve a narrow partition. The guard against inventing an area is the
+        # caller's live-`area:`-label check, which a non-crate name cannot pass.
+        return parts[1]
     for pattern, area in policy.rows:
         if matches(pattern, path):
             return area
@@ -395,8 +404,10 @@ def main(argv=None, runner=None, out=None):
     mode = "APPLIED" if args.apply else "DRY RUN (nothing written)"
     print(f"-- {mode}: {len(prs)} PR(s); {changed} relabelled; "
           f"{kept} left on {GLOBAL} (fail-closed)", file=out)
-    # Report, in the workflow log, which areas were dropped for want of a label.
-    missing = sorted(policy.declared_areas() - known - policy.members)
+    # Report, in the workflow log, which areas were dropped for want of a label — the
+    # declared [[map]] areas AND every workspace member, since a crate with no
+    # `area:` label silently sends every PR that touches it back to __global__.
+    missing = sorted((policy.declared_areas() | policy.members) - known)
     if missing:
         print(f"::warning title=pr-area-label missing labels::declared in "
               f"ci/area-labels.toml but no such label exists: "
@@ -427,8 +438,10 @@ def _self_test():
     assert areas(["no/such/dir/x.txt"]) == (frozenset(), "unresolved")
     assert areas(["crates/sparq-core/src/lib.rs", "no/such/dir/x.txt"]) == (
         frozenset(), "unresolved")
-    # A non-member directory under crates/ is not an area.
+    # An unknown crate directory has no label, so it is unresolved; a file sitting
+    # directly in crates/ is not a crate at all.
     assert areas(["crates/not-a-crate/src/lib.rs"]) == (frozenset(), "unresolved")
+    assert attribute("crates/README.md", policy) is None
     # Genuinely workspace-spanning work stays global.
     wide = [f"crates/{c}/src/lib.rs" for c in sorted(policy.members)[:policy.max_areas + 1]]
     assert areas(wide) == (frozenset(), "cross-cutting")

--- a/scripts/pr-area-labels.py
+++ b/scripts/pr-area-labels.py
@@ -351,6 +351,13 @@ def main(argv=None, runner=None, out=None):
     ap.add_argument("--dry-run", action="store_true",
                     help="explicit no-op default; mutually exclusive with --apply")
     ap.add_argument("--limit", type=int, default=300, help="backfill PR page ceiling")
+    ap.add_argument("--pace", type=float, default=0.0,
+                    help="seconds to wait between label writes during a backfill. Adding a "
+                         "label fires a `pull_request: labeled` event, and ci/bench/fuzz/"
+                         "feature-matrix all trigger on it (as guarded no-op runs). A "
+                         "one-pass backfill of ~85 PRs therefore queues hundreds of short "
+                         "jobs at once; pacing keeps the runners from congesting, which this "
+                         "repo has previously seen turn into FALSE gate failures.")
     ap.add_argument("--head-repo", default=None,
                     help="the PR head repo full_name. When it is not --repo the PR is a "
                          "FORK PR whose `pull_request` token is READ-ONLY: report and exit 0.")
@@ -401,6 +408,9 @@ def main(argv=None, runner=None, out=None):
             kept += 1
         if args.apply and plan["add"]:
             apply_areas(args.repo, plan["number"], plan["add"], runner=runner)
+            if args.pace > 0:
+                import time
+                time.sleep(args.pace)
     mode = "APPLIED" if args.apply else "DRY RUN (nothing written)"
     print(f"-- {mode}: {len(prs)} PR(s); {changed} relabelled; "
           f"{kept} left on {GLOBAL} (fail-closed)", file=out)

--- a/scripts/pr-area-labels.py
+++ b/scripts/pr-area-labels.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+# [OPUS-5] 🤖 SPARQ agent — derive a PR's `area:` conflict-partition labels from its
+# changed paths. Registry issue jeswr/agent-account-registry#677.
+"""pr-area-labels.py — the ONE deriver used by both the per-PR workflow and the backfill.
+
+WHY (measured, reg#677 2026-07-26): the fleet scheduler partitions work by `area:<name>`.
+An in-flight PR RESERVES its areas; a ready issue defers while any of its areas is
+reserved. A PR with NO `area:` label maps to the SERIALIZING `__global__` partition, so
+one such PR defers EVERY issue. 84 of 87 open PRs had no `area:` label because nothing
+in the pipeline ever applied one — making this layer, not `max_concurrent` (reg#689:
+net +0 workers) and not the 28-slot account pool, the binding limiter on throughput.
+
+THE CONTRACT
+  * `__global__` is expressed as the ABSENCE of any `area:` label. This script only ever
+    ADDS labels; there is no removal code path at all, so a human-applied `area:` label
+    can never be dropped (`apply_areas` records every request; the test asserts no
+    DELETE is ever issued).
+  * FAIL CLOSED: it emits NO labels — leaving the PR on `__global__` — when the changed
+    paths are unavailable (`no-paths`), when ANY path is unattributable (`unresolved`),
+    or when more than `[policy] max_areas` distinct areas are implicated
+    (`cross-cutting`). Unknown blast radius must serialize. See ci/area-labels.toml.
+  * It NEVER creates a label. GitHub's "add labels to an issue" REST call SILENTLY
+    CREATES an unknown label, so a typo'd area would become permanent repo state; every
+    candidate area is therefore checked against the repo's live label set first and
+    dropped (loudly) if absent. A dropped area means the PR stays `__global__` — the
+    safe direction.
+  * IDEMPOTENT: areas already on the PR are never re-posted; a second run over an
+    already-labelled PR issues zero writes.
+  * READ-ONLY BY DEFAULT (repo convention, cf. scripts/push-frontier.sh): `--dry-run` is
+    the default and prints exactly what it would do. `--apply` is required to mutate.
+
+MODES
+  --pr N        derive (and with --apply, label) a single PR. Used by the workflow.
+  --backfill    derive (and with --apply, label) every OPEN PR in one pass.
+  --self-test   hermetic assertions; no network. Run by routing-self-tests.yml.
+
+FORK PRs: `pull_request` (not `pull_request_target`) hands a fork PR a READ-ONLY token,
+so no label write can succeed. That path is handled EXPLICITLY: pass
+`--head-repo <full_name>` and the run becomes a reporting no-op with a `::notice` when
+the head repo is not this repo. It is not left to fail confusingly on a 403.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_PATH = REPO_ROOT / "ci" / "area-labels.toml"
+WORKSPACE_MANIFEST = REPO_ROOT / "Cargo.toml"
+
+GLOBAL = "__global__"          # mirrors ready-issues.py / dispatch-claim.py
+AREA_PREFIX = "area:"
+CRATES_DIR = "crates"
+# Reasons the deriver declines to narrow a PR. Every one of these means "stay on
+# __global__"; they are distinguished only so the log says WHY.
+FAIL_CLOSED = ("no-paths", "unresolved", "cross-cutting")
+
+
+class PolicyError(RuntimeError):
+    """A malformed ci/area-labels.toml. Fail loudly — never silently label nothing."""
+
+
+# --------------------------------------------------------------------------- policy
+
+
+class Policy:
+    """The parsed ci/area-labels.toml: the ordered pattern rows + the guard rails."""
+
+    def __init__(self, max_areas, rows, non_crate, members):
+        self.max_areas = max_areas
+        self.rows = rows                # [(pattern, area)] in FILE ORDER; first match wins
+        self.non_crate = frozenset(non_crate)
+        self.members = frozenset(members)   # live workspace crate dir names
+
+    def declared_areas(self):
+        return {area for _, area in self.rows}
+
+
+def load_members(manifest=WORKSPACE_MANIFEST):
+    """The workspace crate directory names — the domain of the implicit `crates/<name>` rule.
+
+    Read from the root manifest rather than `cargo metadata` so this stays hermetic and
+    needs no toolchain. A `crates/<x>/...` path whose `<x>` is not a member is
+    UNRESOLVED (fail closed), which is what stops `crates/README.md` or a stale
+    directory from inventing an area.
+    """
+    data = tomllib.loads(Path(manifest).read_text(encoding="utf-8"))
+    members = ((data.get("workspace") or {}).get("members") or [])
+    out = set()
+    for m in members:
+        if not isinstance(m, str):
+            raise PolicyError(f"non-string workspace member: {m!r}")
+        parts = m.strip("/").split("/")
+        if len(parts) == 2 and parts[0] == CRATES_DIR:
+            out.add(parts[1])
+    if not out:
+        raise PolicyError(f"no crates/* workspace members found in {manifest}")
+    return out
+
+
+def load_policy(path=POLICY_PATH, manifest=WORKSPACE_MANIFEST):
+    data = tomllib.loads(Path(path).read_text(encoding="utf-8"))
+    policy = data.get("policy") or {}
+    max_areas = policy.get("max_areas")
+    if not isinstance(max_areas, int) or isinstance(max_areas, bool) or max_areas < 1:
+        raise PolicyError(f"{path}: [policy] max_areas must be a positive int")
+    non_crate = (data.get("lanes") or {}).get("non_crate") or []
+    if not isinstance(non_crate, list) or not all(isinstance(x, str) and x for x in non_crate):
+        raise PolicyError(f"{path}: [lanes] non_crate must be a list of non-empty strings")
+    rows = []
+    for i, row in enumerate(data.get("map") or []):
+        if not isinstance(row, dict):
+            raise PolicyError(f"{path}: [[map]] entry {i} is not a table")
+        pattern, area = row.get("pattern"), row.get("area")
+        if not isinstance(pattern, str) or not pattern:
+            raise PolicyError(f"{path}: [[map]] entry {i} has no `pattern`")
+        if not isinstance(area, str) or not area:
+            raise PolicyError(f"{path}: [[map]] {pattern!r} has no `area`")
+        rows.append((pattern, area))
+    if not rows:
+        raise PolicyError(f"{path}: no [[map]] rows — every non-crate path would be unresolved")
+    return Policy(max_areas, rows, non_crate, load_members(manifest))
+
+
+def _segment_glob(pattern):
+    """Translate a glob to a regex whose `*`/`?` do NOT cross `/`.
+
+    The deliberate difference from ci/path-ownership.toml's `fnmatch` (documented in
+    ci/area-labels.toml): with fnmatch, a `*.md` row also matches
+    `skills/inference/SKILL.md`, which makes the whole map order-fragile. Here `*.md`
+    means a ROOT markdown file and nothing else.
+    """
+    out = ["(?s:"]
+    for ch in pattern:
+        if ch == "*":
+            out.append("[^/]*")
+        elif ch == "?":
+            out.append("[^/]")
+        else:
+            out.append(re.escape(ch))
+    out.append(")\\Z")
+    return re.compile("".join(out))
+
+
+def matches(pattern, path):
+    """Does `pattern` (see ci/area-labels.toml PATTERN GRAMMAR) match repo-relative `path`?"""
+    if pattern.endswith("/**"):
+        root = pattern[:-3]
+        return path == root or path.startswith(root + "/")
+    return bool(_segment_glob(pattern).match(path))
+
+
+def attribute(path, policy):
+    """The single area a changed path implicates, or None when nothing claims it.
+
+    Resolution order is normative (ci/area-labels.toml): the implicit
+    `crates/<member>/...` rule first, then the first matching `[[map]]` row.
+    """
+    if not isinstance(path, str) or not path:
+        return None
+    path = path[2:] if path.startswith("./") else path
+    parts = path.split("/")
+    if len(parts) >= 2 and parts[0] == CRATES_DIR:
+        # A `crates/` path is claimed ONLY by a live workspace member. Anything else
+        # (a stale dir, `crates/README.md`) is unresolved => fail closed.
+        return parts[1] if parts[1] in policy.members else None
+    for pattern, area in policy.rows:
+        if matches(pattern, path):
+            return area
+    return None
+
+
+def derive_areas(paths, policy, known_areas):
+    """(areas, reason) for a changed-path list. EMPTY areas == stay on `__global__`.
+
+    `known_areas` is the set of area names for which an `area:<name>` label ACTUALLY
+    exists in the repo; an area outside it is treated as unresolved, because applying
+    it would silently create a label (see module docstring).
+    """
+    if not paths:
+        return frozenset(), "no-paths"
+    areas, unresolved = set(), []
+    for path in paths:
+        area = attribute(path, policy)
+        if area is None or area not in known_areas:
+            unresolved.append(path)
+            continue
+        areas.add(area)
+    if unresolved:
+        # STRICT on purpose: one unattributable path means unknown blast radius.
+        return frozenset(), "unresolved"
+    if not areas:
+        return frozenset(), "no-paths"
+    if len(areas) > policy.max_areas:
+        return frozenset(), "cross-cutting"
+    return frozenset(areas), "resolved"
+
+
+def plan_for_pr(pr, policy, known_areas):
+    """The full decision for one PR dict {number, labels:[str], files:[str]}.
+
+    Returns a dict with the derived areas, the labels to ADD (never to remove), and the
+    reason. `partition` is what the scheduler will see AFTER the add.
+    """
+    existing = {lb[len(AREA_PREFIX):] for lb in pr.get("labels") or []
+                if isinstance(lb, str) and lb.startswith(AREA_PREFIX)}
+    areas, reason = derive_areas(pr.get("files") or [], policy, known_areas)
+    add = sorted(areas - existing)
+    after = existing | areas
+    return {
+        "number": pr.get("number"),
+        "existing": sorted(existing),
+        "derived": sorted(areas),
+        "add": [AREA_PREFIX + a for a in add],
+        "reason": reason,
+        # The scheduler reads absence-of-area as `__global__`; a PR that keeps a
+        # human-applied area is NOT global even when derivation failed.
+        "partition": sorted(after) if after else [GLOBAL],
+        "noop": not add,
+    }
+
+
+def unresolved_paths(pr, policy, known_areas):
+    """The paths that blocked narrowing — the actionable output of a `unresolved` run."""
+    out = []
+    for path in pr.get("files") or []:
+        area = attribute(path, policy)
+        if area is None or area not in known_areas:
+            out.append(path)
+    return out
+
+
+# ------------------------------------------------------------------------ github I/O
+
+
+def _gh(args, runner=None, attempts=3, sleep=None):
+    """Run `gh`, retrying a TRANSIENT failure a bounded number of times.
+
+    The retry exists so a 502/secondary-rate-limit blip does not red a gating check; it
+    deliberately does NOT swallow a persistent failure — after `attempts` tries the error
+    is raised and the job fails. (This repo has been bitten three times by a later
+    transient DISCARDING an earned hard failure; the direction here is the opposite.)
+    """
+    if runner is not None:
+        return runner(args)
+    last = ""
+    for attempt in range(attempts):
+        proc = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+        if proc.returncode == 0:
+            return proc.stdout
+        last = proc.stderr.strip()[:400]
+        if attempt + 1 < attempts:
+            (sleep or __import__("time").sleep)(2 * (attempt + 1))
+    raise RuntimeError(f"gh {' '.join(args)} failed after {attempts} attempt(s): {last}")
+
+
+def known_area_labels(repo, runner=None):
+    """The area names that already exist as labels. Fail-closed: an empty/failed read
+    yields an empty set, so NOTHING is labelled and every PR stays `__global__` —
+    the status quo, never a wrong narrow label."""
+    raw = _gh(["api", "--paginate", f"repos/{repo}/labels?per_page=100",
+               "--jq", ".[].name"], runner=runner)
+    return {ln[len(AREA_PREFIX):] for ln in raw.splitlines()
+            if ln.startswith(AREA_PREFIX) and len(ln) > len(AREA_PREFIX)}
+
+
+def fetch_pr(repo, number, runner=None):
+    raw = _gh(["pr", "view", str(number), "--repo", repo,
+               "--json", "number,labels,files"], runner=runner)
+    data = json.loads(raw)
+    return {
+        "number": data.get("number", number),
+        "labels": [lb.get("name") for lb in data.get("labels") or []],
+        "files": [f.get("path") for f in data.get("files") or []],
+    }
+
+
+def fetch_open_prs(repo, limit=300, runner=None):
+    raw = _gh(["pr", "list", "--repo", repo, "--state", "open", "--limit", str(limit),
+               "--json", "number,labels,files,isDraft,title"], runner=runner)
+    out = []
+    for data in json.loads(raw):
+        out.append({
+            "number": data.get("number"),
+            "labels": [lb.get("name") for lb in data.get("labels") or []],
+            "files": [f.get("path") for f in data.get("files") or []],
+            "title": data.get("title") or "",
+            "isDraft": bool(data.get("isDraft")),
+        })
+    return out
+
+
+def apply_areas(repo, number, labels, runner=None):
+    """ADD labels to a PR. There is deliberately no removal counterpart in this module."""
+    if not labels:
+        return
+    args = ["pr", "edit", str(number), "--repo", repo]
+    for lb in labels:
+        args += ["--add-label", lb]
+    _gh(args, runner=runner)
+
+
+# ----------------------------------------------------------------------------- CLI
+
+
+def _emit(plan, pr, policy, known_areas, apply, out):
+    n = plan["number"]
+    if plan["reason"] != "resolved":
+        blockers = unresolved_paths(pr, policy, known_areas)
+        detail = ""
+        if plan["reason"] == "unresolved":
+            detail = "  unattributable: " + ", ".join(sorted(blockers)[:8])
+            if len(blockers) > 8:
+                detail += f" (+{len(blockers) - 8} more)"
+        elif plan["reason"] == "cross-cutting":
+            detail = f"  spans >{policy.max_areas} areas"
+        print(f"#{n} KEEP {GLOBAL} [{plan['reason']}]{detail}", file=out)
+        return 0
+    if plan["noop"]:
+        print(f"#{n} no-change  already {' '.join(plan['existing']) or '(none)'}", file=out)
+        return 0
+    verb = "LABEL" if apply else "would label"
+    print(f"#{n} {verb} {' '.join(plan['add'])}"
+          f"   partition -> {' '.join(plan['partition'])}", file=out)
+    return 1
+
+
+def main(argv=None, runner=None, out=None):
+    out = out or sys.stdout
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=os.environ.get("SPARQ_REPO", "sparq-org/sparq"))
+    ap.add_argument("--pr", type=int, help="derive for a single PR number")
+    ap.add_argument("--backfill", action="store_true", help="derive for every OPEN PR")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually add the labels (default: dry run, touch nothing)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="explicit no-op default; mutually exclusive with --apply")
+    ap.add_argument("--limit", type=int, default=300, help="backfill PR page ceiling")
+    ap.add_argument("--head-repo", default=None,
+                    help="the PR head repo full_name. When it is not --repo the PR is a "
+                         "FORK PR whose `pull_request` token is READ-ONLY: report and exit 0.")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+    if args.apply and args.dry_run:
+        print("--apply and --dry-run are mutually exclusive", file=sys.stderr)
+        return 2
+    # NO-PULL-REQUEST-CONTEXT PATH. The workflow passes `--pr 0` on a merge_group ref
+    # (the payload has no pull request). Decided HERE, in Python, rather than with a
+    # workflow `if:` — an `if:` mutant survives, a Python one dies against a named test.
+    if args.pr == 0 and not args.backfill:
+        print("::notice title=pr-area-label skipped::no pull-request context "
+              "(`--pr 0`); nothing to label on this ref.", file=out)
+        return 0
+    if bool(args.pr) == bool(args.backfill):
+        print("exactly one of --pr N / --backfill is required", file=sys.stderr)
+        return 2
+
+    # FORK PATH, handled explicitly rather than as a confusing 403 (see docstring).
+    # An EMPTY --head-repo is treated the same way: the payload did not tell us the head
+    # repo, so we cannot establish that the token is writable — fail closed, stay global.
+    if args.head_repo is not None and args.head_repo != args.repo:
+        where = f"'{args.head_repo}'" if args.head_repo else "(not reported)"
+        print(f"::notice title=pr-area-label skipped::PR head repo {where} is not "
+              f"'{args.repo}'; a fork `pull_request` run holds a READ-ONLY token, so no "
+              f"`area:` label can be applied. The PR stays on the fail-closed "
+              f"{GLOBAL} partition; label it by hand or from a trusted context.", file=out)
+        return 0
+
+    policy = load_policy()
+    known = known_area_labels(args.repo, runner=runner)
+    if not known:
+        print(f"::warning title=pr-area-label inert::no `{AREA_PREFIX}*` labels readable in "
+              f"{args.repo}; nothing to apply (every PR stays {GLOBAL}).", file=out)
+        return 0
+
+    prs = ([fetch_pr(args.repo, args.pr, runner=runner)] if args.pr
+           else fetch_open_prs(args.repo, limit=args.limit, runner=runner))
+    changed = kept = 0
+    for pr in prs:
+        plan = plan_for_pr(pr, policy, known)
+        changed += _emit(plan, pr, policy, known, args.apply, out)
+        if plan["reason"] != "resolved":
+            kept += 1
+        if args.apply and plan["add"]:
+            apply_areas(args.repo, plan["number"], plan["add"], runner=runner)
+    mode = "APPLIED" if args.apply else "DRY RUN (nothing written)"
+    print(f"-- {mode}: {len(prs)} PR(s); {changed} relabelled; "
+          f"{kept} left on {GLOBAL} (fail-closed)", file=out)
+    # Report, in the workflow log, which areas were dropped for want of a label.
+    missing = sorted(policy.declared_areas() - known - policy.members)
+    if missing:
+        print(f"::warning title=pr-area-label missing labels::declared in "
+              f"ci/area-labels.toml but no such label exists: "
+              f"{', '.join(AREA_PREFIX + m for m in missing)}", file=out)
+    return 0
+
+
+# ----------------------------------------------------------------------- self-test
+
+
+def _self_test():
+    """Hermetic assertions over the REAL ci/area-labels.toml. Full coverage (including
+    the workflow-YAML seam and the fake-gh idempotence/no-delete proofs) lives in
+    scripts/tests/test_pr_area_labels.py; this is the fast in-script smoke the
+    orchestration lane runs alongside the other `--self-test` entry points."""
+    policy = load_policy()
+    known = policy.members | policy.non_crate
+
+    def areas(paths):
+        return derive_areas(paths, policy, known)
+
+    # A crates/x-only PR narrows to exactly x — the reg#677 #4143 case.
+    assert areas(["crates/sparq-reason/src/lib.rs"]) == (frozenset({"sparq-reason"}), "resolved")
+    # ... and the skill that documents it joins the SAME partition.
+    assert areas(["crates/sparq-reason/src/lib.rs", "skills/inference/SKILL.md"]) == (
+        frozenset({"sparq-reason"}), "resolved")
+    # An unattributable path fails CLOSED, and poisons the whole PR.
+    assert areas(["no/such/dir/x.txt"]) == (frozenset(), "unresolved")
+    assert areas(["crates/sparq-core/src/lib.rs", "no/such/dir/x.txt"]) == (
+        frozenset(), "unresolved")
+    # A non-member directory under crates/ is not an area.
+    assert areas(["crates/not-a-crate/src/lib.rs"]) == (frozenset(), "unresolved")
+    # Genuinely workspace-spanning work stays global.
+    wide = [f"crates/{c}/src/lib.rs" for c in sorted(policy.members)[:policy.max_areas + 1]]
+    assert areas(wide) == (frozenset(), "cross-cutting")
+    # ... but max_areas crates is still narrow.
+    ok = [f"crates/{c}/src/lib.rs" for c in sorted(policy.members)[:policy.max_areas]]
+    assert areas(ok)[1] == "resolved" and len(areas(ok)[0]) == policy.max_areas
+    # No paths at all => global.
+    assert areas([]) == (frozenset(), "no-paths")
+    # An area with no live label is unresolved, never auto-created.
+    assert derive_areas(["crates/sparq-core/src/lib.rs"], policy, set()) == (
+        frozenset(), "unresolved")
+    # `*` never crosses `/`: the root-markdown row must not swallow a skill or a crate doc.
+    assert attribute("README.md", policy) == "docs"
+    assert attribute("skills/inference/SKILL.md", policy) == "sparq-reason"
+    assert attribute("crates/sparq-core/README.md", policy) == "sparq-core"
+    # The shared-lane rows the frontier depends on.
+    assert attribute("Cargo.lock", policy) == "deps"
+    assert attribute(".github/workflows/ci.yml", policy) == "ci"
+    assert attribute("scripts/pr-area-labels.py", policy) == "ci"
+    # Additive only: derivation never proposes removing a human label.
+    plan = plan_for_pr({"number": 1, "labels": ["area:sparq-core", "review:parked"],
+                        "files": ["crates/sparq-engine/src/lib.rs"]}, policy, known)
+    assert plan["add"] == ["area:sparq-engine"], plan
+    assert plan["partition"] == ["sparq-core", "sparq-engine"], plan
+    # Idempotent: nothing to add when the derived area is already there.
+    assert plan_for_pr({"number": 2, "labels": ["area:sparq-engine"],
+                        "files": ["crates/sparq-engine/src/lib.rs"]},
+                       policy, known)["noop"] is True
+    # A fail-closed PR that already carries a HUMAN area keeps it (not global).
+    keep = plan_for_pr({"number": 3, "labels": ["area:sparq-zk"],
+                        "files": ["no/such/dir/x.txt"]}, policy, known)
+    assert keep["add"] == [] and keep["partition"] == ["sparq-zk"], keep
+    print("pr-area-labels self-test OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -61,6 +61,26 @@ def _load(name: str, path: Path):
 M = _load("pr_area_labels", DERIVER)
 
 
+def _tracked_paths():
+    """Every git-tracked repo-relative path, or None when git is unavailable."""
+    import subprocess
+    proc = subprocess.run(["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+                          capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        return None
+    return [p for p in proc.stdout.split("\0") if p]
+
+
+def _unattributed_tracked(policy, known):
+    """The tracked paths that attribute to NOTHING under `policy`. Shared by the hard
+    totality gate and by its non-vacuity guard, so the guard exercises the SAME code the
+    gate runs — a neutered computation reds both."""
+    tracked = _tracked_paths()
+    if tracked is None:
+        return []
+    return sorted({p for p in tracked if M.attribute(p, policy) not in known})
+
+
 def _yaml(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
@@ -168,17 +188,18 @@ class TestPolicyTable(unittest.TestCase):
                 missing.append(pattern)
         self.assertEqual(missing, [], f"[[map]] patterns whose root does not exist: {missing}")
 
-    def test_anticipated_roots_are_declared_rows_and_really_absent(self):
-        """Keeps the escape hatch honest: an entry must correspond to a real row, and must
-        be REMOVED once the path lands (otherwise it hides a future typo forever)."""
+    def test_anticipated_roots_are_declared_rows(self):
+        """Keeps the escape hatch honest: an entry must correspond to a real row, so it
+        cannot exempt a pattern that no row uses.
+
+        The companion "remove it once the path lands" rule is reported as DRIFT
+        (`test_table_drift_report_is_advisory_not_gating`), not gated — see that test.
+        Dropping a landed entry loses nothing: `test_every_map_row_pattern_root_exists_on_disk`
+        would pass for that row anyway once the root exists."""
         anticipated = list(self.raw["policy"].get("anticipated_roots") or [])
         patterns = {p for p, _ in self.policy.rows}
         self.assertEqual([a for a in anticipated if a not in patterns], [],
                          "anticipated_roots entry with no matching [[map]] row")
-        landed = [a for a in anticipated
-                  if (REPO_ROOT / (a[:-3] if a.endswith("/**") else a)).exists()]
-        self.assertEqual(landed, [], f"anticipated_roots entries that now EXIST — remove "
-                                     f"them so the strict check covers them: {landed}")
 
     def test_every_crates_subdirectory_is_a_workspace_member(self):
         """The implicit `crates/<name>` rule is only TOTAL if every directory under
@@ -188,12 +209,74 @@ class TestPolicyTable(unittest.TestCase):
                          "crates/ subdirectories that are not workspace members would "
                          "fall back to __global__")
 
-    def test_every_skill_surface_has_a_map_row(self):
-        """A new skill surface with no row silently sends its PRs to `__global__`."""
+    def test_skill_surfaces_without_a_specific_row_still_resolve(self):
+        """The DEMOTED half of the old `test_every_skill_surface_has_a_map_row`.
+
+        Requiring a per-surface `[[map]]` row was a GATING assertion about the whole live
+        tree in a continuously-merging repo: every new `skills/` surface landing on `main`
+        turned this suite red on every unrelated open PR. Measured on `80710d9c`:
+        `skills/e2ee-ng` (#3464) and `skills/solid-lws-server` (#4181) did exactly that,
+        hours after a green check.
+
+        It is safe to demote because a surface with no row costs only a COARSER lane
+        (`docs`, via the `skills/**` catch-all), never a WRONG crate — the direction that
+        would put two workers on one crate. Attribution stays total either way.
+
+        What is NOT demoted: those surfaces must still ATTRIBUTE, from their REAL tracked
+        files (not a synthetic probe). Delete the `skills/**` catch-all row and this goes
+        red — that deletion is the change that would really send those PRs to
+        `__global__`. Surfaces lacking a specific row are printed as drift."""
         patterns = {p for p, _ in self.policy.rows}
-        missing = sorted(d.name for d in SKILLS.iterdir()
-                         if d.is_dir() and f"skills/{d.name}/**" not in patterns)
-        self.assertEqual(missing, [], f"skills/ surfaces with no [[map]] row: {missing}")
+        known = self.members | self.policy.non_crate
+        drift, unattributed = [], []
+        for d in sorted(p for p in SKILLS.iterdir() if p.is_dir()):
+            if f"skills/{d.name}/**" not in patterns:
+                drift.append(d.name)
+            for f in d.rglob("*"):
+                if f.is_file():
+                    rel = f.relative_to(REPO_ROOT).as_posix()
+                    if M.attribute(rel, self.policy) not in known:
+                        unattributed.append(rel)
+        self.assertEqual(sorted(unattributed)[:20], [],
+                         "skills/ path(s) with NO area attribution — the `skills/**` "
+                         "catch-all is gone and these PRs fall to __global__")
+        if drift:
+            print(f"\n  [drift, advisory] skills/ surfaces with no specific [[map]] row "
+                  f"(they take the `docs` catch-all): {drift}")
+
+    def test_landed_anticipated_roots_are_reported_as_drift_but_still_attribute(self):
+        """Same demotion, same reasoning, for `[policy] anticipated_roots`. An entry whose
+        path has LANDED should be removed — but that is housekeeping with no runtime
+        consequence (`test_every_map_row_pattern_root_exists_on_disk` covers the row the
+        moment its root exists), so it must not red an unrelated PR. Measured on
+        `80710d9c`: `rust-toolchain.toml` landing via #3803 did exactly that.
+
+        Strict half kept: a landed path must still attribute."""
+        anticipated = list(self.raw["policy"].get("anticipated_roots") or [])
+        known = self.members | self.policy.non_crate
+        landed = [a for a in anticipated
+                  if (REPO_ROOT / (a[:-3] if a.endswith("/**") else a)).exists()]
+        for a in landed:
+            probe = a[:-3] + "/probe" if a.endswith("/**") else a
+            self.assertIn(M.attribute(probe, self.policy), known,
+                          f"anticipated_roots entry {a!r} has landed and does NOT attribute")
+        if landed:
+            print(f"\n  [drift, advisory] anticipated_roots entries that now EXIST "
+                  f"(drop them; the strict dead-row check covers those rows): {landed}")
+
+    def test_the_totality_check_detects_an_unmapped_path(self):
+        """NON-VACUITY guard for the hard ratchet below. Two ratchets were just demoted to
+        advisory; this pins that the one that stayed a GATE really discriminates. Drop the
+        `[[map]]` row that claims `.github/**` and the totality computation must report
+        those paths — if it reports nothing, `test_every_tracked_file_in_the_repo_resolves`
+        is vacuous and the whole demotion is unsafe."""
+        known = self.members | self.policy.non_crate
+        pruned = M.Policy(self.policy.max_areas,
+                          [(p, a) for p, a in self.policy.rows if p != ".github/**"],
+                          self.policy.non_crate, self.members)
+        self.assertNotEqual(_unattributed_tracked(pruned, known), [],
+                            "removing the `.github/**` row left every tracked path "
+                            "resolvable — the totality check cannot fail")
 
     def test_every_tracked_file_in_the_repo_resolves(self):
         """TOTALITY over the REAL tree — every git-tracked path must attribute to some
@@ -202,16 +285,12 @@ class TestPolicyTable(unittest.TestCase):
         starvation for every PR that touches it. A synthetic `dir/probe.txt` probe would
         NOT discriminate (it can pass while the directory's real layout is unmapped, and
         fail on directories that hold only one known file), so this walks git's index."""
-        import subprocess
-        proc = subprocess.run(["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
-                              capture_output=True, text=True, check=False)
-        if proc.returncode != 0:
+        tracked = _tracked_paths()
+        if tracked is None:
             self.skipTest("git ls-files unavailable")
-        tracked = [p for p in proc.stdout.split("\0") if p]
         self.assertGreater(len(tracked), 1000, "suspiciously small tracked-file set")
         known = self.members | self.policy.non_crate
-        unresolved = sorted({p for p in tracked
-                             if M.attribute(p, self.policy) not in known})
+        unresolved = _unattributed_tracked(self.policy, known)
         self.assertEqual(unresolved, [], f"{len(unresolved)} tracked path(s) with no area "
                                          f"attribution (each sends its PR to __global__): "
                                          f"{unresolved[:20]}")

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import sys
 import tomllib
 import unittest
@@ -566,6 +567,24 @@ class TestWorkflowSeam(unittest.TestCase):
             self.assertIn(arg, run, f"missing/altered call-site argument: {arg}")
         self.assertNotIn("--dry-run", run)
         self.assertNotIn("--backfill", run)
+
+    def test_the_run_block_guards_the_bootstrap_case(self):
+        """The checkout is the DEFAULT BRANCH, so the deriver is absent on the PR that
+        introduces it (measured: this job failed exactly that way on #4170) and on any ref
+        after a revert. The guard must exist, must exit 0, must be a ::warning (a genuine
+        disappearance has to be visible, not look like a healthy no-op), and — the
+        discriminating part — must guard the SAME path the step then executes."""
+        run = next(s["run"] for s in self.steps if "run" in s)
+        flat = " ".join(run.split())
+        guards = re.findall(r"if \[ ! -f (\S+) \]; then", flat)
+        self.assertEqual(len(guards), 1, "expected exactly one existence guard")
+        invoked = re.search(r"python3 (\S+\.py)", flat)
+        self.assertIsNotNone(invoked)
+        self.assertEqual(guards[0], invoked.group(1),
+                         "the guarded path and the invoked path must be the same file")
+        self.assertIn("exit 0", flat)
+        self.assertIn("::warning title=pr-area-label inert::", flat)
+        self.assertNotIn("::notice title=pr-area-label inert::", flat)
 
     def test_deriver_and_policy_paths_referenced_by_the_workflow_exist(self):
         run = " ".join(" ".join(s["run"] for s in self.steps if "run" in s).split())

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -98,10 +98,22 @@ class FakeGH:
     discriminating: they check the resulting label set, not the absence of a string in
     the source. A hypothetical "prune stale areas" feature would remove a label here and
     turn the additive-only test red.
+
+    It also models the INPUT BOUNDARY faithfully, because that is where the interesting
+    failure lives:
+      * `changedFiles` is served from the FULL entry list — it is GitHub's authoritative
+        count and is NOT affected by any page cap;
+      * `api .../pulls/N/files` serves ONE PAGE unless `--paginate` is passed, exactly as
+        `gh` does, so dropping the flag really loses the tail;
+      * on top of that it serves at most `cap` entries, which reproduces a ceiling the
+        caller cannot page past — GraphQL `files(first: 100)`, or REST's 3000-file cap;
+      * an entry may be `"path"` or `("new_path", "previous_path")`, so a rename carries
+        `previous_filename` exactly as the REST payload does.
     """
 
     def __init__(self, prs, labels):
-        # prs: {number: {"labels": [..], "files": [..], "title": str, "isDraft": bool}}
+        # prs: {number: {"labels": [..], "files": [entry..], "cap": int|None,
+        #                "title": str, "isDraft": bool}}
         self.prs = {n: dict(p) for n, p in prs.items()}
         self.labels = list(labels)
         self.calls: list[list[str]] = []
@@ -110,20 +122,46 @@ class FakeGH:
     def writes(self):
         return [c for c in self.calls if c[:2] == ["pr", "edit"]]
 
+    @staticmethod
+    def _entries(pr):
+        out = []
+        for f in pr["files"]:
+            out.append((f, "") if isinstance(f, str) else (f[0], f[1] or ""))
+        return out
+
+    def _files_payload(self, n, url, paginate):
+        """What `gh api [--paginate] .../pulls/N/files --jq ...|@tsv` would print.
+
+        Without `--paginate`, `gh` returns the FIRST PAGE only — modelled here, so
+        dropping the flag really loses the tail. `cap` is the separate, unpageable
+        ceiling."""
+        entries = self._entries(self.prs[n])
+        cap = self.prs[n].get("cap")
+        if cap is not None:
+            entries = entries[:cap]
+        if not paginate:
+            m = re.search(r"per_page=(\d+)", url)
+            entries = entries[:int(m.group(1)) if m else 30]
+        return "".join(f"{new}\t{prev}\n" for new, prev in entries)
+
     def __call__(self, args):
         self.calls.append(list(args))
         if args[0] == "api":
+            url = next((a for a in args if a.startswith("repos/")), "")
+            m = re.search(r"/pulls/(\d+)/files", url)
+            if m:
+                return self._files_payload(int(m.group(1)), url, "--paginate" in args)
             return "".join(f"{name}\n" for name in self.labels)
         if args[:2] == ["pr", "view"]:
             n = int(args[2])
             pr = self.prs[n]
             return json.dumps({"number": n,
                                "labels": [{"name": lb} for lb in pr["labels"]],
-                               "files": [{"path": p} for p in pr["files"]]})
+                               "changedFiles": len(self._entries(pr))})
         if args[:2] == ["pr", "list"]:
             return json.dumps([
                 {"number": n, "labels": [{"name": lb} for lb in p["labels"]],
-                 "files": [{"path": f} for f in p["files"]],
+                 "changedFiles": len(self._entries(p)),
                  "title": p.get("title", ""), "isDraft": p.get("isDraft", False)}
                 for n, p in sorted(self.prs.items())])
         if args[:2] == ["pr", "edit"]:
@@ -222,10 +260,13 @@ class TestPolicyTable(unittest.TestCase):
         (`docs`, via the `skills/**` catch-all), never a WRONG crate — the direction that
         would put two workers on one crate. Attribution stays total either way.
 
-        What is NOT demoted: those surfaces must still ATTRIBUTE, from their REAL tracked
-        files (not a synthetic probe). Delete the `skills/**` catch-all row and this goes
-        red — that deletion is the change that would really send those PRs to
-        `__global__`. Surfaces lacking a specific row are printed as drift."""
+        What is NOT demoted: every surface must still ATTRIBUTE, over its REAL tracked
+        files. Surfaces lacking a specific row are printed as drift.
+
+        The catch-all row that MAKES the demotion safe is pinned separately, by
+        `test_a_future_skill_surface_resolves_through_the_catch_all`. MEASURED: with a
+        specific row now present for every surface on `main`, deleting the catch-all does
+        NOT red this test — so this test alone would be a vacuous guard on it."""
         patterns = {p for p, _ in self.policy.rows}
         known = self.members | self.policy.non_crate
         drift, unattributed = [], []
@@ -243,6 +284,24 @@ class TestPolicyTable(unittest.TestCase):
         if drift:
             print(f"\n  [drift, advisory] skills/ surfaces with no specific [[map]] row "
                   f"(they take the `docs` catch-all): {drift}")
+
+    def test_a_future_skill_surface_resolves_through_the_catch_all(self):
+        """The load-bearing half of the demotion above: a skills surface that has NO
+        `[[map]]` row must still attribute, or "the row is only advisory" is false and a
+        new surface silently takes `__global__` again.
+
+        This is a SYNTHETIC probe, deliberately — a surface with no row is by definition
+        one that has not landed yet, so no real tracked path can exercise the catch-all
+        while the table is complete. Delete the `skills/**` row and this goes red."""
+        known = self.members | self.policy.non_crate
+        patterns = {p for p, _ in self.policy.rows}
+        surface = "surface-that-does-not-exist-yet"
+        self.assertNotIn(f"skills/{surface}/**", patterns)
+        for probe in (f"skills/{surface}/SKILL.md",
+                      f"skills/{surface}/references/deep/nested.md"):
+            self.assertIn(M.attribute(probe, self.policy), known,
+                          f"{probe} attributes to nothing — the `skills/**` catch-all is "
+                          f"gone, so a new surface takes __global__")
 
     def test_landed_anticipated_roots_are_reported_as_drift_but_still_attribute(self):
         """Same demotion, same reasoning, for `[policy] anticipated_roots`. An entry whose
@@ -432,14 +491,16 @@ class TestDerivation(unittest.TestCase):
     def test_plan_never_proposes_removing_a_human_area_label(self):
         plan = M.plan_for_pr({"number": 1,
                               "labels": ["area:sparq-core", "review:parked"],
-                              "files": ["crates/sparq-engine/src/lib.rs"]},
+                              "files": ["crates/sparq-engine/src/lib.rs"],
+                              "complete": True},
                              self.policy, self.known)
         self.assertEqual(plan["add"], ["area:sparq-engine"])
         self.assertEqual(plan["partition"], ["sparq-core", "sparq-engine"])
 
     def test_fail_closed_pr_that_already_has_a_human_area_keeps_it(self):
         plan = M.plan_for_pr({"number": 2, "labels": ["area:sparq-zk"],
-                              "files": ["no/such/top/level/x.txt"]},
+                              "files": ["no/such/top/level/x.txt"],
+                              "complete": True},
                              self.policy, self.known)
         self.assertEqual(plan["add"], [])
         self.assertEqual(plan["partition"], ["sparq-zk"])
@@ -447,7 +508,8 @@ class TestDerivation(unittest.TestCase):
 
     def test_already_labelled_pr_is_a_noop(self):
         plan = M.plan_for_pr({"number": 3, "labels": ["area:sparq-engine"],
-                              "files": ["crates/sparq-engine/src/lib.rs"]},
+                              "files": ["crates/sparq-engine/src/lib.rs"],
+                              "complete": True},
                              self.policy, self.known)
         self.assertTrue(plan["noop"])
         self.assertEqual(plan["add"], [])
@@ -579,6 +641,165 @@ class TestEffects(unittest.TestCase):
                 M._gh(["api", "x"], sleep=lambda _s: None)
         finally:
             sp.run = orig
+
+
+# ============================================================== the INPUT boundary
+
+
+class TestChangedFileEnumeration(unittest.TestCase):
+    """The changed-path list is the ONE input attribution cannot check for itself.
+
+    `attribute` is a pure function of the path string, so within a COMPLETE list two PRs
+    touching one file always derive the same area and always serialize. The property
+    fails only if the list is PARTIAL: a truncated list derives a proper SUBSET of the
+    true areas, and a too-narrow reservation is the CORRUPTING direction (two workers on
+    one crate), where a too-broad one merely delays.
+
+    Measured on this repo (2026-07-26): PR #3581 reports `changedFiles = 646` while
+    `gh pr view --json files` — GraphQL `files(first: 100)` — returns 100.
+
+    Two independent guards, each with its own test below: enumerate with the PAGINATED
+    REST endpoint, AND cross-check the count against `changedFiles`. The cross-check is
+    the one that survives a future API change.
+    """
+
+    # The reviewer's demonstration case, rebuilt exactly: 115 entries in path order, so a
+    # 100-entry cap drops the alphabetically-late `crates/sparq-zk/**` tail.
+    TRUNCATING = (["Cargo.lock"]
+                  + [f"crates/sparq-core/src/m{i:03d}.rs" for i in range(110)]
+                  + [f"crates/sparq-zk/src/z{i}.rs" for i in range(4)])
+
+    def setUp(self):
+        self.policy = M.load_policy()
+        self.live = [f"area:{a}" for a in
+                     sorted(self.policy.members | self.policy.non_crate)]
+
+    def fake(self, files, cap=None, labels=()):
+        return FakeGH({7: {"labels": list(labels), "files": list(files), "cap": cap}},
+                      self.live)
+
+    def test_the_truncated_tail_really_would_have_changed_the_answer(self):
+        """Fixture-validity check, so the guard test below cannot pass for the wrong
+        reason. The first 100 entries and the full 115 must derive DIFFERENT area sets,
+        and the truncated one must be a PROPER SUBSET — otherwise `incomplete-paths` in
+        the next test would prove nothing."""
+        known = self.policy.members | self.policy.non_crate
+        seen, _ = M.derive_areas(self.TRUNCATING[:100], self.policy, known)
+        truth, _ = M.derive_areas(self.TRUNCATING, self.policy, known)
+        self.assertEqual(set(seen), {"deps", "sparq-core"})
+        self.assertEqual(set(truth), {"deps", "sparq-core", "sparq-zk"})
+        self.assertTrue(seen < truth, "fixture does not demonstrate under-reservation")
+
+    def test_a_truncated_file_list_fails_closed_instead_of_deriving_a_subset(self):
+        """THE guard. The API serves only 100 of 115 entries while `changedFiles` still
+        reports 115; the cross-check must catch the disagreement and emit NOTHING.
+
+        Delete the completeness check in `plan_for_pr`/`derive_areas` and this goes red
+        with `area:deps` + `area:sparq-core` applied and `area:sparq-zk` missing — the PR
+        would then be editing `crates/sparq-zk/**` while the scheduler dispatched a
+        `sparq-zk` issue against it."""
+        f = self.fake(self.TRUNCATING, cap=100)
+        out = _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(f.writes, [], "a TRUNCATED file list must not narrow anything")
+        self.assertEqual(f.prs[7]["labels"], [])
+        self.assertIn("incomplete-paths", out)
+        self.assertNotIn("area:sparq-core", out)
+
+    def test_more_than_one_hundred_paths_are_all_enumerated(self):
+        """The paging half. Same 115 entries, no cap: every page must be read, so the
+        full `{deps, sparq-core, sparq-zk}` is derived and applied.
+
+        Stop paginating (or go back to `gh pr view --json files`) and this goes red — the
+        cross-check then reports `incomplete-paths` and nothing is applied at all."""
+        f = self.fake(self.TRUNCATING)
+        _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(sorted(f.prs[7]["labels"]),
+                         ["area:deps", "area:sparq-core", "area:sparq-zk"])
+
+    def test_the_file_list_is_never_read_from_the_capped_graphql_field(self):
+        """Structural, over BOTH entry points — the `--pr` path and the backfill, which
+        was the second consumer of `--json files`. No `--json` selection anywhere may
+        request `files`; the list must come from a `--paginate`d REST `/pulls/N/files`
+        call. Reintroducing `--json ...,files` on EITHER path reds here even if the
+        cross-check were also removed (a merely-fetched `files` field is the trap: it is
+        inert until someone reads it, and then it under-reserves silently)."""
+        for argv, n in ((["--pr", "7", "--apply"], 7), (["--backfill", "--apply"], 7)):
+            f = self.fake(self.TRUNCATING)
+            _run(f, argv)
+            for call in f.calls:
+                if "--json" not in call:
+                    continue
+                fields = call[call.index("--json") + 1].split(",")
+                self.assertNotIn("files", fields,
+                                 f"`--json files` is GraphQL files(first: 100): {call}")
+                self.assertIn("changedFiles", fields,
+                              f"the authoritative count must be fetched too: {call}")
+            rest = [c for c in f.calls
+                    if c[0] == "api" and any(f"/pulls/{n}/files" in a for a in c)]
+            self.assertEqual(len(rest), 1,
+                             f"expected one REST file enumeration for {argv}: {f.calls}")
+            self.assertIn("--paginate", rest[0], "the REST enumeration must page")
+
+    def test_the_backfill_uses_the_same_enumeration_as_the_single_pr_path(self):
+        """The backfill was the second consumer of `--json files`; a guard on only the
+        `--pr` path would leave it under-reserving."""
+        f = FakeGH({11: {"labels": [], "files": self.TRUNCATING, "cap": 100},
+                    12: {"labels": [], "files": self.TRUNCATING}}, self.live)
+        _run(f, ["--backfill", "--apply"])
+        self.assertEqual(f.prs[11]["labels"], [], "truncated PR must stay __global__")
+        self.assertEqual(sorted(f.prs[12]["labels"]),
+                         ["area:deps", "area:sparq-core", "area:sparq-zk"])
+
+    def test_a_cross_crate_rename_implicates_the_source_crate_too(self):
+        """Renames report only the NEW path (`filename` in REST, `path` in GraphQL). A
+        move out of `crates/sparq-core/` into `crates/sparq-zk/` really touches BOTH
+        crates, so `previous_filename` is consumed. Stop consuming it and this goes red
+        with only `area:sparq-zk` — under-reservation again, same quantifier slip."""
+        f = self.fake([("crates/sparq-zk/src/moved.rs", "crates/sparq-core/src/moved.rs")])
+        _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(sorted(f.prs[7]["labels"]),
+                         ["area:sparq-core", "area:sparq-zk"])
+
+    def test_a_rename_out_of_an_unmapped_path_fails_closed(self):
+        """The consumed previous path is held to the SAME standard as a current one: an
+        unattributable source poisons the PR rather than being quietly ignored."""
+        f = self.fake([("crates/sparq-zk/src/moved.rs", "no/such/top/level/moved.rs")])
+        out = _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(f.writes, [])
+        self.assertIn("unresolved", out)
+
+    def test_a_rename_counts_as_one_entry_against_changedFiles(self):
+        """Cross-check arithmetic: a rename contributes TWO paths but ONE changed file.
+        Counting paths instead of entries would make every rename look truncated and
+        send correct PRs back to `__global__` (safe, but wrong and silent)."""
+        paths, entries = M.fetch_changed_files(
+            REPO, 7,
+            runner=self.fake([("crates/sparq-zk/a.rs", "crates/sparq-core/a.rs"),
+                              "crates/sparq-zk/b.rs"]))
+        self.assertEqual(entries, 2)
+        self.assertEqual(sorted(paths), ["crates/sparq-core/a.rs",
+                                         "crates/sparq-zk/a.rs", "crates/sparq-zk/b.rs"])
+
+    def test_paths_are_complete_only_on_an_exact_confident_agreement(self):
+        self.assertTrue(M.paths_are_complete(646, 646))
+        self.assertTrue(M.paths_are_complete(0, 0))
+        self.assertFalse(M.paths_are_complete(100, 646))     # the measured #3581 case
+        self.assertFalse(M.paths_are_complete(3000, 4000))   # the REST 3000-file ceiling
+        self.assertFalse(M.paths_are_complete(5, None))      # count unavailable
+        self.assertFalse(M.paths_are_complete(5, "5"))       # not an int
+        self.assertFalse(M.paths_are_complete(None, 5))
+
+    def test_a_pr_record_with_no_completeness_verdict_fails_closed(self):
+        """A future caller that assembles a PR record without establishing completeness
+        must get `__global__`, not a narrowing derived from an unchecked list. Flip the
+        `is True` to a truthy/`get(..., True)` default and this goes red."""
+        known = self.policy.members | self.policy.non_crate
+        blind = M.plan_for_pr({"number": 9, "labels": [],
+                               "files": ["crates/sparq-core/src/lib.rs"]},
+                              self.policy, known)
+        self.assertEqual(blind["add"], [])
+        self.assertEqual(blind["reason"], "incomplete-paths")
+        self.assertEqual(blind["partition"], [M.GLOBAL])
 
 
 # ======================================================================== YAML seam

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -552,21 +552,37 @@ class TestWorkflowSeam(unittest.TestCase):
 
     # --- the call site -------------------------------------------------------------
     def test_the_labelling_step_exists_and_passes_exactly_the_documented_arguments(self):
-        """Catches a DELETED step and a WRONG INPUT. Each argument is asserted as a
-        whole token pair, so `--pr ${{ github.event.number }}` (a different, sometimes
-        absent field) reds, and so does dropping `--apply` (which would make the live
-        workflow a silent no-op that still reports success)."""
+        """Catches a DELETED step and a WRONG INPUT. Each argument is asserted as a whole
+        token pair, and dropping `--apply` (which would make the live workflow a silent
+        no-op that still reports success) reds too."""
         runs = [s["run"] for s in self.steps if "run" in s]
         self.assertEqual(len(runs), 1, "expected exactly one run step")
         run = " ".join(runs[0].split())          # normalise line continuations
         self.assertIn("python3 scripts/pr-area-labels.py", run)
-        for arg in ('--repo "${{ github.repository }}"',
-                    '--pr "${{ github.event.pull_request.number || 0 }}"',
-                    '--head-repo "${{ github.event.pull_request.head.repo.full_name || \'\' }}"',
-                    "--apply"):
+        for arg in ('--repo "$TARGET_REPO"', '--pr "$PR_NUMBER"',
+                    '--head-repo "$PR_HEAD_REPO"', "--apply"):
             self.assertIn(arg, run, f"missing/altered call-site argument: {arg}")
         self.assertNotIn("--dry-run", run)
         self.assertNotIn("--backfill", run)
+
+    def test_the_env_mapping_binds_exactly_the_right_github_fields(self):
+        """The WRONG-INPUT seam, pinned by EQUALITY. Every `github.*` value reaches the
+        shell through `env:` (no expression interpolation in the `run:` body), so swapping
+        a field — `github.event.number` for the PR number, `head.sha` for the head repo —
+        changes this mapping and reds. A substring check would not: the old spelling can
+        remain in a comment."""
+        step = next(s for s in self.steps if "run" in s)
+        self.assertEqual(step["env"], {
+            "GH_TOKEN": "${{ secrets.GITHUB_TOKEN }}",
+            "TARGET_REPO": "${{ github.repository }}",
+            "PR_NUMBER": "${{ github.event.pull_request.number || 0 }}",
+            "PR_HEAD_REPO": "${{ github.event.pull_request.head.repo.full_name || '' }}",
+        })
+        # ... and no EXECUTABLE line of the run body interpolates an expression
+        # (comment lines may still name one for documentation).
+        code = "\n".join(ln for ln in step["run"].splitlines()
+                         if not ln.lstrip().startswith("#"))
+        self.assertNotIn("${{", code, "expression interpolated into an executable line")
 
     def test_the_run_block_guards_the_bootstrap_case(self):
         """The checkout is the DEFAULT BRANCH, so the deriver is absent on the PR that

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -312,19 +312,30 @@ class TestDerivation(unittest.TestCase):
         areas, reason = self.d(["crates/sparq-core/src/lib.rs", "no/such/top/level/x.txt"])
         self.assertEqual((areas, reason), (frozenset(), "unresolved"))
 
-    def test_non_member_directory_under_crates_is_unresolved(self):
+    def test_unknown_crate_directory_without_a_live_label_is_unresolved(self):
         self.assertEqual(self.d(["crates/not-a-crate/src/lib.rs"]),
                          (frozenset(), "unresolved"))
 
-    def test_member_check_is_what_rejects_a_non_member_crate_directory(self):
-        """DISCRIMINATING: the test above passes even without the member check, because
-        the live-label check then rejects the bogus name — two guards, one fixture. Here
-        the bogus name IS a live label, so ONLY the member check can reject it."""
-        self.assertIsNone(M.attribute("crates/not-a-crate/src/lib.rs", self.policy))
+    def test_a_file_directly_under_crates_is_not_a_crate_area(self):
+        """DISCRIMINATING: `crates/README.md` must not become `area:README.md`. The
+        live-label check would also reject that name, so assert on `attribute` directly —
+        otherwise this fixture passes with the segment guard deleted."""
+        self.assertIsNone(M.attribute("crates/README.md", self.policy))
+        self.assertIsNone(M.attribute("crates", self.policy))
+
+    def test_a_pr_that_ADDS_a_crate_resolves_once_its_label_exists(self):
+        """The workflow reads the DEFAULT BRANCH's manifest, so a crate a PR is adding is
+        not yet a workspace member. Such a PR collides with nothing and must still get a
+        narrow partition — gated only on a human having created the `area:` label. Two
+        live examples in the backfill were exactly this shape (#3464, #3581)."""
+        new = "sparq-brand-new"
+        self.assertNotIn(new, self.policy.members)
         self.assertEqual(
-            M.derive_areas(["crates/not-a-crate/src/lib.rs"], self.policy,
-                           self.known | {"not-a-crate"}),
-            (frozenset(), "unresolved"))
+            M.derive_areas([f"crates/{new}/src/lib.rs"], self.policy, self.known | {new}),
+            (frozenset({new}), "resolved"))
+        # ... and without the label it is still fail-closed.
+        self.assertEqual(M.derive_areas([f"crates/{new}/src/lib.rs"], self.policy, self.known),
+                         (frozenset(), "unresolved"))
 
     def test_empty_change_set_stays_global(self):
         self.assertEqual(self.d([]), (frozenset(), "no-paths"))

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+# [OPUS-5] 🤖 SPARQ agent — the guard suite for PR `area:` attribution.
+# Registry issue jeswr/agent-account-registry#677.
+#
+# Every guard in scripts/pr-area-labels.py + ci/area-labels.toml +
+# .github/workflows/pr-area-label.yml has a NAMED test here that goes RED when the guard
+# is deleted or inverted. The three families:
+#
+#   1. DERIVATION (pure) — a crates/x-only PR narrows to x; a workspace-spanning PR stays
+#      `__global__`; an unattributable path stays `__global__`; an area with no live label
+#      is never invented.
+#   2. EFFECTS (fake `gh`) — the recorded call list IS the assertion: additive-only (a
+#      human `area:` label survives, observed on the fake's simulated label state, not by
+#      grepping the source), idempotent (a second pass writes nothing), dry-run writes
+#      nothing, a fork PR and a no-pull-request ref make ZERO api calls.
+#   3. THE YAML SEAM — parsed STRUCTURALLY, never by substring or `count(...) == N`, which
+#      is what lets `if: false`, a deleted step or a swapped call-site argument survive.
+#      Measured in this project: 18/18 Python mutants died while EVERY surviving mutant
+#      lived in a workflow `if:` / step / call-site. So: the workflow must have NO `if:`
+#      at any level (job or step), the labelling step must exist and pass exactly the
+#      four documented arguments, checkout must be pinned to the default branch (never the
+#      PR head — the job holds `pull-requests: write`), the permissions block must be
+#      exactly the least-privilege pair, `pull_request` must carry NO `paths:` filter, and
+#      routing-self-tests.yml must actually INVOKE this file (a test nobody runs is a
+#      call-site mutant that survives everything else).
+#
+# Needs PyYAML (same dependency the other wiring suites use); everything else is stdlib.
+# Run:  python3 scripts/tests/test_pr_area_labels.py
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tomllib
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DERIVER = REPO_ROOT / "scripts" / "pr-area-labels.py"
+POLICY = REPO_ROOT / "ci" / "area-labels.toml"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pr-area-label.yml"
+ROUTING_WF = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+CRATES = REPO_ROOT / "crates"
+SKILLS = REPO_ROOT / "skills"
+REPO = "sparq-org/sparq"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, path
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+M = _load("pr_area_labels", DERIVER)
+
+
+def _yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on_block(wf: dict) -> dict:
+    """The `on:` mapping. Bare `on` is the YAML boolean True, so PyYAML keys it under
+    `True` (same trick the other workflow-anchor suites use)."""
+    return wf.get("on", wf.get(True, {})) or {}
+
+
+class FakeGH:
+    """A `gh` stand-in that RECORDS every invocation and SIMULATES label state.
+
+    The simulated state is what makes the additive-only and idempotence assertions
+    discriminating: they check the resulting label set, not the absence of a string in
+    the source. A hypothetical "prune stale areas" feature would remove a label here and
+    turn the additive-only test red.
+    """
+
+    def __init__(self, prs, labels):
+        # prs: {number: {"labels": [..], "files": [..], "title": str, "isDraft": bool}}
+        self.prs = {n: dict(p) for n, p in prs.items()}
+        self.labels = list(labels)
+        self.calls: list[list[str]] = []
+
+    @property
+    def writes(self):
+        return [c for c in self.calls if c[:2] == ["pr", "edit"]]
+
+    def __call__(self, args):
+        self.calls.append(list(args))
+        if args[0] == "api":
+            return "".join(f"{name}\n" for name in self.labels)
+        if args[:2] == ["pr", "view"]:
+            n = int(args[2])
+            pr = self.prs[n]
+            return json.dumps({"number": n,
+                               "labels": [{"name": lb} for lb in pr["labels"]],
+                               "files": [{"path": p} for p in pr["files"]]})
+        if args[:2] == ["pr", "list"]:
+            return json.dumps([
+                {"number": n, "labels": [{"name": lb} for lb in p["labels"]],
+                 "files": [{"path": f} for f in p["files"]],
+                 "title": p.get("title", ""), "isDraft": p.get("isDraft", False)}
+                for n, p in sorted(self.prs.items())])
+        if args[:2] == ["pr", "edit"]:
+            n = int(args[2])
+            it = iter(args[3:])
+            for tok in it:
+                if tok == "--add-label":
+                    lb = next(it)
+                    if lb not in self.prs[n]["labels"]:
+                        self.prs[n]["labels"].append(lb)
+                elif tok == "--remove-label":          # never exercised by this module
+                    lb = next(it)
+                    if lb in self.prs[n]["labels"]:
+                        self.prs[n]["labels"].remove(lb)
+            return ""
+        raise AssertionError(f"unexpected gh call: {args}")
+
+
+def _run(fake, argv, expect=0):
+    import io
+    buf = io.StringIO()
+    rc = M.main(argv + ["--repo", REPO], runner=fake, out=buf)
+    assert rc == expect, f"rc={rc} expected {expect}\n{buf.getvalue()}"
+    return buf.getvalue()
+
+
+# =========================================================================== policy
+
+
+class TestPolicyTable(unittest.TestCase):
+    """ci/area-labels.toml must be internally valid and TOTAL over the live tree — an
+    unmapped path silently means `__global__`, i.e. the starvation reg#677 describes."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = M.load_policy()
+        cls.members = cls.policy.members
+        cls.raw = tomllib.loads(POLICY.read_text(encoding="utf-8"))
+
+    def test_every_map_row_area_is_a_live_crate_or_declared_lane(self):
+        """A typo'd `area` would be dropped at runtime and the PR would stay global —
+        so it must fail HERE, hermetically, instead."""
+        allowed = self.members | self.policy.non_crate
+        bad = sorted({a for _, a in self.policy.rows if a not in allowed})
+        self.assertEqual(bad, [], f"[[map]] areas that are neither a workspace member "
+                                 f"nor a [lanes] non_crate name: {bad}")
+
+    def test_every_map_row_pattern_root_exists_on_disk(self):
+        """A dead row is a silent hole: it looks like coverage and matches nothing.
+
+        `[policy] anticipated_roots` is the ONLY escape hatch (a fetched/generated tree,
+        or a file an in-flight PR adds) and is itself checked below."""
+        anticipated = set(self.raw["policy"].get("anticipated_roots") or [])
+        missing = []
+        for pattern, _ in self.policy.rows:
+            if pattern in anticipated:
+                continue
+            root = pattern[:-3] if pattern.endswith("/**") else pattern
+            if "*" in root or "?" in root:
+                continue                      # a glob (e.g. `*.md`) has no fixed root
+            if not (REPO_ROOT / root).exists():
+                missing.append(pattern)
+        self.assertEqual(missing, [], f"[[map]] patterns whose root does not exist: {missing}")
+
+    def test_anticipated_roots_are_declared_rows_and_really_absent(self):
+        """Keeps the escape hatch honest: an entry must correspond to a real row, and must
+        be REMOVED once the path lands (otherwise it hides a future typo forever)."""
+        anticipated = list(self.raw["policy"].get("anticipated_roots") or [])
+        patterns = {p for p, _ in self.policy.rows}
+        self.assertEqual([a for a in anticipated if a not in patterns], [],
+                         "anticipated_roots entry with no matching [[map]] row")
+        landed = [a for a in anticipated
+                  if (REPO_ROOT / (a[:-3] if a.endswith("/**") else a)).exists()]
+        self.assertEqual(landed, [], f"anticipated_roots entries that now EXIST — remove "
+                                     f"them so the strict check covers them: {landed}")
+
+    def test_every_crates_subdirectory_is_a_workspace_member(self):
+        """The implicit `crates/<name>` rule is only TOTAL if every directory under
+        crates/ is a member; a non-member directory resolves to nothing (fail closed)."""
+        dirs = {p.name for p in CRATES.iterdir() if p.is_dir()}
+        self.assertEqual(sorted(dirs - self.members), [],
+                         "crates/ subdirectories that are not workspace members would "
+                         "fall back to __global__")
+
+    def test_every_skill_surface_has_a_map_row(self):
+        """A new skill surface with no row silently sends its PRs to `__global__`."""
+        patterns = {p for p, _ in self.policy.rows}
+        missing = sorted(d.name for d in SKILLS.iterdir()
+                         if d.is_dir() and f"skills/{d.name}/**" not in patterns)
+        self.assertEqual(missing, [], f"skills/ surfaces with no [[map]] row: {missing}")
+
+    def test_every_tracked_file_in_the_repo_resolves(self):
+        """TOTALITY over the REAL tree — every git-tracked path must attribute to some
+        area. This is the test that goes red when a new top-level directory or root file
+        lands without a row, which is exactly the regression that re-opens reg#677's
+        starvation for every PR that touches it. A synthetic `dir/probe.txt` probe would
+        NOT discriminate (it can pass while the directory's real layout is unmapped, and
+        fail on directories that hold only one known file), so this walks git's index."""
+        import subprocess
+        proc = subprocess.run(["git", "-C", str(REPO_ROOT), "ls-files", "-z"],
+                              capture_output=True, text=True, check=False)
+        if proc.returncode != 0:
+            self.skipTest("git ls-files unavailable")
+        tracked = [p for p in proc.stdout.split("\0") if p]
+        self.assertGreater(len(tracked), 1000, "suspiciously small tracked-file set")
+        known = self.members | self.policy.non_crate
+        unresolved = sorted({p for p in tracked
+                             if M.attribute(p, self.policy) not in known})
+        self.assertEqual(unresolved, [], f"{len(unresolved)} tracked path(s) with no area "
+                                         f"attribution (each sends its PR to __global__): "
+                                         f"{unresolved[:20]}")
+
+    def test_malformed_policy_raises_rather_than_labelling_nothing(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            bad = Path(td) / "area-labels.toml"
+            bad.write_text('[policy]\nmax_areas = 0\n[[map]]\npattern = "x"\narea = "ci"\n')
+            with self.assertRaises(M.PolicyError):
+                M.load_policy(path=bad)
+            bad.write_text('[policy]\nmax_areas = 4\n')
+            with self.assertRaises(M.PolicyError):
+                M.load_policy(path=bad)
+
+
+# ======================================================================= derivation
+
+
+class TestDerivation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.policy = M.load_policy()
+        cls.known = cls.policy.members | cls.policy.non_crate
+
+    def d(self, paths, known=None):
+        return M.derive_areas(paths, self.policy, self.known if known is None else known)
+
+    # --- the headline guard: a single-crate PR must NOT be __global__ ---------------
+    def test_single_crate_pr_narrows_to_that_crate_and_not_global(self):
+        """reg#677's live case: draft PR #4143 touched only crates/sparq-reason/** plus
+        skills/inference/SKILL.md, seized all 54 crates, and deferred #2688/#2732/#2786."""
+        areas, reason = self.d(["crates/sparq-reason/src/lib.rs",
+                                "crates/sparq-reason/tests/rules.rs",
+                                "skills/inference/SKILL.md"])
+        self.assertEqual((sorted(areas), reason), (["sparq-reason"], "resolved"))
+        self.assertNotIn(M.GLOBAL, areas)
+        self.assertTrue(areas, "an empty area set IS __global__ — the bug being fixed")
+
+    def test_crate_prefix_wins_over_map_rows(self):
+        # `crates/sparq-core/README.md` must be sparq-core, NOT the root-markdown `docs`
+        # row: a wrong narrow label is worse than a stalled frontier.
+        self.assertEqual(M.attribute("crates/sparq-core/README.md", self.policy), "sparq-core")
+
+    def test_glob_star_does_not_cross_a_slash(self):
+        self.assertEqual(M.attribute("README.md", self.policy), "docs")
+        self.assertEqual(M.attribute("skills/inference/SKILL.md", self.policy), "sparq-reason")
+        self.assertEqual(M.attribute("site/src/app/page.md", self.policy), "site")
+
+    # --- the fail-closed guards ----------------------------------------------------
+    def test_genuinely_cross_cutting_pr_stays_global(self):
+        wide = [f"crates/{c}/src/lib.rs"
+                for c in sorted(self.policy.members)[:self.policy.max_areas + 1]]
+        areas, reason = self.d(wide)
+        self.assertEqual((areas, reason), (frozenset(), "cross-cutting"))
+
+    def test_max_areas_boundary_is_still_narrow(self):
+        """Discriminates the cap from an off-by-one: exactly max_areas must RESOLVE."""
+        ok = [f"crates/{c}/src/lib.rs"
+              for c in sorted(self.policy.members)[:self.policy.max_areas]]
+        areas, reason = self.d(ok)
+        self.assertEqual(reason, "resolved")
+        self.assertEqual(len(areas), self.policy.max_areas)
+
+    def test_one_unattributable_path_poisons_the_whole_pr(self):
+        areas, reason = self.d(["crates/sparq-core/src/lib.rs", "no/such/top/level/x.txt"])
+        self.assertEqual((areas, reason), (frozenset(), "unresolved"))
+
+    def test_non_member_directory_under_crates_is_unresolved(self):
+        self.assertEqual(self.d(["crates/not-a-crate/src/lib.rs"]),
+                         (frozenset(), "unresolved"))
+
+    def test_empty_change_set_stays_global(self):
+        self.assertEqual(self.d([]), (frozenset(), "no-paths"))
+
+    def test_area_with_no_live_label_is_never_invented(self):
+        """The `POST .../labels` call CREATES an unknown label, so an area outside the
+        live label set must be treated as unresolved."""
+        self.assertEqual(
+            M.derive_areas(["crates/sparq-reason/src/lib.rs"], self.policy,
+                           self.known - {"sparq-reason"}),
+            (frozenset(), "unresolved"))
+
+    # --- additive-only planning ----------------------------------------------------
+    def test_plan_never_proposes_removing_a_human_area_label(self):
+        plan = M.plan_for_pr({"number": 1,
+                              "labels": ["area:sparq-core", "review:parked"],
+                              "files": ["crates/sparq-engine/src/lib.rs"]},
+                             self.policy, self.known)
+        self.assertEqual(plan["add"], ["area:sparq-engine"])
+        self.assertEqual(plan["partition"], ["sparq-core", "sparq-engine"])
+
+    def test_fail_closed_pr_that_already_has_a_human_area_keeps_it(self):
+        plan = M.plan_for_pr({"number": 2, "labels": ["area:sparq-zk"],
+                              "files": ["no/such/top/level/x.txt"]},
+                             self.policy, self.known)
+        self.assertEqual(plan["add"], [])
+        self.assertEqual(plan["partition"], ["sparq-zk"])
+        self.assertNotEqual(plan["partition"], [M.GLOBAL])
+
+    def test_already_labelled_pr_is_a_noop(self):
+        plan = M.plan_for_pr({"number": 3, "labels": ["area:sparq-engine"],
+                              "files": ["crates/sparq-engine/src/lib.rs"]},
+                             self.policy, self.known)
+        self.assertTrue(plan["noop"])
+        self.assertEqual(plan["add"], [])
+
+
+# ========================================================================== effects
+
+
+class TestEffects(unittest.TestCase):
+    """What actually reaches `gh`. Assertions are on the recorded call list and the
+    fake's simulated label state, never on the source text."""
+
+    def fake(self, files=("crates/sparq-reason/src/lib.rs",), labels=()):
+        policy = M.load_policy()
+        live = [f"area:{a}" for a in sorted(policy.members | policy.non_crate)]
+        return FakeGH({7: {"labels": list(labels), "files": list(files)}}, live)
+
+    def test_apply_adds_exactly_the_derived_label(self):
+        f = self.fake()
+        _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(f.writes, [["pr", "edit", "7", "--repo", REPO,
+                                     "--add-label", "area:sparq-reason"]])
+        self.assertEqual(f.prs[7]["labels"], ["area:sparq-reason"])
+
+    def test_dry_run_is_the_default_and_writes_nothing(self):
+        f = self.fake()
+        out = _run(f, ["--pr", "7"])
+        self.assertEqual(f.writes, [])
+        self.assertEqual(f.prs[7]["labels"], [])
+        self.assertIn("would label", out)
+        self.assertIn("DRY RUN", out)
+
+    def test_human_applied_area_label_survives_an_apply(self):
+        """Outcome assertion: the fake would DROP the label if a removal were ever
+        issued, so this reds on any future prune-stale-areas behaviour."""
+        f = self.fake(labels=["area:sparq-zk"])
+        _run(f, ["--pr", "7", "--apply"])
+        self.assertIn("area:sparq-zk", f.prs[7]["labels"])
+        self.assertIn("area:sparq-reason", f.prs[7]["labels"])
+        flat = [tok for call in f.calls for tok in call]
+        self.assertNotIn("--remove-label", flat)
+        self.assertNotIn("DELETE", flat)
+
+    def test_second_pass_is_a_pure_noop(self):
+        f = self.fake()
+        _run(f, ["--pr", "7", "--apply"])
+        before = list(f.prs[7]["labels"])
+        f.calls.clear()
+        out = _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(f.writes, [], "idempotence broken: a second pass wrote")
+        self.assertEqual(f.prs[7]["labels"], before)
+        self.assertIn("no-change", out)
+
+    def test_backfill_is_idempotent_across_the_whole_open_set(self):
+        policy = M.load_policy()
+        live = [f"area:{a}" for a in sorted(policy.members | policy.non_crate)]
+        f = FakeGH({
+            11: {"labels": [], "files": ["crates/sparq-core/src/lib.rs"]},
+            12: {"labels": [], "files": ["site/src/app/page.tsx", ".github/workflows/ci.yml"]},
+            13: {"labels": [], "files": ["no/such/top/level/x.txt"]},
+            14: {"labels": ["area:sparq-hdt"], "files": ["crates/sparq-hdt/src/lib.rs"]},
+        }, live)
+        _run(f, ["--backfill", "--apply"])
+        self.assertEqual(sorted(f.prs[11]["labels"]), ["area:sparq-core"])
+        self.assertEqual(sorted(f.prs[12]["labels"]), ["area:ci", "area:site"])
+        self.assertEqual(f.prs[13]["labels"], [], "unresolved PR must stay __global__")
+        self.assertEqual(f.prs[14]["labels"], ["area:sparq-hdt"])
+        snapshot = {n: sorted(p["labels"]) for n, p in f.prs.items()}
+        f.calls.clear()
+        out = _run(f, ["--backfill", "--apply"])
+        self.assertEqual(f.writes, [], "second backfill pass wrote — not idempotent")
+        self.assertEqual({n: sorted(p["labels"]) for n, p in f.prs.items()}, snapshot)
+        self.assertIn("0 relabelled", out)
+
+    def test_fork_pr_makes_zero_api_calls_and_exits_zero(self):
+        """`pull_request` gives a fork a READ-ONLY token. The run must report and stop —
+        not crash, and not mislabel."""
+        f = self.fake()
+        out = _run(f, ["--pr", "7", "--apply", "--head-repo", "someone-else/sparq"])
+        self.assertEqual(f.calls, [], "a fork run must not touch the API at all")
+        self.assertEqual(f.prs[7]["labels"], [])
+        self.assertIn("READ-ONLY token", out)
+
+    def test_same_repo_head_is_not_treated_as_a_fork(self):
+        """Discriminates the fork guard from a blanket skip."""
+        f = self.fake()
+        _run(f, ["--pr", "7", "--apply", "--head-repo", REPO])
+        self.assertEqual(f.prs[7]["labels"], ["area:sparq-reason"])
+
+    def test_empty_head_repo_fails_closed(self):
+        f = self.fake()
+        _run(f, ["--pr", "7", "--apply", "--head-repo", ""])
+        self.assertEqual(f.calls, [])
+
+    def test_no_pull_request_context_makes_zero_api_calls(self):
+        """The merge_group path: the workflow passes `--pr 0`."""
+        f = self.fake()
+        out = _run(f, ["--pr", "0", "--apply", "--head-repo", ""])
+        self.assertEqual(f.calls, [])
+        self.assertIn("no pull-request context", out)
+
+    def test_unreadable_label_set_labels_nothing(self):
+        """Fail-closed on the label read: no labels visible => never guess."""
+        f = FakeGH({7: {"labels": [], "files": ["crates/sparq-reason/src/lib.rs"]}}, [])
+        out = _run(f, ["--pr", "7", "--apply"])
+        self.assertEqual(f.writes, [])
+        self.assertIn("inert", out)
+
+    def test_transient_gh_failure_retries_but_a_persistent_one_raises(self):
+        """A retry must not become exit-zero swallowing of an earned hard failure."""
+        calls = {"n": 0}
+
+        def flaky(args, **kw):
+            calls["n"] += 1
+            return None
+        import subprocess as sp
+
+        class R:
+            def __init__(self, rc):
+                self.returncode, self.stdout, self.stderr = rc, "ok\n", "boom"
+        seq = [R(1), R(0)]
+        orig = sp.run
+        try:
+            sp.run = lambda *a, **k: seq.pop(0)
+            self.assertEqual(M._gh(["api", "x"], sleep=lambda _s: None), "ok\n")
+            seq2 = [R(1), R(1), R(1)]
+            sp.run = lambda *a, **k: seq2.pop(0)
+            with self.assertRaises(RuntimeError):
+                M._gh(["api", "x"], sleep=lambda _s: None)
+        finally:
+            sp.run = orig
+
+
+# ======================================================================== YAML seam
+
+
+class TestWorkflowSeam(unittest.TestCase):
+    """Structural assertions over .github/workflows/pr-area-label.yml.
+
+    A substring or `count(...) == N` check over the workflow TEXT does not catch
+    `if: false`, a deleted step, or a swapped call-site argument — so everything below
+    walks the PARSED document."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = _yaml(WORKFLOW)
+        cls.jobs = cls.wf["jobs"]
+        cls.job = cls.jobs["label"]
+        cls.steps = cls.job["steps"]
+
+    # --- triggers ------------------------------------------------------------------
+    def test_triggers_cover_every_event_that_changes_the_path_set(self):
+        on = _on_block(self.wf)
+        self.assertEqual(sorted(on["pull_request"]["types"]),
+                         ["opened", "ready_for_review", "reopened", "synchronize"])
+        self.assertIn("merge_group", on)
+
+    def test_pull_request_trigger_has_no_paths_filter(self):
+        """A `paths:` filter here re-opens the starvation hole for whatever it excludes."""
+        on = _on_block(self.wf)
+        pr = on["pull_request"]
+        self.assertNotIn("paths", pr)
+        self.assertNotIn("paths-ignore", pr)
+
+    def test_uses_pull_request_not_pull_request_target(self):
+        """`pull_request_target` would hand a FORK's PR a WRITE token — the escalation
+        this design deliberately refuses."""
+        self.assertNotIn("pull_request_target", _on_block(self.wf))
+
+    # --- the `if:` seam ------------------------------------------------------------
+    def test_no_job_level_if_anywhere(self):
+        """Catches `if: false` and every other job-level guard mutation."""
+        guarded = sorted(j for j, spec in self.jobs.items() if "if" in spec)
+        self.assertEqual(guarded, [], f"job-level `if:` found on {guarded}; every skip "
+                                      f"decision belongs in Python (see the workflow header)")
+
+    def test_no_step_level_if_anywhere(self):
+        """Catches `if: false` on the labelling step, the classic surviving mutant."""
+        guarded = [s.get("name") or s.get("uses") for s in self.steps if "if" in s]
+        self.assertEqual(guarded, [], f"step-level `if:` found on {guarded}")
+
+    # --- the call site -------------------------------------------------------------
+    def test_the_labelling_step_exists_and_passes_exactly_the_documented_arguments(self):
+        """Catches a DELETED step and a WRONG INPUT. Each argument is asserted as a
+        whole token pair, so `--pr ${{ github.event.number }}` (a different, sometimes
+        absent field) reds, and so does dropping `--apply` (which would make the live
+        workflow a silent no-op that still reports success)."""
+        runs = [s["run"] for s in self.steps if "run" in s]
+        self.assertEqual(len(runs), 1, "expected exactly one run step")
+        run = " ".join(runs[0].split())          # normalise line continuations
+        self.assertIn("python3 scripts/pr-area-labels.py", run)
+        for arg in ('--repo "${{ github.repository }}"',
+                    '--pr "${{ github.event.pull_request.number || 0 }}"',
+                    '--head-repo "${{ github.event.pull_request.head.repo.full_name || \'\' }}"',
+                    "--apply"):
+            self.assertIn(arg, run, f"missing/altered call-site argument: {arg}")
+        self.assertNotIn("--dry-run", run)
+        self.assertNotIn("--backfill", run)
+
+    def test_deriver_and_policy_paths_referenced_by_the_workflow_exist(self):
+        run = " ".join(" ".join(s["run"] for s in self.steps if "run" in s).split())
+        script = next(tok for tok in run.split() if tok.endswith(".py"))
+        self.assertTrue((REPO_ROOT / script).is_file(), f"{script} does not exist")
+
+    # --- the privileged-token posture ---------------------------------------------
+    def test_checkout_uses_default_branch_not_pr_head(self):
+        """The job holds `pull-requests: write`; running PR-authored code under it is the
+        GITHUB_ENV-class escalation. Checkout MUST be pinned to the default branch."""
+        checkouts = [s for s in self.steps if "actions/checkout" in str(s.get("uses", ""))]
+        self.assertEqual(len(checkouts), 1)
+        with_ = checkouts[0].get("with") or {}
+        self.assertEqual(with_.get("ref"), "${{ github.event.repository.default_branch }}")
+        self.assertIs(with_.get("persist-credentials"), False)
+
+    def test_permissions_are_exactly_the_least_privilege_pair(self):
+        self.assertEqual(self.wf["permissions"],
+                         {"contents": "read", "pull-requests": "write"})
+        for job in self.jobs.values():
+            self.assertNotIn("permissions", job, "a job-level permissions block would "
+                                                 "override the least-privilege default")
+
+    def test_every_action_is_sha_pinned(self):
+        unpinned = []
+        for step in self.steps:
+            uses = step.get("uses")
+            if not uses:
+                continue
+            ref = uses.rsplit("@", 1)[-1]
+            if len(ref) != 40 or not all(c in "0123456789abcdef" for c in ref):
+                unpinned.append(uses)
+        self.assertEqual(unpinned, [], f"actions not SHA-pinned: {unpinned}")
+
+    def test_no_secret_other_than_the_scoped_github_token(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        bad = [ln.strip() for ln in text.splitlines()
+               if "secrets." in ln and "secrets.GITHUB_TOKEN" not in ln]
+        self.assertEqual(bad, [], f"unexpected secret reference: {bad}")
+
+    def test_job_name_is_not_declared_advisory(self):
+        """The gate excludes a check IFF it is in .github/advisory-registry.json; the name
+        token alone is diagnostic. Pin the intended GATING posture from both sides."""
+        self.assertNotIn("advisory", self.job["name"].lower())
+        registry = json.loads((REPO_ROOT / ".github" / "advisory-registry.json")
+                              .read_text(encoding="utf-8"))
+        self.assertNotIn(self.job["name"], registry["jobs"])
+
+
+class TestSelfTestIsActuallyInvoked(unittest.TestCase):
+    """The call-site mutant class: a suite nobody runs cannot go red. routing-self-tests
+    must INVOKE this file and the deriver's own `--self-test`, and must WATCH the paths
+    that can break either."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = _yaml(ROUTING_WF)
+
+    def _run_block(self):
+        steps = self.wf["jobs"]["validate"]["steps"]
+        return " ".join(" ".join(s["run"] for s in steps if "run" in s).split())
+
+    def test_routing_self_tests_invokes_this_suite_and_the_deriver_self_test(self):
+        run = self._run_block()
+        self.assertIn("python3 scripts/tests/test_pr_area_labels.py", run)
+        self.assertIn("python3 scripts/pr-area-labels.py --self-test", run)
+
+    def test_routing_self_tests_watches_every_file_this_suite_pins(self):
+        on = _on_block(self.wf)
+        watched = set(on["pull_request"].get("paths") or []) & set(
+            on["push"].get("paths") or [])
+        for path in ("scripts/pr-area-labels.py", "ci/area-labels.toml",
+                     "scripts/tests/test_pr_area_labels.py",
+                     ".github/workflows/pr-area-label.yml"):
+            self.assertIn(path, watched, f"{path} is not in BOTH paths filters — a change "
+                                         f"to it would not run this suite")
+
+    def test_the_validate_job_has_no_if_guard(self):
+        self.assertNotIn("if", self.wf["jobs"]["validate"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_pr_area_labels.py
+++ b/scripts/tests/test_pr_area_labels.py
@@ -255,6 +255,22 @@ class TestDerivation(unittest.TestCase):
         # row: a wrong narrow label is worse than a stalled frontier.
         self.assertEqual(M.attribute("crates/sparq-core/README.md", self.policy), "sparq-core")
 
+    def test_crate_prefix_wins_even_when_a_map_row_also_matches(self):
+        """DISCRIMINATING form of the precedence guard.
+
+        With the live table no `[[map]]` row can match a `crates/...` path, so simply
+        re-ordering the two rules is an EQUIVALENT mutant against real data — it passes
+        the test above for the wrong reason and only bites later, when someone adds a
+        `crates/**`-shaped row. So construct a policy where both rules match and assert
+        the crate still wins."""
+        overlapping = M.Policy(max_areas=4, rows=[("crates/**", "workspace")],
+                               non_crate=["workspace"], members=self.policy.members)
+        self.assertEqual(M.attribute("crates/sparq-core/src/lib.rs", overlapping),
+                         "sparq-core")
+        # ... and a NON-member path under crates/ does not fall through to that row
+        # either: `crates/` is the member rule's exclusive territory, fail closed.
+        self.assertIsNone(M.attribute("crates/README.md", overlapping))
+
     def test_glob_star_does_not_cross_a_slash(self):
         self.assertEqual(M.attribute("README.md", self.policy), "docs")
         self.assertEqual(M.attribute("skills/inference/SKILL.md", self.policy), "sparq-reason")
@@ -266,6 +282,23 @@ class TestDerivation(unittest.TestCase):
                 for c in sorted(self.policy.members)[:self.policy.max_areas + 1]]
         areas, reason = self.d(wide)
         self.assertEqual((areas, reason), (frozenset(), "cross-cutting"))
+
+    def test_declared_max_areas_is_the_reviewed_value(self):
+        """The cap is a SCHEDULER-SAFETY knob, so it is pinned ABSOLUTELY here.
+
+        Every other cross-cutting test derives its fixture from `policy.max_areas`, which
+        means raising the declared value moves those fixtures with it and nothing goes
+        red — the cap could be set to 60 (i.e. "nothing is ever cross-cutting") silently.
+        Changing the policy is allowed; changing it without updating this line is not."""
+        self.assertEqual(self.policy.max_areas, 4)
+
+    def test_a_five_crate_pr_stays_global_at_the_declared_cap(self):
+        """The absolute-fixture companion to the test above: five NAMED crates, no
+        dependence on `policy.max_areas`."""
+        five = ["crates/sparq-core/src/lib.rs", "crates/sparq-engine/src/lib.rs",
+                "crates/sparq-cli/src/main.rs", "crates/sparq-server/src/main.rs",
+                "crates/sparq-shacl/src/lib.rs"]
+        self.assertEqual(self.d(five), (frozenset(), "cross-cutting"))
 
     def test_max_areas_boundary_is_still_narrow(self):
         """Discriminates the cap from an off-by-one: exactly max_areas must RESOLVE."""
@@ -282,6 +315,16 @@ class TestDerivation(unittest.TestCase):
     def test_non_member_directory_under_crates_is_unresolved(self):
         self.assertEqual(self.d(["crates/not-a-crate/src/lib.rs"]),
                          (frozenset(), "unresolved"))
+
+    def test_member_check_is_what_rejects_a_non_member_crate_directory(self):
+        """DISCRIMINATING: the test above passes even without the member check, because
+        the live-label check then rejects the bogus name — two guards, one fixture. Here
+        the bogus name IS a live label, so ONLY the member check can reject it."""
+        self.assertIsNone(M.attribute("crates/not-a-crate/src/lib.rs", self.policy))
+        self.assertEqual(
+            M.derive_areas(["crates/not-a-crate/src/lib.rs"], self.policy,
+                           self.known | {"not-a-crate"}),
+            (frozenset(), "unresolved"))
 
     def test_empty_change_set_stays_global(self):
         self.assertEqual(self.d([]), (frozenset(), "no-paths"))


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Opus 5) — fixes the **binding limiter on fleet throughput**. Registry issue [jeswr/agent-account-registry#677](https://github.com/jeswr/agent-account-registry/issues/677) item 4 (+ the observability half of item 4's sibling).

## The problem, measured

The scheduler partitions work by `area:<name>`. An in-flight PR **reserves** its areas; a ready issue **defers** while any of its areas is reserved; and a PR with **no `area:` label** maps to the serializing `__global__` partition — so **one** unlabelled PR defers **every** issue, whatever crate it names.

Nothing in the pipeline ever applied an `area:` label to a PR. Measured 2026-07-26 14:45Z: **84 of 87 open PRs had none**. Live layer chain that tick — candidates 12 → frontier 3 → lease 3 → `max_concurrent` 8 → account pool 28, so `min = 3`: **28 account slots idle while 3 workers ran**. Raising `max_concurrent`/`package_width` was measured at **net +0** concurrent workers (reg#689) because this layer, not the caps, is what binds. Caught live: draft PR #4143, touching only `crates/sparq-reason/**` + `skills/inference/SKILL.md`, was holding `__global__` and deferring #2688/#2732/#2786.

It also produced a perverse incentive: only `[not-parked]` PRs seize, so **the frontier opened up when PRs got parked** — the pipeline scheduled better when it was less healthy.

## What this adds

| file | what |
|---|---|
| `ci/area-labels.toml` | the **reviewable declared table**: 94 `[[map]]` rows for non-crate paths, the `[policy] max_areas` cap, the `[lanes] non_crate` inventory, and the fail-closed rule written down |
| `scripts/pr-area-labels.py` | the **one deriver**, used by both the workflow and the backfill (so they cannot drift). `--pr N` / `--backfill`, `--dry-run` default, `--apply` to mutate, `--pace`, `--self-test` |
| `.github/workflows/pr-area-label.yml` | `pull_request: [opened, synchronize, ready_for_review, reopened]` + `merge_group`, `pull-requests: write` only, SHA-pinned, **no `if:` at any level** |
| `scripts/tests/test_pr_area_labels.py` | 50 named guard tests incl. the structural YAML seam |
| `AGENTS.md` | script-catalog entry: what it does, and **"when you add a top-level directory, add a `[[map]]` row"** |

Resolution order: `crates/<name>/<something>` → `area:<name>` **implicitly** (so a new crate needs no table edit), then the first matching `[[map]]` row, else unresolved.

### The fail-closed default is kept — deliberately

`__global__` is expressed as *absence of an `area:` label*, and the deriver emits none in three named cases:

* **`unresolved`** — ANY changed path has no rule, or resolves to an `area:` label that does not exist. Strict on purpose: one unattributable path means unknown blast radius.
* **`cross-cutting`** — more than `max_areas` (**4**) distinct areas.
* **`no-paths`** — the changed-file list is empty/unavailable.

The bug was never the fail-closed rule; it was that *unclassified* was indistinguishable from *genuinely cross-cutting*. I did **not** narrow everything: a wrong narrow label lets two workers collide on one crate, which is worse than a stalled frontier. Where a path is a repo-wide **shared file** rather than crate source (`Cargo.lock`, `deny.toml`, `scripts/**`) it maps to that file's own **shared lane** (`deps`, `ci`) rather than `__global__` — two lockfile PRs really do collide with each other and really do not collide with a docs PR, and the repo's own "same-new-dep beads collide on cargo-vet" finding is exactly this shape.

### It cannot invent a label

GitHub's add-labels REST call **silently creates** an unknown label, so a typo'd area would become permanent repo state. Every candidate is checked against the repo's live label set and dropped with a `::warning` if absent — a drop means the PR stays `__global__`, the safe direction. **13 `area:<crate>` labels were created by hand** for workspace members that had none (`sparq-acbench`, `sparq-conformance-floors`, `sparq-difftest`, `sparq-engine-service`, `sparq-fedclient`, `sparq-http3`, `sparq-jsonld-registry`, `sparq-reason-diff`, `sparq-reason-wasm`, `sparq-rsp-wasm`, `sparq-shaclc`, `sparq-text`, `sparq-text-wasm`), matching the existing convention (colour `0e8a16`, description `crate/surface conflict-partition`). No new label *kinds* were invented.

### Security posture

The job holds `pull-requests: write`, so it must not execute code from the pull request: `actions/checkout` is pinned to **`github.event.repository.default_branch`**, never the PR head or merge ref. That is why attribution is not gated on workspace membership — the manifest it reads is main's, and a PR that *adds* a crate would otherwise be unresolvable forever.

`pull_request`, deliberately **not** `pull_request_target`: a fork PR's token is read-only, and that path is handled explicitly (`--head-repo` → `::notice` + exit 0, **zero API calls**) rather than left to fail on a confusing 403. An empty `--head-repo` fails closed the same way.

### No `if:` anywhere, by design

Every skip decision (fork PR, no pull-request context on the `merge_group` ref) lives in Python. Measured in this project: 18/18 Python mutants died while **every** surviving mutant lived in a workflow `if:`/step/call-site. The seam tests assert the workflow has **no** job- or step-level `if:` at all, so re-introducing one — including `if: false` — turns a named test red.

## Test obligations — the mutation table

**Round 1: 34 mutants applied to the live tree, 34 killed** — the table below. The reviewer of `80710d9c` independently applied **50 of their own, 50/50 killed, 0 survivors**. **Round 2 adds 17 more (16 killed by the named test, 1 survivor by design); its output is pasted in full under *Review round 2* below.** Every guard has a named red test.

| mutant | test(s) that went red |
|---|---|
| `Y1` job-level `if: false` | `test_no_job_level_if_anywhere` |
| `Y2` step-level `if: false` | `test_no_step_level_if_anywhere` |
| `Y3` DELETE the labelling step | `test_the_labelling_step_exists_and_passes_exactly_the_documented_arguments` |
| `Y4` wrong input `--pr ${{ github.event.number }}` | same |
| `Y5` drop `--apply` (silent no-op, still green) | same |
| `Y6` checkout the PR **head** instead of the default branch | `test_checkout_uses_default_branch_not_pr_head` |
| `Y7` add a `paths:` filter | `test_pull_request_trigger_has_no_paths_filter` |
| `Y8` escalate to `issues: write` | `test_permissions_are_exactly_the_least_privilege_pair` |
| `Y9` unpin the action to a tag | `test_every_action_is_sha_pinned` |
| `Y10` `pull_request` → `pull_request_target` | `test_uses_pull_request_not_pull_request_target` |
| `Y11` remove `merge_group` / `Y12` drop `ready_for_review` | `test_triggers_cover_every_event_that_changes_the_path_set` |
| `Y13` rename the job to `(advisory)` | `test_job_name_is_not_declared_advisory` |
| `Y14`/`Y15` delete the suite / `--self-test` invocation | `test_routing_self_tests_invokes_this_suite_and_the_deriver_self_test` |
| `Y16` drop a file from the `paths:` filters | `test_routing_self_tests_watches_every_file_this_suite_pins` |
| `Y17` `if: false` on the `validate` job | `test_the_validate_job_has_no_if_guard` |
| `P1` ignore unresolved paths (fail **open**) | `test_one_unattributable_path_poisons_the_whole_pr` |
| `P2`/`T3` remove or neuter the `max_areas` cap | `test_genuinely_cross_cutting_pr_stays_global`, `test_a_five_crate_pr_stays_global_at_the_declared_cap`, `test_declared_max_areas_is_the_reviewed_value` |
| `P3`/`T2` drop the live-label check / typo an area | `test_area_with_no_live_label_is_never_invented`, `test_every_map_row_area_is_a_live_crate_or_declared_lane` |
| `P4a` accept `crates/<file>` as an area | `test_a_file_directly_under_crates_is_not_a_crate_area` |
| `P4b` re-gate on workspace membership | `test_a_pr_that_ADDS_a_crate_resolves_once_its_label_exists` |
| `P5` `[[map]]` rows before the crate rule | `test_crate_prefix_wins_even_when_a_map_row_also_matches` |
| `P6` prune "stale" areas (removes a human label) | `test_human_applied_area_label_survives_an_apply` |
| `P7` re-post every derived label | `test_second_pass_is_a_pure_noop`, `test_backfill_is_idempotent_across_the_whole_open_set` |
| `P8` delete the fork guard | `test_fork_pr_makes_zero_api_calls_and_exits_zero`, `test_empty_head_repo_fails_closed` |
| `P9` delete the no-PR-context guard | `test_no_pull_request_context_makes_zero_api_calls` |
| `P10` always apply | `test_dry_run_is_the_default_and_writes_nothing` |
| `P11` proceed with an unreadable label set | `test_unreadable_label_set_labels_nothing` |
| `P12` let `*` cross `/` | `test_glob_star_does_not_cross_a_slash` |
| `P13` swallow a persistent `gh` failure | `test_transient_gh_failure_retries_but_a_persistent_one_raises` |
| `T1` delete the `.github/**` row | `test_every_tracked_file_in_the_repo_resolves` |

**Three tests initially passed for the wrong reason and were fixed** (commit `1418e83c`):

1. rejecting a non-member `crates/<x>` dir survived deletion of the member check, because the *live-label* check then rejected the bogus name — two guards, one fixture. The replacement makes the bogus name a live label.
2. re-ordering the crate rule after the `[[map]]` rows was an **equivalent** mutant against real data (no row can match a `crates/` path today). The replacement builds a policy where both rules match.
3. every cross-cutting fixture derived its size from `policy.max_areas`, so raising the cap to 60 moved the fixtures with it and nothing went red. Now pinned absolutely, plus a five-**named**-crate fixture.

The totality test walks `git ls-files` (not synthetic `dir/probe.txt` probes, which pass while the real layout is unmapped). On its first run it found **4 dead `[[map]]` rows and 12 unmapped root paths**.

## Backfill: applied

Dry-run over the live open-PR set (**89 PRs**): **85 relabelled, 3 left on `__global__`, 1 already labelled**. All three residuals are genuinely cross-cutting and were hand-verified against their file lists: **#4041** (ci + bench + sparq-conformance + sparq-jsonld + docs), **#3870** (ci + deps + sparq-cli + sparq-reason-el + sparq-reason), **#3581** (≈20 crates). Full dry-run output is in the review comment below.

## Honest limits

* **This frees issues that *have* an `area:` label.** A ready issue with none maps to `__global__` on the *candidate* side and still defers whenever any PR is busy. The 551 area-less beads (issue #677 item 4) and the double-`priority:` damage are a separate fix.
* The registry's `busy_packages_of_pulls` also unions the **source issue's** areas and falls back to `__global__` when provenance is unreadable — a PR label alone does not rescue a PR whose provenance record is missing (reg#677's original #3641 case). Untouched here.
* Attribution is a **capacity** judgment, not a soundness one; `ci/path-ownership.toml` remains the authority on which crates must be *tested*. The two legitimately disagree (`.github/**` is a full-matrix trigger there, lane `ci` here).
* `max_areas = 4` is a judgment call, documented in the table and pinned by a test so changing it is deliberate.
* Observability (issue #677 item 4's sibling: log the `__global__` holder and its deferral count) is **not** in this PR — it belongs in the registry's `dispatch-claim.py`, not here.

---

## Review round 2 — the two blocking findings on `80710d9c`

### Finding 1 — under-reservation at the input boundary

`gh pr view --json files` is GraphQL `files(first: 100)` and silently truncates. Re-measured live:

```
$ gh pr view 3581 --repo sparq-org/sparq --json changedFiles --jq .changedFiles
646
$ gh pr view 3581 --repo sparq-org/sparq --json files --jq '.files|length'
100
$ gh api --paginate "repos/sparq-org/sparq/pulls/3581/files?per_page=100" \
    --jq '.[] | [.filename, (.previous_filename // "")] | @tsv' | wc -l
646
```

Nothing cross-checked the two, so the deriver reported `resolved` on a partial list — and a
truncated list derives a proper **subset** of the true areas. That is the corrupting
direction: a wrong *narrow* reservation puts two workers on one crate, where a wrong *broad*
one only delays.

**Both** fixes, as the reviewer preferred — the paging makes the answer right, the
cross-check is the guard that survives a future API change:

| | |
|---|---|
| `fetch_changed_files` | enumerates with `gh api --paginate repos/<r>/pulls/<n>/files?per_page=100`. `--json files` is now requested **nowhere** — not by the `--pr` path and not by the backfill (the backfill was the second consumer, and a merely-*fetched* `files` field is the trap: inert until someone reads it). |
| `paths_are_complete(enumerated, changed)` | compares the enumeration against the authoritative `changedFiles`, fetched independently. Disagreement is the new fail-closed reason **`incomplete-paths`**. A missing or non-int count also fails closed — not having *established* completeness is not the same as having established it. This also covers REST's own 3000-file ceiling. |
| `plan_for_pr` | requires `complete is True` **exactly**, so a future caller that assembles a record without establishing completeness fails closed rather than narrowing from an unchecked list. |

**`previous_filename` — yes, consumed.** The reviewer flagged this as not independently
demonstrated (no live rename PR existed to measure), so it is pinned *hermetically* instead,
by three named tests: a cross-crate move implicates **both** ends; an unattributable *source*
path poisons the PR rather than being quietly dropped; and the cross-check arithmetic counts
**entries, not paths** — a rename is two paths but one changed file, and counting paths would
make every rename look truncated. The fake serves `previous_filename` exactly as the REST
payload does. It is cheap (the field is already in the payload we now fetch) and safe (it can
only *widen* attribution, or fail closed).

### Finding 2 — the composed merge

Confirmed and reproduced, then fixed. Rebased onto `origin/main` = `43bbbac9`;
`rust-toolchain.toml` dropped from `anticipated_roots` (#3803), rows added for
`skills/e2ee-ng/**` → `sparq-e2ee-ng` and `skills/solid-lws-server/**` → `sparq-lws-core`
(#3464 / #4181).

**The recurring-ratchet note: acted on, for both halves.** `test_every_skill_surface_has_a_map_row`
and the "remove it once it lands" rule on `anticipated_roots` are the same defect class — a
*gating* assertion about the whole live tree, over something with no runtime consequence, in a
repo that merges continuously. Both are now **advisory drift reports**. The strict half of each
is kept:

* every `skills/` surface must still **attribute**, checked over its real tracked files;
* a landed `anticipated_roots` path must still attribute, and an entry must still correspond to
  a real `[[map]]` row (dropping a landed entry loses nothing — the strict dead-row check covers
  that row automatically once its root exists);
* **`test_every_tracked_file_in_the_repo_resolves` stays a hard gate.** It is what stops an
  unmapped path silently becoming `__global__`. Because two ratchets were softened, it now
  carries a non-vacuity guard of its own — `test_the_totality_check_detects_an_unmapped_path`
  prunes the `.github/**` row and requires the shared totality computation to report those paths.

### The mutation campaign, round 2 — pasted, not summarised

Each mutant applied to the live worktree, the real suite + `--self-test` run, then reverted.
"KILLED" means the **expected named test** was among the failures.

```
baseline: GREEN

KILLED       M1 delete the completeness check in derive_areas  -> ['test_a_pr_record_with_no_completeness_verdict_fails_closed', 'test_a_truncated_file_list_fails_closed_instead_of_deriving_a_subset', 'test_the_backfill_uses_the_same_enumeration_as_the_single_pr_path']
KILLED       M2 plan_for_pr defaults completeness to True (fail OPEN)  -> ['test_a_pr_record_with_no_completeness_verdict_fails_closed']
KILLED       M3 paths_are_complete always True  -> ['test_a_truncated_file_list_fails_closed_instead_of_deriving_a_subset', 'test_paths_are_complete_only_on_an_exact_confident_agreement', 'test_the_backfill_uses_the_same_enumeration_as_the_single_pr_path']
KILLED       M4 paths_are_complete tolerates a missing count  -> ['test_paths_are_complete_only_on_an_exact_confident_agreement']
KILLED       M5 drop --paginate from the REST enumeration  -> ['test_more_than_one_hundred_paths_are_all_enumerated', 'test_the_backfill_uses_the_same_enumeration_as_the_single_pr_path', 'test_the_file_list_is_never_read_from_the_capped_graphql_field']
KILLED       M6 go back to `gh pr view --json files` for the single-PR path  -> ['test_the_file_list_is_never_read_from_the_capped_graphql_field']
KILLED       M7 stop consuming previous_filename (rename under-attribution)  -> ['test_a_cross_crate_rename_implicates_the_source_crate_too', 'test_a_rename_counts_as_one_entry_against_changedFiles', 'test_a_rename_out_of_an_unmapped_path_fails_closed']
KILLED       M8 count PATHS not ENTRIES in the cross-check  -> [11 tests incl. 'test_a_rename_counts_as_one_entry_against_changedFiles']
KILLED       M9 ignore an unattributable PREVIOUS path  -> ['test_a_rename_out_of_an_unmapped_path_fails_closed']
KILLED       M10 backfill keeps the capped GraphQL files field  -> ['test_the_file_list_is_never_read_from_the_capped_graphql_field']
KILLED       M11 delete the `skills/**` catch-all row  -> ['test_a_future_skill_surface_resolves_through_the_catch_all']
KILLED       M12 delete the `.github/**` row (totality ratchet)  -> ['test_backfill_is_idempotent_across_the_whole_open_set', 'test_every_tracked_file_in_the_repo_resolves']
KILLED       M13 neuter the shared totality computation  -> ['test_the_totality_check_detects_an_unmapped_path']
KILLED       M14 anticipated_roots entry with no matching row  -> ['test_anticipated_roots_are_declared_rows']
SURVIVED(by design)  M15 remove the e2ee-ng skill row (must be DRIFT, not a failure)
KILLED       M17 rig the fake: serve changedFiles from the CAPPED list  -> ['test_a_truncated_file_list_fails_closed_instead_of_deriving_a_subset']
KILLED       M16 dead [[map]] row (root does not exist)  -> ['test_every_map_row_pattern_root_exists_on_disk']

16 killed, 1 survived, 0 not applied, of 17
```

**Two REAL survivors were found by this campaign and closed before this was pushed** — the
first pass reported 13/16, not 16/17:

1. the backfill could still request `--json ...,files`; the structural test only inspected the
   `--pr` path. It now runs **both** entry points.
2. deleting the `skills/**` catch-all **red nothing**, because every surface on `main` now has a
   specific row — so the test that was supposed to justify the ratchet demotion was vacuous with
   respect to the row that makes the demotion safe. Added
   `test_a_future_skill_surface_resolves_through_the_catch_all` (a deliberately synthetic probe:
   a surface with no row is by definition one that has not landed).

The `gh` fake was also hardened so the campaign means something: it serves **one page** unless
`--paginate` is passed (so M5 really loses the tail), and serves `changedFiles` from the **full**
entry list — rigging it to serve the capped count is itself a killed mutant (M17).

### Verified at this head

* `scripts/tests/test_pr_area_labels.py` — **65/65**; `scripts/pr-area-labels.py --self-test` — pass.
* Composed against `origin/main` `43bbbac9` (rebased, so the merge *is* the branch): green.
  Both of the reviewer's two failures reproduced first at `80710d9c`, then fixed.
* `typos` clean over `ci/`, the deriver, the suite and `AGENTS.md`.
* Live backfill dry run: **99 open PRs, 16 would relabel, 5 stay `__global__`** — 4 genuinely
  cross-cutting, 1 (#4182) with **0** changed files. **Zero `incomplete-paths`**: the new guard
  costs nothing on today's live set, exactly as the reviewer's "latent, not currently firing"
  severity call predicted.

### One correction to the review

The rescue-value paragraph reduces 13 resolvable PRs to 7 on the premise that two `area:` labels
still collapse to `__global__` (registry #718). That premise is wrong and **#718 is closed as
not-a-defect**: PR occupancy in `busy_packages_of_pulls` is a plain **union**, so a two-area PR
reserves both areas correctly; `plan_package`'s single-value reduction applies to the dispatched
*issue's* plan row, not to PR occupancy. The rescue value is the full **13**. Nothing in this PR
was built on that premise. (The real cause of the remaining global holders is **missing
provenance records** — 13 of 70 open `sparq-agent/*` PRs lack one; registry PR #719 recovers 8.
Out of scope here.)

**Not armed, not auto-merged** — the orchestrator arms centrally.

