### PR TITLE
ci(review-alarm): PRs no review producer can reach are invisible, not reviewed

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -724,6 +724,17 @@ jobs:
       # fail-loud exits (replay error / total blocker => non-zero).
       - name: Self-test the nightly selection-bug alarm (correlation + fail-loud — sq-va7at)
         run: python3 scripts/tests/test_ci_selection_alarm.py
+      # [OPUS-5] The review-lane BLIND-SPOT alarm (scripts/review_lane_alarm.py,
+      # .github/workflows/review-alarm.yml). Hermetic (no gh, no network). Two halves:
+      # the four verdict obligations — no-verdict is not armable, a superseded head does
+      # not count, an author cannot verdict their own PR, and the review brief's own
+      # quoted `VERDICT: pass` instruction text is not a pass — plus the YAML SEAM
+      # inspection (schedule present, self-test ordered before the live step, the call
+      # site intact, and the job's permissions carrying `issues: write` with NO
+      # `pull-requests: write`, so the detector can never acquire arming authority).
+      # The suite also pins its OWN call site here, so it cannot silently leave CI.
+      - name: Self-test the review-lane blind-spot alarm (verdict obligations + YAML seam)
+        run: python3 scripts/tests/test_review_lane_alarm.py
       # [SONNET-4.6] sq-1cb6l: the 5 remaining hermetic test suites found by the
       # #1670 audit, wired here alongside the other ci-scripts self-tests.
       #

--- a/.github/workflows/review-alarm.yml
+++ b/.github/workflows/review-alarm.yml
@@ -1,0 +1,90 @@
+# review-alarm — the review-lane BLIND-SPOT alarm ([OPUS-5]). 🤖 SPARQ agent.
+#
+# WHAT: sparq has no in-repo verdict PRODUCER. Every review a sparq PR receives is produced
+# out of repo by the registry's review-fix.yml, scheduled by the registry's dispatch.yml,
+# whose `enumerate_review_items` admits a PR only if its head ref matches
+# `^sparq-agent/issue-([1-9][0-9]*)-`, its head repo is the target repo, its author is the
+# worker App bot, AND a registry-written provenance record exists. A PR opened by anything
+# else — every PR an interactive agent session pushes — fails all of those by construction
+# and no review is ever dispatched for it. MEASURED 2026-07-26 over all 118 open PRs
+# (paginated, total_count cross-checked): 89 bot-authored PRs, 100% carrying a review:*
+# loop label; 29 jeswr-authored PRs, ZERO carrying review:pass / review:changes /
+# review:needs. Absence of a review produces no artifact, so nothing noticed for weeks.
+# scripts/review_lane_alarm.py enumerates that blind spot and REDs this run (plus files ONE
+# deduped issue) when a PR has sat in it past the threshold.
+#
+# NOT A GATE (same posture as selection-alarm.yml / formal-alarm.yml): scheduled on main,
+# files issues, blocks NO merge. Its job name carries no advisory/informational token, but
+# it never creates a check-run on a PR head or merge-group ref, so it can never enter the
+# `ci-summary / gate` poll set. Redding this run blocks nothing — it exists to be SEEN.
+#
+# NO ARMING AUTHORITY, STRUCTURALLY. This workflow holds `issues: write` and NOTHING else:
+# no `pull-requests: write` (it cannot label, promote, or un-draft a PR) and no
+# `contents: write` (it cannot push). It is a detector. It is deliberately disjoint from
+# verdict-bridge.yml, which owns the comment -> label TRANSPORT hop; this workflow owns
+# noticing that no verdict was ever PRODUCED to transport.
+#
+# FAIL-LOUD: an alarm-infrastructure error (gh api failure, unparseable response) exits
+# non-zero so THIS run goes red and a human notices the detector itself is broken — masking
+# an unreviewed backlog is the one thing the alarm must never do.
+#
+# All actions are SHA-pinned (code-scanning / Scorecard posture). The script self-tests
+# hermetically as the FIRST step of every run (a detector is never trusted to watch
+# anything before it has proved itself on this tick's code), and its suite also gates on
+# every PR via scripts/tests/test_review_lane_alarm.py in docs-quality.yml.
+name: review-alarm
+
+on:
+  # Every six hours, offset off the top of the hour so it never contends with auto-arm
+  # (4,14,24,…) or verdict-bridge (1,11,21,…). Explicit values (no */N) keep it auditable.
+  schedule:
+    - cron: "37 1,7,13,19 * * *"
+  # Manual run for validation / triage.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report the blind spot without filing or updating an issue"
+        type: boolean
+        default: false
+      max_age_hours:
+        description: "Hours a PR may sit with no countable verdict before it alarms"
+        type: string
+        default: "24"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: review-alarm
+  cancel-in-progress: false
+
+jobs:
+  alarm:
+    name: review-lane blind-spot alarm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write # file/update the ONE deduped alarm issue — the only write it has
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/review_lane_alarm.py
+          sparse-checkout-cone-mode: false
+
+      # FIRST, unconditionally: a detector that cannot prove itself never gets to run.
+      - name: Self-test the alarm (hermetic fixtures)
+        run: python3 scripts/review_lane_alarm.py --self-test
+
+      - name: Enumerate PRs no review producer can reach
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+          MAX_AGE_HOURS: ${{ inputs.max_age_hours || '24' }}
+        run: >-
+          python3 scripts/review_lane_alarm.py
+          --max-age-hours "$MAX_AGE_HOURS"
+          $DRY_RUN

--- a/.github/workflows/review-alarm.yml
+++ b/.github/workflows/review-alarm.yml
@@ -82,9 +82,15 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '' }}
           MAX_AGE_HOURS: ${{ inputs.max_age_hours || '24' }}
-        run: >-
-          python3 scripts/review_lane_alarm.py
-          --max-age-hours "$MAX_AGE_HOURS"
-          $DRY_RUN
+        # An args array, not an unquoted `$DRY_RUN` splat: word-splitting an env var into
+        # a flag is exactly the shellcheck SC2086 shape actionlint rejects, and here it
+        # would also let a crafted dispatch input inject an extra flag.
+        run: |
+          set -euo pipefail
+          args=(--max-age-hours "$MAX_AGE_HOURS")
+          if [ -n "$DRY_RUN" ]; then
+            args+=(--dry-run)
+          fi
+          python3 scripts/review_lane_alarm.py "${args[@]}"

--- a/scripts/review_lane_alarm.py
+++ b/scripts/review_lane_alarm.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+# [OPUS-5] Review-lane BLIND-SPOT alarm. 🤖 SPARQ agent.
+#
+# WHAT THIS IS: the "silence must not look like green" safeguard for VERDICT PRODUCTION,
+# the sibling of scripts/formal_lane_alarm.py (which watches verdict production for the
+# formal lanes) and scripts/ci_selection_alarm.py.
+#
+# MEASURED CAUSE (2026-07-26, paginated over all 118 open PRs, total_count cross-checked):
+# every review that sparq PRs receive is produced OUT OF REPO by the registry's
+# review-fix.yml, scheduled by the registry's dispatch.yml. That scheduler admits a PR
+# only through `enumerate_review_items` (registry scripts/dispatch-claim.py), whose first
+# three gates are AUTHOR-SIDE and fail closed:
+#
+#     if not HEAD_REF_RE.match(ref):        continue   # ^sparq-agent/issue-([1-9][0-9]*)-
+#     if head_repo != repo:                 continue
+#     if not login.endswith("[bot]") ...:   continue   # must be the worker App bot
+#
+# followed by a mandatory REGISTRY provenance record (`provenance_admission_error`) that
+# only a host-side worker run can write. A PR opened by anything other than the worker App
+# — every PR an interactive agent session pushes — fails all three by construction and is
+# therefore INVISIBLE to the only review producer that exists. The census that proves it:
+#
+#     89 open PRs by sparq-orchestrator[bot]: 100% carry a review:* loop label
+#     29 open PRs by jeswr:                     0 carry review:pass/changes/needs
+#
+# Zero is not a coincidence, it is a predicate. Nothing in sparq ever noticed, because
+# absence of a review produces no artifact — no red check, no queue entry, nothing. This
+# script makes that absence LOUD.
+#
+# THE ALARM: enumerate the BLIND SPOT — open, non-draft, non-human-held PRs that the
+# registry lane can never reach — and RED this run (plus file one deduped issue) when any
+# of them has sat without a countable verdict for longer than the threshold.
+#
+# WHAT COUNTS AS A VERDICT (deliberately strict; a wrong pass is worse than no pass):
+#   1. LINE-ANCHORED. `VERDICT: pass` / `VERDICT: fail` as the LAST non-blank line of the
+#      comment, matched with ^...$ under re.MULTILINE-free full-line comparison. NEVER a
+#      substring search: the standing review brief quotes the string `VERDICT: pass` in its
+#      own instruction text, and a substring grep has already scored that quotation as a
+#      real pass in this repo.
+#   2. HEAD-BOUND. The comment body must contain the CURRENT head as a standalone 40-hex
+#      SHA. A force-push advances the head, so an old comment stops counting the instant
+#      the tree it reviewed is superseded.
+#   3. AUTHOR XOR REVIEWER. A comment posted by the SAME GitHub account that opened the PR
+#      is never a review of it. Self-approval has already happened in this repo; a detector
+#      that credits it would certify the exact failure it exists to find.
+# A comment failing (1) is not a verdict at all. A comment satisfying (1) but failing (2)
+# or (3) is a DISCREDITED verdict — reported by name in the issue body, because "reviewed
+# on a stale head" and "never reviewed" need different human responses.
+#
+# TWO DESIGN INVARIANTS (mirrors formal_lane_alarm.py / ci_selection_alarm.py):
+#   1. FAIL-LOUD: an alarm-INFRASTRUCTURE error (gh api failure, unparseable response)
+#      exits NON-ZERO with a `::error::` annotation. A broken detector must never look
+#      like a quiet green.
+#   2. NON-SPAMMY: ONE open issue, keyed by a stable `<!-- review-lane-alarm-key: … -->`
+#      body marker searched over open `review-alarm`-labelled issues before filing.
+#
+# WHAT THIS IS NOT. It is NOT a gate: scheduled on main, creates no check-run on any PR
+# head or merge-group ref, blocks no merge. It grants NO arming authority and writes NO PR
+# labels — it cannot arm, promote, or unblock anything, by construction (the workflow holds
+# `issues: write` and nothing else). It does not lower any bar: it never marks a PR
+# reviewed, it only refuses to let "nobody reviewed this" stay silent.
+#
+# Usage:
+#   review_lane_alarm.py                              # real (gh; env GITHUB_REPOSITORY)
+#   review_lane_alarm.py --dry-run                    # print findings; no gh writes
+#   review_lane_alarm.py --prs-file prs.json \
+#       --now 2026-07-26T22:00:00Z --dry-run          # hermetic (tests)
+#   review_lane_alarm.py --self-test                  # hermetic fixtures
+#
+# Stdlib only + the `gh` CLI (present on every GitHub runner).
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+
+BASE_LABELS = ["review-alarm", "auto"]
+KEY_PREFIX = "review-lane-alarm-key"
+ALARM_KEY = "blind-spot"
+
+# The registry review lane's own admission regex, replicated VERBATIM from
+# scripts/dispatch-claim.py (registry, master @ 2026-07-26). Kept byte-identical on
+# purpose: this alarm's whole claim is "the registry lane cannot see these PRs", so the
+# reachability test must be the registry's test and not a paraphrase of it.
+REGISTRY_HEAD_REF_RE = re.compile(r"^sparq-agent/issue-([1-9][0-9]*)-")
+
+# A verdict line, anchored to a WHOLE line. The pattern is applied to an individually
+# stripped line — never searched across a body — so no amount of surrounding prose can
+# make it match.
+VERDICT_LINE_RE = re.compile(r"^VERDICT:[ ]+(pass|fail)$")
+# A standalone 40-hex commit SHA (word-bounded so a 41-char token never matches).
+SHA_RE = re.compile(r"(?<![0-9a-fA-F])([0-9a-f]{40})(?![0-9a-fA-F])")
+
+# Human-owned holds. Terminal: autonomy stands down until a human clears them, so an
+# unreviewed PR carrying one is NOT an alarm — it is a human's open decision.
+HUMAN_HOLD_LABELS = frozenset({"needs:user", "review:needs-user"})
+# The registry loop's own labels. A blind-spot PR cannot legitimately carry one (nothing
+# in the blind spot is enumerable by the lane that writes them), but if a human or a
+# migration puts one there we honour it rather than double-reporting.
+LANE_LABELS = frozenset({"review:pass", "review:changes", "review:needs", "review:parked"})
+
+DEFAULT_MAX_AGE_HOURS = 24
+
+
+class AlarmError(Exception):
+    """Alarm-INFRASTRUCTURE failure — surfaced LOUD (non-zero exit)."""
+
+
+# --------------------------------------------------------------------------- #
+# Reachability: can the registry review lane EVER enumerate this PR?
+# --------------------------------------------------------------------------- #
+def registry_lane_reachable(pr: dict, repo: str) -> bool:
+    """True iff `pr` passes every AUTHOR-SIDE admission gate of the registry review
+    lane's `enumerate_review_items`. False => no review producer in existence can ever
+    see this PR, which is precisely the blind spot this alarm watches.
+
+    Only the three structural gates are replicated. The registry additionally requires a
+    provenance record, but that is a LIVE registry read this repo has no token for, and it
+    can only ever narrow admission further — so treating a PR as reachable here is the
+    CONSERVATIVE direction (it under-reports the blind spot, never over-reports it)."""
+    if not isinstance(pr, dict):
+        raise AlarmError("pull-request listing carried a non-object entry")
+    head = pr.get("head") or {}
+    ref = str(head.get("ref") or "")
+    head_repo = (head.get("repo") or {}).get("full_name")
+    login = str((pr.get("user") or {}).get("login") or "")
+    if not REGISTRY_HEAD_REF_RE.match(ref):
+        return False
+    if head_repo != repo:
+        return False
+    if not login.endswith("[bot]"):
+        return False
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Verdict detection (pure)
+# --------------------------------------------------------------------------- #
+def verdict_polarity(body: str) -> str | None:
+    """The polarity of a comment's verdict line, or None when the comment carries no
+    verdict at all.
+
+    STRICTLY the LAST non-blank line, compared whole. This is the anti-substring rule:
+    the review brief's own instruction text contains the literal `VERDICT: pass`, and a
+    body that merely quotes it — anywhere, including as its own line followed by more
+    prose — is NOT a verdict. Only a comment that ENDS on the line is."""
+    if not isinstance(body, str):
+        return None
+    lines = [line.rstrip() for line in body.replace("\r\n", "\n").split("\n")]
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        match = VERDICT_LINE_RE.match(line.strip())
+        return match.group(1) if match else None
+    return None
+
+
+def comment_binds_head(body: str, head_sha: str) -> bool:
+    """True iff the comment names the CURRENT head as a standalone 40-hex SHA.
+
+    An OCCURRENCE test, exactly as the arming bridge does it: what makes the comment a
+    verdict is its trailing VERDICT line, and what binds it to a tree is naming that
+    tree. A comment naming only the PREVIOUS head fails here the moment a force-push
+    lands, which is the required force-push invalidation."""
+    if not isinstance(body, str) or not isinstance(head_sha, str):
+        return False
+    if not SHA_RE.fullmatch(head_sha):
+        return False
+    return head_sha in SHA_RE.findall(body)
+
+
+def countable_verdict(pr: dict, comments: list[dict]) -> tuple[str | None, list[str]]:
+    """-> (polarity, discredited_reasons).
+
+    `polarity` is 'pass'/'fail' for the LATEST comment that is a verdict AND binds the
+    current head AND was not written by the PR's own author. `discredited_reasons`
+    names every comment that carried a real verdict line but failed one of the other two
+    tests — the difference between "stale review" and "no review" is the difference
+    between two very different human responses, so it is never collapsed."""
+    head_sha = str((pr.get("head") or {}).get("sha") or "")
+    pr_author = str((pr.get("user") or {}).get("login") or "")
+    if not comments:
+        return None, []
+    ordered = sorted(
+        (c for c in comments if isinstance(c, dict)),
+        key=lambda c: str(c.get("created_at") or ""),
+    )
+    polarity: str | None = None
+    discredited: list[str] = []
+    for comment in ordered:
+        body = comment.get("body")
+        found = verdict_polarity(body if isinstance(body, str) else "")
+        if found is None:
+            continue
+        author = str((comment.get("user") or {}).get("login") or "")
+        # AUTHOR XOR REVIEWER, structurally. Checked BEFORE the head test so a
+        # self-review is never reported as merely "stale" — its problem is not its age.
+        if author and pr_author and author == pr_author:
+            discredited.append(f"self-review by the PR author @{author} (never countable)")
+            continue
+        if not comment_binds_head(body if isinstance(body, str) else "", head_sha):
+            discredited.append(
+                f"verdict by @{author or '?'} names no current head "
+                f"{head_sha[:12] or '(unknown)'} — superseded tree"
+            )
+            continue
+        # Latest head-bound, non-self verdict wins: a later retraction defeats an
+        # earlier pass.
+        polarity = found
+    return polarity, discredited
+
+
+# --------------------------------------------------------------------------- #
+# Classification (pure)
+# --------------------------------------------------------------------------- #
+def _labels(pr: dict) -> set[str]:
+    out: set[str] = set()
+    for label in pr.get("labels") or []:
+        name = label.get("name") if isinstance(label, dict) else label
+        if isinstance(name, str) and name:
+            out.add(name)
+    return out
+
+
+def classify_pr(pr: dict, comments: list[dict], repo: str) -> str:
+    """One of: registry-lane | draft | human-held | lane-labelled | has-verdict |
+    blind-spot. Only `blind-spot` is alarm-worthy."""
+    if pr.get("draft") is True:
+        return "draft"
+    if registry_lane_reachable(pr, repo):
+        return "registry-lane"
+    if HUMAN_HOLD_LABELS & _labels(pr):
+        return "human-held"
+    if LANE_LABELS & _labels(pr):
+        return "lane-labelled"
+    polarity, _ = countable_verdict(pr, comments)
+    if polarity is not None:
+        return "has-verdict"
+    return "blind-spot"
+
+
+def _parse_iso(ts: str) -> dt.datetime:
+    try:
+        return dt.datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise AlarmError(f"unparseable timestamp {ts!r}") from exc
+
+
+def find_blind_spot(
+    prs: list[dict], comments_by_pr: dict, repo: str, now: dt.datetime, max_age_hours: float
+) -> tuple[list[dict], dict]:
+    """-> (alarming findings, census). The census counts EVERY state exit, not just the
+    alarming one: a per-state population is the only shape in which a MISSING edge is
+    visible at all (a success-rate cannot express "nothing ever entered this state")."""
+    census: dict = {}
+    findings: list[dict] = []
+    for pr in prs:
+        number = pr.get("number")
+        if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+            raise AlarmError("pull-request listing carried an invalid number")
+        comments = comments_by_pr.get(number) or comments_by_pr.get(str(number)) or []
+        state = classify_pr(pr, comments, repo)
+        census[state] = census.get(state, 0) + 1
+        if state != "blind-spot":
+            continue
+        age = (now - _parse_iso(pr.get("created_at"))).total_seconds() / 3600.0
+        if age < max_age_hours:
+            census["blind-spot-fresh"] = census.get("blind-spot-fresh", 0) + 1
+            continue
+        _, discredited = countable_verdict(pr, comments)
+        findings.append(
+            {
+                "number": number,
+                "title": str(pr.get("title") or "")[:120],
+                "author": str((pr.get("user") or {}).get("login") or "?"),
+                "head_ref": str((pr.get("head") or {}).get("ref") or "?"),
+                "head_sha": str((pr.get("head") or {}).get("sha") or "?"),
+                "age_hours": round(age, 1),
+                "discredited": discredited,
+            }
+        )
+    findings.sort(key=lambda f: -f["age_hours"])
+    return findings, census
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def render_issue_body(findings: list[dict], census: dict, repo: str, max_age_hours: float) -> str:
+    lines = [
+        "> 🤖 SPARQ agent",
+        "",
+        f"`review-alarm`: **{len(findings)} open PR(s)** have gone more than "
+        f"{max_age_hours:g}h with **no countable review verdict**, and no review producer "
+        "can ever reach them.",
+        "",
+        "These PRs fail the registry review lane's author-side admission gates "
+        "(`enumerate_review_items` in the registry's `scripts/dispatch-claim.py`): the head "
+        "ref does not match `^sparq-agent/issue-([1-9][0-9]*)-`, and/or the author is not the "
+        "worker App bot. That lane is the only verdict producer sparq has, so nothing will "
+        "ever dispatch a review for them without a human or an orchestrator doing it by hand.",
+        "",
+        "| PR | age (h) | author | head ref | note |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for finding in findings[:50]:
+        note = "; ".join(finding["discredited"]) or "no verdict comment at all"
+        lines.append(
+            f"| #{finding['number']} | {finding['age_hours']} | {finding['author']} | "
+            f"`{finding['head_ref']}` | {note} |"
+        )
+    if len(findings) > 50:
+        lines.append(f"| … | | | | {len(findings) - 50} more |")
+    lines += [
+        "",
+        "**Census of every state exit** (open PRs in `" + repo + "`):",
+        "",
+        "```",
+        *[f"{state}: {count}" for state, count in sorted(census.items())],
+        "```",
+        "",
+        "A verdict is countable only when it is line-anchored (`VERDICT: pass|fail` as the "
+        "comment's last non-blank line), names the current head as a standalone 40-hex SHA, "
+        "and was **not** posted by the PR's own author.",
+        "",
+        f"<!-- {KEY_PREFIX}: {ALARM_KEY} -->",
+    ]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# gh plumbing
+# --------------------------------------------------------------------------- #
+def _gh(args: list[str], *, parse: bool = True):
+    try:
+        out = subprocess.run(
+            ["gh", *args], check=True, capture_output=True, text=True, timeout=180
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise AlarmError(f"gh {' '.join(args[:2])} failed: {detail}") from exc
+    if not parse:
+        return out.stdout
+    try:
+        return json.loads(out.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise AlarmError(f"gh {' '.join(args[:2])}: unparseable JSON: {exc}") from exc
+
+
+def fetch_open_prs(repo: str) -> list[dict]:
+    """Every OPEN PR, PAGINATED. `gh api --paginate` walks the Link headers; a truncated
+    read would silently shrink the blind spot, so an unexpected shape is fatal."""
+    data = _gh(["api", "--paginate", "--slurp", f"repos/{repo}/pulls?state=open&per_page=100"])
+    if not isinstance(data, list):
+        raise AlarmError("pull-request listing is not a list")
+    prs: list[dict] = []
+    for page in data:
+        if not isinstance(page, list):
+            raise AlarmError("pull-request page is not a list")
+        prs.extend(page)
+    return prs
+
+
+def fetch_comments(repo: str, number: int) -> list[dict]:
+    data = _gh(["api", "--paginate", "--slurp", f"repos/{repo}/issues/{number}/comments"])
+    if not isinstance(data, list):
+        raise AlarmError(f"comment listing for #{number} is not a list")
+    out: list[dict] = []
+    for page in data:
+        if not isinstance(page, list):
+            raise AlarmError(f"comment page for #{number} is not a list")
+        out.extend(page)
+    return out
+
+
+def file_issue(repo: str, body: str, count: int) -> None:
+    """One open issue, keyed by the body marker (the flow-on idempotency mechanism)."""
+    marker = f"<!-- {KEY_PREFIX}: {ALARM_KEY} -->"
+    existing = _gh(
+        [
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{repo}/issues?state=open&labels=review-alarm&per_page=100",
+        ]
+    )
+    if not isinstance(existing, list):
+        raise AlarmError("issue listing is not a list")
+    for page in existing:
+        for issue in page if isinstance(page, list) else []:
+            if isinstance(issue, dict) and marker in str(issue.get("body") or ""):
+                _gh(
+                    [
+                        "api",
+                        "-X",
+                        "PATCH",
+                        f"repos/{repo}/issues/{issue['number']}",
+                        "-f",
+                        f"body={body}",
+                    ]
+                )
+                print(f"::notice::updated existing review-alarm issue #{issue['number']}")
+                return
+    title = f"review-alarm: {count} PR(s) unreachable by every review producer"
+    _gh(
+        [
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/issues",
+            "-f",
+            f"title={title}",
+            "-f",
+            f"body={body}",
+            *[arg for label in BASE_LABELS for arg in ("-f", f"labels[]={label}")],
+        ]
+    )
+    print("::notice::filed a new review-alarm issue")
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+def run(args: argparse.Namespace) -> int:
+    repo = args.repo or os.environ.get("GITHUB_REPOSITORY") or ""
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        raise AlarmError("repo must be OWNER/REPOSITORY (set --repo or GITHUB_REPOSITORY)")
+    now = _parse_iso(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
+
+    if args.prs_file:
+        with open(args.prs_file, encoding="utf-8") as fh:
+            payload = json.load(fh)
+        prs = payload.get("pulls") or []
+        comments_by_pr = payload.get("comments") or {}
+    else:
+        prs = fetch_open_prs(repo)
+        comments_by_pr = {}
+        for pr in prs:
+            number = pr.get("number")
+            if not isinstance(number, int) or isinstance(number, bool):
+                raise AlarmError("pull-request listing carried an invalid number")
+            # Only the blind-spot candidates need their comments read; a reachable or
+            # drafted PR is decided without them.
+            if pr.get("draft") is not True and not registry_lane_reachable(pr, repo):
+                comments_by_pr[number] = fetch_comments(repo, number)
+
+    findings, census = find_blind_spot(prs, comments_by_pr, repo, now, args.max_age_hours)
+
+    print(f"review-alarm census over {len(prs)} open PR(s) in {repo}:")
+    for state, count in sorted(census.items()):
+        print(f"  {state}: {count}")
+    for finding in findings:
+        note = "; ".join(finding["discredited"]) or "no verdict comment at all"
+        print(f"  BLIND SPOT #{finding['number']} ({finding['age_hours']}h) {note}")
+
+    if not findings:
+        print("::notice::no PR is outside every review producer's reach")
+        return 0
+
+    body = render_issue_body(findings, census, repo, args.max_age_hours)
+    if args.dry_run:
+        print(body)
+    else:
+        file_issue(repo, body, len(findings))
+    print(
+        f"::error::{len(findings)} open PR(s) have no countable review verdict and are "
+        "unreachable by every review producer — verdict PRODUCTION, not transport, is the "
+        "stalled stage"
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="")
+    parser.add_argument("--now", default="")
+    parser.add_argument("--prs-file", default="")
+    parser.add_argument("--max-age-hours", type=float, default=DEFAULT_MAX_AGE_HOURS)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    try:
+        return run(args)
+    except AlarmError as exc:
+        print(f"::error::review-lane alarm infrastructure failure: {exc}")
+        return 2
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic self-test (runs as the FIRST step of every scheduled run — a detector is
+# never trusted to watch anything before it has proved itself on this tick's code).
+# --------------------------------------------------------------------------- #
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+# The literal the standing review brief quotes at every reviewer. Substring-grepping for
+# it has already scored a false pass in this repo; the fixture pins that it cannot again.
+BRIEF_QUOTE = (
+    "End with a line-anchored final line, exactly `VERDICT: pass` or `VERDICT: fail`.\n"
+    "Please review the diff now.\n"
+)
+
+
+def _pr(number=1, *, ref="research/x", login="jeswr", sha=SHA_A, draft=False, labels=(),
+        created="2026-07-01T00:00:00Z", repo="sparq-org/sparq"):
+    return {
+        "number": number,
+        "draft": draft,
+        "created_at": created,
+        "title": f"pr {number}",
+        "user": {"login": login},
+        "labels": [{"name": name} for name in labels],
+        "head": {"ref": ref, "sha": sha, "repo": {"full_name": repo}},
+    }
+
+
+def _comment(body, login="reviewer", created="2026-07-02T00:00:00Z"):
+    return {"body": body, "user": {"login": login}, "created_at": created}
+
+
+def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads best flat
+    failures: list[str] = []
+
+    def check(name: str, condition: bool) -> None:
+        if not condition:
+            failures.append(name)
+
+    repo = "sparq-org/sparq"
+
+    # --- reachability: the registry lane's author-side gates, pinned to REAL branch
+    # names measured on 2026-07-26.
+    check(
+        "worker branch + bot author is reachable",
+        registry_lane_reachable(
+            _pr(ref="sparq-agent/issue-2908-30221671021-1", login="sparq-orchestrator[bot]"), repo
+        ),
+    )
+    check(
+        "local agent branch is NOT reachable",
+        not registry_lane_reachable(
+            _pr(ref="ci/pr-freshness-auto-update-branch", login="jeswr"), repo
+        ),
+    )
+    check(
+        "bot author on a non-worker branch is NOT reachable",
+        not registry_lane_reachable(
+            _pr(ref="research/x", login="sparq-orchestrator[bot]"), repo
+        ),
+    )
+    check(
+        "worker branch from a NON-bot author is NOT reachable",
+        not registry_lane_reachable(
+            _pr(ref="sparq-agent/issue-1-2-1", login="jeswr"), repo
+        ),
+    )
+    check(
+        "fork head is NOT reachable",
+        not registry_lane_reachable(
+            _pr(
+                ref="sparq-agent/issue-1-2-1",
+                login="sparq-orchestrator[bot]",
+                repo="attacker/sparq",
+            ),
+            repo,
+        ),
+    )
+    check("issue-0 is not a worker branch", not REGISTRY_HEAD_REF_RE.match("sparq-agent/issue-0-1-1"))
+
+    # --- verdict line: anchored, never a substring.
+    check("plain pass parses", verdict_polarity(f"{SHA_A}\n\nVERDICT: pass") == "pass")
+    check("plain fail parses", verdict_polarity(f"{SHA_A}\n\nVERDICT: fail") == "fail")
+    check("trailing blank lines tolerated", verdict_polarity("VERDICT: pass\n\n  \n") == "pass")
+    check("INSTRUCTION TEXT is not a verdict", verdict_polarity(BRIEF_QUOTE) is None)
+    check(
+        "quoted verdict followed by prose is not a verdict",
+        verdict_polarity("VERDICT: pass\nactually I am still thinking") is None,
+    )
+    check("backticked line is not a verdict", verdict_polarity("`VERDICT: pass`") is None)
+    check("suffixed line is not a verdict", verdict_polarity("VERDICT: pass (with caveats)") is None)
+    check("wrong case is not a verdict", verdict_polarity("VERDICT: PASS") is None)
+    check("unknown polarity is not a verdict", verdict_polarity("VERDICT: maybe") is None)
+    check("empty body is not a verdict", verdict_polarity("") is None)
+    check("non-string body is not a verdict", verdict_polarity(None) is None)
+
+    # --- head binding.
+    check("names current head", comment_binds_head(f"reviewed {SHA_A}\nVERDICT: pass", SHA_A))
+    check("names only the old head", not comment_binds_head(f"reviewed {SHA_B}", SHA_A))
+    check("short sha does not bind", not comment_binds_head(SHA_A[:12], SHA_A))
+    check("41-hex token does not bind", not comment_binds_head(SHA_A + "c", SHA_A))
+    check("unknown head never binds", not comment_binds_head(SHA_A, ""))
+
+    # --- countable_verdict: the three rules composed.
+    pr = _pr(sha=SHA_A, login="jeswr")
+    good = [_comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="reviewer-bot")]
+    check("a clean cross-author head-bound pass counts", countable_verdict(pr, good)[0] == "pass")
+
+    stale = [_comment(f"reviewed {SHA_B}\n\nVERDICT: pass", login="reviewer-bot")]
+    polarity, why = countable_verdict(pr, stale)
+    check("SUPERSEDED HEAD does not count", polarity is None)
+    check("superseded head is reported, not dropped", any("superseded" in r for r in why))
+
+    selfrev = [_comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="jeswr")]
+    polarity, why = countable_verdict(pr, selfrev)
+    check("AUTHOR CANNOT VERDICT THEIR OWN PR", polarity is None)
+    check("self-review is reported by name", any("self-review" in r for r in why))
+
+    quoted = [_comment(f"{SHA_A}\n{BRIEF_QUOTE}", login="reviewer-bot")]
+    check("INSTRUCTION SUBSTRING IS NOT A PASS", countable_verdict(pr, quoted)[0] is None)
+
+    retract = [
+        _comment(f"{SHA_A}\n\nVERDICT: pass", login="r1", created="2026-07-02T00:00:00Z"),
+        _comment(f"{SHA_A}\n\nVERDICT: fail", login="r2", created="2026-07-03T00:00:00Z"),
+    ]
+    check("a later fail supersedes an earlier pass", countable_verdict(pr, retract)[0] == "fail")
+
+    # --- classification + the alarm decision.
+    now = _parse_iso("2026-07-26T00:00:00Z")
+    check(
+        "an unreviewed local-branch PR is a BLIND SPOT",
+        classify_pr(_pr(), [], repo) == "blind-spot",
+    )
+    check(
+        "NO VERDICT IS NOT ARMABLE — it never reads as reviewed",
+        classify_pr(_pr(), [], repo) != "has-verdict",
+    )
+    check("a worker PR is the registry lane's", classify_pr(_pr(
+        ref="sparq-agent/issue-9-1-1", login="sparq-orchestrator[bot]"), [], repo) == "registry-lane")
+    check("a draft is not alarmed", classify_pr(_pr(draft=True), [], repo) == "draft")
+    check(
+        "a human hold is terminal",
+        classify_pr(_pr(labels=("needs:user",)), [], repo) == "human-held",
+    )
+    check(
+        "a lane label is honoured",
+        classify_pr(_pr(labels=("review:pass",)), [], repo) == "lane-labelled",
+    )
+    check("a real verdict clears the blind spot", classify_pr(_pr(), good, repo) == "has-verdict")
+    check(
+        "a SELF verdict does NOT clear the blind spot",
+        classify_pr(_pr(), selfrev, repo) == "blind-spot",
+    )
+
+    old = _pr(number=3426, created="2026-07-18T00:00:00Z")
+    fresh = _pr(number=4342, created="2026-07-25T23:00:00Z")
+    findings, census = find_blind_spot([old, fresh], {}, repo, now, DEFAULT_MAX_AGE_HOURS)
+    check("the aged blind-spot PR alarms", [f["number"] for f in findings] == [3426])
+    check("a fresh blind-spot PR does not alarm yet", census.get("blind-spot-fresh") == 1)
+    check("the census counts every state exit", census.get("blind-spot") == 2)
+
+    findings2, _ = find_blind_spot(
+        [_pr(number=7, created="2026-07-18T00:00:00Z")], {7: good}, repo, now,
+        DEFAULT_MAX_AGE_HOURS)
+    check("a reviewed PR raises no finding", findings2 == [])
+
+    findings3, _ = find_blind_spot(
+        [_pr(number=8, created="2026-07-18T00:00:00Z")], {8: selfrev}, repo, now,
+        DEFAULT_MAX_AGE_HOURS)
+    check("a SELF-reviewed PR still alarms", [f["number"] for f in findings3] == [8])
+    check(
+        "the self-review reason reaches the issue body",
+        bool(findings3) and any("self-review" in r for r in findings3[0]["discredited"]),
+    )
+
+    body = render_issue_body(findings3, {"blind-spot": 1}, repo, DEFAULT_MAX_AGE_HOURS)
+    check("the issue body self-identifies", body.startswith("> 🤖 SPARQ agent"))
+    check("the issue body carries the dedupe key", f"<!-- {KEY_PREFIX}: {ALARM_KEY} -->" in body)
+
+    # --- fail-loud on malformed input (never a quiet green).
+    for name, thunk in (
+        ("malformed PR entry raises", lambda: registry_lane_reachable("nope", repo)),
+        (
+            "invalid PR number raises",
+            lambda: find_blind_spot([{"number": 0}], {}, repo, now, 1.0),
+        ),
+        (
+            "unparseable timestamp raises",
+            lambda: find_blind_spot(
+                [_pr(created="not-a-date")], {}, repo, now, 1.0
+            ),
+        ),
+    ):
+        try:
+            thunk()
+        except AlarmError:
+            pass
+        else:
+            failures.append(name)
+
+    if failures:
+        for name in failures:
+            print(f"FAIL: {name}")
+        print(f"::error::review_lane_alarm self-test: {len(failures)} failure(s)")
+        return 1
+    print("review_lane_alarm self-test: all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review_lane_alarm.py
+++ b/scripts/review_lane_alarm.py
@@ -27,9 +27,38 @@
 # absence of a review produces no artifact — no red check, no queue entry, nothing. This
 # script makes that absence LOUD.
 #
+# WHERE VERDICTS ACTUALLY LIVE (checked, not assumed). The authoritative verdict store is
+# NOT the PR comment thread — it is the registry's `ledger` branch, at
+# `orchestration/review-verdicts/<owner>--<repo>--pr<N>-round<K>.json`, head-bound through
+# a `host_envelope.reviewed_sha` field. 830 records exist, 568 of them sparq. This alarm
+# reads PR COMMENTS, so the obvious objection is that it measures the wrong store and will
+# false-alarm on PRs that hold a ledger verdict. It does not, and the cross-check is the
+# reason this predicate is trustworthy — over the 35 open non-draft sparq PRs on
+# 2026-07-26 the partition is EXACT:
+#
+#     registry_lane_reachable == True   (10 PRs) -> 10/10 hold a ledger verdict record
+#     registry_lane_reachable == False  (25 PRs) ->  0/25 hold a ledger verdict record
+#
+# Zero overlap in either direction, because the registry review lane is the ONLY writer of
+# that store and it writes only for PRs it can enumerate — the very predicate replicated
+# below. So "unreachable" and "has no verdict anywhere" coincide, and this alarm never
+# needs a cross-repo ledger read (which it has no token for anyway). If that partition ever
+# breaks — if some future producer writes ledger records for unreachable PRs — this alarm
+# starts false-alarming, loudly and visibly, which is the correct direction for it to fail.
+#
 # THE ALARM: enumerate the BLIND SPOT — open, non-draft, non-human-held PRs that the
 # registry lane can never reach — and RED this run (plus file one deduped issue) when any
 # of them has sat without a countable verdict for longer than the threshold.
+#
+# THE SAME BLIND SPOT DISARMS NOTHING. The registry's force-push safety net,
+# `enumerate_disarm_items` (same file as the review enumerator), retracts the auto-merge
+# latch whenever an armed PR's live head diverges from its recorded reviewed-sha — a real
+# and correct net. But it replicates the IDENTICAL author-side gates (head-ref regex, head
+# repo, `[bot]` author, provenance record), so it too is blind to this population. On the
+# sparq side auto-arm.py's `expectedHeadOid` CAS binds an arm to the head it just READ, not
+# to the head that was REVIEWED, so it does not substitute. For these PRs no ledger verdict
+# exists today, so there is nothing yet to go stale; the gap opens the moment a
+# comment-sourced `review:pass` lands on one of them.
 #
 # WHAT COUNTS AS A VERDICT (deliberately strict; a wrong pass is worse than no pass):
 #   1. LINE-ANCHORED. `VERDICT: pass` / `VERDICT: fail` as the LAST non-blank line of the

--- a/scripts/tests/test_review_lane_alarm.py
+++ b/scripts/tests/test_review_lane_alarm.py
@@ -271,6 +271,64 @@ class TestNonAlarmingStates(unittest.TestCase):
         )
 
 
+class TestExitCodeCarriesTheVerdict(unittest.TestCase):
+    """FOUND BY MUTATION: rewriting `return 1` to `return 0` in run() survived the whole
+    suite. Nothing asserted that a detected blind spot actually REDS the run — the alarm
+    would have printed its findings into a green log forever, which is the exact
+    exit-zero-swallowing class this repository has been bitten by three times in a day.
+
+    These tests pin the exit code as the alarm's real output. `--dry-run` keeps them
+    hermetic (no gh writes); `--prs-file` supplies the population."""
+
+    def _run(self, pulls, comments=None, *, max_age="24"):
+        import json
+        import tempfile
+        payload = {"pulls": pulls, "comments": comments or {}}
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(payload, fh)
+            path = fh.name
+        return alarm.main([
+            "--repo", REPO, "--prs-file", path, "--now", "2026-07-26T00:00:00Z",
+            "--max-age-hours", max_age, "--dry-run",
+        ])
+
+    def test_an_aged_blind_spot_pr_REDS_the_run(self):
+        self.assertEqual(self._run([pr(number=42, created="2026-07-01T00:00:00Z")]), 1)
+
+    def test_a_clean_population_exits_zero(self):
+        self.assertEqual(
+            self._run([pr(number=5, ref="sparq-agent/issue-5-1-1",
+                          login="sparq-orchestrator[bot]")]),
+            0,
+        )
+
+    def test_a_reviewed_pr_exits_zero(self):
+        good = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass")]
+        self.assertEqual(
+            self._run([pr(number=7, created="2026-07-01T00:00:00Z")], {"7": good}), 0)
+
+    def test_a_SELF_reviewed_pr_still_REDS_the_run(self):
+        selfrev = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="jeswr")]
+        self.assertEqual(
+            self._run([pr(number=8, created="2026-07-01T00:00:00Z")], {"8": selfrev}), 1)
+
+    def test_a_STALE_headed_verdict_still_REDS_the_run(self):
+        stale = [comment(f"reviewed {SHA_B}\n\nVERDICT: pass")]
+        self.assertEqual(
+            self._run([pr(number=9, created="2026-07-01T00:00:00Z")], {"9": stale}), 1)
+
+    def test_an_empty_population_exits_zero(self):
+        self.assertEqual(self._run([]), 0)
+
+    def test_the_three_exit_codes_are_distinct(self):
+        # 0 = clean, 1 = blind spot found, 2 = the detector itself is broken. Collapsing
+        # any pair would make a broken detector indistinguishable from a healthy repo.
+        clean = self._run([])
+        alarmed = self._run([pr(number=1, created="2026-07-01T00:00:00Z")])
+        broken = alarm.main(["--repo", "not-a-slug", "--dry-run"])
+        self.assertEqual((clean, alarmed, broken), (0, 1, 2))
+
+
 class TestFailLoud(unittest.TestCase):
     """A broken detector must never look like a quiet green."""
 

--- a/scripts/tests/test_review_lane_alarm.py
+++ b/scripts/tests/test_review_lane_alarm.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# [OPUS-5] Tests for the review-lane blind-spot alarm (scripts/review_lane_alarm.py +
+# .github/workflows/review-alarm.yml). 🤖 SPARQ agent.
+#
+# TWO HALVES, and the second is the load-bearing one.
+#
+# 1. BEHAVIOUR — the four obligations a verdict detector must meet, each as a NAMED test
+#    that goes red on deletion OR inversion of the guard it covers:
+#      * a PR with no verdict never reads as reviewed (so it can never be armed),
+#      * a verdict bound to a SUPERSEDED head does not count,
+#      * an author cannot verdict their own PR,
+#      * the review brief's own quoted instruction text does not register as a pass.
+#
+# 2. THE YAML SEAM — measured in this repo, every uncaught mutant of an 18-mutant run
+#    lived in a workflow `if:` / step / call-site, not in the Python. YAML `if:`/`on:`/
+#    `permissions:` cannot be unit-tested by execution, so this suite pins their SHAPE:
+#      * the workflow EXISTS and is scheduled (delete the trigger => red),
+#      * the self-test step runs BEFORE the live step (reorder => red),
+#      * the live step actually invokes the script (break the call site => red),
+#      * the job holds `issues: write` and NOT `pull-requests: write` / `contents: write`
+#        (an arming-authority escalation => red),
+#      * docs-quality.yml wires THIS test file (drop the call site => red).
+#
+# The last one is the anti-vacuity anchor: without it, this whole file could be deleted
+# from CI's reachable set and nothing would notice.
+#
+# Stdlib + PyYAML (already a docs-quality dependency). Run:
+#   python3 scripts/tests/test_review_lane_alarm.py
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "review_lane_alarm.py"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "review-alarm.yml"
+DOCS_QUALITY = REPO_ROOT / ".github" / "workflows" / "docs-quality.yml"
+
+_spec = importlib.util.spec_from_file_location("review_lane_alarm", SCRIPT)
+alarm = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(alarm)
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+REPO = "sparq-org/sparq"
+
+# Verbatim from the standing review brief. Substring-grepping for `VERDICT: pass` has
+# already scored this quotation as a real pass in this repository.
+BRIEF_INSTRUCTION = (
+    "Post ONE comment per PR, opening with the `> 🤖 SPARQ agent` blockquote, ending "
+    "with a line-anchored final line, exactly `VERDICT: pass` or `VERDICT: fail` "
+    "(nothing after it).\nState the head SHA you reviewed.\n"
+)
+
+
+def pr(number=1, *, ref="research/x", login="jeswr", sha=SHA_A, draft=False, labels=(),
+       created="2026-07-01T00:00:00Z", repo=REPO):
+    return {
+        "number": number,
+        "draft": draft,
+        "created_at": created,
+        "title": f"pr {number}",
+        "user": {"login": login},
+        "labels": [{"name": name} for name in labels],
+        "head": {"ref": ref, "sha": sha, "repo": {"full_name": repo}},
+    }
+
+
+def comment(body, login="reviewer-bot", created="2026-07-02T00:00:00Z"):
+    return {"body": body, "user": {"login": login}, "created_at": created}
+
+
+class TestNoVerdictIsNotArmable(unittest.TestCase):
+    """OBLIGATION 1: a PR with no verdict must never read as reviewed."""
+
+    def test_no_comments_at_all_is_a_blind_spot(self):
+        self.assertEqual(alarm.classify_pr(pr(), [], REPO), "blind-spot")
+
+    def test_chatter_without_a_verdict_line_is_a_blind_spot(self):
+        chatter = [comment(f"looks good to me, head is {SHA_A}"), comment("bumping")]
+        self.assertEqual(alarm.classify_pr(pr(), chatter, REPO), "blind-spot")
+
+    def test_no_verdict_never_yields_a_polarity(self):
+        self.assertIsNone(alarm.countable_verdict(pr(), [])[0])
+
+    def test_an_unreviewed_pr_past_the_threshold_alarms(self):
+        now = alarm._parse_iso("2026-07-26T00:00:00Z")
+        findings, _ = alarm.find_blind_spot(
+            [pr(number=42, created="2026-07-01T00:00:00Z")], {}, REPO, now, 24)
+        self.assertEqual([f["number"] for f in findings], [42])
+
+
+class TestSupersededHeadDoesNotCount(unittest.TestCase):
+    """OBLIGATION 2: a force-push must invalidate a verdict."""
+
+    def test_verdict_naming_the_previous_head_does_not_count(self):
+        stale = [comment(f"reviewed {SHA_B}\n\nVERDICT: pass")]
+        self.assertIsNone(alarm.countable_verdict(pr(sha=SHA_A), stale)[0])
+
+    def test_superseded_verdict_still_leaves_the_pr_in_the_blind_spot(self):
+        stale = [comment(f"reviewed {SHA_B}\n\nVERDICT: pass")]
+        self.assertEqual(alarm.classify_pr(pr(sha=SHA_A), stale, REPO), "blind-spot")
+
+    def test_the_superseded_reason_is_reported_not_dropped(self):
+        stale = [comment(f"reviewed {SHA_B}\n\nVERDICT: pass")]
+        _, why = alarm.countable_verdict(pr(sha=SHA_A), stale)
+        self.assertTrue(any("superseded" in reason for reason in why), why)
+
+    def test_a_truncated_sha_does_not_bind(self):
+        self.assertFalse(alarm.comment_binds_head(f"reviewed {SHA_A[:12]}", SHA_A))
+
+    def test_a_longer_hex_run_does_not_bind(self):
+        # A 41-hex token must not satisfy a 40-hex binding by prefix.
+        self.assertFalse(alarm.comment_binds_head(SHA_A + "c", SHA_A))
+
+    def test_the_same_verdict_counts_once_the_comment_names_the_new_head(self):
+        fresh = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass")]
+        self.assertEqual(alarm.countable_verdict(pr(sha=SHA_A), fresh)[0], "pass")
+
+
+class TestAuthorCannotVerdictOwnPr(unittest.TestCase):
+    """OBLIGATION 3: author XOR reviewer, structurally.
+
+    This is not hypothetical here. On 2026-07-26 the live repository carried three open
+    PRs (#3765, #3435, #2278) with a line-anchored, HEAD-BOUND `VERDICT:` comment posted
+    by the PR's own author at author_association MEMBER — the exact shape the arming
+    bridge admits. They were all `fail`, so nothing self-armed; a `pass` in the same shape
+    would have."""
+
+    def test_self_posted_pass_does_not_count(self):
+        selfrev = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="jeswr")]
+        self.assertIsNone(alarm.countable_verdict(pr(login="jeswr"), selfrev)[0])
+
+    def test_self_posted_pass_leaves_the_pr_in_the_blind_spot(self):
+        selfrev = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="jeswr")]
+        self.assertEqual(alarm.classify_pr(pr(login="jeswr"), selfrev, REPO), "blind-spot")
+
+    def test_the_self_review_is_named_in_the_report(self):
+        selfrev = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="jeswr")]
+        _, why = alarm.countable_verdict(pr(login="jeswr"), selfrev)
+        self.assertTrue(any("self-review" in reason for reason in why), why)
+
+    def test_self_review_is_reported_as_self_not_merely_stale(self):
+        # Checked BEFORE the head test on purpose: a self-review's problem is not its age,
+        # and a human told "stale" would re-review the head and re-arm the same hole.
+        selfrev = [comment(f"reviewed {SHA_B}\n\nVERDICT: pass", login="jeswr")]
+        _, why = alarm.countable_verdict(pr(login="jeswr", sha=SHA_A), selfrev)
+        self.assertTrue(any("self-review" in reason for reason in why), why)
+
+    def test_a_different_account_on_the_same_head_does_count(self):
+        # The guard must not be so broad that no verdict can ever pass.
+        other = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass", login="someone-else")]
+        self.assertEqual(alarm.countable_verdict(pr(login="jeswr"), other)[0], "pass")
+
+    def test_a_self_pass_cannot_override_a_cross_author_fail(self):
+        comments = [
+            comment(f"{SHA_A}\n\nVERDICT: fail", login="r1", created="2026-07-02T00:00:00Z"),
+            comment(f"{SHA_A}\n\nVERDICT: pass", login="jeswr", created="2026-07-03T00:00:00Z"),
+        ]
+        self.assertEqual(alarm.countable_verdict(pr(login="jeswr"), comments)[0], "fail")
+
+
+class TestInstructionTextIsNotAPass(unittest.TestCase):
+    """OBLIGATION 4: never substring-grep. The brief quotes the literal at every
+    reviewer, and a substring match on that quotation has produced a false pass here."""
+
+    def test_the_brief_instruction_is_not_a_verdict(self):
+        self.assertIsNone(alarm.verdict_polarity(BRIEF_INSTRUCTION))
+
+    def test_a_comment_quoting_the_brief_stays_in_the_blind_spot(self):
+        quoted = [comment(f"{SHA_A}\n{BRIEF_INSTRUCTION}")]
+        self.assertEqual(alarm.classify_pr(pr(), quoted, REPO), "blind-spot")
+
+    def test_backticked_literal_is_not_a_verdict(self):
+        self.assertIsNone(alarm.verdict_polarity("`VERDICT: pass`"))
+
+    def test_verdict_line_followed_by_prose_is_not_a_verdict(self):
+        self.assertIsNone(
+            alarm.verdict_polarity("VERDICT: pass\n\nActually, one more thought:")
+        )
+
+    def test_suffixed_verdict_line_is_not_a_verdict(self):
+        self.assertIsNone(alarm.verdict_polarity("VERDICT: pass (modulo the nit above)"))
+
+    def test_wrong_case_is_not_a_verdict(self):
+        self.assertIsNone(alarm.verdict_polarity("VERDICT: PASS"))
+
+    def test_a_genuine_trailing_verdict_line_does_parse(self):
+        self.assertEqual(alarm.verdict_polarity(f"{SHA_A}\n\nVERDICT: pass\n\n"), "pass")
+
+
+class TestRegistryLaneReachability(unittest.TestCase):
+    """The reachability predicate is the claim this whole alarm rests on: it must be the
+    registry's own admission test, pinned to REAL branch names measured on 2026-07-26."""
+
+    def test_real_worker_branch_is_reachable(self):
+        self.assertTrue(alarm.registry_lane_reachable(
+            pr(ref="sparq-agent/issue-2908-30221671021-1",
+               login="sparq-orchestrator[bot]"), REPO))
+
+    def test_real_local_agent_branches_are_unreachable(self):
+        for ref in ("ci/pr-freshness-auto-update-branch", "research/agent-context-sharing",
+                    "fix/readiness-visibility-opus5", "feat/start-here-renderer"):
+            with self.subTest(ref=ref):
+                self.assertFalse(alarm.registry_lane_reachable(pr(ref=ref, login="jeswr"), REPO))
+
+    def test_non_bot_author_on_a_worker_branch_is_unreachable(self):
+        self.assertFalse(
+            alarm.registry_lane_reachable(pr(ref="sparq-agent/issue-1-2-1", login="jeswr"), REPO))
+
+    def test_fork_head_is_unreachable(self):
+        self.assertFalse(alarm.registry_lane_reachable(
+            pr(ref="sparq-agent/issue-1-2-1", login="sparq-orchestrator[bot]",
+               repo="attacker/sparq"), REPO))
+
+    def test_the_regex_is_byte_identical_to_the_registry_gate(self):
+        # If the registry ever loosens its head-ref gate, this pin must be updated in the
+        # same breath — a paraphrased predicate would silently mis-scope the alarm.
+        self.assertEqual(alarm.REGISTRY_HEAD_REF_RE.pattern,
+                         r"^sparq-agent/issue-([1-9][0-9]*)-")
+
+
+class TestNonAlarmingStates(unittest.TestCase):
+    """The alarm must not be so eager that a human hold or a real review re-fires it."""
+
+    def test_draft_is_not_alarmed(self):
+        self.assertEqual(alarm.classify_pr(pr(draft=True), [], REPO), "draft")
+
+    def test_human_holds_are_terminal(self):
+        for label in ("needs:user", "review:needs-user"):
+            with self.subTest(label=label):
+                self.assertEqual(alarm.classify_pr(pr(labels=(label,)), [], REPO), "human-held")
+
+    def test_lane_labelled_prs_are_not_double_reported(self):
+        self.assertEqual(alarm.classify_pr(pr(labels=("review:pass",)), [], REPO),
+                         "lane-labelled")
+
+    def test_a_genuinely_reviewed_pr_raises_no_finding(self):
+        now = alarm._parse_iso("2026-07-26T00:00:00Z")
+        good = [comment(f"reviewed {SHA_A}\n\nVERDICT: pass")]
+        findings, _ = alarm.find_blind_spot(
+            [pr(number=7, created="2026-07-01T00:00:00Z")], {7: good}, REPO, now, 24)
+        self.assertEqual(findings, [])
+
+    def test_a_fresh_blind_spot_pr_is_counted_but_not_alarmed(self):
+        now = alarm._parse_iso("2026-07-26T00:00:00Z")
+        findings, census = alarm.find_blind_spot(
+            [pr(number=9, created="2026-07-25T23:00:00Z")], {}, REPO, now, 24)
+        self.assertEqual(findings, [])
+        self.assertEqual(census.get("blind-spot-fresh"), 1)
+
+    def test_the_census_counts_every_state_exit(self):
+        now = alarm._parse_iso("2026-07-26T00:00:00Z")
+        _, census = alarm.find_blind_spot(
+            [
+                pr(number=1, created="2026-07-01T00:00:00Z"),
+                pr(number=2, draft=True),
+                pr(number=3, labels=("needs:user",)),
+                pr(number=4, ref="sparq-agent/issue-5-1-1", login="sparq-orchestrator[bot]"),
+            ],
+            {}, REPO, now, 24)
+        self.assertEqual(
+            census,
+            {"blind-spot": 1, "draft": 1, "human-held": 1, "registry-lane": 1},
+        )
+
+
+class TestFailLoud(unittest.TestCase):
+    """A broken detector must never look like a quiet green."""
+
+    def test_malformed_pull_entry_raises(self):
+        with self.assertRaises(alarm.AlarmError):
+            alarm.registry_lane_reachable("not-a-dict", REPO)
+
+    def test_invalid_pr_number_raises(self):
+        now = alarm._parse_iso("2026-07-26T00:00:00Z")
+        with self.assertRaises(alarm.AlarmError):
+            alarm.find_blind_spot([{"number": 0}], {}, REPO, now, 24)
+
+    def test_unparseable_timestamp_raises(self):
+        now = alarm._parse_iso("2026-07-26T00:00:00Z")
+        with self.assertRaises(alarm.AlarmError):
+            alarm.find_blind_spot([pr(created="whenever")], {}, REPO, now, 24)
+
+    def test_bad_repo_slug_raises(self):
+        import argparse
+        args = argparse.Namespace(repo="not-a-slug", now="", prs_file="", max_age_hours=24,
+                                  dry_run=True, self_test=False)
+        with self.assertRaises(alarm.AlarmError):
+            alarm.run(args)
+
+    def test_main_maps_infrastructure_failure_to_exit_two(self):
+        self.assertEqual(alarm.main(["--repo", "not-a-slug", "--dry-run"]), 2)
+
+    def test_the_embedded_self_test_passes(self):
+        self.assertEqual(alarm.main(["--self-test"]), 0)
+
+
+# --------------------------------------------------------------------------- #
+# THE YAML SEAM
+# --------------------------------------------------------------------------- #
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on_block(wf: dict) -> dict:
+    """Bare `on` is the YAML boolean True, so PyYAML keys it under `True`."""
+    return wf.get("on", wf.get(True, {})) or {}
+
+
+class TestWorkflowWiring(unittest.TestCase):
+    """Mutate the workflow and one of these must go red."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = _load(WORKFLOW)
+        cls.job = cls.wf["jobs"]["alarm"]
+        cls.steps = cls.job["steps"]
+
+    def test_the_workflow_exists(self):
+        self.assertTrue(WORKFLOW.is_file(), WORKFLOW)
+
+    def test_it_is_scheduled(self):
+        # Delete the trigger => the detector never runs => red here.
+        schedule = _on_block(self.wf).get("schedule")
+        self.assertTrue(schedule, "review-alarm must keep a schedule trigger")
+        self.assertTrue(all("cron" in entry for entry in schedule))
+
+    def test_the_cron_is_explicit_not_shorthand(self):
+        for entry in _on_block(self.wf)["schedule"]:
+            self.assertNotIn("*/", entry["cron"], "explicit minutes keep the cadence auditable")
+
+    def test_it_is_manually_dispatchable(self):
+        self.assertIn("workflow_dispatch", _on_block(self.wf))
+
+    def test_it_never_triggers_on_a_pr_or_merge_group(self):
+        # A check-run on a PR head would drag this non-gate into the ci-summary poll set.
+        for trigger in ("pull_request", "pull_request_target", "merge_group", "push"):
+            self.assertNotIn(trigger, _on_block(self.wf), trigger)
+
+    def test_the_job_has_no_if_guard(self):
+        # Invert-the-`if:` is the classic vacuity mutant; the job simply has none to invert.
+        self.assertNotIn("if", self.job)
+
+    def test_the_script_is_actually_invoked(self):
+        # Break the call site (rename/typo the script path) => red here.
+        runs = " ".join(str(step.get("run", "")) for step in self.steps)
+        self.assertIn("scripts/review_lane_alarm.py", runs)
+
+    def test_the_self_test_runs_before_the_live_step(self):
+        commands = [str(step.get("run", "")) for step in self.steps]
+        selftest = next(i for i, c in enumerate(commands) if "--self-test" in c)
+        live = next(
+            i for i, c in enumerate(commands)
+            if "review_lane_alarm.py" in c and "--self-test" not in c
+        )
+        self.assertLess(selftest, live, "a detector proves itself before it is trusted")
+
+    def test_the_self_test_step_is_unconditional(self):
+        for step in self.steps:
+            if "--self-test" in str(step.get("run", "")):
+                self.assertNotIn("if", step, "the self-test must never be skippable")
+
+    def test_the_live_step_is_unconditional(self):
+        for step in self.steps:
+            run = str(step.get("run", ""))
+            if "review_lane_alarm.py" in run and "--self-test" not in run:
+                self.assertNotIn("if", step)
+
+    def test_no_continue_on_error_anywhere(self):
+        # Exit-zero swallowing: a later transient must never discard the earned red.
+        self.assertNotIn("continue-on-error", self.job)
+        for step in self.steps:
+            self.assertNotIn("continue-on-error", step)
+
+    def test_the_job_holds_issues_write_only(self):
+        perms = self.job["permissions"]
+        self.assertEqual(perms.get("issues"), "write")
+        self.assertEqual(perms.get("contents"), "read")
+
+    def test_the_job_has_NO_arming_authority(self):
+        # THE escalation guard. Granting pull-requests:write would let this detector
+        # write review:pass and therefore arm — the one thing it must never be able to do.
+        perms = self.job["permissions"]
+        self.assertNotIn("pull-requests", perms)
+        self.assertNotEqual(perms.get("contents"), "write")
+        for forbidden in ("actions", "checks", "id-token"):
+            self.assertNotIn(forbidden, perms, forbidden)
+
+    def test_the_workflow_level_permissions_are_read_only(self):
+        self.assertEqual(self.wf["permissions"], {"contents": "read"})
+
+    def test_it_does_not_act_on_the_transport_workflow(self):
+        # verdict-bridge.yml owns the comment -> label TRANSPORT hop; this workflow owns
+        # noticing that no verdict was ever PRODUCED. They must not both write the same
+        # label or drive each other. Prose may name it (the header does); no executable
+        # step may touch it, and no step may write a PR label at all.
+        for step in self.steps:
+            run = str(step.get("run", ""))
+            self.assertNotIn("verdict-bridge", run)
+            self.assertNotIn("workflow run", run)
+            for label_write in ("gh pr edit", "gh issue edit", "--add-label", "/labels"):
+                self.assertNotIn(label_write, run, label_write)
+
+    def test_actions_are_sha_pinned(self):
+        import re
+        for step in self.steps:
+            uses = step.get("uses")
+            if uses:
+                self.assertRegex(uses, r"@[0-9a-f]{40}$", uses)
+
+    def test_the_job_name_carries_no_advisory_token(self):
+        import re
+        self.assertIsNone(re.search(r"\b(advisory|informational)\b", self.job["name"]))
+
+    def test_the_checkout_does_not_persist_credentials(self):
+        for step in self.steps:
+            if str(step.get("uses", "")).startswith("actions/checkout@"):
+                self.assertIs(step["with"]["persist-credentials"], False)
+
+    def test_the_sparse_checkout_includes_the_script(self):
+        # A sparse-checkout that misses the script would fail the run at HEAD, but silently
+        # drift if the script is ever renamed; pin the pairing.
+        for step in self.steps:
+            if str(step.get("uses", "")).startswith("actions/checkout@"):
+                self.assertIn("scripts/review_lane_alarm.py", step["with"]["sparse-checkout"])
+
+
+class TestGateCallSite(unittest.TestCase):
+    """The anti-vacuity anchor: without this, the whole suite could leave CI unnoticed."""
+
+    def test_docs_quality_runs_this_suite(self):
+        text = DOCS_QUALITY.read_text(encoding="utf-8")
+        self.assertIn("scripts/tests/test_review_lane_alarm.py", text)
+
+    def test_the_call_site_step_is_unconditional(self):
+        wf = _load(DOCS_QUALITY)
+        found = False
+        for job in wf["jobs"].values():
+            for step in job.get("steps") or []:
+                if "test_review_lane_alarm.py" in str(step.get("run", "")):
+                    found = True
+                    self.assertNotIn("if", step, "the suite must not be conditionally skipped")
+                    self.assertNotIn("continue-on-error", step)
+        self.assertTrue(found, "docs-quality.yml must invoke test_review_lane_alarm.py")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, argv=[sys.argv[0], "-v"])

--- a/scripts/tests/test_review_lane_alarm.py
+++ b/scripts/tests/test_review_lane_alarm.py
@@ -406,18 +406,35 @@ class TestWorkflowWiring(unittest.TestCase):
         # Invert-the-`if:` is the classic vacuity mutant; the job simply has none to invert.
         self.assertNotIn("if", self.job)
 
-    def test_the_script_is_actually_invoked(self):
-        # Break the call site (rename/typo the script path) => red here.
-        runs = " ".join(str(step.get("run", "")) for step in self.steps)
-        self.assertIn("scripts/review_lane_alarm.py", runs)
+    def _step_indices(self):
+        """(self-test index, live index) or None for either when absent. Deliberately NOT
+        `next(...)`: a bare next() raises StopIteration on a broken call site, which is a
+        CRASH-kill — it reds, but it reports a traceback instead of naming the defect. A
+        mutation run caught exactly that here."""
+        commands = [str(step.get("run", "")) for step in self.steps]
+        selftest = next(
+            (i for i, c in enumerate(commands) if "review_lane_alarm.py --self-test" in c), None)
+        live = next(
+            (i for i, c in enumerate(commands)
+             if "review_lane_alarm.py" in c and "--self-test" not in c), None)
+        return selftest, live
+
+    def test_the_LIVE_step_actually_invokes_the_script(self):
+        # A whole-workflow substring check is VACUOUS here: the self-test step also names
+        # the script, so typoing ONLY the live call site would satisfy it. Assert against
+        # the live step specifically.
+        _, live = self._step_indices()
+        self.assertIsNotNone(live, "no step invokes the alarm outside --self-test mode")
+        self.assertIn("scripts/review_lane_alarm.py", str(self.steps[live]["run"]))
+
+    def test_the_self_test_step_actually_invokes_the_script(self):
+        selftest, _ = self._step_indices()
+        self.assertIsNotNone(selftest, "no step runs the alarm's --self-test")
 
     def test_the_self_test_runs_before_the_live_step(self):
-        commands = [str(step.get("run", "")) for step in self.steps]
-        selftest = next(i for i, c in enumerate(commands) if "--self-test" in c)
-        live = next(
-            i for i, c in enumerate(commands)
-            if "review_lane_alarm.py" in c and "--self-test" not in c
-        )
+        selftest, live = self._step_indices()
+        self.assertIsNotNone(selftest)
+        self.assertIsNotNone(live)
         self.assertLess(selftest, live, "a detector proves itself before it is trusted")
 
     def test_the_self_test_step_is_unconditional(self):

--- a/scripts/tests/test_review_lane_alarm.py
+++ b/scripts/tests/test_review_lane_alarm.py
@@ -194,6 +194,29 @@ class TestInstructionTextIsNotAPass(unittest.TestCase):
     def test_a_genuine_trailing_verdict_line_does_parse(self):
         self.assertEqual(alarm.verdict_polarity(f"{SHA_A}\n\nVERDICT: pass\n\n"), "pass")
 
+    # FOUND BY MUTATION: dropping the `^` anchor from VERDICT_LINE_RE (leaving the `$`)
+    # survived the whole suite. Every existing negative case put text AFTER the literal,
+    # so nothing covered text BEFORE it. That gap matters more here than almost anywhere:
+    # every comment in this repo opens with the `> 🤖 SPARQ agent` blockquote convention,
+    # so QUOTING another agent's verdict — `> VERDICT: pass` — is the natural shape of a
+    # false positive, and the unanchored regex scores it as a real pass.
+    def test_a_BLOCKQUOTED_verdict_is_not_a_verdict(self):
+        self.assertIsNone(alarm.verdict_polarity("> VERDICT: pass"))
+
+    def test_a_verdict_with_ANY_prefix_text_is_not_a_verdict(self):
+        for line in ("Final answer: VERDICT: pass", "- VERDICT: pass", "1. VERDICT: fail",
+                     "not a VERDICT: pass", "* VERDICT: pass"):
+            with self.subTest(line=line):
+                self.assertIsNone(alarm.verdict_polarity(line))
+
+    def test_quoting_someone_elses_verdict_leaves_the_pr_unreviewed(self):
+        quoted = [comment(f"Copying the earlier review of {SHA_A}:\n\n> VERDICT: pass")]
+        self.assertEqual(alarm.classify_pr(pr(), quoted, REPO), "blind-spot")
+
+    def test_leading_whitespace_is_still_tolerated(self):
+        # The guard must reject PREFIX TEXT, not indentation — the line is stripped first.
+        self.assertEqual(alarm.verdict_polarity("   VERDICT: pass"), "pass")
+
 
 class TestRegistryLaneReachability(unittest.TestCase):
     """The reachability predicate is the claim this whole alarm rests on: it must be the


### PR DESCRIPTION
> 🤖 SPARQ agent

## The stalled stage is verdict PRODUCTION, and it is invisible

sparq has **no in-repo verdict producer**. Every review a sparq PR receives is produced out of
repo by the registry's `review-fix.yml`, scheduled by the registry's `dispatch.yml`. That
scheduler admits a PR only through `enumerate_review_items`, whose first gates are author-side
and fail closed:

```python
if not HEAD_REF_RE.match(ref):        continue   # ^sparq-agent/issue-([1-9][0-9]*)-
if head_repo != repo:                 continue
if not login.endswith("[bot]") ...:   continue   # must be the worker App bot
```

plus a mandatory registry provenance record only a host-side worker run can write. A PR opened
by anything else — **every PR an interactive agent session pushes** — fails all of them by
construction, so no review is ever dispatched for it.

### The census that proves it

Paginated over all 118 open PRs, `total_count` cross-checked:

| author | open PRs | carrying any `review:*` loop label |
| --- | --- | --- |
| `sparq-orchestrator[bot]` | 89 | **89 (100%)** |
| `jeswr` | 29 | **0** |

Zero is not a coincidence, it is a predicate.

### Cross-checked against the authoritative store

Verdicts do **not** live in PR comments — they live on the registry's `ledger` branch at
`orchestration/review-verdicts/<owner>--<repo>--pr<N>-round<K>.json`, head-bound via
`host_envelope.reviewed_sha` (830 records, 568 sparq). Over the 35 open non-draft sparq PRs the
partition against this PR's reachability predicate is **exact**, in both directions:

```
registry_lane_reachable == True   (10 PRs) -> 10/10 hold a ledger verdict record
registry_lane_reachable == False  (25 PRs) ->  0/25 hold a ledger verdict record
```

The registry lane is the only writer of that store and writes only for PRs it can enumerate, so
"unreachable" and "has no verdict anywhere" coincide. That is why a comment-based read never
false-alarms on a ledger-reviewed PR — verified, not assumed.

## Which case is it? Both, and they need opposite responses

Of the 21 PRs originally flagged as verdict-less, checked against **both** predicates:

| population | count | actual state |
| --- | --- | --- |
| fails BOTH author-side gates (`jeswr`, hand branch) | **13** | genuinely never dispatched — case 1 |
| passes both gates (`sparq-orchestrator[bot]`) | **8** | **reviewed and mostly armed** — not stuck |

Not one PR fails only one predicate: local agents push hand branches as `jeswr`, workers push
`sparq-agent/…` as the bot, so the two gates are perfectly correlated in this population.

The 8 bot PRs were reviewed *today* (successful `review-fix review` runs), carry `review:pass`,
and 6 of 8 are armed. They lack a `VERDICT:` comment only because the registry lane records
verdicts as a ledger record plus a label, never as a PR comment. **"Has a `VERDICT:` comment" was
the wrong proxy for "was reviewed" for that half.**

## What this PR changes, and why that layer binds

The predicates are **not widened**. They are correctly fail-closed on the security axis: an
unattested author cannot be given a provider-opposite reviewer, so author-XOR-reviewer cannot be
*proven* for these PRs. Widening would hand review authority to exactly the untrusted-author case
the gate exists for.

The defect is that "cannot be auto-reviewed" currently means **silently invisible** rather than
**routed to a human**. It is a missing terminal edge — a state with no exit, which no per-run
success signal can detect, because absence of a review produces no artifact at all.

So this adds the exit: `scripts/review_lane_alarm.py` + `.github/workflows/review-alarm.yml`,
built to the established `selection-alarm` / `formal-alarm` pattern — census every state, RED the
run and file ONE deduped issue when a PR sits unreviewed past the threshold.

**Live dry-run on this tree** (`--dry-run`, no writes):

```
review-alarm census over 118 open PR(s) in sparq-org/sparq:
  blind-spot: 22
  blind-spot-fresh: 12
  draft: 83
  human-held: 4
  registry-lane: 9
  BLIND SPOT #1607 (501.1h) self-review by the PR author @jeswr (never countable)
  ...
  BLIND SPOT #3798 (24.7h)  self-review by the PR author @jeswr (never countable)
::error::10 open PR(s) have no countable review verdict and are unreachable by every
review producer — verdict PRODUCTION, not transport, is the stalled stage
```

### No arming authority, structurally

The job holds `issues: write` and nothing else — no `pull-requests: write` (it cannot label,
promote or un-draft), no `contents: write`. It never marks a PR reviewed; it only refuses to let
"nobody reviewed this" stay silent. It is deliberately disjoint from `verdict-bridge.yml`, which
owns the comment → label transport hop. **No file owned by the verdict-transport work is touched.**

### What counts as a verdict

Line-anchored (`VERDICT: pass|fail` as the last non-blank line, never a substring), naming the
current head as a standalone 40-hex SHA, and **not** posted by the PR's own author.

## Findings reported, not fixed here

1. **Author-XOR-reviewer is not enforced anywhere on the sparq side.** `scripts/verdict-bridge.py`
   admits any comment whose `author_association` is OWNER/MEMBER/COLLABORATOR and never compares
   the comment author to the PR author. Every local agent posts as `jeswr`, who authors these PRs.
   Live evidence: **#3765, #3435 and #2278 each carry a line-anchored, head-bound `VERDICT:`
   comment posted by the PR's own author at `author_association: MEMBER`** — the exact shape the
   bridge admits. All three are `fail`, so nothing self-armed; a `pass` in the same shape would
   promote to `review:pass` and arm. Note the deeper problem: GitHub identity cannot distinguish
   author from reviewer here, because both agents are `jeswr`. A durable fix needs a reviewer
   attestation distinct from the author's, not a login comparison.
2. **The force-push disarm net shares the same blind spot.** The registry's
   `enumerate_disarm_items` correctly retracts the auto-merge latch when an armed PR's head
   diverges from its recorded reviewed-sha — but it replicates the *identical* author-side gates,
   so it is blind to the same 25 PRs. On the sparq side `auto-arm.py`'s `expectedHeadOid` CAS binds
   an arm to the head it just **read**, not the head that was **reviewed**, so it does not
   substitute. Nothing yet to go stale for these PRs (no ledger verdict exists), but the gap opens
   the moment a comment-sourced `review:pass` lands on one.
3. `verdict-bridge.yml`'s most recent scheduled run (2026-07-26T21:41:54Z) **failed**.

## Test obligations and the mutation run

73 tests, all green. Four required obligations each have named tests: no-verdict is not armable,
a superseded head does not count, an author cannot verdict their own PR, and the brief's quoted
instruction text is not a pass.

**40 mutants, 40 killed** — but three only after the run found real gaps:

| mutant | first result | resolution |
| --- | --- | --- |
| `run()` returns 0 instead of 1 with findings | **SURVIVED** | genuine exit-zero hole — nothing asserted the alarm reds. Added `TestExitCodeCarriesTheVerdict` |
| `^` anchor dropped from `VERDICT_LINE_RE` | **SURVIVED** | genuine — `> VERDICT: pass` (a *blockquoted* verdict, the natural shape here) scored as a pass. Added anchor tests |
| typo ONLY the live call site | crash-kill | the assertion substring-searched the whole workflow and the self-test step also names the script — vacuous. Narrowed to the live step; now a behaviour-kill |

YAML seam, all killed: delete the schedule (1 behaviour + 1 crash), `if: false` on the job / the
self-test step / the live step, break the call site, reorder self-test after the live run,
escalate to `pull-requests: write`, escalate to `contents: write`, add `continue-on-error`, unpin
the action, `persist-credentials: true`, sparse-checkout drops the script, add a `pull_request`
trigger, `*/N` cron shorthand, rename the job `advisory`, delete the whole workflow,
`permissions: write-all`, delete the docs-quality call site, make that call site conditional.

Python guards, all killed: delete/invert the author-XOR guard, delete the head-binding guard,
head-binding by 12-char substring, verdict by substring search, `$` anchor dropped, `^` anchor
dropped, scan all lines instead of the last, drop each of the three reachability gates, allow
`issue-0`, empty the human-hold set, alarm drafts, ignore the age threshold, swallow a bad PR
number, `return 0` with findings, map `AlarmError` to exit 0, first-wins instead of latest-wins,
delete all discredited reporting, reorder the self-check after the head-check.

Two mutants first reported SURVIVED turned out to be no-op seds that never applied; re-run
correctly, both died. Reported as setup failures, not survivors.

## Gate

`actionlint` clean on both changed workflows (it caught a real SC2086 in my first draft — fixed
with a bash args array). `test_gates.py`, `test_ci_select_wiring.py`, `test_path_ownership.py`,
`test_banned_terminology.py` all pass. The only actionlint findings in the tree are pre-existing
ones in `ci.yml`.

## Expected effect on the backlog

Nothing merges that would not have merged before — this grants no arming authority. What changes
is that the 25 structurally unreviewable PRs stop being invisible: one issue names them, and the
scheduled run stays red until they are reviewed or explicitly human-held. The 8 bot PRs need no
action; they were never stuck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
