### PR TITLE
chore(routing): deprecate Fable + Opus 4.8 for Opus 5; docs writing to sol; opus5-first except area:gui

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,7 @@
           {
             "type": "agent",
             "agent": "sparq-perf-reviewer",
-            "model": "opus",
+            "model": "claude-opus-5",
             "timeout": 300,
             "statusMessage": "PERFORMANCE-discretion gate: reviewing PR before arm…",
             "prompt": "You are the sparq PERFORMANCE-discretion gate (the sparq-perf-reviewer agent). This is a PreToolUse hook on Bash. The tool call being gated is:\n\n$ARGUMENTS\n\nFIRST: inspect tool_input.command. If it is NOT a PR-arming command — i.e. it is NOT a `gh pr merge` that arms a PR for the merge train (look for `gh pr merge` with `--auto`) — then this is out of your scope: immediately ALLOW it untouched. Return exactly:\n{\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"permissionDecision\": \"allow\", \"permissionDecisionReason\": \"not a PR-arming command; perf gate not applicable\"}}\n\nIf it IS a `gh pr merge … --auto` arming command: parse the PR number from it, then perform your full perf-discretion review per your agent definition — decide perf_affecting, and if so perf_ok (regression risk + every perf claim evidenced, honesty rules: work-box timings NON-canonical, NO hard-coded perf numbers in markdown, numbers trace to real evidence, deterministic-floor regressions are real). End with your verdict JSON block, then the hookSpecificOutput decision: allow when perf_affecting=false or perf_ok=true; DENY (with a clear 🤖 SPARQ perf-reviewer reason naming the concern and that the maintainer should review) when perf_affecting=true and perf_ok=false, or when you cannot determine perf-impact (fail toward maintainer discretion). Surface canonical-number (perf-baseline floor / published-results) changes in evidence even on allow."

--- a/.claude/workflows/fable-architect-drain.js
+++ b/.claude/workflows/fable-architect-drain.js
@@ -75,11 +75,15 @@ const TIER = {
   // current cheap models claude-sonnet-4-6 / claude-haiku-4-5, per orchestration/routing.toml).
   sonnet: { model: 'sonnet', marker: '[SONNET-4.6]', trailer: 'Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>' },
   haiku:  { model: 'haiku',  marker: '[HAIKU-4.5]',  trailer: 'Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>' },
-  // Downgrade tiers (Opus 5 unavailable) — stamped only by the model that ACTUALLY served.
-  // Reachable two ways: a DELIBERATE downgrade dispatch (pass this row's full `model` id) or a
-  // detected downgraded serving (scripts/fable/detect-tier.sh on the run's transcript).
-  'fable-5':  { model: 'claude-fable-5',  marker: '[FABLE-5]',  trailer: 'Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>' },
-  'opus-4-8': { model: 'claude-opus-4-8', marker: '[OPUS-4.8]', trailer: 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>' },
+  // ATTRIBUTION-ONLY rows (`model: null`). Fable 5 and Opus 4.8 were DEPRECATED as routing
+  // targets on 2026-07-26 (maintainer: "deprecate the use of fable and opus entirely in favour of
+  // opus5"), so neither is dispatchable any more — `model` is null and dispatchModel() THROWS on
+  // these rows rather than returning undefined, which the harness would silently read as "use the
+  // default model". They survive because attribution is not routing: scripts/fable/detect-tier.sh
+  // can still detect that a run was SERVED by a downgraded tier, and the correct stamp for that
+  // run is this row's marker/trailer. Existing [FABLE-5]/[OPUS-4.8] stamps are accurate HISTORY.
+  'fable-5':  { model: null, marker: '[FABLE-5]',  trailer: 'Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>' },
+  'opus-4-8': { model: null, marker: '[OPUS-4.8]', trailer: 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>' },
 }
 const mark = (t) => (TIER[t] || TIER.opus).marker
 const trailer = (t) => (TIER[t] || TIER.opus).trailer
@@ -88,7 +92,19 @@ const trailer = (t) => (TIER[t] || TIER.opus).trailer
 // This workflow has no in-band served-model hook, so attribution rides the dispatched row:
 // safe because full-ID dispatch == served (probe above); verify post-hoc with
 // scripts/fable/detect-tier.sh, whose downgrade verdict routes stamping to the downgrade rows.
-const dispatchModel = (t) => (TIER[t] || TIER.opus).model
+// FAILS CLOSED on a non-dispatchable tier. Returning `undefined` here would hand the harness no
+// --model flag, i.e. a SILENT fallback to whatever the session default happens to be — the exact
+// failure mode the 2026-07-26 deprecation is meant to remove. Refuse instead.
+const dispatchModel = (t) => {
+  const row = TIER[t] || TIER.opus
+  if (!row.model) {
+    throw new Error(
+      `[OPUS-5] tier '${t}' is attribution-only and has no dispatchable model (Fable 5 / Opus 4.8 ` +
+      `were deprecated as routing targets 2026-07-26 in favour of opus5). Dispatch 'opus'/'fable' ` +
+      `(both -> claude-opus-5) instead; this row exists only to STAMP a detected downgraded run.`)
+  }
+  return row.model
+}
 
 const DISK_SCHEMA = {
   type: 'object',

--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -49,6 +49,14 @@ on:
       - "scripts/tests/test_no_deprecated_models.py"
       - ".claude/settings.json"
       - ".claude/workflows/fable-architect-drain.js"
+      # [OPUS-5] the LABELS -> MODEL CHAIN surfaces (review of PR #4211). The `area:gui` carve-out
+      # is decided in route-resolve.py from labels written by these two files, so the end-to-end
+      # suite must re-run when either the role derivation or the label WRITE path changes. The
+      # write path is load-bearing: a discarded --add-label failure that still sets status:ready
+      # is what silently inverted the carve-out.
+      - "scripts/triage.py"
+      - "scripts/retriage.py"
+      - ".github/workflows/triage-issue.yml"
       - ".github/workflows/routing-self-tests.yml"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
@@ -92,6 +100,14 @@ on:
       - "scripts/tests/test_no_deprecated_models.py"
       - ".claude/settings.json"
       - ".claude/workflows/fable-architect-drain.js"
+      # [OPUS-5] the LABELS -> MODEL CHAIN surfaces (review of PR #4211). The `area:gui` carve-out
+      # is decided in route-resolve.py from labels written by these two files, so the end-to-end
+      # suite must re-run when either the role derivation or the label WRITE path changes. The
+      # write path is load-bearing: a discarded --add-label failure that still sets status:ready
+      # is what silently inverted the carve-out.
+      - "scripts/triage.py"
+      - "scripts/retriage.py"
+      - ".github/workflows/triage-issue.yml"
       - ".github/workflows/routing-self-tests.yml"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition

--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -41,6 +41,14 @@ on:
       # in-progress-review and local/orchestrator-parity contracts, and pins this
       # workflow's own run block to the scripts it must invoke.
       - "scripts/tests/test_readiness_visibility.py"
+      # [OPUS-5] the model-DEPRECATION guard (maintainer directive 2026-07-26: fable + opus-4.8
+      # retired in favour of opus5; docs writing off haiku/sonnet onto sol). It is cross-surface
+      # — a model is selected in FOUR places, not just the routing table — so each guarded
+      # surface is its own trigger. Without these entries a PR could reintroduce a retired model
+      # in settings.json or a workflow JS dispatch site without ever running this gate.
+      - "scripts/tests/test_no_deprecated_models.py"
+      - ".claude/settings.json"
+      - ".claude/workflows/fable-architect-drain.js"
       - ".github/workflows/routing-self-tests.yml"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
@@ -76,6 +84,14 @@ on:
       # in-progress-review and local/orchestrator-parity contracts, and pins this
       # workflow's own run block to the scripts it must invoke.
       - "scripts/tests/test_readiness_visibility.py"
+      # [OPUS-5] the model-DEPRECATION guard (maintainer directive 2026-07-26: fable + opus-4.8
+      # retired in favour of opus5; docs writing off haiku/sonnet onto sol). It is cross-surface
+      # — a model is selected in FOUR places, not just the routing table — so each guarded
+      # surface is its own trigger. Without these entries a PR could reintroduce a retired model
+      # in settings.json or a workflow JS dispatch site without ever running this gate.
+      - "scripts/tests/test_no_deprecated_models.py"
+      - ".claude/settings.json"
+      - ".claude/workflows/fable-architect-drain.js"
       - ".github/workflows/routing-self-tests.yml"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
@@ -114,6 +130,11 @@ jobs:
           python3 scripts/dispatch-plan.py --self-test
           python3 scripts/batch-merge.py --self-test
           python3 scripts/tests/test_readiness_visibility.py
+          # [OPUS-5] a deprecated model must not reappear in ANY routing position — the routing
+          # table, a .claude/settings.json agent hook, a workflow JS dispatch site, or agent
+          # frontmatter. This suite also pins its OWN wiring in this workflow structurally
+          # (parsed YAML, not substrings), so `if: false` on the job or the step reds it.
+          python3 scripts/tests/test_no_deprecated_models.py
           # [OPUS-5] reg#677: the PR `area:` deriver + its YAML seam. The suite is
           # invoked HERE and that invocation is itself pinned by
           # test_pr_area_labels.py::TestSelfTestIsActuallyInvoked — a suite nobody

--- a/.github/workflows/triage-issue.yml
+++ b/.github/workflows/triage-issue.yml
@@ -71,12 +71,46 @@ jobs:
               --body "> 🤖 automation — this issue is from a non-collaborator, so it is **quarantined** (\`trust:untrusted\`) and its content is not acted on. A maintainer can approve it by adding a 👍 reaction (the promote cron picks it up)." || true
           fi
 
+      # [OPUS-5] FAIL-CLOSED LABEL WRITES (review of PR #4211).
+      #
+      # This step used to be `for l in $add; do gh issue edit … --add-label "$l" || true; done`.
+      # `gh issue edit --add-label` does NOT create a missing label — it fails with
+      # "'<name>' not found". With one edit PER label and `|| true` on each, a missing ROUTING
+      # label (a `role:*`) silently no-opped while the sibling `status:ready` write in the SAME
+      # loop succeeded. The issue was then promoted as if its role had been written, and
+      # scripts/route-resolve.py — finding no `role:` label — fell through to `[defaults]`.
+      # That is FAIL-OPEN on the dispatch path, and it is what turned a missing `role:gui` label
+      # into a silently INVERTED routing preference for the whole GUI backlog.
+      #
+      # Two changes make it fail-closed:
+      #   1. every label the static pass can emit is ENSURED to exist first (idempotent create,
+      #      restricted to the closed role:/status:/needs: set triage.py actually emits, so this
+      #      can never mint an arbitrary label);
+      #   2. the whole delta goes in ONE `gh issue edit` call, so it is ALL-OR-NOTHING — a failed
+      #      write can no longer leave `status:ready` set without the role label it was paired
+      #      with. `|| true` is gone from that call, so with `set -euo pipefail` a write failure
+      #      REDS the run instead of being discarded. The create is best-effort on purpose (an
+      #      already-existing label reports an error): the ADD is the hard gate that decides.
       - name: Static triage (trusted author)
         if: steps.trust.outputs.trusted == '1'
         run: |
+          set -euo pipefail
           labels=$(gh issue view "$NUM" -R "$REPO" --json labels --jq '[.labels[].name]|join(",")')
           out=$(python3 scripts/triage.py --labels "$labels" --type task)
           add=$(printf '%s\n' "$out" | sed -n 's/^ADD: //p')
           rem=$(printf '%s\n' "$out" | sed -n 's/^REMOVE: //p')
-          for l in $add; do gh issue edit "$NUM" -R "$REPO" --add-label "$l" || true; done
-          for l in $rem; do gh issue edit "$NUM" -R "$REPO" --remove-label "$l" || true; done
+          ensure_label() {
+            case "$1" in
+              role:*|status:*|needs:*) ;;
+              *) echo "refusing to auto-create unexpected label '$1'" >&2; return 0 ;;
+            esac
+            gh label create "$1" -R "$REPO" --color ededed \
+              --description "orchestration routing label (auto-created by triage)" \
+              >/dev/null 2>&1 || true
+          }
+          args=()
+          for l in $add; do ensure_label "$l"; args+=(--add-label "$l"); done
+          for l in $rem; do args+=(--remove-label "$l"); done
+          if [ "${#args[@]}" -gt 0 ]; then
+            gh issue edit "$NUM" -R "$REPO" "${args[@]}"
+          fi

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -157,10 +157,18 @@ role = "perf"
 model_chain = ["sol", "opus5"]
 agent = "sparq-perf-engineer"
 
+# [OPUS-5] research was ["opus5", "fable", "opus"] until 2026-07-26. Deprecating the two tail
+# rungs left a ONE-RUNG chain with no `escalate`, i.e. no exit at all: on an opus5 capacity outage
+# the item could only defer, and defer again, forever — a silent permanent stall with no human
+# ever notified. Deprecating a fallback therefore has to come with an exit, so research now
+# escalates like the other single-rung (review/soundness/security) chains: chain exhaustion parks
+# the issue to needs:user. Deliberately NOT solved by adding `sol`: research authorship stays on
+# the anthropic side, and a cross-provider rung would have hidden the stall rather than surfaced it.
 [[route]]
 role = "research"
 model_chain = ["opus5"]
 agent = "sparq-researcher"
+escalate = true
 
 # DOCS WRITING -> SOL (maintainer directive 2026-07-26: "deprecate sonnet and haiku for docs
 # writing in favor of gpt 5.6 sol"). haiku and sonnet LED this chain until 2026-07-26 and are now

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -151,11 +151,20 @@ agent = "sparq-site"
 # This route PRESERVES the existing UI -> codex/sol original-builder steer (task #331) for the
 # desktop GUI; it is a carve-out from a new default, not a reversal of anything.
 #
+# WHERE THE CARVE-OUT ACTUALLY BINDS. This route alone is NOT sufficient and must not be mistaken
+# for the mechanism: role routes are reached only via a `role:` LABEL, `role:gui` did not exist as a
+# repo label until 2026-07-26, and `triage._role()` returns an EXPLICIT `role:*` before it consults
+# any surface label — so all 35 open `area:gui` issues (33 role:impl, 1 role:perf, 1 role:research)
+# resolved `role:impl` and took the opus5-first default, INVERTING the directive for the whole GUI
+# backlog. The binding rule therefore lives in scripts/route-resolve.py `gui_carve_out()`: it reads
+# the `area:gui` label the issues ALREADY carry, at plan time, and re-orders whatever chain they
+# resolve to. This route is the declarative statement of the same preference for an issue that does
+# carry `role:gui`; the two are asserted to agree.
+#
 # It is a ROLE route, not `match_labels`, for the same reason the site route is: the review lane's
 # arm-side security classifier UNIONS every match_labels keyword, so putting "gui" there would
 # human-arm every GUI PR. scripts/triage.py derives role:gui from `area:gui` alone (it used to
-# fold area:gui into role:site, which is exactly why a separate role is needed to express the
-# carve-out at all).
+# fold area:gui into role:site).
 #
 # PREFERENCE, NOT EXCLUSION: opus5 remains the fallback, so GUI work stays dispatchable during a
 # sol/OpenAI outage. The chain is cross-provider and therefore cannot be starved by one provider.

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -92,7 +92,7 @@ provider_model = "gpt-5.6-luna"        # Second tier of the unified fix ladder o
 credential_format = "codex-auth-json"
 
 [defaults]
-model_chain = ["sol", "opus5"]
+model_chain = ["opus5", "sol"]
 agent = "sparq-rust-impl"
 
 # ---------------------------------------------------------------------------------------------------
@@ -108,15 +108,25 @@ agent = "sparq-reviewer"
 escalate = true                        # consumed by dispatch: on chain-exhaustion, label needs:user
 
 # ---------------------------------------------------------------------------------------------------
-# ROLE ROUTES. Implementation chains LEAD WITH SOL (maintainer directive 2026-07-18: credit
-# abundance; capability order luna < opus5 < sol since 2026-07-26, fable/opus deprecated out of the
-# order entirely). Opus 5 IS the anthropic side — it has no tail fallback — so an OpenAI outage
-# falls to opus5 and an opus5 outage DEFERS the item at the registry claim step (retried next tick)
-# rather than degrading tier. Cross-provider review flips automatically: sol-authored
-# implementation receives Anthropic review, and vice versa.
+# ROLE ROUTES. Implementation chains LEAD WITH OPUS 5 (maintainer directive 2026-07-26: "Opus5
+# should be prioritised over sol on all tasks for which they are both possible implementors;
+# except for GUI work where sol should remain prioritised").
+#
+# WHY THIS CHANGED, because the mechanism matters more than the edit: these chains led with SOL
+# under the 2026-07-18 "credit abundance" directive, taken during a period of high sol
+# availability. Nothing about sol's dominance was adaptive — the registry's account selector walks
+# `model_chain` IN ORDER and claims the first available account (select-and-claim.choose_account),
+# so a sol-first literal simply won every route, every tick, regardless of how availability had
+# since shifted. Measured 2026-07-26: 11 of the 12 most recent orchestrator PRs were
+# openai/sol-implemented. The stale steer was the chain ORDER itself, not a heuristic, so the fix
+# is the order.
+#
+# Cross-provider review flips automatically: opus5-authored implementation receives codex review,
+# and vice versa — so leading with opus5 also moves the review load onto sol, which is where the
+# spare credit actually is.
 [[route]]
 role = "impl"
-model_chain = ["sol", "opus5"]
+model_chain = ["opus5", "sol"]
 agent = "sparq-rust-impl"
 
 # [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
@@ -128,6 +138,29 @@ agent = "sparq-rust-impl"
 # unions ALL match_labels keywords, so UI keywords there would human-arm every UI PR.
 [[route]]
 role = "site"
+model_chain = ["opus5", "sol"]
+agent = "sparq-site"
+
+# [OPUS-5] THE `area:gui` CARVE-OUT (maintainer directive 2026-07-26): "Opus5 should be prioritised
+# over sol on all tasks for which they are both possible implementors; except for GUI work where
+# sol should remain prioritised". Boundary settled by the maintainer the same day: "Let's just go
+# with area:gui work" — so the carve-out is `area:gui` and NOTHING ELSE. The site* surfaces
+# (area:site, area:site-specs, area:site-papers, …) are NOT GUI: they fall under the opus5-first
+# default above, even though "GUI" reads informally as if it covered them.
+#
+# This route PRESERVES the existing UI -> codex/sol original-builder steer (task #331) for the
+# desktop GUI; it is a carve-out from a new default, not a reversal of anything.
+#
+# It is a ROLE route, not `match_labels`, for the same reason the site route is: the review lane's
+# arm-side security classifier UNIONS every match_labels keyword, so putting "gui" there would
+# human-arm every GUI PR. scripts/triage.py derives role:gui from `area:gui` alone (it used to
+# fold area:gui into role:site, which is exactly why a separate role is needed to express the
+# carve-out at all).
+#
+# PREFERENCE, NOT EXCLUSION: opus5 remains the fallback, so GUI work stays dispatchable during a
+# sol/OpenAI outage. The chain is cross-provider and therefore cannot be starved by one provider.
+[[route]]
+role = "gui"
 model_chain = ["sol", "opus5"]
 agent = "sparq-site"
 
@@ -149,12 +182,12 @@ agent = "sparq-site"
 # escalation) — where role:ci and a security surface overlap, the security lane is correct.
 [[route]]
 role = "ci"
-model_chain = ["sol", "opus5"]
+model_chain = ["opus5", "sol"]
 agent = "sparq-ci-infra"
 
 [[route]]
 role = "perf"
-model_chain = ["sol", "opus5"]
+model_chain = ["opus5", "sol"]
 agent = "sparq-perf-engineer"
 
 # [OPUS-5] research was ["opus5", "fable", "opus"] until 2026-07-26. Deprecating the two tail

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -24,38 +24,48 @@
 # fails with an auth error. setup-token also creates a SEPARATE credential, so the worker never
 # rotates the coordinating session's own login out from under it. (anthropic-api-key is also
 # supported by the worker if a Console key is preferred over the subscription.)
+# DEPRECATED ALIASES — `fable` (claude-fable-5) and `opus` (claude-opus-4-8) were REMOVED from this
+# catalog on 2026-07-26 by maintainer directive ("deprecate the use of fable and opus entirely in
+# favour of opus5"). They are no longer routing targets: `opus5` is the sole anthropic tier. The
+# removal is enforced, not merely conventional — scripts/routing-validate.py DEPRECATED_ALIASES /
+# DEPRECATED_PROVIDER_MODELS fail the build if either alias or either provider id reappears in a
+# catalog entry or any model_chain, and scripts/route-resolve.py validate_routing() refuses to
+# RESOLVE a table naming them (fail-closed at plan time, so a reintroduced alias can never route).
+# Existing `[FABLE-5]` / `[OPUS-4.8]` authorship markers in the tree are accurate HISTORY and stay.
 [models.haiku]
 provider = "anthropic"
 harness = "claude"
-provider_model = "claude-haiku-4-5"   # concrete id; maintainer confirms exact pin
+provider_model = "claude-haiku-4-5"   # NOT a routing target (2026-07-26): haiku no longer appears in
+                                      # any model_chain — the maintainer moved DOCS WRITING off the
+                                      # cheap anthropic tiers onto sol. The catalog entry is retained
+                                      # because non-routing consumers still name it (the harness
+                                      # `.claude/agents/*.md` mechanical roles: sparq-pkg-nl NL
+                                      # retrieval, sparq-verify-mechanical, sparq-context-monitor)
+                                      # and registry account records list it in `models`.
 credential_format = "claude-oauth-token"
 [models.sonnet]
 provider = "anthropic"
 harness = "claude"
-provider_model = "claude-sonnet-4-6"
-credential_format = "claude-oauth-token"
-[models.opus]
-provider = "anthropic"
-harness = "claude"
-provider_model = "claude-opus-4-8"     # Tail fallback since 2026-07-24 (opus5 is the primary tier).
-credential_format = "claude-oauth-token"
-[models.fable]
-provider = "anthropic"
-harness = "claude"
-provider_model = "claude-fable-5"      # Tail fallback since 2026-07-24 (opus5 is the primary tier).
+provider_model = "claude-sonnet-4-6"  # NOT a routing target (2026-07-26): same as haiku above.
+                                      # Non-routing consumers: sparq-rust-impl (bulk single-crate
+                                      # implementation) + sparq-issue-sweeper (triage) agent configs.
 credential_format = "claude-oauth-token"
 [models.opus5]
 provider = "anthropic"
 harness = "claude"
-provider_model = "claude-opus-5"       # Opus 5 (maintainer directive 2026-07-24): replaces BOTH
-                                       # fable (claude-fable-5) AND opus (claude-opus-4-8) as the
-                                       # primary model on every task where they were used — opus5
-                                       # is now the TOP anthropic tier. The old tiers stay in every
-                                       # chain as TAIL FALLBACKS only (degradation path: an opus5
-                                       # capacity outage parks work gracefully instead of stalling
-                                       # single-model chains). Probe-verified live 2026-07-24
-                                       # (`claude --model claude-opus-5 -p` -> OK); mirrors the
-                                       # registry's routing.toml (agent-account-registry #562).
+provider_model = "claude-opus-5"       # Opus 5 — the SOLE anthropic routing tier since 2026-07-26.
+                                       # It replaced fable (claude-fable-5) and opus (claude-opus-4-8)
+                                       # as the primary tier on 2026-07-24; the 2026-07-26 directive
+                                       # deprecated both entirely, so they are gone from this catalog
+                                       # rather than retained as tail fallbacks. Chains that used to
+                                       # end at fable/opus now either end at opus5 and DEFER on
+                                       # exhaustion (retried next tick) or carry `escalate = true`
+                                       # and park to needs:user — never a silent degrade.
+                                       # Probe-verified live 2026-07-26: `claude --model
+                                       # claude-opus-5 -p` -> OK, modelUsage reports canonicalModel
+                                       # "claude-opus-5" (1M context). ALWAYS pin the full id: the
+                                       # bare `opus` alias tracked claude-opus-4-8 for days after
+                                       # Opus 5 shipped. Mirrors the registry's routing.toml.
 credential_format = "claude-oauth-token"
 [models.terra]
 provider = "openai"
@@ -82,29 +92,31 @@ provider_model = "gpt-5.6-luna"        # Second tier of the unified fix ladder o
 credential_format = "codex-auth-json"
 
 [defaults]
-model_chain = ["sol", "opus5", "fable", "opus"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-rust-impl"
 
 # ---------------------------------------------------------------------------------------------------
-# SECURITY-LABEL OVERRIDES (first-match; win over role). Soundness surfaces run on Opus 5 (opus-4.8
-# as tail fallback since 2026-07-24, so an opus5 capacity outage degrades to the previous soundness
-# tier instead of stalling the single-model chain) and, on chain-exhaustion, ESCALATE to a human
-# (needs:user) rather than fall to a weaker/cross-provider model.
+# SECURITY-LABEL OVERRIDES (first-match; win over role). Soundness surfaces run on Opus 5 ALONE
+# (2026-07-26: the opus-4.8 tail fallback was deprecated, so there is no weaker anthropic rung to
+# degrade to) and, on chain-exhaustion, ESCALATE to a human (needs:user) rather than fall to a
+# weaker/cross-provider model. That is the intended fail-closed behaviour, not a dead end: an opus5
+# capacity outage now parks the item for a human instead of quietly serving it from a retired tier.
 [[route]]
 match_labels = ["zk", "mpc", "reasoner", "crypto", "auth", "e2ee"]
-model_chain = ["opus5", "opus"]
+model_chain = ["opus5"]
 agent = "sparq-reviewer"
 escalate = true                        # consumed by dispatch: on chain-exhaustion, label needs:user
 
 # ---------------------------------------------------------------------------------------------------
 # ROLE ROUTES. Implementation chains LEAD WITH SOL (maintainer directive 2026-07-18: credit
-# abundance; capability order opus < luna < fable < opus5 < sol since 2026-07-24). Opus 5 leads
-# the anthropic side (fable/opus are its tail fallbacks), so an OpenAI outage does not stall
-# implementation. Cross-provider review flips automatically: sol-authored implementation
-# receives Anthropic review, and vice versa.
+# abundance; capability order luna < opus5 < sol since 2026-07-26, fable/opus deprecated out of the
+# order entirely). Opus 5 IS the anthropic side — it has no tail fallback — so an OpenAI outage
+# falls to opus5 and an opus5 outage DEFERS the item at the registry claim step (retried next tick)
+# rather than degrading tier. Cross-provider review flips automatically: sol-authored
+# implementation receives Anthropic review, and vice versa.
 [[route]]
 role = "impl"
-model_chain = ["sol", "opus5", "fable", "opus"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-rust-impl"
 
 # [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
@@ -116,15 +128,15 @@ agent = "sparq-rust-impl"
 # unions ALL match_labels keywords, so UI keywords there would human-arm every UI PR.
 [[route]]
 role = "site"
-model_chain = ["sol", "opus5", "fable", "opus"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-site"
 
 # [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
 # 2026-07-17; same standing-rule pattern as the UI→codex route above, PR #3416): ALL CI/
 # infrastructure work — .github/workflows, gate aggregators, orchestration/ + dispatch scripts,
 # the self-draining pipeline itself — is authored by a FRONTIER-tier model only: opus5 (Claude
-# Opus 5, the primary anthropic tier since 2026-07-24; fable is its tail fallback) or sol
-# (GPT-5.6 / codex). Cheaper tiers (sonnet/haiku) no longer author infra;
+# Opus 5, the SOLE anthropic tier since 2026-07-26 — fable was deprecated out of this chain) or
+# sol (GPT-5.6 / codex). Cheaper tiers (sonnet/haiku) no longer author infra;
 # cross-provider review is unchanged (whichever provider's frontier writes, the other reviews).
 # The chain is deliberately FRONTIER-ONLY rather than floor-pinned: the routing schema has no
 # floor/pin marker (the fix-floor pin lives in the registry's review loop, not here), and
@@ -137,37 +149,42 @@ agent = "sparq-site"
 # escalation) — where role:ci and a security surface overlap, the security lane is correct.
 [[route]]
 role = "ci"
-model_chain = ["sol", "opus5", "fable"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-ci-infra"
 
 [[route]]
 role = "perf"
-model_chain = ["sol", "opus5", "fable", "opus"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-perf-engineer"
 
 [[route]]
 role = "research"
-model_chain = ["opus5", "fable", "opus"]
+model_chain = ["opus5"]
 agent = "sparq-researcher"
 
-# docs-only cheap tiers (maintainer 2026-07-18): sonnet AND terra appear in THIS chain and
-# nowhere else — scripts/route-resolve.py validate_routing() REJECTS any table naming either
-# outside role=docs.
+# DOCS WRITING -> SOL (maintainer directive 2026-07-26: "deprecate sonnet and haiku for docs
+# writing in favor of gpt 5.6 sol"). haiku and sonnet LED this chain until 2026-07-26 and are now
+# absent from it — and, since role=docs was their only routing consumer, absent from the routing
+# table entirely. scripts/route-resolve.py validate_routing() REJECTS any table that names haiku or
+# sonnet in ANY chain (NOT_A_ROUTING_TARGET), so the cheap tiers cannot creep back into docs or
+# anywhere else. `terra` (the codex CLI default) remains docs-only: it is the same-provider
+# fallback behind sol, and validate_routing() still rejects it outside role=docs. opus5 is the
+# cross-provider tail so a total OpenAI outage does not stall documentation.
 [[route]]
 role = "docs"
-model_chain = ["haiku", "sonnet", "terra", "opus5", "fable"]
+model_chain = ["sol", "terra", "opus5"]
 agent = "sparq-docs"
 
-# Review / soundness: Opus 5 (opus-4.8 tail fallback since 2026-07-24); escalate to human on
-# chain-exhaustion (do NOT fall to a weaker model).
+# Review / soundness: Opus 5 alone (the opus-4.8 tail fallback was deprecated 2026-07-26);
+# escalate to human on chain-exhaustion (do NOT fall to a weaker model).
 [[route]]
 role = "review"
-model_chain = ["opus5", "opus"]
+model_chain = ["opus5"]
 agent = "sparq-reviewer"
 escalate = true
 
 [[route]]
 role = "soundness"
-model_chain = ["opus5", "opus"]
+model_chain = ["opus5"]
 agent = "sparq-reviewer"
 escalate = true

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -238,3 +238,48 @@ role = "soundness"
 model_chain = ["opus5"]
 agent = "sparq-reviewer"
 escalate = true
+
+# ---------------------------------------------------------------------------------------------------
+# [OPUS-5] CHAIN-ORDER PREFERENCES — THE CARVE-OUT, DECLARED WHERE **BOTH** RESOLVERS CAN READ IT.
+#
+# The route above is not enough on its own, and the reason is that the dispatch decision is made
+# TWICE, in two repositories:
+#
+#   PLAN   the registry's dispatch.yml clones THIS repo and runs THIS repo's scripts/dispatch-plan.py
+#          -> scripts/route-resolve.py -> gui_carve_out().
+#   CLAIM  registry `dispatch-claim.py` re-derives the same route with REGISTRY-owned
+#          scripts/policy-resolve.py, reading THIS FILE from the protected default-branch tip, and
+#          `_route_matches` then demands EXACT equality of model_chain / agent / escalate.
+#
+# So a chain-order rule expressed ONLY in this repo's Python is not a preference that half-applies:
+# CLAIM re-derives a different chain, raises DispatchError, and the item is counted
+# `route-policy-failed` and skipped. That comparison is a pure function of the issue's labels and
+# this table, so it produces the identical skip on every subsequent tick — the affected issues
+# stop dispatching ENTIRELY, and the only symptom is a defer counter. Measured against this
+# branch's own resolver before this block existed: 34 of the 35 open `area:gui` issues (33
+# `role:impl` + 1 `role:perf`) diverged.
+#
+# CLAIM cannot import this repo's resolver — running target-authored CODE in the privileged claim
+# step is the escalation registry #119 closed. But it already trusts this file, fetched from the
+# PROTECTED tip; it is where `model_chain` itself comes from. So the rule crosses the repository
+# boundary through that same channel, as DATA. The registry's scripts/chain_preference.py is the
+# shared MECHANISM both resolvers import; this block is the RULE.
+#
+# CONTRACT (identical on both sides, and asserted equal to route-resolve.py's GUI_CARVE_OUT_*
+# constants by `route-resolve --self-test`, so the two representations cannot drift):
+#   labels    EXACT issue labels — ANY one of them selects. Never a substring: `"gui" in label`
+#             would sweep `area:guide` / `area:guidance` into the carve-out.
+#   lead      moved to the FRONT of the resolved chain. Every other rung keeps its relative order,
+#             so this is PREFERENCE, NOT EXCLUSION and the chain still terminates cross-provider.
+#   requires  the rule fires ONLY when the chain ALREADY contains all of these — the directive's
+#             own "tasks for which they are BOTH possible implementors" qualifier. `lead` must be
+#             one of them, which is what makes RE-ORDER the only possible effect: the preference
+#             can never INJECT sol into `role:research` (["opus5"], deliberately anthropic-side and
+#             escalating) and turn a visible stall into a silent cross-provider hop.
+#
+# A SECURITY-override route is exempt on both sides: `area:gui` + `area:sparq-zk` is a ZK issue
+# first, and an implementor preference must never re-order a soundness chain.
+[[chain_preference]]
+labels   = ["area:gui"]
+lead     = "sol"
+requires = ["sol", "opus5"]

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -167,7 +167,7 @@ def _self_test():
     chk("impl -> single row", len(p_impl), 1)
     row = p_impl[0]
     chk("impl row", (row["role"], row["model_chain"][0], row["agent"], row["escalate"]),
-        ("impl", "sol", "sparq-rust-impl", False))
+        ("impl", "opus5", "sparq-rust-impl", False))
     chk("impl package", row["package"], "sparq-core")
     chk("impl priority", row["priority"], 1)
 
@@ -198,7 +198,7 @@ def _self_test():
     ci = compute_ready([iss(8, R + ["priority:P1", "role:ci", "area:ci"])])
     row = plan_dispatch(ci, doc)[0]
     chk("ci -> frontier-only row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
-        ("ci", ["sol", "opus5"], "sparq-ci-infra", False))
+        ("ci", ["opus5", "sol"], "sparq-ci-infra", False))
     chk("ci row has no sub-frontier tier", sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
 
     # --- Fixture: package-conflict pair → only the higher-priority one is planned ----------------

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -175,15 +175,20 @@ def _self_test():
     sec = compute_ready([iss(2, R + ["priority:P0", "role:impl", "area:sparq-zk"])])
     p_sec = plan_dispatch(sec, doc)
     row = p_sec[0]
-    chk("zk -> opus5-led", row["model_chain"], ["opus5", "opus"])
+    chk("zk -> opus5 only", row["model_chain"], ["opus5"])
     chk("zk -> reviewer/escalate", (row["agent"], row["escalate"]), ("sparq-reviewer", True))
     chk("zk role stays declared", row["role"], "impl")
 
-    # --- Fixture: a docs issue → its route (haiku-led) -------------------------------------------
+    # --- Fixture: a docs issue → its route (SOL-led since 2026-07-26) ----------------------------
+    # [OPUS-5] maintainer directive: docs WRITING moved off the cheap anthropic tiers (haiku/
+    # sonnet) onto gpt-5.6 sol. The second assertion is the one that goes red if either tier is
+    # put back into the docs chain.
     docs = compute_ready([iss(3, R + ["priority:P2", "role:docs", "area:sparq-docs"])])
     p_docs = plan_dispatch(docs, doc)
     row = p_docs[0]
-    chk("docs -> haiku", row["model_chain"][0], "haiku")
+    chk("docs -> sol", row["model_chain"][0], "sol")
+    chk("docs row has no cheap anthropic tier",
+        sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
     chk("docs -> sparq-docs", row["agent"], "sparq-docs")
 
     # --- Fixture: a ci/infra issue → frontier-only chain (standing rule 2026-07-17) --------------
@@ -193,7 +198,7 @@ def _self_test():
     ci = compute_ready([iss(8, R + ["priority:P1", "role:ci", "area:ci"])])
     row = plan_dispatch(ci, doc)[0]
     chk("ci -> frontier-only row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
-        ("ci", ["sol", "opus5", "fable"], "sparq-ci-infra", False))
+        ("ci", ["sol", "opus5"], "sparq-ci-infra", False))
     chk("ci row has no sub-frontier tier", sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
 
     # --- Fixture: package-conflict pair → only the higher-priority one is planned ----------------
@@ -225,6 +230,15 @@ def _self_test():
         multi[0]["package"], _ready.GLOBAL)
     zero = plan_dispatch([iss(92, R + ["priority:P2", "role:docs"])], doc)
     chk("#3691 zero-area maps to GLOBAL", zero[0]["package"], _ready.GLOBAL)
+
+    # --- [OPUS-5] DEPRECATION SWEEP over every row this self-test planned ------------------------
+    # The per-fixture assertions above pin the chains we happened to sample. This sweeps ALL of
+    # them, so a deprecated alias reintroduced into a route the fixtures do not cover still fails.
+    _dep = {"fable", "opus"}
+    _all_rows = [r for plan in (p_impl, p_sec, p_docs, plan_dispatch(ci, doc), p_pair)
+                 for r in plan]
+    chk("no planned row names a deprecated alias",
+        sorted({m for r in _all_rows for m in r["model_chain"]} & _dep), [])
 
     print("dispatch-plan self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1

--- a/scripts/retriage.py
+++ b/scripts/retriage.py
@@ -87,13 +87,17 @@ def _gh(args):
 # [OPUS-5] The closed set of labels the static pass can emit. `ensure_labels` will create these and
 # NOTHING else, so a typo in triage.py can never mint an arbitrary repo label.
 _EMITTABLE_LABEL = ("role:", "status:", "needs:", "priority:")
+# Per-run memo. A live sweep promotes hundreds of issues but emits only a handful of DISTINCT
+# labels, so without this the ensure would cost ~3 API calls per issue for no new information.
+_ENSURED = set()
 
 
 def _ensure_labels(repo, labels):
     """Idempotently create every emittable label BEFORE the edit. Best-effort by design: creating an
     existing label reports an error, and the ADD below is the hard gate that actually decides."""
     for lb in sorted(labels):
-        if lb.startswith(_EMITTABLE_LABEL):
+        if lb.startswith(_EMITTABLE_LABEL) and (repo, lb) not in _ENSURED:
+            _ENSURED.add((repo, lb))
             _gh(["label", "create", lb, "-R", repo, "--color", "ededed",
                  "--description", "orchestration routing label (auto-created by retriage)"])
 
@@ -445,6 +449,15 @@ def _self_test():
         apply_labels("o/r", 42, ["area:sparq-core", "role:impl"], [])
         chk("only role:/status:/needs:/priority: labels are auto-created",
             sorted(c[2] for c in writes if c[0:2] == ["label", "create"]), ["role:impl"])
+        # The ensure is memoised per run: a sweep promoting hundreds of issues emits only a
+        # handful of DISTINCT labels, so re-creating them per issue is pure API cost.
+        writes.clear()
+        apply_labels("o/r", 43, ["role:impl", "needs:area"], [])
+        chk("an already-ensured label is not re-created for the next issue "
+            "(role:impl was ensured above; only the new needs:area is created)",
+            [c[2] for c in writes if c[0:2] == ["label", "create"]], ["needs:area"])
+        chk("...but the edit itself still happens for that issue",
+            len([c for c in writes if c[0:2] == ["issue", "edit"]]), 1)
     finally:
         globals()["_gh"] = real_gh
 

--- a/scripts/retriage.py
+++ b/scripts/retriage.py
@@ -84,6 +84,52 @@ def _gh(args):
     return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
 
 
+# [OPUS-5] The closed set of labels the static pass can emit. `ensure_labels` will create these and
+# NOTHING else, so a typo in triage.py can never mint an arbitrary repo label.
+_EMITTABLE_LABEL = ("role:", "status:", "needs:", "priority:")
+
+
+def _ensure_labels(repo, labels):
+    """Idempotently create every emittable label BEFORE the edit. Best-effort by design: creating an
+    existing label reports an error, and the ADD below is the hard gate that actually decides."""
+    for lb in sorted(labels):
+        if lb.startswith(_EMITTABLE_LABEL):
+            _gh(["label", "create", lb, "-R", repo, "--color", "ededed",
+                 "--description", "orchestration routing label (auto-created by retriage)"])
+
+
+def apply_labels(repo, number, add, remove):
+    """Apply an issue's whole label delta ATOMICALLY. Returns True iff it was written.
+
+    [OPUS-5] FAIL-CLOSED (review of PR #4211). This used to be one `_gh(["issue","edit",…,
+    "--add-label", lb])` PER label with the return code never read (`_gh` is `check=False`).
+    `gh issue edit --add-label` does NOT create a missing label — it fails — so a missing ROUTING
+    label (a `role:*`) silently no-opped while the sibling `status:ready` write in the same loop
+    SUCCEEDED. The issue was promoted as if it carried the role it does not, and route-resolve,
+    finding no `role:` label, fell through to `[defaults]`. Fail-open on the dispatch path: it is
+    what turned a missing `role:gui` label into a silently inverted routing preference.
+
+    So: ensure the labels exist, then send the whole delta as ONE `gh issue edit` — all-or-nothing,
+    so a failure can no longer leave `status:ready` set without the role it was paired with — and
+    READ the return code, surfacing the failure to the caller instead of discarding it.
+    """
+    if not add and not remove:      # nothing to write (an empty `gh issue edit` errors out)
+        return True
+    _ensure_labels(repo, add)
+    args = ["issue", "edit", str(number), "-R", repo]
+    for lb in add:
+        args += ["--add-label", lb]
+    for lb in remove:
+        args += ["--remove-label", lb]
+    r = _gh(args)
+    if r.returncode != 0:
+        print(f"#{number}: label write FAILED (rc={r.returncode}) — the issue is left UNPROMOTED "
+              f"rather than status:ready without its role: {(r.stderr or '').strip()[:300]}",
+              file=sys.stderr)
+        return False
+    return True
+
+
 def _trusted_factory(repo):
     cache = {}
 
@@ -339,6 +385,69 @@ def _self_test():
     finally:
         globals()["_gh"] = real_gh
 
+    # -------------------------------------------------------------------------------------------
+    # [OPUS-5] THE WRITE PATH IS FAIL-CLOSED (review of PR #4211).
+    # The defect was not in the PLAN, it was in APPLYING it: one `gh issue edit --add-label` per
+    # label, return code unread. A missing `role:*` label fails that call while the SIBLING
+    # `status:ready` call in the same loop succeeds — the issue promotes with no role and
+    # route-resolve falls through to [defaults]. These assertions are behavioural: they drive
+    # apply_labels() against a stub gh and inspect the calls it actually made.
+    # -------------------------------------------------------------------------------------------
+    writes = []
+
+    class _WResp:
+        def __init__(self, returncode=0, stderr=""):
+            self.stdout, self.returncode, self.stderr = "", returncode, stderr
+
+    def _write_gh(args, fail_on_edit=False):
+        writes.append(list(args))
+        if args[0:2] == ["issue", "edit"] and fail_on_edit:
+            return _WResp(1, "'role:gui' not found\nfailed to update 1 issue")
+        return _WResp()
+
+    real_gh = globals()["_gh"]
+    try:
+        globals()["_gh"] = lambda a: _write_gh(a, fail_on_edit=False)
+        okw = apply_labels("o/r", 42, ["role:gui", "status:ready"], ["status:untriaged"])
+        edits = [c for c in writes if c[0:2] == ["issue", "edit"]]
+        chk("a successful delta is written", okw, True)
+        # ALL-OR-NOTHING: one call carrying the WHOLE delta. Two calls is the defect — the second
+        # one lands even when the first has failed.
+        chk("the whole label delta goes in ONE edit call, not one call per label", len(edits), 1)
+        chk("the role label and status:ready are written by the SAME call",
+            ("role:gui" in edits[0] and "status:ready" in edits[0]), True)
+        chk("the removal is in that same call", "status:untriaged" in edits[0], True)
+        # ensure_labels runs FIRST, so a label the repo lacks is created rather than silently
+        # dropping the routing signal (the `role:gui` case exactly).
+        creates = [c for c in writes if c[0:2] == ["label", "create"]]
+        chk("every emittable add-label is ensured to exist before the edit",
+            sorted(c[2] for c in creates), ["role:gui", "status:ready"])
+        chk("the ensure runs BEFORE the edit", writes.index(edits[0]) > len(creates) - 1, True)
+
+        # THE DECISIVE ONE: when the write fails, the caller must LEARN it. Before this fix the
+        # rc was never read and the cron exited 0 with the issue half-labelled.
+        writes.clear()
+        globals()["_gh"] = lambda a: _write_gh(a, fail_on_edit=True)
+        chk("a FAILED label write is reported, not discarded",
+            apply_labels("o/r", 42, ["role:gui", "status:ready"], []), False)
+        chk("a failed write does not retry-promote with a second call",
+            len([c for c in writes if c[0:2] == ["issue", "edit"]]), 1)
+
+        # Nothing to write -> no gh call at all (an empty `gh issue edit` errors out).
+        writes.clear()
+        globals()["_gh"] = lambda a: _write_gh(a, fail_on_edit=True)
+        chk("an empty delta issues no edit", (apply_labels("o/r", 42, [], []), writes), (True, []))
+
+        # The auto-create is restricted to the closed set triage.py emits: a typo cannot mint an
+        # arbitrary repo label.
+        writes.clear()
+        globals()["_gh"] = lambda a: _write_gh(a, fail_on_edit=False)
+        apply_labels("o/r", 42, ["area:sparq-core", "role:impl"], [])
+        chk("only role:/status:/needs:/priority: labels are auto-created",
+            sorted(c[2] for c in writes if c[0:2] == ["label", "create"]), ["role:impl"])
+    finally:
+        globals()["_gh"] = real_gh
+
     print("retriage self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 
@@ -352,14 +461,18 @@ def main():
     if args.self_test:
         return _self_test()
     actions = plan_retriage(_fetch_candidates(args.repo), _trusted_factory(args.repo))
+    failed = []
     for number, add, remove in actions:
         print(f"#{number}: +{','.join(add) or '-'} -{','.join(remove) or '-'}")
-        if args.apply:
-            for lb in add:
-                _gh(["issue", "edit", str(number), "-R", args.repo, "--add-label", lb])
-            for lb in remove:
-                _gh(["issue", "edit", str(number), "-R", args.repo, "--remove-label", lb])
+        if args.apply and not apply_labels(args.repo, number, add, remove):
+            failed.append(number)
     print(f"retriage: {len(actions)} issue(s) {'promoted' if args.apply else 'promotable (dry-run)'}")
+    if failed:
+        # [OPUS-5] Do NOT exit 0 on a discarded write. A swallowed label failure is invisible in a
+        # cron and leaves the frontier quietly wrong; the run must go red so it is noticed.
+        print(f"retriage: {len(failed)} issue(s) FAILED to apply and are NOT promoted: "
+              f"{failed[:10]}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -15,22 +15,92 @@ except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
 
+# [OPUS-5] DEPRECATION REGISTER (maintainer directive 2026-07-26: "deprecate the use of fable and
+# opus entirely in favour of opus5"). These are the aliases and the concrete provider ids that must
+# never again occupy a routing position. Keeping the ids here — not only the aliases — is what makes
+# the deprecation stick: re-adding `[models.fable]` under a DIFFERENT alias name still trips the
+# provider-id half of the guard.
+DEPRECATED_ALIASES = {"fable", "opus"}
+DEPRECATED_PROVIDER_MODELS = {"claude-fable-5", "claude-opus-4-8"}
+
+# [OPUS-5] Cheap anthropic tiers, deprecated FOR DOCS WRITING on 2026-07-26 ("deprecate sonnet and
+# haiku for docs writing in favor of gpt 5.6 sol"). role=docs was their ONLY routing consumer, so
+# after that directive they hold no routing position at all and this set is the whole rule. They are
+# deliberately still in the [models] CATALOG and still serve non-routing, non-docs-writing roles in
+# the harness agent configs (sparq-pkg-nl NL retrieval, sparq-verify-mechanical, sparq-rust-impl,
+# sparq-issue-sweeper, sparq-context-monitor) — this guard governs the routing table only.
+NOT_A_ROUTING_TARGET = {"haiku", "sonnet"}
+
+# `terra` (the codex CLI default model) stays docs-only: it is sol's same-provider fallback in the
+# docs chain and must not appear anywhere else.
+DOCS_ONLY = {"terra"}
+
+
+def _chains(doc):
+    """Yield (where, chain) for every routing position in the table: defaults + every route."""
+    yield "defaults", list(doc.get("defaults", {}).get("model_chain", []))
+    for r in doc.get("route", []):
+        where = ("role:" + r["role"]) if r.get("role") else \
+            ("match_labels:" + ",".join(r.get("match_labels", []))) or "<unnamed>"
+        yield where, list(r.get("model_chain", []))
+
+
 def validate_routing(doc):
     """Structural invariants a routing table must satisfy before ANY resolution — enforced in
     resolve() so a violating table fails LOUDLY at PLAN time instead of silently routing.
-    Maintainer rule 2026-07-18: the cheap tiers `sonnet` and `terra` author NOTHING but docs —
-    they may appear only in the model_chain of a route whose role == "docs" (never in defaults,
-    a match_labels security rule, or any other role's chain)."""
-    docs_only = {"sonnet", "terra"}
-    offenders = []
-    if docs_only & set(doc.get("defaults", {}).get("model_chain", [])):
-        offenders.append("defaults")
+
+    FAIL-CLOSED. Every rule here raises rather than dropping the offending alias, because the
+    alternative — resolving anyway and letting the chain fall through — is exactly how a deprecated
+    model keeps serving traffic after it is "removed".
+    """
+    models = set(doc.get("models", {}))
+    errs = []
+
+    # (1) DEPRECATION GUARD — fable / opus-4.8 may not occupy ANY routing position. This is the
+    # regression guard for the 2026-07-26 directive: it is what turns the deprecation from a
+    # one-time edit into an invariant.
+    for name, spec in doc.get("models", {}).items():
+        if name in DEPRECATED_ALIASES:
+            errs.append(f"[models.{name}] is a DEPRECATED alias (maintainer 2026-07-26: fable and "
+                        f"opus-4.8 are retired in favour of opus5)")
+        pm = spec.get("provider_model")
+        if pm in DEPRECATED_PROVIDER_MODELS:
+            errs.append(f"[models.{name}] pins DEPRECATED provider_model '{pm}' (retired "
+                        f"2026-07-26 in favour of claude-opus-5)")
+    for where, chain in _chains(doc):
+        for m in chain:
+            if m in DEPRECATED_ALIASES:
+                errs.append(f"{where}: model_chain names DEPRECATED alias '{m}' — use 'opus5'")
+
+    # (2) FAIL CLOSED ON AN UNKNOWN MODEL. Previously only routing-validate.py (a separate CI step)
+    # checked chain membership against the catalog, so a chain naming a model the catalog no longer
+    # defines still RESOLVED — it just handed an unresolvable alias to the registry's account
+    # selector, which found no account serving it and silently walked to the next rung. With
+    # fable/opus now deleted from the catalog that failure mode is live, so refuse here instead.
+    for where, chain in _chains(doc):
+        for m in chain:
+            if m not in models and m not in DEPRECATED_ALIASES:
+                errs.append(f"{where}: model '{m}' is not in the [models] catalog — refusing to "
+                            f"resolve (an unresolvable rung must fail, never fall through)")
+
+    # (3) Cheap anthropic tiers hold no routing position (2026-07-26 docs-writing directive).
+    for where, chain in _chains(doc):
+        for m in chain:
+            if m in NOT_A_ROUTING_TARGET:
+                errs.append(f"{where}: model_chain names '{m}', which is not a routing target "
+                            f"(docs writing moved to sol, maintainer 2026-07-26)")
+
+    # (4) terra remains docs-only.
+    if DOCS_ONLY & set(doc.get("defaults", {}).get("model_chain", [])):
+        errs.append("defaults: names a docs-only model (" + ",".join(sorted(DOCS_ONLY)) + ")")
     for r in doc.get("route", []):
-        if docs_only & set(r.get("model_chain", [])) and r.get("role") != "docs":
-            offenders.append(r.get("role") or ",".join(r.get("match_labels", [])) or "<unnamed>")
-    if offenders:
-        raise ValueError("routing violates the docs-only rule for sonnet/terra (maintainer "
-                         "2026-07-18) in: " + "; ".join(offenders))
+        if DOCS_ONLY & set(r.get("model_chain", [])) and r.get("role") != "docs":
+            where = r.get("role") or ",".join(r.get("match_labels", [])) or "<unnamed>"
+            errs.append(f"{where}: names a docs-only model outside role=docs")
+
+    if errs:
+        raise ValueError("routing table is invalid; refusing to resolve:\n  - " +
+                         "\n  - ".join(errs))
 
 
 def resolve(labels, doc):
@@ -66,30 +136,120 @@ def _self_test():
         ok = ok and good
         print(f"  {'ok  ' if good else 'FAIL'} {n}: {got} (want {want})")
 
-    # impl + a security surface (area:sparq-zk) -> security rule wins over role -> Opus-5-led
-    # (opus-4.8 tail fallback, 2026-07-24), escalate
+    def raises(n, fn, needle):
+        """Assert fn() raises ValueError whose message contains `needle`. A deprecation guard that
+        cannot be shown to REJECT something is a comment, not a guard."""
+        nonlocal ok
+        try:
+            fn()
+        except ValueError as e:
+            good = needle in str(e)
+            ok = ok and good
+            print(f"  {'ok  ' if good else 'FAIL'} {n}: raised {'with' if good else 'WITHOUT'} "
+                  f"{needle!r}")
+        else:
+            ok = False
+            print(f"  FAIL {n}: did NOT raise (expected {needle!r})")
+
+    # impl + a security surface (area:sparq-zk) -> security rule wins over role -> Opus 5 alone
+    # (the opus-4.8 tail fallback was deprecated 2026-07-26), escalate
     mc, ag, esc = resolve(["role:impl", "area:sparq-zk"], doc)
-    chk("impl+zk -> opus5-led/escalate", (mc, ag, esc), (["opus5", "opus"], "sparq-reviewer", True))
+    chk("impl+zk -> opus5/escalate", (mc, ag, esc), (["opus5"], "sparq-reviewer", True))
     # plain impl -> sol-led chain (maintainer directive 2026-07-18)
     mc, ag, esc = resolve(["role:impl", "area:sparq-core"], doc)
-    chk("impl -> sol-led", (mc, ag, esc), (["sol", "opus5", "fable", "opus"], "sparq-rust-impl", False))
-    # docs -> haiku-led
-    chk("docs -> haiku", resolve(["role:docs", "area:x"], doc)[0][0], "haiku")
-    # [FABLE-5] UI ownership: site -> terra-led (GPT-5.6 codex, the original dashboard builder)
-    chk("site -> sol-led (GPT owns UI; terra is docs-only)", resolve(["role:site", "area:site"], doc)[0], ["sol", "opus5", "fable", "opus"])
-    # [FABLE-5] frontier-tier infra authorship (standing rule 2026-07-17): ci -> sol-first
-    # (opus5 the primary anthropic tier since 2026-07-24, fable its tail fallback), FRONTIER-ONLY
-    # chain — no sub-frontier model (sonnet/haiku) anywhere in it, so exhaustion
-    # DEFERS at the registry claim step (retried next tick) instead of degrading tier.
+    chk("impl -> sol-led", (mc, ag, esc), (["sol", "opus5"], "sparq-rust-impl", False))
+    # [OPUS-5] docs -> SOL-led (maintainer 2026-07-26: docs writing off haiku/sonnet onto gpt-5.6
+    # sol). terra is sol's same-provider fallback; opus5 the cross-provider tail.
+    chk("docs -> sol-led", resolve(["role:docs", "area:x"], doc)[0], ["sol", "terra", "opus5"])
+    chk("docs chain has no cheap anthropic tier",
+        sorted(set(resolve(["role:docs", "area:x"], doc)[0]) & NOT_A_ROUTING_TARGET), [])
+    # [FABLE-5] UI ownership: site -> sol-led (GPT-5.6 codex, the original dashboard builder)
+    chk("site -> sol-led (GPT owns UI; terra is docs-only)",
+        resolve(["role:site", "area:site"], doc)[0], ["sol", "opus5"])
+    # [FABLE-5] frontier-tier infra authorship (standing rule 2026-07-17): ci -> sol-first, opus5
+    # the SOLE anthropic tier since 2026-07-26. FRONTIER-ONLY chain — no sub-frontier model
+    # (sonnet/haiku) anywhere in it, so exhaustion DEFERS at the registry claim step (retried next
+    # tick) instead of degrading tier.
     mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
-    chk("ci -> frontier-only sol-first", (mc, ag, esc), (["sol", "opus5", "fable"], "sparq-ci-infra", False))
+    chk("ci -> frontier-only sol-first", (mc, ag, esc), (["sol", "opus5"], "sparq-ci-infra", False))
     chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
     # no role -> defaults (sol-led, 2026-07-18)
     chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "sol")
-    # perf -> sol-led with the fable/opus fallbacks (new order pinned)
-    chk("perf -> sol-led", resolve(["role:perf", "area:sparq-engine"], doc)[0], ["sol", "opus5", "fable", "opus"])
-    # review role -> opus + escalate
-    chk("review -> opus/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))
+    chk("perf -> sol-led", resolve(["role:perf", "area:sparq-engine"], doc)[0], ["sol", "opus5"])
+    chk("research -> opus5 only", resolve(["role:research"], doc)[0], ["opus5"])
+    # review role -> opus5 + escalate
+    chk("review -> opus5/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))
+
+    # ---------------------------------------------------------------------------------------------
+    # [OPUS-5] THE DEPRECATION IS AN INVARIANT, NOT A ONE-TIME EDIT (maintainer 2026-07-26).
+    # Every assertion below fails if the corresponding guard clause in validate_routing() is
+    # deleted or weakened, and the LIVE-TABLE sweeps fail if a deprecated alias is reintroduced
+    # into orchestration/routing.toml by any future edit.
+    # ---------------------------------------------------------------------------------------------
+    live_chains = {w: c for w, c in _chains(doc)}
+    for where, chain in live_chains.items():
+        chk(f"live table: {where} names no deprecated alias",
+            sorted(set(chain) & DEPRECATED_ALIASES), [])
+        chk(f"live table: {where} names no cheap anthropic tier",
+            sorted(set(chain) & NOT_A_ROUTING_TARGET), [])
+    chk("live catalog defines no deprecated alias",
+        sorted(set(doc.get("models", {})) & DEPRECATED_ALIASES), [])
+    chk("live catalog pins no deprecated provider id",
+        sorted({s.get("provider_model") for s in doc.get("models", {}).values()}
+               & DEPRECATED_PROVIDER_MODELS), [])
+    chk("live catalog still defines opus5 -> claude-opus-5",
+        doc.get("models", {}).get("opus5", {}).get("provider_model"), "claude-opus-5")
+    chk("live catalog still defines sol -> gpt-5.6-sol",
+        doc.get("models", {}).get("sol", {}).get("provider_model"), "gpt-5.6-sol")
+
+    def _mutate(**kw):
+        """A copy of the LIVE table with one field replaced — mutation-tests the guard against the
+        real doc rather than a hand-built toy that could drift away from it."""
+        import copy
+        d = copy.deepcopy(doc)
+        for k, v in kw.items():
+            if k == "defaults_chain":
+                d["defaults"]["model_chain"] = v
+            elif k == "catalog":
+                d["models"].update(v)
+        return d
+
+    raises("REJECTS a reintroduced `fable` rung in a chain",
+           lambda: resolve(["role:impl"], _mutate(defaults_chain=["sol", "opus5", "fable"])),
+           "DEPRECATED alias 'fable'")
+    raises("REJECTS a reintroduced `opus` (4.8) rung in a chain",
+           lambda: resolve(["role:impl"], _mutate(defaults_chain=["sol", "opus5", "opus"])),
+           "DEPRECATED alias 'opus'")
+    raises("REJECTS a re-added [models.fable] catalog entry",
+           lambda: resolve(["role:impl"], _mutate(catalog={"fable": {
+               "provider": "anthropic", "harness": "claude",
+               "provider_model": "claude-fable-5", "credential_format": "claude-oauth-token"}})),
+           "DEPRECATED alias")
+    # the provider-id half: a retired model smuggled back under an INNOCENT alias name.
+    raises("REJECTS claude-opus-4-8 smuggled back under a fresh alias",
+           lambda: resolve(["role:impl"], _mutate(catalog={"legacy": {
+               "provider": "anthropic", "harness": "claude",
+               "provider_model": "claude-opus-4-8", "credential_format": "claude-oauth-token"}})),
+           "DEPRECATED provider_model 'claude-opus-4-8'")
+    raises("REJECTS claude-fable-5 smuggled back under a fresh alias",
+           lambda: resolve(["role:impl"], _mutate(catalog={"legacy": {
+               "provider": "anthropic", "harness": "claude",
+               "provider_model": "claude-fable-5", "credential_format": "claude-oauth-token"}})),
+           "DEPRECATED provider_model 'claude-fable-5'")
+    raises("REJECTS haiku creeping back into a chain (docs writing moved to sol)",
+           lambda: resolve(["role:impl"], _mutate(defaults_chain=["haiku", "sol"])),
+           "not a routing target")
+    raises("REJECTS sonnet creeping back into a chain",
+           lambda: resolve(["role:impl"], _mutate(defaults_chain=["sonnet", "sol"])),
+           "not a routing target")
+    # FAIL CLOSED: an unresolvable rung must refuse, never fall through to the next one.
+    raises("FAILS CLOSED on a model absent from the catalog",
+           lambda: resolve(["role:impl"], _mutate(defaults_chain=["sol", "ghost"])),
+           "not in the [models] catalog")
+    raises("REJECTS terra outside role=docs",
+           lambda: resolve(["role:impl"], _mutate(defaults_chain=["terra", "sol"])),
+           "docs-only")
+
     print("route-resolve self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -35,6 +35,61 @@ NOT_A_ROUTING_TARGET = {"haiku", "sonnet"}
 # docs chain and must not appear anywhere else.
 DOCS_ONLY = {"terra"}
 
+# [OPUS-5] THE `area:gui` CARVE-OUT — THE BINDING MECHANISM (review of PR #4211).
+#
+# MAINTAINER DIRECTIVE 2026-07-26: "Opus5 should be prioritised over sol on all tasks for which they
+# are both possible implementors; except for GUI work where sol should remain prioritised", boundary
+# settled the same day as "Let's just go with area:gui work".
+#
+# The first attempt expressed this as a `role:gui` ROUTE and had scripts/triage.py derive that role
+# from `area:gui`. Review proved it could never fire, for two independent reasons:
+#   (1) `role:gui` did not exist as a repo label, and `gh issue edit --add-label` does NOT create a
+#       missing label — it fails. Both writers discarded that failure while the sibling
+#       `status:ready` write succeeded, so GUI issues promoted role-LESS and fell to [defaults].
+#   (2) Even with the label, `_role()` returns an EXPLICIT `role:*` before it ever consults the
+#       surface labels, and all 35 open `area:gui` issues already carried one (33 role:impl,
+#       1 role:perf, 1 role:research). `bd-to-issues.role_for()` never emits `role:gui` either.
+# Net effect measured on the live backlog: GUI work moved from sol-first to opus5-first — the
+# directive's ONLY exception was INVERTED for 100% of it.
+#
+# So the carve-out is now applied HERE, at the layer that actually decides, keyed on the label the
+# issues ALREADY carry. It needs no new label, no relabelling of the backlog, and no write that can
+# fail: `resolve()` reads live labels at plan time.
+#
+# It is a CHAIN-ORDER rule, not a route: it re-orders the chain of whatever route the issue resolves
+# to and leaves the ROLE and the AGENT untouched. That is exactly what the directive asks for (it
+# speaks only about model priority), and it is why a `role:impl` GUI issue keeps `sparq-rust-impl`
+# — the desktop GUI is Rust/Tauri, not the Next.js site — instead of being rerouted.
+#
+# EXACT LABEL, never a substring: `"gui" in lb` would false-match `area:guide`/`area:guidance`. And
+# deliberately NOT a routing `match_labels` rule: the review lane's arm-side security classifier
+# UNIONS every `match_labels` keyword, so "gui" there would human-arm every GUI PR.
+#
+# THE SELECTOR IS `area:gui` AND NOTHING ELSE. `area:site`, `area:site-specs`, `area:site-papers`,
+# `surface:frontend`, `dashboard` are NOT GUI — they take the opus5-first default. Widening this set
+# over a site* label is the likely future mistake and is asserted against.
+GUI_CARVE_OUT_LABELS = frozenset({"area:gui"})
+GUI_CARVE_OUT_LEAD = "sol"
+
+
+def gui_carve_out(labels, chain):
+    """Return `chain` with sol moved to the front IFF this is GUI work and both models are already
+    possible implementors of it.
+
+    "for which they are BOTH possible implementors" is the directive's own qualifier, and it is
+    encoded literally: a chain that does not already contain BOTH `sol` and `opus5` is returned
+    UNCHANGED. That is what stops the carve-out from injecting sol into `role:research`
+    (`["opus5"]`, deliberately anthropic-side + escalating) or from silently rewriting a
+    single-provider chain into a cross-provider one.
+
+    Idempotent: applying it to an already-sol-first chain is a no-op.
+    """
+    if not (set(labels) & GUI_CARVE_OUT_LABELS):
+        return chain
+    if not {GUI_CARVE_OUT_LEAD, "opus5"} <= set(chain):
+        return chain
+    return [GUI_CARVE_OUT_LEAD] + [m for m in chain if m != GUI_CARVE_OUT_LEAD]
+
 
 def _chains(doc):
     """Yield (where, chain) for every routing position in the table: defaults + every route."""
@@ -119,11 +174,14 @@ def resolve(labels, doc):
         kws = r.get("match_labels")
         if kws:  # security-label rule: any keyword is a substring of any label
             if any(k in lb for lb in labels for k in kws):
-                return r["model_chain"], r["agent"], bool(r.get("escalate"))
+                # A SECURITY surface is returned UNMODIFIED — the GUI preference must never
+                # re-order a soundness chain. area:gui + area:sparq-zk is a ZK issue first.
+                return list(r["model_chain"]), r["agent"], bool(r.get("escalate"))
         elif "role" in r and role is not None and r["role"] == role:
-            return r["model_chain"], r["agent"], bool(r.get("escalate"))
+            return (gui_carve_out(labels, list(r["model_chain"])), r["agent"],
+                    bool(r.get("escalate")))
     d = doc.get("defaults", {})
-    return d.get("model_chain", []), d.get("agent"), False
+    return gui_carve_out(labels, list(d.get("model_chain", []))), d.get("agent"), False
 
 
 def _self_test():
@@ -205,6 +263,53 @@ def _self_test():
     chk("research -> opus5 only", resolve(["role:research"], doc)[0], ["opus5"])
     # review role -> opus5 + escalate
     chk("review -> opus5/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))
+
+    # ---------------------------------------------------------------------------------------------
+    # [OPUS-5] THE CARVE-OUT, END TO END: LABELS -> MODEL CHAIN (review of PR #4211).
+    # Everything above this block asserts on the routing TABLE. The defect the review found lived
+    # one layer BELOW that: the table said the right thing, and no real issue could reach it. These
+    # assertions start from the labels a live issue actually carries and end at the chain the
+    # dispatcher will walk, which is the only place the directive is either honoured or inverted.
+    # ---------------------------------------------------------------------------------------------
+    # THE decisive case: 33 of the 35 open area:gui issues carry an explicit role:impl. Before this
+    # mechanism they resolved role:impl -> ["opus5", "sol"], i.e. opus5-FIRST — the exact inversion.
+    chk("area:gui + an explicit role:impl -> SOL-first (the 33-issue case)",
+        resolve(["area:gui", "role:impl", "priority:P2"], doc)[0], ["sol", "opus5"])
+    chk("area:gui + role:impl keeps its implementor agent (carve-out re-orders, never re-routes)",
+        resolve(["area:gui", "role:impl"], doc)[1], "sparq-rust-impl")
+    chk("area:gui with NO role at all -> defaults, SOL-first",
+        resolve(["area:gui", "priority:P2"], doc)[0], ["sol", "opus5"])
+    for _role in ("impl", "site", "ci", "perf", "gui"):
+        mc = resolve(["area:gui", f"role:{_role}"], doc)[0]
+        chk(f"area:gui + role:{_role} -> sol-first", mc[0], "sol")
+        chk(f"area:gui + role:{_role} keeps opus5 reachable (preference, not exclusion)",
+            "opus5" in mc, True)
+    # site* is NOT GUI — the exclusion the review confirmed already works; assert it end to end too.
+    for _area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
+        chk(f"{_area} + role:impl -> OPUS5-first (site is outside the carve-out)",
+            resolve([_area, "role:impl"], doc)[0], ["opus5", "sol"])
+    chk("role:site + area:site -> opus5-first end to end",
+        resolve(["role:site", "area:site"], doc)[0], ["opus5", "sol"])
+    chk("surface:frontend is not in the carve-out",
+        resolve(["surface:frontend", "role:site"], doc)[0][0], "opus5")
+    # EXACT label: a substring selector would sweep area:guide into the sol carve-out.
+    chk("area:guide does NOT false-match the carve-out",
+        resolve(["area:guide", "role:impl"], doc)[0], ["opus5", "sol"])
+    # Security still wins, and its chain is returned UNTOUCHED by the preference rule.
+    chk("area:gui + a security surface -> soundness lane, unmodified",
+        resolve(["area:gui", "area:sparq-zk", "role:impl"], doc),
+        (["opus5"], "sparq-reviewer", True))
+    # "for which they are BOTH possible implementors": a chain without sol is left alone, so the
+    # carve-out cannot quietly turn research (anthropic-side + escalate) into a cross-provider route.
+    chk("area:gui + role:research is NOT rewritten (sol is not an implementor there)",
+        resolve(["area:gui", "role:research"], doc)[:1] + resolve(["area:gui", "role:research"], doc)[2:],
+        (["opus5"], True))
+    chk("area:gui + role:docs keeps the docs chain and the docs agent",
+        resolve(["area:gui", "role:docs"], doc)[:2], (["sol", "terra", "opus5"], "sparq-docs"))
+    # The selector itself, so a future widening has to edit an asserted constant.
+    chk("the carve-out selector is EXACTLY {area:gui}", sorted(GUI_CARVE_OUT_LABELS), ["area:gui"])
+    # Idempotence: applying the rule to an already-sol-first chain must not duplicate the lead.
+    chk("carve-out is idempotent", gui_carve_out({"area:gui"}, ["sol", "opus5"]), ["sol", "opus5"])
 
     # ---------------------------------------------------------------------------------------------
     # [OPUS-5] THE DEPRECATION IS AN INVARIANT, NOT A ONE-TIME EDIT (maintainer 2026-07-26).

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -157,25 +157,51 @@ def _self_test():
     chk("impl+zk -> opus5/escalate", (mc, ag, esc), (["opus5"], "sparq-reviewer", True))
     # plain impl -> sol-led chain (maintainer directive 2026-07-18)
     mc, ag, esc = resolve(["role:impl", "area:sparq-core"], doc)
-    chk("impl -> sol-led", (mc, ag, esc), (["sol", "opus5"], "sparq-rust-impl", False))
+    chk("impl -> opus5-led", (mc, ag, esc), (["opus5", "sol"], "sparq-rust-impl", False))
     # [OPUS-5] docs -> SOL-led (maintainer 2026-07-26: docs writing off haiku/sonnet onto gpt-5.6
     # sol). terra is sol's same-provider fallback; opus5 the cross-provider tail.
     chk("docs -> sol-led", resolve(["role:docs", "area:x"], doc)[0], ["sol", "terra", "opus5"])
     chk("docs chain has no cheap anthropic tier",
         sorted(set(resolve(["role:docs", "area:x"], doc)[0]) & NOT_A_ROUTING_TARGET), [])
     # [FABLE-5] UI ownership: site -> sol-led (GPT-5.6 codex, the original dashboard builder)
-    chk("site -> sol-led (GPT owns UI; terra is docs-only)",
-        resolve(["role:site", "area:site"], doc)[0], ["sol", "opus5"])
+    # [OPUS-5] site is NOT the gui carve-out — it takes the opus5-first default (2026-07-26).
+    chk("site -> opus5-led (site is outside the area:gui carve-out)",
+        resolve(["role:site", "area:site"], doc)[0], ["opus5", "sol"])
     # [FABLE-5] frontier-tier infra authorship (standing rule 2026-07-17): ci -> sol-first, opus5
     # the SOLE anthropic tier since 2026-07-26. FRONTIER-ONLY chain — no sub-frontier model
     # (sonnet/haiku) anywhere in it, so exhaustion DEFERS at the registry claim step (retried next
     # tick) instead of degrading tier.
     mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
-    chk("ci -> frontier-only sol-first", (mc, ag, esc), (["sol", "opus5"], "sparq-ci-infra", False))
+    chk("ci -> frontier-only opus5-first", (mc, ag, esc), (["opus5", "sol"], "sparq-ci-infra", False))
     chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
     # no role -> defaults (sol-led, 2026-07-18)
-    chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "sol")
-    chk("perf -> sol-led", resolve(["role:perf", "area:sparq-engine"], doc)[0], ["sol", "opus5"])
+    chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "opus5")
+    chk("perf -> opus5-led", resolve(["role:perf", "area:sparq-engine"], doc)[0], ["opus5", "sol"])
+
+    # ---------------------------------------------------------------------------------------------
+    # [OPUS-5] OPUS-5-FIRST DEFAULT + THE `area:gui` CARVE-OUT (maintainer 2026-07-26).
+    # ---------------------------------------------------------------------------------------------
+    # Every route where opus5 AND sol are both viable implementors must lead with opus5...
+    for _role in ("impl", "site", "ci", "perf"):
+        mc = resolve([f"role:{_role}"], doc)[0]
+        chk(f"role:{_role} prefers opus5 over sol", mc[0], "opus5")
+        chk(f"role:{_role} keeps sol reachable as a fallback (preference, not exclusion)",
+            "sol" in mc, True)
+    chk("defaults prefer opus5 over sol", resolve(["area:sparq-core"], doc)[0][0], "opus5")
+    # ...EXCEPT role:gui, which keeps the sol lead (original-builder steer, task #331).
+    gui = resolve(["role:gui", "area:gui"], doc)[0]
+    chk("role:gui KEEPS sol first (the carve-out)", gui[0], "sol")
+    chk("role:gui keeps opus5 reachable (GUI stays dispatchable in a sol outage)",
+        "opus5" in gui, True)
+    chk("role:gui routes to the site agent", resolve(["role:gui"], doc)[1], "sparq-site")
+    # The carve-out is EXACTLY role:gui. role:site must NOT be swept into it — "GUI" reads
+    # informally as covering the site surfaces, which is the likely future widening mistake.
+    chk("role:site is NOT in the sol carve-out", resolve(["role:site"], doc)[0][0], "opus5")
+    # Both directions terminate: neither class can become undispatchable.
+    for _role in ("impl", "site", "ci", "perf", "gui"):
+        mc = resolve([f"role:{_role}"], doc)[0]
+        chk(f"role:{_role} chain is cross-provider (cannot be starved by one provider)",
+            sorted({doc["models"][m]["provider"] for m in mc}), ["anthropic", "openai"])
     chk("research -> opus5 only", resolve(["role:research"], doc)[0], ["opus5"])
     # review role -> opus5 + escalate
     chk("review -> opus5/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -299,6 +299,23 @@ def _self_test():
     chk("area:gui + a security surface -> soundness lane, unmodified",
         resolve(["area:gui", "area:sparq-zk", "role:impl"], doc),
         (["opus5"], "sparq-reviewer", True))
+    # ...AND WITH A CROSS-PROVIDER SOUNDNESS CHAIN. The review of this PR observed that the
+    # security exemption had no red test: against the shipped `["opus5"]` chain the both-
+    # implementors condition declines for an unrelated reason, so applying the carve-out to the
+    # security return was an UNDETECTABLE mutation. Asserted now, on a fixture whose soundness
+    # chain is cross-provider, rather than after some future edit makes the real one so.
+    import copy as _cp
+    _xsec = _cp.deepcopy(doc)
+    for _r in _xsec.get("route", []):
+        if _r.get("match_labels"):
+            _r["model_chain"] = ["opus5", "sol"]
+            break
+    chk("a CROSS-PROVIDER security route is STILL returned unmodified under area:gui (the "
+        "exemption is the ROUTE CLASS, not an accident of that chain being single-model)",
+        resolve(["area:gui", "area:sparq-zk", "role:impl"], _xsec)[0], ["opus5", "sol"])
+    chk("...while the same table still applies the carve-out on the role branch (so the check "
+        "above is an exemption, not a dead fixture)",
+        resolve(["area:gui", "role:impl"], _xsec)[0], ["sol", "opus5"])
     # "for which they are BOTH possible implementors": a chain without sol is left alone, so the
     # carve-out cannot quietly turn research (anthropic-side + escalate) into a cross-provider route.
     chk("area:gui + role:research is NOT rewritten (sol is not an implementor there)",
@@ -310,6 +327,58 @@ def _self_test():
     chk("the carve-out selector is EXACTLY {area:gui}", sorted(GUI_CARVE_OUT_LABELS), ["area:gui"])
     # Idempotence: applying the rule to an already-sol-first chain must not duplicate the lead.
     chk("carve-out is idempotent", gui_carve_out({"area:gui"}, ["sol", "opus5"]), ["sol", "opus5"])
+
+    # ---------------------------------------------------------------------------------------------
+    # [OPUS-5] THE CARVE-OUT MUST BE DECLARED IN THE TABLE, NOT ONLY IN THIS FILE.
+    #
+    # This resolver is only the PLAN half. CLAIM (registry `dispatch-claim._route_matches`)
+    # re-derives the same route with REGISTRY-owned `policy-resolve.py` from THIS TABLE fetched at
+    # the protected default tip, and demands EXACT equality — so a rule that lives only in this
+    # module makes every issue it selects raise DispatchError, defer `route-policy-failed`, and,
+    # because the comparison is a pure function of labels and the table, defer again on every
+    # subsequent tick FOREVER. Measured on this branch before the declaration existed: 34 of the
+    # 35 open `area:gui` issues diverged (33 role:impl + 1 role:perf).
+    #
+    # The registry's shared `chain_preference` mechanism reads the `[[chain_preference]]` block
+    # from this file. These assertions pin the two representations to each other, in BOTH
+    # directions, so neither can be edited alone:
+    #   * deleting or narrowing the TOML block         -> red (CLAIM would stop applying the rule)
+    #   * widening/renaming the Python constants       -> red (PLAN would apply a different rule)
+    # ---------------------------------------------------------------------------------------------
+    declared = doc.get("chain_preference", [])
+    chk("the live table DECLARES exactly one chain preference (CLAIM reads this, not the Python)",
+        len(declared), 1)
+    decl = declared[0] if declared else {}
+    chk("the declared selector equals GUI_CARVE_OUT_LABELS",
+        sorted(decl.get("labels", [])), sorted(GUI_CARVE_OUT_LABELS))
+    chk("the declared lead equals GUI_CARVE_OUT_LEAD", decl.get("lead"), GUI_CARVE_OUT_LEAD)
+    chk("the declared `requires` is the both-implementors condition this module applies",
+        sorted(decl.get("requires", [])), sorted({GUI_CARVE_OUT_LEAD, "opus5"}))
+    chk("the declared lead is inside `requires` (so the rule can only RE-ORDER a chain, never "
+        "INJECT a model into one that deliberately excludes it)",
+        decl.get("lead") in decl.get("requires", []), True)
+    chk("the declaration names no field the registry mechanism does not implement",
+        sorted(decl.keys()), ["labels", "lead", "requires"])
+    chk("every model the declaration names is in the live [models] catalog",
+        sorted({decl.get("lead"), *decl.get("requires", [])} - set(doc.get("models", {}))), [])
+    # BEHAVIOURAL EQUIVALENCE, not just field equality: run this module's rule and the declared
+    # rule's semantics over the same rows and require identical chains. A declaration that agreed
+    # field-by-field but was applied to a different set of routes would still split PLAN from CLAIM.
+    def _declared_rule(labels, chain):
+        if not (set(labels) & set(decl.get("labels", []))):
+            return list(chain)
+        if not set(decl.get("requires", [])) <= set(chain):
+            return list(chain)
+        lead = decl.get("lead")
+        return [lead] + [m for m in chain if m != lead]
+
+    for _labels in (["area:gui", "role:impl"], ["area:gui", "role:perf"], ["area:gui"],
+                    ["area:gui", "role:research"], ["area:gui", "role:docs"],
+                    ["area:site", "role:impl"], ["area:guide", "role:impl"],
+                    ["area:sparq-core", "role:impl"], ["surface:frontend", "role:site"]):
+        for _chain in (["opus5", "sol"], ["opus5"], ["sol", "terra", "opus5"], ["sol", "opus5"]):
+            chk(f"declared rule == this module's rule for {_labels} over {_chain}",
+                _declared_rule(_labels, _chain), gui_carve_out(set(_labels), list(_chain)))
 
     # ---------------------------------------------------------------------------------------------
     # [OPUS-5] THE DEPRECATION IS AN INVARIANT, NOT A ONE-TIME EDIT (maintainer 2026-07-26).

--- a/scripts/routing-validate.py
+++ b/scripts/routing-validate.py
@@ -6,6 +6,8 @@ Fails if: a model in any chain (defaults or a route) is not in [models]; a chain
 lacks an agent; a route has neither `role` nor `match_labels`; or a model catalog entry is missing a
 required field. Run in CI to prevent a misspelled model/role or an empty chain from shipping.
 """
+import importlib.util
+import os
 import sys
 
 try:
@@ -15,9 +17,28 @@ except ModuleNotFoundError:  # pragma: no cover
 
 CATALOG_REQUIRED = ("provider", "harness", "provider_model", "credential_format")
 # [FABLE-5] STANDING RULE (maintainer 2026-07-17): CI/infrastructure work is authored by a
-# FRONTIER-tier model only (fable / terra). Validation enforces the floor structurally: a role:ci
-# chain containing a sub-frontier tier fails CI, so exhaustion can only ever DEFER, never degrade.
+# FRONTIER-tier model only (since 2026-07-26: sol / opus5). Validation enforces the floor
+# structurally: a role:ci chain containing a sub-frontier tier fails CI, so exhaustion can only
+# ever DEFER, never degrade.
 SUB_FRONTIER = ("sonnet", "haiku")
+
+
+def _deprecation_register():
+    """[OPUS-5] Load the deprecation register from route-resolve.py — ONE source of truth.
+
+    The register lives next to the resolver because the resolver is the fail-closed enforcement
+    point (it refuses to RESOLVE a table naming a retired model). This validator is the CI-time
+    half of the same rule. Importing rather than re-declaring is deliberate: two hand-maintained
+    copies of a deprecation list is how a model comes back in one of them.
+    """
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "route-resolve.py")
+    spec = importlib.util.spec_from_file_location("route_resolve", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.DEPRECATED_ALIASES, mod.DEPRECATED_PROVIDER_MODELS
+
+
+DEPRECATED_ALIASES, DEPRECATED_PROVIDER_MODELS = _deprecation_register()
 
 
 def validate(doc):
@@ -30,11 +51,23 @@ def validate(doc):
             if f not in spec:
                 errs.append(f"model {name}: missing '{f}'")
 
+    # [OPUS-5] DEPRECATION GUARD (maintainer 2026-07-26: fable + opus-4.8 retired in favour of
+    # opus5). Catalog half — the alias AND the concrete provider id, so a retired model cannot be
+    # smuggled back under a fresh alias name.
+    for name, spec in models.items():
+        if name in DEPRECATED_ALIASES:
+            errs.append(f"model {name}: DEPRECATED alias (retired 2026-07-26 in favour of opus5)")
+        if spec.get("provider_model") in DEPRECATED_PROVIDER_MODELS:
+            errs.append(f"model {name}: DEPRECATED provider_model "
+                        f"'{spec.get('provider_model')}' (retired 2026-07-26)")
+
     def check_chain(where, chain):
         if not chain:
             errs.append(f"{where}: empty model_chain")
         for m in chain:
-            if m not in models:
+            if m in DEPRECATED_ALIASES:
+                errs.append(f"{where}: DEPRECATED model '{m}' in model_chain — use 'opus5'")
+            elif m not in models:
                 errs.append(f"{where}: model '{m}' not in [models] catalog")
 
     defaults = doc.get("defaults", {})
@@ -53,21 +86,21 @@ def validate(doc):
             for m in r.get("model_chain", []):
                 if m in SUB_FRONTIER:
                     errs.append(f"{where}: role:ci chain contains sub-frontier model '{m}' "
-                                "(frontier-tier infra-authorship rule: fable/terra only)")
+                                "(frontier-tier infra-authorship rule: sol/opus5 only)")
     return errs
 
 
 def _self_test():
     good = {
-        "models": {"fable": {"provider": "a", "harness": "claude", "provider_model": "x",
-                             "credential_format": "y"}},
-        "defaults": {"model_chain": ["fable"], "agent": "sparq-rust-impl"},
-        "route": [{"role": "impl", "model_chain": ["fable"], "agent": "sparq-rust-impl"},
+        "models": {"opus5": {"provider": "a", "harness": "claude",
+                             "provider_model": "claude-opus-5", "credential_format": "y"}},
+        "defaults": {"model_chain": ["opus5"], "agent": "sparq-rust-impl"},
+        "route": [{"role": "impl", "model_chain": ["opus5"], "agent": "sparq-rust-impl"},
                   # a frontier-only ci chain is valid (frontier-tier infra-authorship rule)
-                  {"role": "ci", "model_chain": ["fable"], "agent": "sparq-ci-infra"}],
+                  {"role": "ci", "model_chain": ["opus5"], "agent": "sparq-ci-infra"}],
     }
     bad = {
-        "models": {"fable": {"provider": "a"},  # missing fields
+        "models": {"opus5": {"provider": "a"},  # missing fields
                    "sonnet": {"provider": "a", "harness": "claude", "provider_model": "x",
                               "credential_format": "y"}},
         "defaults": {"model_chain": ["ghost"], "agent": ""},  # unknown model + no agent
@@ -75,9 +108,51 @@ def _self_test():
                   # sub-frontier model in a role:ci chain -> frontier-floor violation
                   {"role": "ci", "model_chain": ["sonnet"], "agent": "sparq-ci-infra"}],
     }
+    # [OPUS-5] the deprecation fixtures: each isolates ONE half of the guard, so deleting either
+    # half turns a NAMED assertion below red rather than merely shrinking an error count.
+    dep_alias_catalog = {
+        "models": {"opus5": {"provider": "a", "harness": "claude",
+                             "provider_model": "claude-opus-5", "credential_format": "y"},
+                   "fable": {"provider": "a", "harness": "claude",
+                             "provider_model": "claude-fable-5", "credential_format": "y"}},
+        "defaults": {"model_chain": ["opus5"], "agent": "sparq-rust-impl"},
+        "route": [{"role": "impl", "model_chain": ["opus5"], "agent": "sparq-rust-impl"}],
+    }
+    dep_alias_chain = {
+        "models": {"opus5": {"provider": "a", "harness": "claude",
+                             "provider_model": "claude-opus-5", "credential_format": "y"}},
+        "defaults": {"model_chain": ["opus5"], "agent": "sparq-rust-impl"},
+        "route": [{"role": "impl", "model_chain": ["opus5", "opus"], "agent": "sparq-rust-impl"}],
+    }
+    dep_smuggled_id = {
+        "models": {"legacy": {"provider": "a", "harness": "claude",
+                              "provider_model": "claude-opus-4-8", "credential_format": "y"}},
+        "defaults": {"model_chain": ["legacy"], "agent": "sparq-rust-impl"},
+        "route": [{"role": "impl", "model_chain": ["legacy"], "agent": "sparq-rust-impl"}],
+    }
+
     bad_errs = validate(bad)
-    ok = (not validate(good) and len(bad_errs) >= 5
-          and any("sub-frontier" in e for e in bad_errs))
+    checks = []
+
+    def chk(name, cond):
+        checks.append((name, bool(cond)))
+        print(f"  {'ok  ' if cond else 'FAIL'} {name}")
+
+    chk("a clean opus5-only table validates", not validate(good))
+    chk("the malformed table reports >=5 errors", len(bad_errs) >= 5)
+    chk("the role:ci frontier floor still fires", any("sub-frontier" in e for e in bad_errs))
+    chk("a re-added [models.fable] catalog entry is REJECTED",
+        any("DEPRECATED alias" in e for e in validate(dep_alias_catalog)))
+    chk("a `opus` rung reintroduced into a chain is REJECTED",
+        any("DEPRECATED model 'opus'" in e for e in validate(dep_alias_chain)))
+    chk("claude-opus-4-8 smuggled back under a fresh alias is REJECTED",
+        any("DEPRECATED provider_model 'claude-opus-4-8'" in e
+            for e in validate(dep_smuggled_id)))
+    chk("the register is loaded from route-resolve.py, not re-declared here",
+        DEPRECATED_ALIASES == {"fable", "opus"}
+        and DEPRECATED_PROVIDER_MODELS == {"claude-fable-5", "claude-opus-4-8"})
+
+    ok = all(c for _, c in checks)
     print("good doc errors:", validate(good))
     print("bad doc errors :", validate(bad))
     print("routing-validate self-test", "PASSED" if ok else "FAILED")

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -136,6 +136,95 @@ class TestRoutingTable(unittest.TestCase):
                 f"exhaustion it can only defer forever with no human exit")
 
 
+class TestProviderPreference(unittest.TestCase):
+    """[OPUS-5] Opus 5 is preferred over sol EXCEPT on `area:gui` (maintainer 2026-07-26).
+
+    WHY THIS IS A GUARD AND NOT JUST AN EDIT: sol did not win ~every implementation route through
+    any adaptive heuristic. The registry's allocator walks `model_chain` IN ORDER and claims the
+    first available account, so the sol-first literal — set during a 2026-07-18 high-availability
+    window — simply won every route on every tick, and kept winning long after availability
+    shifted. Measured 2026-07-26: 11 of the 12 most recent orchestrator PRs were sol-implemented.
+    A preference expressed purely as chain ORDER decays exactly this way, so the order is pinned.
+    """
+
+    # The routes where opus5 and sol are BOTH viable implementors. role:docs is excluded: the
+    # separate 2026-07-26 docs-writing directive puts sol first there deliberately.
+    OPUS5_FIRST_ROLES = ("impl", "site", "ci", "perf")
+    GUI_ROLE = "gui"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _routing_doc()
+        cls.routes = {r["role"]: r for r in cls.doc["route"] if r.get("role")}
+
+    def test_default_prefers_opus5_over_sol(self):
+        """MUTANT: reorder any of these chains back to sol-first => RED."""
+        for role in self.OPUS5_FIRST_ROLES:
+            chain = self.routes[role]["model_chain"]
+            self.assertEqual(chain[0], "opus5",
+                             f"role:{role} must prefer opus5 over sol (maintainer 2026-07-26)")
+            self.assertLess(chain.index("opus5"), chain.index("sol"),
+                            f"role:{role}: opus5 must outrank sol")
+
+    def test_defaults_chain_prefers_opus5(self):
+        self.assertEqual(self.doc["defaults"]["model_chain"][0], "opus5")
+
+    def test_preference_is_not_exclusion(self):
+        """sol must stay REACHABLE on non-GUI work. MUTANT: drop sol from a chain => RED."""
+        for role in self.OPUS5_FIRST_ROLES:
+            self.assertIn("sol", self.routes[role]["model_chain"],
+                          f"role:{role}: sol must remain a fallback, not be excluded")
+
+    def test_gui_carve_out_keeps_sol_first(self):
+        """MUTANT: delete the role:gui route, or flip it to opus5-first => RED."""
+        self.assertIn(self.GUI_ROLE, self.routes,
+                      "the area:gui carve-out route is missing entirely")
+        chain = self.routes[self.GUI_ROLE]["model_chain"]
+        self.assertEqual(chain[0], "sol",
+                         "GUI work keeps sol first (original-builder steer, task #331)")
+
+    def test_gui_carve_out_is_preference_not_exclusion(self):
+        """GUI must stay dispatchable during a sol/OpenAI outage."""
+        self.assertIn("opus5", self.routes[self.GUI_ROLE]["model_chain"])
+
+    def test_every_preference_chain_terminates_cross_provider(self):
+        """Both directions must terminate: a chain naming only ONE provider can be starved by that
+        provider's outage with no other rung to fall to."""
+        for role in self.OPUS5_FIRST_ROLES + (self.GUI_ROLE,):
+            chain = self.routes[role]["model_chain"]
+            providers = {self.doc["models"][m]["provider"] for m in chain}
+            self.assertEqual(providers, {"anthropic", "openai"},
+                             f"role:{role} chain {chain} is single-provider — it can be starved")
+
+    def test_carve_out_selector_is_exactly_area_gui(self):
+        """THE ONE THAT MATTERS MOST. "GUI" informally reads as covering the site surfaces, so the
+        likely future mistake is widening the sol carve-out back over `site*`. The carve-out is
+        `area:gui` and nothing else (maintainer: "Let's just go with area:gui work").
+
+        MUTANT: add "area:site" (or any site* label) to triage's GUI_SURFACE_LABELS => RED.
+        """
+        triage_src = (REPO_ROOT / "scripts" / "triage.py").read_text(encoding="utf-8")
+        m = re.search(r"(?m)^GUI_SURFACE_LABELS = \(([^)]*)\)", triage_src)
+        self.assertIsNotNone(m, "GUI_SURFACE_LABELS not found or reshaped")
+        labels = [x.strip().strip("\"'") for x in m.group(1).split(",") if x.strip()]
+        self.assertEqual(labels, ["area:gui"],
+                         "the sol carve-out selector must be EXACTLY area:gui — no site* label, "
+                         "no surface:frontend, no dashboard")
+
+    def test_site_surfaces_are_not_in_the_carve_out(self):
+        """The same property from the other side: the generic UI label set (which routes to the
+        opus5-first role:site) must not contain area:gui, and the gui set must not contain any
+        site* label. MUTANT: move area:gui back into UI_SURFACE_LABELS => RED."""
+        triage_src = (REPO_ROOT / "scripts" / "triage.py").read_text(encoding="utf-8")
+        ui = re.search(r"(?m)^UI_SURFACE_LABELS = \(([^)]*)\)", triage_src)
+        self.assertIsNotNone(ui, "UI_SURFACE_LABELS not found or reshaped")
+        ui_labels = [x.strip().strip("\"'") for x in ui.group(1).split(",") if x.strip()]
+        self.assertNotIn("area:gui", ui_labels,
+                         "area:gui must derive role:gui, not role:site — otherwise the carve-out "
+                         "is inexpressible and GUI silently takes the opus5-first default")
+        self.assertIn("area:site", ui_labels, "role:site must still cover area:site")
+
+
 class TestSettingsHooks(unittest.TestCase):
     """Surface 2 — .claude/settings.json agent hooks. The bare-alias regression lived HERE."""
 

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+# [OPUS-5] Regression guard for the 2026-07-26 model deprecation.
+"""test_no_deprecated_models.py — a deprecated model may not occupy ANY routing position.
+
+MAINTAINER DIRECTIVE 2026-07-26: "deprecate the use of fable and opus entirely in favour of opus5"
+and "deprecate sonnet and haiku for docs writing in favor of gpt 5.6 sol".
+
+Deleting the aliases from orchestration/routing.toml once is an EDIT; it decays the moment someone
+copies an old chain back in. This suite is what makes it an INVARIANT, and it is deliberately
+CROSS-SURFACE, because the routing table is not the only place a model gets selected:
+
+  1. orchestration/routing.toml      — the issue-native routing table (chains + catalog)
+  2. .claude/settings.json           — PreToolUse `type: "agent"` hooks carry their own `model`
+  3. .claude/workflows/*.js          — `agent({model: ...})` dispatch sites + the TIER table
+  4. .claude/agents/*.md             — role-agent frontmatter `model:`
+
+Surface 2 is why this file exists rather than a routing-table-only assertion: the sparq-perf-reviewer
+arm gate sat at `"model": "opus"` — a BARE ALIAS — long after the routing table had moved to opus5.
+A routing-table-scoped guard would have stayed green while the live PR-arming gate ran on the
+deprecated model.
+
+BARE ALIASES ARE THEMSELVES A FINDING. `opus` resolved to claude-opus-4-8 for days after Opus 5
+shipped, so "it points at the right model today" is not a property you can assert about an alias.
+Every routing position must name a FULL model id.
+"""
+import json
+import re
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+
+# Retired 2026-07-26. Both halves matter: the ALIAS (what a chain writes) and the concrete PROVIDER
+# ID (what the alias resolved to) — banning only the alias lets the model return under a new name.
+DEPRECATED_ALIASES = {"fable", "opus"}
+DEPRECATED_PROVIDER_MODELS = {"claude-fable-5", "claude-opus-4-8"}
+
+# Aliases whose target has moved before and can move again. A routing position must not use them.
+BARE_ALIASES = {"opus", "fable", "sonnet", "haiku", "opus5", "sol", "luna", "terra"}
+
+# The surviving top tier, probe-verified 2026-07-26 (`claude --model claude-opus-5 -p` -> OK,
+# modelUsage canonicalModel "claude-opus-5").
+OPUS5_ID = "claude-opus-5"
+
+
+def _routing_doc():
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover
+        import tomli as tomllib
+    with open(REPO_ROOT / "orchestration" / "routing.toml", "rb") as fh:
+        return tomllib.load(fh)
+
+
+class TestRoutingTable(unittest.TestCase):
+    """Surface 1 — orchestration/routing.toml."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _routing_doc()
+
+    def _chains(self):
+        yield "defaults", list(self.doc.get("defaults", {}).get("model_chain", []))
+        for r in self.doc.get("route", []):
+            where = r.get("role") or ",".join(r.get("match_labels", [])) or "<unnamed>"
+            yield where, list(r.get("model_chain", []))
+
+    def test_no_chain_names_a_deprecated_alias(self):
+        """MUTANT: put `fable` or `opus` back in any model_chain => RED."""
+        for where, chain in self._chains():
+            self.assertEqual(
+                sorted(set(chain) & DEPRECATED_ALIASES), [],
+                f"{where}: model_chain names a model retired on 2026-07-26; use 'opus5'")
+
+    def test_catalog_defines_no_deprecated_alias_or_provider_id(self):
+        """MUTANT: re-add [models.fable], or pin claude-opus-4-8 under any alias => RED."""
+        for name, spec in self.doc.get("models", {}).items():
+            self.assertNotIn(name, DEPRECATED_ALIASES,
+                             f"[models.{name}] is a retired alias")
+            self.assertNotIn(
+                spec.get("provider_model"), DEPRECATED_PROVIDER_MODELS,
+                f"[models.{name}] pins a retired provider id under a non-retired alias name")
+
+    def test_opus5_is_the_sole_anthropic_routing_tier(self):
+        """Every anthropic model REACHABLE from a chain must be opus5. This is the positive form
+        of the rule: the negative tests above ban two known names, this one bans an unknown third."""
+        reachable = {m for _, chain in self._chains() for m in chain}
+        anthropic = {m for m in reachable
+                     if self.doc["models"].get(m, {}).get("provider") == "anthropic"}
+        self.assertEqual(anthropic, {"opus5"},
+                         "opus5 must be the only anthropic model reachable from a routing chain")
+
+    def test_opus5_pins_the_full_probe_verified_id(self):
+        self.assertEqual(self.doc["models"]["opus5"]["provider_model"], OPUS5_ID)
+
+    def test_docs_chain_leads_with_sol_and_names_no_cheap_anthropic_tier(self):
+        """MUTANT: put haiku/sonnet back at the head of role=docs => RED.
+
+        This is the SECOND half of the directive ("deprecate sonnet and haiku for docs writing in
+        favor of gpt 5.6 sol"). Scoped to role=docs on purpose: haiku and sonnet are NOT banned
+        from the repo — they still serve non-docs-writing roles in .claude/agents (mechanical
+        retrieval, mechanical verification, bulk implementation, triage, context monitoring),
+        which the maintainer did not deprecate.
+        """
+        docs = [r for r in self.doc["route"] if r.get("role") == "docs"]
+        self.assertEqual(len(docs), 1, "exactly one role=docs route expected")
+        chain = docs[0]["model_chain"]
+        self.assertEqual(chain[0], "sol", "docs writing must lead with sol (gpt-5.6)")
+        self.assertEqual(sorted(set(chain) & {"haiku", "sonnet"}), [],
+                         "docs writing was moved off the cheap anthropic tiers on 2026-07-26")
+
+    def test_no_chain_is_empty(self):
+        """An escalation chain that cannot escalate is worse than a deprecated rung: it dead-ends
+        silently. Every chain must retain at least one reachable model."""
+        for where, chain in self._chains():
+            self.assertTrue(chain, f"{where}: model_chain is empty — it can never dispatch")
+
+    def test_single_model_chains_terminate_explicitly(self):
+        """Collapsing ["opus5", "opus"] onto ["opus5"] removed a rung. A one-rung chain is only
+        safe if exhaustion has a DEFINED exit — `escalate = true` (park to a human) — or if the
+        chain is cross-provider (another provider's outage cannot starve it). Otherwise a single
+        capacity outage stalls the role with no escape."""
+        for r in self.doc.get("route", []):
+            chain = r.get("model_chain", [])
+            if len(chain) > 1:
+                continue
+            where = r.get("role") or ",".join(r.get("match_labels", []))
+            providers = {self.doc["models"][m]["provider"] for m in chain}
+            self.assertTrue(
+                r.get("escalate") or len(providers) > 1,
+                f"{where}: single-model chain {chain} without `escalate = true` — on chain "
+                f"exhaustion it can only defer forever with no human exit")
+
+
+class TestSettingsHooks(unittest.TestCase):
+    """Surface 2 — .claude/settings.json agent hooks. The bare-alias regression lived HERE."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = json.loads(
+            (REPO_ROOT / ".claude" / "settings.json").read_text(encoding="utf-8"))
+
+    def _hook_models(self):
+        found = []
+
+        def walk(node, path):
+            if isinstance(node, dict):
+                if node.get("type") == "agent" and "model" in node:
+                    found.append((path, node["model"]))
+                for k, v in node.items():
+                    walk(v, f"{path}.{k}")
+            elif isinstance(node, list):
+                for i, v in enumerate(node):
+                    walk(v, f"{path}[{i}]")
+
+        walk(self.settings, "settings")
+        return found
+
+    def test_at_least_one_agent_hook_is_scanned(self):
+        """Anti-vacuity: if the settings shape changes so no hook is found, every assertion below
+        passes over an EMPTY list. Fail instead."""
+        self.assertTrue(self._hook_models(),
+                        "no `type: agent` hook with a `model` found — the scan below is vacuous")
+
+    def test_no_hook_uses_a_deprecated_model(self):
+        """MUTANT: set the perf-reviewer arm gate back to `"model": "opus"` => RED."""
+        for path, model in self._hook_models():
+            self.assertNotIn(model, DEPRECATED_ALIASES, f"{path}: retired alias {model!r}")
+            self.assertNotIn(model, DEPRECATED_PROVIDER_MODELS,
+                             f"{path}: retired provider id {model!r}")
+
+    def test_no_hook_uses_a_bare_alias(self):
+        """MUTANT: swap any full id for its bare alias => RED. `opus` silently meant claude-opus-4-8
+        for days after Opus 5 shipped; an alias is not a pin."""
+        for path, model in self._hook_models():
+            self.assertNotIn(
+                model, BARE_ALIASES,
+                f"{path}: {model!r} is a bare alias whose target can move — pin the full model id")
+
+
+class TestWorkflowJsDispatch(unittest.TestCase):
+    """Surface 3 — .claude/workflows/*.js `model:` dispatch values."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.files = sorted((REPO_ROOT / ".claude" / "workflows").glob("*.js"))
+
+    def _model_literals(self):
+        """Every `model: '<literal>'` string in the workflow JS. `model: null` (the
+        attribution-only TIER rows) is intentionally not a string and so not collected."""
+        pat = re.compile(r"""\bmodel\s*:\s*(['"])([^'"]+)\1""")
+        for f in self.files:
+            for m in pat.finditer(f.read_text(encoding="utf-8")):
+                yield f.name, m.group(2)
+
+    def test_workflow_files_are_present(self):
+        self.assertTrue(self.files, "no .claude/workflows/*.js found — scan would be vacuous")
+
+    def test_at_least_one_model_literal_is_scanned(self):
+        self.assertTrue(list(self._model_literals()),
+                        "no `model:` literal found — the scan below is vacuous")
+
+    def test_no_dispatchable_deprecated_model(self):
+        """MUTANT: restore `model: 'claude-fable-5'` on the fable-5 TIER row => RED."""
+        for fname, model in self._model_literals():
+            self.assertNotIn(model, DEPRECATED_PROVIDER_MODELS,
+                             f"{fname}: dispatches retired model {model!r}")
+            self.assertNotIn(model, DEPRECATED_ALIASES,
+                             f"{fname}: dispatches retired alias {model!r}")
+
+    def test_top_tier_dispatch_uses_the_full_id(self):
+        """The `fable`/`opus` TIER keys are retained as stable dispatch TOKENS, but both must
+        resolve to the full claude-opus-5 id — never to the bare alias."""
+        drain = (REPO_ROOT / ".claude" / "workflows" / "fable-architect-drain.js").read_text(
+            encoding="utf-8")
+        for key in ("fable", "opus"):
+            m = re.search(rf"^\s*{key}:\s*\{{\s*model:\s*'([^']+)'", drain, re.M)
+            self.assertIsNotNone(m, f"TIER row {key!r} not found or reshaped")
+            self.assertEqual(m.group(1), OPUS5_ID,
+                             f"TIER row {key!r} must dispatch the full {OPUS5_ID} id")
+
+    def test_attribution_only_rows_are_not_dispatchable(self):
+        """The downgrade rows keep their marker/trailer (attribution is not routing) but must
+        carry no dispatchable model. MUTANT: give them a model id back => RED."""
+        drain = (REPO_ROOT / ".claude" / "workflows" / "fable-architect-drain.js").read_text(
+            encoding="utf-8")
+        for key in ("fable-5", "opus-4-8"):
+            m = re.search(rf"^\s*'{re.escape(key)}':\s*\{{\s*model:\s*([^,]+),", drain, re.M)
+            self.assertIsNotNone(m, f"TIER row {key!r} not found or reshaped")
+            self.assertEqual(m.group(1).strip(), "null",
+                             f"TIER row {key!r} must not be dispatchable")
+
+    def test_dispatch_model_fails_closed_on_a_non_dispatchable_tier(self):
+        """Returning `undefined` for a null-model row would pass NO --model flag, i.e. silently
+        serve the session default. The helper must THROW. MUTANT: delete the throw => RED."""
+        drain = (REPO_ROOT / ".claude" / "workflows" / "fable-architect-drain.js").read_text(
+            encoding="utf-8")
+        body = drain[drain.index("const dispatchModel"):]
+        body = body[:body.index("\n}\n") + 3]
+        self.assertIn("throw new Error", body,
+                      "dispatchModel must refuse a non-dispatchable tier, not return undefined")
+
+
+class TestAgentFrontmatter(unittest.TestCase):
+    """Surface 4 — .claude/agents/*.md `model:` frontmatter."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.agents = sorted((REPO_ROOT / ".claude" / "agents").glob("*.md"))
+
+    def _models(self):
+        for f in self.agents:
+            text = f.read_text(encoding="utf-8")
+            if not text.startswith("---"):
+                continue
+            fm = text.split("---", 2)[1]
+            m = re.search(r"(?m)^model:\s*(\S+)\s*$", fm)
+            if m:
+                yield f.name, m.group(1)
+
+    def test_agents_are_present(self):
+        self.assertTrue(list(self._models()), "no agent frontmatter models found — vacuous scan")
+
+    def test_no_agent_targets_a_deprecated_model(self):
+        """MUTANT: set any agent to `model: opus` or `model: claude-fable-5` => RED."""
+        for name, model in self._models():
+            self.assertNotIn(model, DEPRECATED_ALIASES, f"{name}: retired alias {model!r}")
+            self.assertNotIn(model, DEPRECATED_PROVIDER_MODELS,
+                             f"{name}: retired provider id {model!r}")
+
+
+class TestWorkflowWiring(unittest.TestCase):
+    """THE YAML SEAM. A guard no workflow RUNS is not a guard.
+
+    Substring assertions over the workflow text do NOT catch `if: false` — the text still contains
+    the call site while the step never executes. So this parses the YAML STRUCTURALLY and asserts
+    on the resolved job/step objects.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.raw = WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.raw)
+        cls.job = cls.doc["jobs"]["validate"]
+        cls.steps = cls.job["steps"]
+
+    def _run_steps(self):
+        return [s for s in self.steps if "run" in s]
+
+    def test_job_exists_and_has_no_skip_condition(self):
+        """MUTANT: add `if: false` (or any `if:`) to the validate job => RED."""
+        self.assertNotIn("if", self.job,
+                         "a job-level `if:` can skip the whole routing gate")
+
+    def test_no_gating_step_has_a_skip_condition(self):
+        """MUTANT: add `if: false` to the self-test step => RED. This is the assertion a substring
+        or count(...) check over the workflow text cannot make."""
+        for step in self._run_steps():
+            self.assertNotIn(
+                "if", step,
+                f"step {step.get('name')!r} carries an `if:` — it can silently stop running")
+
+    def test_this_suite_is_actually_invoked(self):
+        """MUTANT: delete the invocation line, or the whole step => RED."""
+        runs = "\n".join(s["run"] for s in self._run_steps())
+        self.assertIn("python3 scripts/tests/test_no_deprecated_models.py", runs,
+                      "this suite is never RUN — its assertions are dead in CI")
+
+    def test_invocation_is_not_neutralised_by_a_trailing_true(self):
+        """MUTANT: append `|| true` to the invocation => RED. Exit-zero swallowing has bitten this
+        repo three times in one day; a guard whose failure is discarded is not a guard."""
+        runs = "\n".join(s["run"] for s in self._run_steps())
+        for line in runs.splitlines():
+            if "test_no_deprecated_models.py" in line:
+                self.assertNotRegex(
+                    line.strip(), r"(\|\|\s*true|;\s*true|\|\|\s*:)\s*$",
+                    "the guard's exit status is discarded")
+
+    def test_run_block_uses_pipefail(self):
+        """Without `set -euo pipefail` a failing early command does not fail the step."""
+        for step in self._run_steps():
+            if "test_no_deprecated_models.py" in step["run"]:
+                self.assertIn("set -euo pipefail", step["run"])
+
+    def test_this_file_is_a_path_trigger_on_both_triggers(self):
+        """MUTANT: drop the paths entry => this suite stops running on its own PRs => RED.
+        Scoped to the trigger section: the filename also appears in the run: block, so a
+        whole-file search would pass for the wrong reason."""
+        trigger_section = self.raw[:self.raw.index("permissions:")]
+        self.assertEqual(
+            trigger_section.count('"scripts/tests/test_no_deprecated_models.py"'), 2,
+            "must be a path trigger on BOTH pull_request and push")
+
+    def test_routing_surfaces_are_path_triggers(self):
+        """The surfaces this suite guards must re-run it when THEY change — otherwise a
+        deprecated model can be reintroduced by a PR that never runs this gate."""
+        trigger_section = self.raw[:self.raw.index("permissions:")]
+        for surface in ("orchestration/routing.toml", ".claude/settings.json",
+                        ".claude/workflows/fable-architect-drain.js"):
+            self.assertEqual(
+                trigger_section.count(f'"{surface}"'), 2,
+                f"{surface} must re-run this gate on BOTH pull_request and push")
+
+    def test_merge_group_trigger_present(self):
+        self.assertIn("merge_group", self.doc.get(True, self.doc.get("on", {})),
+                      "the merge queue must evaluate this gate")
+
+    def test_gate_is_not_declared_advisory(self):
+        """MUTANT: declare routing-self-tests/validate advisory => ci-summary stops gating => RED."""
+        registry = json.loads(
+            (REPO_ROOT / ".github" / "advisory-registry.json").read_text(encoding="utf-8"))
+        declared = {(e.get("workflow"), e.get("job_id"))
+                    for e in registry.get("jobs", {}).values()}
+        self.assertNotIn(("routing-self-tests.yml", "validate"), declared,
+                         "declaring this job advisory stops ci-summary gating on it")
+
+
+if __name__ == "__main__":
+    sys.exit(not unittest.main(verbosity=2, exit=False).result.wasSuccessful())

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -23,6 +23,7 @@ BARE ALIASES ARE THEMSELVES A FINDING. `opus` resolved to claude-opus-4-8 for da
 shipped, so "it points at the right model today" is not a property you can assert about an alias.
 Every routing position must name a FULL model id.
 """
+import importlib.util
 import json
 import re
 import sys
@@ -33,6 +34,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+TRIAGE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "triage-issue.yml"
 
 # Retired 2026-07-26. Both halves matter: the ALIAS (what a chain writes) and the concrete PROVIDER
 # ID (what the alias resolved to) — banning only the alias lets the model return under a new name.
@@ -54,6 +56,14 @@ def _routing_doc():
         import tomli as tomllib
     with open(REPO_ROOT / "orchestration" / "routing.toml", "rb") as fh:
         return tomllib.load(fh)
+
+
+def _load_script(mod_name, filename):
+    """Import a hyphenated scripts/*.py module (same shape as dispatch-plan.py's loader)."""
+    spec = importlib.util.spec_from_file_location(mod_name, REPO_ROOT / "scripts" / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 class TestRoutingTable(unittest.TestCase):
@@ -223,6 +233,219 @@ class TestProviderPreference(unittest.TestCase):
                          "area:gui must derive role:gui, not role:site — otherwise the carve-out "
                          "is inexpressible and GUI silently takes the opus5-first default")
         self.assertIn("area:site", ui_labels, "role:site must still cover area:site")
+
+
+class TestLabelsToModelChain(unittest.TestCase):
+    """[OPUS-5] THE DECISIVE SUITE — LABELS IN, MODEL CHAIN OUT (review of PR #4211).
+
+    Every assertion in `TestProviderPreference` above reads `orchestration/routing.toml` or a
+    constant in `scripts/triage.py`. All of them were GREEN while the maintainer's only exception
+    was INVERTED for 100% of the live GUI backlog, because the table said the right thing and no
+    real issue could reach it:
+
+      * `role:gui` was not a label in this repo, and `gh issue edit --add-label` does not create a
+        missing one — it fails, and both writers discarded that failure while the sibling
+        `status:ready` write succeeded, so GUI issues promoted role-LESS onto `[defaults]`;
+      * even with the label, `triage._role()` returns an EXPLICIT `role:*` before it consults any
+        surface label, and 35 of 35 open `area:gui` issues already carried one (33 `role:impl`,
+        1 `role:perf`, 1 `role:research`).
+
+    A guard that stops at the routing table cannot see either. These tests start from the labels a
+    live issue actually carries and end at the chain the dispatcher will walk — the layer where the
+    directive is either honoured or inverted.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.doc = _routing_doc()
+        cls.rr = _load_script("route_resolve_e2e", "route-resolve.py")
+
+    def chain(self, labels):
+        return self.rr.resolve(labels, self.doc)[0]
+
+    # -- the exception binds -------------------------------------------------------------------
+    def test_area_gui_with_a_preexisting_explicit_role_is_sol_first(self):
+        """THE ONE THAT WOULD HAVE CAUGHT IT. 33 of 35 open `area:gui` issues carry `role:impl`
+        (e.g. #3367). Before the fix they resolved `role:impl` -> ["opus5","sol"], i.e. the exact
+        inversion of "except for GUI work where sol should remain prioritised".
+
+        MUTANT: delete the carve-out from `route-resolve.resolve()` => RED.
+        """
+        for role in ("impl", "perf", "site", "ci", "gui"):
+            chain = self.chain(["area:gui", f"role:{role}", "priority:P2"])
+            self.assertEqual(chain[0], "sol",
+                             f"area:gui + role:{role} must stay sol-first (maintainer 2026-07-26)")
+
+    def test_area_gui_with_no_role_at_all_is_sol_first(self):
+        """The fail-open case the write path produced: a GUI issue promoted with NO role label
+        resolves through `[defaults]`, which is opus5-first. The carve-out must bind there too."""
+        self.assertEqual(self.chain(["area:gui", "priority:P2", "area:sparq-gui"])[0], "sol")
+
+    def test_gui_carve_out_is_preference_not_exclusion_end_to_end(self):
+        """GUI work must stay dispatchable during an OpenAI outage."""
+        for role in ("impl", "perf", "site", "ci", "gui"):
+            self.assertIn("opus5", self.chain(["area:gui", f"role:{role}"]))
+
+    def test_gui_carve_out_re_orders_but_never_re_routes(self):
+        """The directive speaks only about MODEL priority. The carve-out must not change which
+        agent implements the work — the desktop GUI is Rust/Tauri, so a `role:impl` GUI issue
+        keeps `sparq-rust-impl`. MUTANT: turn the carve-out back into a route => RED."""
+        self.assertEqual(self.rr.resolve(["area:gui", "role:impl"], self.doc)[1],
+                         self.rr.resolve(["role:impl"], self.doc)[1])
+        self.assertEqual(self.rr.resolve(["area:gui", "role:perf"], self.doc)[1],
+                         self.rr.resolve(["role:perf"], self.doc)[1])
+
+    # -- the exclusion that already worked, now asserted at the deciding layer ------------------
+    def test_site_surfaces_are_opus5_first_end_to_end(self):
+        """`site*` is NOT in the carve-out (maintainer: "Let's just go with area:gui work").
+        MUTANT: add any site* label to `GUI_CARVE_OUT_LABELS` => RED."""
+        for area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
+            self.assertEqual(self.chain([area, "role:impl", "priority:P2"])[0], "opus5",
+                             f"{area} must take the opus5-first default")
+            self.assertEqual(self.chain([area, "role:site", "priority:P2"])[0], "opus5")
+        self.assertEqual(self.chain(["surface:frontend", "role:site"])[0], "opus5")
+        self.assertEqual(self.chain(["dashboard", "role:site"])[0], "opus5")
+
+    def test_the_selector_is_an_exact_label_not_a_substring(self):
+        """`"gui" in label` would sweep `area:guide` into the sol carve-out."""
+        self.assertEqual(self.chain(["area:guide", "role:impl"])[0], "opus5")
+        self.assertEqual(self.chain(["kind:guidance", "role:impl"])[0], "opus5")
+
+    def test_carve_out_label_set_is_exactly_area_gui(self):
+        """MUTANT: widen `GUI_CARVE_OUT_LABELS` => RED. Pinned as a set as well as behaviourally,
+        so widening it over a label with no open issues still fails."""
+        self.assertEqual(sorted(self.rr.GUI_CARVE_OUT_LABELS), ["area:gui"])
+
+    def test_both_gui_selectors_agree(self):
+        """Two places name the GUI surface — the resolver's carve-out (which decides the chain) and
+        triage's `GUI_SURFACE_LABELS` (which derives the role). They must not drift apart: a widening
+        of either one is the likely future mistake."""
+        triage_src = (REPO_ROOT / "scripts" / "triage.py").read_text(encoding="utf-8")
+        m = re.search(r"(?m)^GUI_SURFACE_LABELS = \(([^)]*)\)", triage_src)
+        self.assertIsNotNone(m, "GUI_SURFACE_LABELS not found or reshaped")
+        triage_labels = {x.strip().strip("\"'") for x in m.group(1).split(",") if x.strip()}
+        self.assertEqual(triage_labels, set(self.rr.GUI_CARVE_OUT_LABELS))
+
+    # -- precedence ----------------------------------------------------------------------------
+    def test_a_security_surface_still_wins_over_the_gui_carve_out(self):
+        """`area:gui` + `area:sparq-zk` is a ZK issue first. The soundness chain must be returned
+        UNMODIFIED — a preference rule must never re-order a soundness lane."""
+        self.assertEqual(self.rr.resolve(["area:gui", "area:sparq-zk", "role:impl"], self.doc),
+                         (["opus5"], "sparq-reviewer", True))
+
+    def test_the_carve_out_never_injects_sol_into_a_chain_that_lacks_it(self):
+        """The directive's own qualifier is "tasks for which they are BOTH possible implementors".
+        `role:research` is deliberately anthropic-side + escalating; the carve-out must leave it
+        alone rather than quietly making it cross-provider (which would hide the stall).
+        MUTANT: drop the both-in-chain condition => RED."""
+        chain, _agent, escalate = self.rr.resolve(["area:gui", "role:research"], self.doc)
+        self.assertEqual(chain, ["opus5"])
+        self.assertTrue(escalate)
+
+    def test_gui_docs_keep_the_docs_route(self):
+        """Docs writing already leads with sol by the separate directive; the carve-out must not
+        change the docs agent or chain."""
+        self.assertEqual(self.rr.resolve(["area:gui", "role:docs"], self.doc)[:2],
+                         (["sol", "terra", "opus5"], "sparq-docs"))
+
+    # -- non-GUI work is unaffected ------------------------------------------------------------
+    def test_non_gui_implementation_work_is_opus5_first_end_to_end(self):
+        """The first directive, asserted the same way: labels in, chain out."""
+        for role in ("impl", "site", "ci", "perf"):
+            self.assertEqual(self.chain([f"role:{role}", "area:sparq-core", "priority:P1"])[0],
+                             "opus5")
+        self.assertEqual(self.chain(["area:sparq-core", "priority:P1"])[0], "opus5")
+
+
+class TestLabelWritesAreFailClosed(unittest.TestCase):
+    """[OPUS-5] The write path that turned "carve-out missing" into "carve-out INVERTED".
+
+    `gh issue edit --add-label` does not create a missing label; it fails and applies nothing from
+    that call. Both writers used ONE edit PER label and discarded the result, so a failed `role:*`
+    write left the SUCCESSFUL `status:ready` write standing — the issue promoted with no role and
+    `route-resolve` fell through to `[defaults]`. Fail-open on the dispatch path.
+
+    Measured against a stubbed `gh` (role:gui absent from the repo, label-create denied):
+    the pre-fix step exits 0 having applied `status:ready` alone; the post-fix step exits 1 having
+    applied nothing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.raw = TRIAGE_WORKFLOW.read_text(encoding="utf-8")
+        cls.doc = yaml.safe_load(cls.raw)
+        cls.steps = cls.doc["jobs"]["triage"]["steps"]
+        cls.step = next(s for s in cls.steps
+                        if "Static triage" in (s.get("name") or ""))
+        cls.retriage_src = (REPO_ROOT / "scripts" / "retriage.py").read_text(encoding="utf-8")
+
+    def test_the_triage_step_exists(self):
+        """Anti-vacuity: if the step is renamed away, every assertion below would scan nothing."""
+        self.assertIn("run", self.step)
+
+    def test_the_label_write_is_not_neutralised_by_a_trailing_true(self):
+        """MUTANT: restore `|| true` on the `gh issue edit` line => RED. This is the exact edit
+        that made the promotion fail-open."""
+        for line in self.step["run"].splitlines():
+            if "gh issue edit" in line:
+                self.assertNotRegex(
+                    line.strip(), r"(\|\|\s*true|;\s*true|\|\|\s*:)\s*$",
+                    "a discarded label-write status is fail-open on the dispatch path")
+
+    def test_the_step_uses_pipefail(self):
+        """Without `set -euo pipefail` the write failure does not fail the step."""
+        self.assertIn("set -euo pipefail", self.step["run"])
+
+    def test_the_delta_is_written_by_a_single_all_or_nothing_edit(self):
+        """MUTANT: go back to `for l in $add; do gh issue edit … --add-label "$l"; done` => RED.
+        Per-label edits are the defect even WITHOUT `|| true`: with `set -e` the loop aborts on the
+        first failure, but any label already applied in an earlier iteration stays — and the
+        sort order puts `role:*` and `status:ready` in separate calls."""
+        run = self.step["run"]
+        self.assertNotRegex(
+            run, r"for\s+l\s+in\s+\$add;\s*do\s+gh\s+issue\s+edit",
+            "adds must not be applied one gh call per label")
+        self.assertEqual(run.count("gh issue edit"), 1,
+                         "the whole label delta must go in ONE gh issue edit invocation")
+
+    def test_missing_labels_are_ensured_before_the_write(self):
+        """MUTANT: delete the `gh label create` ensure => a brand-new routing label reds every
+        triage run instead of being created. The ensure is best-effort; the ADD is the hard gate."""
+        run = self.step["run"]
+        self.assertIn("gh label create", run)
+        self.assertLess(run.index("gh label create"), run.index("gh issue edit"),
+                        "labels must be ensured BEFORE the edit that needs them")
+
+    def test_auto_creation_is_restricted_to_the_labels_triage_emits(self):
+        """The ensure must not be able to mint an arbitrary repo label."""
+        self.assertRegex(self.step["run"], r"role:\*\|status:\*\|needs:\*")
+
+    def test_retriage_reads_the_return_code_of_its_label_write(self):
+        """MUTANT: drop the rc check in `retriage.apply_labels` => RED. `_gh` is `check=False`, so
+        an unread return code is a silently discarded write inside a cron."""
+        src = self.retriage_src
+        self.assertIn("def apply_labels(", src)
+        body = src[src.index("def apply_labels("):]
+        body = body[:body.index("\n\ndef ") if "\n\ndef " in body else len(body)]
+        self.assertIn("r.returncode != 0", body,
+                      "apply_labels must read the return code of the edit")
+        self.assertIn("return False", body,
+                      "a failed write must be reported to the caller, not discarded")
+
+    def test_retriage_main_exits_non_zero_when_a_write_failed(self):
+        """MUTANT: `return 0` unconditionally in main() => RED. A cron that exits 0 having failed
+        to promote is invisible."""
+        src = self.retriage_src
+        main = src[src.index("def main():"):]
+        self.assertRegex(main, r"if failed:[\s\S]*?return 1",
+                         "retriage must exit non-zero when any label write failed")
+
+    def test_retriage_writes_the_delta_in_one_call(self):
+        """The all-or-nothing property, on the cron side. MUTANT: restore the per-label loop
+        (`for lb in add: _gh([... "--add-label", lb])`) => RED."""
+        main = self.retriage_src[self.retriage_src.index("def main():"):]
+        self.assertNotRegex(main, r"for lb in add:",
+                            "retriage must not apply adds one gh call per label")
 
 
 class TestSettingsHooks(unittest.TestCase):
@@ -429,7 +652,11 @@ class TestWorkflowWiring(unittest.TestCase):
         deprecated model can be reintroduced by a PR that never runs this gate."""
         trigger_section = self.raw[:self.raw.index("permissions:")]
         for surface in ("orchestration/routing.toml", ".claude/settings.json",
-                        ".claude/workflows/fable-architect-drain.js"):
+                        ".claude/workflows/fable-architect-drain.js",
+                        # [OPUS-5] the labels -> chain surfaces. Without these a PR could re-break
+                        # the carve-out (or re-open the label write path) and never run this gate.
+                        "scripts/route-resolve.py", "scripts/triage.py", "scripts/retriage.py",
+                        ".github/workflows/triage-issue.yml"):
             self.assertEqual(
                 trigger_section.count(f'"{surface}"'), 2,
                 f"{surface} must re-run this gate on BOTH pull_request and push")

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -41,6 +41,13 @@ UI_SURFACE_LABELS = ("area:site", "surface:frontend", "dashboard")
 # carve-out. Splitting the label out is what lets orchestration/routing.toml give role:gui a
 # sol-first chain while role:site takes the opus5-first default like everything else.
 # EXACT label, never a substring: a substring test would match "guide"/"guidance".
+#
+# THIS IS NOT WHERE THE CARVE-OUT BINDS. This rule fires only for an issue with NO explicit role —
+# the explicit-role branch in _role() returns first — and 35 of 35 open area:gui issues already
+# carry one (33 role:impl, 1 role:perf, 1 role:research), so on its own it reached NONE of the live
+# backlog and GUI work silently took the opus5-first default. The binding rule is
+# scripts/route-resolve.py `gui_carve_out()`, which reads `area:gui` directly at plan time
+# regardless of role. Keep the two label sets in sync — `test_both_gui_selectors_agree`.
 GUI_SURFACE_LABELS = ("area:gui",)
 # [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
 # 2026-07-17, same pattern as the UI→codex rule above / PR #3416): infra-surface labels derive

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -32,7 +32,16 @@ SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
 # role:site chain in orchestration/routing.toml leads with terra/codex). EXACT labels, not
 # substrings: a substring set would false-match (e.g. "gui" in "guide") and UI keywords must NOT
 # enter routing match_labels, which the arm-side security classifier unions into its keyword set.
-UI_SURFACE_LABELS = ("area:site", "area:gui", "surface:frontend", "dashboard")
+UI_SURFACE_LABELS = ("area:site", "surface:frontend", "dashboard")
+# [OPUS-5] `area:gui` gets its OWN role (maintainer directive 2026-07-26). The routing default
+# flipped to opus5-first over sol, "except for GUI work where sol should remain prioritised", and
+# the maintainer settled the boundary as "just go with area:gui work". area:gui used to sit in
+# UI_SURFACE_LABELS above and therefore derived role:site — which made the carve-out inexpressible,
+# because role:site also covers area:site / surface:frontend / dashboard, and those are NOT in the
+# carve-out. Splitting the label out is what lets orchestration/routing.toml give role:gui a
+# sol-first chain while role:site takes the opus5-first default like everything else.
+# EXACT label, never a substring: a substring test would match "guide"/"guidance".
+GUI_SURFACE_LABELS = ("area:gui",)
 # [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
 # 2026-07-17, same pattern as the UI→codex rule above / PR #3416): infra-surface labels derive
 # role:ci so infra work (.github/workflows, gate aggregators, orchestration/ + dispatch scripts)
@@ -62,8 +71,14 @@ def _role(labels, issue_type):
     for lb in labels:
         if lb.startswith("kind:") and lb[5:] in ROLE_BY_KIND:
             return ROLE_BY_KIND[lb[5:]]
-    # [FABLE-5] UI-surface labels derive role:site (codex-led chain) before the generic type map,
-    # after kind (so kind:docs about the site stays docs) and after an explicit role:* label.
+    # [OPUS-5] area:gui derives role:gui — the sol-first carve-out — and is tested BEFORE the
+    # generic UI rule below, which would otherwise swallow it into role:site again. Same
+    # precedence slot otherwise (after security, an explicit role:*, and kind).
+    if any(lb in GUI_SURFACE_LABELS for lb in labels):
+        return "gui"
+    # [FABLE-5] UI-surface labels derive role:site (now the opus5-first default chain) before the
+    # generic type map, after kind (so kind:docs about the site stays docs) and after an explicit
+    # role:* label. NOTE: area:gui is deliberately NOT here — see GUI_SURFACE_LABELS.
     if any(lb in UI_SURFACE_LABELS for lb in labels):
         return "site"
     # [FABLE-5] infra-surface labels derive role:ci (the frontier-only fable/terra chain) before
@@ -153,7 +168,21 @@ def _self_test():
     # [FABLE-5] UI-surface ownership: a UI-surface label derives role:site (the codex/GPT-5.6-led
     # chain) even when the issue type would derive impl; kind (docs) and security still win.
     chk("ui surface -> site", triage(["priority:P2", "area:site"], "feature")["role"], "site")
-    chk("gui surface -> site", triage(["priority:P2", "area:gui"], "task")["role"], "site")
+    # [OPUS-5] the area:gui carve-out (maintainer 2026-07-26): area:gui gets its OWN role so the
+    # routing table can keep it sol-first while everything else prefers opus5.
+    chk("gui surface -> gui (NOT site)", triage(["priority:P2", "area:gui"], "task")["role"], "gui")
+    # THE DISCRIMINATION THAT MATTERS: "GUI" informally reads as covering the site surfaces, so a
+    # future editor could easily widen the carve-out back over them. NO site* area may derive
+    # role:gui — that is the exact property, asserted independently of which non-gui role each
+    # one happens to take (area:site -> site; the narrower area:site-specs / area:site-papers are
+    # not exact UI_SURFACE_LABELS and fall through to the type map, which is fine: every one of
+    # those roles is on the opus5-first default).
+    for _area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
+        chk(f"{_area} does NOT derive role:gui (not swept into the sol carve-out)",
+            triage(["priority:P2", _area], "task")["role"] == "gui", False)
+    chk("surface:frontend stays role:site", triage(["priority:P2", "surface:frontend"], "task")["role"], "site")
+    chk("a 'guide' label does NOT false-match the gui carve-out",
+        triage(["priority:P2", "area:guide"], "task")["role"], "impl")
     chk("explicit impl on ui surface stays impl",
         triage(["priority:P2", "role:impl", "area:site"], "feature")["role"], "impl")
     chk("site docs stay docs", triage(["priority:P3", "kind:docs", "area:site"], "task")["role"], "docs")


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements three maintainer directives of 2026-07-26, all in the routing plane.

1. *"deprecate the use of fable and opus entirely in favour of opus5"*
2. *"deprecate sonnet and haiku for docs writing in favor of gpt 5.6 sol"*
3. *"Opus5 should be prioritised over sol on all tasks for which they are both possible implementors; except for GUI work where sol should remain prioritised"* — boundary settled as *"Let's just go with area:gui work"*

## What changed

**`orchestration/routing.toml`** — `[models.fable]` and `[models.opus]` deleted from the catalog; every chain rewritten.

| route | before | after |
|---|---|---|
| `[defaults]` | `sol, opus5, fable, opus` | `opus5, sol` |
| security override | `opus5, opus` | `opus5` (escalate) |
| `impl` / `site` / `perf` | `sol, opus5, fable, opus` | `opus5, sol` |
| `ci` | `sol, opus5, fable` | `opus5, sol` |
| **`gui` (new)** | — | **`sol, opus5`** |
| `research` | `opus5, fable, opus` | `opus5` **+ `escalate`** |
| `docs` | `haiku, sonnet, terra, opus5, fable` | `sol, terra, opus5` |
| `review` / `soundness` | `opus5, opus` | `opus5` (escalate) |

**`scripts/route-resolve.py`** — becomes the fail-closed enforcement point: a deprecation register (aliases **and** concrete provider ids), a rule that `haiku`/`sonnet` hold no routing position, and an unknown-model check so an unresolvable rung **refuses** instead of falling through to the next one.

**`scripts/routing-validate.py`** — imports that register rather than re-declaring it.

**`.claude/settings.json`** — the `sparq-perf-reviewer` PR-arming hook was `"model": "opus"`, a **bare alias**. Now `claude-opus-5`.

**`.claude/workflows/fable-architect-drain.js`** — the `fable-5` / `opus-4-8` TIER rows were dispatchable (`model: 'claude-fable-5'`). Now `model: null`, attribution-only, and `dispatchModel()` **throws** instead of returning `undefined` (which the harness reads as "use the session default").

**`scripts/triage.py`** — `area:gui` gets its own role. It previously sat in `UI_SURFACE_LABELS` alongside `area:site` / `surface:frontend` / `dashboard` and derived `role:site`, which made the carve-out inexpressible.

**`scripts/tests/test_no_deprecated_models.py`** (new, wired into `routing-self-tests.yml`) — the regression guard.

## Why sol was winning ~everything

Nothing adaptive. `select-and-claim.choose_account` walks `model_chain` **in order** and claims the first available account, so the sol-first literal set during the 2026-07-18 *credit abundance* window won every route on every tick, indefinitely, regardless of how availability later shifted. **The stale steer was the chain order itself**, which is why the fix is the order — and why the order is now pinned by named tests rather than left as a comment.

## The `area:gui` carve-out

Selector is **`area:gui` and nothing else**. `site`, `site-specs`, `site-papers` take the opus5-first default. This *preserves* the existing UI→codex/sol original-builder steer (task #331) for the desktop GUI — it is a carve-out from a new default, not a reversal.

It is a **role** route, not `match_labels`: the review lane's arm-side security classifier unions every `match_labels` keyword, so putting `gui` there would human-arm every GUI PR.

**Preference, not exclusion, both ways** — every implementor chain is cross-provider, so neither class becomes undispatchable during a single provider's outage (asserted).

## A dead-end this found and fixed

Collapsing `role:research` from `[opus5, fable, opus]` to `[opus5]` left a **one-rung chain with no `escalate`** — no exit at all: on an opus5 outage it could only defer, forever, with no human notified. `test_single_model_chains_terminate_explicitly` caught it; research now escalates to `needs:user`.

## Probe verification

| id | result |
|---|---|
| `claude --model claude-opus-5 -p` | OK — `modelUsage` reports `canonicalModel: "claude-opus-5"`, 1M context |
| `codex exec --model gpt-5.6-sol` | OK — returned `PROBE_OK` |
| `claude --model claude-fable-5 -p` | **still live** (`modelUsage: claude-fable-5`) — so removing it from routing is what makes it unreachable, not model retirement |
| `claude --model opus -p` | resolves to `claude-opus-5` **today** — the alias has caught up, but it silently meant 4.8 for days after Opus 5 shipped, so full ids are pinned regardless |

## Guard → red-test table

Every row is a real run of `scripts/tests/test_no_deprecated_models.py` (or the named self-test) against the mutated live tree.

| # | mutant | named test that goes red |
|---|---|---|
| M01 | `fable` back in a chain | `test_no_chain_names_a_deprecated_alias` |
| M02 | same, resolver path | refuses: `ValueError: routing table is invalid; refusing to resolve` |
| M03 | re-add `[models.opus]` | `test_catalog_defines_no_deprecated_alias_or_provider_id` |
| M04 | `claude-fable-5` under a fresh alias | same |
| M05 | docs chain back to haiku-led | `test_docs_chain_leads_with_sol_and_names_no_cheap_anthropic_tier` |
| M06 | drop `escalate` from research | `test_single_model_chains_terminate_explicitly` |
| M07 | arm hook back to `"model": "opus"` | `test_no_hook_uses_a_deprecated_model` |
| M08 | arm hook to any bare alias | `test_no_hook_uses_a_bare_alias` |
| M09 | dispatchable `claude-fable-5` TIER row | `test_attribution_only_rows_are_not_dispatchable` |
| M10 | TIER row back to bare `opus` | `test_top_tier_dispatch_uses_the_full_id` |
| M11 | delete the `dispatchModel` throw | `test_dispatch_model_fails_closed_on_a_non_dispatchable_tier` |
| M12 | agent frontmatter → deprecated alias | `test_no_agent_targets_a_deprecated_model` |
| **M13** | **`if: false` on the validate JOB** | `test_job_exists_and_has_no_skip_condition` |
| **M14** | **`if: false` on the self-test STEP** | `test_no_gating_step_has_a_skip_condition` |
| M15 | delete the invocation line | `test_this_suite_is_actually_invoked` |
| M16 | append `\|\| true` | `test_invocation_is_not_neutralised_by_a_trailing_true` |
| M17 | drop its own paths trigger | `test_this_file_is_a_path_trigger_on_both_triggers` |
| M18 | drop `settings.json` as a trigger | `test_routing_surfaces_are_path_triggers` |
| M19 | remove `set -euo pipefail` | `test_run_block_uses_pipefail` |
| M20 | delete the deprecation clause | `route-resolve --self-test` refuses |
| M21 | delete the fail-closed unknown-model clause | same |
| M22 | delete the haiku/sonnet clause | same |
| M23 | deprecated alias past the catalog check | `routing-validate.py` → `DEPRECATED alias` |
| M24 | deprecated alias reaches a planned row | `dispatch-plan --self-test` refuses |
| M25 | `role:impl` back to sol-first | `test_default_prefers_opus5_over_sol` |
| M26 | defaults back to sol-first | `test_defaults_chain_prefers_opus5` |
| M27 | exclude sol from `role:impl` | `test_preference_is_not_exclusion` |
| M28 | delete the gui carve-out route | `test_gui_carve_out_keeps_sol_first` |
| M29 | flip gui to opus5-first | same |
| M30 | make GUI sol-only | `test_gui_carve_out_is_preference_not_exclusion` |
| **M31** | **widen the carve-out over `area:site`** | `test_carve_out_selector_is_exactly_area_gui` |
| M32 | fold `area:gui` back into `role:site` | `test_site_surfaces_are_not_in_the_carve_out` |
| M33 | `area:gui` stops deriving `role:gui` | `triage --self-test`: `gui surface -> gui (NOT site)` |

**Measured: `SUMMARY: 33/33 mutants DIED`**, with a restore check confirming the tree returns green. M13–M19 are the YAML seam and are caught because the suite parses the workflow with `yaml.safe_load` — substring and `count(...)` assertions cannot see `if: false`.

## Still on Sonnet/Haiku — for the maintainer to decide separately

The directive scoped the cheap tiers to **docs writing**, so these non-docs roles are untouched. They are harness agent configs, not routing chains:

| agent | model | role |
|---|---|---|
| `sparq-pkg-nl` | haiku | PKG NL retrieval — measured ~30× cheaper; explicitly out of scope |
| `sparq-verify-mechanical` | haiku | mechanical verify gate |
| `sparq-context-monitor` | haiku | out-of-band context observer |
| `sparq-rust-impl` | sonnet | bulk single-crate implementation |
| `sparq-issue-sweeper` | sonnet | issue triage sweep |

Plus the cheap fleet rungs inside `fable-*.js` (recon, cross-ref, arming) and `crates/sparq-kb` literature extraction. Say the word and I'll move any of them.

`haiku`/`sonnet` stay in the `[models]` catalog (the agents above name them and registry account records list them) but hold **no routing position** — enforced.

## Test results

All green: `routing-validate` (+self-test), `route-resolve --self-test`, `ready-issues`, `dispatch-plan`, `batch-merge`, `test_readiness_visibility.py`, `test_no_deprecated_models.py`, `triage --self-test`, `bd-to-issues --self-test`.

Companion registry PR: jeswr/agent-account-registry#715.

Not armed — the orchestrator arms centrally.


---

## Fix round 2 — the `area:gui` carve-out now BINDS (review of `10845ede7`, `VERDICT: fail`)

The review was right and the finding is reproduced. Everything above the `## The area:gui carve-out`
heading stands; that section's mechanism did not. **Corrections to the claims above:** the carve-out
described there ("Selector is `area:gui` and nothing else", expressed as a `role:gui` route) was
inert — worse, inverted. New head: `c44bf00b0cc73257ea12dcbb3fe7defae6ed6c5e`.

### Measured, on the live backlog

Resolving the REAL labels of every open `area:gui` issue through `route-resolve.resolve()`:

| | first rung of the resolved chain |
|---|---|
| `10845ede7` (previous head) | `opus5` × 35 |
| `c44bf00b0` (this head) | `sol` × 34, `opus5` × 1 |

The one remaining `opus5` is #3757 (`role:research`, `status:deferred`) — correctly left alone; see
"both possible implementors" below. #3367 concretely: `['opus5','sol']` → `['sol','opus5']`, agent
unchanged (`sparq-rust-impl`).

### Which of the three options, and why

The review offered: (a) let `area:gui` override an explicit role, (b) relabel the 35, (c) **select on
`area:gui` directly**. Taken **(c)**.

(a) and (b) both route through a `role:gui` LABEL WRITE, and every one of those writes can fail
silently — which is the defect. (b) is also a one-time data fix that `bd-to-issues.role_for()`
(which never emits `role:gui`) would immediately start undoing. (c) needs no new label on any issue,
no relabelling, and no write at all: `resolve()` reads the `area:gui` label the issues already carry,
at plan time.

Implemented as a **chain-ORDER rule, not a route** (`route-resolve.gui_carve_out()`):

* it re-orders the chain of whatever route the issue resolves to and leaves **role and agent
  untouched** — the directive speaks only about model priority, and a `role:impl` GUI issue keeps
  `sparq-rust-impl` (the desktop GUI is Rust/Tauri, not the Next.js site);
* it fires **only when both `sol` and `opus5` are already in the chain** — the directive's own
  qualifier, *"tasks for which they are both possible implementors"*. So it cannot inject sol into
  `role:research` (`["opus5"]`, deliberately anthropic-side + escalating) and turn a stall into a
  silent cross-provider hop;
* a **security surface is returned unmodified** — `area:gui` + `area:sparq-zk` is a ZK issue first;
* the selector is the **exact label `area:gui`** and nothing else. `site*`, `surface:frontend`,
  `dashboard`, `area:guide` are all outside it (the exclusion the review confirmed already worked —
  now asserted at the deciding layer as well as in `triage.py`, and the two selectors are asserted to
  agree).

`role:gui` **was created** in `sparq-org/sparq` (it did not exist; all other `role:*` did), so the
`role:gui` route and triage's derivation are now writable — but routing no longer depends on that
write landing.

### Label writes are fail-closed

`gh issue edit --add-label` does not create a missing label; it fails, and applies nothing from that
call. Both writers ran **one edit per label** and discarded the result (`|| true` in
`triage-issue.yml`, `check=False` with the rc unread in `retriage.py`), so a failed `role:*` write
left the **successful** `status:ready` write standing.

Measured against a stubbed `gh` (role:gui absent from the repo, label-create denied), running the
step's own shell extracted from the workflow YAML:

```
OLD step (10845ede7), role:gui MISSING     exit=0   APPLIED: status:ready
NEW step, role:gui MISSING, create DENIED  exit=1   APPLIED: (nothing)
NEW step, role:gui MISSING, create ALLOWED exit=0   APPLIED: role:gui status:ready
```

Now: `ensure_label` first (restricted to the closed `role:`/`status:`/`needs:` set triage emits, so
it cannot mint an arbitrary label), the whole delta in **one all-or-nothing `gh issue edit`**, no
`|| true`, `set -euo pipefail`. `retriage.apply_labels()` does the same and **reads the return
code**; `main()` exits non-zero if any write failed.

### Guard → red-test table (round 2)

Real run of `scripts/tests/test_no_deprecated_models.py` + `route-resolve/triage/retriage/
routing-validate/dispatch-plan --self-test` as the oracle, each mutant applied to the **live tree**,
restored from a byte snapshot between runs.

| # | mutant | named test that goes red |
|---|---|---|
| N01 | delete the carve-out on the ROLE branch (the 33-issue case) | `test_area_gui_with_a_preexisting_explicit_role_is_sol_first` |
| N02 | delete it on the DEFAULTS branch (role-less GUI issue) | `test_area_gui_with_no_role_at_all_is_sol_first` |
| N03 | widen `GUI_CARVE_OUT_LABELS` over `area:site` | `test_both_gui_selectors_agree` + `route-resolve --self-test` |
| N04 | make the selector a SUBSTRING test | `test_the_selector_is_an_exact_label_not_a_substring` |
| N05 | drop the both-possible-implementors condition | `test_the_carve_out_never_injects_sol_into_a_chain_that_lacks_it` |
| N06 | flip the carve-out lead to opus5 (the original inversion) | `test_area_gui_with_a_preexisting_explicit_role_is_sol_first` |
| N07 | widen triage's `GUI_SURFACE_LABELS` over `area:site` | `test_both_gui_selectors_agree` + `triage --self-test` |
| N08 | restore `\|\| true` on the label write | `test_the_label_write_is_not_neutralised_by_a_trailing_true` |
| N09 | restore the per-label edit loop | `test_the_delta_is_written_by_a_single_all_or_nothing_edit` |
| N10 | drop `set -euo pipefail` from the triage step | `test_the_step_uses_pipefail` |
| N11 | delete the `ensure_label` creation | `test_missing_labels_are_ensured_before_the_write` |
| N12 | stop reading the edit's rc in `apply_labels` | `test_retriage_reads_the_return_code_of_its_label_write` + `retriage --self-test` |
| N13 | `retriage main()` exits 0 despite a failed write | `test_retriage_main_exits_non_zero_when_a_write_failed` |
| N14 | restore retriage's per-label add loop | `test_retriage_writes_the_delta_in_one_call` |
| N15 | drop the `scripts/triage.py` path trigger | `test_routing_surfaces_are_path_triggers` |
| N16 | widen the auto-create allowlist to any label | `test_auto_creation_is_restricted_to_the_labels_triage_emits` |
| N17 | flip the `role:gui` route to opus5-first | `test_gui_carve_out_keeps_sol_first` |

Harness output, verbatim: `SUMMARY: 17/17 mutants DIED, 0 survived`, `restore check: GREEN`.
This is **in addition to** the round-1 table above (which the reviewer independently re-derived at
28/28) — nothing there was rewritten.

`scripts/triage.py`, `scripts/retriage.py`, `scripts/route-resolve.py` and
`.github/workflows/triage-issue.yml` are now `paths:` triggers on `routing-self-tests.yml` (both
`pull_request` and `push`), asserted by `test_routing_surfaces_are_path_triggers`.

### Non-blocking notes from the review

* `_chains()` keying by route name: left as-is (cosmetic, enforcement iterates the generator).
* `sparq-docs` frontmatter vs the sol-led `role:docs` chain: left as-is; noted here so nobody
  "fixes" one to match the other.

### Test results

`routing-validate` (+self-test), `route-resolve --self-test`, `ready-issues`, `dispatch-plan`,
`batch-merge`, `test_readiness_visibility.py`, `test_no_deprecated_models.py` (56 tests),
`triage --self-test`, `retriage --self-test`, `bd-to-issues --self-test`,
`ci-close-merged-beads --self-test` — all pass locally.

Not armed — the orchestrator arms centrally.

