### PR TITLE
fix(gate): the three alarm/detector lanes were SILENTLY GATING main (sq-huwr8)

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -1,6 +1,27 @@
 {
  "_doc": "Advisory-job registry. [OPUS-5] sparq-org/sparq#3773 made this file LOAD-BEARING: it is the ONLY thing that can make a check-run non-gating. scripts/ci_summary_gate.py excludes a check-run from the `gate` verdict IFF its name is a key here (whole-name, case-insensitive; a ${{ ... }} expression in a key matches its runtime expansion); everything else GATES, whatever it is called. Before #3773 the gate INFERRED advisory status from the job name matching \\b(advisory|informational)\\b, which silently neutralised four real gates. Every entry needs {owner_bead, promotion_criteria, registered, workflow, job_id}: workflow+job_id is the STABLE IDENTITY the declaration binds to, and check-advisory-registry.py C4 fails if that job's current YAML name is not exactly the key — so renaming a job can never silently flip whether it gates (the renamed job GATES, fail-closed, and C4 REDs until the declaration is updated). A job that intentionally runs a gate-classified command (python/shell/node/npm — C3, now language-agnostic) must also carry gate_script_waiver. C2 keeps requiring that any job whose NAME carries an advisory/informational token be declared here or lose the misleading token. Maintained by scripts/check-advisory-registry.py. PROMOTING a lane = deleting its entry.",
  "jobs": {
+  "review-lane blind-spot alarm": {
+   "workflow": "review-alarm.yml",
+   "job_id": "alarm",
+   "owner_bead": "sq-huwr8",
+   "promotion_criteria": "NEVER promotable — promoting it would INVERT its purpose. This is a DETECTOR: it REDs when it finds PRs that no review producer can reach, and it REDs fail-loud when the detector itself breaks. Neither condition is a property of the commit being gated, so gating on it would block every merge on an unrelated repo-wide backlog — the exact pressure that gets an alarm muted, which is the one outcome that destroys the signal. Registered because the lane was SILENTLY GATING: its header claimed it 'can never enter the ci-summary / gate poll set' on the premise that it creates no check-run on a PR head or merge-group ref, but ci-summary.yml ALSO runs on push to main (timeout-minutes: 80) and this workflow's scheduled run puts its check-run on exactly that head SHA. MEASURED 2026-07-27: ci_summary_gate.py render_verdict() over the real 477-check-run set for main head cb0c6739c listed `review-lane blind-spot alarm: failure` as a GATING failure. Delete this entry only if the workflow is removed.",
+   "registered": "2026-07-27"
+  },
+  "formal-lane no-verdict alarm": {
+   "workflow": "formal-alarm.yml",
+   "job_id": "alarm",
+   "owner_bead": "sq-63ups",
+   "promotion_criteria": "NEVER promotable, same reason as `review-lane blind-spot alarm` — a detector that REDs when a nightly formal lane stopped producing verdicts is reporting on the LANE's health, not on the commit under test, so it must never gate a merge. Same silent-gating defect (sq-huwr8): scheduled on main, so its check-run lands on the same head SHA the push-triggered ci-summary gate polls. Delete this entry only if the workflow is removed.",
+   "registered": "2026-07-27"
+  },
+  "nightly selection-bug alarm": {
+   "workflow": "selection-alarm.yml",
+   "job_id": "alarm",
+   "owner_bead": "sq-va7at",
+   "promotion_criteria": "NEVER promotable, same reason as `review-lane blind-spot alarm` — the lane is declared fail-OPEN by design (research/change-based-test-selection.md §6.1) and correlates a past nightly failure against selection skips, which is not a property of the commit being gated. Same silent-gating defect (sq-huwr8): it fires via workflow_run on CI-on-main completions, so its check-run lands on a main head SHA that a push-triggered ci-summary gate polls (OBSERVED on cb0c6739c, conclusion skipped). Delete this entry only if the workflow is removed.",
+   "registered": "2026-07-27"
+  },
   "changed-code mutation review (advisory)": {
    "workflow": "mutants-diff.yml",
    "job_id": "mutants-diff",

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -748,6 +748,20 @@ jobs:
       # The suite also pins its OWN call site here, so it cannot silently leave CI.
       - name: Self-test the review-lane blind-spot alarm (verdict obligations + YAML seam)
         run: python3 scripts/tests/test_review_lane_alarm.py
+      # [OPUS-5] sq-huwr8: the three DETECTOR lanes (review-alarm / formal-alarm /
+      # selection-alarm) RED by design, and each one's header used to assert it "can
+      # never enter the `ci-summary / gate` poll set" because it creates no check-run on
+      # a PR head or merge-group ref. True premise, false conclusion: ci-summary.yml also
+      # runs on `push: branches: [main]`, so a scheduled alarm's check-run lands on the
+      # very head SHA that gate polls. MEASURED on main head cb0c6739c, render_verdict()
+      # listed `review-lane blind-spot alarm: failure` as a GATING failure. What makes
+      # these lanes safe to RED is their advisory-registry declaration, nothing else.
+      # This suite drives the REAL render_verdict() so deleting a declaration REDs on the
+      # gate's own exit code, carries an UNDECLARED-lane control so the assertions cannot
+      # go vacuous, and DISCOVERS *alarm*.yml from disk so a fourth detector added with
+      # the same false header reds on arrival.
+      - name: Self-test the alarm/detector lanes are DECLARED non-gating (sq-huwr8)
+        run: python3 scripts/tests/test_alarm_lanes_non_gating.py
       # [SONNET-4.6] sq-1cb6l: the 5 remaining hermetic test suites found by the
       # #1670 audit, wired here alongside the other ci-scripts self-tests.
       #

--- a/.github/workflows/formal-alarm.yml
+++ b/.github/workflows/formal-alarm.yml
@@ -14,9 +14,17 @@
 # touch `bd`/`.beads` in CI — same rule as flow-on.yml / selection-alarm.yml).
 #
 # NOT A GATE (same posture as selection-alarm.yml): scheduled on main, files issues,
-# blocks NO merge. Its job name carries no advisory/informational token, but it never
-# creates a check-run on a PR head or merge-group ref, so it can never enter the
-# `ci-summary / gate` poll set. FAIL-LOUD: an alarm-infrastructure error (unreadable
+# blocks NO merge. That holds because this job is DECLARED in
+# `.github/advisory-registry.json` — since #3773 the ONLY thing that can make a check-run
+# non-gating. [OPUS-5] sq-huwr8: this header used to reason from "this workflow creates
+# no check-run on a PR head or merge-group ref" to the conclusion that the gate could
+# therefore never see it. The premise is true; the conclusion is not. ci-summary.yml also runs on
+# `push: branches: [main]` (timeout-minutes: 80), so a scheduled run on main lands its
+# check-run on the very head SHA that gate polls — and the gate waits for the name set to
+# stabilise, so a late sibling is picked up, not missed. Measured on main head cb0c6739c,
+# the sibling review-alarm lane was listed as a GATING failure by render_verdict().
+# Pinned by scripts/tests/test_alarm_lanes_non_gating.py. FAIL-LOUD: an
+# alarm-infrastructure error (unreadable
 # manifest, workflow-runs API failure) exits non-zero so THIS run goes red and a human
 # notices the detector itself is broken — masking a dead lane is the one thing the alarm
 # must never do.

--- a/.github/workflows/review-alarm.yml
+++ b/.github/workflows/review-alarm.yml
@@ -14,9 +14,25 @@
 # deduped issue) when a PR has sat in it past the threshold.
 #
 # NOT A GATE (same posture as selection-alarm.yml / formal-alarm.yml): scheduled on main,
-# files issues, blocks NO merge. Its job name carries no advisory/informational token, but
-# it never creates a check-run on a PR head or merge-group ref, so it can never enter the
-# `ci-summary / gate` poll set. Redding this run blocks nothing — it exists to be SEEN.
+# files issues, blocks NO merge. Redding this run blocks nothing — it exists to be SEEN.
+#
+# That is true because this job is DECLARED in `.github/advisory-registry.json`, which
+# #3773 made the ONLY thing that can make a check-run non-gating. It is NOT true because
+# of where the check-run lands. [OPUS-5] sq-huwr8 corrects the argument this header used
+# to make, which reasoned from "this workflow creates no check-run on a PR head or
+# merge-group ref" to the conclusion that the gate could therefore never see it. The
+# premise holds; the conclusion does not follow. ci-summary.yml also runs on
+# `push: branches: [main]` with `timeout-minutes: 80`, and a SCHEDULED run on main puts
+# its check-run on exactly the head SHA that push-triggered gate polls — and the gate
+# deliberately waits for the check-run name set to STABILISE, so a sibling appearing
+# mid-poll is picked up, not missed. MEASURED 2026-07-27: over the real 477-check-run set
+# for main head cb0c6739c, ci_summary_gate.py render_verdict() listed
+# `review-lane blind-spot alarm: failure` as a GATING failure. The registry entry, not
+# the trigger type, is what makes this lane safe to RED.
+#
+# Pinned by scripts/tests/test_alarm_lanes_non_gating.py, which drives the gate's own
+# is_advisory() + render_verdict() so that deleting the declaration REDs a named test
+# rather than silently re-arming this detector as a merge blocker.
 #
 # NO ARMING AUTHORITY, STRUCTURALLY. This workflow holds `issues: write` and NOTHING else:
 # no `pull-requests: write` (it cannot label, promote, or un-draft a PR) and no

--- a/.github/workflows/selection-alarm.yml
+++ b/.github/workflows/selection-alarm.yml
@@ -11,10 +11,17 @@
 # in CI — same rule as flow-on.yml).
 #
 # NOT A GATE (design §6.1 "fail-open"): this runs AFTER the nightly completes via
-# `workflow_run`, files issues, and blocks NO merge. Its name carries no
-# `advisory`/`informational` token, but it is not on the ci-summary gate's poll
-# set (that polls check-runs on the PR/merge-group head commit; this runs on a
-# past main nightly commit via workflow_run) so it can never affect a merge.
+# `workflow_run`, files issues, and blocks NO merge. That holds because this job
+# is DECLARED in `.github/advisory-registry.json` — since #3773 the ONLY thing
+# that can make a check-run non-gating. [OPUS-5] sq-huwr8: this header used to
+# claim the lane "is not on the ci-summary gate's poll set (that polls check-runs
+# on the PR/merge-group head commit …)". The gate ALSO polls on `push:
+# branches: [main]` (ci-summary.yml, timeout-minutes: 80), and a workflow_run
+# fired by a CI-on-main completion lands its check-run on that main head SHA —
+# OBSERVED on cb0c6739c (2026-07-27), where `nightly selection-bug alarm` was
+# present in the gate's poll set (conclusion `skipped`). A `skipped` conclusion
+# is harmless, but this lane is FAIL-LOUD and REDs on detector breakage, and a
+# red would have gated. Pinned by scripts/tests/test_alarm_lanes_non_gating.py.
 #
 # FAIL-LOUD (design invariant, opposite of ci_select's fail-CLOSED): an
 # alarm-INFRASTRUCTURE error (cannot list the failed jobs / load cargo metadata /

--- a/scripts/tests/test_alarm_lanes_non_gating.py
+++ b/scripts/tests/test_alarm_lanes_non_gating.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# [OPUS-5] sq-huwr8 — the alarm/detector lanes must be DECLARED non-gating, not
+# ASSUMED non-gating. 🤖 SPARQ agent.
+#
+# THE DEFECT THIS PINS. review-alarm.yml / formal-alarm.yml / selection-alarm.yml are
+# detectors: they RED by design when they find a real blind spot, and they RED fail-loud
+# when the detector itself breaks. Each one's header asserted it could never affect a
+# merge, on this reasoning:
+#
+#     "it never creates a check-run on a PR head or merge-group ref, so it can never
+#      enter the `ci-summary / gate` poll set"
+#
+# The premise is TRUE. The conclusion is FALSE. ci-summary.yml also runs on
+# `push: branches: [main]` with `timeout-minutes: 80`, and a `schedule` (or
+# `workflow_run`-on-main) alarm run puts its check-run on exactly that main head SHA —
+# the one the push-triggered gate is polling. The gate deliberately waits for the
+# check-run NAME SET to stabilise, so a sibling that appears mid-poll is picked up, not
+# missed. Since #3773 the ONLY thing that makes a check-run non-gating is a key in
+# `.github/advisory-registry.json`; none of the three was declared, so all three GATED.
+#
+# MEASURED 2026-07-27, ci_summary_gate.render_verdict() over the real, paginated
+# 477-check-run set for main head cb0c6739c7d85420474a2e67be83177660ee1be3:
+#
+#     ### ci-summary: FAILED — 7 non-passing gating check(s) of 462 gating
+#     - ✗ review-lane blind-spot alarm: failure      <-- a DETECTOR gating main
+#     - ✗ run + track benchmarks: failure
+#
+# WHY THIS MATTERS MORE THAN ONE RED SQUARE. An alarm that reds `main` for doing its job
+# is an alarm somebody eventually mutes, and a muted alarm is strictly worse than no
+# alarm — it looks like coverage. The fix is a DECLARATION, never a `|| true`.
+#
+# HOW THIS SUITE IS BUILT TO FAIL.
+#   * Every behaviour test drives the REAL ci_summary_gate.render_verdict() — the exact
+#     function the `gate` job runs — over a check-run set. No re-implementation of the
+#     gating rule lives here, so the test cannot agree with a broken gate.
+#   * test_control_* is the ANTI-VACUITY control: an UNDECLARED lane failing MUST still
+#     RED the gate. Without it, a render_verdict() that returned 0 unconditionally (or a
+#     fixture that silently contained no failure at all) would pass every other test
+#     here. If the control ever goes green, this file is measuring nothing.
+#   * test_every_not_a_gate_alarm_workflow_is_declared DISCOVERS the alarm workflows
+#     from the filesystem instead of hard-coding three names, so a FOURTH alarm added
+#     with the same false header and no declaration REDs on arrival.
+#   * The suite pins its OWN call site in docs-quality.yml, so it cannot silently leave
+#     CI's reachable set.
+#
+# Deleting any of the three registry entries REDs this file with an assertion naming the
+# lane — a BEHAVIOUR kill (the gate's verdict changes), not a crash kill (an import or
+# fixture error). The distinction is checked explicitly: every failure path below runs
+# render_verdict() to completion and asserts on its integer exit code.
+#
+# Stdlib + PyYAML (already a docs-quality dependency). Run:
+#   python3 scripts/tests/test_alarm_lanes_non_gating.py
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import ci_summary_gate as gate  # noqa: E402
+
+REGISTRY_PATH = REPO_ROOT / ".github" / "advisory-registry.json"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# The alarm/detector lanes. Each maps workflow file -> the bead that owns it. These are
+# the lanes whose headers declare "NOT A GATE"; the point of this suite is that the
+# CLAIM is bound to the MECHANISM that makes it true.
+ALARM_WORKFLOWS = {
+    "review-alarm.yml": "review-lane blind-spot alarm",
+    "formal-alarm.yml": "formal-lane no-verdict alarm",
+    "selection-alarm.yml": "nightly selection-bug alarm",
+}
+
+# A name that is deliberately NOT in the registry, used by the anti-vacuity control.
+UNDECLARED_LANE = "some undeclared lane that must gate"
+
+
+def _load_registry() -> None:
+    """Install the LIVE registry into the gate module, exactly as the gate does."""
+    gate.load_advisory_registry(str(REGISTRY_PATH))
+
+
+def _run(name: str, conclusion: str, run_id: int = 1) -> dict:
+    """One terminal check-run, shaped as the checks API returns it."""
+    return {
+        "name": name,
+        "status": "completed",
+        "conclusion": conclusion,
+        "id": abs(hash((name, conclusion))) % 10_000_000,
+        "_workflow_id": run_id,
+    }
+
+
+def _healthy_siblings() -> list[dict]:
+    """A green sibling set, including the selection pre-job the gate requires to be
+    successful before it will trust any `skipped` conclusion."""
+    return [
+        _run("changed-file test selection", "success"),
+        _run("build", "success"),
+        _run("clippy", "success"),
+    ]
+
+
+def _job_name(workflow_file: str) -> str:
+    doc = yaml.safe_load((WORKFLOWS / workflow_file).read_text())
+    jobs = doc["jobs"]
+    assert len(jobs) == 1, f"{workflow_file}: expected exactly one job, got {list(jobs)}"
+    (job,) = jobs.values()
+    return job["name"]
+
+
+class TestAlarmLanesAreDeclaredNonGating(unittest.TestCase):
+    """The DECLARATION half: the gate's own classifier must call each alarm advisory."""
+
+    def setUp(self) -> None:
+        _load_registry()
+
+    def test_every_not_a_gate_alarm_workflow_is_declared(self) -> None:
+        """Discovered from the filesystem, not hard-coded: EVERY *-alarm.yml job name
+        must be declared in the advisory registry. A new alarm workflow that copies the
+        old false header and forgets the declaration REDs here on arrival."""
+        discovered = sorted(p.name for p in WORKFLOWS.glob("*alarm*.yml"))
+        self.assertTrue(discovered, "no *alarm*.yml workflows found — glob broke")
+        self.assertEqual(
+            discovered,
+            sorted(ALARM_WORKFLOWS),
+            "the set of alarm workflows changed; a new detector lane must be declared "
+            "in .github/advisory-registry.json and added to ALARM_WORKFLOWS here",
+        )
+        for wf in discovered:
+            with self.subTest(workflow=wf):
+                name = _job_name(wf)
+                self.assertTrue(
+                    gate.is_advisory(name),
+                    f"{wf}: job {name!r} is NOT declared in "
+                    f".github/advisory-registry.json, so ci_summary_gate.py GATES on it "
+                    f"(#3773). This detector REDs by design — gating on it blocks merges "
+                    f"on an unrelated backlog condition and gets the alarm muted.",
+                )
+
+    def test_registry_key_matches_the_live_yaml_job_name(self) -> None:
+        """C4's binding, asserted from this side too: a rename must not be able to
+        silently re-arm a detector as a merge blocker."""
+        for wf, expected in ALARM_WORKFLOWS.items():
+            with self.subTest(workflow=wf):
+                self.assertEqual(_job_name(wf), expected)
+
+
+class TestAlarmFailureDoesNotRedTheGate(unittest.TestCase):
+    """The BEHAVIOUR half: drive the REAL render_verdict() and assert its exit code."""
+
+    def setUp(self) -> None:
+        _load_registry()
+
+    def test_alarm_failure_does_not_red_the_gate(self) -> None:
+        """THE headline guard. A detector concluding `failure` alongside a green sibling
+        set must leave the gate GREEN. Delete any of the three registry entries and this
+        REDs with the lane named — a behaviour kill, on render_verdict's exit code."""
+        for wf, lane in ALARM_WORKFLOWS.items():
+            with self.subTest(lane=lane):
+                runs = _healthy_siblings() + [_run(lane, "failure")]
+                rc = gate.render_verdict(runs)
+                self.assertEqual(
+                    rc,
+                    0,
+                    f"{wf}: a `failure` from the {lane!r} DETECTOR red the gate "
+                    f"(render_verdict returned {rc}). It must be declared in "
+                    f".github/advisory-registry.json.",
+                )
+
+    def test_control_undeclared_lane_failure_does_red_the_gate(self) -> None:
+        """ANTI-VACUITY CONTROL. Identical fixture shape, but the failing lane is NOT
+        declared. This MUST red. If this test ever passes-as-green, the tests above are
+        measuring nothing — a render_verdict() that always returned 0, or a fixture
+        carrying no real failure, would satisfy them all."""
+        runs = _healthy_siblings() + [_run(UNDECLARED_LANE, "failure")]
+        self.assertFalse(
+            gate.is_advisory(UNDECLARED_LANE),
+            "the control lane must stay UNdeclared for this control to mean anything",
+        )
+        rc = gate.render_verdict(runs)
+        self.assertEqual(
+            rc,
+            1,
+            "CONTROL FAILED: an UNDECLARED lane concluding `failure` did not red the "
+            "gate. The non-gating assertions in this file are therefore vacuous.",
+        )
+
+    def test_declaring_an_alarm_does_not_forgive_a_real_gating_failure(self) -> None:
+        """QUANTIFIER DIRECTION. Declaring the detectors must make the ALARM non-gating,
+        not make the commit's own legs non-gating. A genuine leg failing alongside a
+        failing alarm must still RED — this is what proves the fix did not buy green by
+        weakening the gate."""
+        runs = (
+            _healthy_siblings()
+            + [_run("review-lane blind-spot alarm", "failure")]
+            + [_run("run + track benchmarks", "failure")]
+        )
+        self.assertFalse(gate.is_advisory("run + track benchmarks"))
+        rc = gate.render_verdict(runs)
+        self.assertEqual(
+            rc, 1, "a real gating leg's failure was forgiven — the gate was weakened"
+        )
+
+
+class TestTheRefutedPremise(unittest.TestCase):
+    """Pin the two workflow facts whose CONJUNCTION is what made the old header's
+    reasoning wrong, so nobody re-derives 'it can never enter the poll set'."""
+
+    def test_ci_summary_gate_also_runs_on_pushes_to_main(self) -> None:
+        """Half 1 of the refutation: the gate does not only poll PR / merge-group heads.
+        If this ever stops being true the declarations are still correct, but the
+        rationale recorded in the registry needs revisiting — so red loudly."""
+        doc = yaml.safe_load((WORKFLOWS / "ci-summary.yml").read_text())
+        triggers = doc.get(True) or doc.get("on")
+        self.assertIn(
+            "push",
+            triggers,
+            "ci-summary.yml no longer runs on push — re-derive the sq-huwr8 rationale",
+        )
+        self.assertIn("main", triggers["push"]["branches"])
+
+    def test_alarm_lanes_run_on_main_so_they_share_that_head_sha(self) -> None:
+        """Half 2: each alarm is triggered by `schedule` or `workflow_run` on main, i.e.
+        on a commit that a push-triggered `gate` run polls. Together with half 1 this is
+        exactly why the declaration — not the trigger type — is what keeps them safe."""
+        for wf in ALARM_WORKFLOWS:
+            with self.subTest(workflow=wf):
+                doc = yaml.safe_load((WORKFLOWS / wf).read_text())
+                triggers = doc.get(True) or doc.get("on")
+                self.assertTrue(
+                    {"schedule", "workflow_run"} & set(triggers),
+                    f"{wf}: expected a schedule/workflow_run trigger on main",
+                )
+
+    def test_no_alarm_header_still_claims_it_cannot_enter_the_poll_set(self) -> None:
+        """The false claim itself, pinned as a string. Re-introducing it REDs — a stale
+        comment asserting a safety property the code does not provide is how this defect
+        survived review in the first place."""
+        false_claim = re.compile(
+            r"never\s+enter\s+the\s*\n?#?\s*`?ci-summary\s*/\s*gate`?\s*\n?#?\s*poll\s+set",
+            re.IGNORECASE,
+        )
+        for wf in ALARM_WORKFLOWS:
+            with self.subTest(workflow=wf):
+                text = (WORKFLOWS / wf).read_text()
+                flat = re.sub(r"\n#\s*", " ", text)
+                self.assertIsNone(
+                    false_claim.search(flat),
+                    f"{wf}: header still claims the lane can never enter the gate poll "
+                    f"set. It can (ci-summary runs on push to main); what makes it "
+                    f"non-gating is its advisory-registry declaration.",
+                )
+
+
+class TestSuiteIsWiredIntoCI(unittest.TestCase):
+    """Anti-vacuity anchor: without this, the whole file could leave CI unnoticed."""
+
+    def test_docs_quality_runs_this_suite(self) -> None:
+        text = (WORKFLOWS / "docs-quality.yml").read_text()
+        self.assertIn(
+            "scripts/tests/test_alarm_lanes_non_gating.py",
+            text,
+            "docs-quality.yml no longer invokes this suite — it would stop running",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

`main` is RED. Three checks fail at `cb0c6739c7d85420474a2e67be83177660ee1be3`. This PR fixes exactly one of them — the one that is a real, silent defect. The other two are diagnosed below and routed, not silenced.

## The defect: three DETECTOR lanes were silently GATING

`review-alarm.yml`, `formal-alarm.yml` and `selection-alarm.yml` are detectors. They RED **by design** when they find a real blind spot, and they RED fail-loud when the detector itself breaks. Each header asserted the lane could never affect a merge, reasoning from:

> it never creates a check-run on a PR head or merge-group ref → so it can never enter the `ci-summary / gate` poll set

**The premise is true. The conclusion does not follow.** `ci-summary.yml` also runs on `push: branches: [main]` with `timeout-minutes: 80`, and a `schedule` (or `workflow_run`-on-main) alarm run puts its check-run on *exactly* that main head SHA — the one the push-triggered gate is polling. The gate deliberately waits for the check-run **name set to stabilise**, so a sibling appearing mid-poll is picked up, not missed.

Since #3773, the **only** thing that makes a check-run non-gating is a key in `.github/advisory-registry.json`. None of the three was declared.

### Measured, with the repo's own code

`ci_summary_gate.render_verdict()` over the real, paginated **477**-check-run set for `cb0c6739c` (`total_count` cross-checked):

```
### ci-summary: FAILED — 7 non-passing gating check(s) of 462 gating
- ✗ feature-matrix per-leg report: incomplete
- ✗ batch overflow into omnibus: incomplete
- ✗ feature-matrix per-leg report: incomplete
- ✗ review-lane blind-spot alarm: failure      <-- a DETECTOR, gating main
- ✗ bridge verdict comments to review labels: cancelled
- ✗ run + track benchmarks: failure
- ✗ gate: failure
```

And the gate's own predicate:

```
is_advisory('review-lane blind-spot alarm')  = False  -> GATES
is_advisory('nightly selection-bug alarm')   = False  -> GATES
is_advisory('formal-lane no-verdict alarm')  = False  -> GATES
```

After this PR, over the **same** check-run set:

```
### ci-summary: FAILED — 6 non-passing gating check(s) of 460 gating
- ✗ feature-matrix per-leg report: incomplete
- ✗ batch overflow into omnibus: incomplete
- ✗ feature-matrix per-leg report: incomplete
- ✗ bridge verdict comments to review labels: cancelled
- ✗ run + track benchmarks: failure
- ✗ gate: failure
```

The detector is out of the gating set. **The genuine benchmark gate still REDs.** No `|| true`, no `continue-on-error`, no `set +e`, no waiver — the fix is a *declaration*, which is the mechanism #3773 built for exactly this.

### Why this is worth fixing rather than tolerating

An alarm that reds `main` for doing its job is an alarm somebody eventually mutes, and a muted alarm is strictly worse than no alarm — it looks like coverage. `nightly selection-bug alarm` was already present in this SHA's poll set (concluded `skipped`, so harmless *this* time); it is fail-loud and a red would have gated.

## Guard → red-test table

Snapshot+restore harness (never `git checkout -- .`), marker-verified clean after every mutant. **9/9 killed, 9 BEHAVIOUR kills, 0 crash kills.**

| # | Mutation | Result | Killed by |
|---|---|---|---|
| M1 | drop registry entry `review-lane blind-spot alarm` | KILLED **[BEHAVIOUR]** | `test_alarm_failure_does_not_red_the_gate`, `test_every_not_a_gate_alarm_workflow_is_declared` |
| M2 | drop registry entry `formal-lane no-verdict alarm` | KILLED **[BEHAVIOUR]** | same two |
| M3 | drop registry entry `nightly selection-bug alarm` | KILLED **[BEHAVIOUR]** | same two |
| M4 | invert `is_advisory()` → always `True` | KILLED **[BEHAVIOUR]** | `test_control_undeclared_lane_failure_does_red_the_gate`, `test_declaring_an_alarm_does_not_forgive_a_real_gating_failure` |
| M5 | `render_verdict()` → always `0` | KILLED **[BEHAVIOUR]** | same two |
| M6 | YAML SEAM: remove the `docs-quality.yml` call site | KILLED **[BEHAVIOUR]** | `test_docs_quality_runs_this_suite` |
| M7 | re-introduce the false poll-set claim in a header | KILLED **[BEHAVIOUR]** | `test_no_alarm_header_still_claims_it_cannot_enter_the_poll_set` |
| M8 | add a 4th alarm workflow, undeclared | KILLED **[BEHAVIOUR]** | `test_every_not_a_gate_alarm_workflow_is_declared` |
| M9 | YAML SEAM: `ci-summary.yml` stops running on `push:main` | KILLED **[BEHAVIOUR]** | `test_ci_summary_gate_also_runs_on_pushes_to_main` |

Notes on the design, since "N/N killed" deserves recounting:

- **M4 and M5 are killed only by the CONTROL.** Both make the non-gating assertions *trivially* true. `test_control_undeclared_lane_failure_does_red_the_gate` asserts an **undeclared** lane's failure still REDs the gate — without it this whole file would pass against a `render_verdict` that returned 0 unconditionally. That is the anti-vacuity anchor.
- **Every behaviour test drives the real `render_verdict()`**, not a re-implementation, so the suite cannot agree with a broken gate. All kills are assertions on its integer exit code — hence BEHAVIOUR, not crash.
- **M8 works because the suite discovers `*alarm*.yml` from disk**, so the guard covers detectors that do not exist yet.
- **M7 fired on my own first draft** of the corrected header, which quoted the old claim verbatim. The wording now describes the bad inference without reproducing the string.

## Files I own in this PR

`.github/advisory-registry.json`, `.github/workflows/{review,formal,selection}-alarm.yml`, `.github/workflows/docs-quality.yml` (one added step), `scripts/tests/test_alarm_lanes_non_gating.py`.

**No collision** with #4547 (`check-workflow-swallow.py`), #4385 (`check-model-attribution.py`, `check-workflow-seam.py`) or #4191 (`derive_areas`). `scripts/ci_summary_gate.py` is **not modified** — it was read and executed only.

## The other two reds — diagnosed, not touched here

**1. `gate` is red *because of* `run + track benchmarks`, and nothing else.** From the aggregator's own runtime output (structured job/step data, not `[36;1m` echoed source):

```
### ci-summary: FAILED (fail-fast) — 1 gating check(s) concluded failure while 5
sibling(s) were still running; no later state can turn this verdict green
- ✗ run + track benchmarks: failure
```

The alarm did **not** contribute to *this* particular gate run: the alarm run was created at `16:00:51Z`, 15 minutes *after* the gate concluded at `15:45:30Z`. The two reds are independent. That timing is luck, not design — which is precisely why the declaration matters.

**2. `run + track benchmarks` is a threshold artifact, and it is persistent.** Routed to a separate issue with the measurement rather than patched here — `scripts/bench_hardzone.py` is a hard perf gate and deserves its own review, and this PR must not become a gate edit. Headline: the gate **failed `main` for achieving perfect recall**. `vectors_hnsw_recall_at10` is a recall *deficit* (`bench/vector/README.md`: "every recall metric is emitted as a **DEFICIT**"), so `0` is the optimum; the zero-boundary branch `continue`s before `floor_exempt` is computed, so the `milli` noise floor added specifically for this metric is unreachable at zero. Of the last 60 Benchmarks runs on `main`, **15 failed and 100% of them on this same step**, each on a different, non-overlapping metric set — and because the hard gate runs *before* the Store step, a failing run publishes nothing, so the median never rebases and the trip repeats indefinitely.

## Bead

`sq-huwr8` (P1, bug).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
