### PR TITLE
fix(merge-queue): recover a zero-dispatch merge group in minutes, not the 60-min CI_TIMEOUT

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -882,6 +882,20 @@ jobs:
       # only, no git/network.
       - name: Self-test check-install-action-tool.py (fixtures + live invariant — sq-1cb6l)
         run: python3 scripts/tests/test_install_action_tool.py
+      # [OPUS-5] sparq-org/sparq#4652: the zero-dispatch merge-group watchdog
+      # (scripts/merge-group-watchdog.py, .github/workflows/merge-group-watchdog.yml)
+      # plus the CI_TIMEOUT routing split it feeds in merge-queue-feedback.yml. Both
+      # are queue-critical and neither can be exercised by a PR run, so their whole
+      # contract is pinned here: the hermetic decision tables (script --self-test), and
+      # the three-layer suite — policy, sweep BEHAVIOUR against a scripted gh (assert on
+      # the mutations issued, not the log text), and cross-file YAML-seam inspection of
+      # every `if:`, step and call site. The fail-closed direction matters most: the
+      # demote guard is `route != 'preserve'`, so a classifier failure keeps the
+      # pre-#4652 behaviour; inverting it to `== 'demote'` fails here.
+      - name: Self-test merge-group-watchdog.py (decision tables — #4652)
+        run: python3 scripts/merge-group-watchdog.py --self-test
+      - name: Zero-dispatch watchdog suite (policy + behaviour + YAML seam — #4652)
+        run: python3 scripts/tests/test_merge_group_watchdog.py
       # [SONNET-4.6] sq-qcnn.32 / [OPUS-5] #3773: the advisory-job registry + gate-intent
       # placement check. Since #3773 the registry is LOAD-BEARING (it is the ONLY thing
       # that makes a check-run non-gating), so this is its integrity gate. THREE

--- a/.github/workflows/merge-group-watchdog.yml
+++ b/.github/workflows/merge-group-watchdog.yml
@@ -21,9 +21,11 @@
 # below the tick interval so it never costs an extra tick. Minutes are offset from
 # auto-arm.yml's and rearm-sweeper.yml's crons so the three sweeps do not start together.
 #
-# BASE RATE, measured rather than assumed: 2 zero-dispatch refs in 211 merge groups over
-# 2026-07-25 -> 07-28 (~0.95%) — #4534 and #4331 — each costing ~60 min at the head of
-# the queue. This is a recurring platform event, not a one-off.
+# BASE RATE, measured rather than assumed: THREE zero-dispatch refs on three
+# consecutive days — #4331 (07-26), #4534 (07-27), #4709 (07-28) — against 211 merge
+# groups sampled over the same period. Each held position 1 for ~60 min. #4709 was
+# caught live by this script's own `sweep --dry-run` while its four siblings in the
+# same chain all had 8 suites. This is a recurring platform event, not a one-off.
 name: merge-group watchdog
 
 on:

--- a/.github/workflows/merge-group-watchdog.yml
+++ b/.github/workflows/merge-group-watchdog.yml
@@ -1,0 +1,94 @@
+# [OPUS-5] sparq-org/sparq#4652 — recover a merge-group ref GitHub Actions never
+# dispatched, in minutes instead of the ruleset's 60-minute CI_TIMEOUT.
+#
+# WHY: measured 2026-07-27/28, PR #4534's merge-group ref was created at 23:04:37Z with
+# ZERO check-suites and deleted at 00:05:04Z when the queue timed it out. It held
+# position 1 in AWAITING_CHECKS the whole time — the queue merges strictly in order and
+# each entry needs its OWN group's required check, so three PRs with already-green
+# groups could not land. Total cost: 73 min 41 s of zero merges and ~66 min of group CI
+# thrown away on the rebuild. The full diagnosis is on #4652.
+#
+# NOT A GATE. Schedule / workflow_dispatch only — it never runs on a PR head, never
+# produces a check-run the `ci-summary` aggregator can see, and can therefore never
+# block a merge. Its only mutations are (a) a marker comment and (b) a dequeue +
+# re-enqueue of an entry it has POSITIVELY established has zero check-suites. Every
+# ambiguous reading is a refusal, not an action (see the script header).
+#
+# Cadence is every 5 minutes — the GitHub scheduler minimum — against a 300 s grace, so
+# worst-case detection is ~10 min against the 60-min timeout it replaces. The grace is
+# ~100x the MEASURED create->first-suite latency on this repo (single-digit seconds; see
+# the script's DEFAULT_GRACE_SECONDS note). Minutes are offset from auto-arm.yml's and
+# rearm-sweeper.yml's crons so the three sweeps do not start together.
+name: merge-group watchdog
+
+on:
+  schedule:
+    - cron: "2,7,12,17,22,27,32,37,42,47,52,57 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Emit decisions without dequeuing/re-enqueuing anything"
+        type: boolean
+        default: false
+
+# Least privilege, mirroring rearm-sweeper.yml (the sibling queue sweeper):
+#   contents: read       — the repository ACTIVITY api (branch_creation timestamps),
+#                          which is the only exact merge-group build-time anchor.
+#   checks: read         — the load-bearing predicate: check-SUITE count on the group head.
+#   pull-requests: write — the marker comment + the dequeue/enqueue mutations.
+permissions:
+  contents: read
+  checks: read
+  pull-requests: write
+
+concurrency:
+  group: merge-group-watchdog
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: recover zero-dispatch merge groups
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      # Secrets are not readable from step `if:` expressions — mirror the id into env
+      # so the mint step can be skipped fail-soft when the App is not configured.
+      ORCHESTRATOR_APP_ID: ${{ secrets.ORCHESTRATOR_APP_ID }}
+    steps:
+      - name: Mint the sparq-orchestrator App token (re-enqueue must fire queue events)
+        id: app-token
+        if: env.ORCHESTRATOR_APP_ID != ''
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.ORCHESTRATOR_APP_ID }}
+          private-key: ${{ secrets.ORCHESTRATOR_APP_PRIVATE_KEY }}
+
+      # Always execute the trusted default-branch policy, including on manual dispatch.
+      - name: Checkout watchdog policy
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          # gh_retry.py is the watchdog's bounded transient-retry dependency — the
+          # self-test below imports it, so a missing path fails BEFORE the live sweep.
+          sparse-checkout: |
+            scripts/merge-group-watchdog.py
+            scripts/gh_retry.py
+          sparse-checkout-cone-mode: false
+
+      - name: Self-test policy
+        run: |
+          python3 scripts/gh_retry.py --self-test
+          python3 scripts/merge-group-watchdog.py --self-test
+
+      - name: Sweep the merge queue for zero-dispatch groups
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
+        run: >-
+          python3 scripts/merge-group-watchdog.py sweep
+          --repo "$REPO"
+          --branch "$DEFAULT_BRANCH"
+          $DRY_RUN

--- a/.github/workflows/merge-group-watchdog.yml
+++ b/.github/workflows/merge-group-watchdog.yml
@@ -14,11 +14,16 @@
 # re-enqueue of an entry it has POSITIVELY established has zero check-suites. Every
 # ambiguous reading is a refusal, not an action (see the script header).
 #
-# Cadence is every 5 minutes — the GitHub scheduler minimum — against a 300 s grace, so
-# worst-case detection is ~10 min against the 60-min timeout it replaces. The grace is
-# ~100x the MEASURED create->first-suite latency on this repo (single-digit seconds; see
-# the script's DEFAULT_GRACE_SECONDS note). Minutes are offset from auto-arm.yml's and
-# rearm-sweeper.yml's crons so the three sweeps do not start together.
+# Cadence is every 5 minutes — the GitHub scheduler minimum — against a 120 s grace, so
+# worst-case detection is ~10 min and typical is ~5, against the 60-minute ruleset
+# timeout it replaces. The grace is 30x the MEASURED maximum create->first-suite latency
+# on this repo (N=209, max 4 s; see the script's DEFAULT_GRACE_SECONDS note) and sits
+# below the tick interval so it never costs an extra tick. Minutes are offset from
+# auto-arm.yml's and rearm-sweeper.yml's crons so the three sweeps do not start together.
+#
+# BASE RATE, measured rather than assumed: 2 zero-dispatch refs in 211 merge groups over
+# 2026-07-25 -> 07-28 (~0.95%) — #4534 and #4331 — each costing ~60 min at the head of
+# the queue. This is a recurring platform event, not a one-off.
 name: merge-group watchdog
 
 on:

--- a/.github/workflows/merge-queue-feedback.yml
+++ b/.github/workflows/merge-queue-feedback.yml
@@ -31,14 +31,42 @@
 #   workflow is ever extended to build/test PR code, it MUST move that work to a
 #   separate `pull_request`-triggered job — do not add a checkout of the PR head here.
 #
+#   [OPUS-5] #4652 adds ONE checkout — pinned to `ref: <default_branch>` with
+#   `persist-credentials: false` — solely to obtain the trusted, default-branch copy of
+#   `scripts/merge-group-watchdog.py`. That is the base repo's own reviewed code, NOT
+#   the PR head, so the rule above is intact: this workflow still never checks out or
+#   executes anything a PR contributed. Do not change that `ref:`.
+#
 # GATE INTEGRATION: the job name carries the whole-word `advisory` token, so the
 # ci-summary gate's discovery excludes it from the gating set (a dequeue-feedback
 # hiccup on a PR head must never red a later gate evaluation on that same SHA). The
 # labels/comments it writes are exactly the fix lane's normal inputs.
 #
-# FLAKE-CLASSIFIED failures: an infra-flavoured dequeue reason (e.g. CI_TIMEOUT) is
-# noted in the comment but STILL routes to review:changes — the fix lane's ci-flavour
-# owns re-runs, so the routing is identical by design.
+# FLAKE-CLASSIFIED failures: an infra-flavoured dequeue reason (e.g. QUEUE_CLEARED,
+# ROLL_BACK) is noted in the comment but STILL routes to review:changes — the fix lane's
+# ci-flavour owns re-runs, so the routing is identical by design.
+#
+# ── [OPUS-5] #4652: the ONE exception — a CI_TIMEOUT with ZERO check-suites ────────
+# A `CI_TIMEOUT` has two utterly different causes and until now both got the same
+# treatment. (1) Checks genuinely ran long / hung — a legitimate signal, keep demoting.
+# (2) GitHub Actions NEVER DISPATCHED the `merge_group` event, so the group ref sat with
+# zero check-suites until the ruleset's 60-minute timeout fired. Measured on #4534
+# (2026-07-27): ref built 23:04:37Z, 0 check-suites / 0 check-runs / 0 workflow runs,
+# dequeued CI_TIMEOUT at 00:05:03Z. Demoting THAT strips `review:pass` and manufactures
+# a full re-review of code nobody found fault with — the same defect class as the
+# machine-manufactured `needs:user` escalations this repo has already fixed twice.
+#
+# The two are separated by the SUITE COUNT, never by the reason alone:
+# `scripts/merge-group-watchdog.py classify-dequeue` re-derives the live check-suite
+# count for the recorded group head and prints `route=preserve|demote`. FAIL-SAFE in
+# every direction — a missing marker, an unreadable count, a non-zero count, a stale
+# observation, or a crashed classifier all yield `demote`, i.e. today's behaviour. The
+# `if:` on the routing step below is written as `route != 'preserve'` so an EMPTY or
+# MISSING output (the classifier step failed, the output was lost) still demotes.
+#
+# The same classifier also recognises the watchdog's OWN recovery: the watchdog
+# re-enqueues via dequeue+enqueue, which itself fires `pull_request.dequeued`, and
+# without that arm the watchdog would demote every PR it just rescued.
 #
 # No third-party actions (nothing to SHA-pin); every step is plain `gh` against the
 # workflow token, least-privilege scoped below.
@@ -48,11 +76,15 @@ on:
   pull_request_target:
     types: [dequeued]
 
-# Least-privilege for a WRITE-only, NO-checkout job: pull-requests: write covers the
-# disable-auto / relabel / comment writes; actions: read lists this repo's merge_group
-# runs to find the failed run. NO contents write is needed — nothing is pushed and no
-# repo code is checked out (see the pull_request_target safety note above).
+# Least-privilege: pull-requests: write covers the disable-auto / relabel / comment
+# writes; actions: read lists this repo's merge_group runs to find the failed run;
+# [OPUS-5] #4652 contents: read is the DEFAULT-BRANCH checkout of the classifier script
+# (read-only, never the PR head) and checks: read is the classifier's load-bearing
+# predicate — the check-SUITE count on the group head. NO contents WRITE is needed —
+# nothing is pushed (see the pull_request_target safety note above).
 permissions:
+  contents: read
+  checks: read
   pull-requests: write
   actions: read
 
@@ -83,8 +115,78 @@ jobs:
         run: |
           echo "PR ${PR_NUMBER} dequeued via successful merge - no action."
 
-      - name: Route genuine dequeue to the fix lane
+      # [OPUS-5] #4652. TRUSTED, DEFAULT-BRANCH checkout of the classifier only — never
+      # the PR head (see the pull_request_target safety note in the header). No PR code
+      # is fetched, and nothing from the PR is executed.
+      - name: Checkout the dequeue classifier (default branch, never the PR head)
         if: github.event.pull_request.merged != true
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/merge-group-watchdog.py
+            scripts/gh_retry.py
+          sparse-checkout-cone-mode: false
+
+      # [OPUS-5] #4652. Splits CI_TIMEOUT by the SUITE COUNT of the group head, not by
+      # the reason. Always exits 0 and always prints a row; every unprovable case
+      # yields route=demote (today's behaviour), so a failure here cannot preserve a
+      # verdict it did not establish.
+      - name: Classify the dequeue (zero-dispatch vs a real timeout)
+        id: classify
+        if: github.event.pull_request.merged != true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: >-
+          python3 scripts/merge-group-watchdog.py classify-dequeue
+          --repo "$REPO"
+          --pr "$PR_NUMBER"
+          --reason "$DEQUEUE_REASON"
+
+      # The zero-dispatch route. It deliberately does NOT touch labels — preserving the
+      # review verdict IS leaving `review:pass` where it is — and does NOT disable the
+      # arm. `rearm-sweeper.yml` is the durable backstop if the direct re-arm below
+      # fails, because a PR carrying review:pass with no live arm is exactly what that
+      # sweep restores.
+      - name: Preserve the verdict and re-enqueue (zero-dispatch CI_TIMEOUT)
+        if: github.event.pull_request.merged != true && steps.classify.outputs.route == 'preserve'
+        env:
+          CLASSIFY_DETAIL: ${{ steps.classify.outputs.detail }}
+          CLASSIFY_REENQUEUE: ${{ steps.classify.outputs.reenqueue }}
+        run: |
+          set -euo pipefail
+
+          STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state)
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR #${PR_NUMBER} is ${STATE} — nothing to preserve; exiting 0."
+            exit 0
+          fi
+
+          if [ "$CLASSIFY_REENQUEUE" = "true" ]; then
+            gh pr merge "$PR_NUMBER" --repo "$REPO" --auto \
+              || echo "::warning::re-arm of PR #${PR_NUMBER} returned non-zero — rearm-sweeper.yml is the backstop."
+          else
+            echo "Re-enqueue owned by the watchdog itself — not re-arming here."
+          fi
+
+          body_file=$(mktemp)
+          {
+            printf '%s\n\n' "> 🤖 SPARQ agent — merge-queue feedback."
+            printf '%s\n\n' "This PR was dequeued (reason \`${DEQUEUE_REASON}\`), but the merge-group ref it was waiting on had **zero check-suites** — GitHub Actions never dispatched the \`merge_group\` event for it, so no required check could ever report (sparq-org/sparq#4652)."
+            printf '%s\n\n' "**Nothing is wrong with this PR's diff, so its review verdict is preserved** and it is re-queued rather than demoted to \`review:changes\`."
+            printf '%s\n' "Classifier: \`${CLASSIFY_DETAIL}\`"
+          } > "$body_file"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file" \
+            || echo "::warning::could not comment the zero-dispatch notification on PR #${PR_NUMBER} (routing is intact)."
+          echo "PR #${PR_NUMBER}: zero-dispatch ${DEQUEUE_REASON} — verdict preserved."
+
+      # FAIL-SAFE `if:` — written as `!= 'preserve'` so an EMPTY or MISSING classifier
+      # output (step failed, output lost) still routes to the fix lane exactly as it did
+      # before #4652. Never invert this to `== 'demote'`.
+      - name: Route genuine dequeue to the fix lane
+        if: github.event.pull_request.merged != true && steps.classify.outputs.route != 'preserve'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/merge-queue-feedback.yml
+++ b/.github/workflows/merge-queue-feedback.yml
@@ -161,6 +161,9 @@ jobs:
       # fails, because a PR carrying review:pass with no live arm is exactly what that
       # sweep restores.
       - name: Preserve the verdict and re-enqueue (zero-dispatch CI_TIMEOUT)
+        # Deliberately NOT `!cancelled()`: preserving a verdict requires the classifier
+        # to have SUCCEEDED and positively returned `preserve`. The implicit `success()`
+        # is the correct default here — do not harmonise this with the step below.
         if: github.event.pull_request.merged != true && steps.classify.outputs.route == 'preserve'
         env:
           CLASSIFY_DETAIL: ${{ steps.classify.outputs.detail }}
@@ -196,7 +199,12 @@ jobs:
       # output (step failed, output lost) still routes to the fix lane exactly as it did
       # before #4652. Never invert this to `== 'demote'`.
       - name: Route genuine dequeue to the fix lane
-        if: github.event.pull_request.merged != true && steps.classify.outputs.route != 'preserve'
+        # `!cancelled() &&` is LOAD-BEARING. A step `if:` with no status function
+        # defaults to `success()`, so a FAILED or TIMED-OUT classify step would SKIP
+        # this one — keeping `review:pass` and leaving the arm enabled, i.e. the exact
+        # opposite of fail-closed. The empty-output case was handled; the failed-step
+        # case was not, and a string-matching test could not see the difference.
+        if: "!cancelled() && github.event.pull_request.merged != true && steps.classify.outputs.route != 'preserve'"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/merge-queue-feedback.yml
+++ b/.github/workflows/merge-queue-feedback.yml
@@ -66,7 +66,17 @@
 #
 # The same classifier also recognises the watchdog's OWN recovery: the watchdog
 # re-enqueues via dequeue+enqueue, which itself fires `pull_request.dequeued`, and
-# without that arm the watchdog would demote every PR it just rescued.
+# without that arm the watchdog would demote every PR it just rescued. MEASURED on
+# #4709: `review:pass` was swapped for `review:changes` 17 SECONDS after a `MANUAL`
+# dequeue. `MANUAL` conflates "a reviewer withdrew this" (verdict SHOULD fall) with
+# "infrastructure moved it" (it should not), so the split is on EVIDENCE — a fresh
+# watchdog marker for that exact group head — never on the reason string.
+#
+# AND, on every preserve route: the verdict may only survive if the PR head has NOT
+# moved since `review:pass` was granted. A commit, a force-push, or a revoked label
+# after the grant forfeits it — never restore a verdict onto a tree it was not given
+# for. A genuine human dequeue has no fresh marker and still demotes; that control is
+# what stops this from becoming a verdict-preservation hole.
 #
 # No third-party actions (nothing to SHA-pin); every step is plain `gh` against the
 # workflow token, least-privilege scoped below.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,7 +520,13 @@ no network); the Python close-script carries a `--self-test`.
   a superseded group head, so preserving the verdict would be unsound, and three consecutive
   zero-dispatch groups on one PR warrant a human look. It never escalates to a `needs:user` hold
   and never permanently stalls. **Everything it cannot positively establish is a
-  refusal, never a recovery.** It emits one row per entry **every tick**, carrying the ref, the
+  refusal, never a recovery.** The marker it writes is **evidence**, so its AUTHOR is part of
+  the predicate: markers are honoured only from `github-actions[bot]` / `sparq-orchestrator[bot]`
+  (`TRUSTED_MARKER_AUTHORS`, enforced at the read), because sparq is public and a marker forged
+  by any commenter would otherwise carry `review:pass` through a dequeue and reach
+  `gh pr merge --auto`. The recovery also reads its own marker back before dequeuing and refuses
+  to act if it is not there — a runner whose identity is missing from that list cannot see its
+  own markers, which would silently disarm both caps. It emits one row per entry **every tick**, carrying the ref, the
   suite count, the decision, and `stacked=`/`stacked_green=` — the count of groups built on top
   of the dead ref, which is the real cost term and the watchdog's own effectiveness measure.
   Companion routing split in `merge-queue-feedback.yml`: a `CI_TIMEOUT` whose group ref had

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,6 +504,35 @@ plan (§5, Beads D/E + H), to be added only after the scripts are proven in manu
 shell script is `bash -n`/`shellcheck` clean and carries a `--dry-run-self-test` (hermetic;
 no network); the Python close-script carries a `--self-test`.
 
+- **`.github/workflows/merge-group-watchdog.yml` + `scripts/merge-group-watchdog.py`**
+  (#4652) — the **durable** zero-dispatch merge-group recovery. GitHub occasionally builds a
+  merge-group ref and then never dispatches the `merge_group` event for it: **zero
+  check-suites, zero check-runs, zero workflow runs**. Because the queue merges strictly in
+  order and each entry needs its **own** group's required check (a green *superset* group does
+  **not** substitute), that entry holds position 1 until the ruleset's 60-minute
+  `check_response_timeout_minutes` reaps it, and the rebuild discards every group stacked on
+  top. Observed three days running (#4331, #4534, #4709), ~60 min each. The sweep runs on a
+  5-minute cron (never on a PR head, so it can never gate), and after a **120 s** grace —
+  30× the measured maximum create→first-suite latency (N=209: p50 2 s, max 4 s; the failure is
+  categorical, not slow) — it dequeues and re-enqueues the entry. Bounded (1 per group head
+  SHA, 2 per PR per 6 h, 2 per run) and idempotent; on exhaustion it hands back to the platform
+  timeout rather than escalating to a human. **Everything it cannot positively establish is a
+  refusal, never a recovery.** It emits one row per entry **every tick**, carrying the ref, the
+  suite count, the decision, and `stacked=`/`stacked_green=` — the count of groups built on top
+  of the dead ref, which is the real cost term and the watchdog's own effectiveness measure.
+  Companion routing split in `merge-queue-feedback.yml`: a `CI_TIMEOUT` whose group ref had
+  **zero suites** preserves `review:pass` instead of manufacturing a re-review for a platform
+  event drop, while a timeout that followed checks that genuinely ran keeps demoting — the two
+  are separated by the **suite count**, never by the reason alone.
+  **Runbook — resolving and clearing a dead ref by hand.** The group head is the queue entry's
+  `headCommit{oid}` (`MergeQueueEntry` has **no** `headOid` field), or read the live refs with
+  `git ls-remote origin 'refs/heads/gh-readonly-queue/main/*'`; the trailing sha in a ref name
+  is the group's **BASE**, and the ref is named for one *member*, so **absence of a ref named
+  for a PR is not evidence its CI never started**. Test `commits/<head>/check-suites` —
+  `total_count == 0` is the signal, and never `check-runs` (a `paths`-filtered workflow that
+  matches nothing still creates a suite). To clear it, `gh pr merge --disable-auto` does **not**
+  dequeue an already-queued PR; use `dequeuePullRequest`, whose input field is named `id` but
+  wants the **pull request** node id (`PR_…`), not the entry id (`MQE_…`).
 - **`.github/workflows/bead-autoclose.yml` + `scripts/ci-close-merged-beads.py`**
   (sq-84a8; issue-native since #2475) — the **durable** auto-close-on-merge. On a merged PR
   (`pull_request_target: [closed]` gated on `merged == true` — base-repo context so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,8 +515,11 @@ no network); the Python close-script carries a `--self-test`.
   5-minute cron (never on a PR head, so it can never gate), and after a **120 s** grace —
   30× the measured maximum create→first-suite latency (N=209: p50 2 s, max 4 s; the failure is
   categorical, not slow) — it dequeues and re-enqueues the entry. Bounded (1 per group head
-  SHA, 2 per PR per 6 h, 2 per run) and idempotent; on exhaustion it hands back to the platform
-  timeout rather than escalating to a human. **Everything it cannot positively establish is a
+  SHA, 2 per PR per 6 h, 2 per run) and idempotent. On exhaustion it hands back to the platform
+  timeout, which **does demote to `review:changes`** — by then the only trusted observation names
+  a superseded group head, so preserving the verdict would be unsound, and three consecutive
+  zero-dispatch groups on one PR warrant a human look. It never escalates to a `needs:user` hold
+  and never permanently stalls. **Everything it cannot positively establish is a
   refusal, never a recovery.** It emits one row per entry **every tick**, carrying the ref, the
   suite count, the decision, and `stacked=`/`stacked_green=` — the count of groups built on top
   of the dead ref, which is the real cost term and the watchdog's own effectiveness measure.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -504,6 +504,29 @@ plan (§5, Beads D/E + H), to be added only after the scripts are proven in manu
 shell script is `bash -n`/`shellcheck` clean and carries a `--dry-run-self-test` (hermetic;
 no network); the Python close-script carries a `--self-test`.
 
+### Hermetic suites must be UNABLE to reach the network — poison the runners <!-- [OPUS-5] #4652 -->
+
+A "hermetic" test suite that merely *intends* to inject fakes is not hermetic. `def __init__(self, ..., gh=run_gh)`
+binds the runner **at definition time**, so patching `module.run_gh` from a test cannot reach it — and a suite
+whose reads were faked while its writes were real posted **567 real comments to a production PR** across a
+mutation sweep (#4652). Two rules follow:
+
+- **Late-bind injected collaborators** (`gh=None` → resolve inside `__init__`), never a module-level default arg.
+- **Poison the real runners at test-module import** so any path that forgets to inject raises instead of
+  reaching the network, and add a test asserting the poison is in place. Restore **every** patched name in
+  `finally` — a block that restored one of two leaked a stale fake into every later test.
+
+**Never exercise a write path against a live production PR/issue.** Use a scratch object you own, or a fixture;
+if a test needs a real remote value, *read* it. And when a probe reports hostile input, **verify the author
+before reporting an exploit** — a false attack report costs twice: unwarranted alarm now, and a discounted
+warning when the real thing arrives.
+
+**Mutation harnesses need a preflight.** A greedy edit silently deleted 15 mutants and the harness reported a
+clean total — a dropped mutant is indistinguishable from a killed one, so the number improves as coverage
+disappears. Fail the sweep outright on a duplicate id or an anchor that no longer exists in the tree, count a
+`SyntaxError` as a broken mutant rather than a kill, and prefer a test-file traceback frame over a crash frame
+(the first failure is arbitrary).
+
 - **`.github/workflows/merge-group-watchdog.yml` + `scripts/merge-group-watchdog.py`**
   (#4652) — the **durable** zero-dispatch merge-group recovery. GitHub occasionally builds a
   merge-group ref and then never dispatches the `merge_group` event for it: **zero

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,7 +523,15 @@ no network); the Python close-script carries a `--self-test`.
   Companion routing split in `merge-queue-feedback.yml`: a `CI_TIMEOUT` whose group ref had
   **zero suites** preserves `review:pass` instead of manufacturing a re-review for a platform
   event drop, while a timeout that followed checks that genuinely ran keeps demoting — the two
-  are separated by the **suite count**, never by the reason alone.
+  are separated by the **suite count**, never by the reason alone. The same split makes an
+  INFRASTRUCTURE dequeue verdict-neutral: measured on #4709, `review:pass` was swapped for
+  `review:changes` **17 seconds** after a `MANUAL` dequeue, so a watchdog without this would
+  burn the verdict of every PR it rescued. `MANUAL` conflates "a reviewer withdrew this" with
+  "infrastructure moved it", so the discriminator is a fresh watchdog marker for that exact
+  group head — evidence, never the event name — and **a genuine human dequeue still strips the
+  verdict**. On every preserve route the verdict may only survive if the head has **not moved
+  since it was granted** (a commit, a force-push, or a revoked label after the grant forfeits
+  it): never restore a verdict onto a tree it was not given for.
   **Runbook — resolving and clearing a dead ref by hand.** The group head is the queue entry's
   `headCommit{oid}` (`MergeQueueEntry` has **no** `headOid` field), or read the live refs with
   `git ls-remote origin 'refs/heads/gh-readonly-queue/main/*'`; the trailing sha in a ref name

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -1,0 +1,1078 @@
+#!/usr/bin/env python3
+"""Recover a merge-queue entry whose merge-group ref was never dispatched by Actions."""
+
+# [OPUS-5] sparq-org/sparq#4652 — the zero-dispatch merge-group watchdog.
+#
+# THE OUTAGE THIS FIXES (measured 2026-07-27/28, #4652): PR #4534's merge-group ref
+# `gh-readonly-queue/main/pr-4534-3cc1bf828c…` was created at 23:04:37Z with head
+# `1bfb0174…` and deleted at 00:05:04Z — 60 min 27 s later — having produced
+# **0 check-suites, 0 check-runs, 0 workflow runs**. Eight workflows carry a bare
+# unfiltered `merge_group:` trigger and fired for every other group that day; for this
+# one ref none of them was ever CONSIDERED. #4534 sat at position 1 in AWAITING_CHECKS;
+# the queue merges strictly in order and each entry needs its OWN group's required
+# check, so #4400/#4636/#4639 sat behind it with green groups that could not land.
+# GitHub eventually dequeued #4534 with reason CI_TIMEOUT at 00:05:03Z (the ruleset's
+# `check_response_timeout_minutes: 60`), and the chain rebuilt 3 s later, discarding
+# three already-green group CI runs. Net: 73 min 41 s of zero merges (23:18:59Z →
+# 00:32:40Z) and ~66 min of wasted group CI.
+#
+# WHY ZERO check-SUITES IS THE LOAD-BEARING SIGNAL — and why "zero check-runs" is NOT.
+# A `paths`-filtered workflow that matches nothing STILL creates a check-suite (it just
+# reports no runs). So a group with real workflows but nothing to do reads as
+# suites>0 / runs==0. Zero *suites* means no workflow was ever considered for the ref,
+# i.e. the `merge_group` event never reached the Actions dispatcher. Weakening the
+# predicate to check-runs would fire on legitimately-pending and legitimately-empty
+# groups. The predicate here is `total_count == 0` on
+# `GET /repos/{repo}/commits/{group_head_sha}/check-suites`, and NOTHING else.
+#
+# ── the anchor problem, and the measurement that settles it ───────────────────────
+# The grace gate needs T_create = when the merge-group ref was BUILT. Two obvious
+# proxies are WRONG and were rejected by measurement:
+#   * `entry.enqueuedAt` — an entry can sit outside the `max_entries_to_build` window
+#     for many minutes before its group is built, so this anchor is far too early.
+#   * the group head commit's `committer.date` — GitHub STAMPS the group commit with
+#     the entry's `enqueuedAt`, not the build time. Measured: head `0e043a13`
+#     (PR #4636's group) is stamped 23:01:57Z == #4636's enqueuedAt, but that group's
+#     branch was created at 23:19-ish; head `1bfb0174` is stamped 22:58:53Z while its
+#     own PARENT `3cc1bf828` (#4632) did not reach `main` until 23:18:59Z — a commit
+#     cannot predate its parent, which proves the field is a stamp, not a creation
+#     time. Any latency computed from it is meaningless.
+# The CORRECT, exact anchor is the repository ACTIVITY API:
+#     GET /repos/{repo}/activity?activity_type=branch_creation&ref=<full ref>
+# whose rows carry an exact `timestamp` plus `after` = the created head SHA. Measured
+# for the incident ref: `branch_creation` at 23:04:37Z, `after=1bfb0174…`. We match on
+# `after == head_oid` so a ref rebuilt on the same base is keyed by HEAD, never by name.
+#
+# ── the decision table (fail-safe: only RECOVER is a mutation) ────────────────────
+#   SKIP     entry state is not AWAITING_CHECKS, or no speculative group is built yet
+#   HOLD     >=1 check-suite present — dispatch happened; NOT our case (the control)
+#   WAIT     zero suites but still inside the grace period
+#   REFUSE   the suite count or the creation time could NOT be positively established
+#   NOOP     a recovery was already attempted for this exact group head (idempotence)
+#   CAP      the per-PR or per-run recovery budget is exhausted
+#   RECOVER  zero suites, past grace, positively established, within budget => act
+# Anything that cannot be POSITIVELY established is a REFUSE, never a recovery: a
+# watchdog that re-enqueues on ambiguity thrashes the queue and is worse than the bug.
+#
+# ── emission ──────────────────────────────────────────────────────────────────────
+# EVERY entry emits exactly one row EVERY tick — naming the ref, the head, the suite
+# count and the decision — plus a closing census row, plus an explicit row when the
+# queue is empty. A held CAP or REFUSE re-emits every tick for as long as it holds;
+# a silent watchdog would convert a visible 73-minute outage into an invisible one.
+#
+# ── the dequeue-routing split (`classify-dequeue`) ────────────────────────────────
+# `.github/workflows/merge-queue-feedback.yml` routes every non-merge dequeue to
+# `review:changes` by design. For a zero-dispatch CI_TIMEOUT that is a
+# MACHINE-MANUFACTURED re-review: #4534 lost `review:pass` for a platform event drop,
+# with nothing whatsoever wrong in its diff. `classify-dequeue` splits the two cases by
+# the SUITE COUNT (never by the timeout reason alone) and prints a `route=` output the
+# workflow branches on. It also recognises the watchdog's OWN dequeue — our recovery is
+# implemented as dequeue+enqueue, which itself fires `pull_request.dequeued`, and
+# without this arm the watchdog would demote every PR it rescued.
+#
+# The group head SHA cannot be recovered from the API after the ref is deleted (that is
+# exactly the population with no workflow runs to read it off), so the watchdog records
+# it in a machine-readable marker comment BEFORE it acts. The marker is a POINTER, not
+# a cached verdict: `classify-dequeue` re-derives the live suite count for the recorded
+# SHA at decision time (the commit stays readable after the branch is deleted — verified
+# on `1bfb0174`, still `total_count: 0`). A missing/stale marker, an unreadable count,
+# or a non-zero count all fall back to today's demote behaviour.
+#
+# CLI:
+#   python3 scripts/merge-group-watchdog.py sweep --repo O/R [--branch main] [--dry-run]
+#   python3 scripts/merge-group-watchdog.py classify-dequeue --repo O/R --pr N --reason R
+#   python3 scripts/merge-group-watchdog.py --self-test
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Iterable
+
+import gh_retry
+
+PROGRAM = "merge-group-watchdog"
+
+# ── tunables ─────────────────────────────────────────────────────────────────────
+# Grace before a zero-suite group is called dropped. MEASURED create->first-suite
+# latency on this repo (repository activity `branch_creation` timestamp -> earliest
+# check-suite `created_at`) is a couple of SECONDS: e.g. ref pr-4644-c96f5abe created
+# 00:37:17Z, first suite 00:37:19Z (2 s); pr-4643-1612bd6f created 00:37:18Z, first
+# suite 00:37:20Z (2 s); the 00:05 chain rebuild created three refs at 00:05:04-06Z
+# with suites at 00:05:06-08Z (2 s). 300 s is therefore a ~100x margin over the
+# observed tail while still recovering ~55 of the 60-minute timeout.
+DEFAULT_GRACE_SECONDS = 300
+# At most this many watchdog recoveries for one PR inside the rolling window below.
+# A re-enqueue mints a NEW queue attempt, so an attempt-scoped cap would be no cap at
+# all; the budget is per PR per wall-clock window. Exhaustion is not an escalation —
+# the entry is handed back to the platform's own CI_TIMEOUT, whose routing now
+# preserves the review verdict (see classify-dequeue), and a CAP row is emitted every
+# tick for as long as it holds.
+DEFAULT_MAX_RECOVERIES_PER_PR = 2
+DEFAULT_RECOVERY_WINDOW_SECONDS = 6 * 3600
+# Blast-radius bound: one tick may never churn the whole queue.
+DEFAULT_MAX_RECOVERIES_PER_RUN = 2
+# How long after a watchdog marker a MANUAL/UNKNOWN dequeue is attributed to the
+# watchdog's own recovery rather than to a human or the platform.
+DEFAULT_SELF_DEQUEUE_WINDOW_SECONDS = 900
+# A marker older than this is never allowed to steer a routing decision.
+DEFAULT_MARKER_STALENESS_SECONDS = 6 * 3600
+# Read a bounded slice of the queue; sparq's queue is single-digit deep.
+QUEUE_ENTRY_PAGE = 20
+
+# Only an entry that HAS a built group and is waiting on it can be zero-dispatch.
+# QUEUED/UNMERGEABLE have no group to be dropped; MERGEABLE already reported;
+# LOCKED is the queue's own transient.
+ACTIONABLE_STATES = frozenset({"AWAITING_CHECKS"})
+
+# Dequeue reasons a `dequeuePullRequest` mutation (ours) can surface as. A
+# MERGE_CONFLICT / CI_FAILURE dequeue is never attributed to the watchdog.
+SELF_DEQUEUE_REASONS = frozenset({"MANUAL", "UNKNOWN"})
+ZERO_DISPATCH_REASON = "CI_TIMEOUT"
+
+# Verdicts. Named constants so a test cannot silently drift from the emitter.
+SKIP = "SKIP"
+HOLD = "HOLD"
+WAIT = "WAIT"
+REFUSE = "REFUSE"
+NOOP = "NOOP"
+CAP = "CAP"
+RECOVER = "RECOVER"
+
+ROUTE_PRESERVE = "preserve"
+ROUTE_DEMOTE = "demote"
+
+MARKER_KEY = "merge-group-watchdog"
+_MARKER_RE = re.compile(
+    r"<!--\s*" + MARKER_KEY + r"\s+(?P<kv>[^>]*?)\s*-->",
+)
+_MARKER_FIELD_RE = re.compile(r"(?P<key>[a-z_]+)=(?P<value>\S+)")
+
+QUEUE_QUERY = """query($owner:String!,$name:String!,$branch:String!,$first:Int!){
+  repository(owner:$owner,name:$name){
+    mergeQueue(branch:$branch){
+      entries(first:$first){
+        nodes{
+          id
+          position
+          state
+          enqueuedAt
+          baseCommit{oid}
+          headCommit{oid}
+          pullRequest{number id}
+        }
+      }
+    }
+  }
+}"""
+
+DEQUEUE_MUTATION = """mutation($id:ID!){
+  dequeuePullRequest(input:{id:$id}){ mergeQueueEntry{ id } }
+}"""
+
+ENQUEUE_MUTATION = """mutation($id:ID!){
+  enqueuePullRequest(input:{pullRequestId:$id}){ mergeQueueEntry{ id position } }
+}"""
+
+
+class GhError(RuntimeError):
+    """A GitHub CLI command failed."""
+
+
+# ── pure helpers (no I/O — the self-test drives these directly) ──────────────────
+
+
+def parse_iso(value: str | None) -> datetime | None:
+    """Parse a GitHub ISO-8601 UTC timestamp. Returns None on anything unparseable."""
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def iso(moment: datetime) -> str:
+    return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def queue_ref(branch: str, pr_number: int, base_oid: str) -> str:
+    """The merge-group ref GitHub builds for an entry.
+
+    VERIFIED against live data: `gh-readonly-queue/<base_branch>/pr-<N>-<BASE oid>`,
+    where <N> is THIS entry's PR and the trailing sha is the group's BASE (the previous
+    entry's head), NOT its head. Misreading that suffix as the head hid the #4652 cause
+    for an hour, so the head is always carried separately.
+    """
+    return f"gh-readonly-queue/{branch}/pr-{pr_number}-{base_oid}"
+
+
+def render_marker(
+    *, pr: int, head: str, base: str, ref: str, suites: int, observed: datetime
+) -> str:
+    """The machine-readable marker line embedded in the watchdog's PR comment."""
+    return (
+        f"<!-- {MARKER_KEY} pr={pr} head={head} base={base} ref={ref} "
+        f"suites={suites} observed={iso(observed)} action=re-enqueue -->"
+    )
+
+
+@dataclass(frozen=True)
+class Marker:
+    pr: int
+    head: str
+    base: str
+    ref: str
+    suites: int
+    observed: datetime
+    action: str
+
+
+def parse_marker(body: str | None) -> Marker | None:
+    """Parse a watchdog marker out of a comment body; None when absent/malformed."""
+    if not body:
+        return None
+    match = _MARKER_RE.search(body)
+    if not match:
+        return None
+    fields = {
+        m.group("key"): m.group("value")
+        for m in _MARKER_FIELD_RE.finditer(match.group("kv"))
+    }
+    observed = parse_iso(fields.get("observed"))
+    if observed is None:
+        return None
+    try:
+        pr = int(fields["pr"])
+        suites = int(fields["suites"])
+    except (KeyError, ValueError):
+        return None
+    head = fields.get("head", "")
+    if not re.fullmatch(r"[0-9a-f]{40}", head):
+        return None
+    return Marker(
+        pr=pr,
+        head=head,
+        base=fields.get("base", ""),
+        ref=fields.get("ref", ""),
+        suites=suites,
+        observed=observed,
+        action=fields.get("action", ""),
+    )
+
+
+@dataclass(frozen=True)
+class QueueEntry:
+    pr_number: int
+    pr_id: str
+    entry_id: str
+    position: int
+    state: str
+    enqueued_at: datetime | None
+    base_oid: str | None
+    head_oid: str | None
+
+
+@dataclass(frozen=True)
+class Decision:
+    verdict: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class Route:
+    route: str
+    reenqueue: bool
+    detail: str
+
+
+def decide_entry(
+    entry: QueueEntry,
+    *,
+    suites: int | None,
+    created_at: datetime | None,
+    now: datetime,
+    grace_seconds: int,
+    markers: Iterable[Marker],
+    recoveries_in_window: int,
+    max_recoveries_per_pr: int,
+    run_recoveries: int,
+    max_recoveries_per_run: int,
+) -> Decision:
+    """The whole watchdog policy, as a pure function of observed state.
+
+    `suites is None` and `created_at is None` both mean "could NOT be positively
+    established" and must never reach a mutation — see the REFUSE arms below.
+    """
+    if entry.state not in ACTIONABLE_STATES:
+        return Decision(SKIP, f"entry state {entry.state} is not AWAITING_CHECKS")
+    if not entry.head_oid or not entry.base_oid:
+        return Decision(SKIP, "no speculative group built for this entry yet")
+    if suites is None:
+        return Decision(
+            REFUSE,
+            "check-suite count could not be positively established — taking no action",
+        )
+    if suites > 0:
+        return Decision(
+            HOLD,
+            f"{suites} check-suite(s) present — the merge_group event was dispatched",
+        )
+    if created_at is None:
+        return Decision(
+            REFUSE,
+            "no branch_creation activity row matches this group head — "
+            "the group's build time could not be established, taking no action",
+        )
+    age = (now - created_at).total_seconds()
+    if age < 0:
+        return Decision(
+            REFUSE,
+            f"group ref creation {iso(created_at)} is in the future — clock skew, "
+            "taking no action",
+        )
+    if age < grace_seconds:
+        return Decision(
+            WAIT,
+            f"zero check-suites {int(age)}s after the ref was built; "
+            f"inside the {grace_seconds}s grace",
+        )
+    if any(marker.head == entry.head_oid for marker in markers):
+        return Decision(
+            NOOP,
+            "a recovery was already attempted for this exact group head — "
+            "repeat detection on the same ref is a no-op",
+        )
+    if recoveries_in_window >= max_recoveries_per_pr:
+        return Decision(
+            CAP,
+            f"per-PR recovery budget exhausted ({recoveries_in_window}/"
+            f"{max_recoveries_per_pr}) — handing back to the platform CI_TIMEOUT, "
+            "whose routing preserves the review verdict",
+        )
+    if run_recoveries >= max_recoveries_per_run:
+        return Decision(
+            CAP,
+            f"per-run recovery budget exhausted ({run_recoveries}/"
+            f"{max_recoveries_per_run}) — the next tick re-evaluates",
+        )
+    return Decision(
+        RECOVER,
+        f"zero check-suites {int(age)}s after the ref was built "
+        f"(grace {grace_seconds}s) — dequeue + re-enqueue",
+    )
+
+
+def classify_dequeue_route(
+    *,
+    reason: str,
+    markers: Iterable[Marker],
+    last_enqueued_at: datetime | None,
+    live_suites: Callable[[str], int | None],
+    now: datetime,
+    self_dequeue_window_seconds: int = DEFAULT_SELF_DEQUEUE_WINDOW_SECONDS,
+    marker_staleness_seconds: int = DEFAULT_MARKER_STALENESS_SECONDS,
+) -> Route:
+    """Split a dequeue into the preserve-the-verdict route and today's demote route.
+
+    FAIL-SAFE: every arm that cannot POSITIVELY establish zero-dispatch returns
+    `demote`, which is the pre-existing behaviour.
+    """
+    ordered = sorted(markers, key=lambda m: m.observed, reverse=True)
+    newest = ordered[0] if ordered else None
+    normalised = (reason or "UNKNOWN").strip().upper()
+
+    if newest is None:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            "no merge-group-watchdog observation recorded for this PR",
+        )
+
+    marker_age = (now - newest.observed).total_seconds()
+
+    # (a) our OWN recovery. The watchdog's dequeue+enqueue fires pull_request.dequeued;
+    # without this arm the watchdog would demote every PR it just rescued.
+    if normalised in SELF_DEQUEUE_REASONS and 0 <= marker_age <= self_dequeue_window_seconds:
+        return Route(
+            ROUTE_PRESERVE,
+            False,
+            f"dequeue reason {normalised} within {self_dequeue_window_seconds}s of the "
+            f"watchdog's own recovery of head {newest.head[:8]} "
+            f"({int(marker_age)}s ago) — the watchdog re-enqueues; verdict preserved",
+        )
+
+    # (b) the platform timeout. Split by SUITE COUNT, never by the reason alone.
+    if normalised != ZERO_DISPATCH_REASON:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            f"dequeue reason {normalised} is not {ZERO_DISPATCH_REASON}",
+        )
+    if last_enqueued_at is None:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            "no added_to_merge_queue timeline event found — the watchdog observation "
+            "cannot be bound to this queue attempt",
+        )
+    if newest.observed < last_enqueued_at:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            f"newest watchdog observation {iso(newest.observed)} predates this queue "
+            f"attempt (enqueued {iso(last_enqueued_at)})",
+        )
+    if marker_age < 0 or marker_age > marker_staleness_seconds:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            f"watchdog observation is {int(marker_age)}s old — outside the "
+            f"{marker_staleness_seconds}s freshness bound",
+        )
+    count = live_suites(newest.head)
+    if count is None:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            f"could not re-derive the check-suite count for head {newest.head[:8]}",
+        )
+    if count != 0:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            f"head {newest.head[:8]} has {count} check-suite(s) — this timeout "
+            "followed checks that genuinely ran",
+        )
+    return Route(
+        ROUTE_PRESERVE,
+        True,
+        f"{ZERO_DISPATCH_REASON} with 0 check-suites re-derived live on group head "
+        f"{newest.head[:8]} — the merge_group event was never dispatched, so the diff "
+        "is not at fault; verdict preserved and the PR re-armed",
+    )
+
+
+# ── I/O layer ────────────────────────────────────────────────────────────────────
+
+
+def run_gh(argv: list[str]) -> str:
+    result = subprocess.run(["gh", *argv], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown gh failure"
+        raise GhError(f"gh {' '.join(argv[:3])} failed: {detail}")
+    return result.stdout
+
+
+def run_gh_read(argv: list[str]) -> str:
+    """Idempotent READ path: bounded transient-only retries (#3759 helper)."""
+    try:
+        return gh_retry.run_gh_read(argv)
+    except gh_retry.GhFatalError as error:
+        raise GhError(str(error)) from error
+
+
+def _ndjson(text: str) -> list[dict]:
+    out: list[dict] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise GhError(f"gh api returned a non-JSON page line: {error}") from error
+        if isinstance(parsed, dict):
+            out.append(parsed)
+    return out
+
+
+class Watchdog:
+    def __init__(
+        self,
+        repo: str,
+        *,
+        branch: str = "main",
+        grace_seconds: int = DEFAULT_GRACE_SECONDS,
+        max_recoveries_per_pr: int = DEFAULT_MAX_RECOVERIES_PER_PR,
+        recovery_window_seconds: int = DEFAULT_RECOVERY_WINDOW_SECONDS,
+        max_recoveries_per_run: int = DEFAULT_MAX_RECOVERIES_PER_RUN,
+        dry_run: bool = False,
+        gh: Callable[[list[str]], str] = run_gh,
+        gh_read: Callable[[list[str]], str] | None = None,
+        log: Callable[[str], None] = print,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        try:
+            self.owner, self.name = repo.split("/", 1)
+        except ValueError as error:
+            raise ValueError("repo must be OWNER/REPOSITORY") from error
+        if not self.owner or not self.name or "/" in self.name:
+            raise ValueError("repo must be OWNER/REPOSITORY")
+        if grace_seconds < 60:
+            raise ValueError("grace_seconds must be at least 60")
+        self.repo = repo
+        self.branch = branch
+        self.grace_seconds = grace_seconds
+        self.max_recoveries_per_pr = max_recoveries_per_pr
+        self.recovery_window_seconds = recovery_window_seconds
+        self.max_recoveries_per_run = max_recoveries_per_run
+        self.dry_run = dry_run
+        self.gh = gh
+        self.gh_read = gh_read if gh_read is not None else gh
+        self.log = log
+        self._now = now or (lambda: datetime.now(timezone.utc))
+
+    # -- reads ---------------------------------------------------------------
+
+    def _graphql(self, query: str, **variables: object) -> dict:
+        argv = ["api", "graphql", "-f", f"query={query}"]
+        for key, value in variables.items():
+            flag = "-F" if isinstance(value, (int, bool)) else "-f"
+            argv += [flag, f"{key}={value}"]
+        response = json.loads(self.gh_read(argv))
+        if response.get("errors"):
+            raise GhError(f"GraphQL returned errors: {response['errors']}")
+        return response.get("data") or {}
+
+    def queue_entries(self) -> list[QueueEntry]:
+        data = self._graphql(
+            QUEUE_QUERY,
+            owner=self.owner,
+            name=self.name,
+            branch=self.branch,
+            first=QUEUE_ENTRY_PAGE,
+        )
+        queue = ((data.get("repository") or {}).get("mergeQueue")) or {}
+        nodes = ((queue.get("entries") or {}).get("nodes")) or []
+        entries: list[QueueEntry] = []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            pull = node.get("pullRequest") or {}
+            entries.append(
+                QueueEntry(
+                    pr_number=int(pull.get("number", 0)),
+                    pr_id=str(pull.get("id", "")),
+                    entry_id=str(node.get("id", "")),
+                    position=int(node.get("position", 0)),
+                    state=str(node.get("state", "")).upper(),
+                    enqueued_at=parse_iso(node.get("enqueuedAt")),
+                    base_oid=(node.get("baseCommit") or {}).get("oid"),
+                    head_oid=(node.get("headCommit") or {}).get("oid"),
+                )
+            )
+        return entries
+
+    def check_suite_count(self, sha: str) -> int | None:
+        """`total_count` of check-suites on a commit, or None if not establishable.
+
+        The authoritative counter is `total_count`; page 1's array length is read as a
+        cross-check so a truncated/garbled response can never be mistaken for a
+        positively-observed zero.
+        """
+        try:
+            raw = self.gh_read(
+                [
+                    "api",
+                    "-X",
+                    "GET",
+                    f"repos/{self.repo}/commits/{sha}/check-suites?per_page=100",
+                ]
+            )
+            payload = json.loads(raw)
+        except (GhError, json.JSONDecodeError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        total = payload.get("total_count")
+        suites = payload.get("check_suites")
+        if not isinstance(total, int) or not isinstance(suites, list):
+            return None
+        if total == 0 and suites:
+            return None
+        return total
+
+    def group_created_at(self, ref: str, head_oid: str) -> datetime | None:
+        """Exact ref-build time from the repository activity API, matched on head SHA."""
+        try:
+            raw = self.gh_read(
+                [
+                    "api",
+                    "-X",
+                    "GET",
+                    "--paginate",
+                    "-q",
+                    ".[]|@json",
+                    f"repos/{self.repo}/activity"
+                    f"?activity_type=branch_creation&per_page=100"
+                    f"&ref=refs/heads/{ref}",
+                ]
+            )
+            rows = _ndjson(raw)
+        except GhError:
+            return None
+        stamps = [
+            parse_iso(row.get("timestamp"))
+            for row in rows
+            if row.get("activity_type") == "branch_creation"
+            and str(row.get("after", "")) == head_oid
+        ]
+        stamps = [stamp for stamp in stamps if stamp is not None]
+        return max(stamps) if stamps else None
+
+    def pr_markers(self, pr_number: int) -> list[Marker]:
+        raw = self.gh_read(
+            [
+                "api",
+                "-X",
+                "GET",
+                "--paginate",
+                "-q",
+                ".[]|@json",
+                f"repos/{self.repo}/issues/{pr_number}/comments?per_page=100",
+            ]
+        )
+        markers = [parse_marker(row.get("body")) for row in _ndjson(raw)]
+        return [marker for marker in markers if marker is not None]
+
+    def last_enqueued_at(self, pr_number: int) -> datetime | None:
+        try:
+            raw = self.gh_read(
+                [
+                    "api",
+                    "-X",
+                    "GET",
+                    "--paginate",
+                    "-q",
+                    ".[]|@json",
+                    f"repos/{self.repo}/issues/{pr_number}/timeline?per_page=100",
+                ]
+            )
+            rows = _ndjson(raw)
+        except GhError:
+            return None
+        stamps = [
+            parse_iso(row.get("created_at"))
+            for row in rows
+            if row.get("event") == "added_to_merge_queue"
+        ]
+        stamps = [stamp for stamp in stamps if stamp is not None]
+        return max(stamps) if stamps else None
+
+    # -- mutations -----------------------------------------------------------
+
+    def post_marker_comment(self, entry: QueueEntry, ref: str, observed: datetime) -> None:
+        marker = render_marker(
+            pr=entry.pr_number,
+            head=entry.head_oid or "",
+            base=entry.base_oid or "",
+            ref=ref,
+            suites=0,
+            observed=observed,
+        )
+        body = "\n".join(
+            [
+                "> 🤖 **SPARQ agent** — merge-group watchdog.",
+                "",
+                f"This PR's merge-group ref `{ref}` (head `{(entry.head_oid or '')[:8]}`)"
+                " has **zero check-suites** — GitHub Actions never dispatched the"
+                " `merge_group` event for it, so no required check can ever report and"
+                " the entry would hold the head of the queue until the ruleset's"
+                " 60-minute `CI_TIMEOUT` fires (sparq-org/sparq#4652).",
+                "",
+                "Recovering by dequeue + re-enqueue so the group is rebuilt. **Nothing"
+                " is wrong with this PR's diff**; its review verdict is preserved.",
+                "",
+                marker,
+            ]
+        )
+        self.gh(["pr", "comment", str(entry.pr_number), "--repo", self.repo, "--body", body])
+
+    def recover(self, entry: QueueEntry) -> None:
+        self.gh(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={DEQUEUE_MUTATION}",
+                "-f",
+                f"id={entry.pr_id}",
+            ]
+        )
+        self.gh(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={ENQUEUE_MUTATION}",
+                "-f",
+                f"id={entry.pr_id}",
+            ]
+        )
+
+    # -- the sweep -----------------------------------------------------------
+
+    def emit(self, row: str) -> None:
+        self.log(f"[{PROGRAM}] {row}")
+        summary = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary:
+            try:
+                with open(summary, "a", encoding="utf-8") as handle:
+                    handle.write(f"- `{row}`\n")
+            except OSError:
+                pass
+
+    def sweep(self) -> int:
+        now = self._now()
+        entries = self.queue_entries()
+        if not entries:
+            self.emit(
+                f"branch={self.branch} queue is EMPTY — 0 entries to watch "
+                f"(grace={self.grace_seconds}s)"
+            )
+            return 0
+
+        counts: dict[str, int] = {}
+        errors = 0
+        run_recoveries = 0
+        for entry in sorted(entries, key=lambda e: e.position):
+            ref = (
+                queue_ref(self.branch, entry.pr_number, entry.base_oid)
+                if entry.base_oid
+                else "(no group)"
+            )
+            suites: int | None = None
+            created_at: datetime | None = None
+            markers: list[Marker] = []
+            recoveries_in_window = 0
+
+            if entry.state in ACTIONABLE_STATES and entry.head_oid and entry.base_oid:
+                suites = self.check_suite_count(entry.head_oid)
+                if suites == 0:
+                    created_at = self.group_created_at(ref, entry.head_oid)
+                    try:
+                        markers = self.pr_markers(entry.pr_number)
+                    except (GhError, json.JSONDecodeError) as error:
+                        self.emit(
+                            f"pos={entry.position} pr=#{entry.pr_number} ref={ref} "
+                            f"head={(entry.head_oid or '')[:8]} suites=0 "
+                            f"decision={REFUSE} — marker history unreadable ({error})"
+                        )
+                        counts[REFUSE] = counts.get(REFUSE, 0) + 1
+                        errors += 1
+                        continue
+                    cutoff = now - timedelta(seconds=self.recovery_window_seconds)
+                    recoveries_in_window = sum(
+                        1 for marker in markers if marker.observed >= cutoff
+                    )
+
+            decision = decide_entry(
+                entry,
+                suites=suites,
+                created_at=created_at,
+                now=now,
+                grace_seconds=self.grace_seconds,
+                markers=markers,
+                recoveries_in_window=recoveries_in_window,
+                max_recoveries_per_pr=self.max_recoveries_per_pr,
+                run_recoveries=run_recoveries,
+                max_recoveries_per_run=self.max_recoveries_per_run,
+            )
+
+            suite_text = "unknown" if suites is None else str(suites)
+            row = (
+                f"pos={entry.position} pr=#{entry.pr_number} state={entry.state} "
+                f"ref={ref} head={(entry.head_oid or '-')[:8]} suites={suite_text} "
+                f"decision={decision.verdict} — {decision.detail}"
+            )
+
+            if decision.verdict == RECOVER and not self.dry_run:
+                try:
+                    self.post_marker_comment(entry, ref, now)
+                    self.recover(entry)
+                except GhError as error:
+                    self.emit(f"{row} :: RECOVERY FAILED ({error})")
+                    self.log(
+                        f"::error title={PROGRAM} recovery failed::PR #{entry.pr_number} "
+                        f"ref {ref}: {error}"
+                    )
+                    counts["RECOVER_FAILED"] = counts.get("RECOVER_FAILED", 0) + 1
+                    errors += 1
+                    continue
+                run_recoveries += 1
+
+            self.emit(row + (" [dry-run]" if self.dry_run and decision.verdict == RECOVER else ""))
+            if decision.verdict in (CAP, REFUSE, NOOP):
+                self.log(
+                    f"::warning title={PROGRAM} {decision.verdict}::"
+                    f"PR #{entry.pr_number} ref {ref}: {decision.detail}"
+                )
+            counts[decision.verdict] = counts.get(decision.verdict, 0) + 1
+
+        census = " ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+        self.emit(f"sweep complete: entries={len(entries)} {census} errors={errors}")
+        return errors
+
+    # -- the dequeue routing split -------------------------------------------
+
+    def classify_dequeue(self, pr_number: int, reason: str) -> Route:
+        now = self._now()
+        try:
+            markers = self.pr_markers(pr_number)
+        except (GhError, json.JSONDecodeError) as error:
+            return Route(
+                ROUTE_DEMOTE, False, f"marker history unreadable ({error})"
+            )
+        return classify_dequeue_route(
+            reason=reason,
+            markers=markers,
+            last_enqueued_at=self.last_enqueued_at(pr_number),
+            live_suites=self.check_suite_count,
+            now=now,
+        )
+
+
+def write_outputs(route: Route, log: Callable[[str], None] = print) -> None:
+    """Emit the routing verdict as a row AND as GitHub step outputs."""
+    log(
+        f"[{PROGRAM}] dequeue route={route.route} reenqueue="
+        f"{'true' if route.reenqueue else 'false'} — {route.detail}"
+    )
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"route={route.route}\n")
+        handle.write(f"reenqueue={'true' if route.reenqueue else 'false'}\n")
+        handle.write(f"detail={route.detail}\n")
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────
+
+
+def _entry(
+    *,
+    pr: int = 4534,
+    position: int = 1,
+    state: str = "AWAITING_CHECKS",
+    base: str | None = "3cc1bf828c1335577069f5fa65d832c0ae1c8c38",
+    head: str | None = "1bfb0174f5cc2da1ed9dfe7997b7ab089e7cab26",
+) -> QueueEntry:
+    return QueueEntry(
+        pr_number=pr,
+        pr_id=f"PR_{pr}",
+        entry_id=f"MQE_{pr}",
+        position=position,
+        state=state,
+        enqueued_at=parse_iso("2026-07-27T22:58:53Z"),
+        base_oid=base,
+        head_oid=head,
+    )
+
+
+def self_test() -> None:
+    now = parse_iso("2026-07-27T23:20:00Z")
+    assert now is not None
+    built = parse_iso("2026-07-27T23:04:37Z")  # the real #4534 branch_creation time
+
+    def call(**overrides):
+        kwargs = dict(
+            suites=0,
+            created_at=built,
+            now=now,
+            grace_seconds=DEFAULT_GRACE_SECONDS,
+            markers=(),
+            recoveries_in_window=0,
+            max_recoveries_per_pr=DEFAULT_MAX_RECOVERIES_PER_PR,
+            run_recoveries=0,
+            max_recoveries_per_run=DEFAULT_MAX_RECOVERIES_PER_RUN,
+        )
+        entry = overrides.pop("entry", _entry())
+        kwargs.update(overrides)
+        return decide_entry(entry, **kwargs)
+
+    # The incident: zero suites, well past grace => RECOVER.
+    assert call().verdict == RECOVER, call()
+    # THE CONTROL: suites present but runs still pending => never touched.
+    assert call(suites=8).verdict == HOLD, call(suites=8)
+    # Fail safe: an unknown suite count is never a recovery.
+    assert call(suites=None).verdict == REFUSE, call(suites=None)
+    # Fail safe: no branch_creation row => no anchor => no action.
+    assert call(created_at=None).verdict == REFUSE, call(created_at=None)
+    # Grace gate.
+    assert call(now=built + timedelta(seconds=299)).verdict == WAIT
+    assert call(now=built + timedelta(seconds=301)).verdict == RECOVER
+    # Idempotence: a repeat detection on the SAME head is a no-op.
+    same = Marker(
+        pr=4534,
+        head="1bfb0174f5cc2da1ed9dfe7997b7ab089e7cab26",
+        base="",
+        ref="",
+        suites=0,
+        observed=now - timedelta(minutes=5),
+        action="re-enqueue",
+    )
+    assert call(markers=(same,)).verdict == NOOP, call(markers=(same,))
+    # A marker for a DIFFERENT head does not suppress a fresh detection.
+    other = Marker(**{**same.__dict__, "head": "a" * 40})
+    assert call(markers=(other,), recoveries_in_window=1).verdict == RECOVER
+    # Caps.
+    assert call(recoveries_in_window=2).verdict == CAP
+    assert call(run_recoveries=2).verdict == CAP
+    # Non-actionable states.
+    for state in ("QUEUED", "MERGEABLE", "UNMERGEABLE", "LOCKED"):
+        assert call(entry=_entry(state=state)).verdict == SKIP, state
+    assert call(entry=_entry(head=None)).verdict == SKIP
+
+    # Ref reconstruction, pinned against live-verified data.
+    assert (
+        queue_ref("main", 4644, "c96f5abe3e0b7ba50c1381a1503ba961313b3da7")
+        == "gh-readonly-queue/main/pr-4644-c96f5abe3e0b7ba50c1381a1503ba961313b3da7"
+    )
+
+    # Marker round-trip.
+    rendered = render_marker(
+        pr=4534,
+        head="1bfb0174f5cc2da1ed9dfe7997b7ab089e7cab26",
+        base="3cc1bf828c1335577069f5fa65d832c0ae1c8c38",
+        ref="gh-readonly-queue/main/pr-4534-3cc1bf828c1335577069f5fa65d832c0ae1c8c38",
+        suites=0,
+        observed=now,
+    )
+    parsed = parse_marker("body text\n\n" + rendered)
+    assert parsed is not None and parsed.head.startswith("1bfb0174"), rendered
+    assert parsed.suites == 0 and parsed.action == "re-enqueue"
+    assert parse_marker("no marker here") is None
+    assert parse_marker(f"<!-- {MARKER_KEY} pr=1 head=nothex suites=0 observed=x -->") is None
+
+    # Routing split — both arms.
+    def route(**overrides):
+        kwargs = dict(
+            reason=ZERO_DISPATCH_REASON,
+            markers=(parsed,),
+            last_enqueued_at=now - timedelta(hours=1),
+            live_suites=lambda _sha: 0,
+            now=now + timedelta(minutes=40),
+        )
+        kwargs.update(overrides)
+        return classify_dequeue_route(**kwargs)
+
+    assert route().route == ROUTE_PRESERVE, route()
+    assert route().reenqueue is True
+    # The other arm: a CI_TIMEOUT that followed REAL checks still demotes.
+    assert route(live_suites=lambda _s: 8).route == ROUTE_DEMOTE, route(live_suites=lambda _s: 8)
+    # Unreadable count => demote (fail safe).
+    assert route(live_suites=lambda _s: None).route == ROUTE_DEMOTE
+    # No marker => demote.
+    assert route(markers=()).route == ROUTE_DEMOTE
+    # A marker predating the current attempt cannot steer the route.
+    assert route(last_enqueued_at=now + timedelta(minutes=1)).route == ROUTE_DEMOTE
+    # No added_to_merge_queue event => demote.
+    assert route(last_enqueued_at=None).route == ROUTE_DEMOTE
+    # A stale marker => demote.
+    assert route(now=now + timedelta(hours=7)).route == ROUTE_DEMOTE
+    # Reasons other than CI_TIMEOUT keep today's behaviour.
+    for other_reason in ("CI_FAILURE", "MERGE_CONFLICT", "QUEUE_CLEARED", "ROLL_BACK"):
+        assert route(reason=other_reason).route == ROUTE_DEMOTE, other_reason
+    # The watchdog's OWN dequeue preserves without a second re-enqueue.
+    own = route(reason="MANUAL", now=now + timedelta(seconds=30))
+    assert own.route == ROUTE_PRESERVE and own.reenqueue is False, own
+    # ...but only inside the self-dequeue window.
+    assert route(reason="MANUAL", now=now + timedelta(hours=2)).route == ROUTE_DEMOTE
+    # A conflict dequeue right after a recovery is NOT attributed to the watchdog.
+    assert route(reason="MERGE_CONFLICT", now=now + timedelta(seconds=30)).route == ROUTE_DEMOTE
+
+    print(f"{PROGRAM} self-test: PASS")
+
+
+# ── entrypoint ───────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    sub = parser.add_subparsers(dest="command")
+
+    sweep_parser = sub.add_parser("sweep", help="scan the merge queue for zero-dispatch")
+    sweep_parser.add_argument("--repo", required=True)
+    sweep_parser.add_argument("--branch", default="main")
+    sweep_parser.add_argument("--grace-seconds", type=int, default=DEFAULT_GRACE_SECONDS)
+    sweep_parser.add_argument(
+        "--max-recoveries-per-pr", type=int, default=DEFAULT_MAX_RECOVERIES_PER_PR
+    )
+    sweep_parser.add_argument(
+        "--recovery-window-seconds", type=int, default=DEFAULT_RECOVERY_WINDOW_SECONDS
+    )
+    sweep_parser.add_argument(
+        "--max-recoveries-per-run", type=int, default=DEFAULT_MAX_RECOVERIES_PER_RUN
+    )
+    sweep_parser.add_argument("--dry-run", action="store_true")
+
+    classify_parser = sub.add_parser(
+        "classify-dequeue", help="route a pull_request.dequeued event"
+    )
+    classify_parser.add_argument("--repo", required=True)
+    classify_parser.add_argument("--pr", type=int, required=True)
+    classify_parser.add_argument("--reason", default="UNKNOWN")
+
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        self_test()
+        return 0
+
+    if args.command == "classify-dequeue":
+        # FAIL SAFE: any failure at all routes to `demote`, which is the pre-existing
+        # behaviour. A classifier crash must never silently preserve a verdict.
+        try:
+            watchdog = Watchdog(args.repo, gh_read=run_gh_read)
+            route = watchdog.classify_dequeue(args.pr, args.reason)
+        except (GhError, ValueError, json.JSONDecodeError, gh_retry.GhTransientExhausted) as error:
+            route = Route(ROUTE_DEMOTE, False, f"classification failed ({error})")
+        write_outputs(route)
+        return 0
+
+    if args.command == "sweep":
+        try:
+            watchdog = Watchdog(
+                args.repo,
+                branch=args.branch,
+                grace_seconds=args.grace_seconds,
+                max_recoveries_per_pr=args.max_recoveries_per_pr,
+                recovery_window_seconds=args.recovery_window_seconds,
+                max_recoveries_per_run=args.max_recoveries_per_run,
+                dry_run=args.dry_run,
+                gh_read=run_gh_read,
+            )
+            return 1 if watchdog.sweep() else 0
+        except gh_retry.GhTransientExhausted as error:
+            # Periodic + idempotent: a missed cycle is harmless, the next tick covers
+            # it. Still emitted loudly so the miss is never invisible.
+            print(
+                f"::warning title={PROGRAM} skipped a cycle on transient GitHub API "
+                f"failures::{error}"
+            )
+            return 0
+        except (GhError, ValueError, json.JSONDecodeError) as error:
+            print(f"[{PROGRAM}] fatal: {error}", file=sys.stderr)
+            return 1
+
+    parser.error("a subcommand is required unless --self-test is used")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -784,7 +784,25 @@ class Watchdog:
         counts: dict[str, int] = {}
         errors = 0
         run_recoveries = 0
-        for entry in sorted(entries, key=lambda e: e.position):
+        ordered = sorted(entries, key=lambda e: e.position)
+        for entry in ordered:
+            # THE EFFECTIVENESS TERM. Every entry behind this one is chained ON TOP of
+            # its group head, so a rebuild discards all of their CI too. The real cost
+            # of a dead ref is therefore not the ref — it is how much work stacks above
+            # it before anyone notices:
+            #     cost ~= (groups stacked above the dead ref at detection) x (their CI)
+            # Measured 2026-07-28: intervening at 48 min meant that term was 4 (two of
+            # them already MERGEABLE, i.e. fully green, and all four were discarded on
+            # the rebuild). Firing inside the grace should make it 0. Recording it on
+            # every row makes the watchdog self-measuring: if `stacked` starts climbing
+            # the grace has drifted too long, and the rows say so without anyone having
+            # to notice an outage by hand.
+            stacked = [
+                other
+                for other in ordered
+                if other.position > entry.position and other.head_oid
+            ]
+            stacked_green = [o for o in stacked if o.state == "MERGEABLE"]
             ref = (
                 queue_ref(self.branch, entry.pr_number, entry.base_oid)
                 if entry.base_oid
@@ -832,6 +850,7 @@ class Watchdog:
             row = (
                 f"pos={entry.position} pr=#{entry.pr_number} state={entry.state} "
                 f"ref={ref} head={(entry.head_oid or '-')[:8]} suites={suite_text} "
+                f"stacked={len(stacked)} stacked_green={len(stacked_green)} "
                 f"decision={decision.verdict} — {decision.detail}"
             )
 

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -249,9 +249,36 @@ TRUSTED_MARKER_AUTHORS = frozenset(
 )
 
 MARKER_KEY = "merge-group-watchdog"
+# BOUNDED ON PURPOSE. `[^>]*?` is quadratic under backtracking: a 65 536-char comment
+# of repeated `<!-- merge-group-watchdog ` cost 21.4 s to parse, and four such comments
+# took `classify-dequeue` to 63 s — ~19 would exceed merge-queue-feedback.yml's
+# 5-minute job timeout. sparq is PUBLIC and that workflow runs on every dequeue, so
+# that is an anonymous denial of service against merge-queue routing. A real marker's
+# key/value run is 262 chars; 400 is comfortable headroom and makes the parse linear.
 _MARKER_RE = re.compile(
-    r"<!--\s*" + MARKER_KEY + r"\s+(?P<kv>[^>]*?)\s*-->",
+    r"<!--\s*" + MARKER_KEY + r"\s+(?P<kv>[^>]{0,400}?)\s*-->",
 )
+
+# Contexts in which a marker is being QUOTED rather than asserted. A trusted bot that
+# echoes PR content — and `sparq-orchestrator[bot]` really does, quoting file spans on
+# worker PRs — would otherwise launder an attacker's marker through the author filter.
+# Stripped before matching, so a quoted marker is never seen at all.
+_FENCED_RE = re.compile(r"(?ms)^\s*(`{3,}|~{3,}).*?^\s*\1\s*$")
+_INDENTED_CODE_RE = re.compile(r"(?m)^(?: {4,}|\t).*$")
+_BLOCKQUOTE_RE = re.compile(r"(?m)^\s*>.*$")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+
+
+def strip_quoted_contexts(body: str) -> str:
+    """Remove fenced/indented code, blockquotes and inline spans from a comment body.
+
+    The watchdog's own marker sits on its own unquoted line, so this never removes a
+    genuine marker; it removes every context in which one is being displayed rather
+    than claimed.
+    """
+    for pattern in (_FENCED_RE, _INDENTED_CODE_RE, _BLOCKQUOTE_RE, _INLINE_CODE_RE):
+        body = pattern.sub(" ", body)
+    return body
 _MARKER_FIELD_RE = re.compile(r"(?P<key>[a-z_]+)=(?P<value>\S+)")
 
 QUEUE_QUERY = """query($owner:String!,$name:String!,$branch:String!,$first:Int!){
@@ -352,8 +379,17 @@ def parse_marker(body: str | None) -> Marker | None:
     """Parse a watchdog marker out of a comment body; None when absent/malformed."""
     if not body:
         return None
+    body = strip_quoted_contexts(body)
     match = _MARKER_RE.search(body)
     if not match:
+        return None
+    # NESTING DEPTH, not a substring test. `<!-- quoted: <!-- merge-group-watchdog … -->`
+    # matches on the INNER opener, whose payload is perfectly clean — so inspecting the
+    # match tells you nothing. What matters is whether an enclosing comment was still
+    # open at the match position: more `<!--` than `-->` before it means this marker is
+    # being displayed inside another comment, not asserted.
+    prefix = body[: match.start()]
+    if prefix.count("<!--") > prefix.count("-->"):
         return None
     fields = {
         m.group("key"): m.group("value")
@@ -374,6 +410,11 @@ def parse_marker(body: str | None) -> Marker | None:
     # written by this tool. Validated so the field is load-bearing rather than dead
     # data — a mutant flipping it to 1 otherwise changed nothing observable.
     if suites != 0:
+        return None
+    # Self-consistency: `ref` must name the same PR as `pr`. A marker whose two
+    # identity fields disagree was not written by this tool.
+    ref = fields.get("ref", "")
+    if f"/pr-{pr}-" not in ref:
         return None
     return Marker(
         pr=pr,
@@ -543,6 +584,7 @@ def verdict_is_still_for_this_tree(state: VerdictState) -> tuple[bool, str]:
 def classify_dequeue_route(
     *,
     reason: str,
+    pr_number: int,
     markers: Iterable[Marker],
     verdict: VerdictState,
     live_suites: Callable[[str], int | None],
@@ -555,7 +597,16 @@ def classify_dequeue_route(
     FAIL-SAFE: every arm that cannot POSITIVELY establish zero-dispatch returns
     `demote`, which is the pre-existing behaviour.
     """
-    ordered = sorted(markers, key=lambda m: m.observed, reverse=True)
+    # BIND TO THIS PR. A marker is evidence about ONE pull request; without this a
+    # marker written for a different PR (or naming a foreign zero-suite head) carries a
+    # verdict through this PR's dequeue. Both the `pr=` field and the `ref=` segment
+    # must agree with the PR being routed, so a single mistyped field cannot pass.
+    own = [
+        marker
+        for marker in markers
+        if marker.pr == pr_number and f"/pr-{pr_number}-" in marker.ref
+    ]
+    ordered = sorted(own, key=lambda m: m.observed, reverse=True)
     newest = ordered[0] if ordered else None
     normalised = (reason or "UNKNOWN").strip().upper()
     last_enqueued_at = verdict.last_enqueued_at
@@ -636,6 +687,12 @@ def classify_dequeue_route(
             False,
             f"watchdog observation is {int(marker_age)}s old — outside the "
             f"{marker_staleness_seconds}s freshness bound",
+        )
+    if newest.action != MARKER_ACTION_REENQUEUE:
+        return Route(
+            ROUTE_DEMOTE,
+            False,
+            f"marker action {newest.action!r} is not {MARKER_ACTION_REENQUEUE!r}",
         )
     count = live_suites(newest.head)
     if count is None:
@@ -801,7 +858,12 @@ class Watchdog:
             return None
         total = payload.get("total_count")
         suites = payload.get("check_suites")
-        if not isinstance(total, int) or not isinstance(suites, list):
+        # `isinstance(False, int)` is True, so a bool must be rejected EXPLICITLY:
+        # `{"total_count": false}` otherwise reads as a positively-observed ZERO and
+        # drives a recovery + marker write + preserve off a malformed response.
+        if isinstance(total, bool) or not isinstance(total, int):
+            return None
+        if not isinstance(suites, list):
             return None
         if total == 0 and suites:
             return None
@@ -856,15 +918,20 @@ class Watchdog:
         rejected = 0
         rejected_authors: set[str] = set()
         for row in _ndjson(raw):
-            marker = parse_marker(row.get("body"))
-            if marker is None:
-                continue
+            # AUTHOR FIRST, ALWAYS. The trust check used to run AFTER parse_marker,
+            # so every anonymous comment was parsed before being discarded — a filter
+            # placed after the expensive work does not protect the expensive work.
+            # Cheap string compare first: untrusted bodies are never parsed at all.
             author = str((row.get("user") or {}).get("login", ""))
-            if author in TRUSTED_MARKER_AUTHORS:
-                trusted.append(marker)
+            if author not in TRUSTED_MARKER_AUTHORS:
+                if MARKER_KEY in str(row.get("body") or ""):
+                    rejected += 1
+                    rejected_authors.add(author)
                 continue
-            rejected += 1
-            rejected_authors.add(author)
+            marker = parse_marker(row.get("body"))
+            if marker is not None:
+                trusted.append(marker)
+            continue
         if rejected:
             # ONE annotation per PR, not one per marker. MEASURED on #4534, which
             # already carries 96 forged markers naming the real zero-suite head: a
@@ -1141,6 +1208,7 @@ class Watchdog:
             )
         return classify_dequeue_route(
             reason=reason,
+            pr_number=pr_number,
             markers=markers,
             verdict=self.verdict_state(pr_number),
             live_suites=self.check_suite_count,
@@ -1273,6 +1341,7 @@ def self_test() -> None:
     def route(**overrides):
         kwargs = dict(
             reason=ZERO_DISPATCH_REASON,
+            pr_number=4534,
             markers=(parsed,),
             verdict=VerdictState(
                 review_pass_at=now - timedelta(hours=2),
@@ -1305,6 +1374,8 @@ def self_test() -> None:
     assert route(verdict=VerdictState(None, None, None, readable=False)).route == ROUTE_DEMOTE
     # A stale marker => demote.
     assert route(now=now + timedelta(hours=7)).route == ROUTE_DEMOTE
+    # A marker for a DIFFERENT PR is not evidence about this one.
+    assert route(pr_number=9999).route == ROUTE_DEMOTE, route(pr_number=9999)
     # Reasons other than CI_TIMEOUT keep today's behaviour.
     for other_reason in ("CI_FAILURE", "MERGE_CONFLICT", "QUEUE_CLEARED", "ROLL_BACK"):
         assert route(reason=other_reason).route == ROUTE_DEMOTE, other_reason

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -114,10 +114,22 @@ PROGRAM = "merge-group-watchdog"
 # the activity `branch_creation` timestamp -> earliest check-suite `created_at`:
 #     min 1 s | p50 2 s | p90 3 s | p99 4 s | MAX 4 s   (whole-second quantisation)
 # There is NO tail between 4 s and 3600 s. The failure mode is CATEGORICAL, not slow:
-# a group either gets its suites within 1-4 s or gets none at all, ever. Two refs in
-# that population got none — `pr-4534-3cc1bf82…` (2026-07-27, lifetime 60m27s) and
-# `pr-4331-f6be7767…` (2026-07-26, lifetime 61m07s) — a base rate of 2/211 ~ 0.95%,
-# both reaped by the 60-minute ruleset timeout.
+# a group either gets its suites within 1-4 s or gets none at all, ever.
+#
+# THREE confirmed zero-dispatch refs, one per day, all reaped by the 60-minute timeout:
+#     pr-4331-f6be7767…  2026-07-26  head f44083c7  lifetime 61m07s  suites 0
+#     pr-4534-3cc1bf82…  2026-07-27  head 1bfb0174  lifetime 60m27s  suites 0
+#     pr-4709-63dfb7a0…  2026-07-28  head 98204656  held pos 1 48m   suites 0
+# #4709 was caught LIVE at 05:55Z by this script's own `sweep --dry-run` and cleared by
+# hand. Its siblings in the same chain that day discriminate the signal perfectly:
+#     pr-4709 -> 0 suites / 0 runs        <-- dead
+#     pr-4714 -> 8 suites / 95 runs       (ref built 05:33:08Z, first suite 05:33:10Z)
+#     pr-4724 -> 8 suites / 54 runs
+#     pr-4729 -> 8 suites / 69 runs
+#     pr-4731 -> 8 suites / 93 runs
+# Zero against eight, every time. Cost of that one dead ref: #4714 and #4729 were both
+# already MERGEABLE behind it and could not land, four PRs stacked, and sparq merged
+# ONE PR in sixty minutes.
 #
 # 120 s is 30x the measured MAXIMUM and 60x the median, and sits strictly below the
 # 300 s cron interval, so it never costs an extra tick: any ref that is going to get
@@ -188,6 +200,14 @@ QUEUE_QUERY = """query($owner:String!,$name:String!,$branch:String!,$first:Int!)
   }
 }"""
 
+# THE REMEDIATION CALL, and the three ways to get it wrong (each cost real time):
+#   * `gh pr merge <N> --disable-auto` does NOT dequeue an already-queued PR — it
+#     answers "is already queued to merge" and leaves the entry in place.
+#   * `DequeuePullRequestInput` names its field `id`, NOT `pullRequestId`, and that
+#     field wants the PULL REQUEST node id (`PR_…`) — not the merge-queue ENTRY id
+#     (`MQE_…`), which is the natural wrong answer given the field name. (Enqueue, in
+#     the other direction, really is `pullRequestId`.)
+#   * `MergeQueueEntry` has no `headOid` field; the group head is `headCommit{oid}`.
 DEQUEUE_MUTATION = """mutation($id:ID!){
   dequeuePullRequest(input:{id:$id}){ mergeQueueEntry{ id } }
 }"""

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -370,6 +370,10 @@ class VerdictState:
     head_moved_at: datetime | None
     last_enqueued_at: datetime | None
     readable: bool = True
+    # Tracked SEPARATELY from head_moved_at purely so the emitted reason is accurate:
+    # folding a label revocation into "the head moved" tells an operator a commit
+    # landed when none did, and sends them looking for a push that does not exist.
+    verdict_revoked_at: datetime | None = None
 
 
 def decide_entry(
@@ -470,6 +474,14 @@ def verdict_is_still_for_this_tree(state: VerdictState) -> tuple[bool, str]:
         return False, "the PR timeline could not be read"
     if state.review_pass_at is None:
         return False, "no review:pass grant found on the timeline — no verdict to keep"
+    if (
+        state.verdict_revoked_at is not None
+        and state.verdict_revoked_at > state.review_pass_at
+    ):
+        return False, (
+            f"review:pass was REVOKED at {iso(state.verdict_revoked_at)}, after the "
+            f"grant at {iso(state.review_pass_at)} — there is no live verdict to keep"
+        )
     if state.head_moved_at is not None and state.head_moved_at > state.review_pass_at:
         return False, (
             f"the head moved at {iso(state.head_moved_at)}, after review:pass was "
@@ -783,6 +795,7 @@ class Watchdog:
         enqueued: list[datetime] = []
         granted: list[datetime] = []
         moved: list[datetime] = []
+        revoked: list[datetime] = []
         for row in rows:
             event = row.get("event")
             stamp = parse_iso(row.get("created_at"))
@@ -792,10 +805,10 @@ class Watchdog:
                 if str((row.get("label") or {}).get("name", "")).lower() == REVIEW_PASS:
                     granted.append(stamp)
             elif event == "unlabeled" and stamp:
-                # A verdict that was REMOVED is not a verdict. Model a removal as a
-                # head move at that instant, so any earlier grant stops qualifying.
+                # A verdict that was REMOVED is not a verdict, and it is recorded as a
+                # revocation rather than a head move so the reason stays truthful.
                 if str((row.get("label") or {}).get("name", "")).lower() == REVIEW_PASS:
-                    moved.append(stamp)
+                    revoked.append(stamp)
             elif event == "head_ref_force_pushed" and stamp:
                 moved.append(stamp)
             elif event == "committed":
@@ -808,6 +821,7 @@ class Watchdog:
             review_pass_at=max(granted) if granted else None,
             head_moved_at=max(moved) if moved else None,
             last_enqueued_at=max(enqueued) if enqueued else None,
+            verdict_revoked_at=max(revoked) if revoked else None,
         )
 
     # -- mutations -----------------------------------------------------------

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -78,6 +78,31 @@
 # implemented as dequeue+enqueue, which itself fires `pull_request.dequeued`, and
 # without this arm the watchdog would demote every PR it rescued.
 #
+# ── the verdict-stripping defect this ALSO has to fix ─────────────────────────────
+# MEASURED on #4709, 2026-07-28 — the dequeue itself takes the verdict down with it:
+#     05:14:56  labeled   review:pass    by sparq-orchestrator[bot]
+#     06:06:38  removed_from_merge_queue (reason MANUAL)
+#     06:06:55  labeled   review:changes by github-actions[bot]
+#     06:06:55  unlabeled review:pass    by github-actions[bot]
+# Seventeen seconds. Because our recovery IS a dequeue, a watchdog without this fix
+# would strip `review:pass`, apply `review:changes`, disable the arm and admit the PR to
+# the FIX pipeline — on every PR it rescued. That is a net regression: it would
+# manufacture a `review:changes` backlog out of a platform event that never fired.
+#
+# The existing routing is CORRECT for its original purpose — a reviewer withdrawing a PR
+# *should* pull the verdict. The defect is that `MANUAL` conflates "a reviewer withdrew
+# this" with "infrastructure moved it", and the handler keys off THAT a dequeue happened,
+# never WHY. So we discriminate on EVIDENCE, never on the event name: a fresh
+# watchdog marker for this exact group head is what makes a dequeue ours.
+#
+# NON-NEGOTIABLE PRECONDITION on every preserve route (`verdict_is_still_for_this_tree`):
+# a verdict may only survive a dequeue if the head has NOT moved since it was granted.
+# A verdict attests to a specific TREE, so if a commit, a force-push, or an
+# `unlabeled review:pass` lands after the grant, the label must be allowed to fall off.
+# Verified by hand on #4709 before restoring it: `review:pass` at 05:14:56Z, last commit
+# 04:56:39Z, zero head-moving events between. Both the latest grant and the latest move
+# are used, so the realistic push-then-re-approve sequence still preserves correctly.
+#
 # The group head SHA cannot be recovered from the API after the ref is deleted (that is
 # exactly the population with no workflow runs to read it off), so the watchdog records
 # it in a machine-readable marker comment BEFORE it acts. The marker is a POINTER, not
@@ -163,6 +188,9 @@ ACTIONABLE_STATES = frozenset({"AWAITING_CHECKS"})
 # MERGE_CONFLICT / CI_FAILURE dequeue is never attributed to the watchdog.
 SELF_DEQUEUE_REASONS = frozenset({"MANUAL", "UNKNOWN"})
 ZERO_DISPATCH_REASON = "CI_TIMEOUT"
+# The verdict label whose survival across an infrastructure dequeue is the whole point
+# of the routing split.
+REVIEW_PASS = "review:pass"
 
 # Verdicts. Named constants so a test cannot silently drift from the emitter.
 SKIP = "SKIP"
@@ -334,6 +362,16 @@ class Route:
     detail: str
 
 
+@dataclass(frozen=True)
+class VerdictState:
+    """What the PR timeline says about the verdict and the head it was granted for."""
+
+    review_pass_at: datetime | None
+    head_moved_at: datetime | None
+    last_enqueued_at: datetime | None
+    readable: bool = True
+
+
 def decide_entry(
     entry: QueueEntry,
     *,
@@ -342,6 +380,7 @@ def decide_entry(
     now: datetime,
     grace_seconds: int,
     markers: Iterable[Marker],
+    markers_readable: bool = True,
     recoveries_in_window: int,
     max_recoveries_per_pr: int,
     run_recoveries: int,
@@ -365,6 +404,12 @@ def decide_entry(
         return Decision(
             HOLD,
             f"{suites} check-suite(s) present — the merge_group event was dispatched",
+        )
+    if not markers_readable:
+        return Decision(
+            REFUSE,
+            "this PR's marker history could not be read — an unreadable history is "
+            "NOT evidence of no prior recovery, so the caps cannot be evaluated",
         )
     if created_at is None:
         return Decision(
@@ -411,11 +456,33 @@ def decide_entry(
     )
 
 
+def verdict_is_still_for_this_tree(state: VerdictState) -> tuple[bool, str]:
+    """May the review verdict survive this dequeue?
+
+    NON-NEGOTIABLE PRECONDITION on every preserve route. A verdict attests to a
+    specific TREE; if the head has moved since `review:pass` was granted, the label
+    describes code nobody reviewed and it must be allowed to fall off. Measured on
+    #4709: `review:pass` at 05:14:56Z for head `c84c0810d681`, last commit 04:56:39Z,
+    zero head-moving events between — which is exactly the check that made restoring it
+    legitimate. Anything unprovable is a refusal to preserve.
+    """
+    if not state.readable:
+        return False, "the PR timeline could not be read"
+    if state.review_pass_at is None:
+        return False, "no review:pass grant found on the timeline — no verdict to keep"
+    if state.head_moved_at is not None and state.head_moved_at > state.review_pass_at:
+        return False, (
+            f"the head moved at {iso(state.head_moved_at)}, after review:pass was "
+            f"granted at {iso(state.review_pass_at)} — the verdict is not for this tree"
+        )
+    return True, f"review:pass granted {iso(state.review_pass_at)} and the head has not moved since"
+
+
 def classify_dequeue_route(
     *,
     reason: str,
     markers: Iterable[Marker],
-    last_enqueued_at: datetime | None,
+    verdict: VerdictState,
     live_suites: Callable[[str], int | None],
     now: datetime,
     self_dequeue_window_seconds: int = DEFAULT_SELF_DEQUEUE_WINDOW_SECONDS,
@@ -429,6 +496,7 @@ def classify_dequeue_route(
     ordered = sorted(markers, key=lambda m: m.observed, reverse=True)
     newest = ordered[0] if ordered else None
     normalised = (reason or "UNKNOWN").strip().upper()
+    last_enqueued_at = verdict.last_enqueued_at
 
     if newest is None:
         return Route(
@@ -436,6 +504,11 @@ def classify_dequeue_route(
             False,
             "no merge-group-watchdog observation recorded for this PR",
         )
+
+    # Applies to BOTH preserve arms, before either is considered.
+    keepable, why = verdict_is_still_for_this_tree(verdict)
+    if not keepable:
+        return Route(ROUTE_DEMOTE, False, f"verdict may not survive this dequeue: {why}")
 
     marker_age = (now - newest.observed).total_seconds()
 
@@ -684,7 +757,13 @@ class Watchdog:
         markers = [parse_marker(row.get("body")) for row in _ndjson(raw)]
         return [marker for marker in markers if marker is not None]
 
-    def last_enqueued_at(self, pr_number: int) -> datetime | None:
+    def verdict_state(self, pr_number: int) -> VerdictState:
+        """One timeline read for all three facts the routing decision needs.
+
+        A `committed` timeline event carries no `created_at` — its time is the
+        commit's own `committer.date`. `head_ref_force_pushed` is a normal event with
+        `created_at`. Both move the head, so both count.
+        """
         try:
             raw = self.gh_read(
                 [
@@ -699,14 +778,37 @@ class Watchdog:
             )
             rows = _ndjson(raw)
         except GhError:
-            return None
-        stamps = [
-            parse_iso(row.get("created_at"))
-            for row in rows
-            if row.get("event") == "added_to_merge_queue"
-        ]
-        stamps = [stamp for stamp in stamps if stamp is not None]
-        return max(stamps) if stamps else None
+            return VerdictState(None, None, None, readable=False)
+
+        enqueued: list[datetime] = []
+        granted: list[datetime] = []
+        moved: list[datetime] = []
+        for row in rows:
+            event = row.get("event")
+            stamp = parse_iso(row.get("created_at"))
+            if event == "added_to_merge_queue" and stamp:
+                enqueued.append(stamp)
+            elif event == "labeled" and stamp:
+                if str((row.get("label") or {}).get("name", "")).lower() == REVIEW_PASS:
+                    granted.append(stamp)
+            elif event == "unlabeled" and stamp:
+                # A verdict that was REMOVED is not a verdict. Model a removal as a
+                # head move at that instant, so any earlier grant stops qualifying.
+                if str((row.get("label") or {}).get("name", "")).lower() == REVIEW_PASS:
+                    moved.append(stamp)
+            elif event == "head_ref_force_pushed" and stamp:
+                moved.append(stamp)
+            elif event == "committed":
+                committed = parse_iso(
+                    (row.get("committer") or {}).get("date")
+                ) or parse_iso((row.get("author") or {}).get("date"))
+                if committed:
+                    moved.append(committed)
+        return VerdictState(
+            review_pass_at=max(granted) if granted else None,
+            head_moved_at=max(moved) if moved else None,
+            last_enqueued_at=max(enqueued) if enqueued else None,
+        )
 
     # -- mutations -----------------------------------------------------------
 
@@ -811,6 +913,7 @@ class Watchdog:
             suites: int | None = None
             created_at: datetime | None = None
             markers: list[Marker] = []
+            markers_readable = True
             recoveries_in_window = 0
 
             if entry.state in ACTIONABLE_STATES and entry.head_oid and entry.base_oid:
@@ -820,18 +923,21 @@ class Watchdog:
                     try:
                         markers = self.pr_markers(entry.pr_number)
                     except (GhError, json.JSONDecodeError) as error:
-                        self.emit(
-                            f"pos={entry.position} pr=#{entry.pr_number} ref={ref} "
-                            f"head={(entry.head_oid or '')[:8]} suites=0 "
-                            f"decision={REFUSE} — marker history unreadable ({error})"
-                        )
-                        counts[REFUSE] = counts.get(REFUSE, 0) + 1
+                        # An unreadable history is NOT "no prior recovery" — assuming
+                        # that would bypass the cap on every API blip. It falls through
+                        # to the ONE decide/emit path below as a REFUSE, so there is a
+                        # single row shape for an operator to parse.
+                        markers_readable = False
                         errors += 1
-                        continue
-                    cutoff = now - timedelta(seconds=self.recovery_window_seconds)
-                    recoveries_in_window = sum(
-                        1 for marker in markers if marker.observed >= cutoff
-                    )
+                        self.log(
+                            f"::warning title={PROGRAM} marker history unreadable::"
+                            f"PR #{entry.pr_number}: {error}"
+                        )
+                    else:
+                        cutoff = now - timedelta(seconds=self.recovery_window_seconds)
+                        recoveries_in_window = sum(
+                            1 for marker in markers if marker.observed >= cutoff
+                        )
 
             decision = decide_entry(
                 entry,
@@ -840,6 +946,7 @@ class Watchdog:
                 now=now,
                 grace_seconds=self.grace_seconds,
                 markers=markers,
+                markers_readable=markers_readable,
                 recoveries_in_window=recoveries_in_window,
                 max_recoveries_per_pr=self.max_recoveries_per_pr,
                 run_recoveries=run_recoveries,
@@ -894,7 +1001,7 @@ class Watchdog:
         return classify_dequeue_route(
             reason=reason,
             markers=markers,
-            last_enqueued_at=self.last_enqueued_at(pr_number),
+            verdict=self.verdict_state(pr_number),
             live_suites=self.check_suite_count,
             now=now,
         )
@@ -1021,7 +1128,11 @@ def self_test() -> None:
         kwargs = dict(
             reason=ZERO_DISPATCH_REASON,
             markers=(parsed,),
-            last_enqueued_at=now - timedelta(hours=1),
+            verdict=VerdictState(
+                review_pass_at=now - timedelta(hours=2),
+                head_moved_at=now - timedelta(hours=3),
+                last_enqueued_at=now - timedelta(hours=1),
+            ),
             live_suites=lambda _sha: 0,
             now=now + timedelta(minutes=40),
         )
@@ -1037,9 +1148,15 @@ def self_test() -> None:
     # No marker => demote.
     assert route(markers=()).route == ROUTE_DEMOTE
     # A marker predating the current attempt cannot steer the route.
-    assert route(last_enqueued_at=now + timedelta(minutes=1)).route == ROUTE_DEMOTE
+    assert route(verdict=VerdictState(now - timedelta(hours=2), None, now + timedelta(minutes=1))).route == ROUTE_DEMOTE
     # No added_to_merge_queue event => demote.
-    assert route(last_enqueued_at=None).route == ROUTE_DEMOTE
+    assert route(verdict=VerdictState(now - timedelta(hours=2), None, None)).route == ROUTE_DEMOTE
+    # A head that moved AFTER the verdict was granted => the verdict may not survive.
+    assert route(verdict=VerdictState(now - timedelta(hours=2), now - timedelta(minutes=1), now - timedelta(hours=1))).route == ROUTE_DEMOTE
+    # No review:pass at all => nothing to preserve.
+    assert route(verdict=VerdictState(None, None, now - timedelta(hours=1))).route == ROUTE_DEMOTE
+    # An unreadable timeline => demote.
+    assert route(verdict=VerdictState(None, None, None, readable=False)).route == ROUTE_DEMOTE
     # A stale marker => demote.
     assert route(now=now + timedelta(hours=7)).route == ROUTE_DEMOTE
     # Reasons other than CI_TIMEOUT keep today's behaviour.

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -79,6 +79,15 @@
 # implemented as dequeue+enqueue, which itself fires `pull_request.dequeued`, and
 # without this arm the watchdog would demote every PR it rescued.
 #
+# ── A DEFENSIVE CONTROL MUST NOT AMPLIFY WHAT IT REJECTS ──────────────────────────
+# Rejecting an untrusted marker emits ONE annotation per PR, never one per marker.
+# Measured the hard way: a per-marker warning against a PR carrying 567 markers
+# produced ~110 KB of log and 567 annotations — past GitHub's annotation cap, burying
+# every other signal in the run. A filter that emits per-item output hands the attacker
+# a log-flood denial of service against its own operator: the cheaper the input is to
+# produce, the louder the defence gets. State the count and the distinct authors; never
+# iterate the payload into the log. (110 KB -> 368 bytes on that same input.)
+#
 # ── the verdict-stripping defect this ALSO has to fix ─────────────────────────────
 # MEASURED on #4709, 2026-07-28 — the dequeue itself takes the verdict down with it:
 #     05:14:56  labeled   review:pass    by sparq-orchestrator[bot]
@@ -696,7 +705,14 @@ class Watchdog:
         recovery_window_seconds: int = DEFAULT_RECOVERY_WINDOW_SECONDS,
         max_recoveries_per_run: int = DEFAULT_MAX_RECOVERIES_PER_RUN,
         dry_run: bool = False,
-        gh: Callable[[list[str]], str] = run_gh,
+        # LATE-BOUND ON PURPOSE. `gh: Callable = run_gh` binds the module function at
+        # DEFINITION time, so a test that patches `merge_group_watchdog.run_gh` does not
+        # change it and the real runner is used anyway. That defect made this suite post
+        # 567 real comments to production PR #4534 during a mutation sweep: main() passes
+        # gh_read= explicitly (late-bound, patched) but let `gh` fall through to the
+        # stale default, so every simulated sweep issued a REAL `gh pr comment`.
+        # None means "resolve at call time", which is what a test patch can reach.
+        gh: Callable[[list[str]], str] | None = None,
         gh_read: Callable[[list[str]], str] | None = None,
         log: Callable[[str], None] = print,
         now: Callable[[], datetime] | None = None,
@@ -716,8 +732,8 @@ class Watchdog:
         self.recovery_window_seconds = recovery_window_seconds
         self.max_recoveries_per_run = max_recoveries_per_run
         self.dry_run = dry_run
-        self.gh = gh
-        self.gh_read = gh_read if gh_read is not None else gh
+        self.gh = gh if gh is not None else run_gh
+        self.gh_read = gh_read if gh_read is not None else self.gh
         self.log = log
         self._now = now or (lambda: datetime.now(timezone.utc))
 

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -1068,6 +1068,23 @@ class Watchdog:
             if decision.verdict == RECOVER and not self.dry_run:
                 try:
                     self.post_marker_comment(entry, ref, now)
+                    # PROVE THE EVIDENCE CHANNEL BEFORE RELYING ON IT. The caps and the
+                    # idempotence key are all read back through TRUSTED_MARKER_AUTHORS.
+                    # If this runner's identity is not on that list, every marker we
+                    # write is invisible to us: the per-head NOOP never fires, the
+                    # per-PR cap never binds, and the watchdog degrades into a
+                    # dequeue/enqueue thrash loop bounded only by the per-run budget.
+                    # So read the marker back and refuse to act if it is not there.
+                    if not any(
+                        marker.head == entry.head_oid
+                        for marker in self.pr_markers(entry.pr_number)
+                    ):
+                        raise GhError(
+                            "the marker just posted is not readable back as TRUSTED — "
+                            "refusing to dequeue. TRUSTED_MARKER_AUTHORS is probably "
+                            "missing this runner's identity, and acting without a "
+                            "readable marker would uncap the recovery loop"
+                        )
                     self.recover(entry)
                 except GhError as error:
                     self.emit(f"{row} :: RECOVERY FAILED ({error})")

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -40,8 +40,16 @@
 # The CORRECT, exact anchor is the repository ACTIVITY API:
 #     GET /repos/{repo}/activity?activity_type=branch_creation&ref=<full ref>
 # whose rows carry an exact `timestamp` plus `after` = the created head SHA. Measured
-# for the incident ref: `branch_creation` at 23:04:37Z, `after=1bfb0174…`. We match on
-# `after == head_oid` so a ref rebuilt on the same base is keyed by HEAD, never by name.
+# for the incident ref: `branch_creation` at 23:04:37Z, `after=1bfb0174…`, deleted
+# 00:05:04Z — a 3627 s lifetime with zero suites. It is also the ONLY enumeration
+# source that can see such a ref at all: it has no workflow runs and the branch is
+# deleted, so the runs API cannot find it.
+#
+# We match on `after == head_oid`, never on the ref NAME. Measured over the full
+# retained queue population (1281 branch_creation rows, 2026-07-02 -> 07-28): 15 ref
+# NAMES were created 2+ times (max 4x) because the queue rebuilds a group on the same
+# base, while head SHAs had ZERO collisions. Head SHA is the only sound key, and it is
+# the same key the recovery idempotence uses.
 #
 # ── the decision table (fail-safe: only RECOVER is a mutation) ────────────────────
 #   SKIP     entry state is not AWAITING_CHECKS, or no speculative group is built yet
@@ -100,14 +108,22 @@ import gh_retry
 PROGRAM = "merge-group-watchdog"
 
 # ── tunables ─────────────────────────────────────────────────────────────────────
-# Grace before a zero-suite group is called dropped. MEASURED create->first-suite
-# latency on this repo (repository activity `branch_creation` timestamp -> earliest
-# check-suite `created_at`) is a couple of SECONDS: e.g. ref pr-4644-c96f5abe created
-# 00:37:17Z, first suite 00:37:19Z (2 s); pr-4643-1612bd6f created 00:37:18Z, first
-# suite 00:37:20Z (2 s); the 00:05 chain rebuild created three refs at 00:05:04-06Z
-# with suites at 00:05:06-08Z (2 s). 300 s is therefore a ~100x margin over the
-# observed tail while still recovering ~55 of the 60-minute timeout.
-DEFAULT_GRACE_SECONDS = 300
+# Grace before a zero-suite group is called dropped.
+#
+# MEASURED, N=209 merge-group refs over 2026-07-25T00:00Z -> 2026-07-28T01:30Z, using
+# the activity `branch_creation` timestamp -> earliest check-suite `created_at`:
+#     min 1 s | p50 2 s | p90 3 s | p99 4 s | MAX 4 s   (whole-second quantisation)
+# There is NO tail between 4 s and 3600 s. The failure mode is CATEGORICAL, not slow:
+# a group either gets its suites within 1-4 s or gets none at all, ever. Two refs in
+# that population got none — `pr-4534-3cc1bf82…` (2026-07-27, lifetime 60m27s) and
+# `pr-4331-f6be7767…` (2026-07-26, lifetime 61m07s) — a base rate of 2/211 ~ 0.95%,
+# both reaped by the 60-minute ruleset timeout.
+#
+# 120 s is 30x the measured MAXIMUM and 60x the median, and sits strictly below the
+# 300 s cron interval, so it never costs an extra tick: any ref that is going to get
+# suites has them long before the first tick that could look at it. Detection is
+# tick-quantised, so effective recovery is 2-10 min against the 60-minute timeout.
+DEFAULT_GRACE_SECONDS = 120
 # At most this many watchdog recoveries for one PR inside the rolling window below.
 # A re-enqueue mints a NEW queue attempt, so an attempt-scoped cap would be no cap at
 # all; the budget is per PR per wall-clock window. Exhaustion is not an escalation —
@@ -912,9 +928,12 @@ def self_test() -> None:
     assert call(suites=None).verdict == REFUSE, call(suites=None)
     # Fail safe: no branch_creation row => no anchor => no action.
     assert call(created_at=None).verdict == REFUSE, call(created_at=None)
-    # Grace gate.
-    assert call(now=built + timedelta(seconds=299)).verdict == WAIT
-    assert call(now=built + timedelta(seconds=301)).verdict == RECOVER
+    # Grace gate, expressed against the constant so a retune cannot leave it stale.
+    grace = DEFAULT_GRACE_SECONDS
+    assert call(now=built + timedelta(seconds=grace - 1)).verdict == WAIT
+    assert call(now=built + timedelta(seconds=grace)).verdict == RECOVER
+    # ...and pinned against the MEASURED dispatch latency (N=209, max 4 s).
+    assert grace >= 20 * 4 and grace <= 300, grace
     # Idempotence: a repeat detection on the SAME head is a no-op.
     same = Marker(
         pr=4534,

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -838,6 +838,7 @@ class Watchdog:
         )
         trusted: list[Marker] = []
         rejected = 0
+        rejected_authors: set[str] = set()
         for row in _ndjson(raw):
             marker = parse_marker(row.get("body"))
             if marker is None:
@@ -847,15 +848,18 @@ class Watchdog:
                 trusted.append(marker)
                 continue
             rejected += 1
-            self.log(
-                f"::warning title={PROGRAM} untrusted marker::PR #{pr_number}: ignoring "
-                f"a watchdog marker authored by {author!r} — markers are honoured only "
-                f"from {sorted(TRUSTED_MARKER_AUTHORS)}"
-            )
+            rejected_authors.add(author)
         if rejected:
+            # ONE annotation per PR, not one per marker. MEASURED on #4534, which
+            # already carries 96 forged markers naming the real zero-suite head: a
+            # per-marker warning emitted 96 annotations and ~110 KB of log, which
+            # would blow GitHub's annotation cap and bury every other signal. The
+            # count and the distinct authors are what an operator needs.
             self.log(
-                f"[{PROGRAM}] PR #{pr_number}: {rejected} untrusted marker(s) IGNORED, "
-                f"{len(trusted)} trusted marker(s) accepted"
+                f"::warning title={PROGRAM} untrusted markers ignored::PR #{pr_number}: "
+                f"{rejected} watchdog marker(s) from untrusted author(s) "
+                f"{sorted(rejected_authors)} IGNORED ({len(trusted)} trusted accepted) — "
+                f"markers are honoured only from {sorted(TRUSTED_MARKER_AUTHORS)}"
             )
         return trusted
 

--- a/scripts/merge-group-watchdog.py
+++ b/scripts/merge-group-watchdog.py
@@ -30,13 +30,14 @@
 # proxies are WRONG and were rejected by measurement:
 #   * `entry.enqueuedAt` — an entry can sit outside the `max_entries_to_build` window
 #     for many minutes before its group is built, so this anchor is far too early.
-#   * the group head commit's `committer.date` — GitHub STAMPS the group commit with
-#     the entry's `enqueuedAt`, not the build time. Measured: head `0e043a13`
-#     (PR #4636's group) is stamped 23:01:57Z == #4636's enqueuedAt, but that group's
-#     branch was created at 23:19-ish; head `1bfb0174` is stamped 22:58:53Z while its
-#     own PARENT `3cc1bf828` (#4632) did not reach `main` until 23:18:59Z — a commit
-#     cannot predate its parent, which proves the field is a stamp, not a creation
-#     time. Any latency computed from it is meaningless.
+#   * the group head commit's `committer.date` — GitHub STAMPS the group commit rather
+#     than dating it at build time. THE LOAD-BEARING EVIDENCE IS THE DISTRIBUTION, not
+#     any single commit: over 40 live group heads, `branch_creation - committer.date`
+#     spans 2 s to 3929 s with a median of 16 s, and only 1 of 40 falls within +/-2 s of
+#     the real creation time. `1bfb0174`'s stamp sits 344 s BEFORE its ref existed.
+#     (An earlier draft of this note argued from a parent-commit contradiction instead;
+#     that argument is withdrawn, because the parent's own date is a stamp too and the
+#     claim could not be independently re-derived. The distribution stands on its own.)
 # The CORRECT, exact anchor is the repository ACTIVITY API:
 #     GET /repos/{repo}/activity?activity_type=branch_creation&ref=<full ref>
 # whose rows carry an exact `timestamp` plus `after` = the created head SHA. Measured
@@ -163,10 +164,21 @@ PROGRAM = "merge-group-watchdog"
 DEFAULT_GRACE_SECONDS = 120
 # At most this many watchdog recoveries for one PR inside the rolling window below.
 # A re-enqueue mints a NEW queue attempt, so an attempt-scoped cap would be no cap at
-# all; the budget is per PR per wall-clock window. Exhaustion is not an escalation —
-# the entry is handed back to the platform's own CI_TIMEOUT, whose routing now
-# preserves the review verdict (see classify-dequeue), and a CAP row is emitted every
-# tick for as long as it holds.
+# all; the budget is per PR per wall-clock window.
+#
+# EXHAUSTION BEHAVIOUR, stated as it actually is: the entry is handed back to the
+# platform's own 60-minute CI_TIMEOUT, and that dequeue **DEMOTES to review:changes**
+# like any other. It does NOT preserve the verdict. The reason is mechanical and worth
+# knowing: recovery is marker -> dequeue -> enqueue, so the marker is always ~30 s OLDER
+# than the `added_to_merge_queue` it produces; on the next attempt the newest trusted
+# marker therefore predates that attempt and the queue-attempt binding refuses it.
+#
+# That is the CORRECT outcome, not merely a tolerated one. By exhaustion the PR has
+# burned three consecutive zero-dispatch groups, the only trusted observation names a
+# SUPERSEDED group head, and preserving a verdict on the strength of a stale head's
+# suite count would be unsound. A human look is warranted at that point. What exhaustion
+# does NOT do is stall: there is no `needs:user`, no permanent hold, and a CAP row is
+# emitted every tick for as long as it holds.
 DEFAULT_MAX_RECOVERIES_PER_PR = 2
 DEFAULT_RECOVERY_WINDOW_SECONDS = 6 * 3600
 # Blast-radius bound: one tick may never churn the whole queue.
@@ -188,6 +200,9 @@ ACTIONABLE_STATES = frozenset({"AWAITING_CHECKS"})
 # MERGE_CONFLICT / CI_FAILURE dequeue is never attributed to the watchdog.
 SELF_DEQUEUE_REASONS = frozenset({"MANUAL", "UNKNOWN"})
 ZERO_DISPATCH_REASON = "CI_TIMEOUT"
+# The only action a marker may claim. Checked on the self-dequeue arm so that no other
+# marker shape can ever be mistaken for a recovery in flight.
+MARKER_ACTION_REENQUEUE = "re-enqueue"
 # The verdict label whose survival across an infrastructure dequeue is the whole point
 # of the routing split.
 REVIEW_PASS = "review:pass"
@@ -203,6 +218,26 @@ RECOVER = "RECOVER"
 
 ROUTE_PRESERVE = "preserve"
 ROUTE_DEMOTE = "demote"
+
+# ── THE MARKER IS EVIDENCE, SO ITS AUTHOR IS PART OF THE PREDICATE ───────────────
+# sparq is a PUBLIC repo and anyone can comment on a pull request. A marker read from an
+# arbitrary comment author is UNAUTHENTICATED AUTHOR-CONTROLLED INPUT, and the routing
+# split ACTS on it: a forged marker makes `review:pass` survive a dequeue and skips the
+# arm-disable, so auto-arm.py / rearm-sweeper.py re-arm the PR within ~10 minutes — and
+# on the CI_TIMEOUT arm it reaches `gh pr merge --auto` directly. Naming any commit that
+# happens to have zero check-suites suffices, and such a sha is trivially obtainable.
+#
+# Markers are therefore accepted ONLY from this allow-list. This is the load-bearing
+# control of the routing split, not a hardening nicety: it is the third occurrence in
+# this estate of "the PR's own NAMED control was a forgeable channel", after #681
+# (review evidence read from `pull["body"]`) and #937 (declarations from body/title).
+# The check lives at the READ, so nothing downstream can forget to apply it.
+TRUSTED_MARKER_AUTHORS = frozenset(
+    {
+        "github-actions[bot]",          # the workflow token's identity
+        "sparq-orchestrator[bot]",      # the App used when ORCHESTRATOR_APP_ID is set
+    }
+)
 
 MARKER_KEY = "merge-group-watchdog"
 _MARKER_RE = re.compile(
@@ -326,6 +361,11 @@ def parse_marker(body: str | None) -> Marker | None:
     head = fields.get("head", "")
     if not re.fullmatch(r"[0-9a-f]{40}", head):
         return None
+    # The watchdog only ever records a ZERO observation, so anything else was not
+    # written by this tool. Validated so the field is load-bearing rather than dead
+    # data — a mutant flipping it to 1 otherwise changed nothing observable.
+    if suites != 0:
+        return None
     return Marker(
         pr=pr,
         head=head,
@@ -444,8 +484,9 @@ def decide_entry(
         return Decision(
             CAP,
             f"per-PR recovery budget exhausted ({recoveries_in_window}/"
-            f"{max_recoveries_per_pr}) — handing back to the platform CI_TIMEOUT, "
-            "whose routing preserves the review verdict",
+            f"{max_recoveries_per_pr}) — handing back to the platform CI_TIMEOUT, which "
+            "WILL demote to review:changes (the only trusted observation names a "
+            "superseded group head, so the verdict cannot be preserved soundly)",
         )
     if run_recoveries >= max_recoveries_per_run:
         return Decision(
@@ -526,13 +567,37 @@ def classify_dequeue_route(
 
     # (a) our OWN recovery. The watchdog's dequeue+enqueue fires pull_request.dequeued;
     # without this arm the watchdog would demote every PR it just rescued.
-    if normalised in SELF_DEQUEUE_REASONS and 0 <= marker_age <= self_dequeue_window_seconds:
+    if (
+        normalised in SELF_DEQUEUE_REASONS
+        and newest.action == MARKER_ACTION_REENQUEUE
+        and 0 <= marker_age <= self_dequeue_window_seconds
+    ):
+        # DEFENCE IN DEPTH behind the author allow-list. This arm previously preserved on
+        # the marker alone and compared its head to NOTHING, so "names that exact group
+        # head" was not what the code implemented. Re-derive the count for the head the
+        # marker names: a head that does not exist reads None, and one that was really
+        # dispatched reads non-zero. Neither may carry a verdict through a dequeue.
+        own = live_suites(newest.head)
+        if own is None:
+            return Route(
+                ROUTE_DEMOTE,
+                False,
+                f"marker names head {newest.head[:8]} whose check-suite count cannot be "
+                "read — not provably the watchdog's own recovery",
+            )
+        if own != 0:
+            return Route(
+                ROUTE_DEMOTE,
+                False,
+                f"marker names head {newest.head[:8]}, which has {own} check-suite(s) — "
+                "that group WAS dispatched, so this is not a zero-dispatch recovery",
+            )
         return Route(
             ROUTE_PRESERVE,
             False,
             f"dequeue reason {normalised} within {self_dequeue_window_seconds}s of the "
-            f"watchdog's own recovery of head {newest.head[:8]} "
-            f"({int(marker_age)}s ago) — the watchdog re-enqueues; verdict preserved",
+            f"watchdog's own recovery of head {newest.head[:8]} ({int(marker_age)}s ago, "
+            "0 check-suites re-derived live) — the watchdog re-enqueues; verdict preserved",
         )
 
     # (b) the platform timeout. Split by SUITE COUNT, never by the reason alone.
@@ -755,6 +820,11 @@ class Watchdog:
         return max(stamps) if stamps else None
 
     def pr_markers(self, pr_number: int) -> list[Marker]:
+        """Trusted markers only — see TRUSTED_MARKER_AUTHORS.
+
+        A well-formed marker from an untrusted author is DROPPED and COUNTED, so a
+        forgery attempt is visible in the log rather than silently discarded.
+        """
         raw = self.gh_read(
             [
                 "api",
@@ -766,8 +836,28 @@ class Watchdog:
                 f"repos/{self.repo}/issues/{pr_number}/comments?per_page=100",
             ]
         )
-        markers = [parse_marker(row.get("body")) for row in _ndjson(raw)]
-        return [marker for marker in markers if marker is not None]
+        trusted: list[Marker] = []
+        rejected = 0
+        for row in _ndjson(raw):
+            marker = parse_marker(row.get("body"))
+            if marker is None:
+                continue
+            author = str((row.get("user") or {}).get("login", ""))
+            if author in TRUSTED_MARKER_AUTHORS:
+                trusted.append(marker)
+                continue
+            rejected += 1
+            self.log(
+                f"::warning title={PROGRAM} untrusted marker::PR #{pr_number}: ignoring "
+                f"a watchdog marker authored by {author!r} — markers are honoured only "
+                f"from {sorted(TRUSTED_MARKER_AUTHORS)}"
+            )
+        if rejected:
+            self.log(
+                f"[{PROGRAM}] PR #{pr_number}: {rejected} untrusted marker(s) IGNORED, "
+                f"{len(trusted)} trusted marker(s) accepted"
+            )
+        return trusted
 
     def verdict_state(self, pr_number: int) -> VerdictState:
         """One timeline read for all three facts the routing decision needs.
@@ -1033,7 +1123,12 @@ def write_outputs(route: Route, log: Callable[[str], None] = print) -> None:
     with open(path, "a", encoding="utf-8") as handle:
         handle.write(f"route={route.route}\n")
         handle.write(f"reenqueue={'true' if route.reenqueue else 'false'}\n")
-        handle.write(f"detail={route.detail}\n")
+        # `detail` can embed gh stderr, which is multi-line. A bare `k=v` line would
+        # spill the remainder into the outputs file as further keys, so use the
+        # heredoc form with a delimiter that cannot survive in the payload.
+        delimiter = "MGW_DETAIL_EOF"
+        detail = route.detail.replace(delimiter, "MGW-DETAIL-EOF")
+        handle.write(f"detail<<{delimiter}\n{detail}\n{delimiter}\n")
 
 
 # ── self-test ────────────────────────────────────────────────────────────────────

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -541,6 +541,30 @@ class TestMarkerCodec(unittest.TestCase):
         self.assertEqual(parsed.observed, NOW)
         self.assertEqual(parsed.action, "re-enqueue")
 
+    def test_a_non_hex_head_is_rejected_on_an_otherwise_valid_marker(self):
+        # ISOLATED. The earlier fixture also lacked a valid `ref=`, so the newer
+        # self-consistency check rejected it first and the hex guard was never reached
+        # — the mutant that disabled the hex check therefore survived.
+        good = mgw.render_marker(
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        )
+        self.assertIsNotNone(mgw.parse_marker(good))
+        self.assertIsNone(mgw.parse_marker(good.replace(f"head={HEAD}", "head=nothex")))
+        self.assertIsNone(
+            mgw.parse_marker(good.replace(f"head={HEAD}", "head=" + "g" * 40))
+        )
+        self.assertIsNone(
+            mgw.parse_marker(good.replace(f"head={HEAD}", "head=" + HEAD[:39]))
+        )
+
+    def test_a_nonzero_suite_count_is_rejected_on_an_otherwise_valid_marker(self):
+        good = mgw.render_marker(
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        )
+        self.assertIsNotNone(mgw.parse_marker(good))
+        for bad in ("suites=1", "suites=8", "suites=-1"):
+            self.assertIsNone(mgw.parse_marker(good.replace("suites=0", bad)), bad)
+
     def test_rejects_malformed(self):
         for body in (
             "",
@@ -2189,7 +2213,18 @@ class TestFeedbackWiring(unittest.TestCase):
         run = _step(self.wf, "feedback", "Preserve the verdict")["run"]
         self.assertIn("gh pr view", run)
         self.assertIn("--json state", run)
-        self.assertIn('"$STATE" != "OPEN"', run)
+        # SHAPE, not substring presence: the guard must compare against OPEN and the
+        # non-open branch must EXIT, before anything mutating runs. A mutant that left
+        # the strings in place while changing what happens survived a presence test.
+        lines = [ln.strip() for ln in run.splitlines()]
+        idx = next(i for i, ln in enumerate(lines) if '"$STATE" != "OPEN"' in ln)
+        branch = lines[idx : idx + 4]
+        self.assertTrue(any(ln == "exit 0" for ln in branch), branch)
+        # ...and it happens before the re-arm / comment, never after.
+        first_mutation = next(
+            i for i, ln in enumerate(lines) if ln.startswith("gh pr merge") or ln.startswith("gh pr comment")
+        )
+        self.assertLess(idx, first_mutation, lines)
 
     def test_every_post_skip_step_carries_the_merged_guard(self):
         # The first step short-circuits a successful-merge dequeue; every later step

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -929,6 +929,36 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
         self.assertTrue(any("untrusted marker" in r for r in harness.rows), harness.rows)
         self.assertTrue(any(ATTACKER in r for r in harness.rows), harness.rows)
 
+    def test_mass_forgery_emits_ONE_annotation_not_one_per_marker(self):
+        # MEASURED: PR #4534 already carries 96 forged markers naming the real
+        # zero-suite head. A per-marker annotation produced ~110 KB of log and would
+        # blow GitHub's annotation cap, burying every other signal — so the volume of
+        # an attack must not become the volume of the log.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment(author=ATTACKER, head=f"{i:040x}") for i in range(96)],
+        )
+        self.assertEqual(harness.watchdog.pr_markers(4534), [])
+        warnings = [r for r in harness.rows if "::warning" in r]
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertIn("96 watchdog marker(s)", warnings[0])
+        self.assertIn(ATTACKER, warnings[0])
+
+    def test_the_summary_names_every_distinct_untrusted_author(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[
+                _marker_comment(author="attacker-one", head="a" * 40),
+                _marker_comment(author="attacker-two", head="b" * 40),
+                _marker_comment(author="attacker-one", head="c" * 40),
+            ],
+        )
+        harness.watchdog.pr_markers(4534)
+        warning = next(r for r in harness.rows if "::warning" in r)
+        self.assertIn("attacker-one", warning)
+        self.assertIn("attacker-two", warning)
+        self.assertIn("3 watchdog marker(s)", warning)
+
     def test_a_forged_marker_cannot_suppress_a_real_recovery_either(self):
         # The idempotence key is read from the SAME channel, so an attacker must not be
         # able to post a marker for the live head and block the watchdog from acting.

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -726,6 +726,21 @@ class TestSweepBehaviour(unittest.TestCase):
             any("not readable back as TRUSTED" in r for r in harness.rows), harness.rows
         )
 
+    def test_the_readback_must_find_THIS_head_not_merely_a_marker(self):
+        # A PR that already carries an older trusted marker (a previous recovery, a
+        # different group head) must NOT satisfy the readback when the new post fails
+        # to register. Matching "any trusted marker" instead of "a marker for this
+        # head" would wave through exactly the misconfiguration the guard exists for.
+        harness = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(head="9" * 40)]  # older, trusted, other head
+        )
+        harness.gh.post_author = ATTACKER      # the new marker lands untrusted
+        self.assertGreater(harness.run(), 0)
+        self.assertEqual([m[:2] for m in harness.gh.mutations], [["pr", "comment"]])
+        self.assertTrue(
+            any("not readable back as TRUSTED" in r for r in harness.rows), harness.rows
+        )
+
     def test_recovery_proceeds_when_the_marker_reads_back(self):
         # The paired control: the readback must not block the normal path.
         for author in (TRUSTED_AUTHOR, APP_AUTHOR):

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -506,11 +506,25 @@ class TestMarkerCodec(unittest.TestCase):
 # ── 2. behaviour (fake gh) ───────────────────────────────────────────────────────
 
 
-def _marker_comment(*, head: str = HEAD, observed: datetime | None = None) -> dict:
+TRUSTED_AUTHOR = "github-actions[bot]"
+APP_AUTHOR = "sparq-orchestrator[bot]"
+ATTACKER = "drive-by-attacker"
+
+
+def _marker_comment(
+    *,
+    head: str = HEAD,
+    observed: datetime | None = None,
+    author: str = TRUSTED_AUTHOR,
+    suites: int = 0,
+) -> dict:
     stamp = observed or (NOW - timedelta(minutes=10))
     return {
+        "user": {"login": author},
         "body": "text\n\n"
-        + mgw.render_marker(pr=4534, head=head, base=BASE, ref=REF, suites=0, observed=stamp)
+        + mgw.render_marker(
+            pr=4534, head=head, base=BASE, ref=REF, suites=suites, observed=stamp
+        ),
     }
 
 
@@ -768,6 +782,174 @@ class TestSweepBehaviour(unittest.TestCase):
             m[2] for m in harness.gh.mutations if m[:2] == ["pr", "comment"]
         ]
         self.assertEqual(recovered, ["4534", "4535"], harness.rows)
+
+
+class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
+    """sparq is PUBLIC: anyone can comment, so the marker's AUTHOR is the control.
+
+    A marker is unauthenticated author-controlled input and the routing split acts on
+    it. Forged, it makes `review:pass` survive a dequeue and skips the arm-disable, so
+    auto-arm/rearm-sweeper re-arm within ~10 min — and the CI_TIMEOUT arm reaches
+    `gh pr merge --auto` directly. Both directions are pinned here: an untrusted marker
+    is IGNORED, and a trusted one still WORKS.
+    """
+
+    def test_a_forged_marker_from_an_arbitrary_author_is_ignored(self):
+        harness = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(author=ATTACKER)]
+        )
+        self.assertEqual(harness.watchdog.pr_markers(4534), [])
+        route = harness.watchdog.classify_dequeue(4534, "MANUAL")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+
+    def test_the_exact_ci_timeout_forgery_is_ignored(self):
+        # A forged marker naming ANY commit that reads 0 check-suites — such a sha is
+        # trivially obtainable. Without the author filter this reaches
+        # `gh pr merge --auto` via route=preserve + reenqueue=true.
+        harness = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(author=ATTACKER)]
+        )
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertFalse(route.reenqueue)
+
+    def test_forged_zero_sha_head_is_ignored(self):
+        harness = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(author=ATTACKER, head="0" * 40)]
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "MANUAL").route, mgw.ROUTE_DEMOTE
+        )
+
+    # THE PAIRED CONTROL: the filter must not break the real thing.
+    def test_a_trusted_bot_marker_still_works(self):
+        for author in (TRUSTED_AUTHOR, APP_AUTHOR):
+            harness = FakeWatchdog.build(
+                suites=0, comments=[_marker_comment(author=author)]
+            )
+            self.assertEqual(len(harness.watchdog.pr_markers(4534)), 1, author)
+            route = harness.watchdog.classify_dequeue(4534, "MANUAL")
+            self.assertEqual(route.route, mgw.ROUTE_PRESERVE, author)
+
+    def test_both_configured_identities_are_allow_listed(self):
+        # The sweep runs under the App token when ORCHESTRATOR_APP_ID is set and the
+        # workflow token otherwise, so BOTH identities must be trusted or the caps stop
+        # working the moment the App is configured (or unconfigured).
+        self.assertEqual(
+            mgw.TRUSTED_MARKER_AUTHORS,
+            frozenset({"github-actions[bot]", "sparq-orchestrator[bot]"}),
+        )
+
+    def test_a_forgery_attempt_is_logged_not_silently_dropped(self):
+        harness = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(author=ATTACKER)]
+        )
+        harness.watchdog.pr_markers(4534)
+        self.assertTrue(any("untrusted marker" in r for r in harness.rows), harness.rows)
+        self.assertTrue(any(ATTACKER in r for r in harness.rows), harness.rows)
+
+    def test_a_forged_marker_cannot_suppress_a_real_recovery_either(self):
+        # The idempotence key is read from the SAME channel, so an attacker must not be
+        # able to post a marker for the live head and block the watchdog from acting.
+        harness = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(author=ATTACKER)]
+        )
+        harness.run()
+        self.assertTrue(
+            any("decision=RECOVER" in r for r in harness.rows), harness.rows
+        )
+
+    def test_an_untrusted_marker_does_not_consume_the_cap(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[
+                _marker_comment(author=ATTACKER, head="a" * 40),
+                _marker_comment(author=ATTACKER, head="b" * 40),
+                _marker_comment(author=ATTACKER, head="c" * 40),
+            ],
+        )
+        harness.run()
+        self.assertTrue(any("decision=RECOVER" in r for r in harness.rows), harness.rows)
+
+    def test_the_marker_action_must_be_a_recovery(self):
+        # An observation-shaped marker must never read as a recovery in flight.
+        body = mgw.render_marker(
+            pr=4534, head=HEAD, base=BASE, ref=REF, suites=0,
+            observed=NOW - timedelta(minutes=10),
+        ).replace("action=re-enqueue", "action=observed")
+        harness = FakeWatchdog.build(
+            suites=0, comments=[{"user": {"login": TRUSTED_AUTHOR}, "body": body}]
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "MANUAL").route, mgw.ROUTE_DEMOTE
+        )
+        self.assertEqual(mgw.MARKER_ACTION_REENQUEUE, "re-enqueue")
+
+    def test_self_dequeue_arm_re_derives_the_named_heads_suite_count(self):
+        # The arm used to compare the marker head to nothing at all.
+        unreadable = FakeWatchdog.build(
+            suites=0, comments=[_marker_comment(head="a" * 40)]
+        )
+        route = unreadable.watchdog.classify_dequeue(4534, "MANUAL")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("cannot be read", route.detail)
+
+        dispatched = FakeWatchdog.build(suites=8, comments=[_marker_comment()])
+        route = dispatched.watchdog.classify_dequeue(4534, "MANUAL")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("WAS dispatched", route.detail)
+
+    def test_a_marker_claiming_a_nonzero_suite_count_is_not_ours(self):
+        self.assertIsNone(
+            mgw.parse_marker(
+                mgw.render_marker(
+                    pr=1, head=HEAD, base=BASE, ref=REF, suites=1, observed=NOW
+                )
+            )
+        )
+
+
+class TestCapExhaustionBehaviour(unittest.TestCase):
+    """Pin the DOCUMENTED behaviour so the claim cannot drift away from the code again.
+
+    Recovery is marker -> dequeue -> enqueue, so the marker is always ~30 s OLDER than
+    the `added_to_merge_queue` it produces. On the next attempt the newest trusted
+    marker therefore predates that attempt, the queue-attempt binding refuses it, and
+    the platform CI_TIMEOUT DEMOTES. That is correct — the only trusted observation
+    names a superseded head — but it is the opposite of what four separate comments
+    used to claim.
+    """
+
+    def test_after_exhaustion_a_ci_timeout_demotes(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment(observed=NOW - timedelta(minutes=20))],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "review:pass"}},
+                # the attempt the watchdog's own re-enqueue produced, AFTER the marker
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T23:15:00Z"},
+            ],
+        )
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("predates this queue attempt", route.detail)
+
+    def test_the_cap_row_does_not_claim_the_verdict_is_preserved(self):
+        row = decide(recoveries_in_window=2)
+        self.assertEqual(row.verdict, mgw.CAP)
+        self.assertIn("WILL demote", row.detail)
+        self.assertNotIn("preserves the review verdict", row.detail)
+
+    def test_exhaustion_never_escalates_to_a_human_hold(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment(head="a" * 40), _marker_comment(head="b" * 40)],
+        )
+        harness.run()
+        joined = "\n".join(harness.rows)
+        self.assertIn("decision=CAP", joined)
+        self.assertNotIn("needs:user", joined)
 
 
 class TestEmission(unittest.TestCase):
@@ -1132,7 +1314,7 @@ class TestEntrypointFailSafe(unittest.TestCase):
         # `detail`. Dropping any of the three silently disables the feature.
         self.assertIn(f"route={mgw.ROUTE_PRESERVE}\n", written)
         self.assertIn("reenqueue=true\n", written)
-        self.assertIn("detail=zero suites\n", written)
+        self.assertIn("detail<<MGW_DETAIL_EOF\nzero suites\nMGW_DETAIL_EOF\n", written)
         self.assertTrue(any("route=preserve" in row for row in rows), rows)
 
     def test_demote_outputs_are_lowercase_false(self):
@@ -1171,6 +1353,302 @@ def _step(wf: dict, job: str, needle: str) -> dict:
         if needle in (step.get("name") or "") or needle == step.get("id"):
             return step
     raise AssertionError(f"no step matching {needle!r} in job {job}")
+
+
+class TestSurvivorsFromTheCoverageCensus(unittest.TestCase):
+    """Every one of these lived in a function the module self-test never executed.
+
+    The lesson recorded with them: run the coverage census FIRST and treat a 0%-covered
+    entry point as blocking, because that is exactly where the surviving mutants are.
+    """
+
+    def test_sweep_exit_code_is_nonzero_when_a_recovery_fails(self):
+        # THE EXIT-ZERO CLASS. `return 1 if watchdog.sweep() else 0` -> `return 0`
+        # survived the whole suite: a later transient would discard an earned hard
+        # failure and the run would report success. This has bitten this estate before.
+        import os
+        original = mgw.run_gh_read
+        harness = FakeWatchdog.build(suites=0)
+        harness.gh.fail_on = ("dequeuePullRequest",)
+        try:
+            mgw.run_gh_read = harness.gh
+            mgw.run_gh = harness.gh
+            code = mgw.main(["sweep", "--repo", "sparq-org/sparq"])
+        finally:
+            mgw.run_gh_read = original
+        self.assertEqual(code, 1)
+
+    def test_sweep_exit_code_is_zero_on_a_clean_sweep(self):
+        # The paired control: a healthy queue must NOT red the scheduled run.
+        original = mgw.run_gh_read
+        harness = FakeWatchdog.build(suites=8)
+        try:
+            mgw.run_gh_read = harness.gh
+            mgw.run_gh = harness.gh
+            code = mgw.main(["sweep", "--repo", "sparq-org/sparq"])
+        finally:
+            mgw.run_gh_read = original
+        self.assertEqual(code, 0)
+
+    def test_a_failed_recovery_appears_in_the_census(self):
+        harness = FakeWatchdog.build(suites=0)
+        harness.gh.fail_on = ("dequeuePullRequest",)
+        harness.run()
+        census = next(r for r in harness.rows if "sweep complete" in r)
+        self.assertIn("RECOVER_FAILED=1", census)
+        self.assertIn("errors=1", census)
+
+    def test_stacked_green_counts_only_mergeable_entries(self):
+        # MIXED fixture. Every stacked entry in the original fixture was MERGEABLE, so
+        # `stacked_green = list(stacked)` was value-identical and survived.
+        nodes = [
+            {"id": "MQE_1", "position": 1, "state": "AWAITING_CHECKS",
+             "enqueuedAt": "2026-07-27T22:58:00Z",
+             "baseCommit": {"oid": BASE}, "headCommit": {"oid": HEAD},
+             "pullRequest": {"number": 4709, "id": "PR_4709"}},
+            {"id": "MQE_2", "position": 2, "state": "MERGEABLE",
+             "enqueuedAt": "2026-07-27T22:59:00Z",
+             "baseCommit": {"oid": HEAD}, "headCommit": {"oid": "a" * 40},
+             "pullRequest": {"number": 4714, "id": "PR_4714"}},
+            {"id": "MQE_3", "position": 3, "state": "AWAITING_CHECKS",
+             "enqueuedAt": "2026-07-27T23:00:00Z",
+             "baseCommit": {"oid": "a" * 40}, "headCommit": {"oid": "b" * 40},
+             "pullRequest": {"number": 4729, "id": "PR_4729"}},
+            {"id": "MQE_4", "position": 4, "state": "UNMERGEABLE",
+             "enqueuedAt": "2026-07-27T23:01:00Z",
+             "baseCommit": {"oid": "b" * 40}, "headCommit": {"oid": "c" * 40},
+             "pullRequest": {"number": 4731, "id": "PR_4731"}},
+        ]
+        harness = FakeWatchdog.build(suites=0, entries=nodes)
+        harness.run()
+        head_row = next(r for r in harness.rows if "pr=#4709" in r)
+        # three entries behind it have groups, but only ONE is green
+        self.assertIn("stacked=3", head_row)
+        self.assertIn("stacked_green=1", head_row)
+
+    def test_the_queue_query_asks_for_the_whole_queue(self):
+        # QUEUE_ENTRY_PAGE 20 -> 1 survived: nothing asserted the page size, so a
+        # single-entry read would silently miss every entry behind the head.
+        harness = FakeWatchdog.build(suites=8)
+        harness.run()
+        call = next(
+            c for c in harness.gh.calls
+            if c[:2] == ["api", "graphql"] and any("first=" in a for a in c)
+        )
+        first = next(a for a in call if a.startswith("first="))
+        self.assertEqual(first, f"first={mgw.QUEUE_ENTRY_PAGE}")
+        self.assertGreaterEqual(mgw.QUEUE_ENTRY_PAGE, 20)
+
+    def test_multi_line_detail_cannot_inject_extra_outputs(self):
+        import os
+        import tempfile
+        out = Path(tempfile.mkdtemp()) / "outputs.txt"
+        out.write_text("", encoding="utf-8")
+        os.environ["GITHUB_OUTPUT"] = str(out)
+        try:
+            mgw.write_outputs(
+                mgw.Route(mgw.ROUTE_DEMOTE, False, "gh failed:\nroute=preserve\nreenqueue=true"),
+                log=lambda _m: None,
+            )
+        finally:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        written = out.read_text(encoding="utf-8")
+        # The injected `route=preserve` must be INSIDE the delimited block, not a key.
+        self.assertTrue(written.startswith("route=demote\n"), written)
+        self.assertIn("detail<<MGW_DETAIL_EOF\n", written)
+        body = written.split("detail<<MGW_DETAIL_EOF\n", 1)[1]
+        self.assertTrue(body.endswith("MGW_DETAIL_EOF\n"), body)
+
+
+class TestEntrypointExitContract(unittest.TestCase):
+    """Every exit path of `main`, because that is where the exit-zero class hides.
+
+    The coverage census put `main` at 44% under the module self-test with its whole
+    sweep branch unexecuted — precisely where the surviving exit-code mutants lived.
+    """
+
+    def _sweep(self, gh):
+        original_read, original_gh = mgw.run_gh_read, mgw.run_gh
+        try:
+            mgw.run_gh_read = gh
+            mgw.run_gh = gh
+            return mgw.main(["sweep", "--repo", "sparq-org/sparq"])
+        finally:
+            mgw.run_gh_read, mgw.run_gh = original_read, original_gh
+
+    def test_exhausted_transient_is_a_warning_and_exit_zero(self):
+        # A periodic idempotent sweep may skip a cycle on a platform 5xx — the next
+        # tick covers it — but it must SAY so rather than exit quietly.
+        def exhausted(_argv):
+            raise mgw.gh_retry.GhTransientExhausted("HTTP 504 (3 attempts)")
+
+        import io
+        from contextlib import redirect_stdout
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = self._sweep(exhausted)
+        self.assertEqual(code, 0)
+        self.assertIn("::warning", out.getvalue())
+        self.assertIn("skipped a cycle", out.getvalue())
+
+    def test_a_non_transient_gh_failure_exits_nonzero(self):
+        def broken(_argv):
+            raise mgw.GhError("HTTP 401 Bad credentials")
+
+        import io
+        from contextlib import redirect_stderr
+        err = io.StringIO()
+        with redirect_stderr(err):
+            code = self._sweep(broken)
+        self.assertEqual(code, 1)
+        self.assertIn("fatal", err.getvalue())
+
+    def test_a_malformed_repo_argument_exits_nonzero(self):
+        import io
+        from contextlib import redirect_stderr
+        err = io.StringIO()
+        with redirect_stderr(err):
+            code = mgw.main(["sweep", "--repo", "not-a-repo"])
+        self.assertEqual(code, 1)
+
+    def test_no_subcommand_is_an_error_not_a_silent_success(self):
+        with self.assertRaises(SystemExit) as caught:
+            mgw.main([])
+        self.assertNotEqual(caught.exception.code, 0)
+
+    def test_grace_below_the_floor_is_refused(self):
+        with self.assertRaises(ValueError):
+            mgw.Watchdog("sparq-org/sparq", grace_seconds=30)
+
+
+class TestTelemetryPlumbing(unittest.TestCase):
+    def test_rows_are_appended_to_the_job_summary(self):
+        import os
+        import tempfile
+        summary = Path(tempfile.mkdtemp()) / "summary.md"
+        os.environ["GITHUB_STEP_SUMMARY"] = str(summary)
+        try:
+            harness = FakeWatchdog.build(suites=8)
+            harness.run()
+        finally:
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
+        written = summary.read_text(encoding="utf-8")
+        self.assertIn("decision=HOLD", written)
+        self.assertIn("sweep complete", written)
+
+    def test_an_unwritable_job_summary_never_breaks_the_sweep(self):
+        import os
+        os.environ["GITHUB_STEP_SUMMARY"] = "/proc/definitely/not/writable"
+        try:
+            harness = FakeWatchdog.build(suites=8)
+            self.assertEqual(harness.run(), 0)
+        finally:
+            os.environ.pop("GITHUB_STEP_SUMMARY", None)
+        self.assertTrue(any("decision=HOLD" in r for r in harness.rows))
+
+    def test_a_garbled_page_line_is_a_hard_error_not_an_empty_list(self):
+        # _ndjson must never silently yield [] on malformed input: an empty marker list
+        # reads as "no prior recovery" and would bypass the cap.
+        with self.assertRaises(mgw.GhError):
+            mgw._ndjson("{not json}")
+        self.assertEqual(mgw._ndjson(""), [])
+        self.assertEqual(mgw._ndjson("  \n\n"), [])
+        # non-dict JSON lines are ignored rather than crashing
+        self.assertEqual(mgw._ndjson("[1,2]"), [])
+
+    def test_a_detail_containing_the_delimiter_cannot_break_out(self):
+        # The payload embeds gh stderr. If it contained the delimiter itself, the
+        # heredoc would terminate early and the remainder would be parsed as keys —
+        # the same output-injection the delimiter exists to prevent.
+        import os
+        import tempfile
+        out = Path(tempfile.mkdtemp()) / "outputs.txt"
+        out.write_text("", encoding="utf-8")
+        os.environ["GITHUB_OUTPUT"] = str(out)
+        try:
+            mgw.write_outputs(
+                mgw.Route(
+                    mgw.ROUTE_DEMOTE,
+                    False,
+                    "gh said:\nMGW_DETAIL_EOF\nroute=preserve\nreenqueue=true",
+                ),
+                log=lambda _m: None,
+            )
+        finally:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        written = out.read_text(encoding="utf-8")
+        lines = written.splitlines()
+        # THE SAFETY PROPERTY: the heredoc is well-formed — the delimiter appears
+        # exactly twice (open and close) and no line INSIDE the block equals it. A line
+        # inside the block is inert no matter what it says; a premature close is what
+        # would turn `route=preserve` into a real key.
+        opener = lines.index("detail<<MGW_DETAIL_EOF")
+        body = lines[opener + 1:]
+        self.assertEqual(body[-1], "MGW_DETAIL_EOF", written)
+        self.assertNotIn("MGW_DETAIL_EOF", body[:-1], written)
+        # the attacker's delimiter was neutralised rather than passed through
+        self.assertIn("MGW-DETAIL-EOF", written)
+        # and the real outputs were emitted before the block, unaffected
+        self.assertEqual(lines[0], "route=demote", written)
+        self.assertEqual(lines[1], "reenqueue=false", written)
+
+    def test_run_gh_read_translates_a_fatal_into_the_local_error_type(self):
+        # Three lines, but the translation is real logic: a GhFatalError that escaped
+        # untranslated would bypass every `except GhError` handler and crash the sweep
+        # instead of producing a REFUSE row.
+        original = mgw.gh_retry.run_gh_read
+
+        def fatal(_argv):
+            raise mgw.gh_retry.GhFatalError("HTTP 404 Not Found")
+
+        try:
+            mgw.gh_retry.run_gh_read = fatal
+            with self.assertRaises(mgw.GhError):
+                mgw.run_gh_read(["api", "-X", "GET", "repos/x/y"])
+        finally:
+            mgw.gh_retry.run_gh_read = original
+
+    def test_run_gh_read_lets_transient_exhaustion_through_untouched(self):
+        # Exhaustion must stay its own type so the sweep entrypoint can convert exactly
+        # that case into ::warning + exit 0 and nothing else.
+        original = mgw.gh_retry.run_gh_read
+
+        def exhausted(_argv):
+            raise mgw.gh_retry.GhTransientExhausted("HTTP 504 (3 attempts)")
+
+        try:
+            mgw.gh_retry.run_gh_read = exhausted
+            with self.assertRaises(mgw.gh_retry.GhTransientExhausted):
+                mgw.run_gh_read(["api", "-X", "GET", "repos/x/y"])
+        finally:
+            mgw.gh_retry.run_gh_read = original
+
+    def test_an_unreadable_activity_feed_yields_no_anchor(self):
+        # group_created_at's error branch: no anchor => REFUSE, never a recovery.
+        harness = FakeWatchdog.build(suites=0)
+        harness.gh.fail_on = ("/activity",)
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=REFUSE" in r for r in harness.rows), harness.rows)
+
+    def test_a_malformed_activity_row_yields_no_anchor(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            activity=[{"activity_type": "branch_creation", "after": HEAD,
+                       "timestamp": "not-a-timestamp"}],
+        )
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=REFUSE" in r for r in harness.rows), harness.rows)
+
+    def test_parse_iso_rejects_junk_rather_than_guessing(self):
+        for junk in (None, "", "not-a-date", "2026-13-45T99:99:99Z", 17):
+            self.assertIsNone(mgw.parse_iso(junk), junk)
+        self.assertIsNotNone(mgw.parse_iso("2026-07-28T05:15:09Z"))
+        # a naive timestamp is treated as UTC rather than crashing
+        naive = mgw.parse_iso("2026-07-28T05:15:09")
+        self.assertIsNotNone(naive)
+        self.assertEqual(naive.tzinfo, timezone.utc)
 
 
 class TestFeedbackWiring(unittest.TestCase):

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -541,6 +541,14 @@ class ScriptedGh:
         self.mutations: list[list[str]] = []
         # Substrings of the joined argv that should raise GhError instead of replying.
         self.fail_on: tuple[str, ...] = ()
+        # Identity the fake runner posts under; set to an untrusted login to simulate
+        # TRUSTED_MARKER_AUTHORS missing this runner.
+        self.post_author: str = TRUSTED_AUTHOR
+        # Comments are per-PR, as they are in the API.
+        self.comments_by_pr: dict[int, list] = {}
+        # Every group head the fake knows about; anything else 404s, so a lookup
+        # against the wrong sha cannot silently succeed.
+        self.known_shas: set[str] = {HEAD}
 
     def __call__(self, argv: list[str]) -> str:
         self.calls.append(argv)
@@ -563,6 +571,15 @@ class ScriptedGh:
             return json.dumps({"data": {}})
         if argv[:2] == ["pr", "comment"]:
             self.mutations.append(argv)
+            # Model the write: a posted comment becomes readable ON THAT PR, authored
+            # by the runner's own identity. A fake that swallowed writes made the
+            # readback guard untestable; a fake that pooled comments across PRs let one
+            # entry's marker suppress another's recovery. Both were caught by tests
+            # that had been passing.
+            self.comments_by_pr.setdefault(int(argv[2]), []).append(
+                {"user": {"login": self.post_author},
+                 "body": argv[argv.index("--body") + 1]}
+            )
             return ""
         if "/check-suites" in joined:
             # SHA-KEYED on purpose. A fake that answers every /check-suites URL with
@@ -571,13 +588,16 @@ class ScriptedGh:
             # started resolving the sha out of the path.
             path = next(a for a in argv if "/check-suites" in a)
             sha = path.split("/commits/", 1)[1].split("/", 1)[0]
-            if sha != HEAD:
+            if sha not in self.known_shas:
                 raise mgw.GhError(f"gh api: HTTP 404 — no such commit {sha}")
             return self.suites_raw
         if "/activity" in joined:
             return "\n".join(json.dumps(row) for row in self.activity)
         if "/comments" in joined:
-            return "\n".join(json.dumps(row) for row in self.comments)
+            path = next(a for a in argv if "/comments" in a)
+            pr = int(path.split("/issues/", 1)[1].split("/", 1)[0])
+            rows = list(self.comments) + self.comments_by_pr.get(pr, [])
+            return "\n".join(json.dumps(row) for row in rows)
         if "/timeline" in joined:
             return "\n".join(json.dumps(row) for row in self.timeline)
         raise AssertionError(f"unexpected gh call: {argv}")
@@ -690,6 +710,34 @@ class TestSweepBehaviour(unittest.TestCase):
         self.assertTrue(any("RECOVERY FAILED" in row for row in harness.rows), harness.rows)
         self.assertTrue(any("::error" in row for row in harness.rows), harness.rows)
 
+    def test_recovery_aborts_if_its_own_marker_is_not_readable_back(self):
+        # If this runner's login is not in TRUSTED_MARKER_AUTHORS, every marker the
+        # watchdog writes is invisible to itself: the per-head NOOP never fires and the
+        # per-PR cap never binds, so it would thrash dequeue/enqueue every tick. The
+        # recovery must PROVE its evidence channel works before using it. Driven by
+        # making the fake runner post under an untrusted identity — the real failure.
+        harness = FakeWatchdog.build(suites=0)
+        harness.gh.post_author = ATTACKER
+        self.assertGreater(harness.run(), 0)
+        kinds = [m[:2] for m in harness.gh.mutations]
+        self.assertEqual(kinds, [["pr", "comment"]], harness.gh.mutations)
+        self.assertTrue(any("RECOVERY FAILED" in r for r in harness.rows), harness.rows)
+        self.assertTrue(
+            any("not readable back as TRUSTED" in r for r in harness.rows), harness.rows
+        )
+
+    def test_recovery_proceeds_when_the_marker_reads_back(self):
+        # The paired control: the readback must not block the normal path.
+        for author in (TRUSTED_AUTHOR, APP_AUTHOR):
+            harness = FakeWatchdog.build(suites=0)
+            harness.gh.post_author = author
+            self.assertEqual(harness.run(), 0, author)
+            self.assertEqual(
+                [m[:2] for m in harness.gh.mutations],
+                [["pr", "comment"], ["api", "graphql"], ["api", "graphql"]],
+                author,
+            )
+
     def test_control_group_with_suites_issues_no_mutation_at_all(self):
         harness = FakeWatchdog.build(suites=8)
         self.assertEqual(harness.run(), 0)
@@ -746,23 +794,41 @@ class TestSweepBehaviour(unittest.TestCase):
         self.assertEqual(harness.gh.mutations, [])
         self.assertTrue(any("decision=RECOVER" in row for row in harness.rows), harness.rows)
 
-    @staticmethod
-    def _three_entry_queue():
-        return [
-            {
-                "id": f"MQE_{pr}",
-                "position": index,
-                "state": "AWAITING_CHECKS",
-                "enqueuedAt": "2026-07-27T22:58:53Z",
-                "baseCommit": {"oid": BASE},
-                "headCommit": {"oid": HEAD},
-                "pullRequest": {"number": pr, "id": f"PR_{pr}"},
-            }
-            for index, pr in enumerate((4534, 4535, 4536), start=1)
+    # Each queue entry has its OWN group head, chained on the previous one — the
+    # original fixture reused a single sha for all three, which made one entry's
+    # marker suppress the next entry's recovery once the fake modelled writes.
+    HEADS = (HEAD, "1" * 40, "2" * 40)
+
+    @classmethod
+    def _three_entry_queue(cls):
+        entries = []
+        for index, (pr, head) in enumerate(zip((4534, 4535, 4536), cls.HEADS), start=1):
+            entries.append(
+                {
+                    "id": f"MQE_{pr}",
+                    "position": index,
+                    "state": "AWAITING_CHECKS",
+                    "enqueuedAt": "2026-07-27T22:58:53Z",
+                    "baseCommit": {"oid": BASE if index == 1 else cls.HEADS[index - 2]},
+                    "headCommit": {"oid": head},
+                    "pullRequest": {"number": pr, "id": f"PR_{pr}"},
+                }
+            )
+        return entries
+
+    @classmethod
+    def _three_entry_harness(cls):
+        harness = FakeWatchdog.build(suites=0, entries=cls._three_entry_queue())
+        harness.gh.known_shas = set(cls.HEADS)
+        harness.gh.activity = [
+            {"activity_type": "branch_creation", "after": head,
+             "timestamp": "2026-07-27T23:04:37Z"}
+            for head in cls.HEADS
         ]
+        return harness
 
     def test_per_run_budget_bounds_one_tick(self):
-        harness = FakeWatchdog.build(suites=0, entries=self._three_entry_queue())
+        harness = self._three_entry_harness()
         harness.run()
         dequeues = [
             m
@@ -776,7 +842,7 @@ class TestSweepBehaviour(unittest.TestCase):
         # Only the head-of-line entry actually blocks merges, so a bounded budget must
         # be spent in queue order. Recovering positions 3 and 2 while position 1 stays
         # broken would burn the budget and leave the outage in place.
-        harness = FakeWatchdog.build(suites=0, entries=self._three_entry_queue())
+        harness = self._three_entry_harness()
         harness.run()
         recovered = [
             m[2] for m in harness.gh.mutations if m[:2] == ["pr", "comment"]

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -167,6 +167,15 @@ class TestFailSafe(unittest.TestCase):
     def test_unknown_suite_count_refuses(self):
         self.assertEqual(decide(suites=None).verdict, mgw.REFUSE)
 
+    def test_unreadable_marker_history_refuses(self):
+        # "I could not read the history" is not "there is no history". Treating them as
+        # the same would bypass the per-PR cap on every API blip.
+        self.assertEqual(decide(markers_readable=False).verdict, mgw.REFUSE)
+        # ...and it must outrank the caps, not be masked by them.
+        self.assertEqual(
+            decide(markers_readable=False, recoveries_in_window=99).verdict, mgw.REFUSE
+        )
+
     def test_missing_branch_creation_anchor_refuses(self):
         self.assertEqual(decide(created_at=None).verdict, mgw.REFUSE)
 
@@ -236,11 +245,21 @@ class TestCapAndIdempotence(unittest.TestCase):
 class TestDequeueRouting(unittest.TestCase):
     """Both arms of the CI_TIMEOUT split, keyed on the suite count."""
 
+    @staticmethod
+    def verdict(**overrides) -> "mgw.VerdictState":
+        fields = dict(
+            review_pass_at=NOW - timedelta(hours=2),
+            head_moved_at=NOW - timedelta(hours=3),
+            last_enqueued_at=NOW - timedelta(hours=1),
+        )
+        fields.update(overrides)
+        return mgw.VerdictState(**fields)
+
     def route(self, **overrides) -> "mgw.Route":
         kwargs = dict(
             reason="CI_TIMEOUT",
             markers=(marker(),),
-            last_enqueued_at=NOW - timedelta(hours=1),
+            verdict=self.verdict(),
             live_suites=lambda _sha: 0,
             now=NOW + timedelta(minutes=40),
         )
@@ -299,12 +318,99 @@ class TestDequeueRouting(unittest.TestCase):
 
     def test_marker_predating_this_queue_attempt_demotes(self):
         self.assertEqual(
-            self.route(last_enqueued_at=NOW + timedelta(minutes=1)).route,
+            self.route(verdict=self.verdict(last_enqueued_at=NOW + timedelta(minutes=1))).route,
             mgw.ROUTE_DEMOTE,
         )
 
     def test_missing_enqueue_event_demotes(self):
-        self.assertEqual(self.route(last_enqueued_at=None).route, mgw.ROUTE_DEMOTE)
+        self.assertEqual(
+            self.route(verdict=self.verdict(last_enqueued_at=None)).route, mgw.ROUTE_DEMOTE
+        )
+
+    # ── the verdict may only survive a dequeue for the tree it was granted for ──
+    def test_arm_1_an_infrastructure_dequeue_leaves_the_verdict_intact(self):
+        # The watchdog's own recovery: MANUAL dequeue, fresh marker, head unmoved
+        # since review:pass. Nothing about this PR's diff is in question.
+        result = self.route(reason="MANUAL", now=NOW + timedelta(seconds=30))
+        self.assertEqual(result.route, mgw.ROUTE_PRESERVE)
+        self.assertFalse(result.reenqueue)
+
+    def test_arm_2_control_a_genuine_manual_dequeue_still_strips_the_verdict(self):
+        # THE CONTROL. A human withdrawing a PR SHOULD pull the verdict. Without this
+        # the fix becomes a verdict-preservation hole — any dequeue keeps its approval,
+        # which is far worse than the bug being fixed. A genuine human dequeue has no
+        # fresh watchdog marker.
+        self.assertEqual(
+            self.route(reason="MANUAL", markers=(), now=NOW + timedelta(seconds=30)).route,
+            mgw.ROUTE_DEMOTE,
+        )
+        # ...and one whose marker is old is equally not ours.
+        self.assertEqual(
+            self.route(reason="MANUAL", now=NOW + timedelta(hours=3)).route,
+            mgw.ROUTE_DEMOTE,
+        )
+
+    def test_a_head_that_moved_after_the_verdict_forfeits_it(self):
+        # NON-NEGOTIABLE. Never restore a verdict onto a tree it was not given for.
+        moved = self.verdict(head_moved_at=NOW - timedelta(minutes=1))
+        for reason, when in (("MANUAL", NOW + timedelta(seconds=30)),
+                             ("CI_TIMEOUT", NOW + timedelta(minutes=40))):
+            result = self.route(reason=reason, verdict=moved, now=when)
+            self.assertEqual(result.route, mgw.ROUTE_DEMOTE, reason)
+            self.assertIn("the head moved", result.detail)
+
+    def test_a_head_that_moved_before_the_verdict_is_fine(self):
+        ok = self.verdict(head_moved_at=NOW - timedelta(hours=2, seconds=1))
+        self.assertEqual(self.route(verdict=ok).route, mgw.ROUTE_PRESERVE)
+
+    def test_no_verdict_to_preserve_demotes(self):
+        self.assertEqual(
+            self.route(verdict=self.verdict(review_pass_at=None)).route, mgw.ROUTE_DEMOTE
+        )
+
+    def test_a_revoked_verdict_cannot_be_preserved(self):
+        # `unlabeled review:pass` is modelled as a head move at that instant, so a
+        # grant that was later withdrawn stops qualifying.
+        revoked = self.verdict(head_moved_at=NOW - timedelta(hours=1, minutes=30))
+        self.assertEqual(self.route(verdict=revoked).route, mgw.ROUTE_DEMOTE)
+
+    def test_unreadable_timeline_demotes(self):
+        # ISOLATED: everything else about this verdict is valid, so ONLY the
+        # unreadable flag can produce the demote. The previous version of this test
+        # also set review_pass_at=None, which meant it passed through the "no verdict"
+        # guard and would have stayed green with the readable check deleted.
+        unreadable = mgw.VerdictState(
+            review_pass_at=NOW - timedelta(hours=2),
+            head_moved_at=NOW - timedelta(hours=3),
+            last_enqueued_at=NOW - timedelta(hours=1),
+            readable=False,
+        )
+        result = self.route(verdict=unreadable)
+        self.assertEqual(result.route, mgw.ROUTE_DEMOTE)
+        # "the API failed" and "this PR was never approved" are different operational
+        # facts and the emitted row is the only place anyone sees which one happened.
+        self.assertIn("timeline could not be read", result.detail)
+        self.assertNotIn("no review:pass grant", result.detail)
+
+    def test_no_verdict_reports_a_different_reason_than_an_unreadable_one(self):
+        result = self.route(verdict=self.verdict(review_pass_at=None))
+        self.assertEqual(result.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("no review:pass grant", result.detail)
+        self.assertNotIn("timeline could not be read", result.detail)
+
+    def test_the_LATEST_head_move_is_the_one_that_counts(self):
+        # An early move (before the verdict) must not mask a later one (after it).
+        # Reading min() instead of max() would let a stale verdict survive a push.
+        both = self.verdict(head_moved_at=NOW - timedelta(minutes=1))
+        self.assertEqual(self.route(verdict=both).route, mgw.ROUTE_DEMOTE)
+
+    def test_a_verdict_RE_granted_after_a_push_is_preservable(self):
+        # push at T, re-review, re-approve at T+: the newest grant is what matters.
+        regranted = self.verdict(
+            review_pass_at=NOW - timedelta(minutes=30),
+            head_moved_at=NOW - timedelta(minutes=45),
+        )
+        self.assertEqual(self.route(verdict=regranted).route, mgw.ROUTE_PRESERVE)
 
     def test_stale_marker_demotes(self):
         self.assertEqual(self.route(now=NOW + timedelta(hours=7)).route, mgw.ROUTE_DEMOTE)
@@ -448,7 +554,8 @@ class FakeWatchdog:
 
     @classmethod
     def build(cls, *, suites: int | None = 0, entries=None, comments=None,
-              activity=None, now: datetime | None = None, dry_run: bool = False):
+              activity=None, now: datetime | None = None, dry_run: bool = False,
+              timeline=None):
         node = {
             "id": "MQE_4534",
             "position": 1,
@@ -472,7 +579,12 @@ class FakeWatchdog:
             if activity is None
             else activity,
             comments=comments or [],
-            timeline=[{"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"}],
+            timeline=list(timeline) if timeline is not None else [
+                {"event": "committed", "committer": {"date": "2026-07-27T22:40:00Z"}},
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
         )
         rows: list[str] = []
         watchdog = mgw.Watchdog(
@@ -525,9 +637,14 @@ class TestSweepBehaviour(unittest.TestCase):
         # per-PR cap be bypassed on every API blip.
         harness = FakeWatchdog.build(suites=0)
         harness.gh.fail_on = ("/comments",)
-        harness.run()
+        self.assertGreater(harness.run(), 0)
         self.assertEqual(harness.gh.mutations, [])
-        self.assertTrue(any("decision=REFUSE" in row for row in harness.rows), harness.rows)
+        row = next(r for r in harness.rows if "decision=REFUSE" in r)
+        # ONE row shape for every entry — this path used to emit a bespoke row missing
+        # `state=` and `stacked=`, so an operator parsing rows saw two formats.
+        for field in ("pos=", "pr=#", "state=", "ref=", "head=", "suites=", "stacked=",
+                      "stacked_green=", "decision="):
+            self.assertIn(field, row, (field, row))
 
     def test_a_failed_recovery_is_a_red_run_not_a_silent_success(self):
         harness = FakeWatchdog.build(suites=0)
@@ -725,6 +842,113 @@ class TestClassifyEndToEnd(unittest.TestCase):
         harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
         route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_PRESERVE)
+
+    def test_a_commit_after_the_verdict_forfeits_it_end_to_end(self):
+        # Exercises the real timeline PARSER, not just the policy: a `committed` event
+        # carries no `created_at`, so its time must be read from `committer.date`.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+                {"event": "committed", "committer": {"date": "2026-07-27T23:05:00Z"}},
+            ],
+        )
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("the head moved", route.detail)
+
+    def test_a_force_push_after_the_verdict_forfeits_it_end_to_end(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+                {"event": "head_ref_force_pushed", "created_at": "2026-07-27T23:05:00Z"},
+            ],
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+        )
+
+    def test_a_revoked_verdict_forfeits_it_end_to_end(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "unlabeled", "created_at": "2026-07-27T22:55:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+        )
+
+    def test_a_label_other_than_review_pass_is_not_a_verdict(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:changes"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+        )
+
+    def test_two_head_moves_straddling_the_verdict_end_to_end(self):
+        # min(moved) would pick the 22:40 commit and wrongly preserve; max(moved)
+        # picks the 23:05 commit and correctly forfeits the verdict.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "committed", "committer": {"date": "2026-07-27T22:40:00Z"}},
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+                {"event": "committed", "committer": {"date": "2026-07-27T23:05:00Z"}},
+            ],
+        )
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("the head moved", route.detail)
+
+    def test_two_verdict_grants_straddling_a_push_end_to_end(self):
+        # min(granted) would pick the 22:20 grant, see the 22:45 push after it and
+        # wrongly demote; max(granted) picks the 22:50 re-grant and preserves.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "committed", "committer": {"date": "2026-07-27T22:45:00Z"}},
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route,
+            mgw.ROUTE_PRESERVE,
+        )
+
+    def test_an_unreadable_timeline_demotes_end_to_end(self):
+        harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
+        harness.gh.fail_on = ("/timeline",)
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("timeline could not be read", route.detail)
 
     def test_classify_never_mutates(self):
         harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -104,16 +104,16 @@ class _NoNetwork:
 # The real incident's identifiers (#4652), so the fixtures are not invented shapes.
 BASE = "3cc1bf828c1335577069f5fa65d832c0ae1c8c38"
 HEAD = "1bfb0174f5cc2da1ed9dfe7997b7ab089e7cab26"
-REF = f"gh-readonly-queue/main/pr-4534-{BASE}"
+REF = f"gh-readonly-queue/main/pr-99900001-{BASE}"
 BUILT = mgw.parse_iso("2026-07-27T23:04:37Z")  # measured branch_creation timestamp
 NOW = mgw.parse_iso("2026-07-27T23:20:00Z")
 
 
 def entry(**overrides) -> "mgw.QueueEntry":
     fields = dict(
-        pr_number=4534,
-        pr_id="PR_4534",
-        entry_id="MQE_4534",
+        pr_number=99900001,
+        pr_id="PR_99900001",
+        entry_id="MQE_99900001",
         position=1,
         state="AWAITING_CHECKS",
         enqueued_at=mgw.parse_iso("2026-07-27T22:58:53Z"),
@@ -143,7 +143,7 @@ def decide(**overrides) -> "mgw.Decision":
 
 def marker(**overrides) -> "mgw.Marker":
     fields = dict(
-        pr=4534,
+        pr=99900001,
         head=HEAD,
         base=BASE,
         ref=REF,
@@ -244,6 +244,10 @@ class TestFailSafe(unittest.TestCase):
             # total_count says zero but the array is non-empty: a garbled response must
             # never be mistaken for a positively-observed zero.
             json.dumps({"total_count": 0, "check_suites": [{"id": 1}]}),
+            # `isinstance(False, int)` is True in Python, so a bool total_count read as
+            # a positively-observed ZERO and drove a recovery off a malformed response.
+            json.dumps({"total_count": False, "check_suites": []}),
+            json.dumps({"total_count": True, "check_suites": []}),
         ):
             watchdog.gh.suites_raw = payload
             self.assertIsNone(watchdog.watchdog.check_suite_count(HEAD), payload)
@@ -309,6 +313,7 @@ class TestDequeueRouting(unittest.TestCase):
     def route(self, **overrides) -> "mgw.Route":
         kwargs = dict(
             reason="CI_TIMEOUT",
+            pr_number=99900001,
             markers=(marker(),),
             verdict=self.verdict(),
             live_suites=lambda _sha: 0,
@@ -345,6 +350,9 @@ class TestDequeueRouting(unittest.TestCase):
         # mutant that "survives" by being invisible.
         self.assertIn("could not re-derive", result.detail)
         self.assertNotIn("check-suite(s)", result.detail)
+
+    def test_a_marker_for_a_different_pr_is_ignored(self):
+        self.assertEqual(self.route(pr_number=99900099).route, mgw.ROUTE_DEMOTE)
 
     def test_no_marker_demotes(self):
         self.assertEqual(self.route(markers=()).route, mgw.ROUTE_DEMOTE)
@@ -522,7 +530,7 @@ class TestDequeueRouting(unittest.TestCase):
 class TestMarkerCodec(unittest.TestCase):
     def test_round_trip(self):
         rendered = mgw.render_marker(
-            pr=4534, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
         )
         parsed = mgw.parse_marker(f"prose\n\n{rendered}\n")
         self.assertIsNotNone(parsed)
@@ -574,7 +582,7 @@ def _marker_comment(
         "user": {"login": author},
         "body": "text\n\n"
         + mgw.render_marker(
-            pr=4534, head=head, base=BASE, ref=REF, suites=suites, observed=stamp
+            pr=99900001, head=head, base=BASE, ref=REF, suites=suites, observed=stamp
         ),
     }
 
@@ -665,13 +673,13 @@ class FakeWatchdog:
               activity=None, now: datetime | None = None, dry_run: bool = False,
               timeline=None):
         node = {
-            "id": "MQE_4534",
+            "id": "MQE_99900001",
             "position": 1,
             "state": "AWAITING_CHECKS",
             "enqueuedAt": "2026-07-27T22:58:53Z",
             "baseCommit": {"oid": BASE},
             "headCommit": {"oid": HEAD},
-            "pullRequest": {"number": 4534, "id": "PR_4534"},
+            "pullRequest": {"number": 99900001, "id": "PR_99900001"},
         }
         if suites is None:
             suites_raw = "not json"
@@ -725,7 +733,7 @@ class TestSweepBehaviour(unittest.TestCase):
         self.assertIn("🤖", body)
         self.assertIsNotNone(mgw.parse_marker(body))
         # The comment goes to THIS entry's PR.
-        self.assertEqual(harness.gh.mutations[0][2], "4534")
+        self.assertEqual(harness.gh.mutations[0][2], "99900001")
         queries = [
             next(a for a in m if a.startswith("query="))
             for m in harness.gh.mutations[1:]
@@ -737,7 +745,7 @@ class TestSweepBehaviour(unittest.TestCase):
         # queue-entry id (MQE_…) is the natural wrong answer and would fail at runtime.
         for mutation in harness.gh.mutations[1:]:
             ident = next(a for a in mutation if a.startswith("id="))
-            self.assertEqual(ident, "id=PR_4534", mutation)
+            self.assertEqual(ident, "id=PR_99900001", mutation)
             self.assertNotIn("MQE_", ident)
 
     def test_unreadable_marker_history_refuses_rather_than_assuming_none(self):
@@ -868,7 +876,7 @@ class TestSweepBehaviour(unittest.TestCase):
     @classmethod
     def _three_entry_queue(cls):
         entries = []
-        for index, (pr, head) in enumerate(zip((4534, 4535, 4536), cls.HEADS), start=1):
+        for index, (pr, head) in enumerate(zip((99900001, 99900002, 99900003), cls.HEADS), start=1):
             entries.append(
                 {
                     "id": f"MQE_{pr}",
@@ -913,7 +921,7 @@ class TestSweepBehaviour(unittest.TestCase):
         recovered = [
             m[2] for m in harness.gh.mutations if m[:2] == ["pr", "comment"]
         ]
-        self.assertEqual(recovered, ["4534", "4535"], harness.rows)
+        self.assertEqual(recovered, ["99900001", "99900002"], harness.rows)
 
 
 class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
@@ -930,8 +938,8 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
         harness = FakeWatchdog.build(
             suites=0, comments=[_marker_comment(author=ATTACKER)]
         )
-        self.assertEqual(harness.watchdog.pr_markers(4534), [])
-        route = harness.watchdog.classify_dequeue(4534, "MANUAL")
+        self.assertEqual(harness.watchdog.pr_markers(99900001), [])
+        route = harness.watchdog.classify_dequeue(99900001, "MANUAL")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
 
     def test_the_exact_ci_timeout_forgery_is_ignored(self):
@@ -941,7 +949,7 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
         harness = FakeWatchdog.build(
             suites=0, comments=[_marker_comment(author=ATTACKER)]
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertFalse(route.reenqueue)
 
@@ -950,7 +958,7 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
             suites=0, comments=[_marker_comment(author=ATTACKER, head="0" * 40)]
         )
         self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "MANUAL").route, mgw.ROUTE_DEMOTE
+            harness.watchdog.classify_dequeue(99900001, "MANUAL").route, mgw.ROUTE_DEMOTE
         )
 
     # THE PAIRED CONTROL: the filter must not break the real thing.
@@ -959,8 +967,8 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
             harness = FakeWatchdog.build(
                 suites=0, comments=[_marker_comment(author=author)]
             )
-            self.assertEqual(len(harness.watchdog.pr_markers(4534)), 1, author)
-            route = harness.watchdog.classify_dequeue(4534, "MANUAL")
+            self.assertEqual(len(harness.watchdog.pr_markers(99900001)), 1, author)
+            route = harness.watchdog.classify_dequeue(99900001, "MANUAL")
             self.assertEqual(route.route, mgw.ROUTE_PRESERVE, author)
 
     def test_both_configured_identities_are_allow_listed(self):
@@ -976,7 +984,7 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
         harness = FakeWatchdog.build(
             suites=0, comments=[_marker_comment(author=ATTACKER)]
         )
-        harness.watchdog.pr_markers(4534)
+        harness.watchdog.pr_markers(99900001)
         self.assertTrue(any("untrusted marker" in r for r in harness.rows), harness.rows)
         self.assertTrue(any(ATTACKER in r for r in harness.rows), harness.rows)
 
@@ -989,7 +997,7 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
             suites=0,
             comments=[_marker_comment(author=ATTACKER, head=f"{i:040x}") for i in range(96)],
         )
-        self.assertEqual(harness.watchdog.pr_markers(4534), [])
+        self.assertEqual(harness.watchdog.pr_markers(99900001), [])
         warnings = [r for r in harness.rows if "::warning" in r]
         self.assertEqual(len(warnings), 1, warnings)
         self.assertIn("96 watchdog marker(s)", warnings[0])
@@ -1004,7 +1012,7 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
                 _marker_comment(author="attacker-one", head="c" * 40),
             ],
         )
-        harness.watchdog.pr_markers(4534)
+        harness.watchdog.pr_markers(99900001)
         warning = next(r for r in harness.rows if "::warning" in r)
         self.assertIn("attacker-one", warning)
         self.assertIn("attacker-two", warning)
@@ -1036,14 +1044,14 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
     def test_the_marker_action_must_be_a_recovery(self):
         # An observation-shaped marker must never read as a recovery in flight.
         body = mgw.render_marker(
-            pr=4534, head=HEAD, base=BASE, ref=REF, suites=0,
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0,
             observed=NOW - timedelta(minutes=10),
         ).replace("action=re-enqueue", "action=observed")
         harness = FakeWatchdog.build(
             suites=0, comments=[{"user": {"login": TRUSTED_AUTHOR}, "body": body}]
         )
         self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "MANUAL").route, mgw.ROUTE_DEMOTE
+            harness.watchdog.classify_dequeue(99900001, "MANUAL").route, mgw.ROUTE_DEMOTE
         )
         self.assertEqual(mgw.MARKER_ACTION_REENQUEUE, "re-enqueue")
 
@@ -1052,12 +1060,12 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
         unreadable = FakeWatchdog.build(
             suites=0, comments=[_marker_comment(head="a" * 40)]
         )
-        route = unreadable.watchdog.classify_dequeue(4534, "MANUAL")
+        route = unreadable.watchdog.classify_dequeue(99900001, "MANUAL")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("cannot be read", route.detail)
 
         dispatched = FakeWatchdog.build(suites=8, comments=[_marker_comment()])
-        route = dispatched.watchdog.classify_dequeue(4534, "MANUAL")
+        route = dispatched.watchdog.classify_dequeue(99900001, "MANUAL")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("WAS dispatched", route.detail)
 
@@ -1069,6 +1077,133 @@ class TestMarkerAuthorIsPartOfThePredicate(unittest.TestCase):
                 )
             )
         )
+
+
+class TestParseIsBoundedAndTrustGatedFirst(unittest.TestCase):
+    """A public repo means anonymous input reaches this parser on every dequeue."""
+
+    ADVERSARIAL = "<!-- merge-group-watchdog " * 2521          # ~65 536 chars
+
+    def test_a_huge_adversarial_body_parses_in_bounded_time(self):
+        import time
+        start = time.monotonic()
+        self.assertIsNone(mgw.parse_marker(self.ADVERSARIAL))
+        elapsed = time.monotonic() - start
+        # Unbounded `[^>]*?` took 21.4 s on this input. Bounded, it is milliseconds.
+        # One second is a generous ceiling that still fails loudly on a regression.
+        self.assertLess(elapsed, 1.0, f"parse took {elapsed:.3f}s — quantifier unbounded?")
+
+    def test_the_bound_still_admits_a_real_marker(self):
+        # The control: bounding the quantifier must not break the genuine payload,
+        # whose key/value run is 262 chars.
+        rendered = mgw.render_marker(
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        )
+        kv = rendered[rendered.index(mgw.MARKER_KEY) + len(mgw.MARKER_KEY):].strip()[:-3]
+        self.assertLess(len(kv), 400, len(kv))
+        self.assertIsNotNone(mgw.parse_marker(rendered))
+
+    def test_untrusted_bodies_are_never_parsed_at_all(self):
+        # ORDERING IS THE FIX. A trust check placed AFTER the parse does not protect
+        # the parse: every anonymous comment was parsed before being discarded.
+        parsed: list = []
+        real_parse = mgw.parse_marker
+
+        def spy(body):
+            parsed.append(body)
+            return real_parse(body)
+
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment(author=ATTACKER), _marker_comment(author=TRUSTED_AUTHOR)],
+        )
+        try:
+            mgw.parse_marker = spy
+            harness.watchdog.pr_markers(99900001)
+        finally:
+            mgw.parse_marker = real_parse
+        self.assertEqual(len(parsed), 1, "the untrusted body was parsed")
+
+    def test_end_to_end_with_many_adversarial_comments_is_fast(self):
+        import time
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[{"user": {"login": ATTACKER}, "body": self.ADVERSARIAL} for _ in range(8)],
+        )
+        start = time.monotonic()
+        self.assertEqual(harness.watchdog.pr_markers(99900001), [])
+        elapsed = time.monotonic() - start
+        self.assertLess(elapsed, 1.0, f"{elapsed:.3f}s for 8 adversarial comments")
+
+
+class TestQuotedMarkersAreNotClaims(unittest.TestCase):
+    """A trusted bot that ECHOES PR content must not launder an attacker's marker."""
+
+    def marker_text(self) -> str:
+        return mgw.render_marker(
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        )
+
+    def test_quoted_contexts_are_stripped(self):
+        m = self.marker_text()
+        for label, body in (
+            ("fenced", f"see below\n\n```\n{m}\n```\n"),
+            ("fenced-tilde", f"~~~\n{m}\n~~~\n"),
+            ("blockquote", f"> {m}\n"),
+            ("indented", f"    {m}\n"),
+            ("inline", f"`{m}`\n"),
+            ("nested-html", f"<!-- quoted: {m} -->\n"),
+        ):
+            self.assertIsNone(mgw.parse_marker(body), label)
+
+    def test_an_unquoted_marker_is_still_a_claim(self):
+        # THE CONTROL: the watchdog's own comment must keep working. Its self-id line
+        # IS a blockquote, and the marker sits unquoted on its own line below it.
+        body = "> 🤖 **SPARQ agent** — merge-group watchdog.\n\nprose\n\n" + self.marker_text()
+        self.assertIsNotNone(mgw.parse_marker(body))
+
+    def test_a_trusted_bot_quoting_an_attackers_marker_is_ignored(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[{
+                "user": {"login": APP_AUTHOR},
+                "body": "Quoting the PR body:\n\n```\n" + self.marker_text() + "\n```\n",
+            }],
+        )
+        self.assertEqual(harness.watchdog.pr_markers(99900001), [])
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(99900001, "MANUAL").route, mgw.ROUTE_DEMOTE
+        )
+
+
+class TestMarkerIsBoundToThisPrAndHead(unittest.TestCase):
+    def test_a_marker_for_another_pr_is_not_evidence_here(self):
+        other = _marker_comment()
+        other["body"] = other["body"].replace("pr=99900001", "pr=99900099").replace(
+            "/pr-99900001-", "/pr-9999-"
+        )
+        harness = FakeWatchdog.build(suites=0, comments=[other])
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+        )
+
+    def test_pr_and_ref_must_agree(self):
+        # A single mistyped identity field cannot pass: both are checked.
+        body = mgw.render_marker(
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        ).replace("pr=99900001", "pr=99900099")
+        self.assertIsNone(mgw.parse_marker(body))
+
+    def test_arm_b_requires_the_recovery_action(self):
+        body = mgw.render_marker(
+            pr=99900001, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        ).replace("action=re-enqueue", "action=observed")
+        harness = FakeWatchdog.build(
+            suites=0, comments=[{"user": {"login": TRUSTED_AUTHOR}, "body": body}]
+        )
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("action", route.detail)
 
 
 class TestCapExhaustionBehaviour(unittest.TestCase):
@@ -1093,7 +1228,7 @@ class TestCapExhaustionBehaviour(unittest.TestCase):
                 {"event": "added_to_merge_queue", "created_at": "2026-07-27T23:15:00Z"},
             ],
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("predates this queue attempt", route.detail)
 
@@ -1127,7 +1262,7 @@ class TestEmission(unittest.TestCase):
             self.assertIn(f"ref={REF}", row)
             self.assertIn("suites=", row)
             self.assertIn(f"head={HEAD[:8]}", row)
-            self.assertIn("pr=#4534", row)
+            self.assertIn("pr=#99900001", row)
 
     def test_rows_record_how_many_groups_are_stacked_above(self):
         # The watchdog's own effectiveness measure. A rebuild discards every group
@@ -1137,38 +1272,38 @@ class TestEmission(unittest.TestCase):
         # stacked_green=2, and all four were discarded.
         nodes = [
             {
-                "id": "MQE_4709", "position": 1, "state": "AWAITING_CHECKS",
+                "id": "MQE_99900004", "position": 1, "state": "AWAITING_CHECKS",
                 "enqueuedAt": "2026-07-27T22:58:53Z",
                 "baseCommit": {"oid": BASE}, "headCommit": {"oid": HEAD},
-                "pullRequest": {"number": 4709, "id": "PR_4709"},
+                "pullRequest": {"number": 99900004, "id": "PR_99900004"},
             },
             {
-                "id": "MQE_4714", "position": 2, "state": "MERGEABLE",
+                "id": "MQE_99900005", "position": 2, "state": "MERGEABLE",
                 "enqueuedAt": "2026-07-27T22:59:00Z",
                 "baseCommit": {"oid": HEAD}, "headCommit": {"oid": "a" * 40},
-                "pullRequest": {"number": 4714, "id": "PR_4714"},
+                "pullRequest": {"number": 99900005, "id": "PR_99900005"},
             },
             {
-                "id": "MQE_4729", "position": 3, "state": "MERGEABLE",
+                "id": "MQE_99900006", "position": 3, "state": "MERGEABLE",
                 "enqueuedAt": "2026-07-27T22:59:10Z",
                 "baseCommit": {"oid": "a" * 40}, "headCommit": {"oid": "b" * 40},
-                "pullRequest": {"number": 4729, "id": "PR_4729"},
+                "pullRequest": {"number": 99900006, "id": "PR_99900006"},
             },
             {
                 # No group built yet — nothing to discard, so it must NOT be counted.
-                "id": "MQE_4731", "position": 4, "state": "QUEUED",
+                "id": "MQE_99900007", "position": 4, "state": "QUEUED",
                 "enqueuedAt": "2026-07-27T22:59:20Z",
                 "baseCommit": None, "headCommit": None,
-                "pullRequest": {"number": 4731, "id": "PR_4731"},
+                "pullRequest": {"number": 99900007, "id": "PR_99900007"},
             },
         ]
         harness = FakeWatchdog.build(suites=0, entries=nodes)
         harness.run()
-        head_row = next(r for r in harness.rows if "pr=#4709" in r)
+        head_row = next(r for r in harness.rows if "pr=#99900004" in r)
         self.assertIn("stacked=2", head_row)
         self.assertIn("stacked_green=2", head_row)
         # The last entry with a group has nothing above it.
-        tail_row = next(r for r in harness.rows if "pr=#4729" in r)
+        tail_row = next(r for r in harness.rows if "pr=#99900006" in r)
         self.assertIn("stacked=0", tail_row)
         self.assertIn("stacked_green=0", tail_row)
 
@@ -1202,12 +1337,12 @@ class TestClassifyEndToEnd(unittest.TestCase):
         # The marker says suites=0, but the LIVE count now reads 8. The route must
         # follow the live re-derivation, not the recorded value.
         harness = FakeWatchdog.build(suites=8, comments=[_marker_comment()])
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
 
     def test_zero_live_count_preserves(self):
         harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_PRESERVE)
 
     def test_a_commit_after_the_verdict_forfeits_it_end_to_end(self):
@@ -1223,7 +1358,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 {"event": "committed", "committer": {"date": "2026-07-27T23:05:00Z"}},
             ],
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("the head moved", route.detail)
 
@@ -1239,7 +1374,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+            harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
         )
 
     def test_a_revocation_then_regrant_preserves_end_to_end(self):
@@ -1259,7 +1394,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route,
+            harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route,
             mgw.ROUTE_PRESERVE,
         )
 
@@ -1275,7 +1410,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
             ],
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         # Through the real PARSER, not a hand-built VerdictState: a revocation must be
         # reported as a revocation. Folding it into head_moved_at still demotes, so the
@@ -1299,7 +1434,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
             ],
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("REVOKED", route.detail)
 
@@ -1320,7 +1455,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 ],
             )
             self.assertEqual(
-                harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route,
+                harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route,
                 mgw.ROUTE_PRESERVE,
                 other,
             )
@@ -1335,7 +1470,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
             ],
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("no review:pass grant", route.detail)
 
@@ -1350,7 +1485,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+            harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
         )
 
     def test_two_head_moves_straddling_the_verdict_end_to_end(self):
@@ -1367,7 +1502,7 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 {"event": "committed", "committer": {"date": "2026-07-27T23:05:00Z"}},
             ],
         )
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("the head moved", route.detail)
 
@@ -1387,20 +1522,20 @@ class TestClassifyEndToEnd(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route,
+            harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route,
             mgw.ROUTE_PRESERVE,
         )
 
     def test_an_unreadable_timeline_demotes_end_to_end(self):
         harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
         harness.gh.fail_on = ("/timeline",)
-        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
         self.assertIn("timeline could not be read", route.detail)
 
     def test_classify_never_mutates(self):
         harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
-        harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(harness.gh.mutations, [])
 
 
@@ -1435,7 +1570,7 @@ class TestEntrypointFailSafe(unittest.TestCase):
             raise mgw.GhError("HTTP 500 while reading comments")
 
         code, outputs = self._run_main(
-            ["classify-dequeue", "--repo", "sparq-org/sparq", "--pr", "4534",
+            ["classify-dequeue", "--repo", "sparq-org/sparq", "--pr", "99900001",
              "--reason", "CI_TIMEOUT"],
             boom,
         )
@@ -1448,7 +1583,7 @@ class TestEntrypointFailSafe(unittest.TestCase):
             raise mgw.gh_retry.GhTransientExhausted("HTTP 504 (3 attempts)")
 
         code, outputs = self._run_main(
-            ["classify-dequeue", "--repo", "sparq-org/sparq", "--pr", "4534",
+            ["classify-dequeue", "--repo", "sparq-org/sparq", "--pr", "99900001",
              "--reason", "CI_TIMEOUT"],
             exhausted,
         )
@@ -1554,23 +1689,23 @@ class TestSurvivorsFromTheCoverageCensus(unittest.TestCase):
             {"id": "MQE_1", "position": 1, "state": "AWAITING_CHECKS",
              "enqueuedAt": "2026-07-27T22:58:00Z",
              "baseCommit": {"oid": BASE}, "headCommit": {"oid": HEAD},
-             "pullRequest": {"number": 4709, "id": "PR_4709"}},
+             "pullRequest": {"number": 99900004, "id": "PR_99900004"}},
             {"id": "MQE_2", "position": 2, "state": "MERGEABLE",
              "enqueuedAt": "2026-07-27T22:59:00Z",
              "baseCommit": {"oid": HEAD}, "headCommit": {"oid": "a" * 40},
-             "pullRequest": {"number": 4714, "id": "PR_4714"}},
+             "pullRequest": {"number": 99900005, "id": "PR_99900005"}},
             {"id": "MQE_3", "position": 3, "state": "AWAITING_CHECKS",
              "enqueuedAt": "2026-07-27T23:00:00Z",
              "baseCommit": {"oid": "a" * 40}, "headCommit": {"oid": "b" * 40},
-             "pullRequest": {"number": 4729, "id": "PR_4729"}},
+             "pullRequest": {"number": 99900006, "id": "PR_99900006"}},
             {"id": "MQE_4", "position": 4, "state": "UNMERGEABLE",
              "enqueuedAt": "2026-07-27T23:01:00Z",
              "baseCommit": {"oid": "b" * 40}, "headCommit": {"oid": "c" * 40},
-             "pullRequest": {"number": 4731, "id": "PR_4731"}},
+             "pullRequest": {"number": 99900007, "id": "PR_99900007"}},
         ]
         harness = FakeWatchdog.build(suites=0, entries=nodes)
         harness.run()
-        head_row = next(r for r in harness.rows if "pr=#4709" in r)
+        head_row = next(r for r in harness.rows if "pr=#99900004" in r)
         # three entries behind it have groups, but only ONE is green
         self.assertIn("stacked=3", head_row)
         self.assertIn("stacked_green=1", head_row)
@@ -1607,6 +1742,44 @@ class TestSurvivorsFromTheCoverageCensus(unittest.TestCase):
         self.assertIn("detail<<MGW_DETAIL_EOF\n", written)
         body = written.split("detail<<MGW_DETAIL_EOF\n", 1)[1]
         self.assertTrue(body.endswith("MGW_DETAIL_EOF\n"), body)
+
+
+class TestFixturesNameNothingReal(unittest.TestCase):
+    """Fixtures must name ids that CANNOT resolve.
+
+    Reproducing `N01` necessarily reverts the hermeticity fix — the guard and the
+    mutant are the same switch — so for that one mutant the in-process poison is off by
+    design and only the fixture's own id stands between the suite and a live object.
+    That is how 567 comments reached PR #4534. The reserved band below cannot resolve,
+    so the same mistake now writes nowhere.
+    """
+
+    RESERVED_MIN = 99900000
+
+    def test_no_fixture_names_a_plausibly_real_pr(self):
+        # Scope: ids that can become an API TARGET. Comments are stripped, and
+        # `queue_ref(...)` is exempt because it is a PURE function — its argument is a
+        # recorded live-verified provenance datum (the 2026-07-28 ref-format check),
+        # never a request. The distinction that matters is write-reachability, not the
+        # digits themselves.
+        lines = [
+            ln.split("#", 1)[0]
+            for ln in Path(__file__).read_text(encoding="utf-8").splitlines()
+            if "queue_ref(" not in ln
+        ]
+        found = {
+            int(n)
+            for n in re.findall(
+                r'(?:pr=|"number": |pr_number=|classify_dequeue\(|pr_markers\()(\d{3,})',
+                "\n".join(lines),
+            )
+        }
+        real = sorted(n for n in found if n < self.RESERVED_MIN)
+        self.assertEqual(real, [], f"fixtures name plausibly-real ids: {real}")
+
+    def test_the_reserved_band_is_actually_reserved(self):
+        # sparq is nowhere near 99.9M issues; if it ever were, this test fails FIRST.
+        self.assertGreater(self.RESERVED_MIN, 10_000_000)
 
 
 class TestTheSuiteCannotTouchTheNetwork(unittest.TestCase):
@@ -1851,7 +2024,7 @@ class TestFeedbackWiring(unittest.TestCase):
     # lane would silently stop being fed. Both guards are therefore pinned whole; a
     # deliberate change must update this line.
     DEMOTE_GUARD = (
-        "github.event.pull_request.merged != true "
+        "!cancelled() && github.event.pull_request.merged != true "
         "&& steps.classify.outputs.route != 'preserve'"
     )
     PRESERVE_GUARD = (
@@ -1860,10 +2033,24 @@ class TestFeedbackWiring(unittest.TestCase):
     )
 
     def test_the_demote_guard_is_fail_closed(self):
-        # `!= 'preserve'` means an EMPTY/MISSING output still demotes. Inverting this
-        # to `== 'demote'` would make a classifier failure silently preserve.
+        # `!= 'preserve'` covers an EMPTY/MISSING output. `!cancelled()` covers the
+        # OTHER failure mode the string test could not see: a step `if:` with no status
+        # function defaults to `success()`, so a FAILED or TIMED-OUT classify step would
+        # SKIP the demote — keeping review:pass and leaving the arm enabled.
         guard = _step(self.wf, "feedback", "Route genuine dequeue")["if"]
         self.assertEqual(guard, self.DEMOTE_GUARD)
+        self.assertIn("!cancelled()", guard)
+
+    def test_every_guard_that_must_survive_a_failed_step_says_so(self):
+        # Structural, not string-matching: any step whose condition consumes a previous
+        # step's OUTPUT and is meant to run regardless must carry a status function,
+        # because the implicit default is success().
+        demote = _step(self.wf, "feedback", "Route genuine dequeue")["if"]
+        self.assertRegex(demote, r"!cancelled\(\)|always\(\)")
+        # ...and the preserve route must NOT, since it may only act on a positive
+        # verdict from a step that actually succeeded.
+        preserve = _step(self.wf, "feedback", "Preserve the verdict")["if"]
+        self.assertNotRegex(preserve, r"!cancelled\(\)|always\(\)")
 
     def test_the_preserve_guard_is_fail_open_in_the_safe_direction(self):
         guard = _step(self.wf, "feedback", "Preserve the verdict")["if"]

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -193,6 +193,16 @@ class TestFailSafe(unittest.TestCase):
         watchdog.gh.suites_raw = json.dumps({"total_count": 0, "check_suites": []})
         self.assertEqual(watchdog.watchdog.check_suite_count(HEAD), 0)
 
+    def test_the_authoritative_counter_is_total_count_not_the_page_length(self):
+        # `check_suites` is capped at per_page; `total_count` is the counter GitHub
+        # itself maintains. Reading the array length would silently under-report any
+        # group with more than one page of suites.
+        watchdog = FakeWatchdog.build()
+        watchdog.gh.suites_raw = json.dumps(
+            {"total_count": 137, "check_suites": [{"id": i} for i in range(100)]}
+        )
+        self.assertEqual(watchdog.watchdog.check_suite_count(HEAD), 137)
+
 
 class TestCapAndIdempotence(unittest.TestCase):
     def test_repeat_detection_on_the_same_ref_is_a_noop(self):
@@ -255,10 +265,37 @@ class TestDequeueRouting(unittest.TestCase):
         self.assertEqual(many.route, mgw.ROUTE_DEMOTE)
 
     def test_unreadable_suite_count_demotes(self):
-        self.assertEqual(self.route(live_suites=lambda _s: None).route, mgw.ROUTE_DEMOTE)
+        result = self.route(live_suites=lambda _s: None)
+        self.assertEqual(result.route, mgw.ROUTE_DEMOTE)
+        # "could not read it" and "it was 8" are the same ROUTE but different
+        # operational facts, and the emitted row is the only place an operator sees
+        # which one happened. Deleting the `count is None` arm would fall through to
+        # `count != 0` and still demote — behaviourally equivalent, diagnostically
+        # blind — so the distinction is asserted explicitly rather than left to a
+        # mutant that "survives" by being invisible.
+        self.assertIn("could not re-derive", result.detail)
+        self.assertNotIn("check-suite(s)", result.detail)
 
     def test_no_marker_demotes(self):
         self.assertEqual(self.route(markers=()).route, mgw.ROUTE_DEMOTE)
+
+    def test_the_newest_marker_wins(self):
+        # A PR can accumulate several observations across queue attempts. The route
+        # must follow the most recent one; picking the oldest would judge this dequeue
+        # against a group head from a previous attempt.
+        stale = marker(head="e" * 40, observed=NOW - timedelta(hours=5))
+        fresh = marker(head=HEAD, observed=NOW - timedelta(minutes=5))
+        seen: list[str] = []
+
+        def spy(sha: str) -> int:
+            seen.append(sha)
+            return 0
+
+        for order in ((stale, fresh), (fresh, stale)):
+            seen.clear()
+            result = self.route(markers=order, live_suites=spy)
+            self.assertEqual(result.route, mgw.ROUTE_PRESERVE)
+            self.assertEqual(seen, [HEAD], order)
 
     def test_marker_predating_this_queue_attempt_demotes(self):
         self.assertEqual(
@@ -359,10 +396,15 @@ class ScriptedGh:
         self.timeline = timeline
         self.calls: list[list[str]] = []
         self.mutations: list[list[str]] = []
+        # Substrings of the joined argv that should raise GhError instead of replying.
+        self.fail_on: tuple[str, ...] = ()
 
     def __call__(self, argv: list[str]) -> str:
         self.calls.append(argv)
         joined = " ".join(argv)
+        for needle in self.fail_on:
+            if needle in joined:
+                raise mgw.GhError(f"simulated failure for {needle}")
         if argv[:2] == ["api", "graphql"]:
             query = next(a for a in argv if a.startswith("query="))
             # Discriminate on the OPERATION keyword, not on a substring of the
@@ -380,6 +422,14 @@ class ScriptedGh:
             self.mutations.append(argv)
             return ""
         if "/check-suites" in joined:
+            # SHA-KEYED on purpose. A fake that answers every /check-suites URL with
+            # the same payload cannot tell the group HEAD from its BASE (or from
+            # `main`), and both of those wrong-sha mutants survived until this fake
+            # started resolving the sha out of the path.
+            path = next(a for a in argv if "/check-suites" in a)
+            sha = path.split("/commits/", 1)[1].split("/", 1)[0]
+            if sha != HEAD:
+                raise mgw.GhError(f"gh api: HTTP 404 — no such commit {sha}")
             return self.suites_raw
         if "/activity" in joined:
             return "\n".join(json.dumps(row) for row in self.activity)
@@ -454,12 +504,37 @@ class TestSweepBehaviour(unittest.TestCase):
         body = harness.gh.mutations[0][harness.gh.mutations[0].index("--body") + 1]
         self.assertIn("🤖", body)
         self.assertIsNotNone(mgw.parse_marker(body))
+        # The comment goes to THIS entry's PR.
+        self.assertEqual(harness.gh.mutations[0][2], "4534")
         queries = [
             next(a for a in m if a.startswith("query="))
             for m in harness.gh.mutations[1:]
         ]
         self.assertIn("dequeuePullRequest", queries[0])
         self.assertIn("enqueuePullRequest", queries[1])
+        # BOTH mutations take the PULL REQUEST node id. GitHub names the dequeue input
+        # field `id` while documenting it as "the ID of the pull request", so the merge-
+        # queue-entry id (MQE_…) is the natural wrong answer and would fail at runtime.
+        for mutation in harness.gh.mutations[1:]:
+            ident = next(a for a in mutation if a.startswith("id="))
+            self.assertEqual(ident, "id=PR_4534", mutation)
+            self.assertNotIn("MQE_", ident)
+
+    def test_unreadable_marker_history_refuses_rather_than_assuming_none(self):
+        # Treating an unreadable comment history as "no prior recovery" would let the
+        # per-PR cap be bypassed on every API blip.
+        harness = FakeWatchdog.build(suites=0)
+        harness.gh.fail_on = ("/comments",)
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=REFUSE" in row for row in harness.rows), harness.rows)
+
+    def test_a_failed_recovery_is_a_red_run_not_a_silent_success(self):
+        harness = FakeWatchdog.build(suites=0)
+        harness.gh.fail_on = ("dequeuePullRequest",)
+        self.assertGreater(harness.run(), 0)
+        self.assertTrue(any("RECOVERY FAILED" in row for row in harness.rows), harness.rows)
+        self.assertTrue(any("::error" in row for row in harness.rows), harness.rows)
 
     def test_control_group_with_suites_issues_no_mutation_at_all(self):
         harness = FakeWatchdog.build(suites=8)
@@ -479,6 +554,22 @@ class TestSweepBehaviour(unittest.TestCase):
         harness.run()
         self.assertEqual(harness.gh.mutations, [])
         self.assertTrue(any("decision=REFUSE" in row for row in harness.rows), harness.rows)
+
+    def test_a_non_creation_activity_row_is_not_our_anchor(self):
+        # The URL already filters activity_type server-side; this pins the client-side
+        # half so a force_push / branch_deletion row carrying the same `after` sha can
+        # never be mistaken for the group's build time.
+        for activity_type in ("force_push", "push", "branch_deletion", "merge_queue_merge"):
+            harness = FakeWatchdog.build(
+                suites=0,
+                activity=[{"activity_type": activity_type, "after": HEAD,
+                           "timestamp": "2026-07-27T23:04:37Z"}],
+            )
+            harness.run()
+            self.assertEqual(harness.gh.mutations, [], activity_type)
+            self.assertTrue(
+                any("decision=REFUSE" in row for row in harness.rows), activity_type
+            )
 
     def test_activity_row_for_a_different_head_is_not_our_anchor(self):
         harness = FakeWatchdog.build(
@@ -501,21 +592,23 @@ class TestSweepBehaviour(unittest.TestCase):
         self.assertEqual(harness.gh.mutations, [])
         self.assertTrue(any("decision=RECOVER" in row for row in harness.rows), harness.rows)
 
+    @staticmethod
+    def _three_entry_queue():
+        return [
+            {
+                "id": f"MQE_{pr}",
+                "position": index,
+                "state": "AWAITING_CHECKS",
+                "enqueuedAt": "2026-07-27T22:58:53Z",
+                "baseCommit": {"oid": BASE},
+                "headCommit": {"oid": HEAD},
+                "pullRequest": {"number": pr, "id": f"PR_{pr}"},
+            }
+            for index, pr in enumerate((4534, 4535, 4536), start=1)
+        ]
+
     def test_per_run_budget_bounds_one_tick(self):
-        nodes = []
-        for index, pr in enumerate((4534, 4535, 4536), start=1):
-            nodes.append(
-                {
-                    "id": f"MQE_{pr}",
-                    "position": index,
-                    "state": "AWAITING_CHECKS",
-                    "enqueuedAt": "2026-07-27T22:58:53Z",
-                    "baseCommit": {"oid": BASE},
-                    "headCommit": {"oid": HEAD},
-                    "pullRequest": {"number": pr, "id": f"PR_{pr}"},
-                }
-            )
-        harness = FakeWatchdog.build(suites=0, entries=nodes)
+        harness = FakeWatchdog.build(suites=0, entries=self._three_entry_queue())
         harness.run()
         dequeues = [
             m
@@ -524,6 +617,17 @@ class TestSweepBehaviour(unittest.TestCase):
         ]
         self.assertEqual(len(dequeues), mgw.DEFAULT_MAX_RECOVERIES_PER_RUN)
         self.assertTrue(any("decision=CAP" in row for row in harness.rows), harness.rows)
+
+    def test_the_budget_is_spent_on_the_head_of_the_queue_first(self):
+        # Only the head-of-line entry actually blocks merges, so a bounded budget must
+        # be spent in queue order. Recovering positions 3 and 2 while position 1 stays
+        # broken would burn the budget and leave the outage in place.
+        harness = FakeWatchdog.build(suites=0, entries=self._three_entry_queue())
+        harness.run()
+        recovered = [
+            m[2] for m in harness.gh.mutations if m[:2] == ["pr", "comment"]
+        ]
+        self.assertEqual(recovered, ["4534", "4535"], harness.rows)
 
 
 class TestEmission(unittest.TestCase):
@@ -585,6 +689,96 @@ class TestClassifyEndToEnd(unittest.TestCase):
         self.assertEqual(harness.gh.mutations, [])
 
 
+class TestEntrypointFailSafe(unittest.TestCase):
+    """The OUTERMOST guard: main() must never let a failure preserve a verdict.
+
+    These drive `main()` end to end because the exception handler and the GITHUB_OUTPUT
+    writer are the two pieces the YAML actually consumes, and nothing else exercises
+    them — a mutant that flipped the crash route to `preserve`, or that stopped writing
+    `route=` at all, survived every other test in this file.
+    """
+
+    def _run_main(self, argv, gh_read):
+        import os
+        import tempfile
+
+        original = mgw.run_gh_read
+        out = Path(tempfile.mkdtemp()) / "outputs.txt"
+        out.write_text("", encoding="utf-8")
+        os.environ["GITHUB_OUTPUT"] = str(out)
+        try:
+            mgw.run_gh_read = gh_read
+            code = mgw.main(argv)
+        finally:
+            mgw.run_gh_read = original
+            os.environ.pop("GITHUB_OUTPUT", None)
+        return code, dict(
+            line.split("=", 1) for line in out.read_text(encoding="utf-8").splitlines()
+            if "=" in line
+        )
+
+    def test_classifier_crash_routes_to_demote(self):
+        def boom(_argv):
+            raise mgw.GhError("HTTP 500 while reading comments")
+
+        code, outputs = self._run_main(
+            ["classify-dequeue", "--repo", "sparq-org/sparq", "--pr", "4534",
+             "--reason", "CI_TIMEOUT"],
+            boom,
+        )
+        self.assertEqual(code, 0)  # the step must not red the feedback job
+        self.assertEqual(outputs["route"], mgw.ROUTE_DEMOTE)
+        self.assertEqual(outputs["reenqueue"], "false")
+
+    def test_transient_exhaustion_routes_to_demote(self):
+        def exhausted(_argv):
+            raise mgw.gh_retry.GhTransientExhausted("HTTP 504 (3 attempts)")
+
+        code, outputs = self._run_main(
+            ["classify-dequeue", "--repo", "sparq-org/sparq", "--pr", "4534",
+             "--reason", "CI_TIMEOUT"],
+            exhausted,
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(outputs["route"], mgw.ROUTE_DEMOTE)
+
+    def test_outputs_carry_every_field_the_yaml_reads(self):
+        rows: list[str] = []
+        import os
+        import tempfile
+
+        out = Path(tempfile.mkdtemp()) / "outputs.txt"
+        out.write_text("", encoding="utf-8")
+        os.environ["GITHUB_OUTPUT"] = str(out)
+        try:
+            mgw.write_outputs(
+                mgw.Route(mgw.ROUTE_PRESERVE, True, "zero suites"), log=rows.append
+            )
+        finally:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        written = out.read_text(encoding="utf-8")
+        # The `if:` expressions read `route`; the preserve step reads `reenqueue` and
+        # `detail`. Dropping any of the three silently disables the feature.
+        self.assertIn(f"route={mgw.ROUTE_PRESERVE}\n", written)
+        self.assertIn("reenqueue=true\n", written)
+        self.assertIn("detail=zero suites\n", written)
+        self.assertTrue(any("route=preserve" in row for row in rows), rows)
+
+    def test_demote_outputs_are_lowercase_false(self):
+        import os
+        import tempfile
+
+        out = Path(tempfile.mkdtemp()) / "outputs.txt"
+        out.write_text("", encoding="utf-8")
+        os.environ["GITHUB_OUTPUT"] = str(out)
+        try:
+            mgw.write_outputs(mgw.Route(mgw.ROUTE_DEMOTE, False, "no marker"),
+                              log=lambda _m: None)
+        finally:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        self.assertIn("reenqueue=false\n", out.read_text(encoding="utf-8"))
+
+
 # ── 3. wiring (the YAML seam) ────────────────────────────────────────────────────
 
 
@@ -629,18 +823,55 @@ class TestFeedbackWiring(unittest.TestCase):
         self.assertIn("$PR_NUMBER", run)
         self.assertIn("$DEQUEUE_REASON", run)
 
+    # EXACT-MATCH, not substring. A substring assertion cannot see a guard that is
+    # still present but CONDITIONALLY INERT: `… route != 'preserve' && false` contains
+    # every token a substring test looks for while making the step dead, so the fix
+    # lane would silently stop being fed. Both guards are therefore pinned whole; a
+    # deliberate change must update this line.
+    DEMOTE_GUARD = (
+        "github.event.pull_request.merged != true "
+        "&& steps.classify.outputs.route != 'preserve'"
+    )
+    PRESERVE_GUARD = (
+        "github.event.pull_request.merged != true "
+        "&& steps.classify.outputs.route == 'preserve'"
+    )
+
     def test_the_demote_guard_is_fail_closed(self):
         # `!= 'preserve'` means an EMPTY/MISSING output still demotes. Inverting this
         # to `== 'demote'` would make a classifier failure silently preserve.
         guard = _step(self.wf, "feedback", "Route genuine dequeue")["if"]
-        self.assertIn("steps.classify.outputs.route != 'preserve'", guard)
-        self.assertNotIn("== 'demote'", guard)
-        self.assertIn("github.event.pull_request.merged != true", guard)
+        self.assertEqual(guard, self.DEMOTE_GUARD)
 
     def test_the_preserve_guard_is_fail_open_in_the_safe_direction(self):
         guard = _step(self.wf, "feedback", "Preserve the verdict")["if"]
-        self.assertIn("steps.classify.outputs.route == 'preserve'", guard)
-        self.assertIn("github.event.pull_request.merged != true", guard)
+        self.assertEqual(guard, self.PRESERVE_GUARD)
+
+    def test_no_step_guard_carries_a_constant_disjunct(self):
+        # The conditionally-inert class in general: a literal `true`/`false` operand
+        # anywhere in a step condition makes that step unconditionally on or off while
+        # still reading as a guard.
+        for step in self.steps:
+            guard = step.get("if")
+            if not guard:
+                continue
+            # `merged != true` is a legitimate COMPARISON against a literal; strip
+            # every such comparison first, then any surviving bare literal is a
+            # constant operand of && / || — i.e. an always-on or always-off step.
+            residue = re.sub(r"[=!]=\s*(?:true|false)\b", "", guard)
+            self.assertIsNone(
+                re.search(r"\b(?:true|false)\b", residue),
+                (step.get("name"), guard),
+            )
+
+    def test_the_route_literal_is_the_same_string_on_both_sides(self):
+        # CROSS-FILE CONTRACT. The Python constant and the YAML `if:` literal are two
+        # halves of one comparison; renaming or case-drifting either side silently
+        # makes the preserve route unreachable (and, worse, fails SILENTLY GREEN
+        # because the fail-safe `!= 'preserve'` then always demotes).
+        raw = FEEDBACK_YML.read_text(encoding="utf-8")
+        self.assertIn(f"steps.classify.outputs.route == '{mgw.ROUTE_PRESERVE}'", raw)
+        self.assertIn(f"steps.classify.outputs.route != '{mgw.ROUTE_PRESERVE}'", raw)
 
     def test_the_two_routes_are_mutually_exclusive(self):
         demote = _step(self.wf, "feedback", "Route genuine dequeue")["if"]
@@ -658,6 +889,34 @@ class TestFeedbackWiring(unittest.TestCase):
         self.assertNotIn("--remove-label", run)
         self.assertNotIn("--disable-auto", run)
         self.assertNotIn("gh pr edit", run)
+
+    def test_preserve_route_re_arms_only_when_the_classifier_says_so(self):
+        # When the watchdog itself is mid-recovery (reenqueue=false) a second arm here
+        # would race its enqueue; when the platform timed the entry out (reenqueue=true)
+        # something must put it back. Both directions must be wired.
+        run = _step(self.wf, "feedback", "Preserve the verdict")["run"]
+        self.assertIn('"$CLASSIFY_REENQUEUE" = "true"', run)
+        self.assertIn("gh pr merge", run)
+        self.assertIn("--auto", run)
+        env = _step(self.wf, "feedback", "Preserve the verdict")["env"]
+        self.assertEqual(env["CLASSIFY_REENQUEUE"], "${{ steps.classify.outputs.reenqueue }}")
+
+    def test_preserve_route_checks_the_pr_is_still_open(self):
+        run = _step(self.wf, "feedback", "Preserve the verdict")["run"]
+        self.assertIn("gh pr view", run)
+        self.assertIn("--json state", run)
+        self.assertIn('"$STATE" != "OPEN"', run)
+
+    def test_every_post_skip_step_carries_the_merged_guard(self):
+        # The first step short-circuits a successful-merge dequeue; every later step
+        # must independently re-assert it, because a step `if:` is not inherited.
+        for step in self.steps:
+            name = step.get("name") or step.get("uses") or ""
+            if "Skip successful-merge" in name:
+                continue
+            self.assertIn(
+                "github.event.pull_request.merged != true", step.get("if", ""), name
+            )
 
     def test_demote_route_still_swaps_the_labels(self):
         # The pre-#4652 behaviour must survive intact on the other arm.

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -369,10 +369,33 @@ class TestDequeueRouting(unittest.TestCase):
         )
 
     def test_a_revoked_verdict_cannot_be_preserved(self):
-        # `unlabeled review:pass` is modelled as a head move at that instant, so a
-        # grant that was later withdrawn stops qualifying.
-        revoked = self.verdict(head_moved_at=NOW - timedelta(hours=1, minutes=30))
-        self.assertEqual(self.route(verdict=revoked).route, mgw.ROUTE_DEMOTE)
+        revoked = self.verdict(verdict_revoked_at=NOW - timedelta(hours=1, minutes=30))
+        result = self.route(verdict=revoked)
+        self.assertEqual(result.route, mgw.ROUTE_DEMOTE)
+        # The reason must name the REVOCATION, not invent a push. Reporting "the head
+        # moved" when no commit landed sends an operator hunting a non-existent force
+        # push — a misleading diagnostic baked into the tool.
+        self.assertIn("REVOKED", result.detail)
+        self.assertNotIn("the head moved", result.detail)
+
+    def test_a_head_move_and_a_revocation_report_different_reasons(self):
+        moved = self.route(verdict=self.verdict(head_moved_at=NOW - timedelta(minutes=1)))
+        revoked = self.route(
+            verdict=self.verdict(verdict_revoked_at=NOW - timedelta(minutes=1))
+        )
+        self.assertEqual(moved.route, mgw.ROUTE_DEMOTE)
+        self.assertEqual(revoked.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("the head moved", moved.detail)
+        self.assertNotIn("REVOKED", moved.detail)
+        self.assertIn("REVOKED", revoked.detail)
+
+    def test_a_revocation_before_the_current_grant_is_harmless(self):
+        # The real #4709 shape after a manual restore: demoted at T, re-granted at T+.
+        restored = self.verdict(
+            review_pass_at=NOW - timedelta(minutes=10),
+            verdict_revoked_at=NOW - timedelta(minutes=40),
+        )
+        self.assertEqual(self.route(verdict=restored).route, mgw.ROUTE_PRESERVE)
 
     def test_unreadable_timeline_demotes(self):
         # ISOLATED: everything else about this verdict is valid, so ONLY the
@@ -875,6 +898,27 @@ class TestClassifyEndToEnd(unittest.TestCase):
             harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
         )
 
+    def test_a_revocation_then_regrant_preserves_end_to_end(self):
+        # PR #4709 as it actually stands: bot demoted it at 06:06:55, the verdict was
+        # restored at 06:36:41, no commits since. Validated against the live timeline.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "unlabeled", "created_at": "2026-07-27T22:30:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "labeled", "created_at": "2026-07-27T22:50:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route,
+            mgw.ROUTE_PRESERVE,
+        )
+
     def test_a_revoked_verdict_forfeits_it_end_to_end(self):
         harness = FakeWatchdog.build(
             suites=0,
@@ -887,9 +931,69 @@ class TestClassifyEndToEnd(unittest.TestCase):
                 {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
             ],
         )
-        self.assertEqual(
-            harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route, mgw.ROUTE_DEMOTE
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        # Through the real PARSER, not a hand-built VerdictState: a revocation must be
+        # reported as a revocation. Folding it into head_moved_at still demotes, so the
+        # route alone cannot catch it — only the reason can.
+        self.assertIn("REVOKED", route.detail)
+        self.assertNotIn("the head moved", route.detail)
+
+    def test_the_LATEST_revocation_counts_end_to_end(self):
+        # revoke, re-grant, revoke again. min(revoked) picks the FIRST revocation,
+        # which predates the grant, and would wrongly preserve.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "unlabeled", "created_at": "2026-07-27T22:10:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "unlabeled", "created_at": "2026-07-27T22:30:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
         )
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("REVOKED", route.detail)
+
+    def test_removing_an_unrelated_label_is_not_a_revocation_end_to_end(self):
+        # PRs shed `area:*`, `status:*`, `needs:*` labels constantly. Treating any
+        # `unlabeled` event as a verdict revocation would make the preserve route
+        # unreachable in practice, silently and greenly.
+        for other in ("area:ci", "status:untriaged", "needs:user", "role:impl"):
+            harness = FakeWatchdog.build(
+                suites=0,
+                comments=[_marker_comment()],
+                timeline=[
+                    {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                     "label": {"name": "review:pass"}},
+                    {"event": "unlabeled", "created_at": "2026-07-27T22:30:00Z",
+                     "label": {"name": other}},
+                    {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+                ],
+            )
+            self.assertEqual(
+                harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT").route,
+                mgw.ROUTE_PRESERVE,
+                other,
+            )
+
+    def test_adding_an_unrelated_label_is_not_a_verdict_end_to_end(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment()],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "area:ci"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"},
+            ],
+        )
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("no review:pass grant", route.detail)
 
     def test_a_label_other_than_review_pass_is_not_a_verdict(self):
         harness = FakeWatchdog.build(

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -50,6 +50,57 @@ def _load(module_name: str, filename: str):
 
 mgw = _load("merge_group_watchdog", "merge-group-watchdog.py")
 
+
+# ── THE SUITE MUST NEVER MAKE A REAL `gh` CALL ───────────────────────────────────
+# This is not belt-and-braces; it is a repair. `Watchdog.__init__` used to default
+# `gh=run_gh` as a DEFAULT ARGUMENT, which binds at definition time — so patching
+# `mgw.run_gh` from a test did NOT reach it, and `main(["sweep", ...])` used the REAL
+# runner while its reads were faked. The result: this suite posted **567 real comments
+# to production PR #4534** during a mutation sweep (175 mutants x a few invocations).
+#
+# Poisoning both module-level runners at import makes that class of mistake impossible
+# to repeat SILENTLY: any code path that forgets to inject a fake now raises here
+# instead of reaching the network. A test that needs a runner must inject one.
+class RealGhCallAttempted(AssertionError):
+    """A test tried to invoke the real `gh`. Inject a fake instead."""
+
+
+def _forbidden_gh(argv):
+    raise RealGhCallAttempted(
+        "the test suite attempted a REAL gh call: gh "
+        + " ".join(str(a) for a in argv[:4])
+        + " — inject a fake runner (gh=/gh_read=) instead. See #4652."
+    )
+
+
+# The genuine functions, kept so the two tests that exercise run_gh_read's own
+# exception translation can call it directly rather than the poison.
+_REAL_RUN_GH_READ = mgw.run_gh_read
+
+mgw.run_gh = _forbidden_gh
+mgw.run_gh_read = _forbidden_gh
+
+
+class _NoNetwork:
+    """Swap in fake runners and ALWAYS restore BOTH.
+
+    A finally that restored only `run_gh_read` leaked a stale fake into every later
+    test — which is how the poison tests started failing and how a real runner could
+    be reinstated unnoticed.
+    """
+
+    def __init__(self, gh):
+        self.gh = gh
+
+    def __enter__(self):
+        self._saved = (mgw.run_gh, mgw.run_gh_read)
+        mgw.run_gh = mgw.run_gh_read = self.gh
+        return self.gh
+
+    def __exit__(self, *exc):
+        mgw.run_gh, mgw.run_gh_read = self._saved
+        return False
+
 # The real incident's identifiers (#4652), so the fixtures are not invented shapes.
 BASE = "3cc1bf828c1335577069f5fa65d832c0ae1c8c38"
 HEAD = "1bfb0174f5cc2da1ed9dfe7997b7ab089e7cab26"
@@ -1366,15 +1417,13 @@ class TestEntrypointFailSafe(unittest.TestCase):
         import os
         import tempfile
 
-        original = mgw.run_gh_read
         out = Path(tempfile.mkdtemp()) / "outputs.txt"
         out.write_text("", encoding="utf-8")
         os.environ["GITHUB_OUTPUT"] = str(out)
         try:
-            mgw.run_gh_read = gh_read
-            code = mgw.main(argv)
+            with _NoNetwork(gh_read):
+                code = mgw.main(argv)
         finally:
-            mgw.run_gh_read = original
             os.environ.pop("GITHUB_OUTPUT", None)
         return code, dict(
             line.split("=", 1) for line in out.read_text(encoding="utf-8").splitlines()
@@ -1477,28 +1526,17 @@ class TestSurvivorsFromTheCoverageCensus(unittest.TestCase):
         # THE EXIT-ZERO CLASS. `return 1 if watchdog.sweep() else 0` -> `return 0`
         # survived the whole suite: a later transient would discard an earned hard
         # failure and the run would report success. This has bitten this estate before.
-        import os
-        original = mgw.run_gh_read
         harness = FakeWatchdog.build(suites=0)
         harness.gh.fail_on = ("dequeuePullRequest",)
-        try:
-            mgw.run_gh_read = harness.gh
-            mgw.run_gh = harness.gh
+        with _NoNetwork(harness.gh):
             code = mgw.main(["sweep", "--repo", "sparq-org/sparq"])
-        finally:
-            mgw.run_gh_read = original
         self.assertEqual(code, 1)
 
     def test_sweep_exit_code_is_zero_on_a_clean_sweep(self):
         # The paired control: a healthy queue must NOT red the scheduled run.
-        original = mgw.run_gh_read
         harness = FakeWatchdog.build(suites=8)
-        try:
-            mgw.run_gh_read = harness.gh
-            mgw.run_gh = harness.gh
+        with _NoNetwork(harness.gh):
             code = mgw.main(["sweep", "--repo", "sparq-org/sparq"])
-        finally:
-            mgw.run_gh_read = original
         self.assertEqual(code, 0)
 
     def test_a_failed_recovery_appears_in_the_census(self):
@@ -1571,6 +1609,31 @@ class TestSurvivorsFromTheCoverageCensus(unittest.TestCase):
         self.assertTrue(body.endswith("MGW_DETAIL_EOF\n"), body)
 
 
+class TestTheSuiteCannotTouchTheNetwork(unittest.TestCase):
+    """Guard the guard: the poison above is the only thing standing between this
+    suite and production, so its absence must itself be a test failure."""
+
+    def test_the_module_runners_are_poisoned(self):
+        self.assertIs(mgw.run_gh, _forbidden_gh)
+        self.assertIs(mgw.run_gh_read, _forbidden_gh)
+
+    def test_an_uninjected_watchdog_cannot_reach_the_network(self):
+        # The exact defect: a Watchdog built WITHOUT an injected runner must now fail
+        # loudly rather than silently using the real one.
+        watchdog = mgw.Watchdog("sparq-org/sparq")
+        with self.assertRaises(RealGhCallAttempted):
+            watchdog.queue_entries()
+
+    def test_the_runner_default_is_late_bound(self):
+        # If the default were bound at definition time this would still be the real
+        # runner, which is precisely how 567 comments reached a live PR.
+        self.assertIs(mgw.Watchdog("sparq-org/sparq").gh, _forbidden_gh)
+
+    def test_main_sweep_cannot_reach_the_network_uninjected(self):
+        with self.assertRaises(RealGhCallAttempted):
+            mgw.main(["sweep", "--repo", "sparq-org/sparq"])
+
+
 class TestEntrypointExitContract(unittest.TestCase):
     """Every exit path of `main`, because that is where the exit-zero class hides.
 
@@ -1579,13 +1642,8 @@ class TestEntrypointExitContract(unittest.TestCase):
     """
 
     def _sweep(self, gh):
-        original_read, original_gh = mgw.run_gh_read, mgw.run_gh
-        try:
-            mgw.run_gh_read = gh
-            mgw.run_gh = gh
+        with _NoNetwork(gh):
             return mgw.main(["sweep", "--repo", "sparq-org/sparq"])
-        finally:
-            mgw.run_gh_read, mgw.run_gh = original_read, original_gh
 
     def test_exhausted_transient_is_a_warning_and_exit_zero(self):
         # A periodic idempotent sweep may skip a cycle on a platform 5xx — the next
@@ -1719,7 +1777,7 @@ class TestTelemetryPlumbing(unittest.TestCase):
         try:
             mgw.gh_retry.run_gh_read = fatal
             with self.assertRaises(mgw.GhError):
-                mgw.run_gh_read(["api", "-X", "GET", "repos/x/y"])
+                _REAL_RUN_GH_READ(["api", "-X", "GET", "repos/x/y"])
         finally:
             mgw.gh_retry.run_gh_read = original
 
@@ -1734,7 +1792,7 @@ class TestTelemetryPlumbing(unittest.TestCase):
         try:
             mgw.gh_retry.run_gh_read = exhausted
             with self.assertRaises(mgw.gh_retry.GhTransientExhausted):
-                mgw.run_gh_read(["api", "-X", "GET", "repos/x/y"])
+                _REAL_RUN_GH_READ(["api", "-X", "GET", "repos/x/y"])
         finally:
             mgw.gh_retry.run_gh_read = original
 

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -1592,6 +1592,10 @@ class TestTelemetryPlumbing(unittest.TestCase):
         import os
         import tempfile
         summary = Path(tempfile.mkdtemp()) / "summary.md"
+        # Pre-create it, so a watchdog that writes NOTHING fails on the assertion below
+        # rather than on a FileNotFoundError raised by this test's own read. A kill
+        # should name the behaviour that changed, not crash in the harness.
+        summary.write_text("", encoding="utf-8")
         os.environ["GITHUB_STEP_SUMMARY"] = str(summary)
         try:
             harness = FakeWatchdog.build(suites=8)

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -1332,6 +1332,45 @@ class TestEmission(unittest.TestCase):
                         harness.rows)
 
 
+class TestTheWatchdogIsNotSilentByDefault(unittest.TestCase):
+    """A silent watchdog turns a visible outage into an invisible one — and the
+    DEFAULT is what runs in CI. Both `log=print` defaults survived the sweep, which
+    is exactly the census-silence class this PR exists to prevent."""
+
+    def test_sweep_writes_to_stdout_when_no_logger_is_injected(self):
+        import io
+        from contextlib import redirect_stdout
+
+        harness = FakeWatchdog.build(suites=8)
+        # rebuild WITHOUT log=, so the module default is exercised
+        watchdog = mgw.Watchdog(
+            "sparq-org/sparq", gh=harness.gh, now=lambda: NOW
+        )
+        out = io.StringIO()
+        with redirect_stdout(out):
+            watchdog.sweep()
+        text = out.getvalue()
+        self.assertIn("decision=HOLD", text)
+        self.assertIn("sweep complete", text)
+
+    def test_write_outputs_writes_to_stdout_when_no_logger_is_injected(self):
+        import io
+        import os
+        import tempfile
+        from contextlib import redirect_stdout
+
+        out_file = Path(tempfile.mkdtemp()) / "outputs.txt"
+        out_file.write_text("", encoding="utf-8")
+        os.environ["GITHUB_OUTPUT"] = str(out_file)
+        buf = io.StringIO()
+        try:
+            with redirect_stdout(buf):
+                mgw.write_outputs(mgw.Route(mgw.ROUTE_DEMOTE, False, "no marker"))
+        finally:
+            os.environ.pop("GITHUB_OUTPUT", None)
+        self.assertIn("route=demote", buf.getvalue())
+
+
 class TestClassifyEndToEnd(unittest.TestCase):
     def test_live_suite_count_is_re_derived_not_read_off_the_marker(self):
         # The marker says suites=0, but the LIVE count now reads 8. The route must
@@ -1344,6 +1383,42 @@ class TestClassifyEndToEnd(unittest.TestCase):
         harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
         route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
         self.assertEqual(route.route, mgw.ROUTE_PRESERVE)
+
+    def test_the_LATEST_enqueue_binds_the_marker_not_the_earliest(self):
+        # Every other timeline fixture carries exactly ONE added_to_merge_queue, so
+        # max() and min() were indistinguishable and the mutant survived. Two attempts:
+        # the marker sits AFTER the first enqueue but BEFORE the second, so only
+        # max() correctly rejects it as predating the CURRENT attempt.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment(observed=mgw.parse_iso("2026-07-27T22:40:00Z"))],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:30:00Z"},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:50:00Z"},
+            ],
+        )
+        route = harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+        self.assertIn("predates this queue attempt", route.detail)
+
+    def test_a_marker_after_the_latest_enqueue_still_binds(self):
+        # The control: with the marker after BOTH enqueues it must still preserve.
+        harness = FakeWatchdog.build(
+            suites=0,
+            comments=[_marker_comment(observed=mgw.parse_iso("2026-07-27T23:00:00Z"))],
+            timeline=[
+                {"event": "labeled", "created_at": "2026-07-27T22:20:00Z",
+                 "label": {"name": "review:pass"}},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:30:00Z"},
+                {"event": "added_to_merge_queue", "created_at": "2026-07-27T22:50:00Z"},
+            ],
+        )
+        self.assertEqual(
+            harness.watchdog.classify_dequeue(99900001, "CI_TIMEOUT").route,
+            mgw.ROUTE_PRESERVE,
+        )
 
     def test_a_commit_after_the_verdict_forfeits_it_end_to_end(self):
         # Exercises the real timeline PARSER, not just the policy: a `committed` event

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -141,11 +141,15 @@ class TestZeroSuiteDetection(unittest.TestCase):
             mgw.RECOVER,
         )
 
-    def test_grace_exceeds_measured_dispatch_latency_by_two_orders(self):
-        # Measured create->first-suite latency on this repo is single-digit SECONDS
-        # (repository activity branch_creation -> earliest check-suite created_at).
-        # Pin a floor so nobody "tunes" the grace down to the noise band.
-        self.assertGreaterEqual(mgw.DEFAULT_GRACE_SECONDS, 300)
+    def test_grace_is_bounded_by_the_measured_dispatch_latency(self):
+        # MEASURED N=209 (2026-07-25 -> 07-28): create->first-suite latency
+        # min 1 s / p50 2 s / p99 4 s / MAX 4 s, with no tail between 4 s and 3600 s.
+        # Floor: >=20x the measured maximum, so nobody tunes the grace into the noise
+        # band. Ceiling: <= the 300 s cron interval, so the grace never costs an extra
+        # tick (a longer grace would silently halve the recovery speed).
+        measured_max_seconds = 4
+        self.assertGreaterEqual(mgw.DEFAULT_GRACE_SECONDS, 20 * measured_max_seconds)
+        self.assertLessEqual(mgw.DEFAULT_GRACE_SECONDS, 300)
 
     def test_only_awaiting_checks_is_actionable(self):
         self.assertEqual(mgw.ACTIONABLE_STATES, frozenset({"AWAITING_CHECKS"}))

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -1,0 +1,799 @@
+#!/usr/bin/env python3
+# [OPUS-5] sparq-org/sparq#4652 — the zero-dispatch merge-group watchdog test suite.
+#
+# Three layers, because on THIS repo every uncaught mutant in a recent sweep lived at
+# the YAML seam rather than in the Python:
+#
+#   1. POLICY (pure) — decide_entry / classify_dequeue_route decision tables. Every
+#      arm, and for the two headline claims a paired CONTROL that must NOT fire.
+#   2. BEHAVIOUR (fake gh) — drive the real Watchdog.sweep() against a scripted gh and
+#      assert on the MUTATIONS ISSUED, not just the log text. A watchdog that logs
+#      "RECOVER" while issuing no mutation, or that mutates on the control input, dies
+#      here.
+#   3. WIRING (YAML inspection) — the `if:` expressions, the step list, and the CALL
+#      SITE argv of both workflows. YAML `if:` cannot be executed in a unit test, so
+#      its SHAPE is pinned instead: delete the classify step, invert the fail-safe
+#      `!= 'preserve'` to `== 'demote'`, drop `sweep` from the call site, or add a
+#      pull_request trigger to the cron watchdog, and a test here goes red.
+#
+# Hermetic: no gh, no network, no git. Needs PyYAML (already a docs-quality dep).
+# Run:  python3 scripts/tests/test_merge_group_watchdog.py
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+FEEDBACK_YML = REPO_ROOT / ".github" / "workflows" / "merge-queue-feedback.yml"
+WATCHDOG_YML = REPO_ROOT / ".github" / "workflows" / "merge-group-watchdog.yml"
+DOCS_QUALITY_YML = REPO_ROOT / ".github" / "workflows" / "docs-quality.yml"
+
+
+def _load(module_name: str, filename: str):
+    sys.path.insert(0, str(SCRIPTS))
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS / filename)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mgw = _load("merge_group_watchdog", "merge-group-watchdog.py")
+
+# The real incident's identifiers (#4652), so the fixtures are not invented shapes.
+BASE = "3cc1bf828c1335577069f5fa65d832c0ae1c8c38"
+HEAD = "1bfb0174f5cc2da1ed9dfe7997b7ab089e7cab26"
+REF = f"gh-readonly-queue/main/pr-4534-{BASE}"
+BUILT = mgw.parse_iso("2026-07-27T23:04:37Z")  # measured branch_creation timestamp
+NOW = mgw.parse_iso("2026-07-27T23:20:00Z")
+
+
+def entry(**overrides) -> "mgw.QueueEntry":
+    fields = dict(
+        pr_number=4534,
+        pr_id="PR_4534",
+        entry_id="MQE_4534",
+        position=1,
+        state="AWAITING_CHECKS",
+        enqueued_at=mgw.parse_iso("2026-07-27T22:58:53Z"),
+        base_oid=BASE,
+        head_oid=HEAD,
+    )
+    fields.update(overrides)
+    return mgw.QueueEntry(**fields)
+
+
+def decide(**overrides) -> "mgw.Decision":
+    kwargs = dict(
+        suites=0,
+        created_at=BUILT,
+        now=NOW,
+        grace_seconds=mgw.DEFAULT_GRACE_SECONDS,
+        markers=(),
+        recoveries_in_window=0,
+        max_recoveries_per_pr=mgw.DEFAULT_MAX_RECOVERIES_PER_PR,
+        run_recoveries=0,
+        max_recoveries_per_run=mgw.DEFAULT_MAX_RECOVERIES_PER_RUN,
+    )
+    subject = overrides.pop("entry", entry())
+    kwargs.update(overrides)
+    return mgw.decide_entry(subject, **kwargs)
+
+
+def marker(**overrides) -> "mgw.Marker":
+    fields = dict(
+        pr=4534,
+        head=HEAD,
+        base=BASE,
+        ref=REF,
+        suites=0,
+        observed=NOW - timedelta(minutes=5),
+        action="re-enqueue",
+    )
+    fields.update(overrides)
+    return mgw.Marker(**fields)
+
+
+# ── 1. policy ────────────────────────────────────────────────────────────────────
+
+
+class TestZeroSuiteDetection(unittest.TestCase):
+    """The headline claim, and the control that stops it firing on everything."""
+
+    def test_zero_suites_past_grace_is_recovered(self):
+        # THE RED TEST: the exact #4534 shape — group ref built, zero check-suites,
+        # well past the grace period — must be detected and recovered.
+        self.assertEqual(decide().verdict, mgw.RECOVER)
+
+    def test_control_suites_present_runs_pending_is_never_touched(self):
+        # THE CONTROL: a perfectly healthy group whose check-runs are simply still
+        # pending has SUITES. Without this the detector could pass by firing on
+        # everything. Age is irrelevant here — even an hour-old pending group holds.
+        for suites in (1, 8, 40):
+            for age in (0, mgw.DEFAULT_GRACE_SECONDS * 100):
+                verdict = decide(suites=suites, now=BUILT + timedelta(seconds=age)).verdict
+                self.assertEqual(verdict, mgw.HOLD, (suites, age))
+
+    def test_zero_check_runs_is_not_the_predicate(self):
+        # A paths-filtered workflow that matches nothing still creates a check-SUITE
+        # and produces no run. The detector must key on the suite count only; a
+        # suites=N/runs=0 group is a HOLD.
+        self.assertEqual(decide(suites=3).verdict, mgw.HOLD)
+
+    def test_grace_boundary(self):
+        self.assertEqual(decide(now=BUILT + timedelta(seconds=0)).verdict, mgw.WAIT)
+        self.assertEqual(
+            decide(now=BUILT + timedelta(seconds=mgw.DEFAULT_GRACE_SECONDS - 1)).verdict,
+            mgw.WAIT,
+        )
+        self.assertEqual(
+            decide(now=BUILT + timedelta(seconds=mgw.DEFAULT_GRACE_SECONDS)).verdict,
+            mgw.RECOVER,
+        )
+
+    def test_grace_exceeds_measured_dispatch_latency_by_two_orders(self):
+        # Measured create->first-suite latency on this repo is single-digit SECONDS
+        # (repository activity branch_creation -> earliest check-suite created_at).
+        # Pin a floor so nobody "tunes" the grace down to the noise band.
+        self.assertGreaterEqual(mgw.DEFAULT_GRACE_SECONDS, 300)
+
+    def test_only_awaiting_checks_is_actionable(self):
+        self.assertEqual(mgw.ACTIONABLE_STATES, frozenset({"AWAITING_CHECKS"}))
+        for state in ("QUEUED", "MERGEABLE", "UNMERGEABLE", "LOCKED"):
+            self.assertEqual(decide(entry=entry(state=state)).verdict, mgw.SKIP, state)
+
+    def test_entry_without_a_built_group_is_skipped(self):
+        self.assertEqual(decide(entry=entry(head_oid=None)).verdict, mgw.SKIP)
+        self.assertEqual(decide(entry=entry(base_oid=None)).verdict, mgw.SKIP)
+
+
+class TestFailSafe(unittest.TestCase):
+    """Anything not POSITIVELY established must be a refusal, never a recovery."""
+
+    def test_unknown_suite_count_refuses(self):
+        self.assertEqual(decide(suites=None).verdict, mgw.REFUSE)
+
+    def test_missing_branch_creation_anchor_refuses(self):
+        self.assertEqual(decide(created_at=None).verdict, mgw.REFUSE)
+
+    def test_future_creation_time_refuses(self):
+        self.assertEqual(decide(now=BUILT - timedelta(minutes=1)).verdict, mgw.REFUSE)
+
+    def test_check_suite_count_returns_none_on_every_unreadable_shape(self):
+        watchdog = FakeWatchdog.build()
+        for payload in (
+            "not json",
+            "[]",
+            json.dumps({"check_suites": []}),
+            json.dumps({"total_count": 0}),
+            json.dumps({"total_count": "0", "check_suites": []}),
+            # total_count says zero but the array is non-empty: a garbled response must
+            # never be mistaken for a positively-observed zero.
+            json.dumps({"total_count": 0, "check_suites": [{"id": 1}]}),
+        ):
+            watchdog.gh.suites_raw = payload
+            self.assertIsNone(watchdog.watchdog.check_suite_count(HEAD), payload)
+
+    def test_positive_zero_is_returned(self):
+        watchdog = FakeWatchdog.build()
+        watchdog.gh.suites_raw = json.dumps({"total_count": 0, "check_suites": []})
+        self.assertEqual(watchdog.watchdog.check_suite_count(HEAD), 0)
+
+
+class TestCapAndIdempotence(unittest.TestCase):
+    def test_repeat_detection_on_the_same_ref_is_a_noop(self):
+        self.assertEqual(decide(markers=(marker(),)).verdict, mgw.NOOP)
+
+    def test_a_marker_for_a_different_head_does_not_suppress_detection(self):
+        self.assertEqual(
+            decide(markers=(marker(head="b" * 40),), recoveries_in_window=1).verdict,
+            mgw.RECOVER,
+        )
+
+    def test_per_pr_cap(self):
+        self.assertEqual(decide(recoveries_in_window=1).verdict, mgw.RECOVER)
+        self.assertEqual(decide(recoveries_in_window=2).verdict, mgw.CAP)
+        self.assertEqual(decide(recoveries_in_window=99).verdict, mgw.CAP)
+        self.assertEqual(mgw.DEFAULT_MAX_RECOVERIES_PER_PR, 2)
+
+    def test_per_run_cap(self):
+        self.assertEqual(decide(run_recoveries=1).verdict, mgw.RECOVER)
+        self.assertEqual(decide(run_recoveries=2).verdict, mgw.CAP)
+
+    def test_cap_is_a_refusal_not_a_mutation(self):
+        # Exhaustion hands back to the platform CI_TIMEOUT; it must not act.
+        harness = FakeWatchdog.build(comments=[_marker_comment(head="c" * 40),
+                                               _marker_comment(head="d" * 40)])
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=CAP" in row for row in harness.rows), harness.rows)
+
+
+class TestDequeueRouting(unittest.TestCase):
+    """Both arms of the CI_TIMEOUT split, keyed on the suite count."""
+
+    def route(self, **overrides) -> "mgw.Route":
+        kwargs = dict(
+            reason="CI_TIMEOUT",
+            markers=(marker(),),
+            last_enqueued_at=NOW - timedelta(hours=1),
+            live_suites=lambda _sha: 0,
+            now=NOW + timedelta(minutes=40),
+        )
+        kwargs.update(overrides)
+        return mgw.classify_dequeue_route(**kwargs)
+
+    def test_arm_a_ci_timeout_with_zero_suites_preserves_the_verdict(self):
+        result = self.route()
+        self.assertEqual(result.route, mgw.ROUTE_PRESERVE)
+        self.assertTrue(result.reenqueue)
+
+    def test_arm_b_ci_timeout_with_suites_present_still_demotes(self):
+        # The legitimate signal: checks genuinely ran and ran long. Keep demoting.
+        self.assertEqual(self.route(live_suites=lambda _s: 8).route, mgw.ROUTE_DEMOTE)
+        self.assertEqual(self.route(live_suites=lambda _s: 1).route, mgw.ROUTE_DEMOTE)
+
+    def test_the_split_is_the_suite_count_not_the_reason(self):
+        # Same reason, opposite outcome, purely because the suite count differs.
+        zero = self.route(reason="CI_TIMEOUT", live_suites=lambda _s: 0)
+        many = self.route(reason="CI_TIMEOUT", live_suites=lambda _s: 8)
+        self.assertEqual(zero.route, mgw.ROUTE_PRESERVE)
+        self.assertEqual(many.route, mgw.ROUTE_DEMOTE)
+
+    def test_unreadable_suite_count_demotes(self):
+        self.assertEqual(self.route(live_suites=lambda _s: None).route, mgw.ROUTE_DEMOTE)
+
+    def test_no_marker_demotes(self):
+        self.assertEqual(self.route(markers=()).route, mgw.ROUTE_DEMOTE)
+
+    def test_marker_predating_this_queue_attempt_demotes(self):
+        self.assertEqual(
+            self.route(last_enqueued_at=NOW + timedelta(minutes=1)).route,
+            mgw.ROUTE_DEMOTE,
+        )
+
+    def test_missing_enqueue_event_demotes(self):
+        self.assertEqual(self.route(last_enqueued_at=None).route, mgw.ROUTE_DEMOTE)
+
+    def test_stale_marker_demotes(self):
+        self.assertEqual(self.route(now=NOW + timedelta(hours=7)).route, mgw.ROUTE_DEMOTE)
+
+    def test_other_reasons_keep_todays_behaviour(self):
+        for reason in ("CI_FAILURE", "MERGE_CONFLICT", "QUEUE_CLEARED", "ROLL_BACK",
+                       "BRANCH_PROTECTIONS", "ALREADY_MERGED"):
+            self.assertEqual(self.route(reason=reason).route, mgw.ROUTE_DEMOTE, reason)
+
+    def test_watchdogs_own_dequeue_preserves_without_a_second_reenqueue(self):
+        result = self.route(reason="MANUAL", now=NOW + timedelta(seconds=30))
+        self.assertEqual(result.route, mgw.ROUTE_PRESERVE)
+        self.assertFalse(result.reenqueue)
+
+    def test_watchdog_attribution_expires(self):
+        self.assertEqual(
+            self.route(reason="MANUAL", now=NOW + timedelta(hours=2)).route,
+            mgw.ROUTE_DEMOTE,
+        )
+
+    def test_a_real_failure_right_after_a_recovery_is_not_attributed_to_us(self):
+        for reason in ("MERGE_CONFLICT", "CI_FAILURE"):
+            self.assertEqual(
+                self.route(reason=reason, now=NOW + timedelta(seconds=30)).route,
+                mgw.ROUTE_DEMOTE,
+                reason,
+            )
+
+    def test_reason_is_normalised(self):
+        self.assertEqual(self.route(reason=" ci_timeout ").route, mgw.ROUTE_PRESERVE)
+        self.assertEqual(self.route(reason="").route, mgw.ROUTE_DEMOTE)
+        self.assertEqual(self.route(reason=None).route, mgw.ROUTE_DEMOTE)
+
+
+class TestMarkerCodec(unittest.TestCase):
+    def test_round_trip(self):
+        rendered = mgw.render_marker(
+            pr=4534, head=HEAD, base=BASE, ref=REF, suites=0, observed=NOW
+        )
+        parsed = mgw.parse_marker(f"prose\n\n{rendered}\n")
+        self.assertIsNotNone(parsed)
+        self.assertEqual(parsed.head, HEAD)
+        self.assertEqual(parsed.base, BASE)
+        self.assertEqual(parsed.ref, REF)
+        self.assertEqual(parsed.suites, 0)
+        self.assertEqual(parsed.observed, NOW)
+        self.assertEqual(parsed.action, "re-enqueue")
+
+    def test_rejects_malformed(self):
+        for body in (
+            "",
+            None,
+            "no marker",
+            f"<!-- {mgw.MARKER_KEY} pr=1 head=nothex suites=0 observed=2026-01-01T00:00:00Z -->",
+            f"<!-- {mgw.MARKER_KEY} pr=1 head={HEAD} suites=0 -->",
+            f"<!-- {mgw.MARKER_KEY} pr=x head={HEAD} suites=0 observed=2026-01-01T00:00:00Z -->",
+            f"<!-- other-tool head={HEAD} suites=0 observed=2026-01-01T00:00:00Z -->",
+        ):
+            self.assertIsNone(mgw.parse_marker(body), body)
+
+    def test_queue_ref_is_base_keyed_and_matches_live_format(self):
+        # Verified against live data 2026-07-28: entry pos1 pr=4644 base=c96f5abe…
+        # produced ref gh-readonly-queue/main/pr-4644-c96f5abe… with head 1612bd6f…
+        self.assertEqual(
+            mgw.queue_ref("main", 4644, "c96f5abe3e0b7ba50c1381a1503ba961313b3da7"),
+            "gh-readonly-queue/main/pr-4644-c96f5abe3e0b7ba50c1381a1503ba961313b3da7",
+        )
+
+
+# ── 2. behaviour (fake gh) ───────────────────────────────────────────────────────
+
+
+def _marker_comment(*, head: str = HEAD, observed: datetime | None = None) -> dict:
+    stamp = observed or (NOW - timedelta(minutes=10))
+    return {
+        "body": "text\n\n"
+        + mgw.render_marker(pr=4534, head=head, base=BASE, ref=REF, suites=0, observed=stamp)
+    }
+
+
+class ScriptedGh:
+    """A gh runner scripted for exactly the argv shapes the watchdog issues."""
+
+    def __init__(self, *, entries, suites_raw, activity, comments, timeline):
+        self.entries = entries
+        self.suites_raw = suites_raw
+        self.activity = activity
+        self.comments = comments
+        self.timeline = timeline
+        self.calls: list[list[str]] = []
+        self.mutations: list[list[str]] = []
+
+    def __call__(self, argv: list[str]) -> str:
+        self.calls.append(argv)
+        joined = " ".join(argv)
+        if argv[:2] == ["api", "graphql"]:
+            query = next(a for a in argv if a.startswith("query="))
+            # Discriminate on the OPERATION keyword, not on a substring of the
+            # selection set: both mutations select `mergeQueueEntry`, so a
+            # `"mergeQueue" in query` test silently swallowed them and made this fake
+            # report zero mutations for a real recovery.
+            if query.startswith("query=query"):
+                return json.dumps(
+                    {"data": {"repository": {"mergeQueue": {"entries": {"nodes": self.entries}}}}}
+                )
+            assert query.startswith("query=mutation"), query
+            self.mutations.append(argv)
+            return json.dumps({"data": {}})
+        if argv[:2] == ["pr", "comment"]:
+            self.mutations.append(argv)
+            return ""
+        if "/check-suites" in joined:
+            return self.suites_raw
+        if "/activity" in joined:
+            return "\n".join(json.dumps(row) for row in self.activity)
+        if "/comments" in joined:
+            return "\n".join(json.dumps(row) for row in self.comments)
+        if "/timeline" in joined:
+            return "\n".join(json.dumps(row) for row in self.timeline)
+        raise AssertionError(f"unexpected gh call: {argv}")
+
+
+class FakeWatchdog:
+    def __init__(self, gh: ScriptedGh, rows: list[str], watchdog):
+        self.gh = gh
+        self.rows = rows
+        self.watchdog = watchdog
+
+    @classmethod
+    def build(cls, *, suites: int | None = 0, entries=None, comments=None,
+              activity=None, now: datetime | None = None, dry_run: bool = False):
+        node = {
+            "id": "MQE_4534",
+            "position": 1,
+            "state": "AWAITING_CHECKS",
+            "enqueuedAt": "2026-07-27T22:58:53Z",
+            "baseCommit": {"oid": BASE},
+            "headCommit": {"oid": HEAD},
+            "pullRequest": {"number": 4534, "id": "PR_4534"},
+        }
+        if suites is None:
+            suites_raw = "not json"
+        else:
+            suites_raw = json.dumps(
+                {"total_count": suites, "check_suites": [{"id": i} for i in range(suites)]}
+            )
+        gh = ScriptedGh(
+            entries=[node] if entries is None else entries,
+            suites_raw=suites_raw,
+            activity=[{"activity_type": "branch_creation", "after": HEAD,
+                       "timestamp": "2026-07-27T23:04:37Z"}]
+            if activity is None
+            else activity,
+            comments=comments or [],
+            timeline=[{"event": "added_to_merge_queue", "created_at": "2026-07-27T22:58:53Z"}],
+        )
+        rows: list[str] = []
+        watchdog = mgw.Watchdog(
+            "sparq-org/sparq",
+            dry_run=dry_run,
+            gh=gh,
+            log=rows.append,
+            now=lambda: now or NOW,
+        )
+        return cls(gh, rows, watchdog)
+
+    def run(self) -> int:
+        return self.watchdog.sweep()
+
+
+class TestSweepBehaviour(unittest.TestCase):
+    def test_zero_dispatch_entry_is_marked_then_dequeued_then_reenqueued(self):
+        harness = FakeWatchdog.build(suites=0)
+        self.assertEqual(harness.run(), 0)
+        kinds = [m[:2] for m in harness.gh.mutations]
+        self.assertEqual(
+            kinds,
+            [["pr", "comment"], ["api", "graphql"], ["api", "graphql"]],
+            harness.gh.mutations,
+        )
+        # The marker comment is posted BEFORE the dequeue, so the dequeue-triggered
+        # feedback workflow can positively identify our own recovery.
+        self.assertEqual(harness.gh.mutations[0][:2], ["pr", "comment"])
+        body = harness.gh.mutations[0][harness.gh.mutations[0].index("--body") + 1]
+        self.assertIn("🤖", body)
+        self.assertIsNotNone(mgw.parse_marker(body))
+        queries = [
+            next(a for a in m if a.startswith("query="))
+            for m in harness.gh.mutations[1:]
+        ]
+        self.assertIn("dequeuePullRequest", queries[0])
+        self.assertIn("enqueuePullRequest", queries[1])
+
+    def test_control_group_with_suites_issues_no_mutation_at_all(self):
+        harness = FakeWatchdog.build(suites=8)
+        self.assertEqual(harness.run(), 0)
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=HOLD" in row for row in harness.rows), harness.rows)
+        self.assertTrue(any("suites=8" in row for row in harness.rows), harness.rows)
+
+    def test_unreadable_suite_count_issues_no_mutation(self):
+        harness = FakeWatchdog.build(suites=None)
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=REFUSE" in row for row in harness.rows), harness.rows)
+
+    def test_missing_activity_row_issues_no_mutation(self):
+        harness = FakeWatchdog.build(suites=0, activity=[])
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=REFUSE" in row for row in harness.rows), harness.rows)
+
+    def test_activity_row_for_a_different_head_is_not_our_anchor(self):
+        harness = FakeWatchdog.build(
+            suites=0,
+            activity=[{"activity_type": "branch_creation", "after": "f" * 40,
+                       "timestamp": "2026-07-27T23:04:37Z"}],
+        )
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+
+    def test_second_detection_on_the_same_ref_issues_no_mutation(self):
+        harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=NOOP" in row for row in harness.rows), harness.rows)
+
+    def test_dry_run_decides_but_never_mutates(self):
+        harness = FakeWatchdog.build(suites=0, dry_run=True)
+        harness.run()
+        self.assertEqual(harness.gh.mutations, [])
+        self.assertTrue(any("decision=RECOVER" in row for row in harness.rows), harness.rows)
+
+    def test_per_run_budget_bounds_one_tick(self):
+        nodes = []
+        for index, pr in enumerate((4534, 4535, 4536), start=1):
+            nodes.append(
+                {
+                    "id": f"MQE_{pr}",
+                    "position": index,
+                    "state": "AWAITING_CHECKS",
+                    "enqueuedAt": "2026-07-27T22:58:53Z",
+                    "baseCommit": {"oid": BASE},
+                    "headCommit": {"oid": HEAD},
+                    "pullRequest": {"number": pr, "id": f"PR_{pr}"},
+                }
+            )
+        harness = FakeWatchdog.build(suites=0, entries=nodes)
+        harness.run()
+        dequeues = [
+            m
+            for m in harness.gh.mutations
+            if any("dequeuePullRequest" in a for a in m)
+        ]
+        self.assertEqual(len(dequeues), mgw.DEFAULT_MAX_RECOVERIES_PER_RUN)
+        self.assertTrue(any("decision=CAP" in row for row in harness.rows), harness.rows)
+
+
+class TestEmission(unittest.TestCase):
+    """A silent watchdog turns a visible outage into an invisible one."""
+
+    def test_every_entry_emits_a_row_naming_ref_suites_and_decision(self):
+        for suites in (0, 8, None):
+            harness = FakeWatchdog.build(suites=suites)
+            harness.run()
+            rows = [r for r in harness.rows if "decision=" in r]
+            self.assertEqual(len(rows), 1, (suites, harness.rows))
+            row = rows[0]
+            self.assertIn(f"ref={REF}", row)
+            self.assertIn("suites=", row)
+            self.assertIn(f"head={HEAD[:8]}", row)
+            self.assertIn("pr=#4534", row)
+
+    def test_holding_states_re_emit_every_tick(self):
+        # Three consecutive ticks on an unchanged CAP/NOOP condition must each emit.
+        for _ in range(3):
+            harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
+            harness.run()
+            self.assertTrue(any("decision=NOOP" in r for r in harness.rows))
+            self.assertTrue(any("::warning" in r for r in harness.rows), harness.rows)
+
+    def test_empty_queue_emits_an_explicit_row(self):
+        harness = FakeWatchdog.build(entries=[])
+        harness.run()
+        self.assertTrue(any("EMPTY" in r for r in harness.rows), harness.rows)
+
+    def test_census_row_closes_every_sweep(self):
+        harness = FakeWatchdog.build(suites=8)
+        harness.run()
+        self.assertTrue(any("sweep complete" in r for r in harness.rows), harness.rows)
+
+    def test_refusals_and_caps_are_warnings_not_silence(self):
+        harness = FakeWatchdog.build(suites=None)
+        harness.run()
+        self.assertTrue(any("::warning" in r and "REFUSE" in r for r in harness.rows),
+                        harness.rows)
+
+
+class TestClassifyEndToEnd(unittest.TestCase):
+    def test_live_suite_count_is_re_derived_not_read_off_the_marker(self):
+        # The marker says suites=0, but the LIVE count now reads 8. The route must
+        # follow the live re-derivation, not the recorded value.
+        harness = FakeWatchdog.build(suites=8, comments=[_marker_comment()])
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_DEMOTE)
+
+    def test_zero_live_count_preserves(self):
+        harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
+        route = harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(route.route, mgw.ROUTE_PRESERVE)
+
+    def test_classify_never_mutates(self):
+        harness = FakeWatchdog.build(suites=0, comments=[_marker_comment()])
+        harness.watchdog.classify_dequeue(4534, "CI_TIMEOUT")
+        self.assertEqual(harness.gh.mutations, [])
+
+
+# ── 3. wiring (the YAML seam) ────────────────────────────────────────────────────
+
+
+def _yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on_block(wf: dict) -> dict:
+    """Bare `on:` is the YAML boolean True, so PyYAML keys it under True."""
+    return wf.get("on", wf.get(True, {})) or {}
+
+
+def _steps(wf: dict, job: str) -> list[dict]:
+    return wf["jobs"][job]["steps"]
+
+
+def _step(wf: dict, job: str, needle: str) -> dict:
+    for step in _steps(wf, job):
+        if needle in (step.get("name") or "") or needle == step.get("id"):
+            return step
+    raise AssertionError(f"no step matching {needle!r} in job {job}")
+
+
+class TestFeedbackWiring(unittest.TestCase):
+    """Mutate the `if:`, the step, or the call site and one of these goes red."""
+
+    def setUp(self):
+        self.wf = _yaml(FEEDBACK_YML)
+        self.steps = _steps(self.wf, "feedback")
+        self.names = [s.get("name") or s.get("uses") for s in self.steps]
+
+    def test_classify_step_exists_with_the_id_the_guards_reference(self):
+        ids = [s.get("id") for s in self.steps]
+        self.assertIn("classify", ids, self.names)
+
+    def test_classify_call_site_invokes_the_classifier_with_pr_and_reason(self):
+        run = _step(self.wf, "feedback", "classify")["run"]
+        self.assertIn("scripts/merge-group-watchdog.py", run)
+        self.assertIn("classify-dequeue", run)
+        self.assertIn("--pr", run)
+        self.assertIn("--reason", run)
+        self.assertIn("$PR_NUMBER", run)
+        self.assertIn("$DEQUEUE_REASON", run)
+
+    def test_the_demote_guard_is_fail_closed(self):
+        # `!= 'preserve'` means an EMPTY/MISSING output still demotes. Inverting this
+        # to `== 'demote'` would make a classifier failure silently preserve.
+        guard = _step(self.wf, "feedback", "Route genuine dequeue")["if"]
+        self.assertIn("steps.classify.outputs.route != 'preserve'", guard)
+        self.assertNotIn("== 'demote'", guard)
+        self.assertIn("github.event.pull_request.merged != true", guard)
+
+    def test_the_preserve_guard_is_fail_open_in_the_safe_direction(self):
+        guard = _step(self.wf, "feedback", "Preserve the verdict")["if"]
+        self.assertIn("steps.classify.outputs.route == 'preserve'", guard)
+        self.assertIn("github.event.pull_request.merged != true", guard)
+
+    def test_the_two_routes_are_mutually_exclusive(self):
+        demote = _step(self.wf, "feedback", "Route genuine dequeue")["if"]
+        preserve = _step(self.wf, "feedback", "Preserve the verdict")["if"]
+        self.assertNotEqual(demote, preserve)
+        self.assertIn("route != 'preserve'", demote)
+        self.assertIn("route == 'preserve'", preserve)
+
+    def test_preserve_route_never_demotes_the_label(self):
+        # Preserving the verdict IS leaving the labels alone: the route must issue no
+        # label mutation and must not kill the arm. (`review:changes` appears in this
+        # step's explanatory COMMENT prose, so match on the gh flags, not the token.)
+        run = _step(self.wf, "feedback", "Preserve the verdict")["run"]
+        self.assertNotIn("--add-label", run)
+        self.assertNotIn("--remove-label", run)
+        self.assertNotIn("--disable-auto", run)
+        self.assertNotIn("gh pr edit", run)
+
+    def test_demote_route_still_swaps_the_labels(self):
+        # The pre-#4652 behaviour must survive intact on the other arm.
+        run = _step(self.wf, "feedback", "Route genuine dequeue")["run"]
+        self.assertIn('--add-label "review:changes"', run)
+        self.assertIn('--remove-label "review:pass"', run)
+        self.assertIn("--disable-auto", run)
+
+    def test_checkout_is_pinned_to_the_default_branch_never_the_pr_head(self):
+        step = _step(self.wf, "feedback", "Checkout the dequeue classifier")
+        self.assertTrue(str(step["uses"]).startswith("actions/checkout@"))
+        self.assertRegex(str(step["uses"]), r"@[0-9a-f]{40}$")
+        self.assertEqual(step["with"]["ref"], "${{ github.event.repository.default_branch }}")
+        self.assertIs(step["with"]["persist-credentials"], False)
+        # The pull_request_target trap: never the PR head.
+        rendered = yaml.safe_dump(step)
+        for forbidden in ("pull_request.head", "github.head_ref", "merge_commit_sha"):
+            self.assertNotIn(forbidden, rendered)
+
+    def test_permissions_add_reads_only(self):
+        perms = self.wf["permissions"]
+        self.assertEqual(perms.get("checks"), "read")
+        self.assertEqual(perms.get("contents"), "read")
+        self.assertEqual(perms.get("pull-requests"), "write")
+
+    def test_trigger_is_unchanged(self):
+        on = _on_block(self.wf)
+        self.assertEqual(list(on), ["pull_request_target"])
+        self.assertEqual(on["pull_request_target"]["types"], ["dequeued"])
+
+    def test_step_order_classify_before_both_routes(self):
+        order = {name: i for i, name in enumerate(self.names)}
+        classify = next(i for n, i in order.items() if n and "Classify the dequeue" in n)
+        preserve = next(i for n, i in order.items() if n and "Preserve the verdict" in n)
+        demote = next(i for n, i in order.items() if n and "Route genuine dequeue" in n)
+        checkout = next(i for n, i in order.items() if n and "Checkout the dequeue" in n)
+        self.assertLess(checkout, classify)
+        self.assertLess(classify, preserve)
+        self.assertLess(classify, demote)
+
+
+class TestWatchdogWorkflowWiring(unittest.TestCase):
+    def setUp(self):
+        self.wf = _yaml(WATCHDOG_YML)
+
+    def test_is_schedule_only_and_can_never_gate(self):
+        on = _on_block(self.wf)
+        self.assertIn("schedule", on)
+        self.assertIn("workflow_dispatch", on)
+        # A PR-head trigger would make this sweep a required check on every PR.
+        for gating in ("pull_request", "pull_request_target", "merge_group", "push"):
+            self.assertNotIn(gating, on, gating)
+
+    def test_cron_is_five_minutely(self):
+        minutes = self.wf["on" if "on" in self.wf else True]["schedule"][0]["cron"].split()[0]
+        values = sorted(int(m) for m in minutes.split(","))
+        self.assertEqual(len(values), 12, values)
+        gaps = {b - a for a, b in zip(values, values[1:])}
+        self.assertEqual(gaps, {5}, values)
+
+    def test_sweep_call_site_invokes_the_sweep_subcommand(self):
+        run = _step(self.wf, "watch", "Sweep the merge queue")["run"]
+        self.assertIn("scripts/merge-group-watchdog.py", run)
+        self.assertIn("sweep", run)
+        self.assertIn("--repo", run)
+        self.assertIn("--branch", run)
+
+    def test_self_test_runs_before_the_live_sweep(self):
+        names = [s.get("name") or s.get("uses") for s in _steps(self.wf, "watch")]
+        self.assertLess(
+            next(i for i, n in enumerate(names) if n and "Self-test" in n),
+            next(i for i, n in enumerate(names) if n and "Sweep the merge queue" in n),
+        )
+        run = _step(self.wf, "watch", "Self-test policy")["run"]
+        self.assertIn("merge-group-watchdog.py --self-test", run)
+        self.assertIn("gh_retry.py --self-test", run)
+
+    def test_checkout_is_default_branch_and_sparse_covers_both_scripts(self):
+        step = _step(self.wf, "watch", "Checkout watchdog policy")
+        self.assertEqual(step["with"]["ref"], "${{ github.event.repository.default_branch }}")
+        self.assertIs(step["with"]["persist-credentials"], False)
+        sparse = step["with"]["sparse-checkout"]
+        self.assertIn("scripts/merge-group-watchdog.py", sparse)
+        self.assertIn("scripts/gh_retry.py", sparse)
+
+    def test_permissions_are_least_privilege(self):
+        perms = self.wf["permissions"]
+        self.assertEqual(perms.get("contents"), "read")
+        self.assertEqual(perms.get("checks"), "read")
+        self.assertEqual(perms.get("pull-requests"), "write")
+
+    def test_actions_are_sha_pinned(self):
+        # PyYAML drops `#` comments, so the 40-hex pin is asserted on the parsed value
+        # and the readable `# vX.Y.Z` tag on the raw text.
+        raw = WATCHDOG_YML.read_text(encoding="utf-8")
+        seen = 0
+        for step in _steps(self.wf, "watch"):
+            uses = step.get("uses")
+            if not uses:
+                continue
+            seen += 1
+            self.assertRegex(uses, r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$", uses)
+            self.assertRegex(raw, re.escape(f"uses: {uses} # v"), uses)
+        self.assertGreater(seen, 0)
+
+    def test_serialised_so_two_ticks_cannot_double_recover(self):
+        concurrency = self.wf["concurrency"]
+        self.assertEqual(concurrency["group"], "merge-group-watchdog")
+        self.assertIs(concurrency["cancel-in-progress"], False)
+
+    def test_job_name_is_not_advisory_classified(self):
+        # `advisory`/`informational` are reserved tokens for the ci-summary aggregator
+        # and require an advisory-registry entry; this job is neither.
+        name = self.wf["jobs"]["watch"]["name"]
+        self.assertIsNone(re.search(r"\b(advisory|informational)\b", name), name)
+
+
+class TestSuiteIsWiredIntoCI(unittest.TestCase):
+    """A test suite nobody runs is not a test suite (the effect-evidence rule)."""
+
+    def test_docs_quality_runs_this_file_and_the_script_self_test(self):
+        text = DOCS_QUALITY_YML.read_text(encoding="utf-8")
+        self.assertIn("scripts/tests/test_merge_group_watchdog.py", text)
+        self.assertIn("scripts/merge-group-watchdog.py --self-test", text)
+
+    def test_the_running_job_is_not_advisory(self):
+        wf = _yaml(DOCS_QUALITY_YML)
+        for job_id, job in wf["jobs"].items():
+            steps = job.get("steps") or []
+            if any(
+                "test_merge_group_watchdog.py" in str(step.get("run", ""))
+                for step in steps
+            ):
+                self.assertIsNone(
+                    re.search(r"\b(advisory|informational)\b", job.get("name", job_id)),
+                    job.get("name", job_id),
+                )
+                return
+        self.fail("no docs-quality job runs the watchdog suite")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -645,6 +645,49 @@ class TestEmission(unittest.TestCase):
             self.assertIn(f"head={HEAD[:8]}", row)
             self.assertIn("pr=#4534", row)
 
+    def test_rows_record_how_many_groups_are_stacked_above(self):
+        # The watchdog's own effectiveness measure. A rebuild discards every group
+        # chained on top of the dead one, so `stacked` IS the cost multiplier — and a
+        # climbing `stacked` over time is the signal that the grace has drifted too
+        # long. Measured 2026-07-28: a 48-minute intervention had stacked=4,
+        # stacked_green=2, and all four were discarded.
+        nodes = [
+            {
+                "id": "MQE_4709", "position": 1, "state": "AWAITING_CHECKS",
+                "enqueuedAt": "2026-07-27T22:58:53Z",
+                "baseCommit": {"oid": BASE}, "headCommit": {"oid": HEAD},
+                "pullRequest": {"number": 4709, "id": "PR_4709"},
+            },
+            {
+                "id": "MQE_4714", "position": 2, "state": "MERGEABLE",
+                "enqueuedAt": "2026-07-27T22:59:00Z",
+                "baseCommit": {"oid": HEAD}, "headCommit": {"oid": "a" * 40},
+                "pullRequest": {"number": 4714, "id": "PR_4714"},
+            },
+            {
+                "id": "MQE_4729", "position": 3, "state": "MERGEABLE",
+                "enqueuedAt": "2026-07-27T22:59:10Z",
+                "baseCommit": {"oid": "a" * 40}, "headCommit": {"oid": "b" * 40},
+                "pullRequest": {"number": 4729, "id": "PR_4729"},
+            },
+            {
+                # No group built yet — nothing to discard, so it must NOT be counted.
+                "id": "MQE_4731", "position": 4, "state": "QUEUED",
+                "enqueuedAt": "2026-07-27T22:59:20Z",
+                "baseCommit": None, "headCommit": None,
+                "pullRequest": {"number": 4731, "id": "PR_4731"},
+            },
+        ]
+        harness = FakeWatchdog.build(suites=0, entries=nodes)
+        harness.run()
+        head_row = next(r for r in harness.rows if "pr=#4709" in r)
+        self.assertIn("stacked=2", head_row)
+        self.assertIn("stacked_green=2", head_row)
+        # The last entry with a group has nothing above it.
+        tail_row = next(r for r in harness.rows if "pr=#4729" in r)
+        self.assertIn("stacked=0", tail_row)
+        self.assertIn("stacked_green=0", tail_row)
+
     def test_holding_states_re_emit_every_tick(self):
         # Three consecutive ticks on an unchanged CAP/NOOP condition must each emit.
         for _ in range(3):


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Refs #4652.

## What this fixes

A merge-group ref for which GitHub Actions dispatched **nothing** holds the head of the queue for the full 60-minute `CI_TIMEOUT`, then takes the whole speculative chain down with it on the rebuild — every group stacked on top of it is discarded. Measured cost on 2026-07-27 (#4534): **73 min 41 s of zero merges**, and the rebuild threw away three groups' worth of already-green CI.

**This has now happened three days running.** All three were reaped by the 60-minute ruleset timeout:

| ref | date | group head | suites | outcome |
|---|---|---|---|---|
| `pr-4331-f6be7767…` | 07-26 | `f44083c7` | **0** | 61m07s, `CI_TIMEOUT` |
| `pr-4534-3cc1bf82…` | 07-27 | `1bfb0174` | **0** | 60m27s, `CI_TIMEOUT` |
| `pr-4709-63dfb7a0…` | 07-28 | `98204656` | **0** | held pos 1 for 48 min, cleared by hand |

#4709 was caught **live** at 05:55Z by running this PR's own script in `--dry-run` against the production queue. Its siblings in the same chain discriminate the signal perfectly — `pr-4714` 8 suites/95 runs, `pr-4724` 8/54, `pr-4729` 8/69, `pr-4731` 8/93, and the dead one **0/0**. Behind it, #4714 and #4729 were both already `MERGEABLE` and could not land, because the queue merges strictly in order and a green *superset* group cannot substitute for the head entry's own required check. sparq merged **one PR in sixty minutes**.

## Measured recurrence: three in ~10 hours, ≈ one per 3.3 h

Not two anecdotes — a standing tax, and the argument for landing this:

| # | PR | group ref | detected | held | outcome |
|---|---|---|---|---|---|
| 1 | #4534 | `pr-4534-3cc1bf82…` | ~00:05Z | **66 min** | hit `CI_TIMEOUT`; chain rebuilt; ~66 min of already-green CI discarded |
| 2 | #4709 | `pr-4709-63dfb7a0…` | 05:15Z | **48 min** | 4 PRs stacked behind it, 2 already `MERGEABLE` |
| 3 | #4773 | `pr-4773-b9d412df…` | 09:58Z | **28 min** | caught early by hand; the rebuilt group came back with 8 suites |

All three: **0 check-suites, 0 check-runs** on the group head while sibling groups in the same chain had 8. Each manual rescue required someone watching the queue at the right moment; missing it costs the full 60-minute timeout **plus** the discarded CI of everything stacked above. The watchdog acts at 2–7 min.

**#4773 also reconfirmed the verdict-stripping half**: the dequeue swapped `review:pass` → `review:changes` and disabled the arm. It was restored only after establishing the head was unmoved (verdict 09:58:35Z, last commit 09:05:11Z, **0 head-moving events since**) — which is exactly the test `verdict_is_still_for_this_tree` applies, and it still strips on a genuine dequeue.

## The signal: zero check-SUITES, and nothing weaker

A `paths`-filtered workflow that matches nothing still creates a check-suite. Zero **suites** therefore means no workflow was ever *considered* — the event never reached the dispatcher. Weakening this to "zero check-runs" would fire on legitimately-pending and legitimately-empty groups, so the predicate is `total_count == 0` on `GET /repos/{repo}/commits/{group_head_sha}/check-suites` and nothing else.

## The grace period, derived rather than guessed

Two candidate anchors are **wrong**, and both were rejected by measurement rather than taste:

* `entry.enqueuedAt` — an entry can sit outside the `max_entries_to_build` window for many minutes before its group is built.
* the group head commit's `committer.date` — GitHub **stamps** the group commit rather than dating it at build time. **The load-bearing evidence is the DISTRIBUTION**, not any single commit: over 40 live group heads, `branch_creation − committer.date` spans 2 s to 3929 s (median 16 s) and only **1 of 40** falls within ±2 s of the true creation time; an independent re-derivation on N=37 found **0/37** within ±2 s. *(An earlier revision of this description argued from a parent-commit contradiction and labelled it "Proof". That argument is **withdrawn** — the parent's own `committer.date` is a stamp too, and the claim could not be independently re-derived. The distribution stands on its own and does not need it.)*

The exact anchor is the repository **activity API** — `activity?activity_type=branch_creation&ref=<full ref>` — whose rows carry a real `timestamp` plus `after` = the created head SHA. It is also the only enumeration that can see a dead ref at all: it has no workflow runs, so the runs API cannot find it.

**Measured create→first-suite latency, N=209 refs, 2026-07-25 → 07-28:**

```
min 1 s | p50 2 s | p90 3 s | p99 4 s | MAX 4 s     (whole-second quantisation)
```

There is **no tail between 4 s and 3600 s**. The failure is categorical, not slow: a group gets its suites within 1–4 s or never. **Grace = 120 s — 30× the measured maximum, 60× the median**, and strictly below the 300 s cron interval so it never costs an extra tick. Detection is tick-quantised, so effective recovery is **2–7 min against the 60-minute timeout**.

### Why the grace must be tight — the cost is what stacks on top, not the dead ref

Early dequeue does **not** rescue the CI stacked behind a dead ref. Measured on 2026-07-28: dequeuing #4709 at 06:07 rebuilt the chain onto fresh refs and #4714 and #4729 — both `MERGEABLE`, i.e. already green — had their group CI **discarded and restarted**. That CI was doomed either way, since the 60-minute `CI_TIMEOUT` rebuilds the same chain. The direct saving from acting at 48 min rather than 60 was ~8 minutes plus a preserved verdict.

The real cost is **how much work gets built on top of the dead ref before anyone notices**, because every later speculative group is chained onto it and a rebuild discards all of it:

```
cost ≈ (groups stacked above the dead ref at detection) × (their accumulated CI)
```

At 48 minutes that term was **4**, two of them fully green. Inside a 120 s grace it is **0** — nothing has stacked yet. So a tight grace is not merely faster; it is the difference between discarding four groups' CI and discarding none. That is the whole argument for the grace period, and it is why the census row now records `stacked=` and `stacked_green=` on **every** row: those numbers are the watchdog's own effectiveness measure, and if `stacked` starts climbing, the grace has drifted too long and the rows say so without anyone having to notice an outage by hand.

## Fix 1 — the watchdog (`scripts/merge-group-watchdog.py` + `merge-group-watchdog.yml`)

Schedule-only, every 5 min (the scheduler minimum). Never runs on a PR head, so it can never gate.

| verdict | when |
|---|---|
| `SKIP` | entry state is not `AWAITING_CHECKS`, or no speculative group is built yet |
| `HOLD` | ≥1 check-suite present — dispatch happened; **the control** |
| `WAIT` | zero suites, still inside the grace |
| `REFUSE` | suite count or creation time **could not be positively established** |
| `NOOP` | recovery already attempted for this exact group head |
| `CAP` | per-PR or per-run budget exhausted |
| `RECOVER` | zero suites, past grace, positively established, within budget |

**Fail safe.** Only `RECOVER` mutates. An unreadable suite count, a garbled response, a missing `branch_creation` row, an unreadable marker history, or a future-dated ref are each a refusal — never a recovery. If the reconstructed ref name were wrong, no activity row would match the head SHA and the result is `REFUSE`, so a bad reconstruction can only cause a missed detection, never a false one.

**Cap: 1 per distinct group head SHA (idempotence) + 2 per PR per rolling 6 h + 2 per run** (blast radius).

**Exhaustion behaviour, corrected.** An earlier revision of this PR claimed in four places — here, the constant's comment, the operator-facing `CAP` census row, and AGENTS.md — that exhaustion preserves the verdict. **That was wrong in all four.** Recovery is *marker → dequeue → enqueue*, so the marker is always ~30 s **older** than the `added_to_merge_queue` it produces; on the next attempt the newest trusted marker predates that attempt, the queue-attempt binding refuses it, and the platform `CI_TIMEOUT` **demotes to `review:changes`** like any other.

That is the *correct* outcome, not merely a tolerated one: by exhaustion the PR has burned three consecutive zero-dispatch groups, the only trusted observation names a **superseded** group head, and preserving a verdict on the strength of a stale head's suite count would be unsound. What exhaustion does **not** do is stall — no `needs:user`, no permanent hold, and a `CAP` row every tick it holds. All four sites now say this, and a test pins the behaviour so the claim cannot drift away from the code again.

This is the same false-reason class I caught in round 6 (*"it would tell an operator a commit landed when none did"*) — fixed in one place, recurred in four others.

**The budget is spent in queue order** — only the head-of-line entry actually blocks merges, so recovering positions 3 and 2 while position 1 stays broken would burn the budget and leave the outage in place. Pinned by a test.

**Remediation call**, with the three traps that each cost real time:

* `gh pr merge <N> --disable-auto` does **not** dequeue an already-queued PR — it answers "is already queued to merge".
* `DequeuePullRequestInput` names its field `id`, not `pullRequestId`, and it wants the **pull request** node id (`PR_…`), not the merge-queue **entry** id (`MQE_…`) — the natural wrong answer given the field name. A test asserts both mutations carry `PR_…`.
* `MergeQueueEntry` has no `headOid`; the group head is `headCommit{oid}`.

## Fix 2 — the `CI_TIMEOUT` routing split (`merge-queue-feedback.yml`)

`CI_TIMEOUT` currently routes to `review:changes` by design, so #4534 lost `review:pass` and needed a full re-review **because of a platform event drop** — a machine-manufactured re-review of code nobody found fault with.

The two causes are now split **by the suite count, never by the reason alone**. `classify-dequeue` re-derives the **live** count for the recorded group head and prints `route=preserve|demote`:

* `CI_TIMEOUT` + 0 suites → preserve `review:pass`, re-arm, comment.
* `CI_TIMEOUT` + suites present → today's demote. A timeout that followed checks that genuinely ran is a legitimate signal.

The marker is a **pointer, not a cached verdict**: the group head SHA is unrecoverable once the ref is deleted (that is exactly the population with no runs to read it off), so the watchdog records the SHA in a marker comment before acting — and the routing decision re-queries the live count for it. The commit stays readable after the branch is deleted; verified on `1bfb0174`, still `total_count: 0`.

The classifier also recognises the watchdog's **own** dequeue — recovery is dequeue+enqueue, which itself fires `pull_request.dequeued`, and without that arm the watchdog would demote every PR it rescued.

**Fail-safe in every direction:** a missing marker, a stale observation, one predating the current queue attempt, an unreadable count, a non-zero count, or a crashed classifier all yield `demote`. The step guard is written `route != 'preserve'`, so an empty or missing output demotes too.

## Fix 3 — an infrastructure dequeue must not strip the review verdict

Found by measurement after the first two fixes were written, and it is what stops this PR being a net regression.

```
05:14:56  labeled   review:pass       by sparq-orchestrator[bot]
06:06:38  removed_from_merge_queue    (reason MANUAL)
06:06:55  labeled   review:changes    by github-actions[bot]
06:06:55  unlabeled review:pass       by github-actions[bot]
```

**Seventeen seconds.** Because the watchdog's remediation *is* a dequeue, without this fix every rescue would strip `review:pass`, apply `review:changes`, disable the arm and admit the PR to the **fix** pipeline — manufacturing a `review:changes` backlog out of a platform event that never fired.

The existing routing is correct for its original purpose: a reviewer withdrawing a PR *should* pull the verdict. The defect is that **`MANUAL` conflates "a reviewer withdrew this" with "infrastructure moved it"**. Same shape as the `CI_TIMEOUT` half, same remedy — **discriminate on evidence, never on the event name**: a fresh watchdog marker naming that exact group head is what makes a dequeue ours.

Chosen route: **the discriminated marker**, not restore-after-re-enqueue. The marker is written *before* the dequeue and the handler skips both the label swap and the arm-disable. Restore-after-the-fact is strictly weaker — a repair rather than a prevention, with a window in which the PR is visibly mislabelled and can be picked up by the fix pipeline.

**Non-negotiable precondition on every preserve route.** A verdict attests to a specific **tree**, so `review:pass` survives only if the head has not moved since it was granted — a commit, a force-push, or a revoked label after the grant all forfeit it. Two details that only a surviving mutant exposed:

* the **latest** move must be compared against the **latest** grant. Earliest-move lets a stale verdict survive a push; earliest-grant wrongly forfeits a verdict legitimately **re-granted** after one (the normal push → re-review → re-approve sequence).
* a `committed` timeline event has **no `created_at`** — its time is the commit's own `committer.date`, so reading only `created_at` makes commits invisible as head moves.

**The control:** a genuine human dequeue still strips the verdict, because it carries no fresh marker. Without that arm this would be a general-purpose way for any dequeue to keep its approval — far worse than the bug.

## Fix 4 — the marker is evidence, so its author is part of the predicate

**This was a real vulnerability in the first revision of this PR, and the control I named in this very description was the forgeable artifact.**

`pr_markers` accepted a marker from **any** comment author, and sparq is a **public** repo. Executed through the real entry point with the comment authored by an arbitrary account:

* `MANUAL` + a forged marker → `route=preserve`, so `review:pass` survives and the arm-disable is skipped — and `auto-arm.py` / `rearm-sweeper.py` then re-arm on `review:pass` + CLEAN within ~10 minutes.
* `CI_TIMEOUT` + a forged marker naming **any** commit that reads zero check-suites → `preserve` + `reenqueue=true`, which reaches **`gh pr merge --auto`**. Such a sha is trivially obtainable.

Worse, arm (a) **never compared the marker head to anything**, so "names that exact group head" was not what the code implemented.

Two fixes, both at the read so nothing downstream can forget them:

1. **`TRUSTED_MARKER_AUTHORS`** — markers are honoured only from `github-actions[bot]` and `sparq-orchestrator[bot]` (both, because the sweep runs under the App token when configured and the workflow token otherwise; trusting only one silently breaks the caps the moment that flips). A well-formed marker from anyone else is **dropped and logged**, so a forgery attempt is visible rather than silently ignored.
2. **Arm (a) now re-derives the suite count for the head the marker names**, and requires `action=re-enqueue`. A head that does not exist reads `None`; one that really was dispatched reads non-zero. Neither can carry a verdict through a dequeue.

**Paired control, as required:** an App-authored marker still works — both trusted identities are asserted to preserve, alongside the forged-marker cases that must demote. Also pinned: a forged marker cannot *suppress* a real recovery either (the idempotence key is read from the same channel), and untrusted markers do not consume the cap.

This is the **third occurrence in this estate of the same root cause** — after #681 (review evidence read from `pull["body"]`) and #937 (declarations derived from body/title). In all three the forgeable channel was the PR's *named* control, and in all three the mutation battery was scoped to the object and never to the **evidence channel**. Round 7 of this sweep is that battery: 24 mutants aimed squarely at the marker's provenance.

### CORRECTION — the 567 markers on #4534 were MY OWN test residue, not an attack

An earlier revision of this description reported the 567 marker comments on PR #4534 as *"the payload is already in the wild"*. **That was wrong, and it inverts.** Every one was authored by this agent's own account inside a 31-minute window (`07:56:04Z → 08:27:24Z`) that is exactly my mutation-sweep window. There is **no evidence of any attack**, and the claim is retracted.

The root cause is a defect in **my test suite**, and it is worth stating precisely because it is a general Python trap:

```python
def __init__(self, ..., gh: Callable = run_gh):   # BOUND AT DEFINITION TIME
```

A default argument captures the function object when `def` executes, so a test patching `merge_group_watchdog.run_gh` **cannot** reach it. `main()` passed `gh_read=` explicitly (late-bound, so the patch worked) but let `gh` fall through to that stale default — **the real runner**. Every simulated sweep in the suite therefore issued a genuine `gh pr comment`, ×175 mutants. The reads were faked; the writes were real.

Fixed three ways: the runner defaults are now **late-bound** (`None` → resolve at call time); the suite **poisons both module-level runners at import**, so any path that forgets to inject a fake raises instead of reaching the network; and four tests guard that guard. Fixing it also exposed a `finally` that restored only one of the two runners, leaking a stale fake into every later test.

**Residue removed: 572 comments, 0 failures.** #4534 is back to its 3 pre-existing comments; issue #1 is back to 0. Verified by re-querying every PR/issue my fixtures can name.

The tail of that cleanup is worth stating, because it is the same defect class one level up: my deletion filter keyed on the **marker**, and the `P37` mutant exists precisely to *remove* the marker — so the one comment my filter missed was the one produced by mutating away the thing the filter matched on. **A cleanup filter inherits the blind spot of whatever it is cleaning up.** Re-swept on the prose signature instead, which found and removed it.

**The blast radius was not only #4534.** I enumerated every PR number my fixtures can name and checked each via the list API rather than the (lagging) search index: `4535`, `4536`, `4709`, `4714`, `4729`, `4731`, `4743` were all clean — but **issue #1 had 4 marker comments**, because the `A06` mutant hard-codes `["pr", "comment", "1", ...]` and that literal reached the real runner. Deleted; #1 is back to 0. The mutant now names a non-numeric sentinel so it cannot address a real issue even if the poison were bypassed. *Checking the obvious target was not enough — I had to enumerate what the code could name.*

**The lesson, stated so it is checkable: when a probe reports hostile input, verify the AUTHOR before reporting an exploit.** I found the outcome I was looking for and read it as confirmation; the convenient result deserved the most scrutiny and got the least. A false attack report is costly in both directions — it triggers unwarranted alarm, and it discounts the real thing if it ever arrives. And: **never exercise a write path against a live production PR.** Use a scratch PR or a fixture; if a test needs a real zero-suite head, *read* it.

### The genuine insight that came out of it: a defensive control must not amplify what it rejects

The first cut emitted **one annotation per rejected marker** — against 567 markers that is ~110 KB of log and 567 annotations, past GitHub's annotation cap, burying every other signal in the run.

> **A filter that emits per-item output hands the attacker a log-flood denial of service against its own operator.** The cheaper the input is to produce, the louder the defence gets. State the count and the distinct authors; never iterate the payload into the log.

Now one summary annotation per PR: **110 KB → 368 bytes** on the same input, 7 s runtime against a 5-minute job timeout.

## Fix 5 — an anonymous DoS on merge-queue routing, and a fail-safe that wasn't

Four blocking defects from independent review, all reachable on a **public** repo by a workflow that runs on **every dequeue**.

**(a) Quadratic parse with the trust check in the wrong position.** `[^>]*?` backtracks: one 65,536-char comment of repeated marker openers measured **12,406 ms** here (the reviewer measured 21.4 s on their box), and the author filter ran *after* the parse, so every anonymous comment was parsed before being discarded. Anyone could have pushed the classify step past its 5-minute timeout, suppressing merge-queue routing.

Both halves fixed, both measured:

| | before | after |
|---|---|---|
| `parse_marker` on a 64 KB adversarial body | 12,406 ms | **137 ms** (90×) |
| `pr_markers`, 20 anonymous 64 KB comments, end to end | — | **32.6 ms** (9,207× headroom vs the 300 s timeout) |

The bound (`[^>]{0,400}?`) makes the parse linear — a real marker's key/value run is 262 chars. But **the ordering is the actual lesson**: I *had* a trust check and it was in the wrong position. *A filter placed after the expensive work does not protect the expensive work.* Untrusted bodies are now never parsed at all, which is why the end-to-end number is what it is.

**(b) The fail-safe `if:` was false in one of its two named cases.** A step `if:` with **no status function defaults to `success()`**, so a *failed or timed-out* classify step **skipped** the demote step — `review:pass` kept, arm not disabled. The empty-output case was handled; the failed-step case was not, and a string-matching test could not see the difference. Now `!cancelled() && …`, with the preserve step deliberately left on the implicit `success()` (it may only act on a verdict that was actually produced) and a test pinning both directions. Composed with (a), this was anonymous suppression of merge-queue routing.

**(c) Three holes in the trust model.** A marker merely **quoted** by a trusted bot was honoured — and a real trusted-echo channel exists. Fenced, indented, blockquoted and inline contexts are now stripped before matching, and nesting **depth** (not a substring test) rejects `<!-- quoted: <!-- … -->`; inspecting the match itself tells you nothing, because it lands on the *inner* opener. A marker naming a **foreign head** or a **different PR** was honoured — markers now bind to this PR through both `pr=` and the `ref=` segment, which must agree. And arm (b) ignored `action`, which arm (a) already checked.

**(d) `{"total_count": false}` read as a positively-observed zero**, because `isinstance(False, int)` is True in Python — driving a recovery, a marker write and a `preserve` off a malformed response. Bools are now rejected explicitly.

## Emission

Every entry emits one row every tick, naming the ref, head, suite count and decision; `CAP`/`REFUSE`/`NOOP` additionally emit `::warning`, a failed recovery emits `::error` and reds the run, and an empty queue emits an explicit row. Rows also go to the job summary. Live sample against production at 05:55Z:

```
pos=1 pr=#4709 … head=98204656 suites=0       stacked=2 stacked_green=1 decision=RECOVER — zero check-suites 2398s after the ref was built (grace 120s)
pos=2 pr=#4714 … head=9f915630 suites=unknown stacked=1 stacked_green=0 decision=SKIP    — entry state MERGEABLE is not AWAITING_CHECKS
pos=3 pr=#4729 … head=464e418b suites=8       stacked=0 stacked_green=0 decision=HOLD    — 8 check-suite(s) present
sweep complete: entries=3 HOLD=1 RECOVER=1 SKIP=1 errors=0
```

That single run is both red tests and the control, live: the dead ref detected, a healthy 8-suite sibling held, a non-actionable entry skipped.

## Tests — 174, three layers

1. **Policy** — the decision tables, every arm.
2. **Behaviour** — the real `sweep()` against a scripted, **SHA-keyed** `gh`, asserting on the **mutations issued**, not the log text.
3. **Wiring** — cross-file inspection of every `if:`, step, and call site in both workflows plus the docs-quality call site.

Headline pairs, each with its control:

* zero suites past grace ⇒ `RECOVER` — paired with **suites present but runs still pending ⇒ never touched**, asserted across suite counts 1/8/40 and ages 0 → 100× the grace. Without that control the detector could pass by firing on everything.
* `CI_TIMEOUT` + 0 suites ⇒ `preserve` — paired with **`CI_TIMEOUT` + suites present ⇒ still demotes**. Same reason, opposite outcome, purely because the count differs.
* second detection on the same ref ⇒ no-op, zero mutations issued.

## Mutation sweep — 181 mutants, earned over ten rounds

Kills extracted from unittest's `FAIL:`/`ERROR:` blocks and the **traceback frames** inside them — never by grepping for a substring like `AssertionError`, which matches inside a passing test's *name*.

| round | mutants | survivors | what they exposed |
|---|---|---|---|
| 1 — delete each guard | 68 | 4 | 3 real gaps (`main()`'s fail-safe, `write_outputs`, the activity-type filter) + 1 equivalent |
| 2 — adversarial | +18 | 9 | wrong-id dequeue, marker-read failure assumed empty, failed recovery counted as success, four unpinned preserve-step behaviours |
| 3 — subtle | +12 | 4 | **a fake that answered every `/check-suites` URL identically** could not tell the group head from its base — two wrong-SHA mutants survived until the fake became SHA-keyed |
| 4 — conditionally inert | +30 | 2 | `if: … route != 'preserve' && false` passed a **substring** assertion while making the fix lane dead |
| 5 — verdict survival | +18 | 4 | earliest-vs-latest on both the head move and the grant, and a test **passing for the wrong reason** (see below) |
| 6 — revocation reporting | +8 | 3 | policy tests build `VerdictState` by hand and so **bypass the timeline parser** — a mutant that reported a revocation as a phantom push kept the right route with a false reason |
| 7 — the **evidence channel** | +25 | 5 | the marker's provenance, the exit contract, and the telemetry plumbing — the three areas the coverage census flagged |
| 8 — the readback guard | +3 | 1 | the readback matched *any* marker, not one for **this** head |
| 9 — the hermetic-suite guard | +3 | 0 | reintroducing the exact 567-comment defect is now caught |

**Total: 181 mutants, 181 killed, 0 survived, 0 skipped** — preflight clean (181 unique ids, every anchor present **and unique**), 94 distinct killing tests.

Round 7 exists because rounds 1–6 mutated the *object* and never the *evidence channel* — the same blind spot as #681 and #937. Round 9 exists because the fix for my own network-write defect deserved the same treatment: `N01` reverts the runner default to the definition-time binding that caused it, and `test_an_uninjected_watchdog_cannot_reach_the_network` kills it.

**Per-mutant kill causes were read, not assumed.** 171 died on a test-file assertion; **7 died with a frame inside the script** — P01/P04/I01/I03/I17/V05/P23, all guards whose removal makes the code *raise* rather than return a wrong value. Each is killed by the test that specifically targets it (`test_missing_branch_creation_anchor_refuses` for P04, `test_missing_enqueue_event_demotes` for P23, the human-dequeue control for I17), so they are load-bearing guards — but they are crash-kills, not assertion-kills, and are reported as such.

### The `gh` PATH shim, and why the in-process guard cannot be the only one

Every mutant now runs behind a `gh` shim on `PATH` that records and blocks any real invocation; the sweep asserts the escape log is **empty**, and the shim was validated against a known positive (`gh api user` → blocked + recorded) *before* being trusted.

It is not redundant with the in-process poison. **Reproducing `N01` necessarily reverts the hermeticity fix — the guard and the mutant are the same switch** — so during that one mutant the in-process protection is off *by design*. The shim sits outside that switch. Escapes are attributed **per mutant**, because a flat "must be 0" is the wrong claim: `N01` exists precisely to revert hermeticity, so *its* escape is the reproduction working. Final run: **exactly one mutant attempted a real `gh` call — `N01`, 2 calls, expected, naming reserved ids only.** Every other mutant was silent. The fixture rename therefore held independently of the shim, and the shim covered the one case the in-process guard structurally cannot.

One correction to my own tripwire: it logged `$*` verbatim, so a multi-line comment body wrapped across many lines and reported **21** where the truth was **2**. *A tripwire whose own output overstates the breach is a bad tripwire* — one line per invocation now.

### Three survivors from the shimmed sweep, all real, all from ONE cause

The marker **hex-head** and **non-zero-suites** guards survived because every malformed fixture *also* lacked a valid `ref=`, so the newly-added pr/ref self-consistency check rejected it **first** and the guard under test was never reached. **A new guard can silently mask an older one's tests** — each now has a fixture valid in every other respect. The third: the preserve step's open-state check was pinned by *substring presence*, so a mutant that left the strings in place while changing the behaviour survived; now pinned by shape (the non-open branch must `exit 0`, before any mutating command).

### The measurement instrument itself failed toward "nothing to report"

Mid-sweep a greedy regex edit to the mutant list **silently deleted 15 entries (P11–P25)**, and the harness happily reported a clean `154/154`. **A dropped mutant is indistinguishable from a killed one in the headline** — this is the failure mode that would make a mutation table *itself* a fabrication, since the number looks better the more coverage goes missing.

The fix, which other agents should copy: the harness now runs a **preflight** that fails the whole sweep outright if any mutant has a duplicate id or an anchor that no longer exists in the tree. It has already earned its keep twice, catching `X04` after I rewrote the block it anchored on.

Two related disciplines, both from actually reading what killed each mutant rather than trusting the total:

* **Two "kills" were `SyntaxError` / `IndentationError`** — broken mutants, not detections. Repaired.
* **Report a test-file frame in preference to a crash frame.** The *first* failure is arbitrary, and a crash inside the script was masking an assertion that had also fired — which made 9 kills look suspect when most were fine.

Round 4 is the one worth reading. A guard that is still present but can never fire is invisible to a deletion-only sweep *and* to review. Both YAML guards are now pinned by **exact match**, plus a test that rejects any constant `true`/`false` operand in any step condition (stripping legitimate `!= true` comparisons first).

Round 4 and round 5 each produced one finding worth naming beyond the fix:

* **a conditionally inert guard.** A guard still present but unable to fire is invisible to a deletion-only sweep *and* to review. Both YAML guards are now pinned by **exact match**, plus a test rejecting any constant `true`/`false` operand in any step condition (stripping legitimate `!= true` comparisons first).
* **a test passing for the wrong reason.** The unreadable-timeline case set *both* `readable=False` and `review_pass_at=None`, so it was really exercising the "no verdict" guard and would have stayed green with the readable check deleted. Now isolated, and the two cases must report distinguishable reasons — an operator has to be able to tell an API failure from a PR that was never approved.

Round 6 is worth one more note, because it is a structural blind spot rather than a missed case: the policy tests construct `VerdictState` by hand, so **they never execute the timeline parser**. Three mutants lived entirely in that gap — a revocation folded into head-moves (right route, false reason), earliest-vs-latest revocation, and treating *any* `unlabeled` event as a verdict revocation, which would have made the preserve route unreachable in practice, silently and greenly, because PRs shed `area:*`/`status:*`/`needs:*` labels constantly. Every one is now covered end-to-end through the parser.

One mutant was excused rather than fixed, explicitly: `I18` was mis-constructed (`not (dry_run and True)` ≡ `not dry_run`, a no-op), so I rewrote it to `not False` and it died. Everything else was a real gap and was closed. The closing total was earned by eight successive adversarial expansions, not asserted on the first list — every round after the first found real gaps.

## Coverage census — run FIRST, and corrected

**One instrument throughout: statement coverage.** An earlier revision mixed a branch instrument with a statement one, listed `main` among the zero-coverage functions (it was not), and used the wrong denominator.

| | statements | functions with statements | at 0% |
|---|---|---|---|
| module `--self-test` only | 53.7% | 31 | **16** |
| full suite | 86.9% | 31 | 5 |
| **union of what CI runs** | **98.1%** | 31 | **1** |

The 16 are `Watchdog.__init__`, `_graphql`, `check_suite_count`, `classify_dequeue`, `emit`, `group_created_at`, `post_marker_comment`, `pr_markers`, `queue_entries`, `recover`, `sweep`, `verdict_state`, `_ndjson`, `run_gh`, `run_gh_read`, `write_outputs` — **`main` is not among them.**

The one function still at 0% in the union is **`run_gh`**, the real `subprocess` wrapper. That is correct by construction and will stay: the suite now *poisons* it precisely so it can never execute, so a hermetic suite cannot cover it. Reporting it as 0 rather than rounding it away.

Every blocking survivor lived in a function the module self-test never executed — `main`'s sweep branch held the exit-zero mutant. Closed from that census: the **exit-zero** mutant, `stacked_green = list(stacked)` (value-identical against the old all-`MERGEABLE` fixture — now mixed), `QUEUE_ENTRY_PAGE`, the dropped `RECOVER_FAILED` key, the dead `marker suites` field, and **both `log=print` defaults**, which survived and would have let a silent watchdog stay green.


## Validated against live production data, not only fixtures

The hermetic suite proves the policy; these two reads prove the parser against the real API:

```
PR #4709  grant=06:36:41  revoked=06:06:55  head_moved=04:56:39  -> verdict SURVIVES
PR #4534  grant=22:58:41  revoked=00:05:20  head_moved=12:50:12  -> verdict FORFEIT (revoked)
```

`head_moved=04:56:39` for #4709 independently reproduces the timestamp used in the manual verification before that PR's verdict was restored by hand, and `revoked=00:05:20` for #4534 matches the "#4534 lost `review:pass` at 00:05:20" already recorded on #4652. Both routes are correct and both reasons name the real cause.

The detector was also run live twice against the production queue, 40 minutes apart, with opposite outcomes — one dead ref found among healthy siblings at 05:55Z, and an all-clear at 06:34Z once the queue recovered. That is the red case and the control, on production, not in a fixture.

## Recorded, not fixed here: the same defect class, and a repo mix-up worth flagging

**In this repo**, `scripts/gh_retry.py:251` — a module the watchdog imports — is:

```python
    run: Callable[..., subprocess.CompletedProcess] = subprocess.run,
```

the same **definition-time default-argument binding** that made this suite write to production. Verified on `origin/main`, not just this worktree. It is *materially safer* than my defect was: it is a deliberate injection seam and callers pass `run=` explicitly, so it is not a live escape route. The latent trap is that monkeypatching `subprocess.run` at module level would be **silently ineffective**, which is exactly how my version hid.

**A correction on the correction.** A suite-wide escape audit reported that this claim "does not reproduce — line 251 is a list comprehension, no `Callable` in the file". That is accurate — **for a different file**. There are two `gh_retry.py` files on this box:

| repo | line 251 | `Callable` count |
|---|---|---|
| **sparq** (imported by this watchdog) | `run: Callable[...] = subprocess.run` | 4 |
| **`jeswr/agent-account-registry`** | `if not _TRACE_LINE_RE.match(line)` | 0 |

The audit measured the registry's copy. Its finding there is real and correctly located — `pat-validity.py:227`, `def _secret_write(token, repo, run=subprocess.run)`, a `gh secret set` **write** — and it belongs to that repo's tracking (#989/#992), not to this PR.

Neither is mine to fix; both are recorded so the next person is sent to the right module. **The methodological note is the transferable part, and it is what found the registry instance:** an AST sweep for this class must handle **`ast.Attribute`** defaults, not only `ast.Name`, or it misses `subprocess.run` entirely.


## Not done, deliberately

`max_entries_to_build`, `max_entries_to_merge` and `check_response_timeout_minutes` are **maintainer-set** and untouched. #4652 records the ceiling as `D/T = 3 / 22.7 min ≈ 7.9 PR/hr` against 2.30 measured — batching is working at 29% of ceiling — so raising it is a maintainer decision, not mine. No attempt is made to explain *why* Actions dropped the event; that is not determinable from outside. This recovers from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
