### PR TITLE
feat(routing): role:impl is OPUS5-ONLY + escalate (maintainer decision on registry #738); keep area:gui sol-first across it

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -124,10 +124,52 @@ escalate = true                        # consumed by dispatch: on chain-exhausti
 # Cross-provider review flips automatically: opus5-authored implementation receives codex review,
 # and vice versa — so leading with opus5 also moves the review load onto sol, which is where the
 # spare credit actually is.
+
+# [OPUS-5] `role:impl` IS OPUS5-ONLY SINCE 2026-07-26 — sol was REMOVED, not demoted.
+#
+# MAINTAINER DECISION 2026-07-26, taken on the measurement in registry #738: "Remove sol from impl
+# fallback." This is a deliberate change from PREFERENCE to EXCLUSION and it applies to `role:impl`
+# AND NOTHING ELSE. The standing directive above still governs every other route: `role:site`,
+# `role:ci` and `role:perf` keep sol as a cross-provider fallback, `role:docs` keeps its sol LEAD
+# (the separate docs-writing directive), `role:gui` keeps its sol LEAD, and the review/soundness/
+# security lanes are untouched.
+#
+# WHAT WAS MEASURED (registry #738; `worker.yml`, n=74 runs in a 3h24m window, each issue's labels
+# reconstructed AS OF its run's timestamp so the #733 role-swap cannot manufacture the result):
+#   * `role:impl` first-attempt yield, SAME route, same agent brief, same prompt:
+#     sol 7/40 = 18%, opus5 12/14 = 86%.
+#   * 4 of 4 issues where sol left the tree unchanged and opus5 later ran THAT SAME issue, opus5
+#     produced a PR (#2411 -> PR #4271, #2639 -> #4234, #3110 -> #4294, #3210 -> #4226). No
+#     counterexample in either direction.
+#   * Every issue-side axis is ~4x weaker than the model axis. opus5 converted 6/7 on its own
+#     shortest-body quartile, MEDIAN BODY LENGTH 26 CHARACTERS — so "the issues are
+#     underspecified" does not explain the gap.
+#   * Budget exhaustion is REFUTED: the longest no-diff model step in the window was 177s against a
+#     90-minute worker timeout. sol stops VOLUNTARILY at ~60s median.
+#
+# WHY EXCLUSION RATHER THAN SECOND PLACE. The registry's `select-and-claim.choose_account` walks
+# `model_chain` IN ORDER and claims the first AVAILABLE account, so a second rung is not a
+# tie-break — it is what serves the request whenever the first rung is busy. opus5 holds an account
+# ~17 minutes per run and sol clears in ~1 minute, so during any dispatch burst the low-yield rung
+# served the majority of `role:impl` work. Re-ordering could not fix that; only removal can.
+#
+# THE EXIT — the same shape `role:research` uses, for the same reason. A single-rung chain with no
+# `escalate` has NO exit: on an opus5 capacity outage the item defers, and defers again, forever,
+# with nobody notified. So this route escalates. `escalate = true` is consumed by the registry's
+# `dispatch-claim.escalate_starved` + `escalate_persist_decision`: the FIRST starved tick counts
+# `escalate-tier-starved-transient`, keeps the issue `status:deferred`, and auto-retries as capacity
+# recovers; only CONTINUOUS starvation past the bounded grace is promoted to the MACHINE-owned
+# `status:parked` soft hold, which lifts by itself when capacity returns. It is NEVER `needs:user` —
+# capacity starvation is not a human question.
+#
+# COST, STATED SO IT IS NOT A SURPRISE: this converts a fast-failing fallback into queueing pressure
+# on a slower, scarcer tier. See the PR body for the measured opus5 concurrency and the honest
+# steady-state projection.
 [[route]]
 role = "impl"
-model_chain = ["opus5", "sol"]
+model_chain = ["opus5"]
 agent = "sparq-rust-impl"
+escalate = true
 
 # [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
 # `terra`) implemented the original registry dashboard UI (jeswr/agent-account-registry e4098b9)
@@ -273,13 +315,31 @@ escalate = true
 #             so this is PREFERENCE, NOT EXCLUSION and the chain still terminates cross-provider.
 #   requires  the rule fires ONLY when the chain ALREADY contains all of these — the directive's
 #             own "tasks for which they are BOTH possible implementors" qualifier. `lead` must be
-#             one of them, which is what makes RE-ORDER the only possible effect: the preference
-#             can never INJECT sol into `role:research` (["opus5"], deliberately anthropic-side and
-#             escalating) and turn a visible stall into a silent cross-provider hop.
+#             one of them, which is what makes RE-ORDER the only effect available WITHOUT an
+#             explicit `inject_roles` opt-in: the preference can never INJECT sol into
+#             `role:research` (["opus5"], deliberately anthropic-side and escalating) and turn a
+#             visible stall into a silent cross-provider hop.
+#   inject_roles
+#             the EXACT roles for which `lead` may be ADDED to a chain that lacks it, rather than
+#             only re-ordered. Absent => none, i.e. the original re-order-only rule.
+#
+# WHY `inject_roles` IS NOW REQUIRED HERE (registry #738, 2026-07-26). Re-ordering was sufficient
+# only while every affected route still HAD sol in its chain. `role:impl` is now `["opus5"]`, and a
+# `["opus5"]` chain does not contain sol — so the both-implementors condition DECLINES and the
+# carve-out goes INERT for all 33 open `area:gui` + `role:impl` issues, resolving them opus5-only.
+# That is the exact inversion of the maintainer's one stated exception that PR #4211 fixed, and it
+# has NO SYMPTOM: both resolvers agree on the wrong answer, so the PLAN/CLAIM agreement harness
+# reports nothing. `inject_roles = ["impl"]` is what keeps `area:gui` sol-first across that edit.
+#
+# The allow-list is deliberately minimal. `role:perf` / `role:site` / `role:ci` / `role:docs` still
+# contain sol, so they take the RE-ORDER path and are absent here. The registry mechanism REFUSES to
+# parse `research` / `review` / `soundness` in this field (chain_preference.INJECT_FORBIDDEN_ROLES),
+# so the escalating single-provider lanes cannot be made cross-provider even by editing this table.
 #
 # A SECURITY-override route is exempt on both sides: `area:gui` + `area:sparq-zk` is a ZK issue
-# first, and an implementor preference must never re-order a soundness chain.
+# first, and an implementor preference must never re-order OR extend a soundness chain.
 [[chain_preference]]
-labels   = ["area:gui"]
-lead     = "sol"
-requires = ["sol", "opus5"]
+labels       = ["area:gui"]
+lead         = "sol"
+requires     = ["sol", "opus5"]
+inject_roles = ["impl"]

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -161,13 +161,17 @@ def _self_test():
 
     R = ["status:ready"]
 
-    # --- Fixture: an impl issue → fable-led chain, no escalate ------------------------------------
+    # --- Fixture: an impl issue → OPUS5-ONLY chain + escalate -------------------------------------
+    # [OPUS-5] maintainer decision 2026-07-26 on the registry #738 measurement ("Remove sol from
+    # impl fallback"): sol 18% vs opus5 86% in-cell first-attempt yield, n=74. The WHOLE chain is
+    # asserted, not its head — the planner row is what the registry's CLAIM step compares for EXACT
+    # equality, so a demoted-not-removed sol must red here too.
     impl = compute_ready([iss(1, R + ["priority:P1", "role:impl", "area:sparq-core"])])
     p_impl = plan_dispatch(impl, doc)
     chk("impl -> single row", len(p_impl), 1)
     row = p_impl[0]
-    chk("impl row", (row["role"], row["model_chain"][0], row["agent"], row["escalate"]),
-        ("impl", "opus5", "sparq-rust-impl", False))
+    chk("impl row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
+        ("impl", ["opus5"], "sparq-rust-impl", True))
     chk("impl package", row["package"], "sparq-core")
     chk("impl priority", row["priority"], 1)
 

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -70,25 +70,61 @@ DOCS_ONLY = {"terra"}
 # over a site* label is the likely future mistake and is asserted against.
 GUI_CARVE_OUT_LABELS = frozenset({"area:gui"})
 GUI_CARVE_OUT_LEAD = "sol"
+# [OPUS-5] THE ROLES WHERE THE CARVE-OUT MAY *ADD* sol BACK, not merely re-order it (registry #738).
+#
+# WHY THIS BECAME NECESSARY. The carve-out above was a pure re-ordering, and that was sufficient only
+# while every affected route still HAD sol in its chain. On 2026-07-26 the maintainer, shown the
+# measurement in registry #738 (`role:impl` first-attempt yield: sol 18% vs opus5 86%, n=74, same
+# route and same brief; 4/4 same-issue crossovers), chose "remove sol from impl fallback" — so
+# `role:impl` became `["opus5"]`. A `["opus5"]` chain does not contain sol, so the both-implementors
+# condition DECLINES and the carve-out goes inert: all 33 open `area:gui` + `role:impl` issues would
+# have resolved opus5-only. That is the exact inversion of the maintainer's one stated exception that
+# PR #4211 was written to fix, re-created by an edit two directives later and with no symptom at all
+# (both resolvers agree on the wrong answer, so the PLAN/CLAIM agreement harness cannot see it).
+#
+# So for the roles named here — and ONLY these — the carve-out ADDS its lead to a chain that lacks
+# it. The narrowing is what preserves the original invariant's purpose:
+#   * `role:research` / `role:review` / `role:soundness` are single-provider for AUTHORSHIP reasons
+#     and escalate on exhaustion; a silent cross-provider rung would hide a stall that is meant to be
+#     visible. The registry mechanism REFUSES to parse a declaration naming them
+#     (chain_preference.INJECT_FORBIDDEN_ROLES), so this is structural, not merely undeclared.
+#   * A ROLELESS issue (the `[defaults]` branch) can never be injected into: no role, nothing to
+#     authorise it, fail-closed means decline. `[defaults]` still contains sol anyway.
+#   * `role:perf` / `role:site` / `role:ci` / `role:docs` all still contain sol, so they take the
+#     RE-ORDER path and are deliberately absent here — this set is the minimum that closes the gap.
+GUI_CARVE_OUT_INJECT_ROLES = frozenset({"impl"})
 
 
-def gui_carve_out(labels, chain):
-    """Return `chain` with sol moved to the front IFF this is GUI work and both models are already
-    possible implementors of it.
+def gui_carve_out(labels, chain, role=None):
+    """Return `chain` with sol leading IFF this is GUI work and sol is a permitted implementor of it.
 
-    "for which they are BOTH possible implementors" is the directive's own qualifier, and it is
-    encoded literally: a chain that does not already contain BOTH `sol` and `opus5` is returned
-    UNCHANGED. That is what stops the carve-out from injecting sol into `role:research`
-    (`["opus5"]`, deliberately anthropic-side + escalating) or from silently rewriting a
-    single-provider chain into a cross-provider one.
+    Two modes, mirroring the registry's shared `chain_preference.apply_preferences` exactly (the
+    registry reads the `[[chain_preference]]` declaration in orchestration/routing.toml; this
+    function is the PLAN-side half, and `--self-test` asserts the two agree row by row):
 
-    Idempotent: applying it to an already-sol-first chain is a no-op.
+    * sol ALREADY in the chain -> "for which they are BOTH possible implementors" is the directive's
+      own qualifier, encoded literally: the chain must contain BOTH sol and opus5, and the result is
+      a strict PERMUTATION (re-order only).
+    * sol ABSENT -> the result is the chain with sol PREPENDED, but only when `role` is in
+      GUI_CARVE_OUT_INJECT_ROLES. `role=None` never injects. That is what keeps the carve-out alive
+      now that `role:impl` is a single-rung `["opus5"]` chain, without making `role:research`
+      (anthropic-side + escalating) quietly cross-provider.
+
+    Idempotent in both modes: applying it to an already-sol-first chain is a no-op.
     """
     if not (set(labels) & GUI_CARVE_OUT_LABELS):
         return chain
-    if not {GUI_CARVE_OUT_LEAD, "opus5"} <= set(chain):
+    if GUI_CARVE_OUT_LEAD in chain:
+        if not {GUI_CARVE_OUT_LEAD, "opus5"} <= set(chain):
+            return chain
+        return [GUI_CARVE_OUT_LEAD] + [m for m in chain if m != GUI_CARVE_OUT_LEAD]
+    if role is None or role not in GUI_CARVE_OUT_INJECT_ROLES:
         return chain
-    return [GUI_CARVE_OUT_LEAD] + [m for m in chain if m != GUI_CARVE_OUT_LEAD]
+    if "opus5" not in chain:
+        # `requires` minus the lead: the route must still offer the other model the directive names,
+        # so an unrelated single-rung chain never acquires sol.
+        return chain
+    return [GUI_CARVE_OUT_LEAD] + list(chain)
 
 
 def _chains(doc):
@@ -178,10 +214,16 @@ def resolve(labels, doc):
                 # re-order a soundness chain. area:gui + area:sparq-zk is a ZK issue first.
                 return list(r["model_chain"]), r["agent"], bool(r.get("escalate"))
         elif "role" in r and role is not None and r["role"] == role:
-            return (gui_carve_out(labels, list(r["model_chain"])), r["agent"],
+            # `role` is passed so the injection allow-list can be evaluated: adding sol to a chain
+            # that lacks it is legal only for GUI_CARVE_OUT_INJECT_ROLES. The registry's CLAIM-side
+            # mechanism receives the same value at the same point.
+            return (gui_carve_out(labels, list(r["model_chain"]), role=role), r["agent"],
                     bool(r.get("escalate")))
     d = doc.get("defaults", {})
-    return gui_carve_out(labels, list(d.get("model_chain", []))), d.get("agent"), False
+    # role is None here BY CONSTRUCTION (a roleless issue), so the defaults branch can never be
+    # injected into — passed explicitly rather than left to the parameter default.
+    return (gui_carve_out(labels, list(d.get("model_chain", [])), role=None),
+            d.get("agent"), False)
 
 
 def _self_test():
@@ -213,9 +255,16 @@ def _self_test():
     # (the opus-4.8 tail fallback was deprecated 2026-07-26), escalate
     mc, ag, esc = resolve(["role:impl", "area:sparq-zk"], doc)
     chk("impl+zk -> opus5/escalate", (mc, ag, esc), (["opus5"], "sparq-reviewer", True))
-    # plain impl -> sol-led chain (maintainer directive 2026-07-18)
+    # [OPUS-5] plain impl -> OPUS5-ONLY + escalate (maintainer decision 2026-07-26 on the registry
+    # #738 measurement: "Remove sol from impl fallback"; sol 18% vs opus5 86% in-cell, n=74). The
+    # WHOLE tuple is asserted rather than the chain head, so a future demotion of sol back to a
+    # second rung reds this instead of passing on `mc[0] == "opus5"`.
     mc, ag, esc = resolve(["role:impl", "area:sparq-core"], doc)
-    chk("impl -> opus5-led", (mc, ag, esc), (["opus5", "sol"], "sparq-rust-impl", False))
+    chk("impl -> OPUS5-ONLY, escalating", (mc, ag, esc), (["opus5"], "sparq-rust-impl", True))
+    chk("role:impl names NO openai tier at all (exclusion, not a demotion)",
+        sorted({doc["models"][m]["provider"] for m in mc}), ["anthropic"])
+    chk("role:impl ESCALATES, so a single-rung chain has a machine exit instead of deferring "
+        "forever with nobody notified", esc, True)
     # [OPUS-5] docs -> SOL-led (maintainer 2026-07-26: docs writing off haiku/sonnet onto gpt-5.6
     # sol). terra is sol's same-provider fallback; opus5 the cross-provider tail.
     chk("docs -> sol-led", resolve(["role:docs", "area:x"], doc)[0], ["sol", "terra", "opus5"])
@@ -240,12 +289,21 @@ def _self_test():
     # [OPUS-5] OPUS-5-FIRST DEFAULT + THE `area:gui` CARVE-OUT (maintainer 2026-07-26).
     # ---------------------------------------------------------------------------------------------
     # Every route where opus5 AND sol are both viable implementors must lead with opus5...
-    for _role in ("impl", "site", "ci", "perf"):
+    # `role:impl` is deliberately EXCLUDED from this loop since 2026-07-26: it is the one
+    # implementor route where sol was REMOVED rather than demoted (asserted separately above).
+    for _role in ("site", "ci", "perf"):
         mc = resolve([f"role:{_role}"], doc)[0]
         chk(f"role:{_role} prefers opus5 over sol", mc[0], "opus5")
         chk(f"role:{_role} keeps sol reachable as a fallback (preference, not exclusion)",
             "sol" in mc, True)
     chk("defaults prefer opus5 over sol", resolve(["area:sparq-core"], doc)[0][0], "opus5")
+    # ...and the EXCLUSION is scoped to exactly one role. This is the guard that reds if a future
+    # edit copies the sol removal onto a route the maintainer did not scope it to.
+    chk("role:impl is the ONLY role route with no openai rung besides the escalating lanes",
+        sorted(r for r in ("impl", "site", "gui", "ci", "perf", "docs")
+               if not any(doc["models"][m]["provider"] == "openai"
+                          for m in resolve([f"role:{r}"], doc)[0])),
+        ["impl"])
     # ...EXCEPT role:gui, which keeps the sol lead (original-builder steer, task #331).
     gui = resolve(["role:gui", "area:gui"], doc)[0]
     chk("role:gui KEEPS sol first (the carve-out)", gui[0], "sol")
@@ -255,11 +313,18 @@ def _self_test():
     # The carve-out is EXACTLY role:gui. role:site must NOT be swept into it — "GUI" reads
     # informally as covering the site surfaces, which is the likely future widening mistake.
     chk("role:site is NOT in the sol carve-out", resolve(["role:site"], doc)[0][0], "opus5")
-    # Both directions terminate: neither class can become undispatchable.
-    for _role in ("impl", "site", "ci", "perf", "gui"):
+    # Both directions terminate: neither class can become undispatchable. `role:impl` is now
+    # deliberately single-provider, so its termination guarantee is `escalate = true` (a bounded
+    # starvation ladder ending in a self-clearing machine park) rather than a cross-provider rung —
+    # asserted above and, for the GUI carve-out, immediately below.
+    for _role in ("site", "ci", "perf", "gui"):
         mc = resolve([f"role:{_role}"], doc)[0]
         chk(f"role:{_role} chain is cross-provider (cannot be starved by one provider)",
             sorted({doc["models"][m]["provider"] for m in mc}), ["anthropic", "openai"])
+    chk("role:impl is single-provider, so it MUST escalate (otherwise an opus5 outage is a silent "
+        "permanent stall)",
+        (sorted({doc["models"][m]["provider"] for m in resolve(["role:impl"], doc)[0]}),
+         resolve(["role:impl"], doc)[2]), (["anthropic"], True))
     chk("research -> opus5 only", resolve(["role:research"], doc)[0], ["opus5"])
     # review role -> opus5 + escalate
     chk("review -> opus5/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))
@@ -279,22 +344,45 @@ def _self_test():
         resolve(["area:gui", "role:impl"], doc)[1], "sparq-rust-impl")
     chk("area:gui with NO role at all -> defaults, SOL-first",
         resolve(["area:gui", "priority:P2"], doc)[0], ["sol", "opus5"])
+    # [OPUS-5] THE COLLISION BETWEEN THE TWO DIRECTIVES, as a test rather than as prose
+    # (registry #738). `role:impl` is now a SINGLE-RUNG `["opus5"]` chain, and the carve-out was a
+    # pure re-ordering — so without the `inject_roles` opt-in these 33 issues resolve opus5-only,
+    # re-inverting the maintainer's one stated exception with no symptom whatsoever (both resolvers
+    # agree on the wrong answer, so the PLAN/CLAIM agreement harness reports nothing). These three
+    # rows are the ones that red if the injection branch, the declaration, or the allow-list is
+    # deleted.
+    chk("the live role:impl route really IS single-rung (so the row above is not passing because "
+        "sol happens to still be in the chain)",
+        [r["model_chain"] for r in doc["route"] if r.get("role") == "impl"], [["opus5"]])
+    chk("a re-order-ONLY carve-out would DISARM on that chain (this is the defect being fixed)",
+        gui_carve_out({"area:gui", "role:impl"}, ["opus5"], role=None), ["opus5"])
+    chk("...and the injection allow-list is what restores it",
+        gui_carve_out({"area:gui", "role:impl"}, ["opus5"], role="impl"), ["sol", "opus5"])
+    chk("area:gui + role:impl still ESCALATES (it inherits the impl route's exit; sol is a "
+        "preference on top, not a replacement for the exit)",
+        resolve(["area:gui", "role:impl"], doc)[2], True)
     for _role in ("impl", "site", "ci", "perf", "gui"):
         mc = resolve(["area:gui", f"role:{_role}"], doc)[0]
         chk(f"area:gui + role:{_role} -> sol-first", mc[0], "sol")
         chk(f"area:gui + role:{_role} keeps opus5 reachable (preference, not exclusion)",
             "opus5" in mc, True)
     # site* is NOT GUI — the exclusion the review confirmed already works; assert it end to end too.
+    # Since 2026-07-26 the correct answer for a NON-gui role:impl issue is the OPUS5-ONLY chain, so
+    # these rows are simultaneously the "site is outside the carve-out" guard and the "injection
+    # does not leak past the exact `area:gui` selector" guard.
     for _area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
-        chk(f"{_area} + role:impl -> OPUS5-first (site is outside the carve-out)",
-            resolve([_area, "role:impl"], doc)[0], ["opus5", "sol"])
+        chk(f"{_area} + role:impl -> opus5-ONLY (site is outside the carve-out, and gets no sol)",
+            resolve([_area, "role:impl"], doc)[0], ["opus5"])
     chk("role:site + area:site -> opus5-first end to end",
         resolve(["role:site", "area:site"], doc)[0], ["opus5", "sol"])
     chk("surface:frontend is not in the carve-out",
         resolve(["surface:frontend", "role:site"], doc)[0][0], "opus5")
-    # EXACT label: a substring selector would sweep area:guide into the sol carve-out.
-    chk("area:guide does NOT false-match the carve-out",
-        resolve(["area:guide", "role:impl"], doc)[0], ["opus5", "sol"])
+    # EXACT label: a substring selector would sweep area:guide into the sol carve-out. Now that the
+    # carve-out can ADD sol, a false match is no longer merely a re-order — it would hand a
+    # deliberately excluded model back to a non-GUI issue, so these rows carry more weight.
+    for _near in ("area:guide", "area:guidance", "area:gui-toolkit", "xarea:gui", "gui"):
+        chk(f"{_near} does NOT false-match the carve-out (and is given NO sol rung)",
+            resolve([_near, "role:impl"], doc)[0], ["opus5"])
     # Security still wins, and its chain is returned UNTOUCHED by the preference rule.
     chk("area:gui + a security surface -> soundness lane, unmodified",
         resolve(["area:gui", "area:sparq-zk", "role:impl"], doc),
@@ -358,27 +446,63 @@ def _self_test():
         "INJECT a model into one that deliberately excludes it)",
         decl.get("lead") in decl.get("requires", []), True)
     chk("the declaration names no field the registry mechanism does not implement",
-        sorted(decl.keys()), ["labels", "lead", "requires"])
+        sorted(decl.keys()), ["inject_roles", "labels", "lead", "requires"])
     chk("every model the declaration names is in the live [models] catalog",
         sorted({decl.get("lead"), *decl.get("requires", [])} - set(doc.get("models", {}))), [])
+    # [OPUS-5] THE INJECTION ALLOW-LIST, pinned in BOTH directions (registry #738). Deleting
+    # `inject_roles` from the TOML reds the first row (CLAIM would stop applying the rule and GUI
+    # impl work would silently go opus5-only); widening the Python constant reds it too.
+    chk("the declared `inject_roles` equals GUI_CARVE_OUT_INJECT_ROLES",
+        sorted(decl.get("inject_roles", [])), sorted(GUI_CARVE_OUT_INJECT_ROLES))
+    chk("the declaration DOES name an inject role (a re-order-only declaration would disarm the "
+        "carve-out for every single-rung implementor chain)",
+        bool(decl.get("inject_roles")), True)
+    chk("every role in `inject_roles` is a role this table actually declares (a typo would make "
+        "the carve-out silently never fire)",
+        sorted(set(decl.get("inject_roles", []))
+               - {r["role"] for r in doc.get("route", []) if r.get("role")}), [])
+    chk("`inject_roles` names NO escalating single-provider authorship lane (the registry mechanism "
+        "refuses these at parse time; asserted here so the table cannot even propose one)",
+        sorted(set(decl.get("inject_roles", [])) & {"research", "review", "soundness"}), [])
     # BEHAVIOURAL EQUIVALENCE, not just field equality: run this module's rule and the declared
     # rule's semantics over the same rows and require identical chains. A declaration that agreed
     # field-by-field but was applied to a different set of routes would still split PLAN from CLAIM.
-    def _declared_rule(labels, chain):
+    # The `role` argument is threaded through BOTH sides — without it the comparison would only ever
+    # exercise the re-order path and the injection half would be untested on either side.
+    def _declared_rule(labels, chain, role):
         if not (set(labels) & set(decl.get("labels", []))):
             return list(chain)
-        if not set(decl.get("requires", [])) <= set(chain):
-            return list(chain)
         lead = decl.get("lead")
-        return [lead] + [m for m in chain if m != lead]
+        requires = set(decl.get("requires", []))
+        if lead in chain:
+            if not requires <= set(chain):
+                return list(chain)
+            return [lead] + [m for m in chain if m != lead]
+        if role is None or role not in set(decl.get("inject_roles", [])):
+            return list(chain)
+        if not (requires - {lead}) <= set(chain):
+            return list(chain)
+        return [lead] + list(chain)
 
     for _labels in (["area:gui", "role:impl"], ["area:gui", "role:perf"], ["area:gui"],
-                    ["area:gui", "role:research"], ["area:gui", "role:docs"],
+                    ["area:gui", "role:research"], ["area:gui", "role:review"],
+                    ["area:gui", "role:soundness"], ["area:gui", "role:gui"],
+                    ["area:gui", "role:site"], ["area:gui", "role:ci"],
+                    ["area:gui", "role:docs"],
                     ["area:site", "role:impl"], ["area:guide", "role:impl"],
                     ["area:sparq-core", "role:impl"], ["surface:frontend", "role:site"]):
-        for _chain in (["opus5", "sol"], ["opus5"], ["sol", "terra", "opus5"], ["sol", "opus5"]):
+        _role = next((lb[5:] for lb in _labels if lb.startswith("role:")), None)
+        for _chain in (["opus5", "sol"], ["opus5"], ["sol", "terra", "opus5"], ["sol", "opus5"],
+                       ["luna"], []):
             chk(f"declared rule == this module's rule for {_labels} over {_chain}",
-                _declared_rule(_labels, _chain), gui_carve_out(set(_labels), list(_chain)))
+                _declared_rule(_labels, _chain, _role),
+                gui_carve_out(set(_labels), list(_chain), role=_role))
+    # ...and the equivalence loop is NOT vacuous: at least one row must actually exercise the
+    # INJECTION branch, or the two implementations could agree by both never injecting.
+    chk("the equivalence loop exercises the injection branch",
+        (_declared_rule(["area:gui", "role:impl"], ["opus5"], "impl"),
+         gui_carve_out({"area:gui", "role:impl"}, ["opus5"], role="impl")),
+        (["sol", "opus5"], ["sol", "opus5"]))
 
     # ---------------------------------------------------------------------------------------------
     # [OPUS-5] THE DEPRECATION IS AN INVARIANT, NOT A ONE-TIME EDIT (maintainer 2026-07-26).

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -118,6 +118,12 @@ def gui_carve_out(labels, chain, role=None):
         if not {GUI_CARVE_OUT_LEAD, "opus5"} <= set(chain):
             return chain
         return [GUI_CARVE_OUT_LEAD] + [m for m in chain if m != GUI_CARVE_OUT_LEAD]
+    # HONESTY NOTE, found by mutating this very line: `role is None` is NOT the binding guard —
+    # `None not in GUI_CARVE_OUT_INJECT_ROLES` is already true for every well-formed allow-list, so
+    # deleting the `role is None` half leaves behaviour identical and no test can see it. It is kept
+    # because it states the intent at the point of decision, but the MEMBERSHIP test is what carries
+    # the property, and that is what the assertions pin. (Same shape as the note in the registry's
+    # no_change_routing.excluded_tiers.)
     if role is None or role not in GUI_CARVE_OUT_INJECT_ROLES:
         return chain
     if "opus5" not in chain:

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -759,20 +759,48 @@ class TestWorkflowWiring(unittest.TestCase):
                       "this suite is never RUN — its assertions are dead in CI")
 
     def test_invocation_is_not_neutralised_by_a_trailing_true(self):
-        """MUTANT: append `|| true` to the invocation => RED. Exit-zero swallowing has bitten this
-        repo three times in one day; a guard whose failure is discarded is not a guard."""
-        runs = "\n".join(s["run"] for s in self._run_steps())
-        for line in runs.splitlines():
-            if "test_no_deprecated_models.py" in line:
+        """MUTANT: append `|| true` to ANY invocation in this workflow => RED.
+
+        [OPUS-5] WIDENED, found by mutation. This test previously matched only the line invoking
+        THIS suite, so `python3 scripts/route-resolve.py --self-test || true` — which silently
+        discards the entire routing-resolver contract, including the `area:gui` carve-out and the
+        role:impl chain — SURVIVED. Exit-zero swallowing has bitten this repo repeatedly; the
+        assertion has to cover every gating invocation in the job, not just this file's own."""
+        checked = 0
+        for step in self._run_steps():
+            for line in step["run"].splitlines():
+                stripped = line.strip()
+                if not stripped.startswith("python3 "):
+                    continue
+                checked += 1
                 self.assertNotRegex(
-                    line.strip(), r"(\|\|\s*true|;\s*true|\|\|\s*:)\s*$",
-                    "the guard's exit status is discarded")
+                    stripped, r"(\|\|\s*true|;\s*true|\|\|\s*:)\s*$",
+                    f"the exit status of `{stripped}` is discarded")
+        self.assertGreater(checked, 5,
+                           "no invocations were inspected — the run blocks were not parsed")
+
+    def test_the_routing_contract_scripts_are_actually_invoked(self):
+        """[OPUS-5] A guard nobody runs cannot go red. The routing change of registry #738 lives in
+        `orchestration/routing.toml` + `scripts/route-resolve.py`, and its assertions live in those
+        scripts' own `--self-test`s — so this gate must invoke each of them.
+
+        MUTANT: delete any of these invocation lines (or the whole step) => RED."""
+        runs = "\n".join(s["run"] for s in self._run_steps())
+        for invocation in ("python3 scripts/routing-validate.py --self-test",
+                           "python3 scripts/route-resolve.py --self-test",
+                           "python3 scripts/dispatch-plan.py --self-test",
+                           "python3 scripts/tests/test_no_deprecated_models.py"):
+            self.assertIn(invocation, runs, f"`{invocation}` is never RUN in this gate")
+        self.assertRegex(runs, r"(?m)^\s*python3 scripts/routing-validate\.py\s*$",
+                         "the validator must also run against the LIVE routing.toml, not only "
+                         "against its own fixtures")
 
     def test_run_block_uses_pipefail(self):
-        """Without `set -euo pipefail` a failing early command does not fail the step."""
+        """Without `set -euo pipefail` a failing early command does not fail the step. Applied to
+        EVERY run step in the gating job, not only the one invoking this suite."""
         for step in self._run_steps():
-            if "test_no_deprecated_models.py" in step["run"]:
-                self.assertIn("set -euo pipefail", step["run"])
+            self.assertIn("set -euo pipefail", step["run"],
+                          f"run step {step.get('name', '<unnamed>')!r} lacks pipefail")
 
     def test_this_file_is_a_path_trigger_on_both_triggers(self):
         """MUTANT: drop the paths entry => this suite stops running on its own PRs => RED.

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -157,9 +157,16 @@ class TestProviderPreference(unittest.TestCase):
     A preference expressed purely as chain ORDER decays exactly this way, so the order is pinned.
     """
 
-    # The routes where opus5 and sol are BOTH viable implementors. role:docs is excluded: the
-    # separate 2026-07-26 docs-writing directive puts sol first there deliberately.
-    OPUS5_FIRST_ROLES = ("impl", "site", "ci", "perf")
+    # The routes where opus5 and sol are BOTH viable implementors and the preference is expressed
+    # as ORDER. role:docs is excluded: the separate 2026-07-26 docs-writing directive puts sol first
+    # there deliberately. role:impl is excluded because it is no longer a preference at all — see
+    # OPUS5_ONLY_ROLES.
+    OPUS5_FIRST_ROLES = ("site", "ci", "perf")
+    # [OPUS-5] registry #738 (maintainer decision 2026-07-26: "Remove sol from impl fallback"). The
+    # routes where sol is EXCLUDED, not merely outranked. Measured in-cell `role:impl` first-attempt
+    # yield: sol 7/40 = 18% vs opus5 12/14 = 86%, n=74, same route and same brief; 4/4 same-issue
+    # crossovers; budget exhaustion refuted (longest no-diff model step 177s vs a 90-minute timeout).
+    OPUS5_ONLY_ROLES = ("impl",)
     GUI_ROLE = "gui"
 
     @classmethod
@@ -180,10 +187,48 @@ class TestProviderPreference(unittest.TestCase):
         self.assertEqual(self.doc["defaults"]["model_chain"][0], "opus5")
 
     def test_preference_is_not_exclusion(self):
-        """sol must stay REACHABLE on non-GUI work. MUTANT: drop sol from a chain => RED."""
+        """sol must stay REACHABLE on the ORDER-preference routes. MUTANT: drop sol from one of
+        these chains => RED. `role:impl` is deliberately NOT in this set since 2026-07-26."""
         for role in self.OPUS5_FIRST_ROLES:
             self.assertIn("sol", self.routes[role]["model_chain"],
                           f"role:{role}: sol must remain a fallback, not be excluded")
+
+    def test_impl_route_is_opus5_only(self):
+        """[OPUS-5] registry #738 — the EXCLUSION, asserted as a whole-chain equality rather than a
+        head check so demoting sol back to a second rung reds this too.
+
+        MUTANT: restore ["opus5", "sol"] on role:impl => RED."""
+        for role in self.OPUS5_ONLY_ROLES:
+            chain = self.routes[role]["model_chain"]
+            self.assertEqual(chain, ["opus5"],
+                             f"role:{role} must be opus5-ONLY (maintainer 2026-07-26: remove sol "
+                             f"from impl fallback)")
+            providers = {self.doc["models"][m]["provider"] for m in chain}
+            self.assertEqual(providers, {"anthropic"},
+                             f"role:{role} must name no openai tier at all")
+
+    def test_impl_exclusion_comes_with_an_exit(self):
+        """A single-rung chain with no `escalate` has NO exit: on an opus5 capacity outage the item
+        defers, and defers again, forever, with nobody notified. Deprecating a fallback has to come
+        with an exit — the same shape role:research uses.
+
+        MUTANT: delete `escalate = true` from the role:impl route => RED."""
+        for role in self.OPUS5_ONLY_ROLES:
+            self.assertTrue(self.routes[role].get("escalate"),
+                            f"role:{role} is single-provider and single-rung, so it MUST escalate")
+
+    def test_the_exclusion_is_scoped_to_the_roles_the_maintainer_named(self):
+        """The directive removed sol from `role:impl` and nothing else. This is the guard that reds
+        if a future edit copies the exclusion onto another implementor route (or onto docs/gui).
+
+        MUTANT: drop sol from role:site / role:perf / role:ci / role:gui / role:docs => RED."""
+        excluded = sorted(
+            role for role, r in self.routes.items()
+            if role in ("impl", "site", "ci", "perf", "gui", "docs")
+            and not any(self.doc["models"][m]["provider"] == "openai"
+                        for m in r["model_chain"]))
+        self.assertEqual(excluded, sorted(self.OPUS5_ONLY_ROLES),
+                         "exactly the roles in OPUS5_ONLY_ROLES may lack an openai rung")
 
     def test_gui_carve_out_keeps_sol_first(self):
         """MUTANT: delete the role:gui route, or flip it to opus5-first => RED."""
@@ -199,7 +244,9 @@ class TestProviderPreference(unittest.TestCase):
 
     def test_every_preference_chain_terminates_cross_provider(self):
         """Both directions must terminate: a chain naming only ONE provider can be starved by that
-        provider's outage with no other rung to fall to."""
+        provider's outage with no other rung to fall to. `role:impl` is excluded since 2026-07-26 —
+        it is deliberately single-provider and its termination guarantee is `escalate = true`
+        (test_impl_exclusion_comes_with_an_exit), not a cross-provider rung."""
         for role in self.OPUS5_FIRST_ROLES + (self.GUI_ROLE,):
             chain = self.routes[role]["model_chain"]
             providers = {self.doc["models"][m]["provider"] for m in chain}
@@ -333,14 +380,90 @@ class TestLabelsToModelChain(unittest.TestCase):
         self.assertEqual(self.rr.resolve(["area:gui", "area:sparq-zk", "role:impl"], self.doc),
                          (["opus5"], "sparq-reviewer", True))
 
-    def test_the_carve_out_never_injects_sol_into_a_chain_that_lacks_it(self):
+    def test_the_carve_out_never_injects_sol_into_an_authorship_pinned_chain(self):
         """The directive's own qualifier is "tasks for which they are BOTH possible implementors".
-        `role:research` is deliberately anthropic-side + escalating; the carve-out must leave it
-        alone rather than quietly making it cross-provider (which would hide the stall).
-        MUTANT: drop the both-in-chain condition => RED."""
-        chain, _agent, escalate = self.rr.resolve(["area:gui", "role:research"], self.doc)
-        self.assertEqual(chain, ["opus5"])
-        self.assertTrue(escalate)
+        `role:research` / `role:review` / `role:soundness` are deliberately anthropic-side +
+        escalating; the carve-out must leave them alone rather than quietly making one
+        cross-provider, which would hide a stall that is meant to be visible.
+
+        Since 2026-07-26 the carve-out CAN add sol back (see the tests below), so this is no longer
+        implied by a blanket both-in-chain condition — it is enforced by the `inject_roles`
+        allow-list, and the registry mechanism refuses to even parse these roles in that field.
+        MUTANT: add "research" to GUI_CARVE_OUT_INJECT_ROLES => RED."""
+        for role in ("research", "review", "soundness"):
+            chain, _agent, escalate = self.rr.resolve(["area:gui", f"role:{role}"], self.doc)
+            self.assertEqual(chain, ["opus5"],
+                             f"role:{role} must stay single-provider under area:gui")
+            self.assertTrue(escalate, f"role:{role} must still escalate")
+        self.assertEqual(
+            sorted(set(self.rr.GUI_CARVE_OUT_INJECT_ROLES)
+                   & {"research", "review", "soundness"}), [],
+            "no authorship-pinned escalating lane may be in the injection allow-list")
+
+    def test_gui_impl_work_survives_the_single_rung_impl_chain(self):
+        """[OPUS-5] THE HEADLINE GUARD OF registry #738's ROUTING CHANGE.
+
+        `role:impl` is now `["opus5"]`. The `area:gui` carve-out was a pure RE-ORDERING, so on a
+        chain that no longer contains sol its both-implementors condition declines and the carve-out
+        goes INERT — all 33 open `area:gui` + `role:impl` issues would resolve opus5-only, which is
+        the exact inversion of the maintainer's one stated exception that PR #4211 fixed. And it has
+        NO symptom: PLAN and CLAIM agree on the wrong answer, so the cross-resolver agreement
+        harness reports nothing.
+
+        MUTANT (any of these) => RED:
+          * delete `inject_roles` from the `[[chain_preference]]` block in routing.toml
+          * delete the injection branch from `route-resolve.gui_carve_out`
+          * remove "impl" from `GUI_CARVE_OUT_INJECT_ROLES`
+        """
+        impl_route = next(r for r in self.doc["route"] if r.get("role") == "impl")
+        self.assertEqual(impl_route["model_chain"], ["opus5"],
+                         "precondition: this guard is only meaningful on a single-rung impl chain")
+        for labels in (["area:gui", "role:impl"],
+                       ["area:gui", "role:impl", "priority:P2"],
+                       ["area:gui", "role:impl", "area:sparq-gui"]):
+            self.assertEqual(self.chain(labels), ["sol", "opus5"],
+                             f"{labels} must stay SOL-FIRST (maintainer: GUI keeps sol)")
+        self.assertEqual(self.rr.resolve(["area:gui", "role:impl"], self.doc)[1],
+                         "sparq-rust-impl",
+                         "the carve-out re-orders/leads the chain and never re-routes the agent")
+
+    def test_the_injection_allow_list_is_declared_in_the_table_not_only_in_python(self):
+        """CLAIM re-derives the route from the routing TOML with registry-owned code and
+        `_route_matches` demands EXACT chain equality. An allow-list that existed only in this
+        repo's Python would make every `area:gui` + `role:impl` issue defer `route-policy-failed`
+        on every tick, forever — the #4211 failure mode.
+
+        MUTANT: delete `inject_roles` from routing.toml, or widen the Python constant => RED."""
+        declared = self.doc.get("chain_preference", [])
+        self.assertEqual(len(declared), 1, "exactly one chain preference is declared")
+        self.assertEqual(sorted(declared[0].get("inject_roles", [])),
+                         sorted(self.rr.GUI_CARVE_OUT_INJECT_ROLES),
+                         "the TOML declaration and the resolver constant must not drift")
+        self.assertTrue(declared[0].get("inject_roles"),
+                        "a re-order-only declaration disarms the carve-out on a single-rung chain")
+        declared_roles = {r["role"] for r in self.doc.get("route", []) if r.get("role")}
+        self.assertLessEqual(set(declared[0]["inject_roles"]), declared_roles,
+                             "every inject_roles entry must name a role this table declares — a "
+                             "typo would make the carve-out silently never fire")
+
+    def test_injection_is_scoped_to_the_exact_gui_label(self):
+        """The carve-out can now hand back a model the impl route deliberately excludes, so a
+        false-matching selector is worse than a re-order: it would give sol to non-GUI work.
+
+        MUTANT: make the selector a substring test => RED (area:guide would gain a sol rung)."""
+        for near in ("area:guide", "area:guidance", "area:gui-toolkit", "kind:guidance",
+                     "area:site", "surface:frontend", "dashboard"):
+            self.assertEqual(self.chain([near, "role:impl"]), ["opus5"],
+                             f"{near} is not area:gui and must be given NO sol rung")
+
+    def test_a_roleless_gui_issue_is_never_injected_into(self):
+        """`role=None` (the `[defaults]` branch) has no role to check against the allow-list, so it
+        must decline. The live defaults chain still contains sol, so it is sol-first by re-order —
+        the assertion that carries the property is the direct one on `gui_carve_out`.
+
+        MUTANT: drop the `role is None` clause => RED."""
+        self.assertEqual(self.chain(["area:gui", "priority:P2"]), ["sol", "opus5"])
+        self.assertEqual(self.rr.gui_carve_out({"area:gui"}, ["opus5"], role=None), ["opus5"])
 
     def test_gui_docs_keep_the_docs_route(self):
         """Docs writing already leads with sol by the separate directive; the carve-out must not
@@ -355,6 +478,19 @@ class TestLabelsToModelChain(unittest.TestCase):
             self.assertEqual(self.chain([f"role:{role}", "area:sparq-core", "priority:P1"])[0],
                              "opus5")
         self.assertEqual(self.chain(["area:sparq-core", "priority:P1"])[0], "opus5")
+
+    def test_non_gui_impl_work_gets_no_sol_rung_end_to_end(self):
+        """[OPUS-5] registry #738, at the deciding layer: a plain `role:impl` issue resolves to the
+        WHOLE opus5-only chain. Asserted as an equality rather than a head check, because the defect
+        this replaces (sol serving the majority of impl work) came from the SECOND rung, not the
+        first — a head-only assertion cannot see it.
+
+        MUTANT: restore sol as a second rung on role:impl => RED."""
+        for area in ("area:sparq-core", "area:sparq-engine", "area:orchestration"):
+            self.assertEqual(self.chain(["role:impl", area, "priority:P1"]), ["opus5"],
+                             f"role:impl + {area} must resolve to the opus5-only chain")
+        self.assertTrue(self.rr.resolve(["role:impl", "area:sparq-core"], self.doc)[2],
+                        "and it must escalate, so a capacity outage is not a silent stall")
 
 
 class TestLabelWritesAreFailClosed(unittest.TestCase):


### PR DESCRIPTION
> 🤖 **SPARQ agent**

**Maintainer decision, 2026-07-26:** presented with the measurement in `jeswr/agent-account-registry#738`, the maintainer chose **"Remove sol from impl fallback."** This is the sparq half.

> ⚠️ **MERGE ORDERING — this PR must merge AFTER jeswr/agent-account-registry#742.** Merging it first is a **total sparq dispatch outage**, not a degraded carve-out. Measured evidence below.

## What changes

| route | before | after |
|---|---|---|
| `role:impl` | `["opus5", "sol"]` | **`["opus5"]` + `escalate = true`** |
| `[[chain_preference]]` (`area:gui`) | re-order only | **+ `inject_roles = ["impl"]`** |
| `role:gui`, `role:site`, `role:ci`, `role:perf`, `role:docs`, `role:research`, `role:review`, `role:soundness`, every `match_labels` security route, `[defaults]` | — | **unchanged** |

## The evidence (registry #738), so this can be sanity-checked rather than trusted

`worker.yml`, **n=74** runs in a 3h24m window, each issue's labels reconstructed **as of its run's timestamp** so #733's `role:impl`→`role:research` swap cannot manufacture the result:

* **`role:impl` first-attempt yield, same route and same agent brief: sol 7/40 = 18%, opus5 12/14 = 86%.**
* **4 of 4** issues where sol left the tree unchanged and opus5 later ran *that same issue* → opus5 produced a PR (#2411→#4271, #2639→#4234, #3110→#4294, #3210→#4226). No counterexample either way.
* Every issue-side axis is ~**4× weaker** than the model axis. opus5 converted **6/7 on its own shortest-body quartile, median body length 26 characters** — "the issues are underspecified" does not explain the gap.
* **Budget exhaustion is refuted:** longest no-diff model step **177 s** against a **90-minute** timeout. sol stops *voluntarily*, ~60 s median.

**Why exclusion rather than second place.** The registry's `select-and-claim.choose_account` walks `model_chain` **in order** and claims the first *available* account. A second rung is not a tie-break — it is what serves the request whenever the first rung is busy. opus5 holds an account ~19 min; sol clears in ~2 min. During any burst the 18% rung served the majority of impl work. Re-ordering could not fix that; only removal can.

## Chain ordering, and why

`["opus5"]` — one rung, so there is no ordering question left inside the chain. What *is* a decision is the exit: **`escalate = true`**, mirroring `role:research`. A single-rung chain without it has **no exit at all** — on an opus5 capacity outage the item defers, and defers again, forever, with nobody notified.

The registry consumes it as: first starved tick → counter `escalate-tier-starved-transient`, `status:deferred`, auto-retries, one ops alert; continuous starvation past 30 min → machine-owned `status:parked` that **lifts by itself** when capacity returns; **never `needs:user`**. Both counters are distinct from the generic `no-eligible-account`, so a starved impl frontier cannot hide inside it. Verified against this table in `dispatch-claim --self-test` (registry #742).

## THE COLLISION THIS ALSO FIXES — read this part

**Nobody asked for this and the decision did not anticipate it, so it is called out rather than buried.**

The `area:gui` carve-out (#4211) is a chain **RE-ORDERING**: `gui_carve_out` / `chain_preference.apply_preferences` fire only when the resolved chain **already contains `sol`**. A single-rung `["opus5"]` impl chain therefore **DISARMS it** — and all **33** open `area:gui` + `role:impl` issues carry an explicit `role:impl`, so they would have resolved **opus5-only**. That is the exact inversion of the maintainer's one stated exception ("except GUI work where sol should remain prioritised") that #4211 was written to fix, re-created by an unrelated edit two directives later.

**And it has no symptom.** PLAN and CLAIM would agree on the *wrong* answer, so the cross-resolver agreement harness reports nothing. There is no defer counter, no error, no annotation. It is now a test on both sides:

```
ok  a re-order-ONLY carve-out would DISARM on that chain (this is the defect being fixed)
ok  ...and the injection allow-list is what restores it
```

**Decision taken** (per `proceed-and-document`, rather than stalling on a greenlight): the carve-out declaration gains **`inject_roles = ["impl"]`** — for that role, and only that role, `sol` is **added** to a chain that lacks it rather than merely moved to the front. Alternatives, and why each was rejected:

* *Leave it.* Knowingly re-inverts the GUI directive for 33 issues. Rejected.
* *Relabel the 33 issues `role:impl` → `role:gui`.* Needs an ops sweep; changes their agent from `sparq-rust-impl` to `sparq-site`, and the desktop GUI is **Rust/Tauri, not the Next.js site** — a point the #4211 review made explicitly; regresses on the next `bd-to-issues` batch (`role_for()` never emits `role:gui`); and leaves a window where GUI work is opus5-only. Rejected.
* *`match_labels = ["area:gui"]`.* `match_labels` is **substring**, so it false-matches `area:guide` / `area:guidance`; and the review lane's arm-side classifier unions every `match_labels` keyword, which would **human-arm every GUI PR**. Already rejected twice in-tree for exactly this reason. Rejected.

**What keeps the original no-injection invariant's purpose intact:**

* **Off by default** — absent `inject_roles` is byte-identical to the previous re-order-only behaviour.
* **`research` / `review` / `soundness` are refused at PARSE time** by the registry mechanism (`chain_preference.INJECT_FORBIDDEN_ROLES`). Those routes are single-provider for *authorship* reasons and escalate on exhaustion; a silent cross-provider rung would hide a stall that is meant to be visible. This table cannot even propose it.
* **A roleless issue can never be injected into** (`role=None`, the `[defaults]` branch).
* **`requires` minus the lead is still enforced** — an unrelated single-rung chain never acquires `sol`.
* **Security routes are still returned unmodified**, and `area:gui` + `area:sparq-zk` is still a ZK issue first.
* The selector is still **exactly `area:gui`**, and that now matters *more*: a false match would hand back a model the impl route deliberately excludes, not merely reorder one. Pinned for `area:guide`, `area:guidance`, `area:gui-toolkit`, `xarea:gui`, `gui`, `area:site*`, `surface:frontend`, `dashboard`.

`role:perf` / `role:site` / `role:ci` / `role:docs` all still contain `sol`, so they take the re-order path and are deliberately **absent** from the allow-list. It is the minimum that closes the gap.

## Merge ordering — measured, not argued

`parse_preferences` **refuses** a `[[chain_preference]]` block containing an unknown field, and the registry's CLAIM step parses it on **every** route resolution. So this table landing first does not half-apply the carve-out — it refuses **all** routing:

```
$ # OLD registry (origin/master) CLAIM  vs  THIS branch's table
$ python3 scripts/cross-resolver-agreement.py --target-root <this branch>
::error::PLAN and CLAIM disagree on 22 of 22 routing cases ... every affected issue would
         defer `route-policy-failed` on EVERY tick
DISAGREE a plain crate area + role:impl ['area:sparq-core', 'role:impl']
  PLAN : ('routed', (['opus5'], 'sparq-rust-impl', True))
  CLAIM: ('refused', '')
DISAGREE no labels at all []
  PLAN : ('routed', (['opus5', 'sol'], 'sparq-rust-impl', False))
  CLAIM: ('refused', '')
   ... 22/22
$ echo $?
1
```

With registry#742 merged, both directions are clean:

```
$ # NEW registry CLAIM  vs  sparq origin/main (today's undeclared table) — the no-op end
agreement OK: PLAN and CLAIM derive identical routes for all 22 cases
$ # NEW registry CLAIM  vs  THIS branch
agreement OK: PLAN and CLAIM derive identical routes for all 22 cases
```

The two repos' `role:impl` chains do **not** need to equal each other — `_route_matches` demands exact equality between the PLAN and CLAIM derivations *for one target repo*, and each repo's own table governs its own issues.

## Capacity: measured, and the honest steady-state projection

The #738 diagnosis observed "6 anthropic accounts, mean concurrency ~2.6" and **did not know the per-account cap**. Measured 2026-07-26 ~21:21 UTC:

* **The per-account cap exists and binds:** `max_concurrent_workers = 4` on every anthropic record (`select-and-claim._choose_account_model`). Three accounts sat at exactly 4 in the window; none exceeded it.
* **sparq's pool: 7 opus5-capable accounts × 4 = 28 concurrent slots.** The repo-level `max_concurrent = 40` is **slack**. `sol` is served by **exactly one** account (cap 12).
* **Lease-hold duration** (the correct measure — an Actions *run* brackets the lease): opus5 success **1162 s median (19.4 min)**, `no_change` 192 s; sol `no_change` **103 s**. #738's "~17 min for opus5" is **verified**; its "~1 min for sol" is right for the *model step* (38 s) but understates *slot* cost ~2×. Honest slot ratio: **11.6×**, not ~17×.
* **Observed anthropic lease concurrency:** mean **4.44 / 28 = 16%**, p90 9, max 16 (57%).
* **Ceiling:** ~**92–99 opus5 worker runs/hour** against **16.3 runs/hour** actually dispatched — **~5.7× headroom at the mean.**

**Does capacity bind? At the mean, no — the ~78% projection survives.** The window's 43 sol impl dispatches rerun on opus5 need **+3.6 concurrent slots**, taking mean anthropic utilisation from **16% to ~29–34%**. An independent reconstruction of #738's arithmetic lands at **81%**.

**Expected steady-state `role:impl` throughput:**

| | impl dispatch | impl yield | **PRs/hr** |
|---|---:|---:|---:|
| current mixed tier | 10.6–15.9/hr | 35% | **3.7 – 5.6** |
| **sol removed (this PR)** | 10.6–15.9/hr | 86% | **9.1 – 13.7** |

≈ **2.5× more `role:impl` PRs/hour for the same dispatch rate.**

**Where the projection can still be wrong — stated because the decision was made on a projection:**

1. **Burstiness, not the mean.** Measured peak/mean anthropic concurrency is **3.6×**; applied to a 8.0–9.4 mean that projects intra-window peaks of **29–34 slots against a 28 ceiling**. The peak hour dispatched **70** worker runs — all on opus5 that is ~**23 of 28 slots (82%)** sustained for an hour. **Capacity will bind at peaks.** The cost is latency (deferred claim retries next tick, ~10 min), not lost throughput, provided the mean stays well under 100%.
2. **The ceiling is sensitive to hold time, and hold time is what this change moves.** At the observed *maximum* opus5 hold (3003 s) the ceiling falls from 99 to **34 runs/hr**. Removing sol hands opus5 the harder tail sol declined, so its mean hold may rise. **Re-measure after this lands** rather than assuming 1015 s.
3. **Against the 60/60 goal:** 60 impl runs/hr all on opus5 needs ~**22 of 28 slots (79%)** — reachable, with no burst headroom. Two anthropic accounts (acct03/acct06) are recorded as retired with cancelled credentials; re-enrolling replacements restores 36 slots and takes that to 61%.
4. **The defer counter cannot settle "did capacity bind?" in either direction** — `claim()` distinguishes four reasons and the dispatcher collapses all four into `no-eligible-account`. Follow-up filed on the registry.

## Test obligations → red-on-mutation

Every guard was mutated **in a fresh copy of the live tree** and the enrolled suites re-run. **23 of 24 killed.** Actual output (sparq mutants; the registry half is in registry#742):

```
S1 drop inject_roles from routing.toml                   KILLED   red: route-resolve.py, test_no_deprecated_models.py
S2 delete gui_carve_out injection branch                 KILLED   red: route-resolve.py, test_no_deprecated_models.py
S3 restore sol as the impl 2nd rung                      KILLED   red: dispatch-plan.py, route-resolve.py, test_no_deprecated_models.py
S4 drop escalate from the impl route                     KILLED   red: dispatch-plan.py, route-resolve.py, test_no_deprecated_models.py
S5 widen INJECT_ROLES to include research                KILLED   red: route-resolve.py, test_no_deprecated_models.py
S6 drop the role-is-None clause                          SURVIVED (VACUOUS GUARD)
S6b delete the WHOLE allow-list guard (the binding half) KILLED   red: route-resolve.py, test_no_deprecated_models.py
S7 stop passing role= at the resolve call site           KILLED   red: route-resolve.py, test_no_deprecated_models.py
S8 drop the requires-minus-lead check                    KILLED   red: route-resolve.py
S9 YAML: if:false on the validate job                    KILLED   red: test_no_deprecated_models.py
S10 YAML: drop the routing.toml PR path trigger          KILLED   red: test_no_deprecated_models.py
S11 YAML: || true on the route-resolve invocation        KILLED   red: test_no_deprecated_models.py
S12 YAML: delete the route-resolve invocation entirely   KILLED   red: test_no_deprecated_models.py
S13 YAML: drop pipefail from the gating step             KILLED   red: test_no_deprecated_models.py
S14 YAML: drop the route-resolve.py path trigger         KILLED   red: test_no_deprecated_models.py
```

**The one survivor is reported, not hidden.** `S6` — deleting the `role is None` half of the injection guard — changes nothing, because `None not in GUI_CARVE_OUT_INJECT_ROLES` is already true for any well-formed allow-list. The clause is redundant with its own sibling; its *binding* half (`S6b`) is killed. `scripts/route-resolve.py` now carries an explicit honesty note at the point of decision, in the same shape as the existing note in the registry's `no_change_routing.excluded_tiers`, and the roleless contract is pinned behaviourally rather than via that clause.

**Two of these mutants are findings, not confirmations:**

* **S11 originally SURVIVED — a real YAML-seam hole.** `test_invocation_is_not_neutralised_by_a_trailing_true` matched only the line invoking its *own* suite, so appending `|| true` to `python3 scripts/route-resolve.py --self-test` — which silently discards the entire routing-resolver contract, including the `area:gui` carve-out and this PR's chain change — **passed**. It now inspects every `python3 ` invocation in the gating job's run blocks, asserts a non-zero number were inspected, requires `set -euo pipefail` on **every** run step rather than only the one running this file, and names the four routing invocations the gate must actually make. **S11/S12/S13 are killed only because of that widening.** This is the exact class the repo has been bitten by three times in one day.
* **S1's first run was a false SURVIVED** — the mutation pattern also occurs inside a comment, so `str.replace(…, 1)` edited prose rather than the declaration. Corrected; it kills.

### The YAML seam, structurally

Covered by the existing `TestWorkflowWiring` class in `scripts/tests/test_no_deprecated_models.py`, which parses `routing-self-tests.yml` as **YAML, not substrings** — job `if:`, per-step `if:`, `merge_group` presence, advisory-name check, path triggers on **both** `pull_request` and `push` — now extended by the two widened guards above. Mutants S9/S10/S11/S12/S13/S14 exercise it and all six are killed.

## Guard → named test

| guard | named test | reds when |
|---|---|---|
| `role:impl` resolves to `["opus5"]` (PLAN) | `route-resolve` "impl -> OPUS5-ONLY, escalating" (whole tuple) | S3 |
| `role:impl` resolves to `["opus5"]` (planner row) | `dispatch-plan` "impl row" (whole chain, not the head) | S3 |
| … end to end from labels | `test_non_gui_impl_work_gets_no_sol_rung_end_to_end` | S3 |
| the exclusion is scoped to `role:impl` | `test_the_exclusion_is_scoped_to_the_roles_the_maintainer_named`; `route-resolve` "the ONLY role route with no openai rung…" | copying it elsewhere |
| single-rung ⇒ has an exit | `test_impl_exclusion_comes_with_an_exit`; `route-resolve` "role:impl is single-provider, so it MUST escalate" | S4 |
| **`area:gui` still resolves sol-first** | `test_gui_impl_work_survives_the_single_rung_impl_chain`; `route-resolve` "area:gui + an explicit role:impl -> SOL-first (the 33-issue case)" | S1, S2, S6b |
| the collision is real (as a test) | `route-resolve` "a re-order-ONLY carve-out would DISARM on that chain" | — |
| the allow-list is declared in the TABLE, not only Python | `test_the_injection_allow_list_is_declared_in_the_table_not_only_in_python` | S1 |
| the declaration ⇔ resolver constant cannot drift | `route-resolve` "the declared `inject_roles` equals GUI_CARVE_OUT_INJECT_ROLES" + the behavioural-equivalence loop (14 label sets × 6 chains, `role` threaded through both sides) + "the equivalence loop exercises the injection branch" | S1, S5, S7 |
| research/review/soundness never injected | `test_the_carve_out_never_injects_sol_into_an_authorship_pinned_chain` | S5 |
| roleless never injected | `test_a_roleless_gui_issue_is_never_injected_into` | — (documented redundancy) |
| exact selector under injection | `test_injection_is_scoped_to_the_exact_gui_label`; `route-resolve` "{area:guide,…} does NOT false-match … and is given NO sol rung" | widening the selector |
| `requires` minus lead still enforced | `route-resolve` (S8 target) | S8 |
| `area:gui` + `role:impl` keeps its agent | `route-resolve` "…keeps its implementor agent (carve-out re-orders, never re-routes)" | re-routing to `sparq-site` |
| the gate actually runs the resolvers | `test_the_routing_contract_scripts_are_actually_invoked` | S12 |
| no invocation's exit status is discarded | `test_invocation_is_not_neutralised_by_a_trailing_true` (widened) | S11 |
| every gating step uses pipefail | `test_run_block_uses_pipefail` (widened to all steps) | S13 |

## Suites run — actual results, red included

The verbatim `routing-self-tests.yml` run block, locally:

```
routing-validate --self-test        ok
routing-validate (live table)       routing.toml OK
route-resolve --self-test           PASSED
ready-issues --self-test            PASSED
dispatch-plan --self-test           PASSED
batch-merge --self-test             [self-test] all checks passed
tests/test_readiness_visibility.py  OK
tests/test_no_deprecated_models.py  Ran 65 tests ... OK
pr-area-labels --self-test          OK
tests/test_pr_area_labels.py        OK
bd-to-issues --self-test            PASSED
ci-close-merged-beads --self-test   PASSED
triage --self-test                  PASSED
```

**Nothing red.** `actionlint` reports **30 findings on this branch and 30 on `origin/main`** — identical, i.e. wholly pre-existing; this diff touches no workflow YAML. There is no `flake8`/`ruff` lane in this repo's gate. No Rust crate is touched, so the compile/clippy/coverage lanes are unaffected — the full `gate` aggregator must still confirm on CI.

## Explicitly untouched

`role:gui` keeps its **sol lead**. `role:site`, `role:ci`, `role:perf` keep sol as a cross-provider fallback. `role:docs` keeps its **sol lead** (the separate docs-writing directive) and its `["sol", "terra", "opus5"]` chain. `role:review` / `role:soundness` / every `match_labels` security route: **byte-identical**. `[defaults]` unchanged. The `area:gui` carve-out's **outcome** is preserved (sol-first, agent `sparq-rust-impl`, opus5 still reachable); only the mechanism that delivers it was extended, because the alternative was silently inverting it.

## Not armed

`review:needs`. **No `VERDICT:` line, not armed, not merged** — and it must not be armed before jeswr/agent-account-registry#742 is merged.

---

Refs jeswr/agent-account-registry#738, #733, #730; sparq #4211.
