### PR TITLE
fix(orchestration): containment-aware area: partition keys — sub-crate keys no longer under-serialise their crate (#4336)

### DIFF
--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -475,6 +475,35 @@ def _self_test():
           [[it["number"] for it in compute_ready(
               [pr(73 + i, ["area:sparq-store", label]), waiting], conflict_log=quiet)]
            for i, label in enumerate(sorted(PARKED_AREA_LABELS))], [[20], [20], [20]])
+    # [OPUS-5] sparq#4336 CONTAINMENT fixtures. The registry's dispatch.yml runs THIS --self-test,
+    # so these are the assertions that gate the fleet's own copy of the key algebra.
+    check("sub-crate key resolves to its crate", partition_path("sparq-server-http"),
+          ("sparq-server",))
+    check("real sibling crate resolves to itself", partition_path("sparq-engine-serialize"),
+          ("sparq-engine-serialize",))
+    check("invented sub-crate key resolves to its crate", partition_path("sparq-server-zzz"),
+          ("sparq-server",))
+    check("degenerate key falls all the way to global", partition_path(""), ())
+    check("unrelated crates do not conflict",
+          keys_conflict("sparq-core", "sparq-engine"), False)
+    check("sibling regions of one crate conflict",
+          keys_conflict("sparq-core-store", "sparq-core-nt-dict"), True)
+    check("parent+child enter the frontier together? (must not)",
+          [i["number"] for i in compute_ready(
+              [iss(80, R + ["priority:P1", "area:sparq-server"]),
+               iss(81, R + ["priority:P1", "area:sparq-server-http"])], conflict_log=quiet)], [80])
+    check("child+parent, reversed order (must not)",
+          [i["number"] for i in compute_ready(
+              [iss(80, R + ["priority:P1", "area:sparq-server-http"]),
+               iss(81, R + ["priority:P1", "area:sparq-server"])], conflict_log=quiet)], [80])
+    check("open PR on the parent crate blocks a sub-crate issue",
+          compute_ready([pr(82, ["area:sparq-server"]),
+                         iss(83, R + ["priority:P1", "area:sparq-server-http"])],
+                        conflict_log=quiet), [])
+    check("unknown key under an unknown parent still over-reserves",
+          keys_conflict("upstream", "upstream-noir"), True)
+    check("single-segment unknown key keeps its own partition",
+          partition_path("deps"), ("deps",))
     check("valid_priority single", valid_priority({"priority:P0"}), 0)
     check("valid_priority ambiguous", valid_priority({"priority:P1", "priority:P2"}), None)
     check("valid_priority out-of-range", valid_priority({"priority:P7"}), None)
@@ -620,9 +649,21 @@ def main():
     ap.add_argument("--self-test", action="store_true")
     ap.add_argument("--diagnose", action="store_true",
                     help="print the full visibility taxonomy instead of just the frontier")
+    ap.add_argument("--dump-partitions", action="store_true",
+                    help="print the recognised partition roots (and the resolution of any KEYs) "
+                         "as JSON — the machine-readable contract the registry's dispatch.yml "
+                         "mirror must agree with; offline, no API calls")
+    ap.add_argument("keys", nargs="*", metavar="KEY",
+                    help="area: keys to resolve with --dump-partitions")
     args = ap.parse_args()
     if args.self_test:
         return _self_test()
+    if args.dump_partitions:
+        json.dump({"roots": sorted(workspace_roots()),
+                   "resolved": {k: list(partition_path(k)) for k in args.keys}},
+                  sys.stdout, indent=2, sort_keys=True)
+        print()
+        return 0
     issues = _fetch(args.repo)
     linked = linked_issue_numbers(_fetch_pulls(args.repo), args.repo)
     visible = dispatchable_view(issues, linked)

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -24,6 +24,7 @@ paginated fetch.
 """
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -50,6 +51,126 @@ GLOBAL = "__global__"  # the cross-cutting partition (serializes against everyth
 _PRIO = re.compile(r"^priority:P([0-4])$")   # only P0..P4 are valid
 _PKG = re.compile(r"^area:(.+)$")
 _ROLE = re.compile(r"^role:.+$")
+
+# ---------------------------------------------------------------------------
+# Partition-key algebra (sparq#4336) — CONTAINMENT-aware, TOTAL.
+#
+# [OPUS-5] The under-serialisation defect this replaces: `conflict()` compared partition keys by
+# EXACT-STRING set overlap, so a key naming a region INSIDE a crate never overlapped its parent
+# crate. Five such labels already exist in production — `sparq-server-http`, `sparq-core-nt-dict`,
+# `sparq-core-store`, `sparq-engine-exec`, `sparq-conformance-floors` — so an `area:sparq-server`
+# issue and an `area:sparq-server-http` issue entered the frontier in the SAME tick, and an
+# `area:sparq-server-http` issue entered despite an open PR holding `area:sparq-server`. Two
+# workers in one crate with no lock between them. Measured base rate for that pair sharing a file:
+# 57.1% of same-crate 24h PR pairs (research/crate-region-parallelism.md §4). Textual collisions
+# surface as merge conflicts; SEMANTIC ones (both compile, both pass, together broken) are
+# invisible to git and reach the merge-group gate at the cost of a dequeue plus a batch bisect.
+#
+# Under-serialisation is the CORRUPTING direction. Over-serialisation only costs delay. So the
+# mapping below is TOTAL and biased to over-reserve: every key resolves to the coarsest partition
+# that could contain it, and a key we cannot place at all resolves to GLOBAL.
+_SEP = "-"                       # the hierarchy separator inside an `area:` key
+_PARTITION_MEMO = {}             # key -> path, for the default (workspace-derived) root set
+_WORKSPACE_ROOTS = None          # lazily scanned; None = not yet read
+
+
+def _repo_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def workspace_roots(repo_root=None):
+    """The RECOGNISED partition roots, READ FROM THE REPOSITORY TREE — deliberately not a table.
+
+    A name is a recognised root iff the workspace really contains it as a partition: a crate
+    directory under `crates/`, or a top-level repository directory. The tree is the only authority
+    that can tell `sparq-engine-serialize` (a REAL sibling crate, its own partition) apart from
+    `sparq-engine-exec` (a REGION inside `sparq-engine`) — as strings the two are identical in
+    shape, and a hand-written table of which is which is exactly what goes stale. Reading the tree
+    means a crate added next month registers itself with no code change, and a region label
+    invented next month resolves to its crate with no code change.
+
+    The registry's `dispatch.yml` CLONES this repo and runs this script, so the same tree is
+    present there; `--dump-partitions` exports the resolved mapping for a parity fixture.
+    """
+    global _WORKSPACE_ROOTS
+    if repo_root is None and _WORKSPACE_ROOTS is not None:
+        return _WORKSPACE_ROOTS
+    base = repo_root if repo_root is not None else _repo_root()
+    names = set()
+    for parent in (base, os.path.join(base, "crates")):
+        try:
+            entries = os.listdir(parent)
+        except OSError:
+            continue
+        names.update(e for e in entries
+                     if not e.startswith(".") and os.path.isdir(os.path.join(parent, e)))
+    if repo_root is None:
+        _WORKSPACE_ROOTS = names
+    return names
+
+
+def _ancestors(key):
+    """Every `-`-delimited ancestor prefix of `key`, LONGEST first (`key` itself included)."""
+    segs = key.split(_SEP)
+    return [_SEP.join(segs[:i]) for i in range(len(segs), 0, -1)]
+
+
+def partition_path(key, roots=None):
+    """TOTAL map from an `area:` key to the hierarchical PARTITION PATH it reserves.
+
+    Resolution, longest-recognised-ancestor first, so the failure direction is STRUCTURAL rather
+    than dependent on anyone remembering to register a label:
+
+      1. `GLOBAL` (and any empty/degenerate key) -> `()`, the root of the hierarchy. `()` is a
+         prefix of every path, so GLOBAL conflicts with everything — the existing fail-closed
+         backstop, now expressed as containment instead of two special cases in `conflict()`.
+      2. The longest `-`-ancestor of `key` that the WORKSPACE recognises -> `(that ancestor,)`.
+         `sparq-core-store` and `sparq-core-nt-dict` both resolve to `sparq-core`, so they conflict
+         with their parent crate AND with each other (same crate, same files — a sibling hole would
+         be the identical defect one level down). `sparq-engine-serialize` IS a crate directory, so
+         it resolves to ITSELF and does NOT collapse into `sparq-engine`: genuinely unrelated
+         crates stay parallel and the frontier survives.
+      3. Otherwise the key's HEAD segment -> `(head,)`. A key whose parent the workspace does not
+         know still declares a parent in its own structure, and honouring it over-reserves. This
+         is what makes an invented `area:upstream-noir` conflict with `area:upstream` with no code
+         change, and it leaves every single-segment key (`upstream`, `cli`, `docs`, ...) exactly
+         where it is today — those name nothing narrower, so they cannot be under-serialising.
+
+    The path is currently never deeper than one element ON PURPOSE: a sub-region collapses INTO its
+    container rather than becoming a child of it. research/crate-region-parallelism.md §8 rejects
+    intra-crate region partitioning as a parallelism lever (14.5% ceiling), and a two-level path
+    would reopen the sibling hole. The prefix-based predicate below is depth-agnostic, so a future
+    measured, gated subpartition (that record's Phase 1) can add depth without touching it.
+    """
+    if roots is None:
+        memo = _PARTITION_MEMO
+        if key in memo:
+            return memo[key]
+        path = _resolve(key, workspace_roots())
+        memo[key] = path
+        return path
+    return _resolve(key, roots)
+
+
+def _resolve(key, roots):
+    if not key or key == GLOBAL:
+        return ()
+    for ancestor in _ancestors(key):
+        if ancestor in roots:
+            return (ancestor,)
+    head = key.split(_SEP)[0]
+    return (head,) if head else ()
+
+
+def keys_conflict(a, b, roots=None):
+    """Whether two `area:` keys reserve overlapping work — CONTAINMENT, not string equality.
+
+    True iff one partition path is a prefix of the other, i.e. one region contains the other.
+    Reflexive, symmetric, and NOT transitive-closed beyond containment: `sparq-core` and
+    `sparq-engine` remain independent.
+    """
+    pa, pb = partition_path(a, roots), partition_path(b, roots)
+    return pa[:len(pb)] == pb or pb[:len(pa)] == pa
 
 
 def labels_of(issue):
@@ -222,15 +343,19 @@ def compute_ready(issues, in_progress_packages=None, conflict_log=None):
             blockers.setdefault(pkg, []).append(artifact)
 
     def conflict(pkgs):
-        if GLOBAL in blockers:
-            area = GLOBAL
-        elif GLOBAL in pkgs and blockers:
-            area = sorted(blockers)[0]
-        else:
-            overlap = pkgs & blockers.keys()
-            if not overlap:
-                return None
-            area = sorted(overlap)[0]
+        """The held key that CONTAINS-or-is-contained-by one of `pkgs`, or None.
+
+        [OPUS-5] sparq#4336: was exact-string set overlap (`pkgs & blockers.keys()`) plus two
+        hand-written GLOBAL special cases. Exact-string overlap under-serialised every sub-crate
+        key against its parent crate; the GLOBAL cases are now just the `()` path being a prefix
+        of everything, so there is ONE rule instead of three. Attribution reports the RAW held
+        label (not its resolved partition) so a conflict line still names the artifact's own key;
+        the coarsest holder wins, then alphabetical, so the message stays deterministic.
+        """
+        held = [key for key in blockers if any(keys_conflict(key, p) for p in pkgs)]
+        if not held:
+            return None
+        area = min(held, key=lambda key: (len(partition_path(key)), key))
         return area, blockers[area][0]
 
     for pkg in sorted(set(in_progress_packages or ())):

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -31,7 +31,9 @@ import importlib.util
 import io
 import json
 import re
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -119,6 +121,249 @@ class TestUnlabelledOccupantAttribution(unittest.TestCase):
         board = [iss(72, ["status:in-progress"]),
                  iss(20, READY + ["priority:P1", "area:sparq-core"])]
         self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [20])
+
+
+class TestSubCrateContainment(unittest.TestCase):
+    """sparq#4336 — the UNDER-serialisation defect: a region key never overlapped its crate.
+
+    `conflict()` compared partition keys by exact-string set overlap, so `area:sparq-server-http`
+    did not overlap `area:sparq-server`. Both entered the frontier in one tick, and a sub-crate
+    issue entered despite an open PR holding the parent crate: two workers, one crate, no lock.
+    57.1% of same-crate 24h PR pairs share a file (research/crate-region-parallelism.md §4), and a
+    semantic collision (both compile, both pass, together broken) is invisible to git.
+
+    Every test here goes END-TO-END through compute_ready() where it can, so deleting
+    `keys_conflict`, flattening `partition_path` to the identity, or reverting `conflict()` to
+    `pkgs & blockers.keys()` reds this class.
+    """
+
+    # The four live labels that are NOT workspace crates -> they are regions inside one.
+    CONTAINED = {"sparq-server-http": "sparq-server",
+                 "sparq-core-nt-dict": "sparq-core",
+                 "sparq-core-store": "sparq-core",
+                 "sparq-engine-exec": "sparq-engine"}
+    # The fifth label from the issue's table. It IS a real workspace crate at origin/main, so the
+    # table was already stale — see test_conformance_floors_is_a_real_crate_and_must_stay_split.
+    NOT_CONTAINED = "sparq-conformance-floors"
+
+    def test_every_live_sub_crate_label_conflicts_with_its_parent_crate(self):
+        for child, parent in self.CONTAINED.items():
+            with self.subTest(child=child):
+                self.assertTrue(ready.keys_conflict(child, parent),
+                                f"{child} names a region inside {parent}")
+                self.assertTrue(ready.keys_conflict(parent, child), "conflict must be symmetric")
+                self.assertEqual(ready.partition_path(child), (parent,))
+
+    def test_parent_crate_issue_blocks_a_sub_crate_issue_in_the_same_tick(self):
+        # Ordering A: the PARENT is selected first (lower number wins the priority tie).
+        board = [iss(1, READY + ["priority:P1", "area:sparq-server"]),
+                 iss(2, READY + ["priority:P1", "area:sparq-server-http"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [1],
+                         "area:sparq-server-http must not enter alongside area:sparq-server")
+
+    def test_sub_crate_issue_blocks_a_parent_crate_issue_in_the_same_tick(self):
+        # Ordering B: the CHILD is selected first. Both orderings, per the acceptance criteria.
+        board = [iss(1, READY + ["priority:P1", "area:sparq-server-http"]),
+                 iss(2, READY + ["priority:P1", "area:sparq-server"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [1],
+                         "area:sparq-server must not enter alongside area:sparq-server-http")
+
+    def test_open_pr_holding_the_parent_crate_blocks_a_sub_crate_issue(self):
+        # The OCCUPANCY half of the defect, demonstrated live in the issue.
+        board = [pr(70, ["area:sparq-server"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-server-http"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an open PR on sparq-server must hold the whole crate")
+
+    def test_open_pr_holding_a_sub_crate_blocks_a_parent_crate_issue(self):
+        board = [pr(70, ["area:sparq-core-store"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an open PR on a region must hold its containing crate")
+
+    def test_sibling_sub_crate_keys_of_one_parent_conflict_with_each_other(self):
+        # A sibling hole is the SAME defect one level down: sparq-core-store and
+        # sparq-core-nt-dict are both files in crates/sparq-core. Neither string is a prefix of
+        # the other, so a naive prefix-on-the-raw-key rule would pass the parent tests and still
+        # put two workers in sparq-core.
+        self.assertTrue(ready.keys_conflict("sparq-core-store", "sparq-core-nt-dict"))
+        board = [iss(1, READY + ["priority:P1", "area:sparq-core-store"]),
+                 iss(2, READY + ["priority:P1", "area:sparq-core-nt-dict"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [1])
+
+    def test_unrelated_crates_still_do_not_conflict(self):
+        # The fix must not collapse everything into one lock and destroy the frontier.
+        for a, b in (("sparq-core", "sparq-engine"), ("sparq-server", "sparq-hdt"),
+                     ("sparq-zk", "sparq-mpc"), ("site", "bench")):
+            with self.subTest(pair=(a, b)):
+                self.assertFalse(ready.keys_conflict(a, b))
+        board = [iss(n, READY + ["priority:P1", f"area:{a}"]) for n, a in
+                 ((1, "sparq-core"), (2, "sparq-engine"), (3, "sparq-hdt"), (4, "site"))]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [1, 2, 3, 4])
+
+    def test_real_sibling_crates_sharing_a_name_prefix_stay_independent(self):
+        # `sparq-engine-serialize` is a REAL crate directory, so it is NOT a region inside
+        # `sparq-engine` even though the strings nest. Only the workspace tree can tell these
+        # apart from `sparq-engine-exec`; a hand-written containment table cannot.
+        for crate in ("sparq-engine-serialize", "sparq-engine-service", "sparq-reason-dl",
+                      "sparq-lws-core", "sparq-zk-compose"):
+            with self.subTest(crate=crate):
+                self.assertEqual(ready.partition_path(crate), (crate,))
+        self.assertFalse(ready.keys_conflict("sparq-engine", "sparq-engine-serialize"))
+        self.assertFalse(ready.keys_conflict("sparq-engine-exec", "sparq-engine-serialize"))
+        self.assertTrue(ready.keys_conflict("sparq-engine", "sparq-engine-exec"),
+                        "the non-crate sibling must still collapse into the crate")
+
+    def test_conformance_floors_is_a_real_crate_and_must_stay_split(self):
+        # Issue #4336's table lists area:sparq-conformance-floors as a region inside
+        # crates/sparq-conformance. It is NOT: crates/sparq-conformance-floors is a workspace
+        # member at origin/main. The table was stale before it was written down, which is the
+        # whole argument for deriving containment from the tree instead of listing it.
+        self.assertTrue((REPO_ROOT / "crates" / self.NOT_CONTAINED / "Cargo.toml").is_file())
+        self.assertEqual(ready.partition_path(self.NOT_CONTAINED), (self.NOT_CONTAINED,))
+        self.assertFalse(ready.keys_conflict("sparq-conformance", self.NOT_CONTAINED))
+
+
+class TestTotalPartitionMapping(unittest.TestCase):
+    """The durable half: an UNKNOWN key must fail SAFE with no code change.
+
+    Under-serialisation corrupts; over-serialisation only delays. So the map is total and every
+    unrecognised key resolves UPWARD to the coarsest thing that could contain it.
+    """
+
+    def test_newly_invented_sub_crate_key_resolves_to_its_crate(self):
+        # Nobody registers this label anywhere. It must still be caught by the lock.
+        for invented in ("sparq-server-zzz", "sparq-core-brand-new-region",
+                         "sparq-engine-exec-v2", "sparq-hdt-writer"):
+            with self.subTest(key=invented):
+                parent = ready.partition_path(invented)[0]
+                self.assertIn(parent, ready.workspace_roots())
+                self.assertTrue(invented.startswith(parent + "-"))
+        board = [pr(70, ["area:sparq-server"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-server-zzz"])]
+        self.assertEqual(ready.compute_ready(board, conflict_log=quiet), [],
+                         "an invented region key must fail SAFE into its crate's lock")
+
+    def test_unknown_key_under_an_unknown_parent_still_resolves_upward(self):
+        # `upstream` is not a directory, so the workspace cannot confirm it — the key's own head
+        # segment is then the coarsest partition it names, and honouring it OVER-reserves.
+        self.assertEqual(ready.partition_path("upstream-noir"), ("upstream",))
+        self.assertTrue(ready.keys_conflict("upstream", "upstream-noir"))
+        self.assertTrue(ready.keys_conflict("upstream-noir", "upstream-oxigraph"))
+
+    def test_single_segment_unknown_key_keeps_its_own_partition(self):
+        # It names nothing narrower than itself, so it cannot be under-serialising, and routing it
+        # to __global__ would be a fleet stall, not a fix: MEASURED on the live 2026-07-26
+        # snapshot, a __global__ terminal fallback took the frontier from 6 to 0 because open PR
+        # #4238 carries `area:deps` and `deps` is not a directory.
+        for key in ("upstream", "deps", "workspace", "release", "accuracy", "frobnicate"):
+            with self.subTest(key=key):
+                self.assertEqual(ready.partition_path(key), (key,))
+        board = [iss(1, READY + ["priority:P1", "area:deps"]),
+                 iss(2, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [1, 2])
+
+    def test_degenerate_key_fails_all_the_way_closed_to_global(self):
+        # The terminal of the resolution chain. A key with no head segment to latch onto reserves
+        # EVERYTHING rather than nothing.
+        for degenerate in ("", "-", "---"):
+            with self.subTest(key=degenerate):
+                self.assertEqual(ready.partition_path(degenerate), ())
+                self.assertTrue(ready.keys_conflict(degenerate, "sparq-core"))
+                self.assertTrue(ready.keys_conflict(degenerate, ready.GLOBAL))
+
+    def test_global_conflicts_with_every_key_and_the_mapping_is_total(self):
+        self.assertEqual(ready.partition_path(ready.GLOBAL), ())
+        for key in ("sparq-core", "sparq-server-http", "site-papers", "deps", "zz-top"):
+            with self.subTest(key=key):
+                self.assertTrue(ready.keys_conflict(ready.GLOBAL, key))
+                self.assertTrue(ready.keys_conflict(key, ready.GLOBAL))
+                self.assertIsInstance(ready.partition_path(key), tuple)
+
+    def test_containment_is_reflexive_and_symmetric(self):
+        for key in ("sparq-core", "sparq-core-store", ready.GLOBAL, "deps"):
+            with self.subTest(key=key):
+                self.assertTrue(ready.keys_conflict(key, key))
+        self.assertEqual(ready.keys_conflict("sparq-core", "sparq-core-store"),
+                         ready.keys_conflict("sparq-core-store", "sparq-core"))
+
+
+class TestWorkspaceDerivedRoots(unittest.TestCase):
+    """Roots are READ FROM THE TREE. A table would already be stale (see conformance-floors)."""
+
+    def test_roots_come_from_the_real_repository_tree(self):
+        roots = ready.workspace_roots()
+        for crate in (p.name for p in (REPO_ROOT / "crates").iterdir() if p.is_dir()):
+            self.assertIn(crate, roots, f"crate {crate} must be a recognised partition root")
+        for top in ("site", "bench", "scripts", "research", "crates"):
+            self.assertIn(top, roots)
+        self.assertNotIn(".github", roots, "dot-directories are not area: key names")
+
+    def test_a_crate_added_with_no_code_change_is_recognised_immediately(self):
+        # The anti-staleness property, exercised against a synthetic tree rather than asserted.
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            (base / "crates" / "sparq-brandnew").mkdir(parents=True)
+            (base / "crates" / "sparq-brandnew-region").mkdir(parents=True)
+            (base / "site").mkdir()
+            roots = ready.workspace_roots(str(base))
+            self.assertEqual(roots, {"crates", "site", "sparq-brandnew", "sparq-brandnew-region"})
+            # present in the tree -> its own partition; absent -> collapses into its parent
+            self.assertEqual(ready.partition_path("sparq-brandnew-region", roots),
+                             ("sparq-brandnew-region",))
+            self.assertEqual(ready.partition_path("sparq-brandnew-unlisted", roots),
+                             ("sparq-brandnew",))
+            self.assertFalse(ready.keys_conflict("sparq-brandnew", "sparq-brandnew-region", roots))
+            self.assertTrue(ready.keys_conflict("sparq-brandnew", "sparq-brandnew-unlisted", roots))
+
+    def test_an_unreadable_tree_over_reserves_rather_than_under_reserves(self):
+        # If the scan finds nothing, every key falls back to its head segment. That collapses all
+        # `sparq-*` keys onto `sparq` — a fleet-wide slowdown, never a double dispatch.
+        roots = ready.workspace_roots("/nonexistent/sparq-checkout")
+        self.assertEqual(roots, set())
+        self.assertEqual(ready.partition_path("sparq-core", roots), ("sparq",))
+        self.assertTrue(ready.keys_conflict("sparq-core", "sparq-engine", roots),
+                        "with no tree to read, unrelated crates must OVER-reserve")
+
+    def test_dump_partitions_exports_the_mapping_for_the_registry_parity_fixture(self):
+        # The registry's dispatch.yml mirrors this key space in `busy_packages_of_pulls`; the two
+        # must agree or the fleet double-dispatches. This is the machine-readable contract.
+        out = subprocess.run(
+            [sys.executable, str(SCRIPTS / "ready-issues.py"), "--dump-partitions",
+             "sparq-server-http", "sparq-engine-serialize", "deps"],
+            capture_output=True, text=True, check=True).stdout
+        dumped = json.loads(out)
+        self.assertIn("sparq-core", dumped["roots"])
+        self.assertEqual(dumped["resolved"]["sparq-server-http"], ["sparq-server"])
+        self.assertEqual(dumped["resolved"]["sparq-engine-serialize"], ["sparq-engine-serialize"])
+        self.assertEqual(dumped["resolved"]["deps"], ["deps"])
+
+
+class TestConflictAttribution(unittest.TestCase):
+    """A conflict line must name the RAW held label and the COARSEST holder, deterministically."""
+
+    def test_conflict_line_names_the_raw_parent_label_not_the_resolved_path(self):
+        lines = []
+        board = [pr(70, ["area:sparq-server"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-server-http"])]
+        ready.compute_ready(board, conflict_log=lines.append)
+        self.assertEqual(lines, ["conflict #20: area sparq-server held by pr#70"])
+
+    def test_conflict_line_names_the_raw_child_label_when_the_child_holds(self):
+        lines = []
+        board = [pr(70, ["area:sparq-core-store"]),
+                 iss(20, READY + ["priority:P1", "area:sparq-core"])]
+        ready.compute_ready(board, conflict_log=lines.append)
+        self.assertEqual(lines, ["conflict #20: area sparq-core-store held by pr#70"])
+
+    def test_the_coarsest_holder_is_reported_when_several_conflict(self):
+        # __global__ (path length 0) outranks any named area; named areas tie-break alphabetically.
+        lines = []
+        board = [iss(70, ["status:in-progress"] + ["area:sparq-server"]),
+                 iss(71, ["status:in-progress"] + ["area:sparq-core"]),
+                 iss(30, READY + ["priority:P0"])]
+        ready.compute_ready(board, conflict_log=lines.append)
+        self.assertEqual(lines, ["conflict #30: area sparq-core held by issue#71"])
 
 
 class TestInProgressReviewStatus(unittest.TestCase):

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -87,8 +87,13 @@ class TestUnlabelledOccupantAttribution(unittest.TestCase):
 
     def test_unlabelled_pr_leaves_every_unrelated_crate_dispatchable(self):
         # The blast radius, not just one row: with the bug, ALL of these vanished at once.
+        # [OPUS-5] sparq#4336: the keys were synthetic `area:crate-21/22/23`. Those share the head
+        # segment `crate`, and containment-aware conflict() now (correctly) treats a shared head
+        # as one partition, so the fixture no longer modelled "three UNRELATED crates" at all.
+        # Switched to three real, disjoint workspace crates — the assertion is unchanged in force.
         board = [pr(70, [])] + [
-            iss(n, READY + ["priority:P1", f"area:crate-{n}"]) for n in (21, 22, 23)]
+            iss(n, READY + ["priority:P1", f"area:{a}"])
+            for n, a in ((21, "sparq-core"), (22, "sparq-hdt"), (23, "sparq-geo"))]
         self.assertEqual(
             numbers(ready.compute_ready(board, conflict_log=quiet)), [21, 22, 23])
 
@@ -313,8 +318,11 @@ class TestLocalOrchestratorParity(unittest.TestCase):
     # -- the previously-covered shapes, now through the real CLI ---------------------------
     def test_unlabelled_prs_do_not_make_the_two_views_disagree(self):
         # The exact live shape: many area-less open PRs + attested issues on distinct crates.
+        # [OPUS-5] sparq#4336: real disjoint crates, for the reason recorded on
+        # test_unlabelled_pr_leaves_every_unrelated_crate_dispatchable.
         board = [pr(3803, []), pr(3799, []), pr(3798, [])] + [
-            iss(n, READY + ["priority:P3", f"area:crate-{n}"]) for n in (3694, 3756, 3757)]
+            iss(n, READY + ["priority:P3", f"area:{a}"])
+            for n, a in ((3694, "sparq-core"), (3756, "sparq-hdt"), (3757, "sparq-geo"))]
         self.assertEqual(self._local(board), self._orchestrator(board))
         self.assertEqual(self._local(board), [3694, 3756, 3757])
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes #4336.

`compute_ready()`'s `conflict()` compared `area:` partition keys by **exact-string set overlap**, so a
key naming a region *inside* a crate never overlapped its parent crate. Two workers could hold one
crate at once — the corrupting direction, because a wrong *narrow* reservation puts two diffs on one
file and the worst case (both compile, both pass, together broken) is invisible to git.

**Caught live on today's snapshot, not just in a fixture:** issue **#3186** (`area:sparq-server-http`)
was on the frontier while open PR **#4238** held `area:sparq-server` — and #4238 is literally titled
`feat(sparq-server-http): safety(server): mid-stream truncation…`. Two workers, one code path, no lock.
Same shape for **#2885** (`area:zk-xpath`) against open PR **#4274** holding `area:zk`.

## The layer I changed, and why it binds

**`conflict()` plus a new key-derivation helper (`partition_path` / `keys_conflict`) — not
`compute_ready()`'s selection loop, and not the label vocabulary.**

- Not the **vocabulary**: adding/renaming labels is what *produced* this defect (new keys, unchanged
  comparison semantics). The vocabulary is the input; the bug is in the comparison. Fixing it there
  means the next invented label re-opens the hole.
- Not the **selection loop**: it is a correct priority-ordered greedy reservation over an abstract key
  set. It has no business knowing that `sparq-server-http` sits inside `sparq-server`, and teaching it
  would duplicate that knowledge into the registry's mirror as well.
- **The comparison predicate is the binding layer** because it is the single place every key pair is
  compared: candidate-vs-occupant, candidate-vs-candidate, issue-vs-PR, and the `__global__` backstop
  all route through it. `conflict()` is now *one* rule where it was three (exact overlap + two
  hand-written GLOBAL special cases): `()` is a prefix of every path, so GLOBAL falls out of
  containment instead of being special-cased.

## The containment derivation (no table)

`partition_path(key)` is a **total** map from an `area:` key to the partition path it reserves,
resolved longest-recognised-ancestor first:

1. `__global__`, and any empty/degenerate key, → `()` — the root, a prefix of everything.
2. The longest `-`-delimited ancestor of the key that the **workspace tree** recognises → `(ancestor,)`.
   Recognised = a directory under `crates/`, or a top-level repository directory. Read from the tree at
   runtime, never listed in the source.
3. Otherwise the key's **head segment** → `(head,)`.

`keys_conflict(a, b)` is true iff one path is a prefix of the other.

**Why the tree and not a table.** `sparq-engine-serialize` (a real sibling crate) and
`sparq-engine-exec` (a region inside `sparq-engine`) are structurally identical as strings. Only the
tree can tell them apart. Reading it means a crate added next month registers itself with no code
change, and a region label invented next month resolves to its crate with no code change.

**That is not hypothetical — the issue's own table is already stale.** #4336 lists
`area:sparq-conformance-floors` as a region inside `crates/sparq-conformance/`. It is not:
`crates/sparq-conformance-floors` is a workspace member at `origin/main`. The tree-derived rule keeps
it as its own partition and a table would have wrongly collapsed it. Pinned by
`test_conformance_floors_is_a_real_crate_and_must_stay_split`.

**Sub-crate keys collapse *into* their crate rather than becoming children of it.** Depth is capped at
one on purpose: `sparq-core-store` and `sparq-core-nt-dict` are both files in `crates/sparq-core`, so a
two-level path would leave a *sibling* hole — the identical defect one level down. `research/crate-region-parallelism.md` §8
rejects intra-crate region partitioning as a parallelism lever anyway. The predicate is written
prefix-wise so a future measured, gated subpartition can add depth without touching it.

## Frontier width, measured

Live snapshot `2026-07-26`, fully paginated (15 issue pages + 2 pull pages) and cross-checked against
`total_count`/`totalCount`: **1373 open issues, 107 open PRs** — REST `--paginate --slurp` returned
1480 rows = 1373 + 107, and both the search API and GraphQL agree on both numbers.

| | before | after |
| --- | --- | --- |
| open issues | 1373 | 1373 |
| drainable backlog (`ready_candidates`) | 372 | **372** (unchanged — this is a concurrency fix, not an eligibility one) |
| **concurrency frontier (`compute_ready`)** | **6** | **4** |

Both figures via `diagnose()`/`dispatchable_view()` — the same path `main()` uses. The two rows that
left are exactly the two under-serialised ones:

```
DROPPED #3186 ['sparq-server-http']   conflict #3186: area sparq-server held by pr#4238
DROPPED #2885 ['zk-xpath']            conflict #2885: area zk held by pr#4274
```

(The issue quotes a frontier of 10; that was an earlier snapshot. 6 is what `origin/main` computes on
*this* snapshot, and 4 is what this branch computes on the *same* snapshot — the comparison is
same-input.)

**Cost accepted:** a 33% narrower frontier. It is bought by removing two genuine same-crate races, and
`research/crate-region-parallelism.md` §8's Gate A observes worker yield — not frontier width — is the
current binding constraint, so this should not move realised dispatch throughput.

### The rejected alternative, and why — measured, not argued

The issue asks for an unknown key to resolve "ultimately to `__global__`". I implemented that variant
first and measured it on the same snapshot: **the frontier went to 0.** 14 live labels have no
workspace-recognised ancestor (`deps`, `upstream`, `workspace`, `cli`, `kb`, `trust`, `release`,
`testing`, `performance`, `accuracy`, `e2ee`, `forms`, `wrapper`, `knowledge-graph`), and open PR
**#4238** carries `area:deps`, so all 372 drainable candidates deferred against a single `__global__`
holder. That is a total fleet stall — strictly worse than the bug.

The head-segment fallback keeps that terminal reachable (an empty/degenerate key still resolves to
`()`) while leaving every single-segment key exactly where it is today. A single-segment key names
nothing narrower than itself, so it *cannot* be the under-serialisation class this PR fixes. **0 of the
98 live `area:` labels now resolve to `__global__`.** Pinned by
`test_single_segment_unknown_key_keeps_its_own_partition` (which cites the measurement) and
`test_degenerate_key_fails_all_the_way_closed_to_global`.

## Unknown keys fail safe — confirmed

`partition_path` is total. An invented `area:sparq-server-zzz` resolves to `('sparq-server',)` and is
blocked by an open PR on `area:sparq-server`, with **no code change and no label registration**
(`test_newly_invented_sub_crate_key_resolves_to_its_crate`, end-to-end through `compute_ready`). An
invented key under an *unrecognised* parent still over-reserves upward
(`area:upstream-noir` → `('upstream',)`). If the tree cannot be read at all, every key falls back to
its head segment, collapsing all `sparq-*` onto one lock — a fleet-wide slowdown, never a double
dispatch (`test_an_unreadable_tree_over_reserves_rather_than_under_reserves`).

## Guard → red test (mutation-verified, 12/12 killed)

Every mutant was applied to the **live tree** and both suites re-run. No guard is vacuous.

| # | mutation | first named tests that go red |
| --- | --- | --- |
| G1 | `conflict()` back to `key in pkgs` (exact-string overlap) | `test_parent_crate_issue_blocks_a_sub_crate_issue_in_the_same_tick`, `test_open_pr_holding_the_parent_crate_blocks_a_sub_crate_issue`, `test_sibling_sub_crate_keys_of_one_parent_conflict_with_each_other`, + self-test `parent+child enter the frontier together? (must not)` |
| G2 | `partition_path` → identity (containment removed) | `test_every_live_sub_crate_label_conflicts_with_its_parent_crate`, `test_newly_invented_sub_crate_key_resolves_to_its_crate`, `test_degenerate_key_fails_all_the_way_closed_to_global` |
| G3 | `keys_conflict` → `pa == pb` (prefix dropped) | `test_global_conflicts_with_every_key_and_the_mapping_is_total`, `test_the_coarsest_holder_is_reported_when_several_conflict` |
| G4 | `keys_conflict` one-directional | `test_global_conflicts_with_every_key_and_the_mapping_is_total`, `test_area_less_ISSUE_candidate_still_fails_closed_to_global` |
| G5 | `workspace_roots` scan deleted (returns `∅`) | `test_roots_come_from_the_real_repository_tree`, `test_real_sibling_crates_sharing_a_name_prefix_stay_independent`, `test_conformance_floors_is_a_real_crate_and_must_stay_split` |
| G6 | `workspace_roots` skips `crates/` | same as G5 + `test_area_labelled_pr_still_reserves_exactly_its_crate` |
| G7 | `_ancestors` shortest-first (shortest recognised ancestor wins) | `test_real_sibling_crates_sharing_a_name_prefix_stay_independent`, `test_conformance_floors_is_a_real_crate_and_must_stay_split` |
| G8 | head-segment fallback dropped (terminal `__global__`) | `test_single_segment_unknown_key_keeps_its_own_partition`, `test_unknown_key_under_an_unknown_parent_still_resolves_upward` |
| G9 | degenerate key → its own partition | `test_degenerate_key_fails_all_the_way_closed_to_global` |
| G10 | `conflict()` reports the finest holder, not the coarsest | `test_the_coarsest_holder_is_reported_when_several_conflict` |
| G11 | `conflict()` always returns `None` (lock removed) | `test_compute_ready_serialises_one_per_package` + 7 more |
| G12 | `--dump-partitions` echoes the raw key | `test_dump_partitions_exports_the_mapping_for_the_registry_parity_fixture` |

Suite grew 34 → **56** tests. The tree was restored and re-verified green after the run
(`git status --porcelain` empty).

**Honest note on G4.** Because resolution collapses a region *into* its container, both sides of a
same-crate pair have an *equal* path, so the two-sided prefix test is currently exercised only by the
`()` root (GLOBAL). It is written two-sided so that adding depth later cannot silently make containment
one-directional; today it is not load-bearing for the sub-crate case.

## Test-fixture changes a reviewer should look at

Two pre-existing fixtures used synthetic keys `area:crate-21/22/23` and `area:crate-3694/3756/3757`.
Those share the head segment `crate`, so under containment they are one partition — meaning the
fixtures no longer modelled "three *unrelated* crates", which was their entire point. Switched to three
real, disjoint workspace crates (`sparq-core`, `sparq-hdt`, `sparq-geo`). **The assertions are unchanged
in force** and both still red under G5/G6/G11.

## Also added

`ready-issues.py --dump-partitions [KEY…]` — prints the recognised roots and the resolution of any
keys as JSON, offline, no API calls. This is the machine-readable contract the registry's `dispatch.yml`
mirror must agree with.

## Scope held

Per #4336 and `research/crate-region-parallelism.md`, this PR makes the *current* scheme correct; it
does not make it finer and it does not widen anything for throughput.

- No region-partitioning-inside-crates, no optimistic concurrency, no predicted-file locking (measured
  and rejected at 14.5% ceiling / 57.1% collision base rate / unbounded error rate respectively).
- `packages_of`'s empty-area → `__global__` candidate-side default and `_reserving_packages`' deliberate
  *lack* of one are **untouched**; their existing tests still pass unmodified.
- No new `area:` labels minted.

## Follow-up (not in this PR)

The registry's private `dispatch.yml` mirrors this key space in `busy_packages_of_pulls` and still
compares by exact string; until it is updated the two disagree on sub-crate keys. It is a separate
repository I cannot change from here — `--dump-partitions` exists to make that parity fixture cheap.
Filed separately.

## Gate

Ran the full `routing-self-tests` job step locally against this branch: all 12 invocations green
(`routing-validate` ×2, `route-resolve`, `ready-issues --self-test`, `dispatch-plan`, `batch-merge`,
`test_readiness_visibility` (56 tests), `test_no_deprecated_models`, `pr-area-labels`,
`test_pr_area_labels`, `bd-to-issues`, `ci-close-merged-beads`). `typos` clean; no new lines over the
file's existing length convention. CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
