### PR TITLE
fix(orchestration): the occupancy-gap warning fires on the PROBE, not on an unclearable set

### DIFF
--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -23,6 +23,8 @@ validated `Blocked-by: #NN` body markers — see `open_blocker_count`. Pure `com
 unit-tested; the CLI wraps it over the paginated fetch.
 """
 import argparse
+import contextlib
+import io
 import json
 import os
 import re
@@ -909,14 +911,14 @@ def occupancy_parity(issues, source_links=None):
     """The PR-HALF-STRIPPED occupancy divergence, as a re-runnable measurement.
 
     [OPUS-5] `dispatchable_view` claims local/orchestrator parity on the linked/in-flight axis, and
-    on the CANDIDATE axis it holds. On the OCCUPANCY axis it does not: the registry's dispatch.yml
-    builds its readiness input as `[issue for issue in snapshot("issues") if "pull_request" not in
-    issue]`, so PLAN never sees a PR row and reserves the ISSUE half of every unit only. MEASURED on
-    the live snapshot (2026-07-27): the local CLI holds 49 partition keys and emits a frontier of 3;
-    the orchestrator holds 37 and emits 9 — and 7 of those 9 rows land in a key an open PR already
-    holds. They are not double-dispatched (registry CLAIM re-derives busy areas from the pulls
-    snapshot and drops them), but they are dropped AFTER `compute_ready` committed the frontier, so
-    each one burned a partition with no backfill — the registry's own issue #113 shape.
+    on the CANDIDATE axis it holds. This measures the OCCUPANCY axis: how much of the held key set
+    is contributed by the PR half alone, i.e. exactly what PLAN loses if it is handed the ISSUE
+    half only.
+
+    This is a SIZE, not a verdict. Whether the registry actually strips is decided by
+    `pr_row_occupancy_probe()` — see there, and do NOT reintroduce an unconditional warning off
+    this number: as of registry #773 the orchestrator does NOT strip, so `unheld` is non-empty on
+    every healthy board and a warning keyed on it can never clear.
 
     Returns (pr_aware_keys, issue_only_keys, unheld) where `unheld` is the set of keys the
     issue-only view fails to hold. Pure, so `--diagnose` and the test suite read the same number.
@@ -930,6 +932,62 @@ def occupancy_parity(issues, source_links=None):
     pr_aware = keys(issues, source_links)
     stripped = keys(issue_only, source_links)
     return pr_aware, stripped, pr_aware - stripped
+
+
+# The probe id-space the registry uses. Kept as constants so the mirror below and the tests that
+# characterise it cannot drift apart by a typo'd literal.
+_PROBE_LABELS = ("status:ready", "priority:P0", "role:impl", "area:__pr_probe__")
+_PROBE_PR, _PROBE_RIVAL = 999000001, 999000002
+
+
+def pr_row_occupancy_probe(engine=None):
+    """Does THIS repo's readiness engine still earn PR rows in the orchestrator's occupancy input?
+
+    [OPUS-5 2026-07-27] A VERBATIM mirror of `pr_row_aware()` in the registry's
+    `.github/workflows/dispatch.yml` (jeswr/agent-account-registry, PR #773, merged 15:54Z). That
+    workflow does not strip PR rows any more — it folds every open PR into PLAN's occupancy input
+    — but ONLY IF the target repo's planner passes this probe, and a planner that fails it keeps
+    exactly the old issue-only behaviour. So "does the orchestrator see our PR rows?" is not a
+    property of dispatch.yml at all: it is a property of the function right here in this file, and
+    it is the ONLY thing that can silently turn PR-half occupancy back off.
+
+    Why the mirror lives on THIS side of the seam: when the probe fails, the registry says so in
+    the REGISTRY's own log, on a repo nobody working in sparq reads. The failure would be caused
+    by a sparq commit, land in sparq's CI green, and surface as an unexplained double-dispatch.
+    Running the same probe locally puts the alarm where the cause is.
+
+    Called EXACTLY as the registry calls it — two positional-only invocations of `compute_ready`
+    with no keyword arguments — so a signature change that breaks the orchestrator's call breaks
+    this one too. Two obligations, both executed:
+
+      1. SAFETY — a PR row is never returned as a dispatch candidate (else PLAN emits a plan row
+         whose `number` is a pull request and launches an impl worker against it).
+      2. EFFECT — a PR row really RESERVES the `area:` keys it declares, so an otherwise-ready
+         issue on that key is held. An engine that merely ignores PR rows passes obligation 1
+         while making the whole fold an expensive no-op.
+
+    Fail-closed: an engine that raises is one we cannot characterise, so it does not pass.
+    Returns `(ok, why)`; `why` is the registry's own wording, so the two logs read alike.
+    """
+    compute = compute_ready if engine is None else engine
+    pull = {"number": _PROBE_PR, "state": "OPEN", "labels": list(_PROBE_LABELS),
+            "open_blockers": 0, "pull_request": {}}
+    rival = {"number": _PROBE_RIVAL, "state": "OPEN", "labels": list(_PROBE_LABELS),
+             "open_blockers": 0}
+    try:
+        # The engine's default `conflict_log` writes attribution to stderr; the registry tolerates
+        # that noise, but on `--diagnose` stderr is otherwise clean, so swallow only the probe's
+        # own two calls. The CALL ITSELF stays argument-identical to the orchestrator's.
+        with contextlib.redirect_stderr(io.StringIO()):
+            alone = [row.get("number") for row in compute([pull])]
+            paired = [row.get("number") for row in compute([pull, rival])]
+    except Exception as exc:                       # noqa: BLE001 — characterising a hostile target
+        return False, f"probe raised {type(exc).__name__}"
+    if alone or _PROBE_PR in paired:
+        return False, "planner DISPATCHES a pull-request row as if it were an issue"
+    if paired:
+        return False, "planner does not RESERVE a pull request's declared area"
+    return True, "reserves PR areas and never dispatches a PR row"
 
 
 def diagnose(issues, linked=(), source_links=None):
@@ -1003,12 +1061,26 @@ def main():
         print(f"unit occupancy: {len(units)} unit(s), "
               f"{sum(len(a) for a, _ in units)} reservation(s) over "
               f"{len(set().union(set(), *[a for a, _ in units]))} partition key(s)")
-        _pr_aware, issue_only, unheld = occupancy_parity(visible, source_links)
-        if unheld:
-            print(f"\n::warning:: ORCHESTRATOR OCCUPANCY GAP: dispatch.yml strips PR rows from its "
-                  f"readiness input, so PLAN holds {len(issue_only)} of {len(_pr_aware)} partition "
-                  f"key(s). {len(unheld)} key(s) held here by an open PR are FREE there: "
+        # [OPUS-5 2026-07-27] Gated on the PROBE, not on `unheld`. `unheld` is non-empty whenever
+        # any open PR holds a key its source issue does not — i.e. on every healthy board — so the
+        # old unconditional warning could never clear once registry #773 landed, and an alarm that
+        # cannot clear trains its readers to skip it. The probe is the real precondition: it is
+        # what dispatch.yml itself branches on, so this fires when, and only when, the gap is back.
+        # Reported on EVERY diagnose including the healthy one — a check that goes silent when it
+        # passes is a check nobody notices has stopped running.
+        pr_aware_ok, probe_why = pr_row_occupancy_probe()
+        pr_aware_keys, issue_only, unheld = occupancy_parity(visible, source_links)
+        if not pr_aware_ok:
+            print(f"\n::warning:: ORCHESTRATOR OCCUPANCY GAP: this repo's readiness engine FAILS "
+                  f"the registry's pull-request-awareness probe ({probe_why}), so dispatch.yml "
+                  f"falls back to stripping PR rows from its readiness input and PLAN holds "
+                  f"{len(issue_only)} of {len(pr_aware_keys)} partition key(s). {len(unheld)} "
+                  f"key(s) held here by an open PR are FREE there: "
                   f"{', '.join(sorted(unheld)[:20])}")
+        else:
+            print(f"\norchestrator occupancy: dispatch.yml RESERVES this repo's open PR rows "
+                  f"({probe_why}); {len(unheld)} of {len(pr_aware_keys)} held key(s) come from a "
+                  f"PR half and would be released if that regressed")
         if roleless:
             print(f"\n::warning:: {len(roleless)} attested issue(s) carry NO role:* label and are "
                   f"INVISIBLE to dispatch: {', '.join('#%d' % n for n in roleless[:20])}")

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -36,6 +36,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPTS = REPO_ROOT / "scripts"
@@ -874,20 +875,29 @@ class TestUnitReservation(unittest.TestCase):
 
 
 class TestOrchestratorOccupancyGap(unittest.TestCase):
-    """The measured consequence of dispatch.yml stripping PR rows from its readiness input.
+    """The consequence of PLAN seeing the ISSUE half of every unit only — and its live precondition.
 
-    [OPUS-5] `dispatch.yml` builds `readiness_input` from
+    [OPUS-5] HISTORY. `dispatch.yml` used to build `readiness_input` from
     `[issue for issue in snapshot("issues", index) if "pull_request" not in issue]`, so PLAN
-    reserves the ISSUE half of every unit and never the PR half. MEASURED on the live snapshot
-    (2026-07-27): the PR-aware view holds 49 partition keys and emits a frontier of 3; the
-    issue-only view holds 37 and emits 9 — and 7 of those 9 rows land in a key an open PR already
-    holds. Registry CLAIM re-derives busy areas from the pulls snapshot and drops them, so they are
-    not double-dispatched; but they are dropped AFTER compute_ready committed the frontier, so each
-    burned a partition with no backfill (the registry's own issue #113 shape).
+    reserved the ISSUE half of every unit and never the PR half. Registry CLAIM re-derived busy
+    areas from the pulls snapshot and dropped the doomed rows, so they were never double-dispatched
+    — but it dropped them AFTER compute_ready committed the frontier, so each burned a partition
+    with no backfill (the registry's own issue #113 shape).
 
-    sparq cannot close that from here — PLAN's input is built inside dispatch.yml, which the
-    registry owns. What sparq owns is the DEFINITION (`unit_reservations`) and the measurement, so
-    the gap is loud on every local run instead of being re-derived by hand each time.
+    [OPUS-5 2026-07-27] THAT IS FIXED, and the fix moved the risk to this side of the seam.
+    Registry #773 (merged 15:54Z) folds every open PR row into PLAN's occupancy — but CONDITIONALLY,
+    on an executable capability probe run against the target repo's own planner, and a planner that
+    fails the probe silently keeps the old issue-only behaviour. VERIFIED against the live PLAN job
+    of registry dispatch run 30283405388 (16:24Z, master 84c1b687, which contains #773 at 58dc61bd),
+    whose runtime output reads:
+
+        sparq-org/sparq: PLAN occupancy carries 118 open pull-request row(s)
+        — reserves PR areas and never dispatches a PR row
+
+    So the gap is no longer a property of dispatch.yml; it is a property of `compute_ready` in THIS
+    repo. `ready.pr_row_occupancy_probe` mirrors the registry's probe so a sparq commit that turns
+    PR-half occupancy back off is caught by sparq's own CI instead of by a warning printed in a
+    repository nobody working here reads.
     """
 
     BOARD = (
@@ -917,14 +927,105 @@ class TestOrchestratorOccupancyGap(unittest.TestCase):
         _pr_aware, _issue_only, unheld = ready.occupancy_parity(board, {})
         self.assertEqual(unheld, set())
 
-    def test_diagnose_reports_the_gap_loudly(self):
-        board = [iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
+    # -- the probe: the live precondition for PLAN reserving our PR rows ---------------------
+
+    @staticmethod
+    def _engine(kind):
+        """A planner broken in exactly ONE of the ways the probe must catch."""
+        def compute(rows, *_args, **_kwargs):
+            if kind == "raises":
+                raise RuntimeError("hostile planner")
+            if kind == "ignores_pr_areas":
+                # Never selects a PR row (obligation 1 holds) but reserves nothing for it, so the
+                # rival sails through and the whole fold is an expensive no-op.
+                survivors = [row for row in rows if "pull_request" not in row]
+                return ready.compute_ready(survivors, conflict_log=quiet)
+            if kind == "dispatches_pr":
+                return list(rows)                    # treats a PR row as a dispatch candidate
+            raise AssertionError(f"unknown engine kind {kind!r}")
+        return compute
+
+    def test_the_live_engine_satisfies_the_registrys_pr_row_probe(self):
+        # THE contract. If this goes red, dispatch.yml stops folding sparq's PR rows into PLAN's
+        # occupancy and every open PR's crate reads FREE to the orchestrator again.
+        ok, why = ready.pr_row_occupancy_probe()
+        self.assertTrue(ok, f"registry would strip our PR rows: {why}")
+        self.assertEqual(why, "reserves PR areas and never dispatches a PR row")
+
+    def test_the_probe_rejects_an_engine_that_dispatches_a_pull_request_row(self):
+        ok, why = ready.pr_row_occupancy_probe(self._engine("dispatches_pr"))
+        self.assertFalse(ok)
+        self.assertIn("DISPATCHES", why)
+
+    def test_the_probe_rejects_an_engine_that_ignores_a_pull_requests_area(self):
+        # Passes the SAFETY obligation (never selects the PR) while making the fold a no-op.
+        ok, why = ready.pr_row_occupancy_probe(self._engine("ignores_pr_areas"))
+        self.assertFalse(ok)
+        self.assertIn("does not RESERVE", why)
+
+    def test_the_probe_is_fail_closed_on_an_engine_that_raises(self):
+        ok, why = ready.pr_row_occupancy_probe(self._engine("raises"))
+        self.assertFalse(ok)
+        self.assertIn("probe raised", why)
+
+    def test_the_probe_calls_the_engine_exactly_as_the_orchestrator_does(self):
+        # dispatch.yml calls `planner.compute_ready([...])` positionally with NO keywords. A probe
+        # that passed `conflict_log=` would stay green through a signature change that breaks the
+        # orchestrator's real call.
+        seen = []
+
+        def recorder(rows, *args, **kwargs):
+            seen.append((args, dict(kwargs)))
+            return ready.compute_ready(rows, conflict_log=quiet)
+
+        ready.pr_row_occupancy_probe(recorder)
+        self.assertEqual(seen, [((), {}), ((), {})], "probe must not pass extra arguments")
+
+    def test_the_registry_probes_the_engine_this_module_defines(self):
+        # dispatch.yml loads scripts/dispatch-plan.py and probes ITS `compute_ready`. The local
+        # mirror only characterises the orchestrator while dispatch-plan RE-EXPORTS this engine
+        # rather than wrapping it — a wrapper could satisfy the probe here and fail it there.
+        self.assertIs(plan.compute_ready, plan._ready.compute_ready,
+                      "dispatch-plan must re-export the readiness engine, not redefine it")
+        self.assertTrue(ready.pr_row_occupancy_probe(plan.compute_ready)[0],
+                        "the object the registry actually probes must pass the probe")
+
+    # -- the warning is gated on the probe, not on `unheld` -----------------------------------
+
+    GAP_BOARD = [iss(100, ["status:in-progress-review", "area:sparq-hdt"]),
                  iss(200, READY + ["priority:P1", "area:sparq-geo"])]
-        pulls = [dict(worker_pr(101, 100), labels=[{"name": "area:sparq-core"}])]
-        prs = [dict(p, labels=[lb["name"] for lb in p["labels"]]) for p in pulls]
-        out = TestLocalOrchestratorParity._run_cli(board + prs, pulls, argv=("--diagnose",))
+    GAP_PULLS = [dict(worker_pr(101, 100), labels=[{"name": "area:sparq-core"}])]
+
+    def _diagnose(self):
+        prs = [dict(p, labels=[lb["name"] for lb in p["labels"]]) for p in self.GAP_PULLS]
+        return TestLocalOrchestratorParity._run_cli(
+            self.GAP_BOARD + prs, self.GAP_PULLS, argv=("--diagnose",))
+
+    def test_diagnose_reports_the_gap_loudly_when_the_probe_FAILS(self):
+        with mock.patch.object(ready, "pr_row_occupancy_probe",
+                               lambda engine=None: (False, "planner DISPATCHES a pull-request "
+                                                           "row as if it were an issue")):
+            out = self._diagnose()
         self.assertIn("ORCHESTRATOR OCCUPANCY GAP", out)
         self.assertIn("sparq-core", out.split("ORCHESTRATOR OCCUPANCY GAP")[1])
+
+    def test_diagnose_does_NOT_warn_while_the_probe_PASSES(self):
+        # The stale-alarm fix. `unheld` is non-empty on this board (the PR holds sparq-core and its
+        # source issue does not), so an `if unheld:` warning fires here — forever, on every healthy
+        # board, since registry #773. Deleting the probe gate re-reds this test.
+        self.assertTrue(ready.pr_row_occupancy_probe()[0], "precondition: probe passes")
+        _pr_aware, _issue_only, unheld = ready.occupancy_parity(
+            [dict(p, labels=[lb["name"] for lb in p["labels"]], state="OPEN",
+                  pull_request={}, open_blockers=0) for p in self.GAP_PULLS] + self.GAP_BOARD,
+            {101: {100}})
+        self.assertIn("sparq-core", unheld, "precondition: the old trigger is armed on this board")
+        out = self._diagnose()
+        self.assertNotIn("ORCHESTRATOR OCCUPANCY GAP", out)
+
+    def test_diagnose_states_the_healthy_verdict_rather_than_going_silent(self):
+        out = self._diagnose()
+        self.assertIn("orchestrator occupancy: dispatch.yml RESERVES", out)
+        self.assertIn("reserves PR areas and never dispatches a PR row", out)
 
 
 class TestLinkedIssueDetection(unittest.TestCase):


### PR DESCRIPTION
> 🤖 **SPARQ agent** — authored autonomously. Author only; I have not armed, merged, or relabelled anything.

## The defect: a warning that can never clear

`scripts/ready-issues.py --diagnose` printed this on every run:

```
::warning:: ORCHESTRATOR OCCUPANCY GAP: dispatch.yml strips PR rows from its readiness input,
so PLAN holds 36 of 46 partition key(s). 10 key(s) held here by an open PR are FREE there: ...
```

**That claim is false.** Registry [#773](https://github.com/jeswr/agent-account-registry/pull/773) merged at `2026-07-27T15:54:59Z` and stopped `dispatch.yml` stripping PR rows. Verified on two independent surfaces rather than inferred from the warning text:

**1. The merged YAML on the registry's `master`.** `master` is `84c1b687` (16:04Z); `git compare 58dc61bd...84c1b687` reports `status=ahead ahead=1 behind=0`, so master contains #773's merge commit. That file builds `occupancy_input` from the PR half and prepends it:

```python
ready_input = occupancy_input + [ row for row in readiness_input if ... ]
```

**2. The live PLAN job.** Registry dispatch run `30283405388` (16:24Z, on `84c1b687`), job `90036395740`, **runtime** output — not an echoed `[36;1m` source line:

```
sparq-org/sparq: native blocker channel: LIT (96 of 1483 open issue(s) held by a blocker)
sparq-org/sparq: PLAN occupancy carries 118 open pull-request row(s) — reserves PR areas and never dispatches a PR row
```

All 118 open PR rows are reserved by PLAN. The old trigger was `if unheld:`, and `unheld` is non-empty whenever any open PR holds a key its source issue does not — **on every healthy board**. Live right now that is 10 of 46 held keys. The warning was structurally unclearable.

## Why not just delete the check

The underlying risk is real, but it **moved to this side of the seam**. `dispatch.yml` folds PR rows *conditionally*, on an executable capability probe (`pr_row_aware`) run against the target repo's own planner; a planner that fails the probe **silently keeps the old issue-only behaviour**. `dispatch-plan.py` re-exports this file's `compute_ready`, so the only thing that can turn PR-half occupancy back off is a sparq commit — which would pass sparq CI green and announce itself only in the *registry's* log, on a repo nobody working here reads.

So `pr_row_occupancy_probe()` mirrors the registry's probe verbatim and the warning is gated on **it**. The alarm now fires when, and only when, the gap is actually back.

Design points, each pinned by a test:
- Called **exactly** as the orchestrator calls it — positional, no keyword arguments — so a `compute_ready` signature change that breaks the orchestrator's real call breaks this probe too.
- Both of the registry's obligations are executed: **SAFETY** (a PR row is never returned as a candidate) *and* **EFFECT** (a PR row really reserves its declared areas). An engine that merely ignores PR rows satisfies the first while making the whole fold a no-op.
- **Fail-closed**: an engine that raises is one we cannot characterise, so it does not pass.
- The healthy verdict prints on every diagnose — a check that goes silent when it passes is a check nobody notices has stopped running (`dispatch.yml`'s own stated rule).

## What this does NOT do

- **No reservation is weakened.** `occupancy_parity`, `unit_reservations`, `_reserving_packages` and `compute_ready` are untouched. The same key sets are still computed and still reported — as a *size*, not a verdict.
- **The fail-closed `__global__` default is not narrowed.**
- The frontier is unchanged by this PR (it is a diagnostics change).

## Verification

Full `routing-self-tests` run block, executed verbatim — **12/12 legs PASS**:

```
[PASS] routing-validate.py --self-test        [PASS] tests/test_readiness_visibility.py  (84 tests)
[PASS] routing-validate.py                    [PASS] tests/test_no_deprecated_models.py
[PASS] route-resolve.py --self-test           [PASS] pr-area-labels.py --self-test
[PASS] ready-issues.py --self-test            [PASS] tests/test_pr_area_labels.py
[PASS] dispatch-plan.py --self-test           [PASS] render-start-here.py --self-test
[PASS] batch-merge.py --self-test             [PASS] tests/test_start_here_render.py
```

**Mutation-checked on the live tree — 7/7 killed, each by the intended test:**

| mutant | killed by |
|---|---|
| revert gate to `if unheld:` | `test_diagnose_does_NOT_warn_while_the_probe_PASSES` |
| probe always returns OK | the three `test_the_probe_rejects_*` / fail-closed tests |
| drop the SAFETY obligation | `test_the_probe_rejects_an_engine_that_dispatches_a_pull_request_row` |
| drop the EFFECT obligation | `test_the_probe_rejects_an_engine_that_ignores_a_pull_requests_area` |
| narrow the fail-closed `except` | `test_the_probe_is_fail_closed_on_an_engine_that_raises` |
| delete the healthy-verdict branch | `test_diagnose_states_the_healthy_verdict_rather_than_going_silent` |
| probe passes an extra kwarg | `test_the_probe_calls_the_engine_exactly_as_the_orchestrator_does` |

End-to-end against live sparq, after the patch:

```
drainable backlog (ready_candidates): 348
concurrency frontier (compute_ready): 4
unit occupancy: 74 unit(s), 118 reservation(s) over 46 partition key(s)

orchestrator occupancy: dispatch.yml RESERVES this repo's open PR rows (reserves PR areas and
never dispatches a PR row); 10 of 46 held key(s) come from a PR half and would be released if
that regressed
```

## Files owned

`scripts/ready-issues.py`, `scripts/tests/test_readiness_visibility.py`. No overlap with the live PRs #4547 / #4385 / #4191 (all three touch `.github/workflows/docs-quality.yml`, which this PR does not). No workflow change is needed — both files are already `paths:` triggers on `routing-self-tests.yml`, pinned by that suite's own wiring tests.
