### PR TITLE
fix(orchestration): a PR and its source issue reserve ONE union partition, once

### DIFF
--- a/research/unit-occupancy-and-the-frontier.md
+++ b/research/unit-occupancy-and-the-frontier.md
@@ -1,0 +1,105 @@
+# Unit occupancy: why de-duplicating reservations cannot widen the frontier
+
+> 🤖 SPARQ agent — measured design record. Snapshot: `sparq-org/sparq`, 2026-07-27,
+> 1473 open issues / 123 open PRs, cursor-paginated (`gh api --paginate`, page counts
+> cross-checked against the listing totals).
+
+## The claim under test
+
+The dispatch frontier is narrow while the drainable backlog is large. One proposed cause: a
+worker PR and its source issue are the **same unit of work** and each reserves its `area:`
+partitions independently, so the same work is counted twice. The proposed remedy was to
+**deduplicate** — reserve the union once — explicitly *not* to drop either half.
+
+## What the code actually does
+
+`scripts/ready-issues.py::compute_ready` reserves for a row iff it is OPEN, not parked
+(`needs:user` / `review:needs-user` / `status:blocked`), and is either a PR row or carries
+`status:in-progress` / `status:in-progress-review`. Census over the live snapshot, taken from that
+code path rather than from a description of it:
+
+| population | count |
+| --- | --- |
+| open PRs, occupying, with an `area:` label → reserve | 65 |
+| open PRs, parked → reserve nothing | 49 |
+| open PRs, occupying, no `area:` → reserve nothing | 9 |
+| in-flight issues with an `area:` label → reserve | 46 (44 `in-progress-review` + 2 `in-progress`) |
+| **total** | **111 artifacts, 158 reservations, 49 distinct partition keys** |
+
+Parked PRs contribute **zero**. 20 of the 158 reservations are a duplicate of a key the unit's
+other half already holds.
+
+## Finding 1 — deduplication is frontier-neutral, provably
+
+`conflict()` tests membership in the **set** of held partition keys (`blockers.keys()`). A second
+occupant on an already-held key appends to a list that only attribution ever reads. And a unit
+reserves the union of exactly its members' own reservations, so the union *over units* equals the
+union *over members*. Therefore the held key set — and hence the frontier — is **invariant** under
+folding. Measured, on the live snapshot:
+
+| occupancy | artifacts/units | reservations | distinct keys | frontier |
+| --- | --- | --- | --- | --- |
+| both halves, independent (status quo) | 111 | 158 | 49 | 3 |
+| union folded into one unit each | 81 | 138 | 49 | **3** |
+
+Dedup recovers **zero** slots. Anything that *does* widen the frontier does so by **releasing** a
+key. `test_the_held_key_set_is_invariant_under_folding` pins this so no future frontier assertion
+is written believing it can witness the fold.
+
+## Finding 2 — the issue half cannot be dropped: 41% of pairs are not supersets
+
+Over the 94 open PRs with at least one open linked source issue (same-repo
+`sparq-agent/issue-N-*` head, or a closing keyword from a trusted association):
+
+| relation of PR's `area:` set to its source issue's | pairs |
+| --- | --- |
+| PR ⊋ issue | 31 |
+| identical | 18 |
+| source issue declares no `area:` at all | 6 |
+| **PR ⊊ issue** | **13** |
+| **incomparable — each declares a key the other lacks** | **26** |
+
+So in **39 of 94 pairs (41%)** the PR's file-derived key set is *not* a superset, and dropping the
+issue's reservation would free a key the unit really occupies. Under-serialisation is the
+corrupting direction: two workers in one crate produce semantic conflicts that compile, pass, and
+are invisible to git. The union is the only rule safe in both directions, and it is monotone by
+construction — a unit's reservation is a superset of every member's own.
+
+Registry CLAIM's extra fail-closed step (`areas |= issue_areas or {GLOBAL_PACKAGE}`) is **not**
+adopted here. Applied to the linked population it drives the live frontier to **0** — the same
+whole-fleet seizure `_reserving_packages` exists to prevent.
+
+## Finding 3 — the real defect is the opposite: both layers under-hold
+
+The two layers that consume this engine hold **different, incomparable subsets** of the union:
+
+| view | distinct keys held | frontier |
+| --- | --- | --- |
+| local CLI (`dispatchable_view`, PR rows retained) | 49 | 3 |
+| registry `dispatch.yml` PLAN (PR rows **stripped**) | 37 | 9 |
+
+`dispatch.yml` builds its readiness input as
+`[issue for issue in snapshot("issues", index) if "pull_request" not in issue]`, so PLAN reserves
+the issue half of every unit and never the PR half — 12 keys held here are free there
+(`ci`, `deps`, `release`, `sparq-algos`, `sparq-core`, `sparq-e2ee-ng`, `sparq-engine`,
+`sparq-geo`, `sparq-reason`, `sparq-substrate`, `sparq-trust`, `zk`). **7 of PLAN's 9 frontier rows
+land in a key an open PR already holds.**
+
+They are not double-dispatched — CLAIM's `busy_packages_of_pulls` re-derives busy areas from the
+pulls snapshot and drops them — but they are dropped *after* `compute_ready` committed the
+frontier, so each burned a partition with no backfill. That is the registry's own issue #113 shape,
+one layer up. The counterfactual "+N frontier from dropping the PR half" is therefore not
+recoverable capacity: it is a measurement of serialisation the pipeline is doing on purpose.
+
+## Where the fix binds
+
+The occupancy **definition** is sparq's (`unit_reservations`). The **input** to it on the live
+dispatch path is built inside `dispatch.yml`, which the registry owns, and sparq has no hook into
+it — PLAN is deliberately token-less and cannot fetch pulls itself. So:
+
+* sparq ships the shared, pure definition plus `occupancy_parity`, which reports the gap loudly on
+  every `--diagnose` run instead of it being re-derived by hand.
+* The binding change is registry-side: stop discarding PR rows, and pass `source_links`. The
+  `source_links=None` default makes sparq's half a **no-op** for the existing registry call —
+  verified byte-for-byte on the live snapshot, frontier rows and all 347 conflict-attribution lines
+  identical — so the two repositories may merge in either order.

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -278,10 +278,18 @@ def _reserving_packages(labels):
 
     [OPUS-5] The deliberate asymmetry with `packages_of`. Fail-closed on a candidate costs one
     dispatch; fail-closed on an occupant costs the ENTIRE fleet, because an unattributable
-    occupant would serialize every package at once with no way for the pipeline to clear it
-    (nothing in the pipeline applies `area:` labels to PRs). An occupant we cannot attribute
-    therefore reserves nothing and is instead handled by the linked-issue suppression the
-    registry planner applies (`Closes #N` / `sparq-agent/issue-N-*` heads).
+    occupant would serialize every package at once. An occupant we cannot attribute therefore
+    reserves nothing and is instead handled by the linked-issue suppression the registry planner
+    applies (`Closes #N` / `sparq-agent/issue-N-*` heads) and, since reg#677, by folding it into
+    its source issue's unit — see `unit_reservations`.
+
+    [OPUS-5 2026-07-27] The original justification said "nothing in the pipeline applies `area:`
+    labels to PRs". That is NO LONGER TRUE — `scripts/pr-area-labels.py` (pr-area-label.yml) now
+    derives them from changed paths, and 109 of 123 open PRs carry one. The RULE is unchanged and
+    still right: the deriver is itself fail-closed (it emits no label on unresolved or
+    cross-cutting paths), so 9 open PRs still declare nothing, and making those 9 seize
+    `__global__` would reproduce the measured whole-fleet stall. Only the stated reason needed
+    correcting; leaving a false premise in place is how a correct rule gets "fixed" back.
     """
     return declared_packages(labels)
 

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -447,8 +447,9 @@ def unit_reservations(issues, source_links=None):
     MONOTONE BY CONSTRUCTION: a unit reserves `⋃ _own_reservation(member)`, so its reservation is a
     superset of every member's own — the dedup can never under-serialise relative to today, whoever
     the members are. Registry CLAIM's extra `areas |= issue_areas or {GLOBAL_PACKAGE}` fail-closed
-    step is NOT adopted here: applied to this population it drives the live frontier to 0 (measured),
-    which is the same whole-fleet seizure `_reserving_packages` documents and exists to prevent.
+    step is NOT adopted here: applied to this population it drives the live frontier to 0
+    (measured) — the same whole-fleet seizure `_reserving_packages` documents and exists to
+    prevent.
 
     `source_links=None` (the default, and what the registry's `dispatch.yml` passes today) yields
     exactly the legacy per-row reservations, in the legacy order — see

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -926,8 +926,16 @@ def occupancy_parity(issues, source_links=None):
 def diagnose(issues, linked=(), source_links=None):
     """Re-runnable VISIBILITY taxonomy: why the open backlog is not on the frontier.
 
-    Returns (counts, roleless, candidates, frontier). Every open issue lands in exactly one
+    Returns (counts, roleless, candidates, frontier, units). Every open issue lands in exactly one
     bucket, so the buckets sum to the open-issue count and no class can hide.
+
+    [OPUS-5] `units` is `unit_reservations(visible, source_links)` — the OCCUPANCY accounting, which
+    is the only thing `source_links` can change here. The held KEY SET is provably invariant under
+    folding (a unit reserves the union of exactly the members' own reservations, so the union over
+    all units equals the union over all members), hence `frontier` is identical with and without
+    `source_links` and cannot witness the fold. Returning `units` is what makes the parameter
+    observable at this layer — without it the argument would be an equivalent mutant, green under
+    deletion, which is precisely how a call site rots.
     """
     linked = set(linked)
     counts, open_issues = {}, []
@@ -941,8 +949,13 @@ def diagnose(issues, linked=(), source_links=None):
             reason = exclusion_reason(labels_of(it), it.get("open_blockers", 0)) or "ENUMERABLE"
         counts[reason] = counts.get(reason, 0) + 1
     visible = dispatchable_view(issues, linked)
+    # `source_links` is deliberately NOT passed to compute_ready here: this call discards the
+    # conflict log, and the frontier is PROVABLY invariant under folding (see the docstring and
+    # `test_the_held_key_set_is_invariant_under_folding`). Passing it would be an argument no test
+    # could ever kill — an equivalent mutant, green under deletion, i.e. a call site that rots.
     return (counts, roleless_ready(open_issues), ready_candidates(visible),
-            compute_ready(visible, conflict_log=lambda _m: None, source_links=source_links))
+            compute_ready(visible, conflict_log=lambda _m: None),
+            unit_reservations(visible, source_links))
 
 
 def main():
@@ -971,14 +984,13 @@ def main():
     linked = set().union(set(), *source_links.values())
     visible = dispatchable_view(issues, linked)
     if args.diagnose:
-        counts, roleless, cands, frontier = diagnose(issues, linked, source_links)
+        counts, roleless, cands, frontier, units = diagnose(issues, linked, source_links)
         total = sum(counts.values())
         print(f"open issues: {total}")
         for reason, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
             print(f"  {n:5d}  {100 * n / total:5.1f}%  {reason}")
         print(f"\ndrainable backlog (ready_candidates): {len(cands)}")
         print(f"concurrency frontier (compute_ready): {len(frontier)}")
-        units = unit_reservations(visible, source_links)
         print(f"unit occupancy: {len(units)} unit(s), "
               f"{sum(len(a) for a, _ in units)} reservation(s) over "
               f"{len(set().union(set(), *[a for a, _ in units]))} partition key(s)")

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -396,7 +396,86 @@ def roleless_ready(issues):
     return sorted(numbers)
 
 
-def compute_ready(issues, in_progress_packages=None, conflict_log=None):
+def _own_reservation(row):
+    """What ONE snapshot row reserves BY ITSELF, under the existing per-half occupancy rules.
+
+    Extracted verbatim from `compute_ready`'s occupancy loop so `unit_reservations` can union
+    member reservations WITHOUT restating (and so drifting from) the rule. Every active open PR is
+    in flight, drafts included; an open issue occupies only while `status:in-progress*`; the shared
+    parked predicate vetoes both. A row that reserves nothing returns the empty set.
+    """
+    if str(row.get("state", "OPEN")).upper() != "OPEN" or not occupies_area(row):
+        return set()
+    labels = labels_of(row)
+    if "pull_request" in row or labels & IN_FLIGHT_STATUS:
+        return _reserving_packages(labels)
+    return set()
+
+
+def unit_reservations(issues, source_links=None):
+    """Occupancy as ONE reservation per UNIT OF WORK — a PR together with the issues it closes.
+
+    [OPUS-5] A worker PR and its source issue are the SAME unit of work, and each was reserving
+    independently: MEASURED on the live sparq snapshot (2026-07-27, 1473 open issues / 123 open
+    PRs) 65 occupying PRs plus 46 in-flight issues produced 158 reservations over 49 distinct
+    partition keys — 20 of those reservations duplicates of a key the unit's other half already
+    held. `source_links` (a PR-number -> source-issue-number map from `source_issue_links`) folds
+    each pair into one reservation of the UNION, attributed to the PR.
+
+    Two things this deliberately is NOT, both refuted by measurement rather than by argument:
+
+    * It is NOT a frontier lever. `conflict()` tests membership in the SET of held keys, so a
+      second occupant on an already-held key is a no-op. Deduplicating 158 -> 138 reservations
+      leaves the held set at 49 keys and the live frontier unmoved (3 -> 3). Anything that DOES
+      widen the frontier here widens it by RELEASING a key, and releasing is the corrupting
+      direction — see the next point.
+    * It is NOT permission to drop the issue half. MEASURED over the 94 open PRs with at least one
+      open linked source issue: 31 pairs have PR ⊋ issue, 18 identical, 6 have a source issue with
+      NO `area:` at all — but 13 have PR ⊊ issue and 26 are INCOMPARABLE (each side declares a key
+      the other lacks). So in 39/94 = 41% of pairs the PR's file-derived key set is NOT a superset
+      and dropping the issue's reservation would free a key the unit really occupies. The union is
+      the only rule that is safe in both directions.
+
+    MONOTONE BY CONSTRUCTION: a unit reserves `⋃ _own_reservation(member)`, so its reservation is a
+    superset of every member's own — the dedup can never under-serialise relative to today, whoever
+    the members are. Registry CLAIM's extra `areas |= issue_areas or {GLOBAL_PACKAGE}` fail-closed
+    step is NOT adopted here: applied to this population it drives the live frontier to 0 (measured),
+    which is the same whole-fleet seizure `_reserving_packages` documents and exists to prevent.
+
+    `source_links=None` (the default, and what the registry's `dispatch.yml` passes today) yields
+    exactly the legacy per-row reservations, in the legacy order — see
+    `test_unit_reservations_without_links_is_identical_to_the_legacy_loop`.
+    """
+    links = source_links or {}
+    by_number = {}
+    for row in issues:
+        by_number.setdefault(row.get("number"), row)
+
+    def sources_of(pr_number):
+        for number in sorted(links.get(pr_number) or ()):
+            row = by_number.get(number)
+            if row is not None and "pull_request" not in row:
+                yield number, row
+
+    consumed = {number for row in issues if "pull_request" in row
+                for number, _ in sources_of(row.get("number"))}
+    out = []
+    for row in issues:                      # input order preserved: attribution is order-sensitive
+        number = row.get("number")
+        if "pull_request" not in row:
+            if number in consumed:          # already reserved as part of its PR's unit
+                continue
+            areas = _own_reservation(row)
+        else:
+            areas = set(_own_reservation(row))
+            for _number, source in sources_of(number):
+                areas |= _own_reservation(source)
+        if areas:
+            out.append((areas, row))
+    return out
+
+
+def compute_ready(issues, in_progress_packages=None, conflict_log=None, source_links=None):
     """Conflict-free, priority-ordered, FAIL-CLOSED CONCURRENCY FRONTIER.
 
     This is the one-per-package concurrency WIDTH, not the size of the drainable backlog — use
@@ -404,6 +483,11 @@ def compute_ready(issues, in_progress_packages=None, conflict_log=None):
 
     `conflict_log`, when supplied, receives one attribution line per conflict-excluded candidate;
     the live default writes those diagnostics to stderr without polluting the frontier rows.
+
+    `source_links`, when supplied, makes a PR and the issues it closes reserve ONCE, as the union
+    of both halves — see `unit_reservations`. Omitted, occupancy is byte-identical to the legacy
+    per-row loop, so the registry's existing `compute_ready(ready_input)` call is unaffected and
+    the two repositories may merge in either order.
     """
     blockers = {}
 
@@ -431,12 +515,9 @@ def compute_ready(issues, in_progress_packages=None, conflict_log=None):
         reserve({pkg}, None)
     # [GPT-5.6] Every active open PR is in flight (drafts included); open issues occupy only while
     # status:in-progress. The shared parked predicate is applied before either can reserve areas.
-    for it in issues:
-        if str(it.get("state", "OPEN")).upper() != "OPEN" or not occupies_area(it):
-            continue
-        L = labels_of(it)
-        if "pull_request" in it or L & IN_FLIGHT_STATUS:
-            reserve(_reserving_packages(L), it)
+    # [OPUS-5] ...and a PR plus the issues it closes are ONE unit reserving the union ONCE.
+    for areas, artifact in unit_reservations(issues, source_links):
+        reserve(areas, artifact)
     cands = ready_candidates(issues)
     cands.sort(key=lambda c: (c[0], c[1]))   # priority then number (deterministic)
     ready = []
@@ -672,27 +753,46 @@ _CLOSES = re.compile(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9]
 TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 
 
-def linked_issue_numbers(pulls, repo):
-    """Issues already covered by an open PR — the suppression the REGISTRY planner applies.
+def source_issue_links(pulls, repo):
+    """PR number -> the set of issue numbers that PR is the WORKING ARTIFACT for.
 
-    [OPUS-5] Mirrors dispatch.yml's `linked_issue_numbers` so the local CLI previews the same
-    frontier the orchestrator dispatches. A fork PR must never suppress an issue: only a
-    same-repo `sparq-agent/issue-N-*` head is pipeline-owned provenance (a fork's head branch
-    text is attacker-controlled), and a closing keyword in a body counts only from a trusted
-    author association.
+    [OPUS-5] The pairing behind `unit_reservations`, and the single definition of PR->issue
+    linkage in this file: `linked_issue_numbers` is now its union, so the suppression set and the
+    occupancy pairing can never disagree about what "covered by an open PR" means. Two rules that
+    each re-derive linkage is exactly the mint-vs-adopt drift that lets one layer free a key the
+    other still holds.
+
+    A fork PR must never link an issue: only a same-repo `sparq-agent/issue-N-*` head is
+    pipeline-owned provenance (a fork's head branch text is attacker-controlled), and a closing
+    keyword in a body counts only from a trusted author association. PRs with no linkage are
+    absent from the map rather than present-and-empty, so `unit_reservations` treats them as
+    single-member units.
     """
-    linked = set()
+    links = {}
     for pull in pulls:
         head = pull.get("head") or {}
         ref = head.get("ref") or ""
         body = pull.get("body") or ""
         same_repo = ((head.get("repo") or {}).get("full_name") == repo)
         app_pr = same_repo and _LINK_HEAD.match(ref) is not None
+        found = set()
         if app_pr:
-            linked.update(int(n) for n in _LINK_HEAD.findall(ref))
+            found.update(int(n) for n in _LINK_HEAD.findall(ref))
         if app_pr or str(pull.get("author_association", "")).upper() in TRUSTED_ASSOCIATIONS:
-            linked.update(int(n) for n in _CLOSES.findall(body))
-    return linked
+            found.update(int(n) for n in _CLOSES.findall(body))
+        if found:
+            links.setdefault(pull.get("number"), set()).update(found)
+    return links
+
+
+def linked_issue_numbers(pulls, repo):
+    """Issues already covered by an open PR — the suppression the REGISTRY planner applies.
+
+    [OPUS-5] Mirrors dispatch.yml's `linked_issue_numbers` so the local CLI previews the same
+    frontier the orchestrator dispatches. Derived from `source_issue_links` so the suppression
+    set is, by construction, exactly the set of issues that are somebody's unit-of-work member.
+    """
+    return set().union(set(), *source_issue_links(pulls, repo).values())
 
 
 def _fetch_pulls(repo):
@@ -796,7 +896,34 @@ def dispatchable_view(issues, linked=()):
             if it.get("number") not in linked or labels_of(it) & IN_FLIGHT_STATUS]
 
 
-def diagnose(issues, linked=()):
+def occupancy_parity(issues, source_links=None):
+    """The PR-HALF-STRIPPED occupancy divergence, as a re-runnable measurement.
+
+    [OPUS-5] `dispatchable_view` claims local/orchestrator parity on the linked/in-flight axis, and
+    on the CANDIDATE axis it holds. On the OCCUPANCY axis it does not: the registry's dispatch.yml
+    builds its readiness input as `[issue for issue in snapshot("issues") if "pull_request" not in
+    issue]`, so PLAN never sees a PR row and reserves the ISSUE half of every unit only. MEASURED on
+    the live snapshot (2026-07-27): the local CLI holds 49 partition keys and emits a frontier of 3;
+    the orchestrator holds 37 and emits 9 — and 7 of those 9 rows land in a key an open PR already
+    holds. They are not double-dispatched (registry CLAIM re-derives busy areas from the pulls
+    snapshot and drops them), but they are dropped AFTER `compute_ready` committed the frontier, so
+    each one burned a partition with no backfill — the registry's own issue #113 shape.
+
+    Returns (pr_aware_keys, issue_only_keys, unheld) where `unheld` is the set of keys the
+    issue-only view fails to hold. Pure, so `--diagnose` and the test suite read the same number.
+    """
+    def keys(rows, links):
+        held = set()
+        for areas, _artifact in unit_reservations(rows, links):
+            held |= areas
+        return held
+    issue_only = [row for row in issues if "pull_request" not in row]
+    pr_aware = keys(issues, source_links)
+    stripped = keys(issue_only, source_links)
+    return pr_aware, stripped, pr_aware - stripped
+
+
+def diagnose(issues, linked=(), source_links=None):
     """Re-runnable VISIBILITY taxonomy: why the open backlog is not on the frontier.
 
     Returns (counts, roleless, candidates, frontier). Every open issue lands in exactly one
@@ -814,8 +941,8 @@ def diagnose(issues, linked=()):
             reason = exclusion_reason(labels_of(it), it.get("open_blockers", 0)) or "ENUMERABLE"
         counts[reason] = counts.get(reason, 0) + 1
     visible = dispatchable_view(issues, linked)
-    return (counts, roleless_ready(open_issues),
-            ready_candidates(visible), compute_ready(visible, conflict_log=lambda _m: None))
+    return (counts, roleless_ready(open_issues), ready_candidates(visible),
+            compute_ready(visible, conflict_log=lambda _m: None, source_links=source_links))
 
 
 def main():
@@ -840,21 +967,32 @@ def main():
         print()
         return 0
     issues = _fetch(args.repo)
-    linked = linked_issue_numbers(_fetch_pulls(args.repo), args.repo)
+    source_links = source_issue_links(_fetch_pulls(args.repo), args.repo)
+    linked = set().union(set(), *source_links.values())
     visible = dispatchable_view(issues, linked)
     if args.diagnose:
-        counts, roleless, cands, frontier = diagnose(issues, linked)
+        counts, roleless, cands, frontier = diagnose(issues, linked, source_links)
         total = sum(counts.values())
         print(f"open issues: {total}")
         for reason, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
             print(f"  {n:5d}  {100 * n / total:5.1f}%  {reason}")
         print(f"\ndrainable backlog (ready_candidates): {len(cands)}")
         print(f"concurrency frontier (compute_ready): {len(frontier)}")
+        units = unit_reservations(visible, source_links)
+        print(f"unit occupancy: {len(units)} unit(s), "
+              f"{sum(len(a) for a, _ in units)} reservation(s) over "
+              f"{len(set().union(set(), *[a for a, _ in units]))} partition key(s)")
+        _pr_aware, issue_only, unheld = occupancy_parity(visible, source_links)
+        if unheld:
+            print(f"\n::warning:: ORCHESTRATOR OCCUPANCY GAP: dispatch.yml strips PR rows from its "
+                  f"readiness input, so PLAN holds {len(issue_only)} of {len(_pr_aware)} partition "
+                  f"key(s). {len(unheld)} key(s) held here by an open PR are FREE there: "
+                  f"{', '.join(sorted(unheld)[:20])}")
         if roleless:
             print(f"\n::warning:: {len(roleless)} attested issue(s) carry NO role:* label and are "
                   f"INVISIBLE to dispatch: {', '.join('#%d' % n for n in roleless[:20])}")
         return 0
-    for it in compute_ready(visible):
+    for it in compute_ready(visible, source_links=source_links):
         L = labels_of(it)
         print(f"P{valid_priority(L)}  #{it['number']:5}  {sorted(packages_of(L))}")
     return 0

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -502,8 +502,14 @@ class TestLocalOrchestratorParity(unittest.TestCase):
         return numbers(ready.compute_ready(rows, conflict_log=quiet))
 
     @staticmethod
-    def _run_cli(issues_and_prs, pulls=(), argv=()):
-        """Execute the REAL main() end-to-end; only `_fetch`/`_fetch_pulls` are stubbed."""
+    def _run_cli_streams(issues_and_prs, pulls=(), argv=()):
+        """Execute the REAL main() end-to-end; only `_fetch`/`_fetch_pulls` are stubbed.
+
+        Returns (stdout, stderr). STDERR is not incidental: `compute_ready`'s default
+        `conflict_log` writes the per-conflict ATTRIBUTION line there, and attribution is the one
+        observable the PR/issue unit fold changes on main()'s default path — see
+        `TestUnitReservation.test_the_default_CLI_path_attributes_a_conflict_to_the_PR`.
+        """
         real_fetch, real_pulls, real_argv = ready._fetch, ready._fetch_pulls, sys.argv
         ready._fetch = lambda repo, ceiling=10000: [dict(it) for it in issues_and_prs]
         ready._fetch_pulls = lambda repo: [dict(p) for p in pulls]
@@ -515,7 +521,11 @@ class TestLocalOrchestratorParity(unittest.TestCase):
         finally:
             ready._fetch, ready._fetch_pulls, sys.argv = real_fetch, real_pulls, real_argv
         assert rc == 0, f"main() exited {rc}"
-        return out.getvalue()
+        return out.getvalue(), err.getvalue()
+
+    @classmethod
+    def _run_cli(cls, issues_and_prs, pulls=(), argv=()):
+        return cls._run_cli_streams(issues_and_prs, pulls, argv)[0]
 
     @classmethod
     def _local(cls, issues_and_prs, pulls=()):
@@ -554,7 +564,7 @@ class TestLocalOrchestratorParity(unittest.TestCase):
     def test_diagnose_does_not_call_an_in_flight_row_merely_pr_covered(self):
         # The bucket must agree with the view: a row dispatchable_view KEEPS is reported as
         # busy, not as suppressed. Otherwise the taxonomy explains a drop that never happened.
-        counts, _roleless, _cands, frontier = ready.diagnose(
+        counts, _roleless, _cands, frontier, _units = ready.diagnose(
             list(self.COUNTEREXAMPLE_BOARD), linked={100})
         self.assertEqual(counts.get("busy: status:in-progress-review"), 1)
         self.assertIsNone(counts.get("covered by an open linked PR"))
@@ -725,9 +735,20 @@ class TestUnitReservation(unittest.TestCase):
                                                          "area:sparq-core"]),
                  pr(301, ["area:sparq-hdt"]), iss(300, ["status:in-progress-review",
                                                         "area:sparq-hdt"])]
-        units = ready.unit_reservations(board, {101: {100}, 301: {300}})
+        links = {101: {100}, 301: {300}}
+        units = ready.unit_reservations(board, links)
         self.assertEqual(self.by_pr(units), {101: ["sparq-core"], 301: ["sparq-hdt"]},
                          "two genuinely distinct units must remain two occupants")
+        # ...and EVERY unit must reach `reserve()`, not just the first. Truncating the occupancy
+        # loop (`unit_reservations(...)[:1]`) is a six-character edit that frees every unit after
+        # the first, so assert the SECOND unit's crate is held too.
+        contenders = [iss(200, READY + ["priority:P1", "area:sparq-core"]),
+                      iss(201, READY + ["priority:P2", "area:sparq-hdt"]),
+                      iss(202, READY + ["priority:P3", "area:sparq-geo"])]
+        self.assertEqual(
+            numbers(ready.compute_ready(board + contenders, conflict_log=quiet,
+                                        source_links=links)), [202],
+            "both units must hold their crate — a truncated occupancy loop frees the second")
 
     def test_an_issue_with_no_linked_pr_is_unaffected(self):
         lone = iss(100, ["status:in-progress-review", "area:sparq-core"])
@@ -785,20 +806,71 @@ class TestUnitReservation(unittest.TestCase):
         self.assertEqual(logs, ["conflict #200: area sparq-core held by pr#101"],
                          "omitting source_links must leave attribution exactly as it was")
 
-    # -- the CALL SITE, not just the helper ----------------------------------------------------
-    def test_the_real_CLI_folds_the_pair_into_one_unit(self):
-        # [OPUS-5] The titled leg runs in main(): `compute_ready(visible, source_links=...)`.
-        # Dropping that keyword argument at the call site leaves every helper test above green
-        # while the CLI reverts to two independent reservations, so assert on main()'s own output.
-        board = [iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
-                 iss(200, READY + ["priority:P1", "area:sparq-core"])]
+    # -- the CALL SITES, not just the helper ---------------------------------------------------
+    # [OPUS-5] MEASURED, and the reason these three tests are shaped the way they are: the held
+    # KEY SET is invariant under folding, because a unit reserves the union of exactly its members'
+    # own reservations. So NO frontier assertion anywhere can witness `source_links` being dropped
+    # at a call site — a first cut of this suite asserted frontiers and left both CLI legs' mutants
+    # ALIVE. What the fold does change is (a) how many occupants there are and (b) which artifact a
+    # conflict is attributed to. Each leg is therefore pinned on the observable it actually has.
+    @staticmethod
+    def _pair_board():
+        """Live shape: in-review issue #100 on sparq-hdt + its worker PR #101 on sparq-core."""
         pulls = [dict(worker_pr(101, 100), labels=[{"name": "area:sparq-core"}])]
-        prs = [dict(p, labels=[lb["name"] for lb in p["labels"]]) for p in pulls]
-        out = TestLocalOrchestratorParity._run_cli(board + prs, pulls, argv=("--diagnose",))
+        rows = [iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
+                iss(200, READY + ["priority:P1", "area:sparq-core"])]
+        rows += [dict(p, labels=[lb["name"] for lb in p["labels"]]) for p in pulls]
+        return rows, pulls
+
+    def test_the_held_key_set_is_invariant_under_folding(self):
+        # WHY no frontier assertion can guard the fold, asserted rather than asserted-about. A unit
+        # reserves the union of exactly its members' own reservations, so the union OVER UNITS
+        # equals the union OVER MEMBERS: `conflict()` reads only `blockers.keys()`, therefore the
+        # frontier is identical with and without `source_links`. This is what licenses
+        # `diagnose()` not passing it, and it is why the CLI guards pin attribution + unit count.
+        board = [pr(101, ["area:sparq-core"]),
+                 iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
+                 pr(301, []), iss(300, ["status:in-progress-review", "area:sparq-geo"]),
+                 pr(401, ["area:sparq-zk"]), iss(400, ["status:in-progress-review"]),
+                 iss(200, READY + ["priority:P1", "area:sparq-core"]),
+                 iss(201, READY + ["priority:P2", "area:sparq-hdt"]),
+                 iss(202, READY + ["priority:P3", "area:sparq-mpc"])]
+        links = {101: {100}, 301: {300}, 401: {400}}
+        self.assertEqual(self.keys(ready.unit_reservations(board)),
+                         self.keys(ready.unit_reservations(board, links)),
+                         "folding must not add or remove a single held partition key")
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)),
+                         numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links=links)))
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links=links)), [202],
+                         "sanity: the board must actually exercise conflicts, not be all-free")
+
+    def test_diagnose_reports_the_pair_as_ONE_unit(self):
+        # Kills: `diagnose()` dropping `source_links=` from its compute_ready/unit_reservations.
+        board, pulls = self._pair_board()
+        _c, _r, _cands, _frontier, units = ready.diagnose(
+            board, linked={100}, source_links={101: {100}})
+        self.assertEqual([artifact["number"] for _areas, artifact in units], [101])
+        self.assertEqual(sorted(next(iter(a for a, _ in units))), ["sparq-core", "sparq-hdt"])
+
+    def test_the_diagnose_CLI_leg_prints_the_folded_unit_count(self):
+        # Kills: main() --diagnose losing the fold anywhere between diagnose() and the print.
+        board, pulls = self._pair_board()
+        out = TestLocalOrchestratorParity._run_cli(board, pulls, argv=("--diagnose",))
         self.assertIn("unit occupancy: 1 unit(s), 2 reservation(s) over 2 partition key(s)", out,
-                      "main() must pass source_links so the PR+issue pair is ONE unit")
-        self.assertIn("concurrency frontier (compute_ready): 0", out,
-                      "and the union (sparq-core from the PR) must actually hold #200 back")
+                      "the PR+issue pair must be reported as ONE unit holding TWO keys")
+
+    def test_the_default_CLI_path_attributes_a_conflict_to_the_PR(self):
+        # Kills: main()'s DEFAULT (non---diagnose) leg dropping `source_links=`. That leg's only
+        # observable is the attribution line compute_ready writes to stderr; without the fold the
+        # blocker is reported as `issue#100`, which no one can merge or close.
+        board, pulls = self._pair_board()
+        board = board + [iss(201, READY + ["priority:P1", "area:sparq-hdt"])]
+        _out, err = TestLocalOrchestratorParity._run_cli_streams(board, pulls)
+        self.assertIn("conflict #201: area sparq-hdt held by pr#101", err,
+                      "the default CLI path must fold the unit and attribute to the PR")
+        self.assertNotIn("held by issue#100", err)
 
 
 class TestOrchestratorOccupancyGap(unittest.TestCase):
@@ -893,7 +965,7 @@ class TestDiagnoseTaxonomy(unittest.TestCase):
             pr(70, []),
             iss(6, READY + ["priority:P1", "area:d"], state="CLOSED"),
         ]
-        counts, roleless, cands, frontier = ready.diagnose(board, linked={5})
+        counts, roleless, cands, frontier, _units = ready.diagnose(board, linked={5})
         self.assertEqual(sum(counts.values()), 5, "one bucket per OPEN issue, PRs/closed excluded")
         self.assertEqual(counts["ENUMERABLE"], 1)
         self.assertEqual(counts["covered by an open linked PR"], 1)

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -588,6 +588,273 @@ class TestLocalOrchestratorParity(unittest.TestCase):
                          "main() must suppress issues covered by an open linked PR, as dispatch does")
 
 
+class TestUnitReservation(unittest.TestCase):
+    """A PR and the issues it closes are ONE unit: they reserve the UNION, exactly ONCE.
+
+    [OPUS-5] MEASURED on the live sparq snapshot (2026-07-27, 1473 open issues / 123 open PRs):
+    65 occupying PRs + 46 in-flight issues produced 158 reservations over 49 distinct partition
+    keys — 20 of them a duplicate of a key the unit's other half already held.
+
+    Two facts pin the shape of the rule, and both are measurements rather than opinions:
+
+    * DEDUP IS NOT A FRONTIER LEVER. `conflict()` tests membership in the SET of held keys, so a
+      second occupant on an already-held key changes nothing. 158 -> 138 reservations left the held
+      set at 49 keys and the live frontier at 3 -> 3. Every test below therefore asserts on the
+      RESERVATION STRUCTURE and on end-to-end dispatch decisions, not on a frontier count that the
+      dedup cannot move.
+    * DROPPING THE ISSUE HALF UNDER-SERIALISES. Over the 94 open PRs with an open linked source
+      issue: 31 pairs PR ⊋ issue, 18 identical, 6 source-with-no-`area:`, but 13 PR ⊊ issue and 26
+      INCOMPARABLE. So in 39/94 = 41% of pairs the PR's key set is NOT a superset and dropping the
+      issue's reservation frees a key the unit really occupies — two workers in one crate, the
+      corrupting direction. Hence union, never drop.
+    """
+
+    @staticmethod
+    def keys(units):
+        return set().union(set(), *[areas for areas, _artifact in units])
+
+    @staticmethod
+    def by_pr(units):
+        return {artifact["number"]: sorted(areas) for areas, artifact in units}
+
+    # -- the headline guard, asserted through compute_ready AND through the real CLI ---------
+    def test_pr_and_source_issue_reserve_the_union_exactly_once(self):
+        # THE titled guard. The pair declares {sparq-core} (PR) and {sparq-hdt} (issue): the unit
+        # must hold BOTH, under ONE artifact, and neither key may be reserved twice.
+        source = iss(100, ["status:in-progress-review", "area:sparq-hdt"])
+        worker = pr(101, ["area:sparq-core"])
+        links = {101: {100}}
+        units = ready.unit_reservations([worker, source], links)
+        self.assertEqual(self.by_pr(units), {101: ["sparq-core", "sparq-hdt"]},
+                         "the pair must reserve the union under the PR, as ONE unit")
+        self.assertEqual(len(units), 1, "the source issue must not reserve a second time")
+        # ...and the union is actually enforced: BOTH crates are held against fresh candidates.
+        board = [worker, source,
+                 iss(200, READY + ["priority:P1", "area:sparq-core"]),
+                 iss(201, READY + ["priority:P1", "area:sparq-hdt"]),
+                 iss(202, READY + ["priority:P1", "area:sparq-geo"])]
+        self.assertEqual(
+            numbers(ready.compute_ready(board, conflict_log=quiet, source_links=links)), [202],
+            "both halves of the unit's union must block, and unrelated crates must not")
+
+    def test_the_pair_is_ONE_occupant_not_two(self):
+        # The dedup itself, stated so that removing `consumed` (letting the source issue reserve
+        # again on its own) reds even though the HELD KEY SET is unchanged by that mutation.
+        source = iss(100, ["status:in-progress-review", "area:sparq-core"])
+        units = ready.unit_reservations([pr(101, ["area:sparq-core"]), source], {101: {100}})
+        self.assertEqual([artifact["number"] for _areas, artifact in units], [101])
+        self.assertEqual(sum(len(areas) for areas, _ in units), 1,
+                         "one unit of work must produce exactly one reservation of sparq-core")
+
+    def test_conflict_attribution_names_the_PR_of_a_paired_unit(self):
+        # Attribution is the one thing dedup DOES change, and it changes it for the better: the
+        # PR is the advanceable artifact (it can merge or close), the source issue is not.
+        board = [iss(100, ["status:in-progress-review", "area:sparq-core"]),
+                 pr(101, ["area:sparq-core"]),
+                 iss(200, READY + ["priority:P1", "area:sparq-core"])]
+        logs = []
+        ready.compute_ready(board, conflict_log=logs.append, source_links={101: {100}})
+        self.assertEqual(logs, ["conflict #200: area sparq-core held by pr#101"])
+
+    # -- the four obligations that make the rule impossible to weaken into a DROP ------------
+    def test_source_issue_broader_than_its_pr_does_not_lose_the_extra_areas(self):
+        # 39/94 live pairs are non-superset. Narrowing the unit to the PR's own set here would
+        # free sparq-hdt and sparq-geo while a worker is mid-flight on them.
+        source = iss(100, ["status:in-progress-review", "area:sparq-hdt", "area:sparq-geo"])
+        links = {101: {100}}
+        self.assertEqual(self.by_pr(ready.unit_reservations([pr(101, ["area:sparq-hdt"]), source],
+                                                            links)),
+                         {101: ["sparq-geo", "sparq-hdt"]})
+        board = [pr(101, ["area:sparq-hdt"]), source,
+                 iss(200, READY + ["priority:P1", "area:sparq-geo"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links=links)), [],
+                         "an area the ISSUE half alone declares must still be held by the unit")
+
+    def test_source_issue_with_no_area_keeps_the_units_reservation_intact(self):
+        # sparq#4336 / PR #4360: the source issue carried NO `area:` at all. Folding it into the
+        # unit must not shrink what the unit holds — the PR's own key must survive untouched.
+        source = iss(100, ["status:in-progress-review"])
+        links = {101: {100}}
+        self.assertEqual(self.by_pr(ready.unit_reservations([pr(101, ["area:sparq-core"]), source],
+                                                            links)),
+                         {101: ["sparq-core"]})
+        board = [pr(101, ["area:sparq-core"]), source,
+                 iss(200, READY + ["priority:P1", "area:sparq-core"]),
+                 iss(201, READY + ["priority:P1", "area:sparq-hdt"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links=links)), [201])
+
+    def test_a_units_reservation_is_a_SUPERSET_of_every_members_own(self):
+        # MONOTONICITY — the property that makes under-serialisation structurally impossible,
+        # whatever the two halves declare. Exhaustive over every containment direction, plus the
+        # `{GLOBAL}` member: a half whose own rule yields the serializing partition must keep it.
+        cases = [
+            (["area:sparq-core"], ["area:sparq-core"]),               # identical
+            (["area:sparq-core", "area:sparq-hdt"], ["area:sparq-core"]),   # PR superset
+            (["area:sparq-core"], ["area:sparq-core", "area:sparq-hdt"]),   # issue superset
+            (["area:sparq-core"], ["area:sparq-hdt"]),                # incomparable
+            ([], ["area:sparq-hdt"]),                                 # PR declares nothing
+            (["area:sparq-core"], []),                                # issue declares nothing
+            ([f"area:{ready.GLOBAL}"], ["area:sparq-core"]),          # a GLOBAL-holding half
+            (["area:sparq-core"], [f"area:{ready.GLOBAL}"]),
+        ]
+        for pr_labels, issue_labels in cases:
+            with self.subTest(pr=pr_labels, issue=issue_labels):
+                worker = pr(101, pr_labels)
+                source = iss(100, ["status:in-progress-review"] + issue_labels)
+                units = ready.unit_reservations([worker, source], {101: {100}})
+                held = self.keys(units)
+                for member in (worker, source):
+                    self.assertLessEqual(
+                        ready._own_reservation(member), held,
+                        f"unit dropped a key member #{member['number']} reserves on its own")
+
+    def test_a_GLOBAL_holding_half_still_serializes_the_whole_board(self):
+        # The fail-closed global must survive the fold END-TO-END, not merely in the key set.
+        board = [pr(101, [f"area:{ready.GLOBAL}"]),
+                 iss(100, ["status:in-progress-review", "area:sparq-core"]),
+                 iss(200, READY + ["priority:P1", "area:sparq-geo"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links={101: {100}})), [],
+                         "a unit holding __global__ must still block every unrelated crate")
+
+    # -- the units that must NOT be folded together -------------------------------------------
+    def test_two_unrelated_units_still_reserve_separately(self):
+        board = [pr(101, ["area:sparq-core"]), iss(100, ["status:in-progress-review",
+                                                         "area:sparq-core"]),
+                 pr(301, ["area:sparq-hdt"]), iss(300, ["status:in-progress-review",
+                                                        "area:sparq-hdt"])]
+        units = ready.unit_reservations(board, {101: {100}, 301: {300}})
+        self.assertEqual(self.by_pr(units), {101: ["sparq-core"], 301: ["sparq-hdt"]},
+                         "two genuinely distinct units must remain two occupants")
+
+    def test_an_issue_with_no_linked_pr_is_unaffected(self):
+        lone = iss(100, ["status:in-progress-review", "area:sparq-core"])
+        other = pr(301, ["area:sparq-hdt"])
+        units = ready.unit_reservations([lone, other], {301: set()})
+        self.assertEqual(sorted(a["number"] for _k, a in units), [100, 301])
+        self.assertEqual(self.keys(units), {"sparq-core", "sparq-hdt"})
+        # and it still blocks its own crate on the frontier
+        board = [lone, iss(200, READY + ["priority:P1", "area:sparq-core"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links={301: set()})), [])
+
+    def test_a_fork_PR_never_folds_an_issue_into_its_unit(self):
+        # source_issue_links is the ONLY linkage rule; a fork head is attacker-controlled text.
+        fork = {"number": 101, "state": "OPEN", "labels": [], "pull_request": {}, "draft": False,
+                "head": {"ref": "sparq-agent/issue-100-fix", "repo": {"full_name": "attacker/x"}},
+                "body": "Closes #100", "author_association": "NONE"}
+        self.assertEqual(ready.source_issue_links([fork], "sparq-org/sparq"), {})
+
+    # -- the no-op contract the REGISTRY depends on -------------------------------------------
+    def test_unit_reservations_without_links_is_identical_to_the_legacy_loop(self):
+        # dispatch.yml calls `compute_ready(ready_input)` with no source_links. If that call is not
+        # byte-identical to the pre-refactor loop, the two repositories cannot merge in either
+        # order. Reproduce the LEGACY loop here and compare pairs AND their order (attribution is
+        # order-sensitive: `blockers[area][0]` names the first reserver).
+        board = [pr(101, ["area:sparq-core"]),
+                 iss(100, ["status:in-progress-review", "area:sparq-core"]),
+                 iss(102, ["status:in-progress", "area:sparq-hdt"]),
+                 pr(103, ["area:sparq-geo", "needs:user"]),      # parked -> reserves nothing
+                 pr(104, []),                                    # unattributable -> nothing
+                 iss(105, READY + ["priority:P1", "area:sparq-zk"]),
+                 iss(106, ["status:in-progress-review", "review:needs-user", "area:sparq-mpc"])]
+        legacy = []
+        for row in board:
+            if str(row.get("state", "OPEN")).upper() != "OPEN" or not ready.occupies_area(row):
+                continue
+            labels = ready.labels_of(row)
+            if "pull_request" in row or labels & ready.IN_FLIGHT_STATUS:
+                areas = ready._reserving_packages(labels)
+                if areas:
+                    legacy.append((areas, row["number"]))
+        self.assertEqual([(areas, artifact["number"])
+                          for areas, artifact in ready.unit_reservations(board)], legacy)
+        self.assertEqual(legacy, [({"sparq-core"}, 101), ({"sparq-core"}, 100),
+                                  ({"sparq-hdt"}, 102)],
+                         "sanity: the legacy expectation itself must be the live rule, not a stub")
+
+    def test_compute_ready_without_source_links_is_unchanged(self):
+        board = [pr(101, ["area:sparq-core"]),
+                 iss(100, ["status:in-progress-review", "area:sparq-core"]),
+                 iss(200, READY + ["priority:P1", "area:sparq-core"]),
+                 iss(201, READY + ["priority:P2", "area:sparq-hdt"])]
+        logs = []
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=logs.append)), [201])
+        self.assertEqual(logs, ["conflict #200: area sparq-core held by pr#101"],
+                         "omitting source_links must leave attribution exactly as it was")
+
+    # -- the CALL SITE, not just the helper ----------------------------------------------------
+    def test_the_real_CLI_folds_the_pair_into_one_unit(self):
+        # [OPUS-5] The titled leg runs in main(): `compute_ready(visible, source_links=...)`.
+        # Dropping that keyword argument at the call site leaves every helper test above green
+        # while the CLI reverts to two independent reservations, so assert on main()'s own output.
+        board = [iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
+                 iss(200, READY + ["priority:P1", "area:sparq-core"])]
+        pulls = [dict(worker_pr(101, 100), labels=[{"name": "area:sparq-core"}])]
+        prs = [dict(p, labels=[lb["name"] for lb in p["labels"]]) for p in pulls]
+        out = TestLocalOrchestratorParity._run_cli(board + prs, pulls, argv=("--diagnose",))
+        self.assertIn("unit occupancy: 1 unit(s), 2 reservation(s) over 2 partition key(s)", out,
+                      "main() must pass source_links so the PR+issue pair is ONE unit")
+        self.assertIn("concurrency frontier (compute_ready): 0", out,
+                      "and the union (sparq-core from the PR) must actually hold #200 back")
+
+
+class TestOrchestratorOccupancyGap(unittest.TestCase):
+    """The measured consequence of dispatch.yml stripping PR rows from its readiness input.
+
+    [OPUS-5] `dispatch.yml` builds `readiness_input` from
+    `[issue for issue in snapshot("issues", index) if "pull_request" not in issue]`, so PLAN
+    reserves the ISSUE half of every unit and never the PR half. MEASURED on the live snapshot
+    (2026-07-27): the PR-aware view holds 49 partition keys and emits a frontier of 3; the
+    issue-only view holds 37 and emits 9 — and 7 of those 9 rows land in a key an open PR already
+    holds. Registry CLAIM re-derives busy areas from the pulls snapshot and drops them, so they are
+    not double-dispatched; but they are dropped AFTER compute_ready committed the frontier, so each
+    burned a partition with no backfill (the registry's own issue #113 shape).
+
+    sparq cannot close that from here — PLAN's input is built inside dispatch.yml, which the
+    registry owns. What sparq owns is the DEFINITION (`unit_reservations`) and the measurement, so
+    the gap is loud on every local run instead of being re-derived by hand each time.
+    """
+
+    BOARD = (
+        pr(101, ["area:sparq-core"]),                                   # PR half only
+        iss(100, ["status:in-progress-review", "area:sparq-hdt"]),      # issue half only
+    )
+
+    def test_stripping_pr_rows_loses_the_pr_half_of_every_unit(self):
+        pr_aware, issue_only, unheld = ready.occupancy_parity(list(self.BOARD), {101: {100}})
+        self.assertEqual(pr_aware, {"sparq-core", "sparq-hdt"})
+        self.assertEqual(issue_only, {"sparq-hdt"})
+        self.assertEqual(unheld, {"sparq-core"})
+
+    def test_the_gap_is_exactly_what_lets_a_second_worker_into_the_crate(self):
+        # Behavioural, not a set difference: the issue-only view DISPATCHES onto the PR's crate.
+        board = list(self.BOARD) + [iss(200, READY + ["priority:P1", "area:sparq-core"])]
+        issue_only = [row for row in board if "pull_request" not in row]
+        self.assertEqual(numbers(ready.compute_ready(issue_only, conflict_log=quiet)), [200],
+                         "sanity: this is what the orchestrator does today")
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet,
+                                                     source_links={101: {100}})), [],
+                         "the PR-aware unit view must hold #200 back")
+
+    def test_parity_measurement_is_empty_when_nothing_is_stripped(self):
+        # No false alarm: an issue-only snapshot with no PR-held keys reports no gap.
+        board = [iss(100, ["status:in-progress-review", "area:sparq-hdt"])]
+        _pr_aware, _issue_only, unheld = ready.occupancy_parity(board, {})
+        self.assertEqual(unheld, set())
+
+    def test_diagnose_reports_the_gap_loudly(self):
+        board = [iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
+                 iss(200, READY + ["priority:P1", "area:sparq-geo"])]
+        pulls = [dict(worker_pr(101, 100), labels=[{"name": "area:sparq-core"}])]
+        prs = [dict(p, labels=[lb["name"] for lb in p["labels"]]) for p in pulls]
+        out = TestLocalOrchestratorParity._run_cli(board + prs, pulls, argv=("--diagnose",))
+        self.assertIn("ORCHESTRATOR OCCUPANCY GAP", out)
+        self.assertIn("sparq-core", out.split("ORCHESTRATOR OCCUPANCY GAP")[1])
+
+
 class TestLinkedIssueDetection(unittest.TestCase):
     """Fork PRs must never suppress an issue (the head branch text is attacker-controlled)."""
 


### PR DESCRIPTION
> 🤖 SPARQ agent

## TL;DR — I could not confirm the premise, and I am not claiming its benefit

The brief's remedy was **deduplicate the double reservation to recover frontier**. I implemented
it. It recovers **zero** slots, and that is provable rather than incidental: `conflict()` tests
membership in the **set** of held partition keys, and a unit reserves the union of exactly its
members' own reservations — so the union *over units* equals the union *over members*. Measured on
a live snapshot: **158 → 138 reservations, 49 → 49 keys, frontier 3 → 3.**

What the investigation *did* find is a real defect pointing the other way, and this PR ships the
shared definition needed to close it.

## Measured (live `sparq-org/sparq`, 2026-07-27, cursor-paginated: 1473 open issues / 123 open PRs)

Occupancy census taken from the `compute_ready` code path itself, not from a description of it:

| population | count |
| --- | --- |
| open PRs, occupying, with `area:` → reserve | 65 |
| open PRs, **parked** → reserve nothing | 49 |
| open PRs, occupying, no `area:` → reserve nothing | 9 |
| in-flight issues with `area:` → reserve | 46 (44 `in-progress-review` + 2 `in-progress`) |
| **total** | **111 artifacts, 158 reservations, 49 distinct keys** |

Parked PRs contribute **zero** here, consistent with the corrected reading of the registry side.

### How often do the two `area:` sets differ, and in which direction?

Over the **94** open PRs with ≥1 open linked source issue:

| relation of PR's set to its source issue's | pairs |
| --- | --- |
| PR ⊋ issue | 31 |
| identical | 18 |
| source issue declares **no** `area:` at all | 6 |
| **PR ⊊ issue** | **13** |
| **incomparable** (each declares a key the other lacks) | **26** |

**39 of 94 (41%) are not supersets.** The "PR's set is routinely a strict superset" hypothesis is
refuted, so dropping the issue half would free a key the unit really occupies in 41% of pairs.
Union it is.

### Frontier counterfactuals

| occupancy | units | reservations | keys | frontier |
| --- | --- | --- | --- | --- |
| both halves, independent (status quo) | 111 | 158 | 49 | 3 |
| **union folded, this PR** | **81** | **138** | **49** | **3** |
| drop the issue half (unsafe) | 74 | 108 | 31 | 10 |
| drop the PR half (unsafe) | 46 | 50 | 37 | 9 |

The `+N` in the brief comes from the **drop** rows, not the dedup row. It is not recoverable
capacity — it is a measurement of serialisation the pipeline is doing on purpose.

## The rule, and why it cannot under-serialise

`unit_reservations(issues, source_links)` folds each PR with the open issues it closes and reserves
`⋃ _own_reservation(member)` **once**, attributed to the PR. It is **monotone by construction** —
the unit's reservation is a superset of every member's own — so it can never release a key relative
to today, whoever the members are. `test_a_units_reservation_is_a_SUPERSET_of_every_members_own`
covers all eight containment directions including a `{GLOBAL}`-holding half; verified with 0
violations across all 81 live units.

**On the no-`area:` source issue.** Registry CLAIM's `areas |= issue_areas or {GLOBAL_PACKAGE}` is
deliberately **not** adopted. Nothing is lost by omitting it — in `compute_ready` such an issue
reserves ∅ today, and the fold is monotone so it cannot shrink — whereas adopting it over the
linked population drives the live frontier to **0** (measured), the same whole-fleet seizure
`_reserving_packages` exists to prevent. I am flagging this as a **deliberate divergence from the
brief**, with the measurement, rather than shipping it silently.

## The layer, and why it binds elsewhere

The two consumers hold **different, incomparable subsets** of the union:

| view | keys held | frontier |
| --- | --- | --- |
| local CLI (`dispatchable_view`, PR rows retained) | 49 | 3 |
| registry `dispatch.yml` PLAN (PR rows **stripped**) | 37 | 9 |

`dispatch.yml` builds its input as `[issue for issue in snapshot("issues", i) if "pull_request" not
in issue]`, so PLAN reserves the issue half only — **12 keys** free there that an open PR holds
(`ci`, `deps`, `release`, `sparq-algos`, `sparq-core`, `sparq-e2ee-ng`, `sparq-engine`,
`sparq-geo`, `sparq-reason`, `sparq-substrate`, `sparq-trust`, `zk`) — and **7 of PLAN's 9 frontier
rows land in a key an open PR already holds.** CLAIM drops them, so they are not double-dispatched,
but it drops them *after* `compute_ready` committed the frontier, so each burned a partition with
no backfill (issue #113's shape, one layer up).

**sparq cannot close that from here.** PLAN is token-less and its input is built inside
`dispatch.yml`. So this PR ships the definition + `occupancy_parity`, which reports the gap loudly
on every `--diagnose`; the binding one-line change is registry-side and filed separately.

## Cross-repo merge order is a no-op — verified, not asserted

`source_links=None` is the default and reproduces the legacy per-row loop **in the legacy order**.
Replayed on the live snapshot against pristine `origin/main`: frontier rows identical, and all
**347** conflict-attribution lines identical. `dispatch.yml`'s `compute_ready(ready_input)` is
therefore unaffected and `_route_matches` PLAN/CLAIM agreement is untouched. Either order is safe.

## Guard → red-test table (12 mutants, 12 killed by NAMED tests)

All are behaviour-kills (assertion failures); none are crash-kills. `†` = also reds
`ready-issues.py --self-test`.

| # | mutation | named test(s) that red |
| --- | --- | --- |
| M1 | **titled leg**: `main()` default path drops `source_links=` | `test_the_default_CLI_path_attributes_a_conflict_to_the_PR` |
| M2b | **titled leg**: `diagnose()` drops `source_links` | `test_diagnose_reports_the_pair_as_ONE_unit`, `test_the_diagnose_CLI_leg_prints_the_folded_unit_count` |
| M3 | `compute_ready` ignores the parameter | `test_conflict_attribution_names_the_PR_of_a_paired_unit`, `test_the_default_CLI_path_attributes_a_conflict_to_the_PR` |
| M4 | six-char truncation `unit_reservations(...)[:1]` | `test_two_unrelated_units_still_reserve_separately`, `test_the_held_key_set_is_invariant_under_folding`, `test_the_coarsest_holder_is_reported_when_several_conflict` |
| M5 | **delete the union** | 8 incl. `test_pr_and_source_issue_reserve_the_union_exactly_once`, `test_source_issue_broader_than_its_pr_does_not_lose_the_extra_areas` |
| M6 | **delete the dedup** | 8 incl. `test_the_pair_is_ONE_occupant_not_two` |
| M7 | fold fork PRs too | `test_a_fork_PR_never_folds_an_issue_into_its_unit`, `test_fork_head_does_not_link` |
| M8 | `linked_issue_numbers` stops deriving from `source_issue_links` | 3 incl. `test_linked_pr_suppression_matches_on_both_sides` |
| M9† | monotonicity break (unit drops the PR half) | 19 incl. `test_a_units_reservation_is_a_SUPERSET_of_every_members_own` |
| M10† | parked veto removed from the member rule | `test_unit_reservations_without_links_is_identical_to_the_legacy_loop` |
| M11† | in-flight gate removed | 25 |
| M12 | `occupancy_parity` inverted | `test_stripping_pr_rows_loses_the_pr_half_of_every_unit`, `test_diagnose_reports_the_gap_loudly` |

**A 13th mutant was an equivalent mutant and I deleted the code instead of faking a test.** Passing
`source_links` to `diagnose()`'s `compute_ready` call was unobservable (that call discards the
conflict log, and the frontier is invariant under folding). Rather than leave an argument no test
could ever kill, the argument is removed and the invariance is pinned by
`test_the_held_key_set_is_invariant_under_folding`.

The first cut of this suite left **M1 and M2 alive** while asserting frontiers — the titled leg was
the least-tested thing in the PR. Both legs are now pinned on the observables they actually have
(attribution on stderr; unit count via `diagnose`).

## Gate — actual result

`routing-self-tests.yml`'s full step list run locally, **11/11 rc=0**: `routing-validate`,
`route-resolve`, `ready-issues --self-test`, `dispatch-plan --self-test`, `batch-merge`,
`test_readiness_visibility` (**76 tests OK**), `test_no_deprecated_models`, `pr-area-labels`,
`test_pr_area_labels`, `bd-to-issues`, `ci-close-merged-beads`. Plus `check-no-perf-numbers` (0
findings) and `typos` (clean). Nothing red.

## Also in this PR

`_reserving_packages`'s docstring claimed "nothing in the pipeline applies `area:` labels to PRs".
That premise is **false since reg#677** — `scripts/pr-area-labels.py` derives them and 109/123 open
PRs carry one. The rule is unchanged and still correct (9 PRs still declare nothing, and making
those seize `__global__` reproduces the measured stall); only the stale justification is corrected,
because a false premise is how a correct rule gets "fixed" back.

## Files owned / coordination

Only `scripts/ready-issues.py`, `scripts/tests/test_readiness_visibility.py`, and a new
`research/` record. **No registry files touched** — clear of #761/#765 (`dispatch-claim.py`
~1621-1919, ~3541-3728) and #766 (`park_policy.py`, ~2660-2800). Complementary to #761; its
counterfactual and this one must not be added together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
