### PR TITLE
fix(bench): hard-zone gate must not red main for a PERFECT result, nor on one quantization tick (sq-jxeqz)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -430,6 +430,25 @@ jobs:
       # self-test in differential.yml).
       - name: Self-test demoted-lane failure filer (id/dedupe/append/log-tail logic)
         run: python3 scripts/ci-file-demoted-lane-failure.py --self-test
+      # [OPUS-5] sq-jxeqz / #4559: the bench HARD-ZONE gate's pure logic
+      # (scripts/bench_hardzone.py). Its --self-test previously ran ONLY inside bench.yml's
+      # "Hard zone" step, which is guarded `github.event_name != 'schedule' && github.ref ==
+      # 'refs/heads/main'` — so the gate's own logic was NEVER exercised on a PR, and a change
+      # to it could only be discovered by reddening main AFTER merge. That is exactly how the
+      # zero-boundary defect in #4559 reached main and then persisted (15 of the last 60
+      # Benchmarks runs failed on that one step). Running it HERE, on every PR, means a
+      # regression in the regression gate reds the PR that causes it. Hermetic: no network,
+      # no git, no repo writes (same stdlib-only pattern as the lints above).
+      - name: Self-test bench hard-zone gate (zero boundary + noise floor + resolution bounds)
+        run: python3 scripts/bench_hardzone.py --self-test
+      # ...and the WIRING of that gate: the step above must exist and stay unconditional, the
+      # bench.yml lane must keep `set -euo pipefail` with no `|| true` / continue-on-error, and
+      # the hard-zone step must keep running BEFORE the Store step (the anti-laundering
+      # invariant — Store auto-pushes this run's point, so gating afterwards would publish a
+      # rejected regression into the very median that judges it). This test also asserts its
+      # OWN step is present, so the seam cannot be un-wired one level up.
+      - name: Self-test bench hard-zone WIRING (PR coverage + publish order + no swallow)
+        run: python3 scripts/tests/test_bench_hardzone_wiring.py
       # [FABLE-5] formal-lanes fix: the nightly miri.yml UB lane's verdict CLASSIFIER
       # (scripts/miri_classify_verdict.py) decides whether a shard's non-passes are known
       # per-test-cap TIMEOUTS (cost debt, sq-0s15k — non-fatal) or a GENUINE Miri UB/assertion

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -889,6 +889,9 @@ def run_gate(results_path: str, prev_data_path: str, suite: str,
         Path(report_out).write_text(json.dumps(
             {"suite": suite, "hard_ratio": HARD_RATIO,
              "floor_exempt_units": FLOOR_EXEMPT_UNITS,
+             # The per-unit resolution CEILINGS, so a trail row tagged "resolution-exempt" is
+             # self-describing (the per-metric quantum that actually applied is in its `note`).
+             "resolution_quanta": RESOLUTION_QUANTA,
              "floor_exempt_hard": report["floor_exempt_hard"]},
             indent=2) + "\n", encoding="utf-8")
         log(f"report JSON ({len(report['floor_exempt_hard'])} floor-exempt hard-band row(s)) "

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -376,6 +376,21 @@ def ratio_lower_bound(val: float, med: float, larger_better: bool, quantum: floa
     return max(val - half, 0.0) / (med + half)
 
 
+def resolution_exempts(val: float, med: float, larger_better: bool, quantum: float,
+                       ratio: float) -> bool:
+    """True iff `ratio` reaches HARD_RATIO but the measurement's resolution cannot PROVE it.
+
+    NARROW BY CONSTRUCTION, and both conjuncts are load-bearing:
+      * `ratio >= HARD_RATIO` — the exemption may only ever apply to a row that would otherwise
+        hard-fail. Without it every seconds/milli row would be flagged exempt and flood the
+        durable trail with metrics that are not in the hard band at all.
+      * `lower_bound < HARD_RATIO` — STRICT. A row whose bound lands exactly ON the threshold is
+        proven to reach it and stays gated.
+    """
+    return (quantum > 0.0 and ratio >= HARD_RATIO
+            and ratio_lower_bound(val, med, larger_better, quantum) < HARD_RATIO)
+
+
 def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     """Pure gate logic — unit-tested by --self-test. No I/O, no env access.
 
@@ -510,9 +525,7 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
         # would otherwise be in the hard set, and only when the row's resolution-aware LOWER
         # BOUND does not reach the threshold. "Would hard-fail on the point estimate, but the
         # measurement cannot PROVE it reaches HARD_RATIO." Watch-only, never ungated.
-        resolution_exempt = (quantum > 0.0 and ratio >= HARD_RATIO
-                             and ratio_lower_bound(val, med, larger_better,
-                                                   quantum) < HARD_RATIO)
+        resolution_exempt = resolution_exempts(val, med, larger_better, quantum, ratio)
         rows.append((name, val, med, len(pts), ratio, det, larger_better, floor_exempt,
                      resolution_exempt))
         units[name] = unit
@@ -1167,6 +1180,82 @@ def self_test() -> int:
           and abs(ratio_lower_bound(0.001, 0.0, False, 0.001) - 1.0) < 1e-12
           and abs(ratio_lower_bound(500.0, 1000.0, True, 100.0) - 1.7272727272727273) < 1e-9,
           "ratio_lower_bound: least-regressed reading in both directions, total at a zero median")
+    #     T12b — the bound is CLAMPED at 0 and never returns a negative ratio, for any quantum a
+    #     caller passes (evaluate() only ever passes a quantum that divides the values, but the
+    #     helper is public and a negative "ratio" would corrupt every comparison downstream).
+    #     MUTATION: drop the max(..., 0.0) clamps => red.
+    check(ratio_lower_bound(0.0, 1.0, False, 4.0) == 0.0
+          and ratio_lower_bound(1.0, 0.0, True, 4.0) == 0.0,
+          "ratio_lower_bound clamps at 0 — a coarse quantum never yields a negative ratio")
+    #     T13 — THE SECOND-ORDER LOOP, closed. This fix makes a perfect 0 PUBLISH, so the recall
+    #     deficit's MEDIAN can now legitimately become 0 — and the very next honest run at 1 is a
+    #     PESSIMAL-side zero crossing. Without the `milli` quantum that is fail-closed and main
+    #     REDS AGAIN for the same reason, one publication later. The integer-milli quantum
+    #     (bench/vector/README.md: the deficit is `round(...)`) is what keeps it bounded at 1.00x.
+    #     MUTATION: delete RESOLUTION_QUANTA["milli"] => red.
+    hnsw0 = history_values([{"date": i, "benches": [
+        {"name": "vectors_hnsw_recall_at10", "value": v, "unit": "milli"}]}
+        for i, v in enumerate([0.0, 0.0, 0.0, 1.0, 0.0])])
+    code, rep = evaluate([{"name": "vectors_hnsw_recall_at10", "value": 1.0, "unit": "milli"}],
+                         hnsw0)
+    check(code == 0 and not rep["invalid"] and len(rep["zero_crossing"]) == 1
+          and abs(rep["zero_crossing"][0][3] - 1.0) < 1e-9,
+          "once a perfect 0 has PUBLISHED and the median is 0, the next honest 1-milli deficit "
+          "is resolution-bounded to 1.00x — the loop does not simply move one publication later")
+    #     T14 — resolution_exempts(): BOTH conjuncts pinned.
+    #     MUTATION: dropping `ratio >= HARD_RATIO` reds the first; `<` -> `<=` reds the second.
+    check(not resolution_exempts(1.2, 1.0, False, 1.0, 1.2),
+          "resolution_exempts is False below the hard band — it never flags a row that would "
+          "not hard-fail anyway (which would flood the durable trail)")
+    check(not resolution_exempts(3.5, 1.0, False, 1.0, 3.5)
+          and resolution_exempts(3.4, 1.0, False, 1.0, 3.4),
+          "resolution_exempts is STRICT at the threshold: a bound landing exactly ON "
+          f"{HARD_RATIO:g}x is proven to reach it and stays gated")
+    #     ...and the same "below the hard band is not on the trail" property end-to-end.
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.001)], unit="s"), tick)
+    check(code == 0 and not rep["resolution_exempt"] and not rep["floor_exempt_hard"],
+          "an unchanged resolution-scale metric is neither resolution-exempt nor on the trail")
+    #     T15 — the CURRENT value constrains the inferred quantum, not just the history window.
+    #     A run reporting 0.0025 PROVES the emitter resolves to 1e-4, so the 1 ms allowance is no
+    #     longer justified and the move REDs. MUTATION: infer from `pts` only => red.
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.0025)], unit="s"), tick)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["resolution_exempt"],
+          "a current value with finer granularity than the window SHRINKS the allowance — "
+          "0.0025 vs median 0.001 proves 1e-4 resolution and hard-fails")
+    #     T16 — the markdown table names WHICH exemption applies. This column is what a
+    #     maintainer reads in GITHUB_STEP_SUMMARY, and on a green run it is the only record.
+    #     MUTATION: make _gating_label always return "hard-zone" => red.
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.002)], unit="s"), tick)
+    md = "\n".join(render_report(rep, markdown=True))
+    check("at measurement resolution — watch only" in md and "| hard-zone |" not in md,
+          "the markdown table's gating column names the resolution exemption")
+    check(_gating_label(True, False) == "under noise floor — watch only"
+          and _gating_label(False, True) == "at measurement resolution — watch only"
+          and _gating_label(True, True).count("watch only") == 1
+          and _gating_label(False, False) == "hard-zone",
+          "_gating_label distinguishes all four exemption combinations")
+    #     T17 — a zero-boundary/resolution event makes the run NOTABLE, so the step summary is
+    #     still written even though the run is now GREEN. This gate runs before the Store step,
+    #     so on a green run this summary is the only place the event is recorded.
+    #     MUTATION: drop the new terms from `notable` => red.
+    code, rep = evaluate(_cur([("a", 0.0), ("b", 100.0), ("c", 100.0), ("d", 100.0)]),
+                         history_values(series))
+    saved = os.environ.pop("GITHUB_STEP_SUMMARY", None)
+    try:
+        with tempfile.TemporaryDirectory(prefix="bench-hardzone-selftest-") as td17:
+            sf = Path(td17) / "summary.md"
+            os.environ["GITHUB_STEP_SUMMARY"] = str(sf)
+            with contextlib.redirect_stdout(io.StringIO()):
+                emit_report(rep)
+            written = sf.read_text(encoding="utf-8") if sf.exists() else ""
+    finally:
+        if saved is not None:
+            os.environ["GITHUB_STEP_SUMMARY"] = saved
+        else:
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
+    check(code == 0 and "reached their OPTIMUM" in written,
+          "a GREEN run whose only event is a zero-boundary improvement still writes the step "
+          "summary — the event stays visible after it stopped being fatal")
 
     # 6. Disappeared metrics: warn below the 30% threshold, hard-fail above it.
     code, rep = evaluate(_cur([("a", 10.0), ("b", 10.0), ("c", 10.0)]), history_values(series))

--- a/scripts/bench_hardzone.py
+++ b/scripts/bench_hardzone.py
@@ -19,16 +19,49 @@
 #     (median/current) for names matching `_per_s$`. (Candidate follow-up: store the inverse —
 #     seconds-per-triple — so the whole suite is genuinely smaller-is-better.)
 #   * FAIL-CLOSED NUMERICS: a current value or history-window value that is NaN/non-numeric/
-#     negative, or a value that crosses a zero boundary (current 0 vs positive median, or vice
-#     versa), HARD-FAILS with a per-metric message — never silently skipped. Current values are
+#     negative HARD-FAILS with a per-metric message — never silently skipped. Current values are
 #     validated BEFORE the no-history / insufficient-history early exits (a bad current on a
 #     brand-new or young metric still fails the run), and every value inside a metric's median
 #     window is checked individually (a negative history point cannot hide behind a positive
-#     median). The one deliberate carve-out
-#     (grounded in the LIVE history): current == 0 AND median == 0 is a legitimate stable value —
-#     four published series are all-zero by design (geo_compliance_deficit, nlq_ask_repairs,
-#     rsp_*_w{2,3}_rows, and the sub-resolution sameas_size8_closure_s), so a blanket "<= 0 fails"
-#     would permanently red main; stable zeros are instead compared at ratio 1.0 and listed.
+#     median).
+#   * ZERO BOUNDARY — RESOLVED BY DIRECTION, NOT BY "ratio undefined" (sq-jxeqz / #4559). A
+#     zero boundary is not one situation, it is three, and only ONE of them is an error:
+#       (i)  current == 0 AND median == 0 — a legitimate STABLE value. Four published series are
+#            all-zero by design (geo_compliance_deficit, nlq_ask_repairs, rsp_*_w{2,3}_rows, and
+#            the sub-resolution sameas_size8_closure_s), so a blanket "<= 0 fails" would
+#            permanently red main. Compared at ratio 1.0 and listed.
+#       (ii) current is at the metric's OPTIMUM — smaller-is-better at 0, or `*_per_s` throughput
+#            recovering FROM a zero median. The ratio is perfectly well defined (0.0) and the
+#            move is an IMPROVEMENT BY CONSTRUCTION: on a smaller-is-better scale nothing can be
+#            better than 0, so no comparison against any median can make it a regression. The
+#            previous revision routed this to `invalid` — an UNCONDITIONAL exit 1 that the
+#            uniform-shift exemption never covers — and it red main repeatedly for achieving a
+#            PERFECT result: vectors_hnsw_recall_at10 is a recall DEFICIT (bench/vector/README.md:
+#            `recall_deficit_milli = round((1 - recall@10) * 1000)`), so its 0 is recall@10 =
+#            1.000, the best value the metric can take. It is now compared at ratio 0.0 and
+#            listed in `improved_to_zero` (visible, never fatal). Because the run then goes
+#            GREEN it also PUBLISHES, so the median rebases through the ordinary path — this is
+#            what breaks the self-perpetuating loop (see PUBLISH ORDER below).
+#      (iii) current is at the metric's PESSIMAL side — smaller-is-better rising off a zero
+#            median, or throughput collapsing TO zero. This IS a regression, of unbounded ratio.
+#            It is bounded (and hence gated) only when the metric's measurement RESOLUTION is
+#            known (RESOLUTION_QUANTA); with an unknown quantum the ratio genuinely cannot be
+#            bounded and the row stays FAIL-CLOSED, exactly as before. A `*_per_s` throughput
+#            collapsing to 0 therefore still hard-fails.
+#   * MEASUREMENT RESOLUTION (sq-jxeqz / #4559): a metric cannot express a ratio finer than its
+#     own quantization tick, so a ratio computed across one tick is comparing noise. The gate may
+#     only hard-fail when the ratio is PROVABLY >= HARD_RATIO given the resolution — see
+#     RESOLUTION_QUANTA and ratio_lower_bound(). A row that reaches HARD_RATIO on the point
+#     estimate but whose resolution-aware LOWER BOUND does not is watch-only (same treatment as
+#     the unit noise floor: printed, ::warning'd, and routed to the durable --report-out trail).
+#   * PUBLISH ORDER (sq-jxeqz / #4559): this gate deliberately runs BEFORE the Store step, so a
+#     failing run publishes NOTHING — a rejected regression can never rebase the median that
+#     judges it. That ordering is load-bearing and is NOT changed here. Its cost is that the
+#     published history is a CENSORED (survivorship-biased) sample: every honest run whose noise
+#     exceeded the threshold is absent from the very history the floors are derived from, so the
+#     measured bands below are LOWER BOUNDS on the honest bands. The fix for a self-perpetuating
+#     red is therefore to make the provably-non-regressing case PASS (so it publishes through the
+#     ordinary path), never to publish a failing run's measurements.
 #   * DISAPPEARED METRICS: metrics with a gateable history (>= MIN_HISTORY values) that are absent
 #     from this run's results are warn-listed loudly; the run HARD-FAILS only if more than
 #     DISAPPEAR_FAIL_FRACTION (30%) of the gateable metrics disappeared (suite breakage) — a
@@ -160,6 +193,41 @@ DISAPPEAR_FAIL_FRACTION = 0.30  # > 30% of gateable metrics missing from results
 # DETERMINISTIC metrics are never floor-exempt even in an allow-listed unit.
 FLOOR_EXEMPT_UNITS: dict[str, float] = {"us": 40.0, "milli": 20.0}
 
+# MEASUREMENT RESOLUTION — the COARSEST step a metric of this unit could possibly be printed at,
+# read off the code that emits it (never guessed; a unit whose quantum is not derivable is simply
+# absent, and absent means "no resolution allowance", i.e. fail toward gated). Entries:
+#   * "s" (0.001): the seconds-unit closure metrics are scraped by bench/owl-sameas/run.sh
+#     (`grep -oE 'in [0-9.]+s'`) out of crates/sparq-cli/src/main.rs's `... in {:.3}s` — THREE
+#     decimal places, so one tick is 1 ms. sameas_size32_closure_s publishes 0.001 on every
+#     retained point and its sibling sameas_size8_closure_s publishes 0 (sub-resolution): one
+#     single tick up is EXACTLY the inclusive >= 2.0x hard threshold, with zero margin. A value
+#     printed as 0.001 is really somewhere in [0.0005, 0.0015) and one printed as 0.002 is in
+#     [0.0015, 0.0025), so the TRUE ratio of that "2.00x" spans [1.0, 5.0) — it is consistent
+#     with no change at all. The gate must not call that a regression.
+#   * "milli" (1.0): the vectors_*_recall_at10 deficits are integers by construction —
+#     bench/vector/README.md defines `recall_deficit_milli = round((1 - recall@10) * 1000)`.
+#
+# THE UNIT IS A CEILING, NOT THE ANSWER — measured, not assumed. The `s` unit is NOT uniformly
+# 1 ms-quantized: replaying the published history, of the ten retained `s` series only four
+# (deeptax_d{1000,10000}_closure_s, load_s, rdfs_infer_s, sameas_size32_closure_s) actually print
+# at 3 decimals; hdt_load_s / snikmeta_decode_s / text_build_s / vectors_build_s come from a
+# different emitter and carry 6-7. snikmeta_decode_s in particular has a MEDIAN BELOW ONE
+# 1 ms tick, so a blanket per-unit 1 ms allowance would have handed it an allowance several times
+# its own median and gutted its gate — precisely the "widen the threshold until it passes" failure
+# this fix exists to avoid. So the effective quantum is
+#     min(this unit's ceiling, the granularity the metric's own values DEMONSTRATE)
+# — see observed_quantum(). Per-metric inference can only ever make the allowance SMALLER, and the
+# unit ceiling bounds it for a metric whose values are coincidentally round. Both halves are
+# load-bearing and separately mutation-tested.
+#
+# The allowance this buys is an ABSOLUTE band of (HARD_RATIO + 1)/2 = 1.5 quanta (see
+# ratio_lower_bound) — NOT a widened ratio threshold. As a fraction of the hard threshold that is
+# ~150% for a 1 ms closure and ~0.19% for a 0.4 s load: it shrinks to nothing exactly where the
+# ratio threshold is meaningful. It is not zero there, though — a load_s at EXACTLY 2.0000x is
+# inside it (the honest cost of only failing when the resolution PROVES the threshold is
+# reached); the band's far edge is pinned from both sides in the self-test.
+RESOLUTION_QUANTA: dict[str, float] = {"s": 0.001, "milli": 1.0}
+
 # Deterministic (byte/count/structural) metric classification. UNIT-first because the live metric
 # NAMES are trappy: bsbm_query01_count_us / lubm_*_count_us are TIMING metrics whose names contain
 # "count", store_bytes_per_triple carries "bytes" mid-name, and rsp_persistentdict_triples_per_s
@@ -240,18 +308,90 @@ def _floor_desc() -> str:
     return ", ".join(f"{u} < {f:g}" for u, f in sorted(FLOOR_EXEMPT_UNITS.items()))
 
 
+def observed_quantum(values: list[float], ceiling: float) -> float:
+    """Coarsest decimal step <= `ceiling` that EVERY observed non-zero value is a multiple of.
+
+    The published values are the only direct evidence of what precision the emitter actually
+    prints at, and they bound the allowance from below: a series carrying 0.000462 demonstrably
+    resolves to 1e-6 and must not be handed a 1 ms allowance just because its UNIT is seconds.
+    Zeros constrain nothing (every step divides 0); with no non-zero value at all the ceiling
+    stands, which only happens on the stable-zero path where no ratio is computed anyway.
+    """
+    nz = [abs(v) for v in values if v != 0.0]
+    if not nz:
+        return ceiling
+    # Walk DECIMAL EXPONENTS, never `q /= 10.0`: repeated division accumulates float error and
+    # would return 1.0000000000000002e-06 where 1e-06 is meant, making the quantum (and every
+    # bound derived from it) non-canonical. Every RESOLUTION_QUANTA ceiling is a power of ten —
+    # asserted in the self-test — so its exponent is exact.
+    exp = round(math.log10(ceiling))
+    q = ceiling
+    for k in range(10):  # at most 9 decades below the unit ceiling
+        q = 10.0 ** (exp - k)
+        # Exact-multiple test with an absolute+relative epsilon: v/q must land on an integer.
+        if all(abs(v / q - round(v / q)) * q <= 1e-12 * (1.0 + v) for v in nz):
+            return q
+    return q
+
+
+def resolution_quantum(unit: str, det: bool, values: list[float]) -> float:
+    """The smallest change this metric can EXPRESS, or 0.0 when it is not derivable.
+
+    Two independent bounds, both load-bearing (see RESOLUTION_QUANTA):
+      * the UNIT ceiling — the coarsest step the emitting code could print, from the allow-list;
+        a unit that is not allow-listed gets NO allowance at all (fail toward gated);
+      * the metric's OWN demonstrated granularity — never coarser than its values prove.
+
+    DETERMINISTIC metrics get 0.0 unconditionally: a byte/count/gate output is exact, so there is
+    no measurement resolution to allow for and a 2x move on one is real at any scale (the same
+    rule the unit noise floor uses). This guard is LOAD-BEARING, not belt-and-braces: a count
+    series reading 1000/2000/3000 would otherwise infer a quantum of 1000 and silence itself.
+    """
+    if det:
+        return 0.0
+    ceiling = RESOLUTION_QUANTA.get(unit)
+    if ceiling is None:
+        return 0.0
+    return observed_quantum(values, float(ceiling))
+
+
+def ratio_lower_bound(val: float, med: float, larger_better: bool, quantum: float) -> float:
+    """SMALLEST direction-adjusted ratio consistent with two values quantized at `quantum`.
+
+    A value REPORTED as `v` was really somewhere in [v - q/2, v + q/2); the median of a window of
+    such values is an order statistic of them and carries the same half-tick uncertainty. The
+    least-regressed reading is therefore the smallest possible numerator over the largest possible
+    denominator. `quantum` must be > 0 (callers use resolution_quantum() and check), which also
+    makes the denominator strictly positive — so this is total even at a zero median, the one
+    place the plain ratio genuinely divides by zero.
+
+    The gate hard-fails only when THIS bound reaches HARD_RATIO — i.e. only when the measurement's
+    own resolution PROVES the threshold is reached. Algebraically that is the plain test plus an
+    absolute allowance of exactly (HARD_RATIO + 1) * q / 2, independent of magnitude: a metric
+    measured far above its resolution is unaffected, one measured AT it is fully protected.
+    """
+    half = quantum / 2.0
+    if larger_better:
+        return max(med - half, 0.0) / (val + half)
+    return max(val - half, 0.0) / (med + half)
+
+
 def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     """Pure gate logic — unit-tested by --self-test. No I/O, no env access.
 
     `current` is this run's bench-results.json rows ({name,value,unit}); `hist` is the per-metric
     history value lists (see history_values). Returns (exit_code, report) where report carries:
       compared      — number of ratio-compared metrics (gated + floor-exempt)
-      rows          — [(name, cur, median, n, ratio, deterministic, larger_better, floor_exempt)]
-      watch         — the >= WATCH_RATIO subset of rows (floor-exempt rows included, flagged)
-      hard          — the >= HARD_RATIO subset of GATED rows (floor-exempt can never hard-fail)
+      rows          — [(name, cur, median, n, ratio, deterministic, larger_better, floor_exempt,
+                      resolution_exempt)]
+      watch         — the >= WATCH_RATIO subset of rows (exempt rows included, flagged)
+      hard          — the >= HARD_RATIO subset of GATED rows, minus the resolution-exempt ones
+                      (neither exemption can hard-fail the run alone)
       floor_exempt  — rows whose UNIT is in FLOOR_EXEMPT_UNITS with median under that unit's
                       floor (watch-only; unit-aware allow-list, unknown units stay gated)
-      floor_exempt_hard — floor-exempt rows at >= HARD_RATIO, in the soft-triage comparison
+      resolution_exempt — rows at >= HARD_RATIO on the point estimate whose resolution-aware
+                      LOWER BOUND (see ratio_lower_bound) does not reach HARD_RATIO (watch-only)
+      floor_exempt_hard — BOTH exemptions' hard-band rows, in the soft-triage comparison
                       shape ({name,current,previous,ratio_pct,unit,note}; previous = the
                       MEDIAN-of-history) — the durable-trail payload written by --report-out
                       and merged into the deduped bench-flake issue by bench-triage.py
@@ -261,6 +401,10 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
       ungated       — [(name, n)] metrics with 1..MIN_HISTORY-1 history values (listed, not gated)
       new           — metric names present in results with NO history at all
       stable_zero   — metrics compared as legitimate 0 == 0
+      improved_to_zero — [(name, cur, median, unit)] metrics that reached their OPTIMUM across a
+                      zero boundary (ratio 0.0): visible, never fatal (#4559)
+      zero_crossing — [(name, cur, median, ratio, unit)] PESSIMAL-side zero crossings whose ratio
+                      is bounded by the metric's measurement resolution rather than undefined
       disappeared   — gateable metrics absent from this run's results
       disappeared_frac / uniform_shift / exemption_reasons
     """
@@ -269,7 +413,10 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     ungated: list[tuple[str, int]] = []
     new: list[str] = []
     stable_zero: list[str] = []
+    improved_to_zero: list[tuple] = []
+    zero_crossing: list[tuple] = []
     units: dict[str, str] = {}
+    quanta: dict[str, float] = {}
 
     current_by_name: dict[str, dict] = {}
     for row in current:
@@ -314,27 +461,62 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
         med = float(statistics.median(pts))
         larger_better = bool(LARGER_IS_BETTER_RE.search(name))
         det = is_deterministic(name, unit)
+        # The metric's OWN observations — this run's value plus its median window — are what
+        # bound the resolution allowance from below (see resolution_quantum).
+        quantum = resolution_quantum(unit, det, [val] + [float(p) for p in pts])
+        # ZERO BOUNDARY — resolved by DIRECTION (see the header). The denominator of the
+        # direction-adjusted ratio is the median for a smaller-is-better metric and the CURRENT
+        # value for a `*_per_s` throughput; only a zero DENOMINATOR is undefined, and only that
+        # case is on the metric's pessimal side. A zero NUMERATOR is the metric sitting at its
+        # optimum, which is ratio 0.0 — an improvement by construction, never a regression.
+        denom = val if larger_better else med
         if val == 0 and med == 0:
             # Stable zero — legitimate for deterministic zero-counts and the sub-resolution
             # timing series that live history proves are all-zero by design. Compared, not skipped.
             stable_zero.append(name)
             ratio = 1.0
-        elif val == 0 or med == 0:
-            invalid.append((name, f"zero-boundary change (current {val:g} vs median {med:g}) — "
-                                  f"ratio undefined; fail-closed"))
-            continue
+        elif denom == 0:
+            # PESSIMAL-side zero crossing: a real regression of unbounded ratio. Bounded ONLY by
+            # the metric's measurement resolution; with no derivable quantum the ratio truly
+            # cannot be bounded, so this stays fail-closed exactly as before (a `*_per_s`
+            # throughput collapsing to 0 has no quantum and therefore still hard-fails).
+            if quantum <= 0.0:
+                invalid.append((name, f"zero-boundary change (current {val:g} vs median "
+                                      f"{med:g}) on the metric's PESSIMAL side and unit "
+                                      f"{unit or '<none>'!r} has no derivable measurement "
+                                      f"resolution — ratio unbounded; fail-closed"))
+                continue
+            ratio = ratio_lower_bound(val, med, larger_better, quantum)
+            zero_crossing.append((name, val, med, ratio, unit))
         else:
             # customSmallerIsBetter suite, EXCEPT `*_per_s` throughput (larger is better): invert.
+            # A zero NUMERATOR lands here and yields ratio 0.0 — the metric is at its optimum.
             ratio = (med / val) if larger_better else (val / med)
+            if val == 0 or med == 0:
+                improved_to_zero.append((name, val, med, unit))
         # NOISE FLOOR — UNIT-AWARE: exempt ONLY allow-listed units ("us"/"milli") whose median
         # sits under that unit's measured floor (see FLOOR_EXEMPT_UNITS). Every other unit —
         # "s" seconds, "ns_per_byte", "ratio", `*_per_s`, unknown — is gated regardless of
         # magnitude (unknown units fail toward gated), and deterministic metrics are NEVER
         # exempt (belt-and-braces: no deterministic unit is allow-listed).
+        #
+        # THIS IS COMPUTED FOR EVERY COMPARED ROW, INCLUDING THE ZERO-BOUNDARY ONES. The previous
+        # revision `continue`d out of the zero branch BEFORE reaching here, which made the floor
+        # UNREACHABLE at zero — the defect that red main for a perfect vectors_hnsw_recall_at10
+        # even though the "milli" floor had been added for precisely that metric (#4559).
         unit_floor = FLOOR_EXEMPT_UNITS.get(unit)
         floor_exempt = (not det) and unit_floor is not None and med < unit_floor
-        rows.append((name, val, med, len(pts), ratio, det, larger_better, floor_exempt))
+        # RESOLUTION EXEMPTION — narrow by construction: it can only ever apply to a row that
+        # would otherwise be in the hard set, and only when the row's resolution-aware LOWER
+        # BOUND does not reach the threshold. "Would hard-fail on the point estimate, but the
+        # measurement cannot PROVE it reaches HARD_RATIO." Watch-only, never ungated.
+        resolution_exempt = (quantum > 0.0 and ratio >= HARD_RATIO
+                             and ratio_lower_bound(val, med, larger_better,
+                                                   quantum) < HARD_RATIO)
+        rows.append((name, val, med, len(pts), ratio, det, larger_better, floor_exempt,
+                     resolution_exempt))
         units[name] = unit
+        quanta[name] = quantum
 
     compared = len(rows)
     # Floor-exempt rows stay in the watch TABLE (flagged "under noise floor — watch only") but
@@ -343,19 +525,38 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     # alike (the honest sub-floor history reaches 4.0x on pure noise).
     gated_rows = [r for r in rows if not r[7]]
     floor_exempt_rows = [r for r in rows if r[7]]
+    # Resolution-exempt rows deliberately STAY inside gated_rows. They are excluded from `hard`
+    # (they cannot fail the run alone) but keep feeding every uniform-shift condition, where an
+    # inflated near-resolution ratio can only make the exemption HARDER to obtain — the
+    # fail-toward-gated direction. Only the magnitude-based floor exemption removes rows outright.
+    resolution_exempt_rows = [r for r in gated_rows if r[8]]
     watch = [r for r in rows if r[4] >= WATCH_RATIO]
-    hard = [r for r in gated_rows if r[4] >= HARD_RATIO]
+    hard = [r for r in gated_rows if r[4] >= HARD_RATIO and not r[8]]
     # DURABLE TRAIL — floor-exempt rows at/above HARD_RATIO never red the gate, and after a few
     # accepted points the regressed median REBASES, erasing the gate-side evidence. Emit them in
     # the soft-triage comparison-row shape (`previous` = the MEDIAN-of-history, tagged in `note`)
     # so bench-triage.py --mode soft --hardzone-report merges them into the rolling deduped
     # bench-flake issue (see --report-out).
+    #
+    # [sq-jxeqz / #4559] RESOLUTION-exempt rows ride the SAME trail under the same key: they are
+    # watch-only for exactly the same reason (a measurement the gate must not call a regression
+    # alone) and need exactly the same durable record. bench-triage.py consumes `floor_exempt_hard`
+    # positionally and only reads {name,current,previous,ratio_pct,unit,note}, so widening the
+    # producer needs no change there — the `note` carries which exemption applied.
+    def _trail_row(r: tuple, note: str) -> dict:
+        return {"name": r[0], "current": r[1], "previous": r[2],
+                "ratio_pct": round(r[4] * 100.0, 1), "unit": units.get(r[0], ""), "note": note}
+
     floor_exempt_hard = [
-        {"name": r[0], "current": r[1], "previous": r[2],
-         "ratio_pct": round(r[4] * 100.0, 1), "unit": units.get(r[0], ""),
-         "note": f"floor-exempt hard-band (>= {HARD_RATIO:g}x median-of-history; "
-                 f"watch-only for the gate)"}
+        _trail_row(r, f"floor-exempt hard-band (>= {HARD_RATIO:g}x median-of-history; "
+                      f"watch-only for the gate)")
         for r in floor_exempt_rows if r[4] >= HARD_RATIO
+    ] + [
+        _trail_row(r, f"resolution-exempt hard-band (>= {HARD_RATIO:g}x median-of-history on the "
+                      f"point estimate, but the metric's measurement quantum of "
+                      f"{quanta.get(r[0], 0.0):g} {units.get(r[0], '')} cannot prove it; "
+                      f"watch-only for the gate)")
+        for r in resolution_exempt_rows
     ]
 
     # Uniform-shift exemption — ALL four conditions must hold (see header), computed over the
@@ -410,30 +611,45 @@ def evaluate(current: list[dict], hist: dict[str, list]) -> tuple[int, dict]:
     report = {
         "compared": compared, "rows": rows, "watch": watch, "hard": hard,
         "floor_exempt": floor_exempt_rows, "floor_exempt_hard": floor_exempt_hard,
+        "resolution_exempt": resolution_exempt_rows,
         "gated_compared": len(gated_rows), "gated_watch": len(gated_watch),
         "invalid": invalid, "ungated": ungated, "new": new, "stable_zero": stable_zero,
+        "improved_to_zero": improved_to_zero, "zero_crossing": zero_crossing,
         "disappeared": disappeared, "disappeared_frac": disappeared_frac,
         "uniform_shift": uniform, "exemption_reasons": exemption_reasons,
     }
     return (1 if fail else 0), report
 
 
+def _gating_label(floor: bool, res: bool) -> str:
+    """Which exemption (if any) makes a row watch-only, for the table's `gating` column."""
+    if floor and res:
+        return "under noise floor + at measurement resolution — watch only"
+    if floor:
+        return "under noise floor — watch only"
+    if res:
+        return "at measurement resolution — watch only"
+    return "hard-zone"
+
+
 def _table_lines(entries: list[tuple], markdown: bool) -> list[str]:
-    """Render [(name, cur, med, n, ratio, det, larger_better, floor_exempt)] rows as a table."""
+    """Render [(name, cur, med, n, ratio, det, larger_better, floor, resolution)] rows."""
     out = []
     if markdown:
         out.append("| metric | current | median (n) | ratio | direction | gating |")
         out.append("|---|---:|---:|---:|---|---|")
-        for name, cur, med, n, ratio, _det, lb, floor in sorted(entries, key=lambda t: -t[4]):
-            gating = "under noise floor — watch only" if floor else "hard-zone"
+        for name, cur, med, n, ratio, _det, lb, floor, res in sorted(entries, key=lambda t: -t[4]):
             out.append(f"| `{name}` | {cur:.6g} | {med:.6g} (n={n}) | {ratio:.2f}x |"
-                       f" {'larger-is-better' if lb else 'smaller-is-better'} | {gating} |")
+                       f" {'larger-is-better' if lb else 'smaller-is-better'} |"
+                       f" {_gating_label(floor, res)} |")
     else:
         out.append(f"  {'metric':<60} {'current':>14} {'median(n)':>18} {'ratio':>7}")
-        for name, cur, med, n, ratio, _det, lb, floor in sorted(entries, key=lambda t: -t[4]):
+        for name, cur, med, n, ratio, _det, lb, floor, res in sorted(entries, key=lambda t: -t[4]):
             suffix = "  [larger-is-better]" if lb else ""
             if floor:
                 suffix += "  [under noise floor — watch only]"
+            if res:
+                suffix += "  [at measurement resolution — watch only]"
             out.append(f"  {name:<60} {cur:>14.4g} {med:>13.4g}(n={n}) {ratio:>6.2f}x{suffix}")
     return out
 
@@ -456,6 +672,25 @@ def render_report(report: dict, markdown: bool) -> list[str]:
                      f"floor (allow-list: {_floor_desc()}): watch-only, never a hard fail alone "
                      f"(measured honest bands at that scale exceed {HARD_RATIO}x); "
                      f"{floor_watch} currently >= {WATCH_RATIO}x median (flagged in the table).")
+    if report.get("resolution_exempt"):
+        names = ", ".join(f"{r[0]} ({r[4]:.2f}x, median {r[2]:.6g})"
+                          for r in report["resolution_exempt"])
+        lines.append(f"{len(report['resolution_exempt'])} metric(s) at/above {HARD_RATIO}x on the "
+                     f"point estimate but NOT provably so at their measurement resolution "
+                     f"(quanta: {', '.join(f'{u} {q:g}' for u, q in sorted(RESOLUTION_QUANTA.items()))}"
+                     f"): watch-only, routed to the durable trail — {names}")
+    if report.get("improved_to_zero"):
+        names = ", ".join(f"{n} ({c:g} vs median {m:g} {u})"
+                          for n, c, m, u in report["improved_to_zero"])
+        lines.append(f"{len(report['improved_to_zero'])} metric(s) reached their OPTIMUM across a "
+                     f"zero boundary (compared at ratio 0.0 — an improvement by construction on "
+                     f"this direction, never a regression): {names}")
+    if report.get("zero_crossing"):
+        names = ", ".join(f"{n} ({c:g} vs median {m:g} {u}, resolution-bounded {r:.2f}x)"
+                          for n, c, m, r, u in report["zero_crossing"])
+        lines.append(f"{len(report['zero_crossing'])} PESSIMAL-side zero crossing(s) — ratio "
+                     f"unbounded in principle, bounded here by the unit's measurement "
+                     f"resolution: {names}")
     if report["invalid"]:
         lines.append("")
         lines.append("**Fail-closed numeric errors (each one fails the run):**" if markdown
@@ -511,7 +746,11 @@ def emit_report(report: dict) -> None:
     for line in render_report(report, markdown=False):
         print(line)
     notable = (report["watch"] or report["hard"] or report["invalid"]
-               or report["disappeared"] or report["uniform_shift"])
+               or report["disappeared"] or report["uniform_shift"]
+               # [#4559] a zero-boundary move never fails the run any more, so the SUMMARY is
+               # the only place it stays visible — it must make the run "notable".
+               or report.get("improved_to_zero") or report.get("zero_crossing")
+               or report.get("resolution_exempt"))
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if notable and summary_path:
         with open(summary_path, "a", encoding="utf-8") as f:
@@ -548,8 +787,18 @@ def emit_report(report: dict) -> None:
               f"here, in the watch table, in the Store step's comparison comment, AND it is "
               f"routed via the --report-out JSON into the soft-triage deduped bench-flake "
               f"issue — the durable trail that survives the median rebasing.")
+    res_hot = report.get("resolution_exempt") or []
+    if res_hot:
+        names = ", ".join(f"{r[0]} ({r[4]:.2f}x, median {r[2]:.6g})" for r in res_hot)
+        print(f"::warning title=bench hard zone — at measurement resolution, watch only::{names} "
+              f"at/above {HARD_RATIO}x median on the point estimate, but the metric cannot "
+              f"EXPRESS a ratio that fine: one quantization tick of its unit already spans the "
+              f"threshold, so the resolution-aware lower bound (see ratio_lower_bound) stays "
+              f"under {HARD_RATIO}x. It cannot fail the gate alone. It stays visible here, in "
+              f"the watch table, AND it is routed via the --report-out JSON into the soft-triage "
+              f"deduped bench-flake issue — the durable trail that survives the median rebasing.")
     if report["hard"] and not report["uniform_shift"]:
-        for name, cur, med, n, ratio, _det, lb, _floor in report["hard"]:
+        for name, cur, med, n, ratio, _det, lb, _floor, _res in report["hard"]:
             direction = "median/current (larger-is-better)" if lb else "current/median"
             print(f"::error title=bench hard zone::{name} is {ratio:.2f}x its "
                   f"median-of-{n} history ({direction}: {cur:.6g} vs median {med:.6g}) — "
@@ -749,16 +998,175 @@ def self_test() -> int:
     code, rep = evaluate(_cur([("a", 10.0)]), neg_hist)
     check(code == 1 and len(rep["invalid"]) == 1,
           "negative history value inside the window fails closed despite a positive median")
-    code, rep = evaluate(_cur([("a", 0.0)]), history_values(series))
-    check(code == 1 and len(rep["invalid"]) == 1,
-          "current 0 vs positive median is a zero-boundary change — fails closed")
     zero_series = history_values(_series([[("z", 0.0)]] * 5))
     code, rep = evaluate(_cur([("z", 5.0)]), zero_series)
     check(code == 1 and len(rep["invalid"]) == 1,
-          "positive current vs zero median is a zero-boundary change — fails closed")
+          "positive current vs zero median on a unit with NO derivable resolution is a "
+          "zero-boundary change — fails closed")
     code, rep = evaluate(_cur([("z", 0.0)]), zero_series)
     check(code == 0 and rep["stable_zero"] == ["z"] and rep["compared"] == 1,
           "stable zero (current 0, median 0) is legitimate — compared at ratio 1.0")
+
+    # 5b. ZERO BOUNDARY BY DIRECTION (sq-jxeqz / #4559). The previous revision routed EVERY
+    #     zero boundary to `invalid` (an unconditional exit 1 the uniform-shift exemption never
+    #     covers) and `continue`d BEFORE the noise floor was computed. That red main for
+    #     achieving a PERFECT vectors_hnsw_recall_at10 — a recall DEFICIT (bench/vector/README.md:
+    #     `recall_deficit_milli = round((1 - recall@10) * 1000)`), whose 0 is recall@10 = 1.000,
+    #     the best value the metric can take. Live: run 30279965305 @ cb0c6739c7, "current 0 vs
+    #     median 2 — ratio undefined; fail-closed".
+    #     Each check below names the mutation that must turn exactly IT red.
+    #     T1 — the headline: a smaller-is-better metric AT ITS OPTIMUM cannot fail.
+    #     MUTATION: restore `elif val == 0 or med == 0: invalid.append(...); continue` => red.
+    code, rep = evaluate(_cur([("a", 0.0), ("b", 100.0), ("c", 100.0), ("d", 100.0)]),
+                         history_values(series))
+    check(code == 0 and not rep["invalid"] and not rep["hard"]
+          and [r for r in rep["rows"] if r[0] == "a"][0][4] == 0.0
+          and [n for n, _c, _m, _u in rep["improved_to_zero"]] == ["a"],
+          "smaller-is-better metric AT ITS OPTIMUM (current 0 vs positive median) is compared "
+          "at ratio 0.0 and passes — an improvement can never be a regression")
+    #     T2 — the unit noise floor is REACHABLE AT ZERO. The `milli` floor was added FOR
+    #     vectors_hnsw_recall_at10, but the old `continue` fired before floor_exempt was ever
+    #     computed, so the metric the floor exists for could never reach it.
+    #     MUTATION: move the floor_exempt computation back below a zero-boundary `continue` => red.
+    hnsw = history_values([{"date": i, "benches": [
+        {"name": "vectors_hnsw_recall_at10", "value": 2.0, "unit": "milli"}]} for i in range(5)])
+    code, rep = evaluate([{"name": "vectors_hnsw_recall_at10", "value": 0.0, "unit": "milli"}],
+                         hnsw)
+    check(code == 0 and [r[0] for r in rep["floor_exempt"]] == ["vectors_hnsw_recall_at10"]
+          and rep["compared"] == 1 and not rep["invalid"],
+          "the unit noise floor is REACHABLE at zero — a floor-exempt metric at its optimum is "
+          "COMPARED and floor-flagged, not routed to invalid before the floor is computed")
+    #     T3 — QUANTIFIER DIRECTION: "a zero is an improvement" is true only on the OPTIMUM side.
+    #     A `*_per_s` THROUGHPUT COLLAPSING TO ZERO is the metric's PESSIMAL value and must still
+    #     hard-fail. MUTATION: treat any `val == 0` as the optimum (drop the `denom` direction
+    #     switch, i.e. `denom = med` unconditionally) => red.
+    thr0 = history_values(_series([[("rsp_x_triples_per_s", 1000.0)]] * 5))
+    code, rep = evaluate(_cur([("rsp_x_triples_per_s", 0.0)], unit="triples_per_s"), thr0)
+    check(code == 1 and len(rep["invalid"]) == 1 and not rep["improved_to_zero"],
+          "a `_per_s` throughput COLLAPSING to zero is the PESSIMAL side — still fails closed "
+          "(a zero is only an improvement on the metric's optimum side)")
+    #     T4 — the mirror image: a throughput RECOVERING from a zero median IS an improvement.
+    thr_zero = history_values(_series([[("rsp_x_triples_per_s", 0.0)]] * 5))
+    code, rep = evaluate(_cur([("rsp_x_triples_per_s", 1000.0)], unit="triples_per_s"), thr_zero)
+    check(code == 0 and not rep["invalid"]
+          and [n for n, _c, _m, _u in rep["improved_to_zero"]] == ["rsp_x_triples_per_s"],
+          "a `_per_s` throughput recovering FROM a zero median is an improvement (ratio 0.0)")
+    #     T5 — a PESSIMAL-side zero crossing on a unit WITH a known quantum is bounded, not
+    #     undefined — and a big one still REDs. MUTATION: make the pessimal branch pass
+    #     unconditionally => red.
+    s_zero = history_values(_series([[("closure_s", 0.0)]] * 5))
+    code, rep = evaluate(_cur([("closure_s", 0.05)], unit="s"), s_zero)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["invalid"]
+          and len(rep["zero_crossing"]) == 1,
+          "a PESSIMAL-side zero crossing far above the unit's resolution still HARD-FAILS "
+          "(bounded by the quantum, not silently undefined)")
+    #     ...while a crossing of ONE tick off a zero median cannot be distinguished from noise.
+    code, rep = evaluate(_cur([("closure_s", 0.001)], unit="s"), s_zero)
+    check(code == 0 and not rep["hard"] and len(rep["zero_crossing"]) == 1
+          and abs(rep["zero_crossing"][0][3] - 1.0) < 1e-9,
+          "a ONE-TICK pessimal zero crossing is resolution-bounded to 1.00x — listed, not fatal")
+
+    # 5c. MEASUREMENT RESOLUTION (sq-jxeqz / #4559). sameas_size32_closure_s is scraped from a
+    #     `{:.3}s` print, so one tick is 1 ms; it publishes 0.001 on every retained point and one
+    #     tick up is EXACTLY the inclusive >= 2.0x threshold. Live: run 30279965305 failed on
+    #     "0.002 vs median 0.001 — 2.00x".
+    #     T6 — one tick no longer fails. MUTATION: delete RESOLUTION_QUANTA["s"] (or the
+    #     `resolution_exempt` term in the `hard` filter) => red.
+    tick = history_values(_series([[("sameas_size32_closure_s", 0.001)]] * 5))
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.002)], unit="s"), tick)
+    check(code == 0 and not rep["hard"] and len(rep["resolution_exempt"]) == 1
+          and abs(rep["resolution_exempt"][0][4] - 2.0) < 1e-9,
+          "a 1 ms-quantized seconds metric moving ONE tick (0.001 -> 0.002 = exactly 2.00x) is "
+          "watch-only — the metric cannot express a ratio that fine")
+    #     ...and it is routed to the DURABLE TRAIL under the key bench-triage.py consumes, so the
+    #     evidence survives the median rebasing that the now-green run performs.
+    check(len(rep["floor_exempt_hard"]) == 1
+          and rep["floor_exempt_hard"][0]["name"] == "sameas_size32_closure_s"
+          and rep["floor_exempt_hard"][0]["previous"] == 0.001
+          and "resolution-exempt hard-band" in rep["floor_exempt_hard"][0]["note"],
+          "the resolution-exempt hit rides the soft-triage durable trail, tagged with its reason")
+    #     T7 — CONTROL, the SAME metric: the real 5.00x incident (run 30235240748, 0.005 vs
+    #     0.001) STILL HARD-FAILS. This is the proof the metric was not silenced.
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.005)], unit="s"), tick)
+    check(code == 1 and len(rep["hard"]) == 1
+          and rep["hard"][0][0] == "sameas_size32_closure_s" and not rep["resolution_exempt"],
+          "the SAME metric at the real 5.00x incident value STILL hard-fails — the resolution "
+          "allowance is one tick wide, not a silenced metric")
+    #     T8 — the allowance is ABSOLUTE (1.5 quanta), NOT a widened ratio threshold. HONEST
+    #     DISCLOSURE: absolute does not mean zero. On a 0.4 s metric the 1.5 ms band is 0.19% of
+    #     the 2.0x point, so a metric sitting at EXACTLY 2.0000x is inside it (the cost of only
+    #     failing when the resolution PROVES the threshold) — but 0.19% past it REDs, where the
+    #     1 ms closure needs 3.5x. Pinned from both sides so the band cannot silently widen.
+    #     MUTATION: turn the exemption into a per-unit RATIO exemption => the second check reds.
+    load = history_values(_series([[("load_s", 0.4)]] * 5))
+    code, rep = evaluate(_cur([("load_s", 0.8)], unit="s"), load)
+    check(code == 0 and len(rep["resolution_exempt"]) == 1,
+          "an `s` metric at 0.4 s is inside the absolute 1.5 ms band at EXACTLY 2.0000x "
+          "(disclosed cost: 0.19% of the threshold)")
+    code, rep = evaluate(_cur([("load_s", 0.8016)], unit="s"), load)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["resolution_exempt"],
+          "the same 0.4 s metric HARD-FAILS 0.2% past 2.0x — the allowance is 1.5 ms absolute, "
+          "not a ratio widening (the 1 ms closure needs 3.5x for the same allowance)")
+    #     T8b — THE UNIT IS ONLY A CEILING. snikmeta_decode_s is an `s` metric whose real
+    #     emitter prints 6 decimals and whose MEDIAN is below one 1 ms tick; a blanket per-unit
+    #     1 ms allowance would exceed its median several times over and silence its gate
+    #     completely. Per-metric inference must cut the quantum to what its values demonstrate.
+    #     MUTATION: drop observed_quantum() from resolution_quantum() (use the unit ceiling
+    #     directly) => this reds.
+    snik = history_values(_series([[("snikmeta_decode_s", 0.000462)]] * 5))
+    code, rep = evaluate(_cur([("snikmeta_decode_s", 0.001386)], unit="s"), snik)  # 3.00x
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["resolution_exempt"],
+          "a sub-millisecond `s` metric TRIPLING still HARD-FAILS — with the unit ceiling used "
+          "directly its 1 ms allowance would exceed its own median and exempt even this")
+    check(observed_quantum([0.000462, 0.000924], 0.001) == 1e-6
+          and observed_quantum([0.001, 0.002], 0.001) == 0.001
+          and observed_quantum([0.388, 0.3, 0.547], 0.001) == 0.001
+          and observed_quantum([2.0, 1.0], 1.0) == 1.0
+          and observed_quantum([0.0, 0.0], 0.001) == 0.001,
+          "observed_quantum: coarsest decimal step every non-zero value is a multiple of, "
+          "capped by the unit ceiling; zeros constrain nothing; result is a canonical power of 10")
+    check(all(abs(q - 10.0 ** round(math.log10(q))) < 1e-18 for q in RESOLUTION_QUANTA.values()),
+          "every RESOLUTION_QUANTA ceiling is an exact power of ten (observed_quantum walks "
+          "decimal EXPONENTS and relies on it)")
+    #     T9 — the allowance boundary pinned from BOTH sides, in values the `{:.3}s` emitter can
+    #     actually PRINT (a 1 ms-quantized metric can never report 0.0035). Against a 0.001
+    #     median the exempt band is exactly {0.002, 0.003} and 0.004 REDs.
+    #     MUTATION: widening the half-tick to a full tick moves the boundary => the second reds.
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.003)], unit="s"), tick)
+    check(code == 0 and len(rep["resolution_exempt"]) == 1,
+          "TWO ticks (0.003 vs 0.001, 3.00x) is still inside the resolution allowance")
+    code, rep = evaluate(_cur([("sameas_size32_closure_s", 0.004)], unit="s"), tick)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["resolution_exempt"],
+          "THREE ticks (0.004 vs 0.001) HARD-FAILS — the allowance ends inside the values this "
+          "metric can actually print, so it is a real gate, not a silenced one")
+    #     T10 — `milli` metrics ABOVE the noise floor keep a gate that is only ~1.5 milli wide.
+    #     The vectors_diskann/pq recall deficits (~34 / ~22) sit above the milli floor and stay
+    #     hard-gated; the resolution allowance costs them 1.5 milli, disclosed and pinned here.
+    #     (They are ALSO exact-gated by bench/vector/run.sh against expected.tsv and ratcheted by
+    #     scripts/perf-gate.py, so this lane is not their only line of defence.)
+    dk = history_values([{"date": i, "benches": [
+        {"name": "vectors_diskann_recall_at10", "value": 34.0, "unit": "milli"}]}
+        for i in range(5)])
+    code, rep = evaluate([{"name": "vectors_diskann_recall_at10", "value": 70.0,
+                           "unit": "milli"}], dk)
+    check(code == 1 and len(rep["hard"]) == 1 and not rep["floor_exempt"],
+          "an above-floor `milli` deficit doubling (34 -> 70) still HARD-FAILS — a real recall "
+          "regression on the gated recall family is detected")
+    #     T11 — deterministic metrics get NO resolution allowance, even if their unit ever gains
+    #     a quantum. MUTATION: drop the `det` guard in resolution_quantum() => red.
+    check(resolution_quantum("s", False, [0.001, 0.002]) == 0.001
+          and resolution_quantum("s", True, [0.001, 0.002]) == 0.0
+          and resolution_quantum("mystery_unit", False, [0.001, 0.002]) == 0.0
+          and resolution_quantum("count", False, [1000.0, 2000.0]) == 0.0,
+          "resolution_quantum: allow-listed unit only, and NEVER for a deterministic metric "
+          "(a 1000/2000 count series would otherwise infer a quantum of 1000 and silence itself)")
+    #     T12 — ratio_lower_bound math, both directions, including the zero-median case the
+    #     plain ratio cannot express. MUTATION: any sign/side error here reds.
+    check(abs(ratio_lower_bound(0.002, 0.001, False, 0.001) - 1.0) < 1e-12
+          and abs(ratio_lower_bound(0.005, 0.001, False, 0.001) - 3.0) < 1e-12
+          and abs(ratio_lower_bound(0.001, 0.0, False, 0.001) - 1.0) < 1e-12
+          and abs(ratio_lower_bound(500.0, 1000.0, True, 100.0) - 1.7272727272727273) < 1e-9,
+          "ratio_lower_bound: least-regressed reading in both directions, total at a zero median")
 
     # 6. Disappeared metrics: warn below the 30% threshold, hard-fail above it.
     code, rep = evaluate(_cur([("a", 10.0), ("b", 10.0), ("c", 10.0)]), history_values(series))

--- a/scripts/tests/test_bench_hardzone_wiring.py
+++ b/scripts/tests/test_bench_hardzone_wiring.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# [OPUS-5] issue #4559 (bead sq-jxeqz) — the NAMED wiring + invariant test for the bench
+# HARD-ZONE gate (scripts/bench_hardzone.py).
+#
+# WHY THIS EXISTS. Two independent failures met in #4559:
+#
+#   1. The gate FAILED main for achieving a PERFECT result. `vectors_hnsw_recall_at10` is a
+#      recall DEFICIT (bench/vector/README.md), so 0 is its optimum — and the gate routed that
+#      to a fail-closed `invalid`. 15 of the last 60 Benchmarks runs on main failed, 100% on
+#      that one step.
+#   2. NOTHING CAUGHT IT BEFORE MERGE. `bench_hardzone.py --self-test` ran ONLY inside
+#      bench.yml's "Hard zone" step, which is guarded to main pushes — so the gate's own logic
+#      was never exercised on a PR. A regression in the regression gate could only be
+#      discovered by reddening main after merge. The YAML seam is where vacuity lives: a check
+#      that does not execute in the gating matrix is not a check.
+#
+# Every assertion below is a MUTATION anchor:
+#
+#   TestSelfTestRunsOnPullRequests — delete the docs-quality step (or its `run:` call site)
+#                       => the hard-zone gate's 89 self-test checks stop gating a PR => RED.
+#   TestSelfAnchoring — delete THIS test's own step => RED (the wiring test must itself be
+#                       wired, or the regress just moves up one level).
+#   TestBenchLaneNotSilenced — add `|| true` / `continue-on-error` / `set +e`, or drop the
+#                       real gate invocation, in the bench.yml Hard zone step => RED.
+#   TestPublishOrderIsTheAntiLaunderingGuard — move the gate AFTER the Store step, or make
+#                       Store `if: always()` => RED. This is the guard that stops a REJECTED
+#                       regression being published into the very median that judges it.
+#   TestOptimumIsNeverARegression — a behaviour anchor executed against the real module, so
+#                       deleting the in-script self-test section does not leave zero coverage
+#                       of the defect this issue is about.
+#
+# Run:  python3 scripts/tests/test_bench_hardzone_wiring.py
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+GATE_PY = REPO_ROOT / "scripts" / "bench_hardzone.py"
+BENCH_YML = REPO_ROOT / ".github" / "workflows" / "bench.yml"
+DOCS_QUALITY_YML = REPO_ROOT / ".github" / "workflows" / "docs-quality.yml"
+
+SELF_TEST_CALL = re.compile(r"python3\s+scripts/bench_hardzone\.py\s+--self-test")
+WIRING_TEST_CALL = re.compile(r"python3\s+scripts/tests/test_bench_hardzone_wiring\.py")
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _steps(doc: dict, job: str) -> list[dict]:
+    return doc["jobs"][job].get("steps", [])
+
+
+def _runs(steps: list[dict]) -> str:
+    return "\n".join(s.get("run", "") for s in steps if isinstance(s.get("run"), str))
+
+
+def _load_gate_module():
+    spec = importlib.util.spec_from_file_location("bench_hardzone", GATE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestSelfTestRunsOnPullRequests(unittest.TestCase):
+    """The gate's own logic must be exercised in the PR-gating matrix, not only on main."""
+
+    def setUp(self):
+        self.doc = _load(DOCS_QUALITY_YML)
+        self.steps = _steps(self.doc, "quick-gates")
+
+    def test_self_test_call_site_present(self):
+        """MUTANT: delete the step or its `run:` line => the 89 checks stop gating a PR."""
+        self.assertRegex(
+            _runs(self.steps), SELF_TEST_CALL,
+            "docs-quality `quick-gates` must run `python3 scripts/bench_hardzone.py "
+            "--self-test`. Without it the hard-zone gate's logic is only ever executed by "
+            "bench.yml's main-push-guarded step, so a regression in the regression gate can "
+            "only be found by reddening main after merge (issue #4559).",
+        )
+
+    def test_step_is_not_conditioned_away(self):
+        """MUTANT: add an `if:` to the step so it silently never runs => RED."""
+        for step in self.steps:
+            if isinstance(step.get("run"), str) and SELF_TEST_CALL.search(step["run"]):
+                self.assertNotIn(
+                    "if", step,
+                    "the hard-zone self-test step must run unconditionally in quick-gates — "
+                    "a step-level `if:` is how a gate becomes a no-op without going red",
+                )
+
+    def test_job_is_not_conditioned_away(self):
+        """MUTANT: add a job-level `if:` that skips quick-gates => RED."""
+        self.assertNotIn(
+            "if", self.doc["jobs"]["quick-gates"],
+            "quick-gates must not carry a job-level `if:` — a skipped job reports neutral, "
+            "and every self-test it hosts stops gating at once",
+        )
+
+    def test_runs_in_the_required_matrix(self):
+        """MUTANT: drop pull_request / merge_group => the gate stops guarding merges."""
+        triggers = self.doc.get("on", self.doc.get(True))
+        self.assertIsNotNone(triggers, "docs-quality must declare triggers")
+        for needed in ("pull_request", "merge_group"):
+            self.assertIn(
+                needed, triggers,
+                f"docs-quality must trigger on {needed} — `ci-summary / gate` polls the "
+                "check-runs that exist on the ref, so a lane absent there is not a gate",
+            )
+
+
+class TestSelfAnchoring(unittest.TestCase):
+    """A wiring test that is not itself wired just moves the vacuity up one level."""
+
+    def test_this_test_runs_in_quick_gates(self):
+        """MUTANT: delete THIS test's own step from docs-quality => RED."""
+        self.assertRegex(
+            _runs(_steps(_load(DOCS_QUALITY_YML), "quick-gates")), WIRING_TEST_CALL,
+            "docs-quality `quick-gates` must also run this wiring test itself, otherwise the "
+            "wiring assertions never execute and the seam is unguarded again",
+        )
+
+
+class TestBenchLaneNotSilenced(unittest.TestCase):
+    """The main-push hard gate must stay a HARD gate."""
+
+    def setUp(self):
+        self.doc = _load(BENCH_YML)
+        self.steps = _steps(self.doc, "bench")
+        self.gate = next(s for s in self.steps
+                         if "Hard zone" in (s.get("name") or ""))
+
+    def test_gate_step_still_invokes_the_real_gate(self):
+        """MUTANT: drop the real invocation and leave only --self-test => RED."""
+        run = self.gate.get("run", "")
+        self.assertRegex(run, SELF_TEST_CALL,
+                         "the bench lane must still self-test before trusting the gate")
+        self.assertRegex(
+            run, r"scripts/bench_hardzone\.py\s*\\?\s*\n?\s*--results",
+            "the bench lane must still run the gate over the real bench-results.json — a "
+            "self-test-only step verifies the logic and gates nothing",
+        )
+
+    def test_no_exit_zero_swallow(self):
+        """MUTANT: add `|| true` / `set +e` / `continue-on-error` => RED.
+
+        An exit-zero swallow discards an already-earned hard failure; this repo has had three
+        separate incidents of exactly that, and #4547 exists to catch the class repo-wide.
+        """
+        run = self.gate.get("run", "")
+        self.assertIn("set -euo pipefail", run,
+                      "the hard-zone step must keep `set -euo pipefail`")
+        for banned in ("|| true", "set +e", "|| :"):
+            self.assertNotIn(banned, run,
+                             f"the hard-zone step must never swallow a failure with {banned!r}")
+        self.assertNotIn(
+            "continue-on-error", self.gate,
+            "the hard-zone step must never be continue-on-error — a benchmark gate that "
+            "cannot fail is worse than one that fails spuriously",
+        )
+
+
+class TestPublishOrderIsTheAntiLaunderingGuard(unittest.TestCase):
+    """The gate runs BEFORE Store, and Store must stay skippable by a gate failure.
+
+    This encodes the deliberate decision NOT to publish a failing run's measurements
+    (#4559). Store auto-pushes this run's point into the benchmark-data history; if a
+    failing run published, a REJECTED regression would enter the very history the gate
+    computes its median from, and after a few red runs the regression would BECOME the
+    baseline — silently raising the floor for everyone. The self-perpetuating red that
+    motivated #4559 is instead broken at the source: the provably-non-regressing cases now
+    PASS, so they publish through the ordinary path and the median rebases normally.
+    """
+
+    def setUp(self):
+        self.steps = _steps(_load(BENCH_YML), "bench")
+        self.names = [s.get("name") or "" for s in self.steps]
+
+    def _index(self, needle: str) -> int:
+        for i, n in enumerate(self.names):
+            if needle in n:
+                return i
+        self.fail(f"no step named like {needle!r} in the bench job")
+
+    def test_gate_precedes_store(self):
+        """MUTANT: move the Store step above the Hard zone step => RED."""
+        self.assertLess(
+            self._index("Hard zone"), self._index("Store + compare against history"),
+            "the hard-zone gate MUST run before the Store step: Store auto-pushes this run's "
+            "point into benchmark-data, so gating afterwards would publish a rejected "
+            "regression and let it rebase the median that judges it",
+        )
+
+    def test_store_does_not_run_when_the_gate_failed(self):
+        """MUTANT: add `if: always()` to Store => RED (it would publish a rejected run)."""
+        store = self.steps[self._index("Store + compare against history")]
+        cond = str(store.get("if", ""))
+        self.assertNotIn(
+            "always()", cond,
+            "the Store step must NOT be `if: always()` — that would publish the measurements "
+            "of a run the hard zone just rejected, rebasing the median toward the regression",
+        )
+
+    def test_the_ordering_rationale_is_documented_at_the_seam(self):
+        """MUTANT: delete the ORDERING comment => the next editor reorders it innocently."""
+        text = BENCH_YML.read_text(encoding="utf-8")
+        self.assertIn(
+            "ORDERING", text,
+            "the deliberate gate-before-Store ordering must stay documented in bench.yml",
+        )
+
+
+class TestOptimumIsNeverARegression(unittest.TestCase):
+    """Behaviour anchor for the #4559 defect, independent of the in-script self-test."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.hz = _load_gate_module()
+
+    def _hist(self, name, unit, values):
+        return self.hz.history_values([
+            {"date": i, "benches": [{"name": name, "value": v, "unit": unit}]}
+            for i, v in enumerate(values)
+        ])
+
+    def test_recall_deficit_at_zero_passes(self):
+        """MUTANT: route the optimum-side zero boundary back to `invalid` => RED.
+
+        The live failure: run 30279965305 @ cb0c6739c7 reported
+        `vectors_hnsw_recall_at10: zero-boundary change (current 0 vs median 2)`.
+        A deficit of 0 is recall@10 = 1.000 — the best value the metric can take.
+        """
+        hist = self._hist("vectors_hnsw_recall_at10", "milli", [1, 1, 2, 2, 2])
+        code, rep = self.hz.evaluate(
+            [{"name": "vectors_hnsw_recall_at10", "value": 0, "unit": "milli"}], hist)
+        self.assertEqual(code, 0, f"a perfect recall deficit must not fail: {rep['invalid']}")
+        self.assertEqual(rep["invalid"], [])
+        self.assertEqual([n for n, _c, _m, _u in rep["improved_to_zero"]],
+                         ["vectors_hnsw_recall_at10"])
+
+    def test_noise_floor_is_reachable_at_zero(self):
+        """MUTANT: compute floor_exempt after a zero-boundary `continue` => RED."""
+        hist = self._hist("vectors_hnsw_recall_at10", "milli", [1, 1, 2, 2, 2])
+        _code, rep = self.hz.evaluate(
+            [{"name": "vectors_hnsw_recall_at10", "value": 0, "unit": "milli"}], hist)
+        self.assertEqual([r[0] for r in rep["floor_exempt"]], ["vectors_hnsw_recall_at10"],
+                         "the `milli` noise floor was added for this metric and must be "
+                         "reachable at its optimum, not skipped by an early `continue`")
+
+    def test_one_quantization_tick_is_not_a_regression(self):
+        """MUTANT: delete RESOLUTION_QUANTA['s'] => RED.
+
+        `sameas_size32_closure_s` is scraped from a `{:.3}s` print, so one tick is 1 ms and
+        0.001 -> 0.002 is exactly the inclusive 2.0x threshold with zero margin.
+        """
+        hist = self._hist("sameas_size32_closure_s", "s", [0.001] * 5)
+        code, rep = self.hz.evaluate(
+            [{"name": "sameas_size32_closure_s", "value": 0.002, "unit": "s"}], hist)
+        self.assertEqual(code, 0)
+        self.assertEqual([r[0] for r in rep["resolution_exempt"]], ["sameas_size32_closure_s"])
+
+    def test_a_genuine_regression_still_reds(self):
+        """CONTROL. MUTANT: widen the allowance until this passes => RED.
+
+        The same metric at the value from the real 5.00x incident (run 30235240748) must
+        still hard-fail — the resolution allowance is one tick wide, not a silenced metric.
+        """
+        hist = self._hist("sameas_size32_closure_s", "s", [0.001] * 5)
+        code, rep = self.hz.evaluate(
+            [{"name": "sameas_size32_closure_s", "value": 0.005, "unit": "s"}], hist)
+        self.assertEqual(code, 1, "a 5x move on the same metric must still fail the gate")
+        self.assertEqual([r[0] for r in rep["hard"]], ["sameas_size32_closure_s"])
+
+    def test_throughput_collapse_to_zero_still_fails_closed(self):
+        """QUANTIFIER DIRECTION. MUTANT: treat every zero as an improvement => RED."""
+        hist = self._hist("rsp_x_triples_per_s", "triples_per_s", [1000.0] * 5)
+        code, rep = self.hz.evaluate(
+            [{"name": "rsp_x_triples_per_s", "value": 0, "unit": "triples_per_s"}], hist)
+        self.assertEqual(code, 1, "a throughput collapsing to zero is the PESSIMAL side")
+        self.assertEqual(len(rep["invalid"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes #4559 (bead `sq-jxeqz`). **AUTHOR ONLY — not reviewed, not armed.**

`main`'s Benchmarks lane fails on `#20 Hard zone` because the gate treats a metric reaching its
**optimum** as a fail-closed numeric error, and because it compares a **1 ms-quantized** metric at a
ratio finer than that metric can express.

## Files I own in this PR

| file | change |
|---|---|
| `scripts/bench_hardzone.py` | the two metric fixes + 89-check self-test (was 62) |
| `scripts/tests/test_bench_hardzone_wiring.py` | **new** — self-anchoring wiring + invariant test |
| `.github/workflows/docs-quality.yml` | two steps added to `quick-gates` |

I did **not** touch `.github/advisory-registry.json`, any `*-alarm.yml` (#4558),
`check-workflow-swallow.py` (#4547 — not present at this SHA), `check-model-attribution.py` (#4385),
`triage-area.py` (#4191), or `scripts/bench-triage.py`.

## Fix 1 — the zero boundary is three situations, not one

Semantics derived from `bench/vector/README.md`, not from the comparison code:
`recall_deficit_milli = round((1 - recall@10) * 1000)`, smaller-is-better, so **`0` is the optimum**
(recall@10 = 1.000). The old branch routed *every* zero crossing to `invalid` — an unconditional
`exit 1` the uniform-shift exemption never covers — and `continue`d before `floor_exempt` was
computed, so the `milli` floor added *for this very metric* was unreachable at zero.

The boundary is now resolved by **direction**. Only a zero **denominator** of the direction-adjusted
ratio is undefined, and only that case is on the metric's pessimal side:

| case | old | new |
|---|---|---|
| `0` vs `0` | stable zero, ratio 1.0 | unchanged |
| smaller-is-better at `0` vs positive median | `invalid` → **exit 1** | ratio **0.0**, listed in `improved_to_zero` |
| `*_per_s` recovering from a `0` median | `invalid` → exit 1 | ratio 0.0 (improvement) |
| smaller-is-better rising off a `0` median | `invalid` → exit 1 | bounded by resolution, else **still fail-closed** |
| `*_per_s` **collapsing to 0** | `invalid` → exit 1 | **still fail-closed** (no quantum ⇒ unbounded) |

## Fix 2 — gate on a resolution-aware ratio *lower bound*

`sameas_size32_closure_s` is scraped by `bench/owl-sameas/run.sh:80` from `crates/sparq-cli/src/main.rs`'s
`... in {:.3}s`. A value printed `0.001` is really in `[0.0005, 0.0015)` and `0.002` is in
`[0.0015, 0.0025)` — the "2.00x" is consistent with a **true ratio of 1.0**. So:

> the gate may hard-fail only when the ratio is **provably** ≥ `HARD_RATIO` at the measurement's own resolution.

Algebraically that is the plain test plus an **absolute** allowance of `(HARD_RATIO + 1)/2 = 1.5`
quanta — *not* a widened ratio threshold. It is ~150% of the threshold for a 1 ms closure and ~0.19%
for a 0.4 s load: it shrinks to nothing exactly where the ratio threshold is meaningful.

### Costed alternatives (issue suggestion 3)

| option | cost | verdict |
|---|---|---|
| widen `{:.3}s` print precision | changes a **user-facing CLI string** + every scraper; fixes one metric, leaves the class | rejected |
| raise the tier so closure ≫ 1 ms | more per-commit bench wall-clock; still arbitrary, and re-breaks at the next scale | rejected |
| exclude the metric from the gate | silences a lane; forbidden by the brief, and leaves the same trap for its 9 `s`-unit siblings | rejected |
| **absolute-resolution lower bound** | ~0.19% effective widening on well-resolved metrics, disclosed + pinned both sides | **chosen** — derived, not tuned, and fixes the whole class |

### Measurement refuted my first draft

I first used a flat per-unit quantum. Replaying the published history showed **`s` is not uniformly
1 ms-quantized**: only 4 of 10 retained `s` series print 3 decimals; `hdt_load_s` / `snikmeta_decode_s`
/ `text_build_s` / `vectors_build_s` carry 6-7. **`snikmeta_decode_s`'s median is below one claimed
tick** — a flat 1 ms allowance would have exceeded its own median and gutted its gate, exactly the
failure mode this PR exists to avoid. The quantum is now
`min(unit ceiling, granularity the metric's own values demonstrate)`. Both halves are separately
mutation-tested (`M6`, `M19`).

## The publish-order loop — I did **not** reorder, and here is why

The ordering (gate **before** Store) is load-bearing and correct: Store auto-pushes this run's point,
so gating afterwards would publish a **rejected** regression into the very median that judges it, and
after a few red runs the regression becomes the baseline. Publishing a failing run's measurements is
laundering, and no single run can prove its own failure spurious.

**The loop is broken by making the provably-non-regressing case PASS, not by making the failing case
publish.** Those runs then publish through the ordinary path and the median rebases normally — no
carve-out, no spuriousness oracle, no new trust.

Verified on the real data: run `30279965305` @ `cb0c6739c7` now exits **0**, so its point *publishes*
and both medians rebase. The remaining honest cost of the ordering — the published history is a
**censored, survivorship-biased sample**, so the floors derived from it are *lower bounds* — is now
stated at the top of the script, and every watch-only hit still rides the `--report-out` durable trail
into the deduped `bench-flake` issue.

The anti-laundering invariant is no longer a comment: `TestPublishOrderIsTheAntiLaunderingGuard` reds
if the gate moves after Store or if Store gains `if: always()`.

### Second-order loop, found by mutation and closed

Because a perfect `0` now publishes, the deficit's **median can become 0** — and the next honest `1`
is a pessimal crossing. Without the `milli` quantum that is fail-closed and main reds again, one
publication later. Pinned by `T13`.

## The seam that let this reach main

`bench_hardzone.py --self-test` ran **only** inside bench.yml's main-push-guarded step — the gate's own
logic never gated a PR, so a regression in the regression gate could only be found by reddening main
*after* merge. It now runs in `docs-quality / quick-gates`, with a **self-anchoring** wiring test that
also asserts its own step exists.

## Evidence — every number below is from a run in this PR's transcript

**Exact reproduction, then fix, on the real published history** (438 real metrics; current =
`cb0c6739c7`'s measurements, history = `prev-data.js` as that run fetched it):

before → `vectors_hnsw_recall_at10: zero-boundary change (current 0 vs median 2) — ratio undefined;
fail-closed` + `sameas_size32_closure_s ... 2.00x`, **EXIT 1** (byte-identical to the run log).
after → **EXIT 0**, 438 compared (was 437 — the metric now enters the comparison), floor-exempt
103 → **104** (the floor is reachable at zero), `sameas_size32_closure_s` flagged
`[at measurement resolution — watch only]` and routed to the trail.

**A genuine regression still reds — proved by construction.** Injecting a real regression into every
one of the 438 metrics, one at a time, against `origin/main` and this branch:

| factor | old detected/missed | new detected/missed | newly missed |
|---|---|---|---|
| 2.5x | 326 / 112 | 326 / 112 | **0** |
| 4x | 326 / 112 | 326 / 112 | **0** |
| 10x | 326 / 112 | 326 / 112 | **0** |

The missed sets are **byte-identical** (`cmp` clean) at all three factors — this PR removes **zero**
detection capability. All 112 are pre-existing watch-only families (103 sub-40µs `us`, 8 stable-zero
series, 1 sub-floor `milli`), not new blind spots.

End-to-end control, gate invoked exactly as bench.yml does, same input plus a genuine 3x on `load_s`:
`::error ... load_s is 3.77x its median-of-5 history ... Treating as a real regression.` **EXIT 1**.

## Guard → red-test table

Every row executed: the guard was mutated in the **live tree** (`cp` snapshot + marker-verified
restore, never `git checkout`), the suite re-run, and the kill classified.

| # | guard | mutation | kill |
|---|---|---|---|
| M1 | zero boundary by direction | restore `invalid` + `continue` | behaviour (7) |
| M2 | `floor_exempt` computed for every row | recompute only for non-zero rows | behaviour (1) |
| M3 | resolution exemption excluded from `hard` | drop the term | behaviour (3) |
| M4 | `RESOLUTION_QUANTA["s"]` | delete | behaviour (8) |
| M5 | `RESOLUTION_QUANTA["milli"]` | delete | behaviour (1) |
| M6 | per-metric inference | use the unit ceiling directly | behaviour (2) |
| M7 | deterministic gets no allowance | drop the `det` guard | behaviour (1) |
| M8 | direction switch on the denominator | `denom = med` always | **crash** (ZeroDivisionError) |
| M9 | half-tick uncertainty | half → full tick | behaviour (6) |
| M10 | lower bound clamped at 0 | drop `max(…, 0.0)` | behaviour (1) |
| M11 | larger-is-better inversion | swap the branch | behaviour (12) |
| M12 | `improved_to_zero` visibility | never record | behaviour (3) |
| M13 | `zero_crossing` visibility | never record | behaviour (3) |
| M14 | exemption only in the hard band | drop the `ratio >= HARD_RATIO` conjunct | behaviour (2) |
| M15 | strict at the threshold | `<` → `<=` | behaviour (1) |
| M16 | durable trail carries resolution rows | drop them | behaviour (1) |
| M17 | zero-boundary event is `notable` | drop the terms | behaviour (1) |
| M18 | table names which exemption applies | always "hard-zone" | behaviour (2) |
| M19 | current value constrains the quantum | infer from the window only | behaviour (1) |

**19/19 killed — 18 behaviour, 1 crash.** M8 is reported as a crash-kill honestly: it also breaks a
behaviour assertion (`T4`), but the ZeroDivisionError aborts the run first.

Seven of these **survived the first round** — `M5`, `M10`, `M14`, `M15`, `M17`, `M18`, `M19` — and the
tests that kill them were written afterwards. `M5` was the load-bearing one: it exposed the
second-order loop above.

### YAML seam — mutated separately, because that is where vacuity lives here

| # | YAML mutation | kill |
|---|---|---|
| Y1 | delete the `--self-test` step from docs-quality | behaviour |
| Y2 | `if: false` on that step | behaviour |
| Y3 | delete the wiring test's **own** step | behaviour |
| Y4 | job-level `if: false` on `quick-gates` | behaviour |
| Y5 | drop the `merge_group` trigger | behaviour |
| Y6 | `continue-on-error: true` on the bench Hard zone step | behaviour |
| Y7 | append `\|\| true` to the real gate invocation | behaviour |
| Y8 | weaken `set -euo pipefail` → `set -uo pipefail` | behaviour |
| Y9 | `if: always()` on the Store step (publish a rejected run) | behaviour |
| Y10 | insert a Store step **before** the gate | behaviour |
| Y11 | drop `--self-test` from the bench lane | behaviour |
| Y12 | drop the real gate invocation, keep only `--self-test` | behaviour |

**12/12 killed, all behaviour-kills.**

### The class mutation cannot reach

AST scan over `bench_hardzone.py` + `bench-triage.py` for duplicate/shadowed top-level `def`s,
re-assigned top-level constants, duplicate methods and duplicate nested `def`s: **none**. Also
asserted all 84 constant-labelled self-test descriptions are **unique** — two checks sharing a label
is the same silent-shadowing failure one level up.

## Hard constraints

- No `continue-on-error`, no `|| true`, no `set +e`, no threshold widened to make it pass — and `Y6`/`Y7`/`Y8` now **red** if anyone adds one.
- No markdown touched, so no hard-coded performance numbers were introduced.
- Local gates run green: `check-advisory-registry.py` (self-test + enforce), `check-fast-fix-ring-guard.py`, `coverage-gate.py --self-test`, `bench-triage.py --self-test`, `test_path_ownership.py`, `test_gates.py`, `test_ci_select_wiring.py`, `test_ci_summary_gate.py`.
- `scripts/bench-triage.py` is **unchanged**: resolution rows ride the existing `floor_exempt_hard` key, and I verified its live `load_hardzone_soft_rows` accepts the emitted row.

## Residual risks, stated plainly

1. A metric sitting at **exactly** `2.0000x` and well above its resolution is now inside the absolute band (0.19% of the threshold at 0.4 s). Disclosed, pinned both sides.
2. `vectors_diskann/pq_recall_at10` lose ~1.5 milli of gate width. They are independently exact-gated by `bench/vector/run.sh` against `expected.tsv` and ratcheted by `perf-gate.py`, so this lane is not their only defence. `T10` pins that a real doubling still reds.
3. Per-metric inference could overstate a quantum if **every** observation in a window were coincidentally round. Bounded by the unit ceiling, and it only ever applies to non-deterministic metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
