### PR TITLE
feat(triage): clear the needs:area dispatch block with an evidence-ordered classifier

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -438,6 +438,18 @@ jobs:
         run: |
           python3 scripts/triage.py --self-test
           python3 scripts/retriage.py --self-test
+      # [OPUS-5] #1135: scripts/triage-area.py is the third member of that triage
+      # family — it CLEARS the `needs:area` park triage.py sets. It runs by hand
+      # (no cron), so without a PR-time gate a rule-table edit would only be
+      # discovered by mislabeling live issues, and a wrong `area:` routes a worker
+      # at the wrong crate. Both suites are hermetic (stdlib only, no gh/network):
+      # the script's own rule self-test, plus the independent safety tests
+      # (fail-closed / no unpark-without-an-area / no invented label / the three
+      # rule orderings that were measured wrong on the live backlog).
+      - name: Self-test triage-area.py (needs:area classifier — fail-closed + no-drift)
+        run: |
+          python3 scripts/triage-area.py --self-test
+          python3 scripts/tests/test_triage_area.py
       # [FABLE-5] #3759 / registry#563 item 4: the transient-tolerant gh READ retry
       # helper (scripts/gh_retry.py — bounded, transient-5xx-only, fail-closed
       # read-allow-list so mutations/arm calls can never be wrapped) and the two arm

--- a/scripts/tests/test_triage_area.py
+++ b/scripts/tests/test_triage_area.py
@@ -28,7 +28,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import re
 import sys
 import unittest
@@ -254,7 +256,8 @@ class TestNoDrift(unittest.TestCase):
         self.addCleanup(lambda: setattr(sys, "argv", real_argv))
 
         try:
-            self.assertEqual(TA.main(), 0)
+            with contextlib.redirect_stdout(io.StringIO()):  # main() prints the plan
+                self.assertEqual(TA.main(), 0)
         except ValueError as exc:
             # apply_row's own fail-closed guard caught it one layer down. That is
             # the SECOND line of defence firing; report it as this test's failure

--- a/scripts/tests/test_triage_area.py
+++ b/scripts/tests/test_triage_area.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# [OPUS-5] Hermetic tests for scripts/triage-area.py — the `needs:area` backlog
+# classifier that clears the migration's 257-issue dispatch block (#1135).
+#
+# These are DELIBERATELY not a copy of the script's own `--self-test`. That one
+# proves the rules do what the author meant; this one proves the two properties
+# that make the tool SAFE to point at 257 live issues:
+#
+#   1. FAIL CLOSED — no evidence must yield NO label. A wrong `area:` routes a
+#      worker at the wrong crate and can put two workers on one conflict
+#      partition; the park is maintainer-visible and self-clearing.
+#   2. NO DRIFT between the two writes — `needs:area` is removed ONLY together
+#      with >=1 real `area:` label. Either half alone re-breaks dispatch (a
+#      still-parked issue stays invisible; an unparked no-area issue silently
+#      reserves the serializing `__global__` partition).
+#
+# and the invariant that stops the rule table rotting:
+#
+#   3. EVERY area the rule table can emit must be a label the repo ALREADY has.
+#      Enumerated statically from RULES — no network.
+#
+# Run:  python3 scripts/tests/test_triage_area.py
+# (stdlib only; no pytest required — also discoverable by `pytest`.)
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, REPO_ROOT / "scripts" / filename)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+TA = _load("triage_area", "triage-area.py")
+CRATES = TA.crate_names()
+
+
+def areas(title: str, body: str = "") -> list:
+    return TA.classify(title, body, CRATES)[0]
+
+
+class TestFailClosed(unittest.TestCase):
+    """No evidence => no label. This is the property the whole design rests on."""
+
+    def test_no_evidence_stays_parked(self):
+        for title in ("do the thing",
+                      "make sure the pinned overview issue gets maintained",
+                      "Recurring chore: worktree disk-hygiene sweep",
+                      "LinkedIn advert post: enumerate ALL implemented specs"):
+            self.assertEqual(areas(title), [], title)
+
+    def test_declaration_naming_no_real_crate_stays_parked(self):
+        # sq-lsp7k.12 declares "NEW opt-in crate" — a package that does not exist.
+        # Inventing one here would be the exact misroute the park exists to avoid.
+        self.assertEqual(
+            areas("BI/SQL wire-protocol facade",
+                  "crate_or_surface: NEW opt-in crate (pgwire-class) | effort:XL"), [])
+
+    def test_a_body_name_drop_is_not_evidence(self):
+        # A bead that merely cites a neighbouring crate in prose must NOT be
+        # partitioned into it — the failure mode that produced these 257 parks.
+        self.assertEqual(
+            areas("formalize the codex-EC2 worker tooling",
+                  "the harness has been used against sparq-core and sparq-jsonld"), [])
+
+
+class TestNoDrift(unittest.TestCase):
+    """`needs:area` and the `area:` labels are written in ONE call, or not at all."""
+
+    def test_plan_emits_labels_only_for_classifiable_issues(self):
+        rows = TA.plan([
+            {"number": 1, "title": "DL L4: narrow the RL disjointWith guard",
+             "body": "", "labels": [{"name": TA.PARK_LABEL}]},
+            {"number": 2, "title": "do the thing", "body": "",
+             "labels": [{"name": TA.PARK_LABEL}]},
+        ], CRATES)
+        self.assertEqual(rows[0][1], ["area:sparq-reason-dl"])
+        self.assertEqual(rows[1][1], [])
+
+    def test_unpark_is_never_emitted_without_an_area(self):
+        # apply_row is the ONLY writer, and it always carries both halves. Assert
+        # on the argv it would build rather than trusting the prose above it.
+        seen = {}
+        TA._gh = lambda a: seen.setdefault("argv", a) or ""
+        TA.apply_row(7, ["area:sparq-core", "area:sparq-vectors"])
+        argv = seen["argv"]
+        self.assertIn("--remove-label", argv)
+        self.assertEqual(argv[argv.index("--remove-label") + 1], TA.PARK_LABEL)
+        self.assertEqual(argv.count("--add-label"), 2)
+
+    def test_already_classified_issue_is_a_no_op(self):
+        # Idempotence: a re-run must never re-decide settled work.
+        rows = TA.plan([{"number": 3, "title": "DL L4: whatever", "body": "",
+                         "labels": [{"name": "area:sparq-core"},
+                                    {"name": TA.PARK_LABEL}]}], CRATES)
+        self.assertEqual(rows[0][1], [])
+        self.assertTrue(rows[0][2].startswith("SKIP"))
+
+
+class TestRuleTableHygiene(unittest.TestCase):
+    def test_every_emitted_area_is_a_real_crate_or_a_known_surface(self):
+        """Never invent a label. An `area:` the repo does not have is invisible to
+        ready-issues.py and push-frontier.sh, so the issue stays undispatchable
+        while LOOKING triaged — strictly worse than the park."""
+        # The non-crate surfaces the repo really carries (checked against
+        # `gh label list` when this test was written, 2026-07-26).
+        surfaces = {"site", "site-specs", "site-papers", "gui", "js", "bench", "ci",
+                    "docs", "deps", "release", "workspace", "upstream", "e2ee",
+                    "zk", "zk-xpath", "knowledge-graph", "deploy-demo"}
+        for rid, _scope, _rx, emitted, _why in TA.RULES:
+            for a in emitted:
+                self.assertTrue(a in CRATES or a in surfaces,
+                                f"rule {rid} emits unknown area {a!r}")
+
+    def test_rule_order_survives_the_known_name_drop_collisions(self):
+        """Three orderings were each MEASURED wrong on the live backlog. Pin them:
+        reordering the table silently re-breaks these and nothing else would."""
+        # A .typ spec that names zk/ieee754 + zk/xpath is SPEC work.
+        self.assertEqual(
+            areas("zksparql.typ 7.3 stale estate sentence: still names zk/ieee754 "
+                  "+ zk/xpath as in-tree"), ["site-specs"])
+        # An ieee754 bead whose body literally reads "FILE: zk/xpath NO -- zk/ieee754/..."
+        self.assertEqual(
+            areas("ieee754 OPT: gate-neutral kernels.nr cleanups",
+                  "FILE: zk/xpath NO -- zk/ieee754/src/ops/kernels.nr"), ["zk"])
+        # An ODRL bead whose paper recorded it is ODRL work, not paper work.
+        self.assertEqual(
+            areas("odrl-bridge: materialise rule-level provenance",
+                  "recorded as limitation #5 in site/papers/odrl-policy-bridge.typ"),
+            ["sparq-policy"])
+
+    def test_cross_cutting_issues_keep_every_area(self):
+        """The partitioner maps multi-area to __global__ deliberately. Collapsing a
+        genuinely cross-crate issue to one crate to make it look dispatchable is a
+        lie that lands two workers in one partition."""
+        self.assertEqual(
+            areas("MPC M4-v1: attestation GATE assembly",
+                  "Crate: sparq-mpc (pipeline.rs/proof.rs) + sparq-zk-compose "
+                  "(federated reconstruct_public_inputs reuse). The buildable M4 v1:"),
+            ["sparq-mpc", "sparq-zk-compose"])
+        self.assertEqual(
+            areas("[epic] Proof-of-correctness program for sparq_ieee754 & noir_XPath"),
+            ["zk", "zk-xpath"])
+
+    def test_declaration_span_stops_at_the_sentence_break(self):
+        """sq-p4zci's field is followed by prose containing 'docs/SKILL examples';
+        running the span to end-of-line derived a spurious area:docs."""
+        self.assertEqual(
+            areas("Datalog: surface wiring",
+                  "crates: sparq-reason + sparq-cli. CLI flag + a handle for datalog "
+                  "programs; docs/SKILL examples beyond the API reference."),
+            ["sparq-reason", "sparq-cli"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_triage_area.py
+++ b/scripts/tests/test_triage_area.py
@@ -18,6 +18,10 @@
 #
 #   3. EVERY area the rule table can emit must be a label the repo ALREADY has.
 #      Enumerated statically from RULES — no network.
+#   4. SCOPE DISCIPLINE — a `title`-scoped rule must never fire off a BODY mention.
+#      60 of the 70 rules are title-scoped, and body-matching is the documented
+#      root cause of the mislabels this tool exists to clean up. Asserted PER RULE
+#      (see TestScopeDiscipline), because the realistic edit changes one rule.
 #
 # Run:  python3 scripts/tests/test_triage_area.py
 # (stdlib only; no pytest required — also discoverable by `pytest`.)
@@ -25,9 +29,15 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import unittest
 from pathlib import Path
+
+try:  # the parsed-regex API moved in 3.11
+    from re import _parser as sre_parser
+except ImportError:  # pragma: no cover - Python < 3.11
+    import sre_parse as sre_parser  # type: ignore[no-redef]
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -47,6 +57,106 @@ CRATES = TA.crate_names()
 
 def areas(title: str, body: str = "") -> list:
     return TA.classify(title, body, CRATES)[0]
+
+
+def evidence(title: str, body: str = "") -> str:
+    return TA.classify(title, body, CRATES)[1]
+
+
+# --- a MATCHING witness string for an arbitrary rule regex ----------------------
+# The scope property has to be asserted per rule (the realistic edit tweaks ONE
+# rule), and 60 hand-written fixtures would rot the moment a rule's regex moves.
+# So derive the fixture FROM the regex: walk the parsed pattern and emit the
+# shortest string it accepts. Every witness is then re-checked against the live
+# regex in test_every_title_rule_has_a_witness_that_actually_matches, so a
+# generator that silently produced a non-matching string fails LOUDLY instead of
+# turning the whole property into a vacuous pass.
+#
+# Unsupported node kinds raise: a new regex construct must be taught to the
+# generator, never silently skipped (a skipped rule is an unguarded rule).
+_CATEGORY_SAMPLE = {"CATEGORY_WORD": "x", "CATEGORY_DIGIT": "1", "CATEGORY_SPACE": " "}
+
+
+def _sample_from_set(items) -> str:
+    for op, arg in items:
+        name = str(op)
+        if name == "LITERAL":
+            return chr(arg)
+        if name == "RANGE":
+            return chr(arg[0])
+        if name == "CATEGORY":
+            return _CATEGORY_SAMPLE[str(arg)]
+    raise ValueError(f"unsupported character set {items!r}")
+
+
+def _emit(parsed) -> tuple[str, bool]:
+    """(shortest accepted string, is_anchored_at_string_start) for a parsed regex.
+
+    A `^`-anchored alternative can only ever match at offset 0 — i.e. the start of
+    the TITLE, since classify() searches `title + "\\n" + body`. Such a rule is
+    scope-immune by construction, so BRANCH prefers an unanchored alternative and
+    reports back when every alternative is anchored."""
+    out: list[str] = []
+    anchored = False
+    for op, arg in parsed:
+        name = str(op)
+        if name == "LITERAL":
+            out.append(chr(arg))
+        elif name == "ANY":
+            out.append("x")
+        elif name == "IN":
+            out.append(_sample_from_set(arg))
+        elif name == "AT":
+            if str(arg) in ("AT_BEGINNING", "AT_BEGINNING_STRING") and not out:
+                anchored = True
+        elif name == "SUBPATTERN":
+            text, sub_anchored = _emit(arg[3])
+            anchored = anchored or (sub_anchored and not out)
+            out.append(text)
+        elif name in ("MAX_REPEAT", "MIN_REPEAT"):
+            low, _high, sub = arg
+            text, _ = _emit(sub)
+            out.append(text * low if low else "")
+        elif name == "BRANCH":
+            alternatives = [_emit(alt) for alt in arg[1]]
+            unanchored = [t for t, a in alternatives if not a]
+            if unanchored:
+                out.append(unanchored[0])
+            else:
+                out.append(alternatives[0][0])
+                anchored = True
+        else:
+            raise ValueError(f"unsupported regex node {name} in {parsed!r}")
+    return "".join(out), anchored
+
+
+def rule_witness(regex: str) -> tuple[str, bool]:
+    return _emit(sre_parser.parse(regex, flags=0))
+
+
+def title_rules():
+    return [r for r in TA.RULES if r[1] == "title"]
+
+
+def text_rules():
+    return [r for r in TA.RULES if r[1] == "text"]
+
+
+#: The ONLY rules permitted to match an issue BODY. Body-matching is what let
+#: `derive_areas` label a zkSPARQL spec bead `area:site` off one incidental word,
+#: so the list is short, hand-reviewed, and pinned by name — see
+#: TestRuleTableHygiene.test_only_the_pinned_rules_are_allowed_to_read_the_body.
+#: Each of these matches a repo PATH or a code SYMBOL, which a body cites
+#: deliberately and a neighbouring bead does not name in passing.
+TEXT_SCOPED_RULES = frozenset({
+    "site-specs", "site-papers", "zk-xpath", "zk-compose", "reason-dl-floor",
+    "js", "gui-tauri", "site-app", "bench", "ci",
+})
+
+# A title with no evidence of its own — pinned by the assertion in
+# TestScopeDiscipline.setUp so it can never quietly acquire an area and turn the
+# per-rule property into a tautology.
+NEUTRAL_TITLE = "Recurring chore: worktree disk-hygiene sweep"
 
 
 class TestFailClosed(unittest.TestCase):
@@ -87,16 +197,76 @@ class TestNoDrift(unittest.TestCase):
         self.assertEqual(rows[0][1], ["area:sparq-reason-dl"])
         self.assertEqual(rows[1][1], [])
 
-    def test_unpark_is_never_emitted_without_an_area(self):
-        # apply_row is the ONLY writer, and it always carries both halves. Assert
-        # on the argv it would build rather than trusting the prose above it.
-        seen = {}
-        TA._gh = lambda a: seen.setdefault("argv", a) or ""
+    def _capture_gh(self):
+        """Record every argv apply_row/main would hand to `gh`, and restore the
+        real _gh afterwards so one test can never leak a stub into the next."""
+        calls = []
+        real = TA._gh
+        TA._gh = lambda a: (calls.append(list(a)), "")[1]
+        self.addCleanup(lambda: setattr(TA, "_gh", real))
+        return calls
+
+    def test_the_unpark_and_the_areas_travel_in_one_call(self):
+        # apply_row is the ONLY writer. Assert on the argv it builds rather than
+        # trusting the prose above it. (This case has AREAS — the empty-add case
+        # is test_unpark_is_never_emitted_without_an_area below, and the two are
+        # separate because a call carrying two areas can never exhibit the bug
+        # that a call carrying none does.)
+        calls = self._capture_gh()
         TA.apply_row(7, ["area:sparq-core", "area:sparq-vectors"])
-        argv = seen["argv"]
+        argv = calls[0]
         self.assertIn("--remove-label", argv)
         self.assertEqual(argv[argv.index("--remove-label") + 1], TA.PARK_LABEL)
         self.assertEqual(argv.count("--add-label"), 2)
+
+    def test_unpark_is_never_emitted_without_an_area(self):
+        """The named case: apply_row called with NO areas must not reach `gh` at
+        all. A bare `--remove-label needs:area` is the worst output this tool can
+        produce — the issue looks triaged, retriage.py promotes it, and it then
+        reserves the serializing `__global__` partition, collapsing the dispatch
+        frontier to a single worker."""
+        calls = self._capture_gh()
+        with self.assertRaises(ValueError):
+            TA.apply_row(4242, [])
+        self.assertEqual(calls, [], f"a bare unpark reached gh: {calls}")
+
+    def test_main_never_applies_an_unclassified_row(self):
+        """End-to-end over `main() --apply`: the filter that decides WHICH rows are
+        written is exercised, not merely described. Feed it one classifiable and
+        two unclassifiable issues and assert only the classifiable one is written,
+        and that no emitted argv removes the park without adding an area."""
+        calls = self._capture_gh()
+        issues = [
+            {"number": 11, "title": "DL L4: narrow the RL disjointWith guard",
+             "body": "", "labels": [{"name": TA.PARK_LABEL}]},
+            {"number": 12, "title": "do the thing", "body": "it would be nice",
+             "labels": [{"name": TA.PARK_LABEL}]},
+            {"number": 13, "title": "make sure the pinned overview issue is kept",
+             "body": "", "labels": [{"name": TA.PARK_LABEL}]},
+        ]
+        for name, stub in (("parked_issues", lambda: issues),
+                           ("live_area_labels", lambda: {"area:sparq-reason-dl"})):
+            real = getattr(TA, name)
+            setattr(TA, name, stub)
+            self.addCleanup(lambda n=name, r=real: setattr(TA, n, r))
+        real_argv = sys.argv
+        sys.argv = ["triage-area.py", "--apply"]
+        self.addCleanup(lambda: setattr(sys, "argv", real_argv))
+
+        try:
+            self.assertEqual(TA.main(), 0)
+        except ValueError as exc:
+            # apply_row's own fail-closed guard caught it one layer down. That is
+            # the SECOND line of defence firing; report it as this test's failure
+            # rather than as an unhandled error, so the diagnosis names the filter.
+            self.fail(f"main() handed an unclassified row to apply_row: {exc}")
+
+        edits = [c for c in calls if c[:2] == ["issue", "edit"]]
+        self.assertEqual([c[2] for c in edits], ["11"],
+                         f"main() wrote issues it did not classify: {edits}")
+        for argv in edits:
+            self.assertGreaterEqual(argv.count("--add-label"), 1,
+                                    f"bare unpark emitted by main(): {argv}")
 
     def test_already_classified_issue_is_a_no_op(self):
         # Idempotence: a re-run must never re-decide settled work.
@@ -160,6 +330,123 @@ class TestRuleTableHygiene(unittest.TestCase):
                   "crates: sparq-reason + sparq-cli. CLI flag + a handle for datalog "
                   "programs; docs/SKILL examples beyond the API reference."),
             ["sparq-reason", "sparq-cli"])
+
+    def test_scope_is_declared_and_only_ever_title_or_text(self):
+        """`scope` is a two-valued dispatch in classify(); a typo'd third value
+        would silently fall through to the body-matching branch."""
+        self.assertEqual({r[1] for r in TA.RULES}, {"title", "text"})
+
+    def test_only_the_pinned_rules_are_allowed_to_read_the_body(self):
+        """The scope of a rule is a POLICY decision, and widening one from `title`
+        to `text` is the commonest rule-table edit there is. It cannot be caught
+        behaviourally — a widened rule behaves exactly like a rule that was always
+        text-scoped — so the allow-list is pinned by NAME here. A flip fails with
+        the rule id in the diff, which is the review prompt: does this rule's
+        evidence really live in bodies, or is it about to inherit `derive_areas`'s
+        mislabels?"""
+        self.assertEqual({r[0] for r in TA.RULES if r[1] == "text"}, TEXT_SCOPED_RULES)
+
+
+class TestScopeDiscipline(unittest.TestCase):
+    """A `title`-scoped rule must NEVER fire off a BODY mention — asserted PER RULE.
+
+    This is the anti-mislabel mechanism the whole rule table leans on: 60 of the 70
+    rules are title-scoped, and matching bodies is precisely how the migration-time
+    `derive_areas` sent a zkSPARQL spec bead to `area:site` off one incidental word.
+
+    Asserted per rule rather than with a single fixture because the failure mode is
+    per rule: the realistic edit is not "delete the scope dispatch", it is "flip one
+    rule's `\"title\"` to `\"text\"` while tuning it" — the exact shape of a rule-table
+    change. A single fixture pins one rule and leaves the other 59 unguarded.
+
+    Division of labour with TestRuleTableHygiene: the tests here prove the DISPATCH
+    still works as declared (a mechanism check, which is what the one-line
+    `hay = text` collapse breaks); the pinned TEXT_SCOPED_RULES allow-list there
+    proves the DECLARATION has not moved (a policy check). A widened rule behaves
+    exactly like a rule that was always text-scoped, so only the allow-list can
+    catch it — which is why both exist."""
+
+    #: Rules whose every alternative is `^`-anchored. classify() searches
+    #: `title + "\n" + body`, so `^` can only match at the start of the TITLE and
+    #: the scope flag is behaviourally inert for them. Pinned rather than skipped:
+    #: dropping a `^` moves a rule OUT of this set, which reds this test and
+    #: simultaneously brings the rule under the per-rule assertion below.
+    ANCHORED_ONLY = {"difftest-normaliser", "difftest-harness", "kani-harness",
+                     "site-page", "deploy-demo"}
+
+    def setUp(self):
+        # Anti-tautology: the carrier title must itself classify to nothing, or
+        # "the rule did not fire" would be true for uninteresting reasons.
+        self.assertEqual(areas(NEUTRAL_TITLE), [], NEUTRAL_TITLE)
+
+    def test_every_rule_has_a_witness_that_actually_matches(self):
+        """The generated fixtures are the substrate of both properties below; if one
+        stopped matching its own regex they would pass vacuously. Two checks per
+        rule: the witness matches the regex, AND it reaches THAT rule through the
+        real classify() path (a witness shadowed by an earlier rule could never
+        demonstrate anything about this one)."""
+        checked = 0
+        for rid, _scope, rx, _areas, _why in TA.RULES:
+            witness, _anchored = rule_witness(rx)
+            self.assertTrue(re.search(rx, witness, re.I),
+                            f"rule {rid}: generated witness {witness!r} does not match {rx!r}")
+            self.assertTrue(evidence(witness).startswith(f"T1 {rid}:"),
+                            f"rule {rid}: witness {witness!r} is claimed by "
+                            f"{evidence(witness)!r} — the rule is unreachable")
+            checked += 1
+        self.assertEqual(checked, len(TA.RULES))
+        self.assertGreater(checked, 0)
+
+    def test_a_title_scoped_rule_never_fires_from_the_body_alone(self):
+        """THE property. Each title rule's own witness, moved into the body of an
+        issue whose title carries no evidence, must not produce that rule's areas.
+        Ranges over the DECLARED title rules, so it stays true as the table grows —
+        the pinned allow-list in TestRuleTableHygiene is what makes a rule leaving
+        this set a reviewed act rather than a silent one."""
+        leaked = []
+        for rid, _scope, rx, _rule_areas, _why in title_rules():
+            witness, _anchored = rule_witness(rx)
+            got = TA.classify(NEUTRAL_TITLE, witness, CRATES)
+            if got[1].startswith(f"T1 {rid}:"):
+                leaked.append(f"{rid} fired from a body-only {witness!r} -> {got[0]}")
+        self.assertEqual(leaked, [], "title-scoped rules matched the body:\n  "
+                                     + "\n  ".join(leaked))
+
+    def test_a_text_scoped_rule_does_fire_from_the_body(self):
+        """The other direction of the same dispatch. The `text`-scoped rules exist
+        precisely BECAUSE their evidence (a repo path, a symbol name) lives in
+        bodies; collapsing the dispatch the other way — `hay = low_title` — would
+        silently stop them finding it and quietly shrink the tool's yield. Without
+        this, only one of the two branches of the scope dispatch is pinned."""
+        missed = []
+        for rid, _scope, rx, _areas, _why in text_rules():
+            witness, _anchored = rule_witness(rx)
+            got = TA.classify(NEUTRAL_TITLE, witness, CRATES)
+            if not got[1].startswith(f"T1 {rid}:"):
+                missed.append(f"{rid} did not fire on body-only {witness!r} "
+                              f"(got {got[1]!r})")
+        self.assertEqual(missed, [], "text-scoped rules ignored the body:\n  "
+                                     + "\n  ".join(missed))
+
+    def test_the_scope_immune_rules_are_exactly_the_fully_anchored_ones(self):
+        """Keeps the exemption above honest: a rule is exempt only because every
+        alternative is `^`-anchored, and that fact is re-derived from the regex,
+        never assumed. Derived over the WHOLE table so it is independent of the
+        scope flags — dropping a `^` reds here whatever the rule's scope says."""
+        anchored = {rid for rid, _s, rx, _a, _w in TA.RULES if rule_witness(rx)[1]}
+        self.assertEqual(anchored, self.ANCHORED_ONLY)
+
+    def test_zk_ieee754_scope_is_pinned_not_only_its_order(self):
+        """The rule's own comment gives TWO reasons it is safe — "TITLE-scoped and
+        ahead of zk-xpath". test_rule_order_survives_the_known_name_drop_collisions
+        pins only the "ahead of" half; sq-3x7dl.10's body reads "FILE: zk/xpath NO
+        -- zk/ieee754/...", so if `ieee754` could match a body then every issue that
+        merely discusses float semantics would be routed at zk/ieee754."""
+        self.assertEqual(
+            areas("Recurring chore: worktree disk-hygiene sweep",
+                  "background: the failure only shows up under ieee754 rounding"), [])
+        # ...while the same token in the TITLE still routes there (the rule works).
+        self.assertEqual(areas("ieee754 OPT: gate-neutral kernels.nr cleanups"), ["zk"])
 
 
 if __name__ == "__main__":

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -500,8 +500,19 @@ def self_test():
               ["sparq-reason-dl"])
     f += _chk("el lane", c("EL abox+cdomain DataPropertyAssertion point-range rescue"),
               ["sparq-reason-el"])
-    f += _chk("difftest", c("sq-qcnn.5: diff-test: wire canonical binding-MULTISET check"),
-              ["sparq-difftest"])
+    # The diff-test DAG splits across TWO crates and the split is not the obvious one,
+    # so pin BOTH branches of the split — a single case cannot catch a rule that
+    # collapses the family onto one crate. Node A (the engine-independent normaliser)
+    # is crates/sparq-difftest; the harness it feeds (check_ordered lives at
+    # crates/sparq-bench/src/fuzz.rs) is crates/sparq-bench. A bead that WIRES the
+    # normaliser into the harness therefore moves both.
+    f += _chk("difftest normaliser+harness",
+              c("sq-qcnn.5: diff-test: wire canonical binding-MULTISET check"),
+              ["sparq-difftest", "sparq-bench"])
+    # ...but a harness-only diff-test bead must NOT drag the normaliser crate in.
+    f += _chk("difftest harness only",
+              c("sq-qcnn.7: diff-test: add an oracle adapter to the generator"),
+              ["sparq-bench"])
 
     # T2 fallback still works (a conventional title scope prefix).
     f += _chk("t2 title scope", c("bug(sparq-solid): fail-closed ACP"), ["sparq-solid"])

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -440,7 +440,19 @@ def plan(issues, crates):
 def apply_row(number, add):
     """Add the area labels AND drop the park in ONE call. They must not drift: an
     issue with an area but still parked stays undispatchable, and a cleared park
-    with no area silently reserves the serializing __global__ partition."""
+    with no area silently reserves the serializing __global__ partition.
+
+    FAIL CLOSED on an empty `add`. `main()` already filters unclassified rows out
+    before it gets here, but that filter is one edit away from the apply loop and
+    a BARE UNPARK is the worst outcome this tool can produce: the issue looks
+    triaged, `retriage.py` promotes it, and it then reserves the serializing
+    `__global__` partition — which collapses the dispatch frontier to a single
+    worker. The invariant therefore lives in the ONLY function that can emit the
+    unpark, not in the caller that happens to protect it today."""
+    if not add:
+        raise ValueError(
+            f"refusing a bare unpark of #{number}: `{PARK_LABEL}` may only be "
+            "removed in the same call that adds >=1 area: label")
     args = ["issue", "edit", str(number), "--repo", REPO, "--remove-label", PARK_LABEL]
     for a in add:
         args += ["--add-label", a]
@@ -475,6 +487,18 @@ def self_test():
 
     # FAIL CLOSED is the headline behaviour: no evidence => no label.
     f += _chk("no evidence -> parked", c("do the thing", "it would be nice"), [])
+
+    # SCOPE is the other half of the anti-mislabel design, and 60 of the 70 rules
+    # rely on it: a `title`-scoped rule must NOT fire off a body mention. This is
+    # the axis `derive_areas` got wrong (one incidental word in a body labelled a
+    # zkSPARQL spec bead `area:site`). Collapsing the scope dispatch in classify()
+    # to `hay = text` is a ONE-LINE edit, and it is the shape every rule-table
+    # tweak takes, so pin it here as well as in the per-rule property test in
+    # scripts/tests/test_triage_area.py.
+    f += _chk("body-only mention does not fire a title rule",
+              c("do the thing", "we should benchmark this before deciding"), [])
+    f += _chk("body-only ieee754 does not fire the title-scoped zk rule",
+              c("do the thing", "background notes: this touches ieee754 rounding"), [])
 
     # Ordering: a .typ spec that merely NAMES zk/xpath is spec work, not zk work.
     f += _chk("spec beats zk",

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+# [OPUS-5] Orchestration automation — the `needs:area` BACKLOG CLASSIFIER.
+#
+# triage-area.py   (dry-run by DEFAULT; `--apply` is the only mutating mode)
+#
+# WHY THIS EXISTS
+# ---------------
+# `scripts/triage.py` refuses to promote an issue that carries no `area:<crate>`
+# label: a no-area issue reserves the readiness engine's serializing `__global__`
+# partition, so at backlog scale every no-area `status:ready` issue collapses the
+# dispatch frontier to one worker. Such an issue is parked `needs:area` instead —
+# correct, but terminal: `retriage.py` only emits PROMOTING deltas, so nothing ever
+# clears the park on its own. The 2026-07-25 bd->issues migration parked 257 open
+# issues that way (20 of them P1), i.e. 257 items that cannot be dispatched at all.
+#
+# `bd-to-issues.derive_areas()` is the migration-time deriver, and these 257 are
+# exactly its residue: it only reads a conventional `verb(scope):` title prefix, a
+# crate token in the TITLE, a surface keyword in the title's scope region, and a
+# single-crate description. sparq's real backlog does not talk that way — it names
+# `rl.rs`, `zk/xpath`, `DL L4`, `noir upstream`, `perf-gate`, `nightly sweep`. So
+# this script adds the evidence tiers that residue actually carries.
+#
+# EVIDENCE TIERS (most authoritative first; FIRST match wins)
+#   T0  an EXPLICIT author declaration in the body — the `crate_or_surface:` /
+#       `crates:` / `Crate:` field the decomposition templates emit. Nothing beats
+#       the author naming the package.
+#   T1  an ordered table of REPO-PATH + TOPIC rules (RULES below). Each rule is a
+#       narrow regex plus the areas it implies plus the evidence that justifies it.
+#       Narrow on purpose: a rule that could fire on two unrelated families is a
+#       misroute waiting to happen.
+#   T2  `bd-to-issues.derive_areas()` — the migration deriver, reused verbatim so a
+#       freshly-migrated issue is classified the same way twice.
+#
+# FAIL CLOSED. When no tier produces an area the issue KEEPS `needs:area`. That is
+# the correct outcome, not a failure: a wrong `area:` routes a worker at the wrong
+# crate and can put two workers on one conflict partition, whereas the park is
+# maintainer-visible and `retriage.py` promotes the moment an area lands.
+#
+# NEVER INVENT A LABEL. Every produced area is checked against the repo's LIVE
+# label list before anything is written; an unknown area is a hard error, not a
+# `gh label create`.
+#
+# IDEMPOTENT + RE-RUNNABLE. An issue that already carries an `area:` is skipped
+# (its area is the maintainer's/author's, not ours). `needs:area` is removed ONLY
+# in the same call that adds >=1 real `area:` label, so the two never drift.
+#
+#   python3 scripts/triage-area.py --self-test    # offline rule unit tests
+#   python3 scripts/triage-area.py                # dry run: full proposed mapping
+#   python3 scripts/triage-area.py --apply        # apply (add area:*, drop needs:area)
+#
+# Maintainer authorisation for the automated pass: sparq-org/sparq#1135 (2026-07-26).
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+REPO = os.environ.get("SPARQ_REPO", "sparq-org/sparq")
+PARK_LABEL = "needs:area"
+
+# --- T1: the rule table ---------------------------------------------------------
+# (rule_id, scope, regex, areas, evidence).  `scope` is "title" or "text"
+# (title+body).  Prefer "title" — a body mentions neighbouring crates constantly and
+# matching it is how `derive_areas` mislabeled a zkSPARQL spec bead `area:site` off
+# one incidental word.  FIRST MATCH WINS, so order is load-bearing: the narrow,
+# family-specific rules come before the broad surface rules.
+RULES = [
+    # -- workflow lanes that merely *mention* another surface ---------------------
+    # These must precede the surface rules they name, else the named surface wins.
+    ("zk-toolchain-lane", "title", r"into the zk-toolchain\.yml lane",
+     ["ci"], "adds a step to .github/workflows/zk-toolchain.yml"),
+
+    # -- external repositories (work does not land in this tree) -----------------
+    ("noir-upstream", "title", r"\bnoir upstream:",
+     ["upstream"], "PR against noir-lang/noir"),
+    ("noir-paper-p1", "title", r"noir-opt paper p1\b",
+     ["bench"], "commits a reproducible measurement harness"),
+    ("noir-paper-p3", "title", r"noir-opt paper p3\b",
+     ["upstream"], "code-level pass over unexamined noir compiler stages"),
+    ("noir-paper", "title", r"noir-opt paper p[245]\b|paper: optimising noir",
+     ["site-papers"], "paper-factory deliverable"),
+    ("rdf-shuttle-upstream", "title",
+     r"upstream rdf-shuttle|gen-rs backend gaps|shuttle generate-mode",
+     ["upstream"], "jeswr/rdf-shuttle"),
+    ("shaclcjs-upstream", "title", r"upstream hygiene: shaclcjs",
+     ["upstream"], "jeswr/shaclcjs + jeswr/shaclc-1.2"),
+    ("hdt-upstream", "title", r"upstream hdt pr",
+     ["upstream"], "KonradHoeffner/hdt"),
+    ("n3-cg-upstream", "title", r"open w3c/n3 issue",
+     ["upstream"], "w3c/N3 community group"),
+    ("rdfjs-upstream", "title", r"propose @rdfjs-test/conformance",
+     ["upstream"], "contribution to the rdfjs/ org"),
+    ("spec-upstream", "title",
+     r"spec publish:|spec tests: contribute|contribute the solid\+sparql spec drafts",
+     ["upstream"], "publishes into a maintainer/w3id-controlled namespace"),
+
+    # -- documentation-only work -------------------------------------------------
+    # EARLY on purpose: a doc-sync bead names the surface it is documenting, so a
+    # later surface rule would claim it. `Doc-sync: AGENTS.md noir_XPath version
+    # stale` edits AGENTS.md, not zk/xpath.
+    ("docs", "title",
+     r"^sq-\w+(\.\w+)*: doc-sync:|doc honesty|^docs:|docs website|"
+     r"docs-site jscpd|^sq-\w+: research: append|reconcile research/|"
+     r"migrate docs/adrs|compliance/sbom/controls|^sq-\w+: codify ",
+     ["docs"], "documentation-only change"),
+
+    # -- surfaces that are frequently NAME-DROPPED by neighbouring beads ---------
+    # Ordered ahead of the spec/paper/zk rules: a paper's Limitations section names
+    # the crate it limits, and an ODRL bead names the paper that surfaced it.
+    ("trust-graph", "title",
+     r"solid-authz-trust|trust-graph|pfae\.|live-status gate",
+     ["sparq-trust"], "the solid trust-graph / admission surface"),
+    ("acbench", "title", r"acbench",
+     ["sparq-acbench"], "crates/sparq-acbench"),
+    ("pkg-fo-bench", "title", r"fo benchmark round|gufo closure-prior",
+     ["knowledge-graph", "bench"], "FO-KM measurement under bench/fo-km"),
+    ("pkg", "title",
+     r"\bpkg\b|foundational-ontology|fo-km metric|provenance-driven genai kb",
+     ["knowledge-graph"], "the project-knowledge-graph surface"),
+    # sq-aiut is an MPC bead whose DRIVER is ODRL — the crate is sparq-mpc, so it
+    # must be decided before the ODRL rule claims every title containing "ODRL".
+    ("mpc-odrl-driven", "title", r"privacy-preserving federated join",
+     ["sparq-mpc"], "crates/sparq-mpc (ODRL is the disclosure driver, not the crate)"),
+    ("odrl", "title", r"\bodrl\b|odrl-bridge",
+     ["sparq-policy"], "ODRL evaluation lives in crates/sparq-policy"),
+
+    # -- house spec + paper surfaces (site/specs, site/papers) -------------------
+    # Before the zk rules: a .typ spec that *names* zk/xpath is spec work, not zk work.
+    ("site-specs", "text",
+     r"site/specs/|zksparql spec|zksparql\.typ|\bspec upd:|spec fold-in:|"
+     r"extended shacl compact syntax",
+     ["site-specs"], "authors/edits a Typst UPD under site/specs"),
+    ("site-papers", "text",
+     r"site/papers/|paper-evidence|paper factory|papers rewrite|"
+     r"papers/fo-km-agent|logic-bug paper|\bpapers: wire\b|paper open items",
+     ["site-papers"], "paper-factory artifact"),
+
+    ("e2ee", "title", r"\be2ee\b",
+     ["e2ee"], "the end-to-end-encryption program"),
+
+    # -- the externalised noir libraries under zk/ -------------------------------
+    ("zk-proof-program", "title", r"ieee754 & noir_xpath|sparq_ieee754 & noir_xpath",
+     ["zk", "zk-xpath"], "spans BOTH zk value-semantics libraries"),
+    # TITLE-scoped and ahead of zk-xpath: sq-3x7dl.10's body literally reads
+    # "FILE: zk/xpath NO -- zk/ieee754/src/ops/kernels.nr", so a text match on
+    # zk/xpath sends an ieee754 bead to the wrong library.
+    ("zk-ieee754-title", "title", r"ieee754",
+     ["zk"], "zk/ieee754 (sparq_ieee754) named in the title"),
+    ("zk-xpath", "text",
+     r"zk/xpath|noir_xpath|\bxpath opt:|xpath: regenerate|fn:avg\(\(\)\)",
+     ["zk-xpath"], "zk/xpath (noir_XPath) sources"),
+    ("zk-compose", "text",
+     r"zk/compose|sparq-zk-compose|reconstruct_public_inputs|bind_joins|"
+     r"hiddenissuerattestation|resolve_commitment_salt|join_eq_r",
+     ["sparq-zk-compose"], "zk-compose circuit/verifier surface"),
+    ("zk-schnorr", "title", r"ct schnorr scalar-mul",
+     ["sparq-zk"], "Baby-JubJub Schnorr lives in crates/sparq-zk"),
+
+    # -- reasoner family ---------------------------------------------------------
+    ("reason-dl", "title",
+     r"\bdl l[0-9]\b|tableau|tableux|pbz04\.4|owl profile dispatch",
+     ["sparq-reason-dl"], "the DL (ALCH tableau / profile-dispatch) lane"),
+    ("reason-el", "title", r"\bel abox|\bel top|pbz04\.2",
+     ["sparq-reason-el"], "the EL profile lane"),
+    ("reason-diff", "title", r"reason-diff",
+     ["sparq-reason-diff"], "crates/sparq-reason-diff"),
+    ("eyereasoner-bundle", "title", r"eyereasoner-compat.*(iife|<script>|bundle)",
+     ["sparq-reason-wasm"], "ships a browser bundle"),
+    ("eyereasoner", "title", r"eyereasoner-compat",
+     ["sparq-reason"], "the eyereasoner-compat surface in crates/sparq-reason"),
+    ("rif-conformance", "title", r"rif wg core (suite|floor)|re-measure rif",
+     ["sparq-conformance", "sparq-reason"], "RIF_WG_CORE_FLOOR lives in sparq-conformance"),
+    ("reason-topic", "title",
+     r"^sq-\w+(\.\w+)*: (reasoner|reason\(owl\)|rif-xml|compiled-rules):|"
+     r"incremental reasoning|beyond-rl|stratified datalog|reasoning profiler",
+     ["sparq-reason"], "crates/sparq-reason"),
+
+    # -- engine / core / substrate ----------------------------------------------
+    ("core-memory", "title",
+     r"perf\(memory\)|bulk-load|memory-accounting|dictionary raw-slot",
+     ["sparq-core"], "store.rs / Dict memory + bulk-load path"),
+    ("core-nt", "title", r"native nt\.rs",
+     ["sparq-core", "sparq-conformance"], "crates/sparq-core/src/nt.rs + the syntax ratchet floors"),
+    ("core-durable", "title", r"shared durable backend",
+     ["sparq-core"], "the store/persistence layer"),
+    ("engine-topic", "title",
+     r"dpccp|dp::plan|join order|cardinality estimator|anti-join|order by|"
+     r"explain_json|sp2bench complex-shape|q08/q12b|select-json path|"
+     r"access-audit: engine-internal",
+     ["sparq-engine"], "crates/sparq-engine planner/executor"),
+    ("substrate-num", "title", r"num::lexical",
+     ["sparq-substrate"], "Num lives in crates/sparq-substrate"),
+    ("canon-fuzz", "title", r"canonicalize_nquads",
+     ["sparq-canon"], "RDFC-1.0 canonicalization in crates/sparq-canon"),
+
+    # -- other crate families ----------------------------------------------------
+    ("difftest", "title", r"^sq-\w+(\.\w+)*: diff-test:",
+     ["sparq-difftest"], "crates/sparq-difftest"),
+    ("mpc-seam-plan", "title", r"mpc seam phase 6",
+     ["sparq-fedplan-mpc"], "source-selection/combination lives in sparq-fedplan-mpc"),
+    ("mpc-seam", "title", r"mpc seam phase",
+     ["sparq-fedplan-mpc", "sparq-mpc"], "the untrusted-planner seam + the proof pipeline"),
+    ("mpc", "title", r"\bmpc m[0-9]|privacy-preserving federated join",
+     ["sparq-mpc"], "crates/sparq-mpc"),
+    ("shacl-12", "title", r"shacl 1\.2:",
+     ["sparq-shacl"], "crates/sparq-shacl"),
+    ("jsonld", "title", r"json-ld conformance",
+     ["sparq-jsonld"], "crates/sparq-jsonld"),
+    ("hdt-migration", "title", r"hdt 0\.4",
+     ["sparq-hdt", "deps"], "crates/sparq-hdt + a supply-chain review"),
+    ("lws", "title", r"^sq-\w+(\.\w+)*: (chore\(lws\)|embeddedsparqclient)|"
+     r"solid cth conformance harness|port.*housekeeping/security branches",
+     ["sparq-lws-core"], "the ported Solid/LWS server crate"),
+    ("solid-authz-server", "title", r"stateful /authz",
+     ["sparq-server"], "the sparq-server http.rs authz path"),
+    ("mcp", "title", r"mcp tool-surface",
+     ["sparq-mcp"], "crates/sparq-mcp"),
+    ("vectors-spqv", "title", r"\.spqv\b|vec:hybrid",
+     ["sparq-vectors"], "the .spqv / fusion surface in crates/sparq-vectors"),
+    ("genai-planner", "title", r"gnce-style planner",
+     ["sparq-engine"], "a planner-only cardinality estimator"),
+    ("kani-harness", "title", r"^sq-\w+: kani:",
+     ["sparq-core", "sparq-vectors"], "the two crates owning the timing-out harnesses"),
+
+    # -- javascript / wasm client -----------------------------------------------
+    ("js", "text",
+     r"js/src/|js/package\.json|@jeswr/sparq|rdf/js conformance|\bjs gate\b",
+     ["js"], "the js/ RDF-JS client"),
+
+    # -- website + desktop GUI ---------------------------------------------------
+    ("gui-tauri", "text", r"gui/src-tauri",
+     ["gui", "deps"], "the Tauri desktop shell's dependency stack"),
+    ("site-a11y-vr", "title",
+     r"^sq-\w+(\.\w+)*: (a11y|nightly[- ]sweeps?|website)\b|"
+     r"visual-regression|axe ratchet",
+     ["site"], "site/e2e + site/src surfaces"),
+    ("site-page", "title", r"^sq-\w+: page: /surface/",
+     ["site"], "a site/ route"),
+    ("site-app", "text", r"sparq\.jeswr\.org/app|site/src/app/",
+     ["site"], "a site/ route"),
+    ("deploy-demo", "title", r"^sq-\w+: deploy\(demo\)",
+     ["deploy-demo"], "the hosted demo deployment"),
+
+    # -- benchmarks --------------------------------------------------------------
+    ("bench", "text",
+     r"bench/dashboard|bench/lubm|bench/serve-throughput|bench/fo-km|bench/ harness|"
+     r"gather-competitors|virtuoso-same-box|http-sparql|perf-gate:|benchmark-data|"
+     r"in-site benchmarks|ann gather|competitor engines|competitor numbers|"
+     r"diskann-ref",
+     ["bench"], "the bench/ harness + competitor gather"),
+    ("bench-generic", "title", r"\bbenchmark",
+     ["bench"], "a benchmarking deliverable"),
+
+    # -- CI / release / dependencies / workspace ---------------------------------
+    # `workspace` before `release`: sq-qxq5m is a `git rm --cached` of a repo-root
+    # tracked file that merely MENTIONS release-plz cleanliness as its motivation.
+    ("fmt", "title",
+     r"cargo fmt|rustfmt|proptest-regressions|untrack \.beads/interactions",
+     ["workspace"], "a workspace-wide mechanical/hygiene change"),
+    ("security-txt", "title", r"security\.txt",
+     ["workspace"], "the repo-root .well-known/ metadata"),
+    ("release", "title",
+     r"release-plz|release sbom job|slsa build l3|v0\.1\.0 release",
+     ["release"], "the release pipeline"),
+    ("deps", "title",
+     r"dependabot bumps|cyclonedx-npm|supply-chain:",
+     ["deps"], "dependency management"),
+    ("ci", "text",
+     r"\.github/workflows/|feature-matrix\.d|merge-queue|ci-summary|nextest|"
+     r"cargo-mutants|scorecard\.yml|fuzz\.yml|\.beads/issues\.jsonl|"
+     r"autonomous-scheduler|\.claude/workflows|bd-to-issues|skipping tests in prs|"
+     r"follow up tasks / tickets|production-readiness",
+     ["ci"], "CI / orchestration infrastructure"),
+
+    ("website", "title", r"\bwebsite\b",
+     ["site"], "the marketing/docs website"),
+]
+
+
+# --- T0: an explicit author declaration in the body -----------------------------
+_DECL = re.compile(
+    r"(?:crate_or_surface|crates?|surface)\s*[:=]\s*(.+?)(?:\||\n|\.\s|$)", re.I)
+_SURFACE_TOKENS = {"site": "site", "gui": "gui", "docs": "docs", "bench": "bench",
+                   "ci": "ci", "js": "js"}
+# Path fragments a declaration may use instead of a bare token —
+# `surface=.github/workflows/ci.yml` names CI, but "ci" there is preceded by "/".
+_DECL_PATHS = ((".github/workflows", "ci"), ("bench/", "bench"), ("site/", "site"),
+               ("gui/", "gui"), ("js/", "js"), ("docs/", "docs"),
+               ("zk/xpath", "zk-xpath"), ("zk/ieee754", "zk"))
+
+
+def declared_areas(body, crates):
+    """Areas the AUTHOR declared in a `crate_or_surface:` / `crates:` / `Crate:`
+    field. The decomposition templates emit this field verbatim, and an author
+    naming the package beats every inference below it. Returns [] when the field is
+    absent or names something that is not a real crate/surface (e.g. sq-lsp7k.12's
+    "NEW opt-in crate" — that issue is genuinely unclassifiable and stays parked).
+
+    The span ends at the first `|`, newline, or SENTENCE BREAK: sq-p4zci's field
+    reads "crates: sparq-reason + sparq-cli. CLI flag + ... docs/SKILL examples",
+    and running to end-of-line would derive a spurious `area:docs` from the prose
+    that follows the declaration."""
+    out = []
+    for m in _DECL.finditer(body or ""):
+        span = m.group(1).lower()
+        # Ordered by FIRST OCCURRENCE in the declaration, longest crate name
+        # winning over any name it contains (sparq-reason-el over sparq-reason) —
+        # the same discipline bd-to-issues._token_hits uses, and the reason the
+        # output is stable enough to assert on.
+        hits = []
+        for name in sorted(crates, key=len, reverse=True):
+            mm = re.search(r"(?<![a-z0-9\-])" + re.escape(name) + r"(?![a-z0-9\-])", span)
+            if mm and not any(name in n for _, n in hits):
+                hits.append((mm.start(), name))
+        for frag, area in _DECL_PATHS:
+            if frag in span:
+                hits.append((span.index(frag), area))
+        for tok, area in _SURFACE_TOKENS.items():
+            mm = re.search(r"(?<![a-z0-9\-/])" + tok + r"(?![a-z0-9\-])", span)
+            if mm:
+                hits.append((mm.start(), area))
+        for _, area in sorted(hits):
+            if area not in out:
+                out.append(area)
+    return out
+
+
+def classify(title, body, crates):
+    """(areas, evidence) for one issue. `areas` == [] means LEAVE IT PARKED."""
+    title = title or ""
+    body = body or ""
+    text = (title + "\n" + body).lower()
+    low_title = title.lower()
+
+    d = declared_areas(body, crates)
+    if d:
+        return d, "T0 author-declared crate_or_surface/crates field"
+
+    for rid, scope, rx, areas, why in RULES:
+        hay = low_title if scope == "title" else text
+        if re.search(rx, hay, re.I):
+            return list(areas), f"T1 {rid}: {why}"
+
+    fallback = _bd_derive(title, body, crates)
+    if fallback:
+        return fallback, "T2 bd-to-issues.derive_areas (title scope/crate token)"
+    return [], ""
+
+
+def _bd_derive(title, body, crates):
+    """Reuse the migration-time deriver verbatim so a freshly-migrated issue is
+    classified identically by both code paths. Imported lazily + defensively: this
+    script must still self-test if bd-to-issues.py is unavailable."""
+    try:
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "bd_to_issues", os.path.join(HERE, "bd-to-issues.py"))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.derive_areas({"title": title, "description": body}, crates)
+    except Exception:
+        return []
+
+
+# --- github I/O -----------------------------------------------------------------
+def _gh(args):
+    return subprocess.run(["gh"] + args, capture_output=True, text=True, check=True).stdout
+
+
+def crate_names():
+    base = os.path.join(HERE, os.pardir, "crates")
+    try:
+        return tuple(sorted(d for d in os.listdir(base)
+                            if os.path.isdir(os.path.join(base, d)) and not d.startswith(".")))
+    except OSError:
+        return ()
+
+
+def live_area_labels():
+    """The area labels that ALREADY EXIST. Never `gh label create` — an invented
+    partition is invisible to every consumer (ready-issues.py, push-frontier.sh)
+    and silently mis-partitions the frontier."""
+    data = json.loads(_gh(["label", "list", "--repo", REPO, "--limit", "500", "--json", "name"]))
+    return {d["name"] for d in data if d["name"].startswith("area:")}
+
+
+def parked_issues():
+    """LIST API, fully paginated — `gh search` reads a lagging index and has caused
+    three wrong conclusions in this repo."""
+    return json.loads(_gh(["issue", "list", "--repo", REPO, "--label", PARK_LABEL,
+                           "--state", "open", "--limit", "1000",
+                           "--json", "number,title,body,labels"]))
+
+
+def plan(issues, crates):
+    """The proposed mapping. Deterministic, and a no-op for an issue that already
+    carries an area (idempotence: re-running never re-decides settled work)."""
+    rows = []
+    for it in sorted(issues, key=lambda i: i["number"]):
+        names = [lb["name"] for lb in it.get("labels", [])]
+        if any(n.startswith("area:") for n in names):
+            rows.append((it, [], "SKIP already carries an area: label"))
+            continue
+        areas, why = classify(it["title"], it.get("body") or "", crates)
+        rows.append((it, [f"area:{a}" for a in areas], why))
+    return rows
+
+
+def apply_row(number, add):
+    """Add the area labels AND drop the park in ONE call. They must not drift: an
+    issue with an area but still parked stays undispatchable, and a cleared park
+    with no area silently reserves the serializing __global__ partition."""
+    args = ["issue", "edit", str(number), "--repo", REPO, "--remove-label", PARK_LABEL]
+    for a in add:
+        args += ["--add-label", a]
+    _gh(args)
+
+
+# --- self-test ------------------------------------------------------------------
+def _chk(name, got, want):
+    if got != want:
+        print(f"FAIL {name}: got {got!r} want {want!r}")
+        return 1
+    print(f"ok   {name}")
+    return 0
+
+
+def self_test():
+    crates = crate_names() or ("sparq-core", "sparq-engine", "sparq-reason", "sparq-py",
+                               "sparq-server", "sparq-zk-compose", "sparq-mpc")
+    f = 0
+    c = lambda t, b="": classify(t, b, crates)[0]
+
+    # T0 beats everything: the author named the package.
+    f += _chk("declared single", c("whatever", "crate_or_surface: sparq-reason | effort:M"),
+              ["sparq-reason"])
+    f += _chk("declared multi", c("x", "crates: sparq-reason + sparq-cli."),
+              ["sparq-reason", "sparq-cli"])
+    f += _chk("declared surface", c("x", "crate_or_surface: sparq-py (magic) + site + docs"),
+              ["sparq-py", "site", "docs"])
+    # A declaration that names no real crate must NOT invent one.
+    f += _chk("declared new-crate -> parked",
+              c("BI/SQL facade", "crate_or_surface: NEW opt-in crate | effort:XL"), [])
+
+    # FAIL CLOSED is the headline behaviour: no evidence => no label.
+    f += _chk("no evidence -> parked", c("do the thing", "it would be nice"), [])
+
+    # Ordering: a .typ spec that merely NAMES zk/xpath is spec work, not zk work.
+    f += _chk("spec beats zk",
+              c("zksparql.typ 7.3 stale estate sentence: still names zk/ieee754 + zk/xpath"),
+              ["site-specs"])
+    # ...and a workflow-lane wiring bead that names zk-compose is CI work.
+    f += _chk("workflow lane beats zk-compose",
+              c("Wire bench/zk-compose/scripts/eval_pack.py --check into the zk-toolchain.yml lane"),
+              ["ci"])
+    # ...and an upstream noir bead that names SSA files is upstream, not a crate.
+    f += _chk("noir upstream",
+              c("noir upstream: NOT-canonicalization to unlock IfElse merging (simplify.rs TODOs)"),
+              ["upstream"])
+
+    # Genuinely cross-cutting stays cross-cutting (the partitioner maps it to
+    # __global__ deliberately; collapsing it to one crate would be a lie).
+    f += _chk("dual zk libraries",
+              c("[epic] Proof-of-correctness program for sparq_ieee754 & noir_XPath"),
+              ["zk", "zk-xpath"])
+
+    # Narrow families resolve to their own crate, not the parent reasoner.
+    f += _chk("dl lane", c("DL L4: narrow the RL disjointWith divergence guard"),
+              ["sparq-reason-dl"])
+    f += _chk("el lane", c("EL abox+cdomain DataPropertyAssertion point-range rescue"),
+              ["sparq-reason-el"])
+    f += _chk("difftest", c("sq-qcnn.5: diff-test: wire canonical binding-MULTISET check"),
+              ["sparq-difftest"])
+
+    # T2 fallback still works (a conventional title scope prefix).
+    f += _chk("t2 title scope", c("bug(sparq-solid): fail-closed ACP"), ["sparq-solid"])
+
+    # Idempotence: an issue that already has an area is never re-decided.
+    rows = plan([{"number": 1, "title": "DL L4: whatever", "body": "",
+                  "labels": [{"name": "area:sparq-core"}, {"name": PARK_LABEL}]}], crates)
+    f += _chk("already-area is a no-op", rows[0][1], [])
+
+    print("SELF-TEST", "FAILED" if f else "PASSED")
+    return 1 if f else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Classify the needs:area backlog.")
+    ap.add_argument("--apply", action="store_true", help="write labels (default: dry run)")
+    ap.add_argument("--self-test", action="store_true", help="offline rule unit tests")
+    ap.add_argument("--json", action="store_true", help="emit the plan as JSON")
+    a = ap.parse_args()
+    if a.self_test:
+        return self_test()
+
+    crates = crate_names()
+    known = live_area_labels()
+    rows = plan(parked_issues(), crates)
+
+    unknown = sorted({lb for _, add, _ in rows for lb in add} - known)
+    if unknown:
+        print(f"ERROR: rule table produced labels that do not exist: {unknown}", file=sys.stderr)
+        print("Fix the rule table — do NOT create the label.", file=sys.stderr)
+        return 2
+
+    if a.json:
+        print(json.dumps([{"number": it["number"], "title": it["title"],
+                           "areas": add, "evidence": why} for it, add, why in rows], indent=1))
+        return 0
+
+    classified = [r for r in rows if r[1]]
+    left = [r for r in rows if not r[1] and not r[2].startswith("SKIP")]
+    for it, add, why in rows:
+        if not add:
+            continue
+        print(f"#{it['number']:<5} {','.join(a[5:] for a in add):<40} {why}")
+        print(f"       {it['title'][:150]}")
+    print(f"\n-- {len(classified)} classified, {len(left)} left parked "
+          f"(no confident evidence), {len(rows)} scanned")
+    for it, _, _ in left:
+        print(f"   LEFT #{it['number']} {it['title'][:120]}")
+
+    if not a.apply:
+        print("\n(dry run — re-run with --apply to write labels)")
+        return 0
+    for it, add, _ in classified:
+        apply_row(it["number"], add)
+        print(f"applied #{it['number']} {','.join(add)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -220,7 +220,9 @@ RULES = [
     # the oracle adapters, check_ordered, the generator) lives in crates/sparq-bench.
     # A whole-family `area:sparq-difftest` therefore points every one of these
     # beads at a crate most of them never edit; caught by the post-apply sample
-    # re-derivation, which found check_ordered/fuzz.rs:307 in sparq-bench.
+    # re-derivation, which found check_ordered in sparq-bench (crates/sparq-bench/
+    # src/fuzz.rs:861 — the earlier :307 / :668 line cites were both wrong, though
+    # the crate attribution they were used for was right).
     ("difftest-normaliser", "title",
      r"^sq-\w+(\.\w+)*: diff-test:.*(isomorphism|multiset)",
      ["sparq-difftest", "sparq-bench"],

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -187,10 +187,13 @@ RULES = [
      ["sparq-core", "sparq-conformance"], "crates/sparq-core/src/nt.rs + the syntax ratchet floors"),
     ("core-durable", "title", r"shared durable backend",
      ["sparq-core"], "the store/persistence layer"),
+    # The trace is engine-side but the only sink today is sparq-server's
+    # per-request one (crates/sparq-server/src/http.rs), so both crates move.
+    ("access-audit", "title", r"access-audit: engine-internal",
+     ["sparq-engine", "sparq-server"], "engine-side trace wired to the server sink"),
     ("engine-topic", "title",
      r"dpccp|dp::plan|join order|cardinality estimator|anti-join|order by|"
-     r"explain_json|sp2bench complex-shape|q08/q12b|select-json path|"
-     r"access-audit: engine-internal",
+     r"explain_json|sp2bench complex-shape|q08/q12b|select-json path",
      ["sparq-engine"], "crates/sparq-engine planner/executor"),
     ("substrate-num", "title", r"num::lexical",
      ["sparq-substrate"], "Num lives in crates/sparq-substrate"),
@@ -198,8 +201,19 @@ RULES = [
      ["sparq-canon"], "RDFC-1.0 canonicalization in crates/sparq-canon"),
 
     # -- other crate families ----------------------------------------------------
-    ("difftest", "title", r"^sq-\w+(\.\w+)*: diff-test:",
-     ["sparq-difftest"], "crates/sparq-difftest"),
+    # The sq-qcnn diff-test DAG spans two crates and the split is not the obvious
+    # one. crates/sparq-difftest is node A ONLY — the value normaliser, which by
+    # design has NO sparq dependency. The differential HARNESS it feeds (fuzz.rs,
+    # the oracle adapters, check_ordered, the generator) lives in crates/sparq-bench.
+    # A whole-family `area:sparq-difftest` therefore points every one of these
+    # beads at a crate most of them never edit; caught by the post-apply sample
+    # re-derivation, which found check_ordered/fuzz.rs:307 in sparq-bench.
+    ("difftest-normaliser", "title",
+     r"^sq-\w+(\.\w+)*: diff-test:.*(isomorphism|multiset)",
+     ["sparq-difftest", "sparq-bench"],
+     "extends the independent normaliser AND wires it into the harness"),
+    ("difftest-harness", "title", r"^sq-\w+(\.\w+)*: diff-test:",
+     ["sparq-bench"], "the differential harness (fuzz.rs / oracle adapters)"),
     ("mpc-seam-plan", "title", r"mpc seam phase 6",
      ["sparq-fedplan-mpc"], "source-selection/combination lives in sparq-fedplan-mpc"),
     ("mpc-seam", "title", r"mpc seam phase",

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -111,6 +111,13 @@ RULES = [
     # -- surfaces that are frequently NAME-DROPPED by neighbouring beads ---------
     # Ordered ahead of the spec/paper/zk rules: a paper's Limitations section names
     # the crate it limits, and an ODRL bead names the paper that surfaced it.
+    # sq-wvne is a trust-graph REQUIREMENT whose three pieces are all circuits:
+    # its body names sparq-zk-compose/src/issuer.rs, verifier.rs and
+    # tests/holder_pok_binding.rs. Labelling it trust-only would send a worker to
+    # a crate that holds none of the code it must change.
+    ("trust-zk-composite", "title", r"zkaps-grade unlinkable presentation",
+     ["sparq-trust", "sparq-zk-compose"],
+     "the composite is built in sparq-zk-compose; the requirement is the trust graph's"),
     ("trust-graph", "title",
      r"solid-authz-trust|trust-graph|pfae\.|live-status gate",
      ["sparq-trust"], "the solid trust-graph / admission surface"),
@@ -161,6 +168,12 @@ RULES = [
      ["sparq-zk"], "Baby-JubJub Schnorr lives in crates/sparq-zk"),
 
     # -- reasoner family ---------------------------------------------------------
+    # A DL bead that moves a measured floor also edits the floor: every
+    # DL_*_FLOOR / DL_PROFILE_NEGATIVE_* constant and tests/dl_suite.rs live in
+    # crates/sparq-conformance, not in the reasoner.
+    ("reason-dl-floor", "text", r"dl_[a-z_]*floor|dl_profile_negative|dl_suite\.rs",
+     ["sparq-reason-dl", "sparq-conformance"],
+     "the DL lane plus the conformance floor constants it ratchets"),
     ("reason-dl", "title",
      r"\bdl l[0-9]\b|tableau|tableux|pbz04\.4|owl profile dispatch",
      ["sparq-reason-dl"], "the DL (ALCH tableau / profile-dispatch) lane"),


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Opus 5) — automated `needs:area` pass, authorised by the maintainer in #1135 (2026-07-26).

## The block

**257 open issues carried `needs:area`, 20 of them P1, and none of them could be dispatched at all.**

`scripts/triage.py` refuses to promote a no-area issue — it would reserve the readiness engine's serializing `__global__` partition — so it parks it `needs:area`. `scripts/retriage.py` only emits PROMOTING deltas, so nothing ever clears that park. The state is terminal: present in GitHub, invisible to the orchestrator. Meanwhile the live layer chain was `L1 candidates 12 → L2 frontier 3 → L3 lease 3 → L4 max_concurrent 8 → L5 account pool 28` — 28 account slots idle behind 3 running workers, because the candidate pool was starved.

Those 257 are precisely the residue of `bd-to-issues.derive_areas()`, which reads only a conventional `verb(scope):` prefix, a crate token in the *title*, a surface keyword in the title's scope region, and a single-crate description. This backlog does not talk that way. It names `rl.rs`, `zk/xpath`, `DL L4`, `noir upstream`, `perf-gate`, `nightly sweep`.

## What this adds

`scripts/triage-area.py` — the third member of the triage family, and the one that *clears* the park `triage.py` sets. Three evidence tiers, first match wins:

| Tier | Evidence |
|---|---|
| T0 | the author's own `crate_or_surface:` / `crates:` / `Crate:` field — nothing beats the author naming the package |
| T1 | an ordered table of repo-path + topic rules, each carrying the evidence that justifies it |
| T2 | `derive_areas()` itself, reused verbatim so a freshly-migrated issue classifies identically by both code paths |

### The three properties that make it safe to point at 257 live issues

**It fails closed.** No evidence yields no label and the issue stays parked. That is the correct outcome, not a failure: a wrong `area:` routes a worker at the wrong crate and can put two workers on one conflict partition, whereas the park is maintainer-visible and `retriage.py` promotes the moment an area lands.

**It never invents a label.** Every emitted area is checked against the repo's live label list before anything is written; an unknown area is a hard error, not a `gh label create`. An `area:` the repo does not have is invisible to `ready-issues.py` and `push-frontier.sh` — the issue would stay undispatchable while *looking* triaged, strictly worse than the park.

**The two writes cannot drift.** `needs:area` is removed only in the same call that adds ≥1 real `area:`. Either half alone re-breaks dispatch.

## Why the rule ORDER is pinned by a test

Three orderings were each measured wrong against the live backlog, all the same failure: a bead names a neighbouring surface and the wrong rule claims it.

- `zksparql.typ §7.3 stale estate sentence: still names zk/ieee754 + zk/xpath` is **spec** work, not zk work.
- `ieee754 OPT: kernels.nr cleanups` has a body reading literally `FILE: zk/xpath NO — zk/ieee754/src/ops/kernels.nr`; a text match on `zk/xpath` sent it to the wrong library.
- `odrl-bridge: materialise rule-level provenance` cites the paper that recorded it; the paper rule claimed it.

`test_rule_order_survives_the_known_name_drop_collisions` pins all three. Nothing else would catch a reorder.

## Result of the pass

**257 → 16.** 241 issues classified, 16 deliberately left parked (recurrent orchestration duties with no file to edit, a protected `.claude/agents/` surface, a crate that does not exist yet, and three maintainer-only ops chores). Zero issues ended up holding both an `area:` and `needs:area`.

## The two audits, and what they found

A single sample pass would have shipped a 6-issue misroute. Both audits are recorded here because the *first* one was not enough.

**Sample re-derivation (10 of 241, re-decided independently against the workspace): 2 wrong.** The whole `sq-qcnn` `diff-test:` family had gone to `area:sparq-difftest` — but that crate is node A *only*, the value normaliser, which by design carries no sparq dependency. `check_ordered` is in `crates/sparq-bench` — `crates/sparq-bench/src/fuzz.rs:861` (**correction:** this PR previously cited `fuzz.rs:307` and a review comment cited `:668`; both line numbers were wrong, the crate attribution they supported was right) — as are the generator and every oracle adapter. Four of the six never touch `sparq-difftest`.

**Mechanical cross-check (all 90 crate-labelled issues).** For each, resolve every `.rs` filename and distinctive identifier its text names to its owning crate, and flag any issue whose evidence lives in no crate it was labelled with. Three more misses, all the same shape — the label named where the *thinking* happens and omitted where the *code* is: `sq-wvne` names `sparq-zk-compose/src/issuer.rs`, `verifier.rs:3158`, `tests/holder_pok_binding.rs`; `sq-9nmpg` and `sq-witnz` ratchet `DL_DIRECT_FLOOR` / `DL_PROFILE_NEGATIVE_*`, which live in `crates/sparq-conformance`.

Every rule is now keyed on that evidence rather than on the family name, so the next DL-floor bead and the next trust-graph circuit bead classify correctly without a hand-fix. The live labels are corrected.

## Tests

`scripts/tests/test_triage_area.py` is deliberately *not* a copy of the script's `--self-test` — that one proves the rules do what the author meant, this one proves the safety properties. Both suites are wired into `docs-quality.yml` beside `triage.py` / `retriage.py` (`docs-quality quick-gates`, which is **not** in `.github/advisory-registry.json`, so `ci_summary_gate.py` treats it as gating). The script has no cron, so without a PR-time gate a rule-table edit would only ever be discovered by mislabeling live issues — the same silent-drift hole #3419 fixed for its two siblings.

### Two guards could not fail for the case they were named after — fixed

An adversarial re-review of this PR found, and reproduced by execution, that the first version of the gate did not catch the two commonest edits it exists to catch.

**1. SCOPE had zero coverage.** 60 of the 70 rules are `title`-scoped, and title-scoping *is* the anti-mislabel mechanism — matching bodies is how `derive_areas` sent a zkSPARQL spec bead to `area:site` off one incidental word. Collapsing the dispatch in `classify()` to `hay = text` — **one line** — left **15/15 self-test cases and 10/10 unittests green**. Flipping each title-scoped rule to `"text"` one at a time: **60 of 60 flips survived both suites**, and 19 of those 60 changed the classification of live open issues (`bench-generic` 31, `odrl` 15, `pkg` 14, `release` 8, `acbench` 6, `engine-topic` 6, …). `zk-ieee754-title` survived its own flip even though the source comment on that very rule says *"TITLE-scoped and ahead of `zk-xpath`"* is the protection — only the "ahead of" half was pinned.

**2. `test_unpark_is_never_emitted_without_an_area` never called `apply_row` with an empty add list.** Executed, `apply_row(4242, [])` built `['issue','edit','4242','--repo','sparq-org/sparq','--remove-label','needs:area']` — a **bare unpark**. All three of its assertions were evaluated on a call carrying *two* areas, so none could be false when `add == []` is the bug. The only real protection was `classified = [r for r in rows if r[1]]` in `main()`, which no test exercised: iterating `rows` instead left both suites green.

### What the guard set is now

Scope is asserted as a **per-rule property**, not a fixture, because the realistic edit changes one rule. A witness generator derives a matching string *from* each rule's regex; every witness is re-validated against the live regex and required to reach its own rule through `classify()`, so the property cannot pass on a broken generator (sabotaging the generator reds 3 tests). `apply_row` now also fails closed on an empty add list — the invariant lives in the only function that can emit the unpark, not in the caller that happens to protect it today.

| Mutation (applied to the live tree) | Result |
|---|---|
| `hay = low_title if scope == "title" else text` → `hay = text` | **killed** — `test_a_title_scoped_rule_never_fires_from_the_body_alone`, `test_zk_ieee754_scope_is_pinned_not_only_its_order`, + 2 named `--self-test` cases |
| … → `hay = low_title` (the other branch) | **killed** — `test_a_text_scoped_rule_does_fire_from_the_body` |
| any one of the 60 title rules flipped to `"text"` | **killed 60/60** — `test_only_the_pinned_rules_are_allowed_to_read_the_body` (all 60), `test_a_text_scoped_rule_does_fire_from_the_body` (6 of them) |
| a scope-immune rule drops its `^` anchor | **killed** — `test_the_scope_immune_rules_are_exactly_the_fully_anchored_ones` |
| `apply_row`'s new empty-add guard deleted / inverted | **killed** — `test_unpark_is_never_emitted_without_an_area` |
| `main()` applies `rows` instead of `classified` | **killed** — `test_main_never_applies_an_unclassified_row` |
| the `classified` filter widened to admit unclassified rows | **killed** — `test_main_never_applies_an_unclassified_row` |
| `apply_row` drops the `--remove-label` half | **killed** — `test_the_unpark_and_the_areas_travel_in_one_call` |
| `apply_row` unparks some *other* label | **killed** — `test_the_unpark_and_the_areas_travel_in_one_call` |
| classifier fails OPEN (defaults to a crate) | **killed** — 4 failures |
| rule table reordered | **killed** — `test_rule_order_survives_the_known_name_drop_collisions` |

Every kill above is a **behaviour**-kill (a failed assertion), not a crash-kill.

A flip of one rule's scope cannot be caught behaviourally — a widened rule behaves exactly like a rule that was always text-scoped — so the ten body-reading rules are additionally pinned **by name** in `TEXT_SCOPED_RULES`, which makes a widening a reviewed act and names the rule in the failure diff. The behavioural tests prove the *dispatch mechanism* still works as declared; the allow-list proves the *declaration* has not moved.

`classify()` itself is unchanged by the guard fix: re-derived over the 722 live open issues that carry no `area:` label, **0 classifications differ**.

## Scope

Tooling only. The label changes are a data operation and are already applied. No other label was touched — no `status:ready`, `needs:user`, `role:*` or `priority:*` — and no PR was touched.
