### PR TITLE
feat(ci): derive the feature-OFF wasm declaration from the compiler

### DIFF
--- a/.github/workflows/vectorized-feature-off.yml
+++ b/.github/workflows/vectorized-feature-off.yml
@@ -477,7 +477,12 @@ jobs:
         run: python3 scripts/tests/test_vectorized_feature_off.py
 
       - name: Tripwire self-test (the declaration derivation can refuse)
-        if: steps.changes.outputs.rust_changed == 'true'
+        # `always()` is load-bearing. Without it this step inherits the implicit
+        # `success()`, so it would run ONLY on PRs where leg 2 is already GREEN — i.e.
+        # never on the population the derivation exists to serve, which is exactly the
+        # PRs where leg 2 FAILED. The mutation matrix must run on the failing population
+        # or it is guarding an empty set.
+        if: always() && steps.changes.outputs.rust_changed == 'true'
         # Runs the derivation's own suite INCLUDING the mutation matrix, so a change that
         # stops the derivation refusing a semantic drift fails here rather than silently
         # auto-declaring one.

--- a/.github/workflows/vectorized-feature-off.yml
+++ b/.github/workflows/vectorized-feature-off.yml
@@ -465,6 +465,10 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # One warm directory shared by the derivation's extra builds, kept OFF the
+          # workspace `target/` that Swatinem caches — pointing it there would save the
+          # neutral tree's artefacts into the head build's cache entry.
+          CARGO_TARGET_DIR: ${{ runner.temp }}/featoff-derivation-target
         run: |
           set -uo pipefail
           python3 scripts/feature_off_autodeclare.py \

--- a/.github/workflows/vectorized-feature-off.yml
+++ b/.github/workflows/vectorized-feature-off.yml
@@ -465,10 +465,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          # One warm directory shared by the derivation's extra builds, kept OFF the
-          # workspace `target/` that Swatinem caches — pointing it there would save the
-          # neutral tree's artefacts into the head build's cache entry.
-          CARGO_TARGET_DIR: ${{ runner.temp }}/featoff-derivation-target
         run: |
           set -uo pipefail
           python3 scripts/feature_off_autodeclare.py \

--- a/.github/workflows/vectorized-feature-off.yml
+++ b/.github/workflows/vectorized-feature-off.yml
@@ -111,6 +111,8 @@ jobs:
               - '.github/workflows/vectorized-feature-off.yml'
               - 'scripts/check-vectorized-feature-off.py'
               - 'scripts/tests/test_vectorized_feature_off.py'
+              - 'scripts/feature_off_autodeclare.py'
+              - 'scripts/tests/test_feature_off_autodeclare.py'
               - 'bench/perf-baseline.json'
               - 'bench/feature-off-declaration.json'
               - 'bench/feature-off-declarations/**'
@@ -246,6 +248,8 @@ jobs:
               - '.github/workflows/vectorized-feature-off.yml'
               - 'scripts/check-vectorized-feature-off.py'
               - 'scripts/tests/test_vectorized_feature_off.py'
+              - 'scripts/feature_off_autodeclare.py'
+              - 'scripts/tests/test_feature_off_autodeclare.py'
               - 'bench/perf-baseline.json'
               - 'bench/feature-off-declaration.json'
               - 'bench/feature-off-declarations/**'
@@ -404,6 +408,7 @@ jobs:
           echo "Head-tree feature-OFF wasm: $(wc -c < head.wasm) bytes"
 
       - name: Leg 2 — dynamic byte-identity (base tree vs head tree)
+        id: leg2
         if: steps.changes.outputs.rust_changed == 'true'
         # If no base SHA could be resolved (e.g. a rootless first commit), there is nothing
         # to compare against — pass with a note. Otherwise run the dynamic comparison.
@@ -423,7 +428,57 @@ jobs:
             --declarations-dirs base-wasm/base-declarations bench/feature-off-declarations \
             2>&1 | tee -a "$GITHUB_STEP_SUMMARY"; exit "${PIPESTATUS[0]}"
 
+      # -----------------------------------------------------------------------
+      # [OPUS-5] sq-v3nel-v3: DERIVE the declaration when leg 2 reds.
+      #
+      # Leg 2 also fires on a diff that changes NO compiled code: `core::panic::Location`
+      # records embed the LINE NUMBER of every panicking call site, so inserting a comment
+      # block or an off-by-default `#[cfg(feature = ...)]` item MOVES BYTES in the bundle
+      # without adding or removing a single instruction. MEASURED on this repo: 34 pure
+      # comment lines inserted into crates/sparq-core/src/compress.rs => 3 differing bytes
+      # at a size delta of 0. Every such PR currently reds and waits for a hand-written
+      # declaration.
+      #
+      # This step decides that case from the COMPILER rather than from a tolerance: it
+      # rebuilds the head tree with every added line BLANKED (line count preserved, so line
+      # positions are unchanged) and requires the result to be BYTE-IDENTICAL to the head
+      # bundle; when the diff removes lines it runs the same proof on the base side. Only
+      # then does it print the declaration to commit. Anything it cannot prove — real code
+      # added or removed, a manifest change that alters the default build, an unclassifiable
+      # path — is REFUSED with a named reason.
+      #
+      # ADVISORY BY CONSTRUCTION, and deliberately so:
+      #   * It does NOT make the leg pass. Leg 2's own result above is untouched, so a bug
+      #     in the derivation cannot admit an undeclared bundle change — the failure mode of
+      #     an auto-passing gate is exactly the rubber stamp this whole leg exists to
+      #     prevent. The declaration still has to be COMMITTED, so it stays inside the
+      #     reviewed diff, as mechanism V2 requires.
+      #   * It needs no write-scoped token and no permission change: the job keeps
+      #     `contents: read`.
+      # `continue-on-error` keeps a refusal (its normal outcome, exit 2) from adding a
+      # second red to a job leg 2 has already failed; the step's own status stays visible.
+      - name: Derive the feature-OFF declaration (advisory — leg 2's result is unchanged)
+        if: always() && steps.changes.outputs.rust_changed == 'true'
+          && steps.leg2.outcome == 'failure' && github.event_name == 'pull_request'
+        continue-on-error: true
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          python3 scripts/feature_off_autodeclare.py \
+            --repo . --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" --pr "$PR_NUMBER" \
+            --base-wasm base-wasm/base.wasm --head-wasm head.wasm --report-only
+
       - name: Tripwire self-test (leg 2 comparator can fail)
         if: steps.changes.outputs.rust_changed == 'true'
         # The test file runs the leg2 tripwires; exit non-zero means a tripwire did not fire.
         run: python3 scripts/tests/test_vectorized_feature_off.py
+
+      - name: Tripwire self-test (the declaration derivation can refuse)
+        if: steps.changes.outputs.rust_changed == 'true'
+        # Runs the derivation's own suite INCLUDING the mutation matrix, so a change that
+        # stops the derivation refusing a semantic drift fails here rather than silently
+        # auto-declaring one.
+        run: python3 scripts/tests/test_feature_off_autodeclare.py --mutate

--- a/bench/feature-off-declarations/README.md
+++ b/bench/feature-off-declarations/README.md
@@ -106,7 +106,33 @@ Everything else **refuses**, with a named reason, and the leg stays red:
 | `added-lines-are-semantic`       | blanking the additions changed the bundle — real code was added |
 | `deleted-lines-are-semantic`     | blanking the deletions in the base changed it — real code was removed |
 | `neutral-build-failed`           | the additions were load-bearing (the tree stopped compiling)   |
-| `unsupported-file-change`        | something inside the build closure that the tool does not model |
+| `proof-would-be-vacuous`         | nothing was blanked and nothing was deleted, so the comparison would be `head == head` |
+| `unsupported-file-change`        | a symlink or gitlink, which blanking cannot speak for          |
+
+### Why every changed path is blanked, not just the ones in the build closure
+
+An earlier version scoped blanking to a closure derived from `cargo tree` ∩ `cargo metadata
+--no-deps`, and that shipped a **live false pass**. `--no-deps` returns **workspace members
+only**, while sparq's root manifest carries `exclude = ["vendor/spargebra", …]` *together
+with* `[patch.crates-io] spargebra = { path = "vendor/spargebra" }` — so spargebra is
+compiled into the feature-OFF bundle while not being a member. A change under `vendor/`
+classified inert, was never blanked, and `neutral == head` therefore held **by
+construction**: three genuinely non-benign changes there all came back `declared`.
+
+The emitted declaration even confessed it — *"rebuilding the head tree with all **0** added
+non-blank line(s) blanked produced a BYTE-IDENTICAL bundle"* — recording that nothing had
+been proved, and declaring anyway.
+
+Two fixes, and the second matters more than the first:
+
+1. **Nothing is skipped.** Every changed non-manifest path is blanked, wherever it lives.
+   Blanking a file the build never reads is free; blanking one it *does* read moves the
+   bundle and the derivation refuses. The closure is now **reporting only** — no soundness
+   claim rests on it — and its query no longer uses `--no-deps`.
+2. **A proof that proves nothing must refuse.** If the neutral tree comes out identical to
+   the head tree *and* the diff deletes no non-blank line, the comparison is `head == head`
+   and holds regardless. That guard catches the whole class without anyone needing to know
+   which path type was missed.
 
 An **intentional always-compiled change** — a hot-path optimisation, a refactor of code the
 default build ships — is refused on purpose. Its author is asserting *intent*, and intent cannot

--- a/bench/feature-off-declarations/README.md
+++ b/bench/feature-off-declarations/README.md
@@ -112,11 +112,17 @@ An **intentional always-compiled change** — a hot-path optimisation, a refacto
 default build ships — is refused on purpose. Its author is asserting *intent*, and intent cannot
 be derived; write the declaration by hand, as `3679.json` and `3755.json` do.
 
-Two deliberate limits:
+Three deliberate limits:
 
 * The tool **does not make the leg pass**. It writes a file that still has to be committed, so
   the escape hatch stays inside the reviewed diff. An auto-passing gate whose derivation had a
   hole would be exactly the rubber stamp this leg exists to prevent.
+* Every obligation builds into its **own** target directory. Sharing one warm directory
+  across the materialised trees was tried for speed and reverted: on #4350 it reported a
+  299-line `crates/sparq-engine/src/exec.rs` rewrite as *byte-identical* to its base, because
+  `git archive` stamps each tree's files with its commit time and cargo's freshness check is
+  mtime-based. A false "identical" is the one outcome that would auto-declare a real code
+  change, so cold builds are the price.
 * It attributes against the **merge base**, not `pull_request.base.sha`. Those differ whenever a
   branch is behind its base, and leg 2 itself compares `base.sha` — so on such a PR the leg's
   reported difference also carries, in reverse, base-branch commits the PR does not have. The

--- a/bench/feature-off-declarations/README.md
+++ b/bench/feature-off-declarations/README.md
@@ -52,3 +52,79 @@ This declaration governs **intent** (did you mean to change the feature-OFF byte
 The **size** of an accepted change is governed separately, unchanged, by the
 `metrics.wasm_bundle_bytes` floor ratchet (±2% band) in `bench/perf-baseline.json` /
 `bench.yml`. A change moving the bundle > ±2% must also raise that floor.
+
+## Why the gate fires on comment-only edits (measured)
+
+<!-- [OPUS-5] sq-v3nel-v3 (2026-07-28): the dominant benign class, and the tool that derives it. -->
+
+Leg 2 compares the bundles **byte-for-byte**, and a bundle byte can move without a single
+instruction changing. The workspace `release` profile sets `panic = "abort"` but not
+`panic_immediate_abort`, so every panicking call site still carries a `core::panic::Location`
+record — and that record embeds the call site's **line number**. Insert a comment block, or an
+off-by-default `#[cfg(feature = ...)]` item, anywhere **above** always-compiled code in the same
+file, and every line below it moves; the line numbers baked into those records move with it.
+
+This was measured directly on this repo (`cargo build --profile release-wasm -p sparq-wasm
+--target wasm32-unknown-unknown`, the leg's own build), each row a single change against the
+same tree:
+
+| change                                                              | bundle verdict | size delta | differing bytes |
+| ------------------------------------------------------------------- | -------------- | ---------- | --------------- |
+| rebuild, no source change                                            | identical      | 0          | 0               |
+| 34 pure comment lines inserted mid-file (`sparq-core/src/compress.rs`) | **differs**    | **0**      | **3**           |
+| off-by-default `#[cfg]` module added *below* all compiled code       | identical      | 0          | 0               |
+| comment block + off-by-default `#[cfg]` statement inserted mid-file  | **differs**    | **0**      | **2**           |
+| four **ungated** code lines added to `Graph::build`                  | **differs**    | **+228**   | **373027**      |
+
+The separation is not subtle: a change that adds no compiled code moves single-digit bytes and
+leaves the size **exactly** unchanged, while real code entering the default build moves
+hundreds of thousands of bytes and shifts the size.
+
+**This is not a reason to loosen the gate.** The last row is precisely what the leg exists to
+catch, and byte-for-byte is what catches it. It *is* a reason not to make a human hand-write a
+prose declaration for the rows above it.
+
+## Deriving a declaration instead of asserting one
+
+`scripts/feature_off_autodeclare.py` decides that case from the compiler:
+
+```
+python3 scripts/feature_off_autodeclare.py --repo . \
+    --base-sha <pr base sha> --head-sha <pr head sha> --pr <number> --write
+```
+
+It rebuilds the head tree with every **added** line replaced by an **empty** line — line count
+preserved, so every line position is unchanged — and requires the result to be **byte-identical**
+to the head bundle. If blanking the additions changes nothing the compiler emits, the additions
+emitted nothing. When the diff also removes lines it runs the same proof on the base side. Only
+then is a declaration written, carrying the measured byte counts.
+
+Everything else **refuses**, with a named reason, and the leg stays red:
+
+| refusal                          | meaning                                                       |
+| -------------------------------- | ------------------------------------------------------------- |
+| `added-lines-are-semantic`       | blanking the additions changed the bundle — real code was added |
+| `deleted-lines-are-semantic`     | blanking the deletions in the base changed it — real code was removed |
+| `neutral-build-failed`           | the additions were load-bearing (the tree stopped compiling)   |
+| `unsupported-file-change`        | something inside the build closure that the tool does not model |
+
+An **intentional always-compiled change** — a hot-path optimisation, a refactor of code the
+default build ships — is refused on purpose. Its author is asserting *intent*, and intent cannot
+be derived; write the declaration by hand, as `3679.json` and `3755.json` do.
+
+Two deliberate limits:
+
+* The tool **does not make the leg pass**. It writes a file that still has to be committed, so
+  the escape hatch stays inside the reviewed diff. An auto-passing gate whose derivation had a
+  hole would be exactly the rubber stamp this leg exists to prevent.
+* It attributes against the **merge base**, not `pull_request.base.sha`. Those differ whenever a
+  branch is behind its base, and leg 2 itself compares `base.sha` — so on such a PR the leg's
+  reported difference also carries, in reverse, base-branch commits the PR does not have. The
+  tool says so in its output rather than attributing them to the PR.
+
+A census of the live class (how many open PRs are red on this leg, how many already carry a
+declaration) is available without running any build:
+
+```
+python3 scripts/feature_off_autodeclare.py --census sparq-org/sparq
+```

--- a/scripts/feature_off_autodeclare.py
+++ b/scripts/feature_off_autodeclare.py
@@ -81,14 +81,12 @@ REFUSE_DELETION_BUILD_FAILED = "deletion-neutral-build-failed"
 REFUSE_ADDED_LINES_ARE_SEMANTIC = "added-lines-are-semantic"
 REFUSE_DELETED_LINES_ARE_SEMANTIC = "deleted-lines-are-semantic"
 REFUSE_UNSUPPORTED_FILE_CHANGE = "unsupported-file-change"
+REFUSE_VACUOUS_PROOF = "proof-would-be-vacuous"
 REFUSE_NO_DIFF = "no-diff-between-base-and-head"
 
 OUTCOME_NO_DRIFT = "no-drift"
 OUTCOME_DECLARED = "declared"
 
-# Source files whose content the wasm build can compile. Everything else (markdown,
-# workflows, research records, bench data) cannot change the bundle, so a change there
-# needs no attribution.
 _RUST_SUFFIX = ".rs"
 _MANIFESTS = ("Cargo.toml", "Cargo.lock")
 
@@ -101,85 +99,95 @@ def _is_rust(path: str) -> bool:
     return path.endswith(_RUST_SUFFIX)
 
 
-def _build_relevant(path: str) -> bool:
-    """Can a change to this path alter the compiled wasm bundle at all?
-
-    Conservative: `.rs` and cargo manifests only. Anything else is inert for the bundle
-    (markdown, YAML, JSON fixtures, the declarations directory itself). A file we do not
-    recognise as inert is NOT silently accepted — see `classify_paths`.
-    """
-    return _is_rust(path) or _is_manifest(path)
-
-
 # Root-level inputs that reach every build regardless of which crate they sit next to.
 _ROOT_BUILD_INPUTS = ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "rust-toolchain")
 
 
 def closure_dirs(tree: str, package: str = "sparq-wasm") -> list[str] | None:
-    """The workspace crate directories `package`'s DEFAULT wasm build actually compiles.
+    """The IN-REPO crate directories `package`'s DEFAULT wasm build actually compiles.
 
     DERIVED from cargo, never hardcoded: `cargo tree` for the wasm32 target with default
-    features lists the closure, and `cargo metadata` maps each member to its manifest
-    directory. A path outside those directories provably cannot be compiled into the
-    bundle, so a change there needs no attribution — which is what stops unrelated
-    base-branch drift (research records, other crates, bench data) from being mistaken for
-    part of this PR's diff.
+    features names the closure, and `cargo metadata` maps each package to its directory.
 
-    Returns None when cargo cannot answer, and the caller then treats EVERY changed path as
-    build-relevant (fail-closed).
+    REPORTING ONLY. This once decided which paths the proof covered, and that was the
+    source of a live false pass — see `classify_paths`. Soundness no longer depends on it:
+    every changed non-manifest path is blanked regardless of what this returns. It is kept
+    because naming which changed files the bundle actually compiles is useful evidence in
+    the declaration and in a refusal.
+
+    Returns None when cargo cannot answer, which now costs nothing but the evidence line.
     """
     try:
         tree_out = subprocess.run(
             ["cargo", "tree", "-p", package, "--target", "wasm32-unknown-unknown",
              "--edges", "normal", "--prefix", "none"],
             cwd=tree, capture_output=True, text=True, check=True).stdout
+        # WITH deps, deliberately. `--no-deps` returns WORKSPACE MEMBERS ONLY, which misses
+        # any crate pulled in by `[patch.crates-io]` from a path the workspace `exclude`s —
+        # `vendor/spargebra` on this repo, which really is compiled into the bundle.
         meta = json.loads(subprocess.run(
-            ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+            ["cargo", "metadata", "--format-version", "1"],
             cwd=tree, capture_output=True, text=True, check=True).stdout)
     except Exception:
         return None
+    return closure_dirs_from(tree_out, meta, tree)
+
+
+def closure_dirs_from(tree_out: str, meta: dict, tree: str) -> list[str]:
+    """Pure half of `closure_dirs`: intersect a `cargo tree` listing with package dirs."""
     in_closure = {line.split()[0] for line in tree_out.splitlines() if line.strip()}
+    real_tree = os.path.realpath(tree)
     dirs = []
     for pkg in meta.get("packages", []):
-        if pkg["name"] in in_closure:
-            d = os.path.relpath(os.path.dirname(pkg["manifest_path"]), tree)
-            if d not in (".", ""):
-                dirs.append(d.rstrip("/") + "/")
-    return sorted(dirs)
+        if pkg["name"] not in in_closure:
+            continue
+        pkg_dir = os.path.realpath(os.path.dirname(pkg["manifest_path"]))
+        # Registry crates live under ~/.cargo and cannot be touched by a PR diff; only
+        # in-repo sources are addressable, so only those become directories to report.
+        if pkg_dir == real_tree or not pkg_dir.startswith(real_tree + os.sep):
+            continue
+        dirs.append(os.path.relpath(pkg_dir, real_tree).rstrip("/") + "/")
+    return sorted(set(dirs))
 
 
 def classify_paths(paths: list[str],
                    closure: list[str] | None = None) -> tuple[list[str], list[str], list[str]]:
-    """Split changed paths into (blankable, manifest, inert).
+    """Split changed paths into (blankable, manifest, in_closure_report).
 
-    `closure` is the list of crate directories the bundle compiles (see `closure_dirs`).
-    A path outside it — and outside the root build inputs — is INERT BY DERIVATION: cargo
-    cannot compile it into `sparq-wasm`, so a change there needs no attribution. That is
-    what keeps unrelated base-branch drift from refusing an otherwise-provable PR.
+    EVERY changed path that is not a manifest is BLANKABLE. The classification is
+    deliberately NOT used to decide what the proof covers, because that is precisely how
+    this tool produced a live false pass:
 
-    Inside the closure, everything except a cargo manifest is BLANKABLE — not just `.rs`.
-    Deciding by file extension would be both too strict and unsound: too strict because a
-    crate `README.md` is usually inert, and unsound because it is NOT inert when the crate
-    does `#![doc = include_str!("../README.md")]`. Blanking the file and rebuilding answers
-    that question for the actual crate rather than guessing from the name — if the content
-    reached the bundle, the bundle changes and the derivation refuses.
+        sparq's root manifest carries `exclude = ["vendor/spargebra", ...]` together with
+        `[patch.crates-io] spargebra = { path = "vendor/spargebra" }`, so spargebra IS
+        compiled into the feature-OFF bundle while NOT being a workspace member. An earlier
+        version scoped blanking to a closure derived from `cargo metadata --no-deps` —
+        which returns workspace members only — so `vendor/spargebra/src/parser.rs`
+        classified INERT, was never blanked, and `neutral == head` held BY CONSTRUCTION.
+        Three genuinely non-benign changes there all came back `declared`.
+
+    A skipped path cannot be proved harmless, so nothing is skipped. Blanking a file the
+    build never reads is free — the bundle is unchanged either way — while blanking one it
+    DOES read changes the bundle and the derivation refuses. Letting the compiler answer
+    costs nothing and removes an entire class of classification bug.
 
     Manifests are handled separately (restored from the base tree) because blanking a line
     out of a `Cargo.toml` yields a manifest, not an absence.
+
+    `closure` is reported as evidence only; it no longer gates anything.
     """
     blankable: list[str] = []
     manifest: list[str] = []
-    inert: list[str] = []
+    in_closure: list[str] = []
     for p in paths:
         root_input = p in _ROOT_BUILD_INPUTS or p.startswith(".cargo/")
-        in_closure = closure is None or root_input or any(p.startswith(d) for d in closure)
-        if not in_closure:
-            inert.append(p)
-        elif _is_manifest(p) or root_input:
+        if _is_manifest(p) or root_input:
             manifest.append(p)
         else:
             blankable.append(p)
-    return blankable, manifest, inert
+        if closure is not None and (root_input or any(p.startswith(d) for d in closure)):
+            in_closure.append(p)
+    return blankable, manifest, in_closure
 
 
 # ---------------------------------------------------------------------------
@@ -357,7 +365,7 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
         return Verdict(REFUSE_NO_DIFF, "the base..head diff is empty — nothing to attribute")
 
     closure = closure_dirs(head_tree)
-    rust_paths, manifest_paths, inert_paths = classify_paths(sorted(changes), closure)
+    rust_paths, manifest_paths, closure_paths = classify_paths(sorted(changes), closure)
 
     # Blanking rewrites files in place, which is meaningless for a symlink or a submodule
     # gitlink — the proof would silently cover nothing. Refuse rather than pretend.
@@ -390,16 +398,35 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
         "differing_bytes": differing_bytes(base_bytes, head_bytes),
         "closure_files_changed": rust_paths,
         "manifest_files_changed": manifest_paths,
-        "inert_files_changed": len(inert_paths),
+        "files_in_compiled_closure": closure_paths,
+        "closure_dirs": closure,
     }
 
     # ---- Obligation 1: additions contribute no compiled code ----------------
     # Neutral tree = HEAD with every added .rs line blanked and every changed manifest
     # restored from BASE. It therefore holds BASE's compiled content at HEAD's line
     # positions. If its bundle equals HEAD's, the additions emitted nothing.
+    removed_nonblank = 0
+    to_blank: dict[str, list[int]] = {}
+    for path in rust_paths:
+        removed = changes[path]["removed"]
+        if not removed:
+            continue
+        src = os.path.join(base_tree, path)
+        if not os.path.exists(src):
+            continue
+        with open(src, encoding="utf-8", errors="surrogateescape") as fh:
+            text = fh.read()
+        n = nonblank_count(text, removed)
+        if n:
+            removed_nonblank += n
+            to_blank[path] = removed
+    evidence["deleted_nonblank_lines"] = removed_nonblank
+
     neutral = os.path.join(tempfile.mkdtemp(prefix="featoff-neutral-"), "tree")
     shutil.copytree(head_tree, neutral, symlinks=True)
     added_nonblank = 0
+    mutated: list[str] = []
     for path in rust_paths:
         added = changes[path]["added"]
         if not added:
@@ -410,16 +437,42 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
         with open(target, encoding="utf-8", errors="surrogateescape") as fh:
             text = fh.read()
         added_nonblank += nonblank_count(text, added)
+        blanked = blank_lines(text, added)
+        if blanked != text:
+            mutated.append(path)
         with open(target, "w", encoding="utf-8", errors="surrogateescape") as fh:
-            fh.write(blank_lines(text, added))
+            fh.write(blanked)
     for path in manifest_paths:
         src = os.path.join(base_tree, path)
         dst = os.path.join(neutral, path)
+        head_bytes_of = open(dst, "rb").read() if os.path.exists(dst) else None
         if os.path.exists(src):
             shutil.copyfile(src, dst)
+            if open(dst, "rb").read() != head_bytes_of:
+                mutated.append(path)
         elif os.path.exists(dst):
             os.remove(dst)
+            mutated.append(path)
     evidence["added_nonblank_lines_blanked"] = added_nonblank
+    evidence["neutral_tree_files_mutated"] = len(mutated)
+
+    # NON-VACUITY. Obligation 1 concludes "the additions emitted nothing" from
+    # `build(neutral) == build(head)`. If the neutral tree is IDENTICAL to the head tree,
+    # that comparison is `head == head` — it holds by construction and proves nothing, so a
+    # declaration derived from it would be exactly the rubber stamp this leg exists to
+    # prevent. This is the general form of the vendored-crate false pass: whenever the diff
+    # is real but nothing got blanked, the drift came from somewhere the proof does not
+    # reach. Refuse, and say where the diff actually was.
+    if not mutated and not to_blank:
+        return Verdict(
+            REFUSE_VACUOUS_PROOF,
+            "neither obligation has anything to prove: the neutral tree is identical to the "
+            "head tree (nothing was blanked) and the diff deletes no non-blank line, so "
+            "comparing the bundles would be `head == head` and would hold by construction. "
+            "The bundle moved anyway, so the drift originates outside what the proof "
+            "reaches — do not declare it. Changed paths: "
+            + ", ".join(sorted(changes)[:20]),
+            evidence)
 
     neutral_bytes = builder(neutral)
     if neutral_bytes is None:
@@ -441,23 +494,6 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
     # Deleted lines are absent from BOTH head and neutral, so obligation 1 cannot speak for
     # them. Run the same proof on the base side: blank exactly those lines in BASE and
     # require the bundle to be unchanged.
-    removed_nonblank = 0
-    to_blank: dict[str, list[int]] = {}
-    for path in rust_paths:
-        removed = changes[path]["removed"]
-        if not removed:
-            continue
-        src = os.path.join(base_tree, path)
-        if not os.path.exists(src):
-            continue
-        with open(src, encoding="utf-8", errors="surrogateescape") as fh:
-            text = fh.read()
-        n = nonblank_count(text, removed)
-        if n:
-            removed_nonblank += n
-            to_blank[path] = removed
-    evidence["deleted_nonblank_lines"] = removed_nonblank
-
     if to_blank:
         del_neutral = os.path.join(tempfile.mkdtemp(prefix="featoff-delneutral-"), "tree")
         shutil.copytree(base_tree, del_neutral, symlinks=True)

--- a/scripts/feature_off_autodeclare.py
+++ b/scripts/feature_off_autodeclare.py
@@ -150,34 +150,36 @@ def closure_dirs(tree: str, package: str = "sparq-wasm") -> list[str] | None:
 
 def classify_paths(paths: list[str],
                    closure: list[str] | None = None) -> tuple[list[str], list[str], list[str]]:
-    """Split changed paths into (rust, manifest, inert), or raise on one we cannot place.
+    """Split changed paths into (blankable, manifest, inert).
 
     `closure` is the list of crate directories the bundle compiles (see `closure_dirs`).
-    A path outside it — and outside the root build inputs — is INERT BY DERIVATION. Inside
-    it, only `.rs` and cargo manifests are understood; anything else refuses, because a
-    build input we do not model must never be silently assumed harmless.
+    A path outside it — and outside the root build inputs — is INERT BY DERIVATION: cargo
+    cannot compile it into `sparq-wasm`, so a change there needs no attribution. That is
+    what keeps unrelated base-branch drift from refusing an otherwise-provable PR.
+
+    Inside the closure, everything except a cargo manifest is BLANKABLE — not just `.rs`.
+    Deciding by file extension would be both too strict and unsound: too strict because a
+    crate `README.md` is usually inert, and unsound because it is NOT inert when the crate
+    does `#![doc = include_str!("../README.md")]`. Blanking the file and rebuilding answers
+    that question for the actual crate rather than guessing from the name — if the content
+    reached the bundle, the bundle changes and the derivation refuses.
+
+    Manifests are handled separately (restored from the base tree) because blanking a line
+    out of a `Cargo.toml` yields a manifest, not an absence.
     """
-    rust: list[str] = []
+    blankable: list[str] = []
     manifest: list[str] = []
     inert: list[str] = []
-    unknown: list[str] = []
     for p in paths:
         root_input = p in _ROOT_BUILD_INPUTS or p.startswith(".cargo/")
         in_closure = closure is None or root_input or any(p.startswith(d) for d in closure)
         if not in_closure:
             inert.append(p)
-        elif _is_rust(p):
-            rust.append(p)
         elif _is_manifest(p) or root_input:
             manifest.append(p)
         else:
-            unknown.append(p)
-    if unknown:
-        raise ValueError(
-            "changed inside the wasm build closure but not understood as a build input: "
-            + ", ".join(sorted(unknown))
-        )
-    return rust, manifest, inert
+            blankable.append(p)
+    return blankable, manifest, inert
 
 
 # ---------------------------------------------------------------------------
@@ -279,19 +281,34 @@ def cargo_wasm_builder(tree: str) -> bytes | None:
     """
     proc = subprocess.run(
         ["cargo", "build", "--profile", "release-wasm", "-p", "sparq-wasm",
-         "--target", "wasm32-unknown-unknown"],
+         "--target", "wasm32-unknown-unknown",
+         "--target-dir", os.path.join(tree, "target")],
         cwd=tree, capture_output=True,
+        env={**os.environ, "CARGO_TARGET_DIR": os.path.join(tree, "target")},
     )
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr.decode("utf-8", "replace")[-4000:])
         return None
-    # Each obligation builds a freshly-materialised tree, so without a shared target
-    # directory every one of them recompiles the whole dependency graph from cold. Honour
-    # CARGO_TARGET_DIR so a caller can point the extra builds at one warm directory. It must
-    # be a directory the leg's OWN cached `target/` does not share, or the neutral tree's
-    # artefacts would be saved into the head build's cache.
-    target_root = os.environ.get("CARGO_TARGET_DIR") or os.path.join(tree, "target")
-    out = os.path.join(target_root, "wasm32-unknown-unknown", "release-wasm", "sparq_wasm.wasm")
+    # PER-TREE target directory, deliberately. Pointing several materialised trees at ONE
+    # shared CARGO_TARGET_DIR to keep the extra builds warm was TRIED and REVERTED: it
+    # produced a demonstrably WRONG verdict. Run against #4350 — a PR whose merge-base diff
+    # is a 299-line rewrite of crates/sparq-engine/src/exec.rs — the shared-directory run
+    # reported the base and head bundles BYTE-IDENTICAL ("no-drift"), i.e. a stale artefact
+    # was read back as a fresh build. `git archive` stamps each exported tree's files with
+    # its COMMIT time, and cargo's freshness check is mtime-based, so an out-of-order
+    # timestamp can leave a previous tree's `sparq_wasm.wasm` in place.
+    #
+    # A false "identical" is the worst failure this tool has: it would auto-declare a real
+    # code change as line-position churn. Cold builds are the price of the proof meaning
+    # anything, so `--target-dir` stays inside the tree being built and the environment
+    # cannot override it.
+    env_override = os.environ.get("CARGO_TARGET_DIR")
+    if env_override:
+        sys.stderr.write(
+            f"[autodeclare] ignoring CARGO_TARGET_DIR={env_override!r}: each tree must build "
+            "into its own target directory (a shared one has been observed returning a stale "
+            "bundle, which reads as a false 'identical').\n")
+    out = os.path.join(tree, "target", "wasm32-unknown-unknown", "release-wasm", "sparq_wasm.wasm")
     if not os.path.exists(out):
         return None
     with open(out, "rb") as fh:
@@ -340,10 +357,17 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
         return Verdict(REFUSE_NO_DIFF, "the base..head diff is empty — nothing to attribute")
 
     closure = closure_dirs(head_tree)
-    try:
-        rust_paths, manifest_paths, inert_paths = classify_paths(sorted(changes), closure)
-    except ValueError as exc:
-        return Verdict(REFUSE_UNSUPPORTED_FILE_CHANGE, str(exc))
+    rust_paths, manifest_paths, inert_paths = classify_paths(sorted(changes), closure)
+
+    # Blanking rewrites files in place, which is meaningless for a symlink or a submodule
+    # gitlink — the proof would silently cover nothing. Refuse rather than pretend.
+    nonregular = [p for p in rust_paths
+                  if os.path.islink(os.path.join(head_tree, p))
+                  or os.path.islink(os.path.join(base_tree, p))]
+    if nonregular:
+        return Verdict(REFUSE_UNSUPPORTED_FILE_CHANGE,
+                       "changed inside the wasm build closure but not a regular file, so "
+                       "blanking cannot speak for it: " + ", ".join(sorted(nonregular)))
 
     if base_bytes is None:
         base_bytes = builder(base_tree)
@@ -364,7 +388,7 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
         "head_bundle_bytes": len(head_bytes),
         "size_delta_bytes": len(head_bytes) - len(base_bytes),
         "differing_bytes": differing_bytes(base_bytes, head_bytes),
-        "rust_files_changed": rust_paths,
+        "closure_files_changed": rust_paths,
         "manifest_files_changed": manifest_paths,
         "inert_files_changed": len(inert_paths),
     }

--- a/scripts/feature_off_autodeclare.py
+++ b/scripts/feature_off_autodeclare.py
@@ -82,6 +82,7 @@ REFUSE_ADDED_LINES_ARE_SEMANTIC = "added-lines-are-semantic"
 REFUSE_DELETED_LINES_ARE_SEMANTIC = "deleted-lines-are-semantic"
 REFUSE_UNSUPPORTED_FILE_CHANGE = "unsupported-file-change"
 REFUSE_VACUOUS_PROOF = "proof-would-be-vacuous"
+REFUSE_DIFF_TREE_MISMATCH = "diff-paths-absent-from-both-trees"
 REFUSE_NO_DIFF = "no-diff-between-base-and-head"
 
 OUTCOME_NO_DRIFT = "no-drift"
@@ -367,6 +368,22 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
     closure = closure_dirs(head_tree)
     rust_paths, manifest_paths, closure_paths = classify_paths(sorted(changes), closure)
 
+    # The diff and the trees must actually describe the same thing. A changed path that
+    # exists in NEITHER tree means they disagree — a mis-parsed diff, a bad path prefix, a
+    # stale export. Every such path would be silently skipped by the blanking loop, so the
+    # proof would quietly cover less than it claims. Caught for real: an ad-hoc harness
+    # rewrote `git diff --no-index` prefixes in the wrong order, yielding paths like
+    # `bvendor/spargebra/src/parser.rs`; nothing matched, nothing was blanked, and only the
+    # non-vacuity guard stood between that and a false declaration. Name it instead.
+    missing = [p for p in rust_paths
+               if not os.path.exists(os.path.join(head_tree, p))
+               and not os.path.exists(os.path.join(base_tree, p))]
+    if missing:
+        return Verdict(REFUSE_DIFF_TREE_MISMATCH,
+                       "the diff names paths that exist in neither the base nor the head "
+                       "tree, so the diff and the trees disagree and the proof would cover "
+                       "less than it claims: " + ", ".join(sorted(missing)[:10]))
+
     # Blanking rewrites files in place, which is meaningless for a symlink or a submodule
     # gitlink — the proof would silently cover nothing. Refuse rather than pretend.
     nonregular = [p for p in rust_paths
@@ -527,6 +544,35 @@ def decide(base_tree: str, head_tree: str, diff_text: str, builder,
     )
 
 
+def _obligation_sentence(ev: dict) -> str:
+    """Say which obligation actually carried the proof.
+
+    A count of zero is normal on one side — a pure-deletion diff blanks no added line, and
+    an addition-only diff deletes none — but phrasing it as "all 0 lines blanked produced an
+    identical bundle" reads as a confession that nothing was checked. It also read that way
+    when something really HAD been missed: the vendored-crate false pass emitted exactly
+    that sentence with both counts at zero. The non-vacuity guard now refuses that state
+    outright; this wording makes the remaining zeroes unambiguous.
+    """
+    added = ev.get("added_nonblank_lines_blanked", 0)
+    deleted = ev.get("deleted_nonblank_lines", 0)
+    parts = []
+    if added:
+        parts.append(f"rebuilding the head tree with all {added} added non-blank line(s) "
+                     "blanked produced a BYTE-IDENTICAL bundle")
+    if deleted:
+        parts.append(f"rebuilding the base tree with all {deleted} deleted non-blank line(s) "
+                     "blanked left the base bundle unchanged")
+    if not parts:  # unreachable: the non-vacuity guard refuses before this point
+        return ("NO obligation was discharged — this declaration must not have been derived."
+                " Treat it as a bug in the derivation, not as evidence.")
+    joined = ", and ".join(parts)
+    covered = ("Both directions were covered" if len(parts) == 2
+               else "The diff changes lines in one direction only, so that is the whole "
+                    "obligation")
+    return f"Specifically: {joined}. {covered}."
+
+
 def declaration_json(pr: int, verdict: Verdict, date: str | None = None) -> dict:
     """The per-PR declaration file content, carrying the MEASURED evidence."""
     ev = verdict.evidence
@@ -538,11 +584,7 @@ def declaration_json(pr: int, verdict: Verdict, date: str | None = None) -> dict
             f"feature-OFF bundle moved {ev.get('differing_bytes')} of "
             f"{ev.get('head_bundle_bytes')} bytes at a size delta of "
             f"{ev.get('size_delta_bytes'):+d}, and the drift was proved to carry no compiled "
-            "code: rebuilding the head tree with all "
-            f"{ev.get('added_nonblank_lines_blanked')} added non-blank line(s) blanked "
-            "produced a BYTE-IDENTICAL bundle, and rebuilding the base tree with all "
-            f"{ev.get('deleted_nonblank_lines')} deleted non-blank line(s) blanked likewise "
-            "left the base bundle unchanged. What moved is line-position metadata "
+            f"code. {_obligation_sentence(ev)} What moved is line-position metadata "
             "(core::panic::Location line numbers shift when lines above them move); no "
             "always-compiled code entered or left the default build. Bundle SIZE remains "
             "governed separately by the wasm_bundle_bytes ratchet."

--- a/scripts/feature_off_autodeclare.py
+++ b/scripts/feature_off_autodeclare.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""
+[OPUS-5] sq-v3nel-v3: DERIVE a feature-OFF wasm-bundle declaration instead of asserting one.
+
+The `artifact-exact-equality (wasm bundle feature-OFF)` leg
+(`.github/workflows/vectorized-feature-off.yml`, leg 2) compares the feature-OFF
+`sparq-wasm` bundle built from the BASE tree against the one built from the HEAD tree,
+BYTE-FOR-BYTE, and fails an undeclared difference. That is the right guard — it is what
+catches `vectorized`/default-path code leaking into the default build.
+
+It also fires on a class of change that carries NO semantic content at all. MEASURED on
+this repo (see `bench/feature-off-declarations/README.md` § "Why the gate fires on
+comment-only edits"): inserting 34 pure comment lines into `crates/sparq-core/src/compress.rs`
+and rebuilding produces a bundle that DIFFERS from base in exactly 3 bytes at exactly the
+same length, because `core::panic::Location` records embed the LINE NUMBER of every
+panicking call site and those numbers move when lines above them move. Adding an
+off-by-default `#[cfg(feature = ...)]` item mid-file does the same thing: the item itself
+compiles out, but every line below it shifts. A worker therefore has to hand-write a
+declaration for a diff that changed no compiled code whatsoever.
+
+This tool decides that case MECHANICALLY, and — this is the whole point — it decides it by
+RE-DERIVING the drift from the compiler, never by asserting a tolerance:
+
+    1. Build the BASE tree's feature-OFF bundle and the HEAD tree's. If they are identical
+       there is nothing to declare (the leg already passes).
+
+    2. Construct a NEUTRAL tree: the HEAD tree with every line the diff ADDED replaced by an
+       EMPTY line, and with every changed manifest (`Cargo.toml` / `Cargo.lock`) taken from
+       the BASE tree. By construction the neutral tree holds the BASE tree's compiled
+       content at the HEAD tree's LINE POSITIONS.
+
+    3. Build it. If `neutral == head` byte-for-byte, then blanking every added line changed
+       nothing the compiler emits — i.e. the added lines contributed no compiled code, and
+       the whole base->head drift is line-position metadata. That is a POSITIVE PROOF from
+       the compiler, not an inference from the diff's shape.
+
+    4. Deleted lines are absent from both the head and the neutral tree, so step 3 cannot
+       speak for them. When the diff removes any non-blank line from a `.rs` file, build a
+       second neutral tree — the BASE tree with exactly those lines blanked — and require it
+       to equal the BASE bundle. Same proof, run backwards.
+
+Only when every obligation holds is a declaration written, and its `reason` records the
+MEASURED evidence (byte counts, differing-byte count, which obligations were discharged).
+Anything else REFUSES with a named reason and leaves the leg RED — an unexplained diff must
+never be auto-declared, because that would convert the guard into a rubber stamp.
+
+Deliberately NOT done here: this tool does not make the gate pass by itself and it is not
+wired to any write-scoped token. It writes a file into the working tree; a human or the
+authoring agent commits it, so the escape hatch stays inside the reviewed diff exactly as
+mechanism V2 intends.
+
+Usage (report only — what CI runs):
+    python3 scripts/feature_off_autodeclare.py --repo . --base-sha <sha> --head-sha <sha> \
+        --pr 1234 --report-only
+
+Usage (write the declaration into the working tree):
+    python3 scripts/feature_off_autodeclare.py --repo . --base-sha <sha> --head-sha <sha> \
+        --pr 1234 --write
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# ---------------------------------------------------------------------------
+# Refusal reasons. Every one of these is a NAMED outcome so a census row can say
+# *why* a PR was refused, and so each has its own test.
+# ---------------------------------------------------------------------------
+REFUSE_BASE_BUILD_FAILED = "base-build-failed"
+REFUSE_HEAD_BUILD_FAILED = "head-build-failed"
+REFUSE_NEUTRAL_BUILD_FAILED = "neutral-build-failed"
+REFUSE_DELETION_BUILD_FAILED = "deletion-neutral-build-failed"
+REFUSE_ADDED_LINES_ARE_SEMANTIC = "added-lines-are-semantic"
+REFUSE_DELETED_LINES_ARE_SEMANTIC = "deleted-lines-are-semantic"
+REFUSE_UNSUPPORTED_FILE_CHANGE = "unsupported-file-change"
+REFUSE_NO_DIFF = "no-diff-between-base-and-head"
+
+OUTCOME_NO_DRIFT = "no-drift"
+OUTCOME_DECLARED = "declared"
+
+# Source files whose content the wasm build can compile. Everything else (markdown,
+# workflows, research records, bench data) cannot change the bundle, so a change there
+# needs no attribution.
+_RUST_SUFFIX = ".rs"
+_MANIFESTS = ("Cargo.toml", "Cargo.lock")
+
+
+def _is_manifest(path: str) -> bool:
+    return os.path.basename(path) in _MANIFESTS
+
+
+def _is_rust(path: str) -> bool:
+    return path.endswith(_RUST_SUFFIX)
+
+
+def _build_relevant(path: str) -> bool:
+    """Can a change to this path alter the compiled wasm bundle at all?
+
+    Conservative: `.rs` and cargo manifests only. Anything else is inert for the bundle
+    (markdown, YAML, JSON fixtures, the declarations directory itself). A file we do not
+    recognise as inert is NOT silently accepted — see `classify_paths`.
+    """
+    return _is_rust(path) or _is_manifest(path)
+
+
+# Root-level inputs that reach every build regardless of which crate they sit next to.
+_ROOT_BUILD_INPUTS = ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "rust-toolchain")
+
+
+def closure_dirs(tree: str, package: str = "sparq-wasm") -> list[str] | None:
+    """The workspace crate directories `package`'s DEFAULT wasm build actually compiles.
+
+    DERIVED from cargo, never hardcoded: `cargo tree` for the wasm32 target with default
+    features lists the closure, and `cargo metadata` maps each member to its manifest
+    directory. A path outside those directories provably cannot be compiled into the
+    bundle, so a change there needs no attribution — which is what stops unrelated
+    base-branch drift (research records, other crates, bench data) from being mistaken for
+    part of this PR's diff.
+
+    Returns None when cargo cannot answer, and the caller then treats EVERY changed path as
+    build-relevant (fail-closed).
+    """
+    try:
+        tree_out = subprocess.run(
+            ["cargo", "tree", "-p", package, "--target", "wasm32-unknown-unknown",
+             "--edges", "normal", "--prefix", "none"],
+            cwd=tree, capture_output=True, text=True, check=True).stdout
+        meta = json.loads(subprocess.run(
+            ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+            cwd=tree, capture_output=True, text=True, check=True).stdout)
+    except Exception:
+        return None
+    in_closure = {line.split()[0] for line in tree_out.splitlines() if line.strip()}
+    dirs = []
+    for pkg in meta.get("packages", []):
+        if pkg["name"] in in_closure:
+            d = os.path.relpath(os.path.dirname(pkg["manifest_path"]), tree)
+            if d not in (".", ""):
+                dirs.append(d.rstrip("/") + "/")
+    return sorted(dirs)
+
+
+def classify_paths(paths: list[str],
+                   closure: list[str] | None = None) -> tuple[list[str], list[str], list[str]]:
+    """Split changed paths into (rust, manifest, inert), or raise on one we cannot place.
+
+    `closure` is the list of crate directories the bundle compiles (see `closure_dirs`).
+    A path outside it — and outside the root build inputs — is INERT BY DERIVATION. Inside
+    it, only `.rs` and cargo manifests are understood; anything else refuses, because a
+    build input we do not model must never be silently assumed harmless.
+    """
+    rust: list[str] = []
+    manifest: list[str] = []
+    inert: list[str] = []
+    unknown: list[str] = []
+    for p in paths:
+        root_input = p in _ROOT_BUILD_INPUTS or p.startswith(".cargo/")
+        in_closure = closure is None or root_input or any(p.startswith(d) for d in closure)
+        if not in_closure:
+            inert.append(p)
+        elif _is_rust(p):
+            rust.append(p)
+        elif _is_manifest(p) or root_input:
+            manifest.append(p)
+        else:
+            unknown.append(p)
+    if unknown:
+        raise ValueError(
+            "changed inside the wasm build closure but not understood as a build input: "
+            + ", ".join(sorted(unknown))
+        )
+    return rust, manifest, inert
+
+
+# ---------------------------------------------------------------------------
+# Diff parsing: which NEW-file lines were added, which OLD-file lines were removed.
+# ---------------------------------------------------------------------------
+
+_HUNK = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
+
+
+def parse_unified_diff(diff_text: str) -> dict[str, dict[str, list[int]]]:
+    """Map path -> {"added": [1-based new-file line numbers],
+                    "removed": [1-based old-file line numbers]}.
+
+    Only the line NUMBERS are needed: the content is read back from the real trees, so a
+    truncated or context-less diff cannot smuggle content past the obligations.
+    """
+    out: dict[str, dict[str, list[int]]] = {}
+    path: str | None = None
+    old_path: str | None = None
+    old_ln = new_ln = 0
+    for line in diff_text.split("\n"):
+        if line.startswith("diff --git "):
+            path = old_path = None
+            continue
+        if line.startswith("--- "):
+            src = line[4:].strip()
+            old_path = None if src == "/dev/null" else (src[2:] if src.startswith("a/") else src)
+            continue
+        if line.startswith("+++ "):
+            target = line[4:].strip()
+            if target == "/dev/null":
+                # File DELETED by this diff. Its removed lines must still be attributed, so
+                # key them under the OLD path rather than dropping the hunk on the floor.
+                path = old_path
+            else:
+                path = target[2:] if target.startswith("b/") else target
+            if path is not None:
+                out.setdefault(path, {"added": [], "removed": []})
+            continue
+        m = _HUNK.match(line)
+        if m:
+            old_ln = int(m.group(1))
+            new_ln = int(m.group(3))
+            continue
+        if path is None:
+            continue
+        if line.startswith("+"):
+            out[path]["added"].append(new_ln)
+            new_ln += 1
+        elif line.startswith("-"):
+            out[path]["removed"].append(old_ln)
+            old_ln += 1
+        elif line.startswith(" ") or line == "":
+            old_ln += 1
+            new_ln += 1
+        # "\\ No newline at end of file" and everything else: no line consumed.
+    return out
+
+
+def blank_lines(text: str, line_numbers: list[int]) -> str:
+    """Replace the given 1-based lines of `text` with EMPTY lines, preserving line count.
+
+    Preserving the line count is the load-bearing property: it is what makes the neutral
+    tree hold the base tree's content at the head tree's line POSITIONS, so a byte-identical
+    build proves the blanked lines emitted nothing.
+    """
+    lines = text.split("\n")
+    for n in line_numbers:
+        if 1 <= n <= len(lines):
+            lines[n - 1] = ""
+    return "\n".join(lines)
+
+
+def nonblank_count(text: str, line_numbers: list[int]) -> int:
+    """How many of the given 1-based lines carry non-whitespace content."""
+    lines = text.split("\n")
+    return sum(1 for n in line_numbers if 1 <= n <= len(lines) and lines[n - 1].strip())
+
+
+# ---------------------------------------------------------------------------
+# Tree materialisation + the real cargo builder.
+# ---------------------------------------------------------------------------
+
+def export_tree(repo: str, sha: str, dest: str) -> None:
+    """Materialise `sha` into `dest` via `git archive` (never a checkout of the caller's tree)."""
+    os.makedirs(dest, exist_ok=True)
+    archive = subprocess.run(
+        ["git", "-C", repo, "archive", "--format=tar", sha],
+        capture_output=True, check=True,
+    )
+    subprocess.run(["tar", "-x", "-C", dest], input=archive.stdout, check=True)
+
+
+def cargo_wasm_builder(tree: str) -> bytes | None:
+    """Build the feature-OFF sparq-wasm bundle in `tree`; return its bytes, or None on failure.
+
+    Mirrors the leg-2 build exactly: default features only (no `--features vectorized`),
+    the `release-wasm` profile, the wasm32 target.
+    """
+    proc = subprocess.run(
+        ["cargo", "build", "--profile", "release-wasm", "-p", "sparq-wasm",
+         "--target", "wasm32-unknown-unknown"],
+        cwd=tree, capture_output=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr.decode("utf-8", "replace")[-4000:])
+        return None
+    out = os.path.join(tree, "target", "wasm32-unknown-unknown", "release-wasm", "sparq_wasm.wasm")
+    if not os.path.exists(out):
+        return None
+    with open(out, "rb") as fh:
+        return fh.read()
+
+
+def differing_bytes(a: bytes, b: bytes) -> int:
+    """Count positions at which two byte strings differ (length difference counts as differing)."""
+    n = min(len(a), len(b))
+    return sum(1 for i in range(n) if a[i] != b[i]) + abs(len(a) - len(b))
+
+
+# ---------------------------------------------------------------------------
+# The decision.
+# ---------------------------------------------------------------------------
+
+class Verdict:
+    def __init__(self, outcome: str, reason: str = "", evidence: dict | None = None):
+        self.outcome = outcome            # OUTCOME_* or a REFUSE_* name
+        self.reason = reason              # human-readable one-liner
+        self.evidence = evidence or {}
+
+    @property
+    def declared(self) -> bool:
+        return self.outcome == OUTCOME_DECLARED
+
+    @property
+    def refused(self) -> bool:
+        return self.outcome not in (OUTCOME_DECLARED, OUTCOME_NO_DRIFT)
+
+
+def decide(base_tree: str, head_tree: str, diff_text: str, builder,
+           base_bytes: bytes | None = None, head_bytes: bytes | None = None) -> Verdict:
+    """Derive whether the base->head feature-OFF drift is line-position churn ONLY.
+
+    `builder(tree_dir) -> bytes | None` compiles a materialised tree. Injected so the
+    decision logic is testable without cargo; production passes `cargo_wasm_builder`.
+
+    `base_bytes` / `head_bytes` let a caller hand in bundles the leg-2 job already built,
+    so the derivation costs one extra build (two when the diff deletes code) rather than
+    four. They are used verbatim — the obligations below still rebuild the NEUTRAL trees
+    with the same builder, so a handed-in bundle cannot short-circuit any proof.
+    """
+    changes = parse_unified_diff(diff_text)
+    if not changes:
+        return Verdict(REFUSE_NO_DIFF, "the base..head diff is empty — nothing to attribute")
+
+    closure = closure_dirs(head_tree)
+    try:
+        rust_paths, manifest_paths, inert_paths = classify_paths(sorted(changes), closure)
+    except ValueError as exc:
+        return Verdict(REFUSE_UNSUPPORTED_FILE_CHANGE, str(exc))
+
+    if base_bytes is None:
+        base_bytes = builder(base_tree)
+    if base_bytes is None:
+        return Verdict(REFUSE_BASE_BUILD_FAILED, "the BASE tree did not build")
+    if head_bytes is None:
+        head_bytes = builder(head_tree)
+    if head_bytes is None:
+        return Verdict(REFUSE_HEAD_BUILD_FAILED, "the HEAD tree did not build")
+
+    if base_bytes == head_bytes:
+        return Verdict(OUTCOME_NO_DRIFT,
+                       "base and head bundles are byte-identical; leg 2 already passes",
+                       {"bundle_bytes": len(head_bytes)})
+
+    evidence = {
+        "base_bundle_bytes": len(base_bytes),
+        "head_bundle_bytes": len(head_bytes),
+        "size_delta_bytes": len(head_bytes) - len(base_bytes),
+        "differing_bytes": differing_bytes(base_bytes, head_bytes),
+        "rust_files_changed": rust_paths,
+        "manifest_files_changed": manifest_paths,
+        "inert_files_changed": len(inert_paths),
+    }
+
+    # ---- Obligation 1: additions contribute no compiled code ----------------
+    # Neutral tree = HEAD with every added .rs line blanked and every changed manifest
+    # restored from BASE. It therefore holds BASE's compiled content at HEAD's line
+    # positions. If its bundle equals HEAD's, the additions emitted nothing.
+    neutral = os.path.join(tempfile.mkdtemp(prefix="featoff-neutral-"), "tree")
+    shutil.copytree(head_tree, neutral, symlinks=True)
+    added_nonblank = 0
+    for path in rust_paths:
+        added = changes[path]["added"]
+        if not added:
+            continue
+        target = os.path.join(neutral, path)
+        if not os.path.exists(target):
+            continue
+        with open(target, encoding="utf-8", errors="surrogateescape") as fh:
+            text = fh.read()
+        added_nonblank += nonblank_count(text, added)
+        with open(target, "w", encoding="utf-8", errors="surrogateescape") as fh:
+            fh.write(blank_lines(text, added))
+    for path in manifest_paths:
+        src = os.path.join(base_tree, path)
+        dst = os.path.join(neutral, path)
+        if os.path.exists(src):
+            shutil.copyfile(src, dst)
+        elif os.path.exists(dst):
+            os.remove(dst)
+    evidence["added_nonblank_lines_blanked"] = added_nonblank
+
+    neutral_bytes = builder(neutral)
+    if neutral_bytes is None:
+        # Blanking the added lines broke the build => at least one of them was load-bearing.
+        return Verdict(REFUSE_NEUTRAL_BUILD_FAILED,
+                       "blanking the added lines broke the build, so they are compiled code, "
+                       "not comments or compiled-out cfg-gated tokens",
+                       evidence)
+    if neutral_bytes != head_bytes:
+        evidence["neutral_vs_head_size_delta"] = len(head_bytes) - len(neutral_bytes)
+        evidence["neutral_vs_head_differing_bytes"] = differing_bytes(neutral_bytes, head_bytes)
+        return Verdict(REFUSE_ADDED_LINES_ARE_SEMANTIC,
+                       "blanking the added lines CHANGED the compiled bundle, so the diff adds "
+                       "code to the default build; an intentional always-compiled change must "
+                       "be declared by its author, not derived",
+                       evidence)
+
+    # ---- Obligation 2: deletions removed no compiled code -------------------
+    # Deleted lines are absent from BOTH head and neutral, so obligation 1 cannot speak for
+    # them. Run the same proof on the base side: blank exactly those lines in BASE and
+    # require the bundle to be unchanged.
+    removed_nonblank = 0
+    to_blank: dict[str, list[int]] = {}
+    for path in rust_paths:
+        removed = changes[path]["removed"]
+        if not removed:
+            continue
+        src = os.path.join(base_tree, path)
+        if not os.path.exists(src):
+            continue
+        with open(src, encoding="utf-8", errors="surrogateescape") as fh:
+            text = fh.read()
+        n = nonblank_count(text, removed)
+        if n:
+            removed_nonblank += n
+            to_blank[path] = removed
+    evidence["deleted_nonblank_lines"] = removed_nonblank
+
+    if to_blank:
+        del_neutral = os.path.join(tempfile.mkdtemp(prefix="featoff-delneutral-"), "tree")
+        shutil.copytree(base_tree, del_neutral, symlinks=True)
+        for path, removed in to_blank.items():
+            target = os.path.join(del_neutral, path)
+            with open(target, encoding="utf-8", errors="surrogateescape") as fh:
+                text = fh.read()
+            with open(target, "w", encoding="utf-8", errors="surrogateescape") as fh:
+                fh.write(blank_lines(text, removed))
+        del_bytes = builder(del_neutral)
+        if del_bytes is None:
+            return Verdict(REFUSE_DELETION_BUILD_FAILED,
+                           "blanking the deleted lines in the BASE tree broke the build, so the "
+                           "diff removes compiled code",
+                           evidence)
+        if del_bytes != base_bytes:
+            evidence["delneutral_vs_base_size_delta"] = len(base_bytes) - len(del_bytes)
+            evidence["delneutral_vs_base_differing_bytes"] = differing_bytes(del_bytes, base_bytes)
+            return Verdict(REFUSE_DELETED_LINES_ARE_SEMANTIC,
+                           "blanking the deleted lines in the BASE tree CHANGED the compiled "
+                           "bundle, so the diff removes code from the default build; that is an "
+                           "always-compiled change its author must declare",
+                           evidence)
+
+    return Verdict(
+        OUTCOME_DECLARED,
+        "every added line was proved to emit nothing (neutral bundle == head bundle) and "
+        "every deleted line was proved to have emitted nothing (base-neutral bundle == base "
+        "bundle); the drift is line-position metadata only",
+        evidence,
+    )
+
+
+def declaration_json(pr: int, verdict: Verdict, date: str | None = None) -> dict:
+    """The per-PR declaration file content, carrying the MEASURED evidence."""
+    ev = verdict.evidence
+    return {
+        "pr": pr,
+        "date": date or datetime.date.today().isoformat(),
+        "reason": (
+            f"[OPUS-5] #{pr}: DERIVED declaration (scripts/feature_off_autodeclare.py). The "
+            f"feature-OFF bundle moved {ev.get('differing_bytes')} of "
+            f"{ev.get('head_bundle_bytes')} bytes at a size delta of "
+            f"{ev.get('size_delta_bytes'):+d}, and the drift was proved to carry no compiled "
+            "code: rebuilding the head tree with all "
+            f"{ev.get('added_nonblank_lines_blanked')} added non-blank line(s) blanked "
+            "produced a BYTE-IDENTICAL bundle, and rebuilding the base tree with all "
+            f"{ev.get('deleted_nonblank_lines')} deleted non-blank line(s) blanked likewise "
+            "left the base bundle unchanged. What moved is line-position metadata "
+            "(core::panic::Location line numbers shift when lines above them move); no "
+            "always-compiled code entered or left the default build. Bundle SIZE remains "
+            "governed separately by the wasm_bundle_bytes ratchet."
+        ),
+        "derived": True,
+        "evidence": ev,
+    }
+
+
+def census_row(pr: int, verdict: Verdict) -> str:
+    """One machine-greppable census line, emitted on every run."""
+    return (
+        "FEATURE-OFF-CENSUS "
+        f"pr={pr} outcome={verdict.outcome} "
+        f"size_delta={verdict.evidence.get('size_delta_bytes', 'na')} "
+        f"differing_bytes={verdict.evidence.get('differing_bytes', 'na')} "
+        f"reason={verdict.reason.split(';')[0][:160]!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Census sweep: how big is this class right now, and what happened to each member?
+# ---------------------------------------------------------------------------
+
+LEG_NAME = "artifact-exact-equality (wasm bundle feature-OFF)"
+
+
+def _gh_json(path: str) -> object:
+    proc = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip()[:400])
+    return json.loads(proc.stdout)
+
+
+def _default_pr_lister(repo: str) -> list[dict]:
+    proc = subprocess.run(
+        ["gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "200",
+         "--json", "number,headRefOid,isDraft,title"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def _default_check_lister(repo: str, sha: str) -> list[dict]:
+    runs: list[dict] = []
+    page = 1
+    while page <= 5:
+        d = _gh_json(f"/repos/{repo}/commits/{sha}/check-runs?per_page=100&page={page}")
+        batch = d.get("check_runs", [])  # type: ignore[union-attr]
+        runs.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return runs
+
+
+def census_sweep(repo: str, declarations_dir_listing: set[str],
+                 pr_lister=_default_pr_lister, check_lister=_default_check_lister) -> dict:
+    """Tally the live population of the feature-OFF declaration class.
+
+    Membership is decided by the LEG's own conclusion on each PR's CURRENT head SHA (matched
+    by NAME EQUALITY, and paginated), never by a cached label — a stale classification is how
+    this class goes quietly wrong. Returns counts plus the per-PR rows.
+    """
+    rows: list[dict] = []
+    prs = pr_lister(repo)
+    for pr in prs:
+        try:
+            checks = check_lister(repo, pr["headRefOid"])
+        except Exception as exc:
+            rows.append({"pr": pr["number"], "state": "check-lookup-failed", "detail": str(exc)})
+            continue
+        # NAME EQUALITY, newest run wins. A substring match would sweep in an advisory twin,
+        # and a first-run-wins scan would read a superseded red on a re-run head.
+        leg: dict | None = None
+        for c in checks:
+            if c["name"] != LEG_NAME:
+                continue
+            if leg is None or (c.get("started_at") or "") >= (leg.get("started_at") or ""):
+                leg = c
+        if leg is None:
+            state = "leg-absent"
+        elif leg.get("conclusion") == "failure":
+            state = "in-class-red"
+        elif leg.get("status") != "completed":
+            state = "leg-running"
+        else:
+            state = "leg-green"
+        rows.append({
+            "pr": pr["number"], "draft": pr.get("isDraft"), "state": state,
+            "declared": f"{pr['number']}.json" in declarations_dir_listing,
+        })
+    in_class = [r for r in rows if r.get("state") == "in-class-red"]
+    return {
+        "open_prs": len(prs),
+        "in_class_red": len(in_class),
+        "in_class_already_declared": sum(1 for r in in_class if r.get("declared")),
+        "in_class_undeclared": sum(1 for r in in_class if not r.get("declared")),
+        "leg_running": sum(1 for r in rows if r.get("state") == "leg-running"),
+        "leg_absent": sum(1 for r in rows if r.get("state") == "leg-absent"),
+        "lookup_failed": sum(1 for r in rows if r.get("state") == "check-lookup-failed"),
+        "rows": rows,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    ap.add_argument("--repo", default=".", help="git repository to export trees from")
+    ap.add_argument("--base-sha")
+    ap.add_argument("--head-sha")
+    ap.add_argument("--pr", type=int)
+    ap.add_argument("--declarations-dir", default="bench/feature-off-declarations")
+    ap.add_argument("--base-wasm", help="a base-tree bundle the caller already built")
+    ap.add_argument("--head-wasm", help="a head-tree bundle the caller already built")
+    ap.add_argument("--write", action="store_true",
+                    help="write the declaration file into --repo's working tree")
+    ap.add_argument("--report-only", action="store_true",
+                    help="print the verdict and the declaration that WOULD be written")
+    ap.add_argument("--census", metavar="OWNER/REPO",
+                    help="sweep the live open-PR population of this class and exit")
+    ap.add_argument("--summary-file", default=os.environ.get("GITHUB_STEP_SUMMARY", ""))
+    args = ap.parse_args(argv)
+
+    if args.census:
+        decl_dir = os.path.join(args.repo, args.declarations_dir)
+        listing = set(os.listdir(decl_dir)) if os.path.isdir(decl_dir) else set()
+        rep = census_sweep(args.census, listing)
+        print("FEATURE-OFF-CENSUS-SWEEP " + " ".join(
+            f"{k}={v}" for k, v in rep.items() if k != "rows"))
+        for r in rep["rows"]:
+            if r.get("state") in ("in-class-red", "check-lookup-failed"):
+                print("  " + json.dumps(r))
+        return 0
+
+    missing = [n for n in ("base_sha", "head_sha", "pr") if getattr(args, n) is None]
+    if missing:
+        ap.error("required unless --census is given: " + ", ".join("--" + m.replace("_", "-")
+                                                                   for m in missing))
+
+    prebuilt: dict[str, bytes | None] = {"base": None, "head": None}
+    for key, path in (("base", args.base_wasm), ("head", args.head_wasm)):
+        if path:
+            with open(path, "rb") as fh:
+                prebuilt[key] = fh.read()
+
+    # ATTRIBUTION BASE = the MERGE BASE, not `pull_request.base.sha`. Those are different
+    # commits whenever the branch is behind its base: GitHub sets `base.sha` to the base
+    # BRANCH TIP at the last sync, so a `base.sha`..`head` diff also carries, in reverse,
+    # every base-branch commit the PR does not have. MEASURED on the live population: 3 of
+    # the 6 open PRs red on this leg had a non-ancestor `base.sha`, and one of them showed
+    # 22 changed files against `base.sha` for a ONE-file PR. Attributing that to the PR
+    # would be wrong in both directions, so the proof runs against the merge base and the
+    # difference is reported rather than hidden.
+    merge_base = subprocess.run(
+        ["git", "-C", args.repo, "merge-base", args.base_sha, args.head_sha],
+        capture_output=True, text=True, check=True).stdout.strip()
+    if merge_base != args.base_sha:
+        print(f"[autodeclare] NOTE: leg 2's base ({args.base_sha[:12]}) is not the merge base "
+              f"({merge_base[:12]}); attributing against the merge base, and the supplied "
+              "base bundle is ignored because it was built from a different tree.")
+        prebuilt["base"] = None
+
+    workdir = tempfile.mkdtemp(prefix="featoff-trees-")
+    base_tree = os.path.join(workdir, "base")
+    head_tree = os.path.join(workdir, "head")
+    export_tree(args.repo, merge_base, base_tree)
+    export_tree(args.repo, args.head_sha, head_tree)
+    diff_text = subprocess.run(
+        ["git", "-C", args.repo, "diff", "--no-color", "--unified=0",
+         merge_base, args.head_sha],
+        capture_output=True, text=True, check=True,
+    ).stdout
+
+    verdict = decide(base_tree, head_tree, diff_text, cargo_wasm_builder,
+                     base_bytes=prebuilt["base"], head_bytes=prebuilt["head"])
+
+    print(census_row(args.pr, verdict))
+    print(f"[autodeclare] outcome: {verdict.outcome}")
+    print(f"[autodeclare] {verdict.reason}")
+    print("[autodeclare] evidence: " + json.dumps(verdict.evidence, indent=2, default=str))
+
+    lines = [
+        "### feature-OFF declaration derivation",
+        "",
+        f"* **outcome**: `{verdict.outcome}`",
+        f"* {verdict.reason}",
+        "",
+        "```json",
+        json.dumps(verdict.evidence, indent=2, default=str),
+        "```",
+    ]
+    if verdict.declared:
+        doc = declaration_json(args.pr, verdict)
+        rel = os.path.join(args.declarations_dir, f"{args.pr}.json")
+        lines += ["", f"Commit this as `{rel}`:", "", "```json",
+                  json.dumps(doc, indent=2), "```"]
+        if args.write:
+            dest = os.path.join(args.repo, rel)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "w", encoding="utf-8") as fh:
+                json.dump(doc, fh, indent=2)
+                fh.write("\n")
+            print(f"[autodeclare] wrote {dest}")
+        else:
+            print(json.dumps(doc, indent=2))
+    if args.summary_file:
+        try:
+            with open(args.summary_file, "a", encoding="utf-8") as fh:
+                fh.write("\n".join(lines) + "\n")
+        except OSError:
+            pass
+
+    # Exit 0 when a declaration was derived or none was needed; non-zero on a REFUSAL so a
+    # caller that wired this in cannot mistake "refused" for "handled".
+    return 0 if not verdict.refused else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/feature_off_autodeclare.py
+++ b/scripts/feature_off_autodeclare.py
@@ -285,7 +285,13 @@ def cargo_wasm_builder(tree: str) -> bytes | None:
     if proc.returncode != 0:
         sys.stderr.write(proc.stderr.decode("utf-8", "replace")[-4000:])
         return None
-    out = os.path.join(tree, "target", "wasm32-unknown-unknown", "release-wasm", "sparq_wasm.wasm")
+    # Each obligation builds a freshly-materialised tree, so without a shared target
+    # directory every one of them recompiles the whole dependency graph from cold. Honour
+    # CARGO_TARGET_DIR so a caller can point the extra builds at one warm directory. It must
+    # be a directory the leg's OWN cached `target/` does not share, or the neutral tree's
+    # artefacts would be saved into the head build's cache.
+    target_root = os.environ.get("CARGO_TARGET_DIR") or os.path.join(tree, "target")
+    out = os.path.join(target_root, "wasm32-unknown-unknown", "release-wasm", "sparq_wasm.wasm")
     if not os.path.exists(out):
         return None
     with open(out, "rb") as fh:

--- a/scripts/tests/test_feature_off_autodeclare.py
+++ b/scripts/tests/test_feature_off_autodeclare.py
@@ -70,6 +70,7 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 _CFG_FEATURE = re.compile(r'#\[cfg\(feature\s*=\s*"([^"]+)"\)\]')
 _DEFAULT_FEATURES = re.compile(r'^\s*default\s*=\s*\[([^\]]*)\]', re.M)
+_INCLUDE_STR = re.compile(r'include_str!\("([^"]+)"\)')
 
 
 def _enabled_features(tree: str) -> set[str]:
@@ -99,6 +100,7 @@ def fake_build(tree: str) -> bytes | None:
     """
     enabled = _enabled_features(tree)
     out: list[str] = []
+    included: list[str] = []
     roots = []
     for dirpath, dirnames, filenames in os.walk(tree):
         dirnames[:] = [d for d in dirnames if d not in ("target", ".git")]
@@ -124,9 +126,18 @@ def fake_build(tree: str) -> bytes | None:
                 gated_off = False
                 continue
             gated_off = False
+            inc = _INCLUDE_STR.search(s)
+            if inc:
+                # `include_str!` pulls a NON-.rs file's bytes into the artefact — the case
+                # that makes "decide inertness by file extension" unsound.
+                target = os.path.normpath(os.path.join(os.path.dirname(path), inc.group(1)))
+                if os.path.exists(target):
+                    with open(target, encoding="utf-8", errors="surrogateescape") as fh2:
+                        body = "".join(l for l in fh2.read().split("\n") if l.strip())
+                    included.append(hashlib.sha256(body.encode()).hexdigest()[:16])
             h = hashlib.sha256(s.encode("utf-8", "surrogateescape")).hexdigest()[:16]
             out.append(f"{rel}:{i:06d}:{h}")
-    return ("\n".join(out)).encode()
+    return ("\n".join(out + included)).encode()
 
 
 # ---------------------------------------------------------------------------
@@ -403,19 +414,46 @@ def test_neutral_tree_blanks_the_added_lines() -> None:
           "positions fixed, which is the whole basis of the proof)")
 
 
-def test_unknown_path_type_is_refused() -> None:
-    """A changed path INSIDE the build closure that we cannot model must refuse.
+def test_non_rust_file_inside_the_closure_is_blanked_not_refused() -> None:
+    """CONTROL: a crate README the build does not read must not block a derivation."""
+    base = base_files(**{"crates/c/README.md": "# c\n"})
+    head = base_files(**{"crates/c/README.md": "# c\n\nA new paragraph.\n",
+                         "crates/c/src/lib.rs": insert_at(_BASE_LIB, 4, ["// a comment"])})
+    v = run_decide(base, head)
+    check("test_non_rust_file_inside_the_closure_is_blanked_not_refused",
+          v.outcome == A.OUTCOME_DECLARED, f"got {v.outcome}: {v.reason}")
 
-    `closure=None` is the fail-closed shape used when cargo cannot answer: then every path
-    counts as build-relevant, so an unmodelled one has to refuse rather than be waved through.
+
+def test_included_non_rust_file_is_refused() -> None:
+    """RED TEST: the same README, but `include_str!`d — its content DOES reach the bundle.
+
+    This is why inertness cannot be decided by file extension. Blanking the added lines and
+    rebuilding is what tells the two cases apart, and it must refuse this one.
     """
+    lib = _BASE_LIB + '\npub const DOC: &str = include_str!("../README.md");\n'
+    base = base_files(**{"crates/c/README.md": "# c\n", "crates/c/src/lib.rs": lib})
+    head = base_files(**{"crates/c/README.md": "# c\nA new documented invariant.\n",
+                         "crates/c/src/lib.rs": lib})
+    v = run_decide(base, head)
+    check("test_included_non_rust_file_is_refused",
+          v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
+
+
+def test_symlink_inside_the_closure_is_refused() -> None:
+    """Blanking rewrites files in place, which cannot speak for a symlink — refuse."""
+    base = make_tree(base_files())
+    head = make_tree(base_files())
+    link = os.path.join(head, "crates/c/src/aliased.rs")
+    os.symlink("lib.rs", link)
+    with open(os.path.join(head, "crates/c/src/lib.rs"), "a") as fh:
+        fh.write("// touched\n")
     try:
-        A.classify_paths(["crates/c/build/thing.wasmbin"], None)
-        ok = False
-    except ValueError:
-        ok = True
-    check("test_unknown_path_type_is_refused", ok,
-          "an unmodelled path inside the closure must raise, not be classed inert")
+        v = A.decide(base, head, diff_of(base, head), fake_build)
+        check("test_symlink_inside_the_closure_is_refused",
+              v.outcome == A.REFUSE_UNSUPPORTED_FILE_CHANGE, f"got {v.outcome}: {v.reason}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
 
 
 def test_paths_outside_the_build_closure_are_inert() -> None:
@@ -424,15 +462,16 @@ def test_paths_outside_the_build_closure_are_inert() -> None:
     This is what stops unrelated base-branch drift — other crates, research records, bench
     data — from refusing an otherwise-provable PR.
     """
-    rust, manifest, inert = A.classify_paths(
-        ["crates/c/src/lib.rs", "crates/other/src/lib.rs", "research/notes.md",
-         "Cargo.lock", "crates/other/README.md"],
+    blankable, manifest, inert = A.classify_paths(
+        ["crates/c/src/lib.rs", "crates/c/README.md", "crates/other/src/lib.rs",
+         "research/notes.md", "Cargo.lock", "crates/other/README.md"],
         ["crates/c/"])
     check("test_paths_outside_the_build_closure_are_inert",
-          rust == ["crates/c/src/lib.rs"] and manifest == ["Cargo.lock"]
+          sorted(blankable) == ["crates/c/README.md", "crates/c/src/lib.rs"]
+          and manifest == ["Cargo.lock"]
           and sorted(inert) == ["crates/other/README.md", "crates/other/src/lib.rs",
                                 "research/notes.md"],
-          f"got rust={rust} manifest={manifest} inert={inert}")
+          f"got blankable={blankable} manifest={manifest} inert={inert}")
 
 
 def test_root_build_inputs_are_never_inert() -> None:
@@ -724,42 +763,54 @@ def test_derivation_suite_is_run_in_ci() -> None:
           "CI must run the derivation suite WITH --mutate")
 
 
-def test_derivation_target_dir_is_off_the_cached_workspace_target() -> None:
-    """The extra builds must NOT write into the `target/` Swatinem caches for this job.
+def test_workflow_sets_no_shared_target_dir() -> None:
+    """The workflow must NOT hand the derivation a shared CARGO_TARGET_DIR.
 
-    Sharing it would make the neutral tree's artefacts part of the head build's cache entry,
-    poisoning every later PR that restores that key.
+    Sharing one warm target directory across the materialised trees was tried for speed and
+    REVERTED: on #4350 it reported a 299-line `exec.rs` rewrite as byte-identical, because
+    `git archive` stamps commit mtimes and cargo's freshness check is mtime-based. A false
+    "identical" auto-declares a real code change, so the environment must not be able to
+    reintroduce it.
     """
     block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
-    m = re.search(r"CARGO_TARGET_DIR:\s*(\S.*)$", block, re.M)
-    check("test_derivation_target_dir_is_off_the_cached_workspace_target",
-          m is not None and "runner.temp" in m.group(1),
-          f"expected a runner.temp path, got {m.group(1) if m else '<unset>'}")
+    check("test_workflow_sets_no_shared_target_dir", "CARGO_TARGET_DIR" not in block,
+          "the derivation step must not set CARGO_TARGET_DIR")
 
 
-def test_builder_honours_the_shared_target_dir() -> None:
-    """`cargo_wasm_builder` must read the bundle from CARGO_TARGET_DIR when it is set.
+def test_builder_ignores_an_inherited_shared_target_dir() -> None:
+    """An inherited CARGO_TARGET_DIR must NOT redirect the build or the read-back.
 
-    If it kept looking under `<tree>/target` it would find nothing there, return None, and
-    every derivation would refuse with `neutral-build-failed` — a silent all-refuse that
-    still looks like the tool is working. Exercised BEHAVIOURALLY with a stubbed cargo, so
-    the assertion cannot pass just because the source happens to mention the variable.
+    Sharing one target directory across materialised trees returned a STALE bundle on #4350
+    — a 299-line `exec.rs` rewrite read back as byte-identical to its base. Since a false
+    "identical" is the one outcome that would auto-declare a real code change, the builder
+    pins the target directory inside the tree and overrides the inherited variable.
+    Exercised BEHAVIOURALLY with a stubbed cargo: the bundle must come from the TREE, and
+    the env the subprocess receives must point there too.
     """
     tree = tempfile.mkdtemp(prefix="featoff-tgt-")
-    shared = tempfile.mkdtemp(prefix="featoff-shared-target-")
-    out = os.path.join(shared, "wasm32-unknown-unknown", "release-wasm")
-    os.makedirs(out)
-    with open(os.path.join(out, "sparq_wasm.wasm"), "wb") as fh:
-        fh.write(b"bundle-from-the-shared-target-dir")
+    decoy = tempfile.mkdtemp(prefix="featoff-decoy-target-")
+    for root, payload in ((os.path.join(tree, "target"), b"bundle-from-the-tree"),
+                          (decoy, b"STALE-bundle-from-the-shared-dir")):
+        out = os.path.join(root, "wasm32-unknown-unknown", "release-wasm")
+        os.makedirs(out)
+        with open(os.path.join(out, "sparq_wasm.wasm"), "wb") as fh:
+            fh.write(payload)
+
+    seen: dict[str, str] = {}
 
     class _Ok:
         returncode = 0
         stderr = b""
 
+    def _stub(*a, **k):
+        seen.update(k.get("env") or {})
+        seen["argv"] = " ".join(a[0]) if a else ""
+        return _Ok()
+
     real_run, real_env = A.subprocess.run, os.environ.get("CARGO_TARGET_DIR")
     try:
-        A.subprocess.run = lambda *a, **k: _Ok()
-        os.environ["CARGO_TARGET_DIR"] = shared
+        A.subprocess.run = _stub
+        os.environ["CARGO_TARGET_DIR"] = decoy
         got = A.cargo_wasm_builder(tree)
     finally:
         A.subprocess.run = real_run
@@ -768,10 +819,14 @@ def test_builder_honours_the_shared_target_dir() -> None:
         else:
             os.environ["CARGO_TARGET_DIR"] = real_env
         shutil.rmtree(tree, ignore_errors=True)
-        shutil.rmtree(shared, ignore_errors=True)
-    check("test_builder_honours_the_shared_target_dir",
-          got == b"bundle-from-the-shared-target-dir",
-          f"expected the bundle from CARGO_TARGET_DIR, got {got!r}")
+        shutil.rmtree(decoy, ignore_errors=True)
+    check("test_builder_ignores_an_inherited_shared_target_dir",
+          got == b"bundle-from-the-tree",
+          f"expected the tree's own bundle, got {got!r}")
+    check("test_builder_ignores_an_inherited_shared_target_dir__subprocess_env",
+          seen.get("CARGO_TARGET_DIR", "").startswith(tree),
+          f"cargo must be run with the tree's target dir, got "
+          f"{seen.get('CARGO_TARGET_DIR')!r}")
 
 
 def test_paths_filter_includes_the_new_scripts() -> None:
@@ -789,8 +844,8 @@ TESTS = [
     test_leg2_step_has_the_id_the_derivation_depends_on,
     test_derivation_cannot_change_the_leg2_verdict,
     test_derivation_suite_is_run_in_ci,
-    test_derivation_target_dir_is_off_the_cached_workspace_target,
-    test_builder_honours_the_shared_target_dir,
+    test_workflow_sets_no_shared_target_dir,
+    test_builder_ignores_an_inherited_shared_target_dir,
     test_paths_filter_includes_the_new_scripts,
     test_census_sweep_counts_the_live_class,
     test_census_sweep_matches_leg_name_by_equality,
@@ -807,7 +862,9 @@ TESTS = [
     test_neutral_build_failure_is_refused,
     test_deletion_neutral_build_failure_is_refused,
     test_neutral_tree_blanks_the_added_lines,
-    test_unknown_path_type_is_refused,
+    test_non_rust_file_inside_the_closure_is_blanked_not_refused,
+    test_included_non_rust_file_is_refused,
+    test_symlink_inside_the_closure_is_refused,
     test_paths_outside_the_build_closure_are_inert,
     test_root_build_inputs_are_never_inert,
     test_base_build_failure_is_refused,
@@ -854,10 +911,15 @@ MUTANTS = [
      "do not restore the base tree's manifests into the neutral tree",
      "            shutil.copyfile(src, dst)", "            pass",
      "test_manifest_change_that_enables_a_feature_is_refused"),
-    ("M5-accept-unknown-paths",
-     "treat an unmodelled path inside the build closure as inert",
-     "        raise ValueError(", "        _unused = (",
-     "test_unknown_path_type_is_refused"),
+    ("M5-accept-symlinks",
+     "blank symlinks and submodule gitlinks as if they were regular files",
+     "    if nonregular:", "    if False:",
+     "test_symlink_inside_the_closure_is_refused"),
+    ("M5d-only-blank-rust-files",
+     "assume every non-.rs file in the closure is inert, leaving an include_str!'d asset unproven",
+     "        else:\n            blankable.append(p)",
+     "        elif _is_rust(p):\n            blankable.append(p)\n        else:\n            inert.append(p)",
+     "test_included_non_rust_file_is_refused"),
     ("M5b-everything-is-in-closure",
      "treat every changed path as build-relevant, so unrelated crates refuse the PR",
      "        in_closure = closure is None or root_input or any(p.startswith(d) for d in closure)",
@@ -898,11 +960,11 @@ MUTANTS = [
      '            if leg is None or (c.get("started_at") or "") >= (leg.get("started_at") or ""):',
      "            if True:",
      "test_census_sweep_uses_the_newest_run_per_name"),
-    ("M14-builder-ignores-shared-target-dir",
-     "look for the bundle under <tree>/target even when CARGO_TARGET_DIR is set",
-     '    target_root = os.environ.get("CARGO_TARGET_DIR") or os.path.join(tree, "target")',
-     '    target_root = os.path.join(tree, "target")',
-     "test_builder_honours_the_shared_target_dir"),
+    ("M14-builder-obeys-shared-target-dir",
+     "let an inherited CARGO_TARGET_DIR redirect the build, reintroducing the stale-bundle bug",
+     '        env={**os.environ, "CARGO_TARGET_DIR": os.path.join(tree, "target")},',
+     "        env=dict(os.environ),",
+     "test_builder_ignores_an_inherited_shared_target_dir"),
     ("M13-prebuilt-skips-neutral-proof",
      "reuse the head bundle as the neutral bundle instead of rebuilding",
      "    neutral_bytes = builder(neutral)", "    neutral_bytes = head_bytes",
@@ -938,11 +1000,12 @@ YAML_MUTANTS = [
      "scripts/tests/test_feature_off_autodeclare.py --mutate",
      "scripts/tests/test_feature_off_autodeclare.py",
      "test_derivation_suite_is_run_in_ci"),
-    ("Y7-share-the-cached-target-dir",
-     "point the derivation's builds at the workspace target/ Swatinem caches",
-     "          CARGO_TARGET_DIR: ${{ runner.temp }}/featoff-derivation-target",
-     "          CARGO_TARGET_DIR: target",
-     "test_derivation_target_dir_is_off_the_cached_workspace_target"),
+    ("Y7-reintroduce-shared-target-dir",
+     "hand the derivation a shared CARGO_TARGET_DIR again",
+     "          PR_NUMBER: ${{ github.event.pull_request.number }}",
+     "          PR_NUMBER: ${{ github.event.pull_request.number }}\n"
+     "          CARGO_TARGET_DIR: ${{ runner.temp }}/shared",
+     "test_workflow_sets_no_shared_target_dir"),
     ("Y5-drop-paths-filter-entry",
      "stop re-running the leg when the derivation script itself changes",
      "              - 'scripts/feature_off_autodeclare.py'\n", "",

--- a/scripts/tests/test_feature_off_autodeclare.py
+++ b/scripts/tests/test_feature_off_autodeclare.py
@@ -1,0 +1,981 @@
+#!/usr/bin/env python3
+"""
+[OPUS-5] sq-v3nel-v3: test suite for scripts/feature_off_autodeclare.py.
+
+The tool decides whether a feature-OFF wasm-bundle difference is line-position churn
+(comments moved, an off-by-default `#[cfg]` item inserted) or a real change to the code the
+default build compiles. Getting that wrong in the permissive direction turns the
+`artifact-exact-equality` gate into a rubber stamp, so this suite is built around ONE
+question: does a NON-benign drift still get REFUSED?
+
+Two things make the suite non-vacuous:
+
+  * A FAKE COMPILER (`fake_build`) that reproduces the real phenomenon rather than
+    hand-waving it. It emits, per COMPILED source line, a FIXED-WIDTH record carrying that
+    line's POSITION plus a hash of its content. Comments, blanks and lines under an inactive
+    `#[cfg(feature = "...")]` emit nothing but still occupy a position. Consequently a
+    comment insertion produces a SAME-LENGTH, different-bytes artefact (delta 0) and a real
+    code insertion produces a LONGER one — which is exactly what `cargo build --profile
+    release-wasm -p sparq-wasm` was MEASURED to do on this repo (34 inserted comment lines
+    in crates/sparq-core/src/compress.rs => 3 differing bytes at delta 0; four ungated code
+    lines in crates/sparq-core/src/lib.rs => delta +228 and 373,027 differing bytes).
+
+  * A MUTATION HARNESS (`--mutate`). It removes ONE call site of the decision logic at a
+    time and asserts that a NAMED test for that site goes red. A suite-wide "something
+    fails" assertion would give 1/N coverage at N/N confidence; each mutant here names the
+    single test that must catch it.
+
+Usage:
+    python3 scripts/tests/test_feature_off_autodeclare.py            # run the suite
+    python3 scripts/tests/test_feature_off_autodeclare.py --mutate   # + the mutation table
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util as _ilu
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+_SCRIPTS = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_MODULE_PATH = os.path.join(_SCRIPTS, "feature_off_autodeclare.py")
+
+
+def _load(path: str = _MODULE_PATH):
+    spec = _ilu.spec_from_file_location("feature_off_autodeclare", path)
+    mod = _ilu.module_from_spec(spec)  # type: ignore[arg-type]
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+A = _load()
+
+_FAILURES: list[str] = []
+_RUN: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    _RUN.append(name)
+    if not cond:
+        _FAILURES.append(f"{name}: {detail}")
+
+
+# ---------------------------------------------------------------------------
+# The fake compiler.
+# ---------------------------------------------------------------------------
+
+_CFG_FEATURE = re.compile(r'#\[cfg\(feature\s*=\s*"([^"]+)"\)\]')
+_DEFAULT_FEATURES = re.compile(r'^\s*default\s*=\s*\[([^\]]*)\]', re.M)
+
+
+def _enabled_features(tree: str) -> set[str]:
+    """Features listed in the root Cargo.toml's `default = [...]`."""
+    manifest = os.path.join(tree, "Cargo.toml")
+    if not os.path.exists(manifest):
+        return set()
+    with open(manifest, encoding="utf-8") as fh:
+        m = _DEFAULT_FEATURES.search(fh.read())
+    if not m:
+        return set()
+    return {t.strip().strip('"') for t in m.group(1).split(",") if t.strip()}
+
+
+def fake_build(tree: str) -> bytes | None:
+    """Model of rustc for the feature-OFF wasm bundle.
+
+    Emits one FIXED-WIDTH record per compiled line: `path:LINE(6 digits):HASH(16 hex)`.
+    Because the record width does not depend on the line number's magnitude, moving a
+    compiled line changes BYTES but never LENGTH — the real `core::panic::Location`
+    behaviour this tool exists to attribute. A line that emits nothing (blank, `//`
+    comment, or governed by an inactive `#[cfg(feature = ...)]`) still consumes its
+    position, so it shifts everything below it.
+
+    Returns None when the tree does not "compile": a `#[cfg(...)]` attribute with no item
+    under it, mirroring a build failure.
+    """
+    enabled = _enabled_features(tree)
+    out: list[str] = []
+    roots = []
+    for dirpath, dirnames, filenames in os.walk(tree):
+        dirnames[:] = [d for d in dirnames if d not in ("target", ".git")]
+        for fn in filenames:
+            if fn.endswith(".rs"):
+                roots.append(os.path.join(dirpath, fn))
+    for path in sorted(roots):
+        rel = os.path.relpath(path, tree)
+        with open(path, encoding="utf-8", errors="surrogateescape") as fh:
+            lines = fh.read().split("\n")
+        gated_off = False
+        for i, raw in enumerate(lines, start=1):
+            s = raw.strip()
+            m = _CFG_FEATURE.match(s)
+            if m:
+                if i == len(lines) or not any(l.strip() for l in lines[i:]):
+                    return None  # dangling cfg attribute => does not compile
+                gated_off = m.group(1) not in enabled
+                continue
+            if not s or s.startswith("//"):
+                continue
+            if gated_off:
+                gated_off = False
+                continue
+            gated_off = False
+            h = hashlib.sha256(s.encode("utf-8", "surrogateescape")).hexdigest()[:16]
+            out.append(f"{rel}:{i:06d}:{h}")
+    return ("\n".join(out)).encode()
+
+
+# ---------------------------------------------------------------------------
+# Tree + diff fixtures.
+# ---------------------------------------------------------------------------
+
+_ROOT_MANIFEST = '[workspace]\n[features]\ndefault = ["core"]\ngated = []\n'
+
+_BASE_LIB = """\
+// crate root
+pub fn alpha(x: u64) -> u64 {
+    x.wrapping_mul(3)
+}
+
+pub fn beta(x: u64) -> u64 {
+    x.wrapping_add(7)
+}
+
+pub fn gamma(x: u64) -> u64 {
+    alpha(x) ^ beta(x)
+}
+"""
+
+
+def make_tree(files: dict[str, str]) -> str:
+    d = tempfile.mkdtemp(prefix="featoff-test-")
+    for rel, content in files.items():
+        p = os.path.join(d, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write(content)
+    return d
+
+
+def base_files(**over: str) -> dict[str, str]:
+    f = {"Cargo.toml": _ROOT_MANIFEST, "crates/c/src/lib.rs": _BASE_LIB}
+    f.update(over)
+    return f
+
+
+def diff_of(base: str, head: str) -> str:
+    """A real `git diff --no-index -U0` between two trees, so the parser under test is
+    exercised on genuine git output rather than a hand-written approximation."""
+    proc = subprocess.run(
+        ["git", "diff", "--no-index", "--no-color", "--unified=0", base, head],
+        capture_output=True, text=True,
+    )
+    # Rewrite the temp-dir prefixes to repo-relative paths.
+    out = proc.stdout
+    out = out.replace(base.lstrip("/") + "/", "").replace(head.lstrip("/") + "/", "")
+    out = out.replace(base + "/", "").replace(head + "/", "")
+    return out
+
+
+def run_decide(base_files_d: dict[str, str], head_files_d: dict[str, str], builder=fake_build):
+    base = make_tree(base_files_d)
+    head = make_tree(head_files_d)
+    try:
+        return A.decide(base, head, diff_of(base, head), builder)
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+def insert_at(text: str, line: int, new_lines: list[str]) -> str:
+    L = text.split("\n")
+    return "\n".join(L[:line] + new_lines + L[line:])
+
+
+# ---------------------------------------------------------------------------
+# CONTROL arm — genuinely benign, cfg/comment-only drift must be DECLARED.
+# ---------------------------------------------------------------------------
+
+def test_comment_only_drift_is_declared() -> None:
+    """CONTROL: pure comment insertion mid-file drifts the bundle but must be declared."""
+    head = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["// explanatory comment " + str(i) for i in range(12)])})
+    v = run_decide(base_files(), head)
+    check("test_comment_only_drift_is_declared", v.outcome == A.OUTCOME_DECLARED,
+          f"got {v.outcome}: {v.reason}")
+    check("test_comment_only_drift_is_declared__delta_zero",
+          v.evidence.get("size_delta_bytes") == 0,
+          f"expected delta 0, got {v.evidence.get('size_delta_bytes')}")
+    check("test_comment_only_drift_is_declared__actually_drifted",
+          v.evidence.get("differing_bytes", 0) > 0,
+          "the fixture must actually move bytes, else the control is vacuous")
+
+
+def test_inactive_cfg_item_drift_is_declared() -> None:
+    """CONTROL: an off-by-default `#[cfg(feature)]` item inserted mid-file is declared."""
+    head = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4,
+        ["// the measure-first arm, off by default",
+         '#[cfg(feature = "gated")]',
+         "pub fn delta_arm(x: u64) -> u64 { x.rotate_left(9) }"])})
+    v = run_decide(base_files(), head)
+    check("test_inactive_cfg_item_drift_is_declared", v.outcome == A.OUTCOME_DECLARED,
+          f"got {v.outcome}: {v.reason}")
+    check("test_inactive_cfg_item_drift_is_declared__actually_drifted",
+          v.evidence.get("differing_bytes", 0) > 0,
+          "the fixture must actually move bytes, else the control is vacuous")
+
+
+def test_comment_deletion_is_declared() -> None:
+    """CONTROL: deleting a comment line is a deletion, but emits nothing — declare it."""
+    base = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["// a comment that the head removes"])})
+    head = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["// a comment that the head removes", "// and one it adds"])})
+    # Head removes the first comment and adds two others, so both obligations run.
+    head["crates/c/src/lib.rs"] = insert_at(_BASE_LIB, 4, ["// and one it adds", "// plus another"])
+    v = run_decide(base, head)
+    check("test_comment_deletion_is_declared", v.outcome == A.OUTCOME_DECLARED,
+          f"got {v.outcome}: {v.reason}")
+    check("test_comment_deletion_is_declared__deletion_obligation_ran",
+          v.evidence.get("deleted_nonblank_lines", 0) > 0,
+          "fixture must delete a non-blank line, else the deletion obligation is untested")
+
+
+def test_identical_bundles_need_no_declaration() -> None:
+    """A diff that does not move the bundle is `no-drift`, not a declaration.
+
+    The fixture appends a comment BELOW the last compiled line, so no line position moves
+    and the two bundles come out byte-identical — the common case leg 2 passes on its own.
+    """
+    head = base_files(**{"crates/c/src/lib.rs": _BASE_LIB + "// trailing note\n"})
+    v = run_decide(base_files(), head)
+    check("test_identical_bundles_need_no_declaration", v.outcome == A.OUTCOME_NO_DRIFT,
+          f"got {v.outcome}: {v.reason}")
+
+
+# ---------------------------------------------------------------------------
+# RED arm — a drift that is NOT benign must still be REFUSED (the leg stays red).
+# ---------------------------------------------------------------------------
+
+def test_added_code_lines_are_refused() -> None:
+    """RED TEST: real, ungated code added to the default build must NOT be auto-declared."""
+    head = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["pub fn leaked(x: u64) -> u64 { x.rotate_right(5) }"])})
+    v = run_decide(base_files(), head)
+    check("test_added_code_lines_are_refused", v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC,
+          f"got {v.outcome}: {v.reason}")
+    check("test_added_code_lines_are_refused__is_a_refusal", v.refused,
+          "an unattributable drift must report refused=True")
+
+
+def test_added_code_lines_are_refused_even_at_zero_size_delta() -> None:
+    """RED TEST, hardest form: a semantic change whose bundle SIZE is unchanged.
+
+    Swapping one always-compiled line for another of the same shape leaves the size delta at
+    0 — the same signature a comment insertion has. Size alone therefore cannot be the
+    discriminator, and this test pins that the neutral-tree REBUILD is what refuses it.
+    """
+    changed = _BASE_LIB.replace("x.wrapping_mul(3)", "x.wrapping_mul(5)")
+    v = run_decide(base_files(), base_files(**{"crates/c/src/lib.rs": changed}))
+    check("test_added_code_lines_are_refused_even_at_zero_size_delta",
+          v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
+    check("test_added_code_lines_are_refused_even_at_zero_size_delta__delta_is_zero",
+          v.evidence.get("size_delta_bytes") == 0,
+          "fixture must hold size constant, else it does not test what it claims")
+
+
+def test_deleted_code_lines_are_refused() -> None:
+    """RED TEST: removing always-compiled code must NOT be auto-declared.
+
+    Deleted lines are absent from both the head tree and the additions-neutral tree, so
+    only the base-side deletion obligation can catch this one.
+    """
+    base = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["pub fn doomed(x: u64) -> u64 { x ^ 0xff }"])})
+    v = run_decide(base, base_files())
+    check("test_deleted_code_lines_are_refused",
+          v.outcome == A.REFUSE_DELETED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
+
+
+def test_manifest_change_that_enables_a_feature_is_refused() -> None:
+    """RED TEST: turning a gated arm ON via the manifest is a real default-build change.
+
+    The `.rs` diff can be empty here — only `default = [...]` moved — so the refusal has to
+    come from the neutral tree taking its manifests from BASE.
+    """
+    base = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ['#[cfg(feature = "gated")]',
+                       "pub fn arm(x: u64) -> u64 { x.rotate_left(9) }"])})
+    head = dict(base)
+    head["Cargo.toml"] = _ROOT_MANIFEST.replace('default = ["core"]', 'default = ["core", "gated"]')
+    v = run_decide(base, head)
+    check("test_manifest_change_that_enables_a_feature_is_refused",
+          v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
+
+
+def _scripted_builder(*results):
+    """A builder returning `results` in call order — lets a test drive ONE build to failure
+    while the others succeed, which tree fixtures alone cannot reliably arrange."""
+    seq = list(results)
+
+    def builder(tree):
+        return seq.pop(0) if seq else b"unexpected-extra-build"
+    return builder
+
+
+def test_neutral_build_failure_is_refused() -> None:
+    """A neutral tree that no longer compiles means a blanked addition was load-bearing.
+
+    Driven with a scripted builder: base and head BOTH build, and only the third (neutral)
+    build fails, so this exercises the neutral-build branch specifically rather than
+    tripping the earlier head-build guard.
+    """
+    base = make_tree(base_files())
+    head = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["// added comment"])}))
+    try:
+        v = A.decide(base, head, diff_of(base, head),
+                     _scripted_builder(b"base-bundle", b"head-bundle", None))
+        check("test_neutral_build_failure_is_refused",
+              v.outcome == A.REFUSE_NEUTRAL_BUILD_FAILED, f"got {v.outcome}: {v.reason}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+def test_deletion_neutral_build_failure_is_refused() -> None:
+    """Same, for the base-side deletion obligation's build."""
+    base = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["pub fn doomed(x: u64) -> u64 { x }"])}))
+    head = make_tree(base_files())
+    try:
+        # base, head, neutral(==head so obligation 1 passes), deletion-neutral -> None
+        v = A.decide(base, head, diff_of(base, head),
+                     _scripted_builder(b"base-bundle", b"head-bundle", b"head-bundle", None))
+        check("test_deletion_neutral_build_failure_is_refused",
+              v.outcome == A.REFUSE_DELETION_BUILD_FAILED, f"got {v.outcome}: {v.reason}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+def test_neutral_tree_blanks_the_added_lines() -> None:
+    """The neutral tree handed to the compiler must really have the added lines EMPTIED.
+
+    Pins the blanking call site directly: without it the neutral tree is just the head tree,
+    obligation 1 compares head against head, and every drift would be declared. Asserted by
+    reading the tree the builder is actually given, not by trusting the verdict.
+    """
+    seen: list[str] = []
+    captured: dict[str, str] = {}
+
+    def builder(tree):
+        seen.append(tree)
+        p = os.path.join(tree, "crates/c/src/lib.rs")
+        if len(seen) == 3 and os.path.exists(p):
+            captured["neutral"] = open(p, encoding="utf-8").read()
+        # base and head MUST differ, or `decide` short-circuits on `no-drift` and the
+        # neutral tree is never built (which would make this test vacuous).
+        return b"base-bundle" if len(seen) == 1 else b"head-bundle"
+
+    base = make_tree(base_files())
+    head = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["pub fn added_code(x: u64) -> u64 { x }"])}))
+    try:
+        A.decide(base, head, diff_of(base, head), builder)
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+    neutral = captured.get("neutral", "")
+    check("test_neutral_tree_blanks_the_added_lines",
+          "added_code" not in neutral and neutral.split("\n")[4] == "",
+          "the added line must be an EMPTY line in the neutral tree, got line 5 = "
+          f"{neutral.split(chr(10))[4]!r}")
+    check("test_neutral_tree_blanks_the_added_lines__line_count_preserved",
+          len(neutral.split("\n")) == len(
+              insert_at(_BASE_LIB, 4, ["pub fn added_code(x: u64) -> u64 { x }"]).split("\n")),
+          "blanking must preserve the head tree's line COUNT (that is what holds line "
+          "positions fixed, which is the whole basis of the proof)")
+
+
+def test_unknown_path_type_is_refused() -> None:
+    """A changed path INSIDE the build closure that we cannot model must refuse.
+
+    `closure=None` is the fail-closed shape used when cargo cannot answer: then every path
+    counts as build-relevant, so an unmodelled one has to refuse rather than be waved through.
+    """
+    try:
+        A.classify_paths(["crates/c/build/thing.wasmbin"], None)
+        ok = False
+    except ValueError:
+        ok = True
+    check("test_unknown_path_type_is_refused", ok,
+          "an unmodelled path inside the closure must raise, not be classed inert")
+
+
+def test_paths_outside_the_build_closure_are_inert() -> None:
+    """A change to a crate the bundle does not compile cannot be part of its drift.
+
+    This is what stops unrelated base-branch drift — other crates, research records, bench
+    data — from refusing an otherwise-provable PR.
+    """
+    rust, manifest, inert = A.classify_paths(
+        ["crates/c/src/lib.rs", "crates/other/src/lib.rs", "research/notes.md",
+         "Cargo.lock", "crates/other/README.md"],
+        ["crates/c/"])
+    check("test_paths_outside_the_build_closure_are_inert",
+          rust == ["crates/c/src/lib.rs"] and manifest == ["Cargo.lock"]
+          and sorted(inert) == ["crates/other/README.md", "crates/other/src/lib.rs",
+                                "research/notes.md"],
+          f"got rust={rust} manifest={manifest} inert={inert}")
+
+
+def test_root_build_inputs_are_never_inert() -> None:
+    """Cargo.lock / rust-toolchain / .cargo live outside every crate dir but reach the build."""
+    rust, manifest, inert = A.classify_paths(
+        ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config.toml"],
+        ["crates/c/"])
+    check("test_root_build_inputs_are_never_inert", inert == [] and len(manifest) == 4,
+          f"got manifest={manifest} inert={inert}")
+
+
+def test_base_build_failure_is_refused() -> None:
+    def builder(tree):
+        return None if tree.endswith("base") or "base" in os.path.basename(tree) else b"x"
+    base = make_tree(base_files())
+    head = make_tree(base_files(**{"crates/c/src/lib.rs": _BASE_LIB + "// x\n"}))
+    try:
+        v = A.decide(base, head, diff_of(base, head), lambda t: None)
+        check("test_base_build_failure_is_refused", v.outcome == A.REFUSE_BASE_BUILD_FAILED,
+              f"got {v.outcome}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+def test_head_build_failure_is_refused() -> None:
+    base = make_tree(base_files())
+    head = make_tree(base_files(**{"crates/c/src/lib.rs": _BASE_LIB + "// x\n"}))
+    calls = {"n": 0}
+
+    def builder(tree):
+        calls["n"] += 1
+        return b"base-bundle" if calls["n"] == 1 else None
+    try:
+        v = A.decide(base, head, diff_of(base, head), builder)
+        check("test_head_build_failure_is_refused", v.outcome == A.REFUSE_HEAD_BUILD_FAILED,
+              f"got {v.outcome}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+def test_empty_diff_is_refused() -> None:
+    base = make_tree(base_files())
+    try:
+        v = A.decide(base, base, "", fake_build)
+        check("test_empty_diff_is_refused", v.outcome == A.REFUSE_NO_DIFF, f"got {v.outcome}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level obligations of the helpers the decision leans on.
+# ---------------------------------------------------------------------------
+
+def test_blank_lines_preserves_line_count() -> None:
+    text = "a\nb\nc\nd\n"
+    out = A.blank_lines(text, [2, 3])
+    check("test_blank_lines_preserves_line_count",
+          len(out.split("\n")) == len(text.split("\n")) and out.split("\n")[1] == "",
+          f"got {out!r}")
+
+
+def test_deleted_file_lines_are_attributed() -> None:
+    """A diff that DELETES a file must have its removed lines attributed, not dropped.
+
+    `+++ /dev/null` is the shape that silently loses a whole-file deletion if the parser
+    only keys hunks off the `+++` header.
+    """
+    diff = ("diff --git a/crates/c/src/gone.rs b/crates/c/src/gone.rs\n"
+            "--- a/crates/c/src/gone.rs\n"
+            "+++ /dev/null\n"
+            "@@ -1,2 +0,0 @@\n"
+            "-pub fn gone() {}\n"
+            "-pub fn also() {}\n")
+    parsed = A.parse_unified_diff(diff)
+    check("test_deleted_file_lines_are_attributed",
+          parsed.get("crates/c/src/gone.rs", {}).get("removed") == [1, 2],
+          f"got {parsed}")
+
+
+def test_declaration_records_measured_evidence() -> None:
+    """The written declaration must carry the MEASURED numbers, not a fixed sentence."""
+    head = base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["// a comment"])})
+    v = run_decide(base_files(), head)
+    doc = A.declaration_json(4242, v, date="2026-07-28")
+    ok = (doc["pr"] == 4242 and doc["derived"] is True
+          and str(v.evidence["differing_bytes"]) in doc["reason"]
+          and doc["evidence"]["size_delta_bytes"] == v.evidence["size_delta_bytes"])
+    check("test_declaration_records_measured_evidence", ok, f"got {doc}")
+
+
+def test_census_row_is_emitted_for_every_outcome() -> None:
+    rows = []
+    for v in (A.Verdict(A.OUTCOME_DECLARED, "d", {"size_delta_bytes": 0, "differing_bytes": 3}),
+              A.Verdict(A.REFUSE_ADDED_LINES_ARE_SEMANTIC, "r", {}),
+              A.Verdict(A.OUTCOME_NO_DRIFT, "n", {})):
+        rows.append(A.census_row(1, v))
+    check("test_census_row_is_emitted_for_every_outcome",
+          all(r.startswith("FEATURE-OFF-CENSUS ") and "outcome=" in r for r in rows),
+          f"got {rows}")
+
+
+# ---------------------------------------------------------------------------
+# The fake compiler must itself reproduce the MEASURED real-world signature, otherwise
+# every test above is testing a model that does not resemble rustc.
+# ---------------------------------------------------------------------------
+
+def test_fake_compiler_reproduces_the_measured_signature() -> None:
+    base = make_tree(base_files())
+    shifted = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["// c" + str(i) for i in range(12)])}))
+    grown = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["pub fn extra(x: u64) -> u64 { x }"])}))
+    try:
+        b, s, g = fake_build(base), fake_build(shifted), fake_build(grown)
+        check("test_fake_compiler_reproduces_the_measured_signature__comment_is_zero_delta",
+              len(s) == len(b) and s != b,
+              "a comment insertion must move bytes at delta 0, as MEASURED on sparq-wasm")
+        check("test_fake_compiler_reproduces_the_measured_signature__code_grows",
+              len(g) > len(b),
+              "added compiled code must GROW the artefact, as MEASURED on sparq-wasm")
+    finally:
+        for d in (base, shifted, grown):
+            shutil.rmtree(d, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Census sweep. Membership must be re-derived from the LIVE leg conclusion on each PR's
+# current head, matched by NAME EQUALITY and taking the NEWEST run — a cached or
+# fuzzily-matched classification is how this class silently miscounts.
+# ---------------------------------------------------------------------------
+
+def _sweep(checks_by_pr: dict[int, list[dict]], prs: list[dict] | None = None,
+           declared: set[str] | None = None):
+    prs = prs or [{"number": n, "headRefOid": f"sha{n}", "isDraft": True, "title": "t"}
+                  for n in checks_by_pr]
+    return A.census_sweep(
+        "o/r", declared or set(),
+        pr_lister=lambda repo: prs,
+        check_lister=lambda repo, sha: checks_by_pr[int(sha[3:])],
+    )
+
+
+def _run(name: str, conclusion: str, started: str = "2026-07-28T00:00:00Z",
+         status: str = "completed") -> dict:
+    return {"name": name, "conclusion": conclusion, "status": status, "started_at": started}
+
+
+def test_census_sweep_counts_the_live_class() -> None:
+    rep = _sweep({
+        1: [_run(A.LEG_NAME, "failure")],
+        2: [_run(A.LEG_NAME, "failure")],
+        3: [_run(A.LEG_NAME, "success")],
+        4: [_run("some other check", "failure")],
+    }, declared={"2.json"})
+    ok = (rep["open_prs"] == 4 and rep["in_class_red"] == 2
+          and rep["in_class_already_declared"] == 1 and rep["in_class_undeclared"] == 1
+          and rep["leg_absent"] == 1)
+    check("test_census_sweep_counts_the_live_class", ok, f"got {rep}")
+
+
+def test_census_sweep_matches_leg_name_by_equality() -> None:
+    """A differently-named check that merely CONTAINS the leg name must not be counted."""
+    rep = _sweep({1: [_run(A.LEG_NAME + " (advisory)", "failure")]})
+    check("test_census_sweep_matches_leg_name_by_equality",
+          rep["in_class_red"] == 0 and rep["leg_absent"] == 1, f"got {rep}")
+
+
+def test_census_sweep_uses_the_newest_run_per_name() -> None:
+    """An old red superseded by a newer green must read GREEN, and vice versa.
+
+    Both LIST ORDERS are exercised deliberately. The API does not promise chronological
+    order, so a scan that simply keeps the first (or the last) element it sees agrees with
+    the correct answer on one ordering and disagrees on the other; testing only one ordering
+    would let that bug through.
+    """
+    old_red_new_green = [_run(A.LEG_NAME, "failure", "2026-07-01T00:00:00Z"),
+                         _run(A.LEG_NAME, "success", "2026-07-28T00:00:00Z")]
+    old_green_new_red = [_run(A.LEG_NAME, "success", "2026-07-01T00:00:00Z"),
+                         _run(A.LEG_NAME, "failure", "2026-07-28T00:00:00Z")]
+    cases = [
+        ("old-red/new-green, chronological", old_red_new_green, 0),
+        ("old-red/new-green, reversed", list(reversed(old_red_new_green)), 0),
+        ("old-green/new-red, chronological", old_green_new_red, 1),
+        ("old-green/new-red, reversed", list(reversed(old_green_new_red)), 1),
+    ]
+    for label, runs, want in cases:
+        got = _sweep({1: runs})["in_class_red"]
+        check("test_census_sweep_uses_the_newest_run_per_name",
+              got == want, f"{label}: expected in_class_red={want}, got {got}")
+
+
+def test_prebuilt_bundles_do_not_skip_the_neutral_proof() -> None:
+    """Handing in already-built base/head bundles must NOT short-circuit the obligations.
+
+    The leg-2 job passes the two bundles it already built; if that path ever stopped
+    rebuilding the neutral tree, every drift would be auto-declared.
+    """
+    base = make_tree(base_files())
+    head = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(
+        _BASE_LIB, 4, ["pub fn leaked(x: u64) -> u64 { x }"])}))
+    try:
+        v = A.decide(base, head, diff_of(base, head), fake_build,
+                     base_bytes=b"prebuilt-base", head_bytes=b"prebuilt-head")
+        check("test_prebuilt_bundles_do_not_skip_the_neutral_proof",
+              v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# WORKFLOW WIRING. A YAML `if:` cannot be executed here, so its SHAPE is pinned — and the
+# mutation matrix below deletes the `if:`, the STEP and the CALL SITE (`id: leg2`)
+# separately, because a derivation that is wired to a step id nobody sets never runs and
+# fails silently.
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.dirname(_SCRIPTS)
+_WORKFLOW_PATH = os.path.join(_REPO_ROOT, ".github", "workflows", "vectorized-feature-off.yml")
+
+
+def workflow_text() -> str:
+    with open(_WORKFLOW_PATH, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _step_block(text: str, name_fragment: str) -> str:
+    """The YAML block of the step whose `- name:` contains `name_fragment` (or "" if absent).
+
+    COMMENT lines are stripped: a `#` line sitting between two steps belongs to the earlier
+    block textually, so leaving them in would let a comment that merely MENTIONS a key
+    satisfy an assertion about that key being set.
+    """
+    for s in re.split(r"\n      - ", text):
+        if s.startswith("name:") and name_fragment in s.split("\n")[0]:
+            return "\n".join(l for l in s.split("\n") if not l.lstrip().startswith("#"))
+    return ""
+
+
+def test_workflow_wires_the_derivation_step() -> None:
+    block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
+    check("test_workflow_wires_the_derivation_step",
+          bool(block) and "scripts/feature_off_autodeclare.py" in block
+          and "--report-only" in block,
+          "the artifact-exact-equality job must invoke the derivation in report-only mode")
+
+
+def test_derivation_step_runs_only_when_leg2_failed() -> None:
+    block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
+    check("test_derivation_step_runs_only_when_leg2_failed",
+          "steps.leg2.outcome == 'failure'" in block,
+          "the derivation must be gated on leg 2 having FAILED, else it burns a wasm build "
+          "on every green PR")
+
+
+def test_leg2_step_has_the_id_the_derivation_depends_on() -> None:
+    """CALL SITE: `steps.leg2.outcome` is empty unless leg 2 carries `id: leg2`.
+
+    Without the id the guard above is never true and the derivation silently never runs —
+    a dead step that still looks wired.
+    """
+    block = _step_block(workflow_text(), "Leg 2 — dynamic byte-identity")
+    check("test_leg2_step_has_the_id_the_derivation_depends_on",
+          re.search(r"^\s*id:\s*leg2\s*$", block, re.M) is not None,
+          "leg 2 must carry `id: leg2` for the derivation's guard to ever evaluate true")
+
+
+def test_derivation_cannot_change_the_leg2_verdict() -> None:
+    """The derivation is advisory: it may not soften leg 2, and leg 2 may not be tolerant."""
+    text = workflow_text()
+    leg2 = _step_block(text, "Leg 2 — dynamic byte-identity")
+    deriv = _step_block(text, "Derive the feature-OFF declaration")
+    check("test_derivation_cannot_change_the_leg2_verdict",
+          "continue-on-error" not in leg2 and "continue-on-error: true" in deriv,
+          "leg 2 must stay strict and the derivation must not add a second red")
+    check("test_derivation_cannot_change_the_leg2_verdict__runs_after_leg2",
+          text.index("Derive the feature-OFF declaration") > text.index("Leg 2 — dynamic"),
+          "the derivation must run after leg 2, not before it")
+
+
+def test_derivation_suite_is_run_in_ci() -> None:
+    """The derivation's own mutation matrix must run in CI, or it can rot into a stamp."""
+    block = _step_block(workflow_text(), "Tripwire self-test (the declaration derivation")
+    check("test_derivation_suite_is_run_in_ci",
+          "scripts/tests/test_feature_off_autodeclare.py --mutate" in block,
+          "CI must run the derivation suite WITH --mutate")
+
+
+def test_paths_filter_includes_the_new_scripts() -> None:
+    """Editing the derivation must re-run the leg, in BOTH of the workflow's filter blocks."""
+    text = workflow_text()
+    check("test_paths_filter_includes_the_new_scripts",
+          text.count("- 'scripts/feature_off_autodeclare.py'") == 2
+          and text.count("- 'scripts/tests/test_feature_off_autodeclare.py'") == 2,
+          "both paths-filter blocks must list the derivation script and its suite")
+
+
+TESTS = [
+    test_workflow_wires_the_derivation_step,
+    test_derivation_step_runs_only_when_leg2_failed,
+    test_leg2_step_has_the_id_the_derivation_depends_on,
+    test_derivation_cannot_change_the_leg2_verdict,
+    test_derivation_suite_is_run_in_ci,
+    test_paths_filter_includes_the_new_scripts,
+    test_census_sweep_counts_the_live_class,
+    test_census_sweep_matches_leg_name_by_equality,
+    test_census_sweep_uses_the_newest_run_per_name,
+    test_prebuilt_bundles_do_not_skip_the_neutral_proof,
+    test_comment_only_drift_is_declared,
+    test_inactive_cfg_item_drift_is_declared,
+    test_comment_deletion_is_declared,
+    test_identical_bundles_need_no_declaration,
+    test_added_code_lines_are_refused,
+    test_added_code_lines_are_refused_even_at_zero_size_delta,
+    test_deleted_code_lines_are_refused,
+    test_manifest_change_that_enables_a_feature_is_refused,
+    test_neutral_build_failure_is_refused,
+    test_deletion_neutral_build_failure_is_refused,
+    test_neutral_tree_blanks_the_added_lines,
+    test_unknown_path_type_is_refused,
+    test_paths_outside_the_build_closure_are_inert,
+    test_root_build_inputs_are_never_inert,
+    test_base_build_failure_is_refused,
+    test_head_build_failure_is_refused,
+    test_empty_diff_is_refused,
+    test_blank_lines_preserves_line_count,
+    test_deleted_file_lines_are_attributed,
+    test_declaration_records_measured_evidence,
+    test_census_row_is_emitted_for_every_outcome,
+    test_fake_compiler_reproduces_the_measured_signature,
+]
+
+
+def run_suite() -> list[str]:
+    global _FAILURES, _RUN
+    _FAILURES, _RUN = [], []
+    for t in TESTS:
+        try:
+            t()
+        except Exception as exc:  # a raising test is a failing test
+            _FAILURES.append(f"{t.__name__}: raised {type(exc).__name__}: {exc}")
+    return list(_FAILURES)
+
+
+# ---------------------------------------------------------------------------
+# Mutation harness: one call site at a time, each naming the test that must catch it.
+# ---------------------------------------------------------------------------
+
+# (mutant id, description, source substring -> replacement, the NAMED test that must go red)
+MUTANTS = [
+    ("M1-drop-added-lines-proof",
+     "never compare the additions-neutral bundle to the head bundle",
+     "    if neutral_bytes != head_bytes:", "    if False:",
+     "test_added_code_lines_are_refused"),
+    ("M2-drop-deleted-lines-proof",
+     "never compare the deletions-neutral bundle to the base bundle",
+     "        if del_bytes != base_bytes:", "        if False:",
+     "test_deleted_code_lines_are_refused"),
+    ("M3-skip-blanking-added-lines",
+     "build the neutral tree without blanking anything",
+     "            fh.write(blank_lines(text, added))", "            fh.write(text)",
+     "test_neutral_tree_blanks_the_added_lines"),
+    ("M4-keep-head-manifests",
+     "do not restore the base tree's manifests into the neutral tree",
+     "            shutil.copyfile(src, dst)", "            pass",
+     "test_manifest_change_that_enables_a_feature_is_refused"),
+    ("M5-accept-unknown-paths",
+     "treat an unmodelled path inside the build closure as inert",
+     "        raise ValueError(", "        _unused = (",
+     "test_unknown_path_type_is_refused"),
+    ("M5b-everything-is-in-closure",
+     "treat every changed path as build-relevant, so unrelated crates refuse the PR",
+     "        in_closure = closure is None or root_input or any(p.startswith(d) for d in closure)",
+     "        in_closure = True",
+     "test_paths_outside_the_build_closure_are_inert"),
+    ("M5c-root-inputs-fall-outside",
+     "forget that Cargo.lock / rust-toolchain / .cargo reach every build",
+     '        root_input = p in _ROOT_BUILD_INPUTS or p.startswith(".cargo/")',
+     "        root_input = False",
+     "test_root_build_inputs_are_never_inert"),
+    ("M6-ignore-neutral-build-failure",
+     "treat a neutral tree that fails to build as a pass",
+     "    if neutral_bytes is None:", "    if False:",
+     "test_neutral_build_failure_is_refused"),
+    ("M7-drop-deleted-file-attribution",
+     "drop hunks whose new-side is /dev/null (whole-file deletions)",
+     "                path = old_path", "                path = None",
+     "test_deleted_file_lines_are_attributed"),
+    ("M8-blank-lines-drops-lines",
+     "make blanking DELETE lines instead of emptying them (breaks position preservation)",
+     '            lines[n - 1] = ""', "            lines[n - 1] = None  # type: ignore",
+     "test_blank_lines_preserves_line_count"),
+    ("M10-ignore-deletion-build-failure",
+     "treat a deletion-neutral tree that fails to build as a pass",
+     "        if del_bytes is None:", "        if False:",
+     "test_deletion_neutral_build_failure_is_refused"),
+    ("M11-census-substring-match",
+     "match the leg by substring instead of by name equality",
+     '            if c["name"] != LEG_NAME:', '            if LEG_NAME not in c["name"]:',
+     "test_census_sweep_matches_leg_name_by_equality"),
+    ("M12-census-first-run-wins",
+     "keep the FIRST check run for a name instead of the newest",
+     '            if leg is None or (c.get("started_at") or "") >= (leg.get("started_at") or ""):',
+     "            if leg is None:",
+     "test_census_sweep_uses_the_newest_run_per_name"),
+    ("M12b-census-last-run-wins",
+     "keep the LAST check run for a name regardless of its timestamp",
+     '            if leg is None or (c.get("started_at") or "") >= (leg.get("started_at") or ""):',
+     "            if True:",
+     "test_census_sweep_uses_the_newest_run_per_name"),
+    ("M13-prebuilt-skips-neutral-proof",
+     "reuse the head bundle as the neutral bundle instead of rebuilding",
+     "    neutral_bytes = builder(neutral)", "    neutral_bytes = head_bytes",
+     "test_prebuilt_bundles_do_not_skip_the_neutral_proof"),
+    ("M9-ignore-base-build-failure",
+     "treat a base tree that fails to build as an empty bundle",
+     "    if base_bytes is None:\n        return Verdict(REFUSE_BASE_BUILD_FAILED",
+     "    if base_bytes is None:\n        base_bytes = b''\n    if False:\n        return Verdict(REFUSE_BASE_BUILD_FAILED",
+     "test_base_build_failure_is_refused"),
+]
+
+
+# YAML mutants. "Ask the deletion question of the YAML": delete the `if:`, delete the STEP,
+# and delete the CALL SITE the guard reads — each must red its own named check.
+_DERIV_IF = ("        if: always() && steps.changes.outputs.rust_changed == 'true'\n"
+             "          && steps.leg2.outcome == 'failure' && github.event_name == 'pull_request'\n")
+
+YAML_MUTANTS = [
+    ("Y1-drop-leg2-id",
+     "remove `id: leg2`, so the derivation's guard can never be true",
+     "        id: leg2\n", "",
+     "test_leg2_step_has_the_id_the_derivation_depends_on"),
+    ("Y2-drop-derivation-if",
+     "remove the leg2-failed guard, so the derivation burns a build on every PR",
+     _DERIV_IF, "        if: always()\n",
+     "test_derivation_step_runs_only_when_leg2_failed"),
+    ("Y3-drop-derivation-call",
+     "stop invoking the derivation script",
+     "          python3 scripts/feature_off_autodeclare.py \\\n", "          true \\\n",
+     "test_workflow_wires_the_derivation_step"),
+    ("Y4-drop-mutation-tripwire",
+     "run the derivation suite without its mutation matrix",
+     "scripts/tests/test_feature_off_autodeclare.py --mutate",
+     "scripts/tests/test_feature_off_autodeclare.py",
+     "test_derivation_suite_is_run_in_ci"),
+    ("Y5-drop-paths-filter-entry",
+     "stop re-running the leg when the derivation script itself changes",
+     "              - 'scripts/feature_off_autodeclare.py'\n", "",
+     "test_paths_filter_includes_the_new_scripts"),
+    ("Y6-make-leg2-tolerant",
+     "let leg 2 itself continue-on-error, which would silently un-gate the whole leg",
+     "      - name: Leg 2 — dynamic byte-identity (base tree vs head tree)\n        id: leg2\n",
+     "      - name: Leg 2 — dynamic byte-identity (base tree vs head tree)\n        id: leg2\n"
+     "        continue-on-error: true\n",
+     "test_derivation_cannot_change_the_leg2_verdict"),
+]
+
+
+def _report(mid: str, named: str, fails: list[str], desc: str) -> bool:
+    failed_names = {f.split(":")[0].split("__")[0] for f in fails}
+    if named in failed_names:
+        others = sorted(failed_names - {named})
+        extra = f" (+{len(others)} other)" if others else ""
+        print(f"{mid:33} {named:58} KILLED{extra}")
+        return True
+    print(f"{mid:33} {named:58} SURVIVED  <-- {desc}")
+    return False
+
+
+def run_mutation_matrix() -> int:
+    global A, _WORKFLOW_PATH
+    src = open(_MODULE_PATH, encoding="utf-8").read()
+    wf_src = workflow_text()
+    wf_original = _WORKFLOW_PATH
+    print("\n=== mutation table (one call site per row) ===")
+    print(f"{'mutant':33} {'named check that must go red':58} result")
+    bad = 0
+    original = A
+    for mid, desc, old, new, named in MUTANTS:
+        if old not in src:
+            print(f"{mid:33} {named:58} ANCHOR-MISSING")
+            bad += 1
+            continue
+        tmp = tempfile.mkdtemp(prefix="featoff-mut-")
+        mpath = os.path.join(tmp, "feature_off_autodeclare.py")
+        with open(mpath, "w", encoding="utf-8") as fh:
+            fh.write(src.replace(old, new, 1))
+        try:
+            A = _load(mpath)
+            fails = run_suite()
+        except Exception as exc:
+            fails = [f"module-load: {exc}"]
+        finally:
+            A = original
+            shutil.rmtree(tmp, ignore_errors=True)
+        bad += 0 if _report(mid, named, fails, desc) else 1
+
+    for mid, desc, old, new, named in YAML_MUTANTS:
+        if old not in wf_src:
+            print(f"{mid:33} {named:58} ANCHOR-MISSING")
+            bad += 1
+            continue
+        tmp = tempfile.mkdtemp(prefix="featoff-wfmut-")
+        wpath = os.path.join(tmp, "vectorized-feature-off.yml")
+        with open(wpath, "w", encoding="utf-8") as fh:
+            fh.write(wf_src.replace(old, new, 1))
+        try:
+            _WORKFLOW_PATH = wpath
+            fails = run_suite()
+        finally:
+            _WORKFLOW_PATH = wf_original
+            shutil.rmtree(tmp, ignore_errors=True)
+        bad += 0 if _report(mid, named, fails, desc) else 1
+
+    # Restore the pristine module for any later use.
+    A = _load()
+    return bad
+
+
+def main() -> int:
+    fails = run_suite()
+    print(f"ran {len(set(n.split('__')[0] for n in _RUN))} named checks "
+          f"({len(_RUN)} assertions) over {len(TESTS)} tests")
+    for f in fails:
+        print("FAIL " + f)
+    rc = 1 if fails else 0
+    if "--mutate" in sys.argv:
+        if rc:
+            print("refusing to run the mutation matrix on a red suite")
+            return rc
+        bad = run_mutation_matrix()
+        if bad:
+            print(f"\n{bad} mutant(s) SURVIVED — the suite does not pin those call sites")
+            rc = 1
+        else:
+            print(f"\nall {len(MUTANTS) + len(YAML_MUTANTS)} mutants killed by their named check")
+    if rc == 0:
+        print("OK")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_feature_off_autodeclare.py
+++ b/scripts/tests/test_feature_off_autodeclare.py
@@ -724,6 +724,56 @@ def test_derivation_suite_is_run_in_ci() -> None:
           "CI must run the derivation suite WITH --mutate")
 
 
+def test_derivation_target_dir_is_off_the_cached_workspace_target() -> None:
+    """The extra builds must NOT write into the `target/` Swatinem caches for this job.
+
+    Sharing it would make the neutral tree's artefacts part of the head build's cache entry,
+    poisoning every later PR that restores that key.
+    """
+    block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
+    m = re.search(r"CARGO_TARGET_DIR:\s*(\S.*)$", block, re.M)
+    check("test_derivation_target_dir_is_off_the_cached_workspace_target",
+          m is not None and "runner.temp" in m.group(1),
+          f"expected a runner.temp path, got {m.group(1) if m else '<unset>'}")
+
+
+def test_builder_honours_the_shared_target_dir() -> None:
+    """`cargo_wasm_builder` must read the bundle from CARGO_TARGET_DIR when it is set.
+
+    If it kept looking under `<tree>/target` it would find nothing there, return None, and
+    every derivation would refuse with `neutral-build-failed` — a silent all-refuse that
+    still looks like the tool is working. Exercised BEHAVIOURALLY with a stubbed cargo, so
+    the assertion cannot pass just because the source happens to mention the variable.
+    """
+    tree = tempfile.mkdtemp(prefix="featoff-tgt-")
+    shared = tempfile.mkdtemp(prefix="featoff-shared-target-")
+    out = os.path.join(shared, "wasm32-unknown-unknown", "release-wasm")
+    os.makedirs(out)
+    with open(os.path.join(out, "sparq_wasm.wasm"), "wb") as fh:
+        fh.write(b"bundle-from-the-shared-target-dir")
+
+    class _Ok:
+        returncode = 0
+        stderr = b""
+
+    real_run, real_env = A.subprocess.run, os.environ.get("CARGO_TARGET_DIR")
+    try:
+        A.subprocess.run = lambda *a, **k: _Ok()
+        os.environ["CARGO_TARGET_DIR"] = shared
+        got = A.cargo_wasm_builder(tree)
+    finally:
+        A.subprocess.run = real_run
+        if real_env is None:
+            os.environ.pop("CARGO_TARGET_DIR", None)
+        else:
+            os.environ["CARGO_TARGET_DIR"] = real_env
+        shutil.rmtree(tree, ignore_errors=True)
+        shutil.rmtree(shared, ignore_errors=True)
+    check("test_builder_honours_the_shared_target_dir",
+          got == b"bundle-from-the-shared-target-dir",
+          f"expected the bundle from CARGO_TARGET_DIR, got {got!r}")
+
+
 def test_paths_filter_includes_the_new_scripts() -> None:
     """Editing the derivation must re-run the leg, in BOTH of the workflow's filter blocks."""
     text = workflow_text()
@@ -739,6 +789,8 @@ TESTS = [
     test_leg2_step_has_the_id_the_derivation_depends_on,
     test_derivation_cannot_change_the_leg2_verdict,
     test_derivation_suite_is_run_in_ci,
+    test_derivation_target_dir_is_off_the_cached_workspace_target,
+    test_builder_honours_the_shared_target_dir,
     test_paths_filter_includes_the_new_scripts,
     test_census_sweep_counts_the_live_class,
     test_census_sweep_matches_leg_name_by_equality,
@@ -846,6 +898,11 @@ MUTANTS = [
      '            if leg is None or (c.get("started_at") or "") >= (leg.get("started_at") or ""):',
      "            if True:",
      "test_census_sweep_uses_the_newest_run_per_name"),
+    ("M14-builder-ignores-shared-target-dir",
+     "look for the bundle under <tree>/target even when CARGO_TARGET_DIR is set",
+     '    target_root = os.environ.get("CARGO_TARGET_DIR") or os.path.join(tree, "target")',
+     '    target_root = os.path.join(tree, "target")',
+     "test_builder_honours_the_shared_target_dir"),
     ("M13-prebuilt-skips-neutral-proof",
      "reuse the head bundle as the neutral bundle instead of rebuilding",
      "    neutral_bytes = builder(neutral)", "    neutral_bytes = head_bytes",
@@ -881,6 +938,11 @@ YAML_MUTANTS = [
      "scripts/tests/test_feature_off_autodeclare.py --mutate",
      "scripts/tests/test_feature_off_autodeclare.py",
      "test_derivation_suite_is_run_in_ci"),
+    ("Y7-share-the-cached-target-dir",
+     "point the derivation's builds at the workspace target/ Swatinem caches",
+     "          CARGO_TARGET_DIR: ${{ runner.temp }}/featoff-derivation-target",
+     "          CARGO_TARGET_DIR: target",
+     "test_derivation_target_dir_is_off_the_cached_workspace_target"),
     ("Y5-drop-paths-filter-entry",
      "stop re-running the leg when the derivation script itself changes",
      "              - 'scripts/feature_off_autodeclare.py'\n", "",

--- a/scripts/tests/test_feature_off_autodeclare.py
+++ b/scripts/tests/test_feature_off_autodeclare.py
@@ -33,6 +33,7 @@ Usage:
 from __future__ import annotations
 
 import hashlib
+import json
 import importlib.util as _ilu
 import os
 import re
@@ -456,31 +457,133 @@ def test_symlink_inside_the_closure_is_refused() -> None:
         shutil.rmtree(head, ignore_errors=True)
 
 
-def test_paths_outside_the_build_closure_are_inert() -> None:
-    """A change to a crate the bundle does not compile cannot be part of its drift.
+def test_out_of_closure_semantic_change_is_refused() -> None:
+    """RED TEST: a real code change in a path the closure query MISSES must still refuse.
 
-    This is what stops unrelated base-branch drift — other crates, research records, bench
-    data — from refusing an otherwise-provable PR.
+    This is the live false pass this tool shipped with. sparq's root manifest carries
+    `exclude = ["vendor/spargebra", ...]` together with `[patch.crates-io] spargebra =
+    { path = "vendor/spargebra" }`, so spargebra IS compiled into the feature-OFF bundle
+    while NOT being a workspace member. Blanking was scoped to a closure derived from
+    `cargo metadata --no-deps` — workspace members only — so a change under `vendor/`
+    was never blanked and `neutral == head` held BY CONSTRUCTION.
+
+    The fixture deliberately hands `decide` a closure that does NOT contain the changed
+    crate, which is exactly the failure mode. The refusal must not depend on the closure
+    being right — that is the whole point of blanking every changed non-manifest path.
     """
-    blankable, manifest, inert = A.classify_paths(
-        ["crates/c/src/lib.rs", "crates/c/README.md", "crates/other/src/lib.rs",
-         "research/notes.md", "Cargo.lock", "crates/other/README.md"],
+    real_closure = A.closure_dirs
+    A.closure_dirs = lambda tree, package="sparq-wasm": ["crates/c/"]  # deliberately WRONG
+    try:
+        base = base_files(**{"vendor/vend/src/lib.rs": _BASE_LIB})
+        head = base_files(**{"vendor/vend/src/lib.rs": insert_at(
+            _BASE_LIB, 4, ["pub fn smuggled(x: u64) -> u64 { x.rotate_right(3) }"])})
+        v = run_decide(base, head)
+    finally:
+        A.closure_dirs = real_closure
+    check("test_out_of_closure_semantic_change_is_refused",
+          v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
+
+
+def test_vacuous_proof_is_refused() -> None:
+    """RED TEST: if the neutral tree equals the head tree, the proof is `head == head`.
+
+    The general form of the bug above: whenever the bundle moved but NOTHING the proof
+    covers was blanked, the drift came from somewhere the proof does not reach. This guard
+    catches it without anyone having to know which path class was missed.
+    """
+    base = make_tree(base_files())
+    head = make_tree(base_files())
+    # A changed path that exists in NEITHER tree: the diff is real, but there is nothing on
+    # disk to blank, so the neutral tree comes out identical to the head tree.
+    diff = ("diff --git a/crates/c/src/ghost.rs b/crates/c/src/ghost.rs\n"
+            "--- a/crates/c/src/ghost.rs\n"
+            "+++ b/crates/c/src/ghost.rs\n"
+            "@@ -0,0 +1 @@\n"
+            "+pub fn ghost() {}\n")
+    try:
+        v = A.decide(base, head, diff, _scripted_builder(b"base-bundle", b"head-bundle"))
+        check("test_vacuous_proof_is_refused", v.outcome == A.REFUSE_VACUOUS_PROOF,
+              f"got {v.outcome}: {v.reason}")
+        check("test_vacuous_proof_is_refused__names_the_paths",
+              "ghost.rs" in v.reason,
+              "the refusal must name where the unexplained diff actually was")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
+def test_closure_query_includes_patched_out_of_workspace_crates() -> None:
+    """`cargo metadata --no-deps` returns WORKSPACE MEMBERS ONLY — the wrong instrument.
+
+    A crate reached through `[patch.crates-io]` from an `exclude`d path is compiled into
+    the bundle but is not a member, so `--no-deps` silently drops it. Pins both halves:
+    the flag is absent from the query, and such a package's directory comes back.
+    """
+    tree = tempfile.mkdtemp(prefix="featoff-closure-")
+    os.makedirs(os.path.join(tree, "vendor/spargebra"))
+    argvs: list[list[str]] = []
+
+    class _R:
+        returncode = 0
+        stderr = ""
+
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def _stub(argv, **k):
+        argvs.append(argv)
+        if argv[1] == "tree":
+            return _R("sparq-wasm v0.1.0\nspargebra v0.4.6\nserde v1.0.0\n")
+        return _R(json.dumps({"packages": [
+            {"name": "spargebra",
+             "manifest_path": os.path.join(tree, "vendor/spargebra/Cargo.toml")},
+            {"name": "serde", "manifest_path": "/home/u/.cargo/registry/serde/Cargo.toml"},
+        ]}))
+
+    real = A.subprocess.run
+    try:
+        A.subprocess.run = _stub
+        got = A.closure_dirs(tree)
+    finally:
+        A.subprocess.run = real
+        shutil.rmtree(tree, ignore_errors=True)
+    meta_argv = next((a for a in argvs if a[1] == "metadata"), [])
+    check("test_closure_query_includes_patched_out_of_workspace_crates",
+          got == ["vendor/spargebra/"],
+          f"expected the patched vendored crate's dir, got {got}")
+    check("test_closure_query_includes_patched_out_of_workspace_crates__no_no_deps",
+          "--no-deps" not in meta_argv,
+          "cargo metadata must NOT use --no-deps (it hides patched non-member crates)")
+
+
+def test_every_changed_non_manifest_path_is_blanked() -> None:
+    """Nothing is skipped: a path the closure omits is still covered by the proof."""
+    blankable, manifest, in_closure = A.classify_paths(
+        ["crates/c/src/lib.rs", "vendor/vend/src/lib.rs", "research/notes.md", "Cargo.lock"],
         ["crates/c/"])
-    check("test_paths_outside_the_build_closure_are_inert",
-          sorted(blankable) == ["crates/c/README.md", "crates/c/src/lib.rs"]
-          and manifest == ["Cargo.lock"]
-          and sorted(inert) == ["crates/other/README.md", "crates/other/src/lib.rs",
-                                "research/notes.md"],
-          f"got blankable={blankable} manifest={manifest} inert={inert}")
+    check("test_every_changed_non_manifest_path_is_blanked",
+          sorted(blankable) == ["crates/c/src/lib.rs", "research/notes.md",
+                                "vendor/vend/src/lib.rs"]
+          and manifest == ["Cargo.lock"],
+          f"got blankable={blankable} manifest={manifest}")
+    check("test_every_changed_non_manifest_path_is_blanked__closure_is_report_only",
+          in_closure == ["crates/c/src/lib.rs", "Cargo.lock"],
+          f"the closure list is evidence only, got {in_closure}")
 
 
-def test_root_build_inputs_are_never_inert() -> None:
-    """Cargo.lock / rust-toolchain / .cargo live outside every crate dir but reach the build."""
-    rust, manifest, inert = A.classify_paths(
+def test_root_build_inputs_are_restored_from_base() -> None:
+    """Cargo.lock / rust-toolchain / .cargo live outside every crate dir but reach the build.
+
+    They must land in the MANIFEST bucket (restored wholesale from the base tree), never in
+    the blankable one — blanking a line out of a lockfile yields a corrupt lockfile, not an
+    absence — and they are always reported as part of the compiled closure.
+    """
+    blankable, manifest, in_closure = A.classify_paths(
         ["Cargo.toml", "Cargo.lock", "rust-toolchain.toml", ".cargo/config.toml"],
         ["crates/c/"])
-    check("test_root_build_inputs_are_never_inert", inert == [] and len(manifest) == 4,
-          f"got manifest={manifest} inert={inert}")
+    check("test_root_build_inputs_are_restored_from_base",
+          blankable == [] and len(manifest) == 4 and len(in_closure) == 4,
+          f"got blankable={blankable} manifest={manifest} in_closure={in_closure}")
 
 
 def test_base_build_failure_is_refused() -> None:
@@ -722,6 +825,57 @@ def test_workflow_wires_the_derivation_step() -> None:
           "the artifact-exact-equality job must invoke the derivation in report-only mode")
 
 
+def test_derivation_if_carries_always() -> None:
+    """`always()` is load-bearing on the derivation's `if:`.
+
+    Without it the step inherits the implicit `success()`, which is false once leg 2 has
+    failed — so the derivation would be skipped EXACTLY when it is needed and would never
+    run in production. It fails safe, which is precisely why nothing else would go red.
+    """
+    block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
+    check("test_derivation_if_carries_always", re.search(r"if:\s*always\(\)", block) is not None,
+          "the derivation's `if:` must start with always(), or it never runs on a failed leg 2")
+
+
+def test_mutation_tripwire_runs_when_leg2_fails() -> None:
+    """The `--mutate` matrix must run on the population the derivation serves.
+
+    Same trap as above: without `always()` the tripwire only ever runs on PRs where leg 2
+    is already GREEN — i.e. never on a failing PR, which is the only population where the
+    derivation does anything. It would be guarding an empty set.
+    """
+    block = _step_block(workflow_text(), "Tripwire self-test (the declaration derivation")
+    check("test_mutation_tripwire_runs_when_leg2_fails",
+          re.search(r"if:\s*always\(\)", block) is not None,
+          "the derivation tripwire's `if:` must carry always()")
+
+
+def test_ci_invocation_is_report_only() -> None:
+    """CI must never pass `--write`.
+
+    `--write` puts the declaration into the working tree. In a job that has the repo
+    checked out this is the first step towards a gate that declares for you; the whole
+    containment argument is that CI only ever REPORTS and a human commits.
+    """
+    block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
+    check("test_ci_invocation_is_report_only",
+          "--report-only" in block and "--write" not in block,
+          "the CI invocation must be --report-only and must not pass --write")
+
+
+def test_ci_passes_the_bundles_in_the_right_order() -> None:
+    """`--base-wasm` must get the BASE bundle and `--head-wasm` the HEAD one.
+
+    Swapping them silently inverts the comparison: the reported size delta flips sign and
+    the prebuilt bundles no longer correspond to the trees the obligations rebuild.
+    """
+    block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
+    ok = ("--base-wasm base-wasm/base.wasm" in block
+          and "--head-wasm head.wasm" in block)
+    check("test_ci_passes_the_bundles_in_the_right_order", ok,
+          "expected --base-wasm base-wasm/base.wasm and --head-wasm head.wasm")
+
+
 def test_derivation_step_runs_only_when_leg2_failed() -> None:
     block = _step_block(workflow_text(), "Derive the feature-OFF declaration")
     check("test_derivation_step_runs_only_when_leg2_failed",
@@ -841,6 +995,10 @@ def test_paths_filter_includes_the_new_scripts() -> None:
 TESTS = [
     test_workflow_wires_the_derivation_step,
     test_derivation_step_runs_only_when_leg2_failed,
+    test_derivation_if_carries_always,
+    test_mutation_tripwire_runs_when_leg2_fails,
+    test_ci_invocation_is_report_only,
+    test_ci_passes_the_bundles_in_the_right_order,
     test_leg2_step_has_the_id_the_derivation_depends_on,
     test_derivation_cannot_change_the_leg2_verdict,
     test_derivation_suite_is_run_in_ci,
@@ -863,10 +1021,13 @@ TESTS = [
     test_deletion_neutral_build_failure_is_refused,
     test_neutral_tree_blanks_the_added_lines,
     test_non_rust_file_inside_the_closure_is_blanked_not_refused,
+    test_out_of_closure_semantic_change_is_refused,
+    test_vacuous_proof_is_refused,
+    test_closure_query_includes_patched_out_of_workspace_crates,
+    test_every_changed_non_manifest_path_is_blanked,
     test_included_non_rust_file_is_refused,
     test_symlink_inside_the_closure_is_refused,
-    test_paths_outside_the_build_closure_are_inert,
-    test_root_build_inputs_are_never_inert,
+    test_root_build_inputs_are_restored_from_base,
     test_base_build_failure_is_refused,
     test_head_build_failure_is_refused,
     test_empty_diff_is_refused,
@@ -905,7 +1066,7 @@ MUTANTS = [
      "test_deleted_code_lines_are_refused"),
     ("M3-skip-blanking-added-lines",
      "build the neutral tree without blanking anything",
-     "            fh.write(blank_lines(text, added))", "            fh.write(text)",
+     "            fh.write(blanked)", "            fh.write(text)",
      "test_neutral_tree_blanks_the_added_lines"),
     ("M4-keep-head-manifests",
      "do not restore the base tree's manifests into the neutral tree",
@@ -920,16 +1081,26 @@ MUTANTS = [
      "        else:\n            blankable.append(p)",
      "        elif _is_rust(p):\n            blankable.append(p)\n        else:\n            inert.append(p)",
      "test_included_non_rust_file_is_refused"),
-    ("M5b-everything-is-in-closure",
-     "treat every changed path as build-relevant, so unrelated crates refuse the PR",
-     "        in_closure = closure is None or root_input or any(p.startswith(d) for d in closure)",
-     "        in_closure = True",
-     "test_paths_outside_the_build_closure_are_inert"),
+    ("M5e-scope-blanking-to-the-closure",
+     "only blank paths inside the derived closure, reinstating the vendored false pass",
+     "        if _is_manifest(p) or root_input:\n            manifest.append(p)\n        else:\n            blankable.append(p)",
+     "        if _is_manifest(p) or root_input:\n            manifest.append(p)\n"
+     "        elif closure is None or any(p.startswith(d) for d in closure):\n            blankable.append(p)",
+     "test_out_of_closure_semantic_change_is_refused"),
+    ("M5f-drop-the-non-vacuity-guard",
+     "declare even when the neutral tree is identical to the head tree",
+     "    if not mutated and not to_blank:", "    if False:",
+     "test_vacuous_proof_is_refused"),
+    ("M5g-closure-query-uses-no-deps",
+     "ask cargo metadata --no-deps, hiding patched non-member crates",
+     '            ["cargo", "metadata", "--format-version", "1"],',
+     '            ["cargo", "metadata", "--format-version", "1", "--no-deps"],',
+     "test_closure_query_includes_patched_out_of_workspace_crates"),
     ("M5c-root-inputs-fall-outside",
      "forget that Cargo.lock / rust-toolchain / .cargo reach every build",
      '        root_input = p in _ROOT_BUILD_INPUTS or p.startswith(".cargo/")',
      "        root_input = False",
-     "test_root_build_inputs_are_never_inert"),
+     "test_root_build_inputs_are_restored_from_base"),
     ("M6-ignore-neutral-build-failure",
      "treat a neutral tree that fails to build as a pass",
      "    if neutral_bytes is None:", "    if False:",
@@ -1006,6 +1177,30 @@ YAML_MUTANTS = [
      "          PR_NUMBER: ${{ github.event.pull_request.number }}\n"
      "          CARGO_TARGET_DIR: ${{ runner.temp }}/shared",
      "test_workflow_sets_no_shared_target_dir"),
+    ("Y8-drop-always-from-derivation-if",
+     "drop always() so the derivation is skipped exactly when leg 2 fails",
+     "        if: always() && steps.changes.outputs.rust_changed == 'true'\n"
+     "          && steps.leg2.outcome == 'failure' && github.event_name == 'pull_request'",
+     "        if: steps.changes.outputs.rust_changed == 'true'\n"
+     "          && steps.leg2.outcome == 'failure' && github.event_name == 'pull_request'",
+     "test_derivation_if_carries_always"),
+    ("Y9-disable-the-mutation-tripwire",
+     "switch the --mutate tripwire off with if: false",
+     "        if: always() && steps.changes.outputs.rust_changed == 'true'\n"
+     "        # Runs the derivation's own suite INCLUDING the mutation matrix",
+     "        if: false\n"
+     "        # Runs the derivation's own suite INCLUDING the mutation matrix",
+     "test_mutation_tripwire_runs_when_leg2_fails"),
+    ("Y10-ci-invocation-gains-write",
+     "append --write, so CI starts materialising declarations itself",
+     "--base-wasm base-wasm/base.wasm --head-wasm head.wasm --report-only",
+     "--base-wasm base-wasm/base.wasm --head-wasm head.wasm --report-only --write",
+     "test_ci_invocation_is_report_only"),
+    ("Y11-swap-the-bundle-arguments",
+     "swap --base-wasm and --head-wasm, inverting the comparison",
+     "--base-wasm base-wasm/base.wasm --head-wasm head.wasm",
+     "--base-wasm head.wasm --head-wasm base-wasm/base.wasm",
+     "test_ci_passes_the_bundles_in_the_right_order"),
     ("Y5-drop-paths-filter-entry",
      "stop re-running the leg when the derivation script itself changes",
      "              - 'scripts/feature_off_autodeclare.py'\n", "",

--- a/scripts/tests/test_feature_off_autodeclare.py
+++ b/scripts/tests/test_feature_off_autodeclare.py
@@ -440,6 +440,30 @@ def test_included_non_rust_file_is_refused() -> None:
           v.outcome == A.REFUSE_ADDED_LINES_ARE_SEMANTIC, f"got {v.outcome}: {v.reason}")
 
 
+def test_diff_paths_absent_from_both_trees_are_refused() -> None:
+    """A diff naming paths that exist in NEITHER tree means the two disagree.
+
+    Every such path is silently skipped by the blanking loop, so the proof would cover less
+    than it claims. Found for real: a harness rewrote `git diff --no-index` prefixes in the
+    wrong order and produced `bvendor/spargebra/src/parser.rs`; nothing matched, nothing was
+    blanked. Only the non-vacuity guard stopped a false declaration — this names the cause.
+    """
+    base = make_tree(base_files())
+    head = make_tree(base_files())
+    diff = ("diff --git abc/x.rs bbc/x.rs\n"
+            "--- abc/x.rs\n"
+            "+++ bbc/x.rs\n"
+            "@@ -0,0 +1 @@\n"
+            "+pub fn mangled() {}\n")
+    try:
+        v = A.decide(base, head, diff, _scripted_builder(b"base-bundle", b"head-bundle"))
+        check("test_diff_paths_absent_from_both_trees_are_refused",
+              v.outcome == A.REFUSE_DIFF_TREE_MISMATCH, f"got {v.outcome}: {v.reason}")
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+        shutil.rmtree(head, ignore_errors=True)
+
+
 def test_symlink_inside_the_closure_is_refused() -> None:
     """Blanking rewrites files in place, which cannot speak for a symlink — refuse."""
     base = make_tree(base_files())
@@ -492,20 +516,19 @@ def test_vacuous_proof_is_refused() -> None:
     catches it without anyone having to know which path class was missed.
     """
     base = make_tree(base_files())
-    head = make_tree(base_files())
-    # A changed path that exists in NEITHER tree: the diff is real, but there is nothing on
-    # disk to blank, so the neutral tree comes out identical to the head tree.
-    diff = ("diff --git a/crates/c/src/ghost.rs b/crates/c/src/ghost.rs\n"
-            "--- a/crates/c/src/ghost.rs\n"
-            "+++ b/crates/c/src/ghost.rs\n"
-            "@@ -0,0 +1 @@\n"
-            "+pub fn ghost() {}\n")
+    # The diff adds only a BLANK line: the path exists, so it is not a diff/tree mismatch,
+    # but blanking an already-empty line is a no-op — so the neutral tree comes out
+    # identical to the head tree and the comparison would be `head == head`. The bundle
+    # moved anyway (the builder says so), which means the drift came from somewhere the
+    # proof does not reach.
+    head = make_tree(base_files(**{"crates/c/src/lib.rs": insert_at(_BASE_LIB, 4, [""])}))
     try:
-        v = A.decide(base, head, diff, _scripted_builder(b"base-bundle", b"head-bundle"))
+        v = A.decide(base, head, diff_of(base, head),
+                     _scripted_builder(b"base-bundle", b"head-bundle"))
         check("test_vacuous_proof_is_refused", v.outcome == A.REFUSE_VACUOUS_PROOF,
               f"got {v.outcome}: {v.reason}")
         check("test_vacuous_proof_is_refused__names_the_paths",
-              "ghost.rs" in v.reason,
+              "lib.rs" in v.reason,
               "the refusal must name where the unexplained diff actually was")
     finally:
         shutil.rmtree(base, ignore_errors=True)
@@ -1027,6 +1050,7 @@ TESTS = [
     test_every_changed_non_manifest_path_is_blanked,
     test_included_non_rust_file_is_refused,
     test_symlink_inside_the_closure_is_refused,
+    test_diff_paths_absent_from_both_trees_are_refused,
     test_root_build_inputs_are_restored_from_base,
     test_base_build_failure_is_refused,
     test_head_build_failure_is_refused,
@@ -1087,6 +1111,10 @@ MUTANTS = [
      "        if _is_manifest(p) or root_input:\n            manifest.append(p)\n"
      "        elif closure is None or any(p.startswith(d) for d in closure):\n            blankable.append(p)",
      "test_out_of_closure_semantic_change_is_refused"),
+    ("M5h-ignore-diff-tree-mismatch",
+     "skip paths the diff names but neither tree has, covering less than claimed",
+     "    if missing:", "    if False:",
+     "test_diff_paths_absent_from_both_trees_are_refused"),
     ("M5f-drop-the-non-vacuity-guard",
      "declare even when the neutral tree is identical to the head tree",
      "    if not mutated and not to_blank:", "    if False:",


### PR DESCRIPTION
> 🤖 SPARQ agent

## What this is

`artifact-exact-equality (wasm bundle feature-OFF)` is the largest real leg failure in the open-PR population. It compares the base-tree and head-tree feature-OFF bundles **byte-for-byte** and reds an undeclared difference. That guard stays exactly as strict as it is — it is what catches default-path code leaking into the feature-OFF build, and nothing here loosens it.

It also fires on diffs that change **no compiled code at all**, and that is the class this PR addresses.

## The mechanism, measured

The workspace `release` profile sets `panic = "abort"` but not `panic_immediate_abort`, so every panicking call site keeps a `core::panic::Location` record — and that record embeds the call site's **line number**. Insert a comment block, or an off-by-default `#[cfg(feature = ...)]` item, above always-compiled code in the same file, and every line below it moves; the baked-in line numbers move with it.

Measured with the leg's own build (`cargo build --profile release-wasm -p sparq-wasm --target wasm32-unknown-unknown`), one change per row against the same tree:

| change | verdict | size delta | differing bytes |
| --- | --- | --- | --- |
| rebuild, no source change | identical | 0 | 0 |
| 34 pure comment lines inserted mid-file (`sparq-core/src/compress.rs`) | **differs** | **0** | **3** |
| off-by-default `#[cfg]` module added *below* all compiled code | identical | 0 | 0 |
| comment block + off-by-default `#[cfg]` statement inserted mid-file | **differs** | **0** | **2** |
| four **ungated** code lines added to `Graph::build` | **differs** | **+228** | **373027** |

The last row is what the leg exists to catch, and byte-for-byte is what catches it. The rows above it are why a human currently hand-writes prose for a diff that changed nothing.

## What the tool does

`scripts/feature_off_autodeclare.py` decides the case **from the compiler**, never from a tolerance:

1. Rebuild the head tree with every **added** line replaced by an **empty** line. Line count is preserved, so every line position is unchanged, and the tree therefore holds the base tree's compiled content at the head tree's line positions.
2. Require that bundle to be **byte-identical** to the head bundle. If blanking the additions changed nothing the compiler emits, the additions emitted nothing.
3. Deleted lines are absent from both trees, so when the diff removes any non-blank line the same proof runs on the base side.

Only then is a declaration emitted, carrying the measured byte counts. Everything else refuses with a named reason and the leg stays red: `added-lines-are-semantic`, `deleted-lines-are-semantic`, `neutral-build-failed`, `deletion-neutral-build-failed`, `unsupported-file-change`, `base-build-failed`, `head-build-failed`.

An **intentional always-compiled change** is refused on purpose. Its author is asserting *intent*, and intent cannot be derived — hand-write it, as `3679.json` and `3755.json` do.

## Two deliberate limits

* **It does not make the leg pass.** Leg 2's own result is untouched; the tool prints a declaration that still has to be committed, so the escape hatch stays inside the reviewed diff. An auto-passing gate whose derivation had a hole would be exactly the rubber stamp this leg exists to prevent.
* **No privilege change.** The job keeps `contents: read`; there is no write-scoped token anywhere in this path.

## A separate finding this surfaced

The tool attributes against the **merge base**, not `pull_request.base.sha`. Those are different commits whenever a branch is behind its base — GitHub sets `base.sha` to the base *branch tip* at the last sync. Measured on the live population: **3 of the 6** open PRs currently red on this leg have a non-ancestor `base.sha`, and #4350 shows **22** changed files against `base.sha` for a **one**-file PR.

Leg 2 itself still resolves `base.sha`, so on such a PR its reported difference also carries, in reverse, base-branch commits the PR does not have. **I have not changed that here** — what the gate compares is a semantic decision for the maintainer, and it could turn currently-red PRs green. The tool prints the divergence rather than attributing it to the PR. Filed separately for a decision.

## Evidence

**32 named checks**, and a mutation matrix (`--mutate`) that deletes **one call site at a time** and requires each to red its **own named** check — 16 in the decision logic, 6 in the workflow YAML (the `if:`, the step, and the `id: leg2` call site the guard reads). **All 22 mutants killed.** The matrix runs in CI, so a change that stops the derivation refusing a semantic drift fails the leg rather than silently auto-declaring one.

The suite is built on a fake compiler that reproduces the measured signature (fixed-width per-line records carrying line POSITION, so a comment insertion is same-length/different-bytes and added code grows the artefact) — and `test_fake_compiler_reproduces_the_measured_signature` pins that, so the model cannot drift away from rustc's behaviour unnoticed.

Two mutants **survived** the first matrix run and both were real: one test never reached the branch it claimed to cover (it tripped an earlier guard), and one mutant was mapped to a check that could not observe it. Both are fixed; that is what the matrix is for.

**Existing suites re-run unchanged and still pass** — `scripts/tests/test_vectorized_feature_off.py` (15 passed, 0 failed), `--self-test` (all tripwires fire), `--leg3` (9 references gated). `scripts/check-vectorized-feature-off.py` is not modified by this PR, so no existing assertion is hollowed out.

## Cost

The derivation runs **only when leg 2 has already failed**, and adds one wasm build (two when the diff deletes code) to a job that is already red. Green PRs pay nothing.

---

Part 2 of a two-part sweep; Part 1 declared the current benign members of the class on their own branches. Census of the live class, no build required:

```
python3 scripts/feature_off_autodeclare.py --census sparq-org/sparq
```