### PR TITLE
feat(ci): CI execution-latency alarm — cron firing deficit + execution overrun; queue wait documented as NOT DETECTED (sq-1lc4i)

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -8,6 +8,13 @@
    "promotion_criteria": "NEVER promotable — promoting it would INVERT its purpose. This is a DETECTOR: it REDs when it finds PRs that no review producer can reach, and it REDs fail-loud when the detector itself breaks. Neither condition is a property of the commit being gated, so gating on it would block every merge on an unrelated repo-wide backlog — the exact pressure that gets an alarm muted, which is the one outcome that destroys the signal. Registered because the lane was SILENTLY GATING: its header claimed it 'can never enter the ci-summary / gate poll set' on the premise that it creates no check-run on a PR head or merge-group ref, but ci-summary.yml ALSO runs on push to main (timeout-minutes: 80) and this workflow's scheduled run puts its check-run on exactly that head SHA. MEASURED 2026-07-27: ci_summary_gate.py render_verdict() over the real 477-check-run set for main head cb0c6739c listed `review-lane blind-spot alarm: failure` as a GATING failure. Delete this entry only if the workflow is removed.",
    "registered": "2026-07-27"
   },
+  "CI execution-latency alarm": {
+   "workflow": "ci-latency-alarm.yml",
+   "job_id": "alarm",
+   "owner_bead": "sq-1lc4i",
+   "promotion_criteria": "NEVER promotable, same reason as `review-lane blind-spot alarm` — this is a DETECTOR of repo-wide CI EXECUTION LATENCY (cron firing deficit, queue wait, execution overrun). Every condition it REDs on is a property of the runner fleet and the scheduler, never of the commit under test, so gating on it would block every merge whenever CI is merely slow — which is exactly the pressure that gets an alarm muted, the one outcome that destroys the signal. It also REDs fail-loud (exit 2) when the detector itself breaks or its scan set is empty. Declared for the same silent-gating reason as its sibling lanes (sq-huwr8): it is scheduled on main, so its check-run lands on the same head SHA the push-triggered ci-summary gate polls. Delete this entry only if the workflow is removed.",
+   "registered": "2026-07-28"
+  },
   "formal-lane no-verdict alarm": {
    "workflow": "formal-alarm.yml",
    "job_id": "alarm",

--- a/.github/workflows/ci-latency-alarm.yml
+++ b/.github/workflows/ci-latency-alarm.yml
@@ -1,0 +1,94 @@
+# ci-latency-alarm — the CI EXECUTION-LATENCY alarm ([OPUS-5] bead sq-1lc4i).
+# 🤖 SPARQ agent.
+#
+# WHAT: maintainer-requested 2026-07-28 — "alerting for when runners are not picked up for
+# crons or delayed for other dispatches on both repos. This is an indicator that you are
+# choking on runner availability." scripts/ci_execution_latency_alarm.py runs hourly and
+# checks three DISTINCT choke modes, because they have different signatures and only one of
+# them is runner availability proper:
+#
+#   M1 a scheduled lane firing far below what its own `cron:` expects. This mode produces
+#      NO ARTIFACT — a cron that never fires leaves no run, no conclusion, no check-run —
+#      so it is invisible to anything that inspects runs, and can only be caught by
+#      computing the expectation and comparing.
+#   M2 a run sitting in `queued` past a measured threshold. Runner availability proper.
+#      MEASURED known-positive: jeswr/agent-account-registry queued 7 `pr-gate` runs for
+#      12.8-99.5 minutes inside a single 00:58-02:24Z window on 2026-07-28.
+#   M3 a run `in_progress` far past its own lane's measured duration. It consumes capacity
+#      while looking perfectly healthy — no red, no alert, no artifact. MEASURED
+#      known-positive: nightly ci.yml ran 17.33h on 2026-07-27 against an 8.35h p90.
+#
+# WHY THIS IS NOT sparq-org/sparq#4368. That PR's `cron_lane_liveness.py` watches CRON-ONLY
+# lanes (every `on:` key in {schedule, workflow_dispatch}) and asks "is this lane DEAD?"
+# from run CONCLUSIONS. M1 here is the EXACT SET COMPLEMENT, computed with the same
+# predicate rather than listed, so the two partition the scheduled workflows and can never
+# both raise on one lane. The complement is where the throughput-critical lanes live:
+# ci.yml, auto-arm.yml, batch-merge.yml, verdict-bridge.yml and 9 more all carry a
+# `schedule:` PLUS other triggers, so #4368 structurally cannot see any of them. M2/M3 key
+# on live run STATE, which #4368 does not read in any scope.
+#
+# NOT A GATE (same posture as review-alarm.yml / formal-alarm.yml): scheduled on main,
+# files issues, blocks NO merge. That holds because this job is DECLARED in
+# `.github/advisory-registry.json` — since #3773 the ONLY thing that can make a check-run
+# non-gating. It is NOT true because of where the check-run lands: ci-summary.yml also runs
+# on `push: branches: [main]`, so a scheduled run on main puts its check-run on the very
+# head SHA the gate polls. The registry entry, not the trigger type, is what makes this
+# lane safe to RED. Pinned by scripts/tests/test_alarm_lanes_non_gating.py.
+#
+# NO ARMING AUTHORITY, STRUCTURALLY: this job holds `issues: write`, `actions: read` and
+# `contents: read` and nothing else — no `pull-requests: write` (it cannot label, promote
+# or un-draft), no `contents: write` (it cannot push). It is a detector.
+#
+# FAIL-LOUD: a detector-infrastructure error (gh failure, unparseable workflow YAML, an
+# EMPTY scan set) exits 2 so THIS run goes red and a human notices the detector itself is
+# broken. Reporting health over an empty population is the one thing it must never do.
+#
+# All actions are SHA-pinned. The script self-tests hermetically as the FIRST step of every
+# run (a detector is never trusted to watch anything before it has proved itself on this
+# tick's code), and its suite also gates every PR via docs-quality.yml.
+name: ci-latency-alarm
+
+on:
+  # Hourly at :26 — explicit (no */N) so it is auditable, and offset off every existing
+  # sub-hourly lane: auto-arm (4,14,…), verdict-bridge (1,11,…), rearm-sweeper (8,18,…),
+  # batch-merge (7,22,37,52), merge-group-watchdog (2,7,12,…). Hourly is well inside the
+  # 24h M1 window, and M2/M3 read live state, so a missed tick cannot hide a choke.
+  schedule:
+    - cron: "26 * * * *"
+  # Manual run for validation / triage.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-latency-alarm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  alarm:
+    name: CI execution-latency alarm
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: read # list workflow runs + live run state
+      issues: write # file the alarm issue (idempotent, labelled)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          # M1 derives each lane's expectation from the workflow files themselves, so the
+          # workflows directory is an INPUT, not incidental. Omitting it would make every
+          # lane read as `not-scheduled` — a silent total blind spot rather than an error.
+          sparse-checkout: |
+            scripts/ci_execution_latency_alarm.py
+            .github/workflows
+          sparse-checkout-cone-mode: false
+      - name: Self-test the CI execution-latency alarm (hermetic fixtures)
+        run: python3 scripts/ci_execution_latency_alarm.py --self-test
+      - name: Check cron delivery, queue wait, and execution overrun
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/ci_execution_latency_alarm.py

--- a/.github/workflows/ci-latency-alarm.yml
+++ b/.github/workflows/ci-latency-alarm.yml
@@ -4,14 +4,15 @@
 # WHAT: maintainer-requested 2026-07-28 — "alerting for when runners are not picked up for
 # crons or delayed for other dispatches on both repos. This is an indicator that you are
 # choking on runner availability." scripts/ci_execution_latency_alarm.py runs hourly and
-# checks three DISTINCT choke modes, because they have different signatures and only one of
+# checks two DISTINCT choke modes, because they have different signatures and only one of
 # them is runner availability proper:
 #
 #   M1 a scheduled lane firing far below what its own `cron:` expects. This mode produces
 #      NO ARTIFACT — a cron that never fires leaves no run, no conclusion, no check-run —
 #      so it is invisible to anything that inspects runs, and can only be caught by
 #      computing the expectation and comparing.
-#   M2 a run sitting in `queued` past a measured threshold. Runner availability proper.
+#   -- queue wait is NOT detected: a deliberate, documented gap (see the script's
+#      QUEUE WAIT note). The variable never moved across 44,190 completed runs.
 #      MEASURED known-positive: jeswr/agent-account-registry queued 7 `pr-gate` runs for
 #      12.8-99.5 minutes inside a single 00:58-02:24Z window on 2026-07-28.
 #   M3 a run `in_progress` far past its own lane's measured duration. It consumes capacity
@@ -24,7 +25,7 @@
 # predicate rather than listed, so the two partition the scheduled workflows and can never
 # both raise on one lane. The complement is where the throughput-critical lanes live:
 # ci.yml, auto-arm.yml, batch-merge.yml, verdict-bridge.yml and 9 more all carry a
-# `schedule:` PLUS other triggers, so #4368 structurally cannot see any of them. M2/M3 key
+# `schedule:` PLUS other triggers, so #4368 structurally cannot see any of them. M3 keys
 # on live run STATE, which #4368 does not read in any scope.
 #
 # NOT A GATE (same posture as review-alarm.yml / formal-alarm.yml): scheduled on main,
@@ -52,7 +53,7 @@ on:
   # Hourly at :26 — explicit (no */N) so it is auditable, and offset off every existing
   # sub-hourly lane: auto-arm (4,14,…), verdict-bridge (1,11,…), rearm-sweeper (8,18,…),
   # batch-merge (7,22,37,52), merge-group-watchdog (2,7,12,…). Hourly is well inside the
-  # 24h M1 window, and M2/M3 read live state, so a missed tick cannot hide a choke.
+  # 24h M1 window, and M3 reads live state, so a missed tick cannot hide a choke.
   schedule:
     - cron: "26 * * * *"
   # Manual run for validation / triage.

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -841,6 +841,23 @@ jobs:
       # the same false header reds on arrival.
       - name: Self-test the alarm/detector lanes are DECLARED non-gating (sq-huwr8)
         run: python3 scripts/tests/test_alarm_lanes_non_gating.py
+      # [OPUS-5] sq-1lc4i: the CI EXECUTION-LATENCY alarm
+      # (scripts/ci_execution_latency_alarm.py, .github/workflows/ci-latency-alarm.yml).
+      # Hermetic (no gh, no network). Three halves: the classifiers for all three choke
+      # modes — including the two guards that fail SILENTLY if broken, namely the
+      # missing-baseline fallback (a lane whose runs never complete must still be
+      # watchable, or the detector goes quiet exactly when a lane is 100% hung) and the
+      # empty-scan-set fail-loud (reporting health over an empty population); the
+      # DISJOINTNESS with #4368's cron_lane_liveness.py, asserted over the REAL workflow
+      # tree in both directions so neither a duplicate nor a hole can open; and the YAML
+      # SEAM (self-test ordered before the detector, both invocations matched EXACTLY
+      # rather than by containment, no step `if:`/`continue-on-error`, SHA-pinned actions,
+      # the sparse-checkout that M1 reads its expectation from, and permissions carrying
+      # `issues: write` with NO `pull-requests: write` so the detector can never acquire
+      # arming authority). The suite pins its OWN call site here, so it cannot silently
+      # leave CI.
+      - name: Self-test the CI execution-latency alarm (3 choke modes + YAML seam)
+        run: python3 scripts/tests/test_ci_execution_latency_alarm.py
       # [SONNET-4.6] sq-1cb6l: the 5 remaining hermetic test suites found by the
       # #1670 audit, wired here alongside the other ci-scripts self-tests.
       #

--- a/scripts/ci_execution_latency_alarm.py
+++ b/scripts/ci_execution_latency_alarm.py
@@ -1,24 +1,28 @@
 #!/usr/bin/env python3
-"""CI EXECUTION-LATENCY alarm — three distinct choke modes, one detector. 🤖 SPARQ agent.
+"""CI EXECUTION-LATENCY alarm — two detected choke modes, one documented gap. 🤖 SPARQ agent.
 
 Bead sq-1lc4i. Maintainer-requested (2026-07-28): "setting up alerting for when runners
 are not picked up for crons or delayed for other dispatches on both repos. This is an
 indicator that you are choking on runner availability and is something that we would need
 to manage."
 
-WHY THREE MODES. They have different signatures and only ONE of them is runner
-availability proper, so a single detector keyed on any one of them is blind to the other
-two:
+WHAT IS AND IS NOT COVERED. Two modes are detected. The third — queue wait, which is
+runner availability proper and the maintainer's literal ask — is NOT detected, and that
+gap is documented rather than filled with a check that cannot see it. Read the QUEUE WAIT
+section below the constants before assuming this file covers starvation; it does not.
 
-  M1 CRON-FIRING DEFICIT   a scheduled run that never fires produces NO artifact at all.
-                           There is no run to inspect, no conclusion, no check-run. The
-                           only way to see it is to compute what the lane's own `cron:`
+  M1 CRON-FIRING DEFICIT   DETECTED. A scheduled run that never fires produces NO artifact
+                           at all. There is no run to inspect, no conclusion, no check-run.
+                           The only way to see it is to compute what the lane's own `cron:`
                            EXPECTED and compare against what arrived.
-  M2 QUEUE WAIT            a run sitting in `queued` past a measured threshold. This is
-                           runner availability proper — the maintainer's stated concern.
-  M3 EXECUTION OVERRUN     a run that is `in_progress` far past its lane's own measured
-                           duration. It consumes capacity while looking perfectly healthy:
-                           no red, no alert, no artifact.
+  M3 EXECUTION OVERRUN     DETECTED. A run that is `in_progress` far past its lane's own
+                           measured duration. It consumes capacity while looking perfectly
+                           healthy: no red, no alert, no artifact.
+  QUEUE WAIT               NOT DETECTED — deliberate, documented gap. Zero non-zero queue
+                           waits across 44,190 completed runs, and the one event that
+                           motivated a detector turned out to be a configured
+                           `max-parallel: 8`, not withheld runners. See the long note
+                           below the constants.
 
 =============================================================================
 THE MEASUREMENT TRAP THIS DETECTOR EXISTS BECAUSE OF — read before editing
@@ -28,15 +32,23 @@ The obvious instrument for "are runners being picked up" is job-level
 the SAFE-LOOKING direction: it reports health while a leak is live.
 
 MEASURED 2026-07-28 on run 30333511110 (sparq-org/sparq, a `schedule` CI run on main that
-had been `in_progress` for 6.7 hours with 8 live jobs), N=65 jobs:
+ran 6.7 hours), RE-MEASURED over the completed run, N=84 jobs:
 
-    pickup lag (started_at - created_at):   min 0s   p50 3s   MAX 10s   >60s: 0 jobs
-    job-creation lag (created_at - run.created_at):        MAX 383 min  (6.4 hours)
+    pickup lag (started_at - created_at):        min 0s   MAX 10s   >60s: 0 jobs
+    job-creation lag (job.created_at - run.created_at):    MAX 402 min  (6.7 hours)
 
-Every job was picked up within ten seconds of EXISTING. The wait was invisible because a
-matrix leg throttled behind `max-parallel` (or behind an account concurrency ceiling) is
-not created as a job object at all while it waits — so it contributes no queue depth and
-no pickup lag. `status=queued` read ZERO for the whole 6.7 hours.
+Every job was picked up within ten seconds of EXISTING. A matrix leg waiting behind a
+concurrency limit is not created as a job object at all, so it contributes no queue depth
+and no pickup lag; `status=queued` read ZERO for the whole 6.7 hours.
+
+CORRECTION, and it matters. An earlier revision presented this run as evidence of an
+invisible CAPACITY problem. It is not. The 402 minutes is INTRA-MATRIX — `mutation ratchet`
+has 51 legs spread over 401.9 min, while the `test` matrix (5 legs, no `max-parallel`) has
+a spread of 0.0 min — and `mutants-nightly-advisory` declares `max-parallel: 8`. 51 legs at
+8 concurrent is 6.4 waves, which IS the 402 minutes. This run shows a configured cap
+working correctly, not GitHub withholding runners. The API observation below stands; the
+capacity inference drawn from it did not, and was removed along with the detector built on
+it.
 
 Two consequences, both load-bearing:
 
@@ -76,7 +88,7 @@ plus bench/codeql/container-scan/fuzz/scorecard/xpath-differential/zk-toolchain.
 cannot see any of them, and `ci.yml` — the single largest capacity consumer in the repo —
 is among them.
 
-M2 and M3 are keyed on live run STATE, which #4368 does not look at in any scope.
+M3 is keyed on live run STATE, which #4368 does not look at in any scope.
 
 =============================================================================
 THRESHOLDS — every one derived from measurement, with the N stated
@@ -173,74 +185,67 @@ CRON_MIN_EXPECTED = 1
 # halving of a sub-hourly lane's achieved rate (12 -> 6 of a capped 12 = 0.50).
 CRON_DELIVERY_FLOOR = 0.60
 
-# --- M2: queue wait (runner availability proper) -----------------------------------
+# =============================================================================
+# QUEUE WAIT / RUNNER STARVATION — DELIBERATELY NOT DETECTED. Read this before
+# adding a detector for it; the obvious one does not work and was removed.
+# =============================================================================
+# There is NO detector on this route. That is a documented gap, not an oversight, and it
+# is recorded here rather than papered over with a check that cannot see the thing.
 #
-# THE RE-RUN TRAP — read before touching anything in this mode.
-# `created_at` on the RUN-level object is the creation time of ATTEMPT 1 and does NOT
-# reset when a run is re-run, while `run_attempt` and `run_started_at` DO track the live
-# attempt. MEASURED 2026-07-28 on jeswr/agent-account-registry run 30318886362:
-#     run-level    run_attempt=2  created_at=00:58:13Z  run_started_at=02:37:40Z
-#     /attempts/1                 created_at=00:58:13Z  run_started_at=00:58:13Z   0s
-#     /attempts/2                 created_at=02:37:41Z  run_started_at=02:37:40Z   0s
-# Neither attempt ever queued. The 99-minute "wait" is the IDLE GAP between attempt 1
-# failing at 01:00Z and a re-run being pressed at 02:37Z.
-# Executed on that exact payload, `now - run["created_at"]` reports waited_seconds=5967
-# for an attempt picked up in under a second — so the naive form fires on EVERY re-run
-# older than the threshold, which is the normal case, and a permanently-red alarm is a
-# muted alarm. `attempt_created_at()` below is the fix. Do not reintroduce a bare
-# `run.get("created_at")` here.
+# An earlier revision of this file shipped "M2", a queue-wait mode keyed on
+# `now - run["created_at"]` for runs in `status=queued`. It was removed for three
+# measured reasons, in increasing order of importance.
 #
-# THRESHOLD — and an HONEST statement of what does and does not support it.
-# WITHDRAWN: an earlier revision of this file claimed "fires on 3 of 13,802 sparq runs
-# (0.022%) and 6 of 3,920 registry runs (0.153%)", and cited the registry six as a real
-# queue event. Both figures were produced by the contaminated estimator above, and the
-# "real event" was those seven `run_attempt: 2` re-runs. That evidence is retracted.
+# 1. THE ESTIMATOR WAS WRONG. The run-level `created_at` is the creation time of ATTEMPT 1
+#    and does NOT reset on re-run, while `run_attempt` and `run_started_at` DO track the
+#    live attempt. MEASURED on jeswr/agent-account-registry run 30318886362:
+#        run-level    run_attempt=2  created_at=00:58:13Z  run_started_at=02:37:40Z
+#        /attempts/1                 created_at=00:58:13Z  run_started_at=00:58:13Z   0s
+#        /attempts/2                 created_at=02:37:41Z  run_started_at=02:37:40Z   0s
+#    Neither attempt ever queued; the 99 minutes is idle time before a human pressed
+#    re-run. Executed on that payload the detector reported waited_seconds=5967 for a
+#    sub-second pickup, i.e. it fired on every re-run older than the threshold.
 #
-# RE-DERIVED 2026-07-28 with the decontaminated estimator, over a per-workflow scan (the
-# repo-wide `actions/runs` listing hard-caps at 1000), splitting on `run_attempt` and
-# resolving every re-run's TRUE wait against its own `/attempts/{n}` record:
+# 2. AFTER FIXING THAT, THE VARIABLE NEVER MOVES. Per-workflow scan, splitting on
+#    `run_attempt` and resolving every re-run against its own `/attempts/{n}`:
 #
-#                                          sparq-org/sparq   jeswr/agent-account-registry
-#   completed runs scanned                          35,128                          9,062
-#   contaminated estimator, over 15 min                  7                              6
-#     ... of which are RE-RUNS                     7 (ALL)                        6 (ALL)
-#   DECONTAMINATED (run_attempt == 1)               35,070                          9,053
-#     over 15 min                                        0                              0
-#     with ANY non-zero wait at all                      0                              0
-#     maximum observed wait                           0.0s                           0.0s
-#   re-runs resolved per-attempt                        58                              9
-#     over 15 min                                        0                              0
-#     true maximum wait                              -1.0s                          -1.0s
+#                                             sparq-org/sparq   agent-account-registry
+#      completed runs scanned                          35,128                    9,062
+#      contaminated estimator, over 15 min                  7                        6
+#        ... of which are RE-RUNS                     7 (ALL)                  6 (ALL)
+#      DECONTAMINATED (run_attempt == 1)               35,070                    9,053
+#        over 15 min                                        0                        0
+#        with ANY non-zero wait at all                      0                        0
+#        maximum observed wait                           0.0s                     0.0s
 #
-# Every single row the old estimator flagged, on BOTH repos, was a re-run artefact. Across
-# 44,190 completed runs there is not ONE attempt whose own queue wait was even non-zero.
+#    Across 44,190 completed runs not ONE attempt recorded even a non-zero queue wait.
+#    The distribution is not zero-INFLATED, it is exactly all-zero, so no percentile,
+#    multiple or maximum exists to anchor a threshold to.
 #
-# SO M2 HAS NO VALIDATED KNOWN POSITIVE. There is no run in either observed corpus that
-# this mode would have fired on. That is stated plainly rather than papered over, and it
-# has two consequences that must not be lost:
+# 3. THE ONE EVENT THAT MOTIVATED THE MODE WAS NOT A CAPACITY EVENT. Run 30333511110 was
+#    cited as a 6.7h run whose starvation was invisible to `status=queued`. Re-measured:
+#      job PICKUP lag (started_at - created_at), N=84:   max 10s,  over 60s: ZERO
+#      job CREATION lag (job.created_at - run.created_at):        max 402 min
+#      the 402 min is INTRA-MATRIX, in `mutation ratchet` (51 legs, spread 401.9 min)
+#      control: `test` (5 legs, no max-parallel) has spread 0.0 min
+#    and `mutants-nightly-advisory` declares `max-parallel: 8`. 51 legs at 8 concurrent
+#    is 6.4 waves; the 402 minutes IS the configured cap working correctly. It is
+#    self-inflicted scheduling, not GitHub withholding runners. So this repository has NO
+#    observed instance of the phenomenon a queue-wait alarm would exist to catch.
 #
-#   (i)  The threshold CANNOT be derived from the observed distribution, because after
-#        decontamination the distribution is not merely zero-inflated, it is essentially
-#        ALL ZERO. There is no percentile, multiple, or maximum to anchor to. The corpus
-#        constrains this constant from BELOW only (any value above the observed max has a
-#        measured false-positive rate of zero); it says nothing about where in that
-#        half-line to sit. 15 min is therefore a JUDGMENT about how long a human should
-#        wait before being told, not a measurement, and is labelled as such.
-#   (ii) The corpus proxy is itself weak. `run_started_at - created_at` is a RUN-level
-#        statistic, and the measurement trap in the header is precisely that a run whose
-#        jobs are throttled behind `max-parallel` reads `status=queued` ZERO for hours.
-#        So a zero here is consistent with "no queueing happened" AND with "the API does
-#        not express the queueing that happened". It cannot distinguish them.
+# WHY NOT RE-POINT IT AT JOB-CREATION LAG. That variable does move, but on THIS corpus it
+# moves because of our own `max-parallel`, so an alarm keyed on it would fire on every
+# nightly mutation run forever. A permanently-red alarm is a muted alarm — the same reason
+# the M1 expectation is capped at what GitHub actually delivers rather than at nominal
+# cron rate. Separating a configured cap from a genuine account-level ceiling needs a model
+# of each lane's configured concurrency and per-leg duration, and there is no observed
+# positive to validate such a model against. That is a research task, not a threshold.
 #
-# M2 therefore ships as an UNVALIDATED detector for the maintainer's stated concern, with
-# a measured false-positive rate of 0 over N and no demonstrated true positive. It is
-# cheap (it reads live state already fetched for M3) and it is the only watcher on
-# `status=queued` at all. It is not evidence that queue waits are being caught.
-QUEUE_MAX_WAIT_SECONDS = 15 * 60
-# Key the fetch layer writes onto a queued run whose live attempt is NOT attempt 1: the
-# `created_at` of that attempt's own `/attempts/{n}` record. Absent on attempt-1 runs by
-# design — for those the run-level field is the attempt's field.
-ATTEMPT_CREATED_KEY = "_attempt_created_at"
+# WHAT WOULD CHANGE THIS. A run observed with `status=queued` and a genuine per-attempt
+# wait — i.e. `/attempts/{n}` showing `run_started_at - created_at` materially above zero.
+# If one appears, the estimator to use is the per-attempt one (point 1), NOT the run-level
+# field. Until then an alarm here would answer "would we know if we were starved?" with a
+# confident yes that the measurements above do not support.
 
 # --- M3: execution overrun ---------------------------------------------------------
 # Threshold = max(EXEC_OVERRUN_MULTIPLE x p90(completed durations for this workflow+event),
@@ -481,64 +486,6 @@ def find_cron_deficits(lanes: list[dict], now: dt.datetime,
     return findings, census
 
 
-def attempt_created_at(run: dict) -> str | None:
-    """The creation time of the run's CURRENTLY-EXECUTING attempt, or None if it cannot
-    be determined.
-
-    This is not `run["created_at"]`. See the RE-RUN TRAP note on QUEUE_MAX_WAIT_SECONDS:
-    the run-level `created_at` is frozen at attempt 1 and does not reset on re-run, so
-    reading it for a re-run charges the idle gap before the re-run press as queue wait.
-
-    Attempt 1 -> the run-level field IS the attempt's field (MEASURED equal on every
-    sampled run). Attempt N>1 -> the value the fetch layer resolved from
-    `/actions/runs/{id}/attempts/{n}`; None when that resolution was unavailable, which
-    the caller must treat as INDETERMINATE and count, never as the run-level value.
-    """
-    if int(run.get("run_attempt") or 1) > 1:
-        return run.get(ATTEMPT_CREATED_KEY) or None
-    return run.get("created_at") or None
-
-
-def find_queue_overruns(live_runs: list[dict], now: dt.datetime,
-                        max_wait: float = QUEUE_MAX_WAIT_SECONDS
-                        ) -> tuple[list[dict], dict]:
-    """M2. Runner availability proper: a run still in `queued` past `max_wait`."""
-    findings: list[dict] = []
-    census: dict[str, int] = {}
-
-    def bump(state: str) -> None:
-        census[state] = census.get(state, 0) + 1
-
-    for run in live_runs:
-        if run.get("status") != "queued":
-            continue
-        created = attempt_created_at(run)
-        if not created:
-            # A re-run whose own attempt record could not be resolved is INDETERMINATE.
-            # Fail-safe QUIET but COUNTED: the run-level `created_at` is available and
-            # known-wrong here, and firing a known-false alarm is worse than a visible
-            # gap. Two distinct census states so the two causes stay separable.
-            bump("queued-rerun-attempt-unresolved"
-                 if int(run.get("run_attempt") or 1) > 1 else "queued-no-timestamp")
-            continue
-        waited = (now - _ts(created)).total_seconds()
-        if waited > max_wait:
-            bump("queued-over-threshold")
-            findings.append({
-                "mode": "M2-queue-wait",
-                "workflow": run.get("name") or run.get("path") or "?",
-                "run_id": run.get("id"),
-                "event": run.get("event"),
-                "waited_seconds": int(waited),
-                "threshold_seconds": int(max_wait),
-                "run_attempt": int(run.get("run_attempt") or 1),
-                "head_branch": run.get("head_branch"),
-            })
-        else:
-            bump("queued-within-threshold")
-    return findings, census
-
-
 def find_execution_overruns(live_runs: list[dict], baselines: dict, now: dt.datetime,
                             multiple: float = EXEC_OVERRUN_MULTIPLE,
                             floor: float = EXEC_FLOOR_SECONDS
@@ -647,45 +594,15 @@ def _paged_runs(repo: str, query: str) -> list[dict]:
     raise AlarmError(f"workflow-run listing exceeded {RUNS_PAGE_CAP} pages for {query!r}")
 
 
-def resolve_attempt_created(repo: str, runs: list[dict]) -> list[dict]:
-    """Enrich every QUEUED run whose live attempt is not attempt 1 with that attempt's own
-    `created_at`, under ATTEMPT_CREATED_KEY.
-
-    WITHOUT THIS CALL M2 IS A FALSE-POSITIVE GENERATOR — see the RE-RUN TRAP note. It is
-    a separate pass rather than logic inside `find_queue_overruns` so the detectors stay
-    pure functions over already-fetched state and remain hermetically testable.
-
-    REQUEST COST is zero in the common case: the pass touches only `queued` runs at
-    attempt > 1. MEASURED over the newest 1000 completed runs per repo on 2026-07-28,
-    re-runs were 2/1000 on sparq and 0/1000 on the registry, and the `queued` population
-    is normally empty. A failed lookup leaves the key absent, which the detector counts as
-    `queued-rerun-attempt-unresolved` rather than falling back to the known-wrong value.
-    """
-    for run in runs:
-        if run.get("status") != "queued":
-            continue
-        attempt = int(run.get("run_attempt") or 1)
-        if attempt <= 1 or not run.get("id"):
-            continue
-        try:
-            payload = _gh(["api", f"repos/{repo}/actions/runs/{run['id']}"
-                                  f"/attempts/{attempt}"])
-        except AlarmError:
-            # Quiet + counted downstream. One unresolvable attempt record must not abort
-            # the whole tick and take M1 and M3 down with it.
-            continue
-        if isinstance(payload, dict) and payload.get("created_at"):
-            run[ATTEMPT_CREATED_KEY] = payload["created_at"]
-    return runs
-
-
 def fetch_live_runs(repo: str) -> list[dict]:
-    """Every run currently `queued` or `in_progress`. This is the live-state read that
-    M2 and M3 key on; it is NOT derived from completed work (header note (a))."""
-    live: list[dict] = []
-    for status in ("queued", "in_progress"):
-        live.extend(_paged_runs(repo, f"status={status}"))
-    return resolve_attempt_created(repo, live)
+    """Every run currently `in_progress`. This is the live-state read M3 keys on; it is
+    NOT derived from completed work (header note (a)).
+
+    `status=queued` is deliberately NOT fetched — see the QUEUE WAIT note near the top.
+    Nothing reads it any more, and fetching a population no detector consumes would be
+    the shape of coverage this file exists to avoid.
+    """
+    return _paged_runs(repo, "status=in_progress")
 
 
 def fetch_baseline(repo: str, workflow_path: str, event: str) -> dict:
@@ -779,11 +696,6 @@ def render_issue_body(repo: str, findings: list[dict], census: dict[str, dict],
                     f"**{f['expected']}** in the last {f['window_hours']:g}h "
                     f"(ratio {f['ratio']}, floor {CRON_DELIVERY_FLOOR}); "
                     f"cron `{' | '.join(f['crons'])}`")
-            elif mode.startswith("M2"):
-                lines.append(
-                    f"- `{f['workflow']}` run {f['run_id']} ({f['event']}) has been "
-                    f"**queued {f['waited_seconds']//60} min**, threshold "
-                    f"{f['threshold_seconds']//60} min")
             else:
                 lines.append(
                     f"- `{f['workflow']}` run {f['run_id']} ({f['event']}) has been "
@@ -868,11 +780,9 @@ def run(args: argparse.Namespace) -> int:
             "predicate broke. Refusing to report health over an empty population.")
 
     m1, c1 = find_cron_deficits(lanes, now, args.window_hours)
-    m2, c2 = find_queue_overruns(live, now)
     m3, c3 = find_execution_overruns(live, baselines, now)
-    findings = m1 + m2 + m3
-    census = {"M1-cron-firing-deficit": c1, "M2-queue-wait": c2,
-              "M3-execution-overrun": c3}
+    findings = m1 + m3
+    census = {"M1-cron-firing-deficit": c1, "M3-execution-overrun": c3}
 
     print(f"ci-latency census for {repo} at {now:%Y-%m-%dT%H:%M:%SZ} "
           f"({len(lanes)} workflows, {len(live)} live runs):")
@@ -929,8 +839,7 @@ def _lane(workflow="a.yml", crons=("*/10 * * * *",), cron_only=False,
 
 
 def _run_obj(status="in_progress", event="schedule", path=".github/workflows/a.yml",
-             age_min=10, now=None, name="A", attempt=1, created_age_min=None,
-             attempt_created_age_min=None):
+             age_min=10, now=None, name="A", attempt=1, created_age_min=None):
     """The REAL shape of an `actions/runs` element, not a minimal hand-built dict.
 
     A narrow fixture is a vacuity generator. `started = run.get("updated_at") or
@@ -940,8 +849,9 @@ def _run_obj(status="in_progress", event="schedule", path=".github/workflows/a.y
     again. The keys and their relationships below are taken from a real payload
     (jeswr/agent-account-registry run 30318886362).
 
-    `created_age_min` exists to reproduce the RE-RUN shape, where the run-level
-    `created_at` is FROZEN at attempt 1 while `run_started_at` tracks the live attempt.
+    `created_age_min` reproduces the RE-RUN shape, where the run-level `created_at` is
+    FROZEN at attempt 1 while `run_started_at` tracks the live attempt — M3 must key on
+    the latter. See the QUEUE WAIT note near the top of this file.
     """
     now = now or dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
 
@@ -959,8 +869,6 @@ def _run_obj(status="in_progress", event="schedule", path=".github/workflows/a.y
         "updated_at": stamp(0) if status != "completed" else stamp(age_min),
         "html_url": "https://example.invalid/run/1",
     }
-    if attempt_created_age_min is not None:
-        obj[ATTEMPT_CREATED_KEY] = stamp(attempt_created_age_min)
     return obj
 
 
@@ -987,7 +895,6 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
     check("CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR matches the measured sparq ceiling",
           CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR == 0.5)
     check("CRON_GRACE_MINUTES is 15", CRON_GRACE_MINUTES == 15)
-    check("QUEUE_MAX_WAIT_SECONDS is 15 minutes", QUEUE_MAX_WAIT_SECONDS == 15 * 60)
     check("EXEC_OVERRUN_MULTIPLE is inside the band that still catches the 2.08x outlier",
           1.25 <= EXEC_OVERRUN_MULTIPLE <= 2.0)
     check("EXEC_FLOOR_SECONDS is GitHub's 6h hosted-runner job ceiling",
@@ -1116,102 +1023,6 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
     check("M1 judges a lane born 25h ago (outside the 24h window)",
           len(f) == 1 and c.get("firing-deficit") == 1)
 
-    # --- M2 ---
-    late = _run_obj(status="queued", age_min=int(QUEUE_MAX_WAIT_SECONDS / 60) + 5, now=NOW)
-    early = _run_obj(status="queued", age_min=1, now=NOW)
-    f, c = find_queue_overruns([late], NOW)
-    check("M2 raises past the queue threshold",
-          len(f) == 1 and c.get("queued-over-threshold") == 1)
-    f, c = find_queue_overruns([early], NOW)
-    check("M2 quiet within the queue threshold",
-          not f and c.get("queued-within-threshold") == 1)
-    f, _ = find_queue_overruns([_run_obj(status="in_progress", age_min=999, now=NOW)], NOW)
-    check("M2 ignores in_progress runs (that is M3's job)", not f)
-    # ABSOLUTE fixtures. The two above derive their age FROM QUEUE_MAX_WAIT_SECONDS and
-    # rescale with it, so a mutant that multiplied the constant by 10**6 survived them.
-    f, _ = find_queue_overruns([_run_obj(status="queued", age_min=60, now=NOW)], NOW)
-    check("an hour in `queued` raises under the SHIPPED threshold", len(f) == 1)
-    f, _ = find_queue_overruns([_run_obj(status="queued", age_min=2, now=NOW)], NOW)
-    check("two minutes in `queued` stays quiet under the SHIPPED threshold", not f)
-
-    # --- M2 RE-RUN TRAP: the reason the shipped detector is not `now - created_at` -----
-    # The exact shape of jeswr/agent-account-registry run 30318886362: attempt 2, whose
-    # own creation was 1 minute ago, on a run-level object still reporting attempt 1's
-    # creation 99 minutes ago. The naive form reports a 99-minute queue wait for a
-    # pickup that took under a second.
-    rerun = _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99,
-                     attempt_created_age_min=1, now=NOW)
-    check("the re-run fixture reproduces the FROZEN run-level created_at",
-          (now_minus := (NOW - _ts(rerun["created_at"])).total_seconds()) > 90 * 60
-          and (NOW - _ts(rerun[ATTEMPT_CREATED_KEY])).total_seconds() < 5 * 60)
-    check("the naive `now - created_at` WOULD have fired on it (fixture is not vacuous)",
-          now_minus > QUEUE_MAX_WAIT_SECONDS)
-    f, c = find_queue_overruns([rerun], NOW)
-    check("M2 does NOT charge a re-run's idle gap as queue wait", not f)
-    check("M2 counts the re-run as within threshold, not as a skip",
-          c.get("queued-within-threshold") == 1)
-    # A re-run whose attempt record could not be resolved is INDETERMINATE — quiet, but
-    # counted, never silently scored with the known-wrong run-level value.
-    unresolved = _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99,
-                          now=NOW)
-    f, c = find_queue_overruns([unresolved], NOW)
-    check("an unresolved re-run is quiet", not f)
-    check("an unresolved re-run is COUNTED in its own census state",
-          c.get("queued-rerun-attempt-unresolved") == 1)
-    # And the fix must not have simply disabled M2: a genuine attempt-1 wait still fires.
-    f, _ = find_queue_overruns([_run_obj(status="queued", age_min=60, attempt=1, now=NOW)],
-                               NOW)
-    check("a genuine ATTEMPT-1 queue wait still raises after the re-run fix", len(f) == 1)
-    # A re-run whose CURRENT attempt really has been queued past the threshold must fire.
-    f, _ = find_queue_overruns(
-        [_run_obj(status="queued", age_min=60, attempt=3, created_age_min=999,
-                  attempt_created_age_min=60, now=NOW)], NOW)
-    check("a genuine queue wait ON a re-run attempt still raises", len(f) == 1)
-
-    # THE CALL SITE. A pure detector that reads ATTEMPT_CREATED_KEY is worthless if
-    # nothing ever writes it, and that omission is invisible to every assertion above.
-    _real_gh = globals()["_gh"]
-    try:
-        seen: list[str] = []
-
-        def _fake_gh(args, *, parse=True):
-            seen.append(args[-1])
-            return {"created_at": "2026-07-28T11:59:00Z",
-                    "run_started_at": "2026-07-28T11:59:00Z", "run_attempt": 2}
-
-        globals()["_gh"] = _fake_gh
-        enriched = resolve_attempt_created("o/r", [
-            _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99, now=NOW),
-            _run_obj(status="queued", age_min=99, attempt=1, now=NOW),
-            _run_obj(status="in_progress", age_min=99, attempt=2, now=NOW),
-        ])
-        check("the fetch layer resolves a QUEUED re-run against /attempts/{n}",
-              enriched[0].get(ATTEMPT_CREATED_KEY) == "2026-07-28T11:59:00Z")
-        check("the fetch layer asks for the LIVE attempt number",
-              len(seen) == 1 and seen[0].endswith("/attempts/2"))
-        check("the fetch layer spends no request on an attempt-1 run",
-              ATTEMPT_CREATED_KEY not in enriched[1])
-        check("the fetch layer spends no request on an in_progress run (M3's population)",
-              ATTEMPT_CREATED_KEY not in enriched[2])
-        # End to end through the enrichment: the pass must SILENCE the false positive.
-        f, _ = find_queue_overruns(enriched, NOW)
-        check("enrichment turns the re-run false positive into silence",
-              [x["run_attempt"] for x in f] == [1])
-
-        def _raising_gh(args, *, parse=True):
-            raise AlarmError("attempt lookup unavailable")
-
-        globals()["_gh"] = _raising_gh
-        degraded = resolve_attempt_created("o/r", [
-            _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99, now=NOW)])
-        check("a failed attempt lookup does not abort the tick",
-              ATTEMPT_CREATED_KEY not in degraded[0])
-        _, c = find_queue_overruns(degraded, NOW)
-        check("a failed attempt lookup lands in the unresolved census state",
-              c.get("queued-rerun-attempt-unresolved") == 1)
-    finally:
-        globals()["_gh"] = _real_gh
-
     # --- M3: detection variable is LIVE in_progress age ---
     base = {(".github/workflows/a.yml", "schedule"): {"p90": 3600.0, "n": 50}}
     f, c = find_execution_overruns([_run_obj(age_min=30, now=NOW)], base, NOW)
@@ -1260,16 +1071,16 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
 
     # --- census is emitted even on the all-clear ---
     _, c1 = find_cron_deficits([_lane(fires=36, now=NOW)], NOW)
-    _, c2 = find_queue_overruns([early], NOW)
     _, c3 = find_execution_overruns([_run_obj(age_min=1, now=NOW)], base, NOW)
     check("a clean run still emits a non-empty census for every mode",
-          bool(c1) and bool(c2) and bool(c3))
+          bool(c1) and bool(c3))
 
     # --- issue body carries the dedupe marker ---
-    body = render_issue_body("o/r", [{"mode": "M2-queue-wait", "workflow": "a.yml",
-                                      "run_id": 1, "event": "push", "waited_seconds": 99,
-                                      "threshold_seconds": 60, "head_branch": "main"}],
-                             {"M2-queue-wait": {"queued-over-threshold": 1}}, NOW)
+    body = render_issue_body("o/r", [{"mode": "M3-execution-overrun", "workflow": "a.yml",
+                                      "run_id": 1, "event": "push", "age_seconds": 99,
+                                      "threshold_seconds": 60, "basis": "floor",
+                                      "head_branch": "main"}],
+                             {"M3-execution-overrun": {"execution-overrun": 1}}, NOW)
     check("issue body ends with the dedupe marker",
           body.rstrip().endswith(f"<!-- {KEY_PREFIX}: o/r -->"))
     check("issue body self-identifies as a SPARQ agent", body.startswith("> 🤖"))

--- a/scripts/ci_execution_latency_alarm.py
+++ b/scripts/ci_execution_latency_alarm.py
@@ -1,0 +1,968 @@
+#!/usr/bin/env python3
+"""CI EXECUTION-LATENCY alarm — three distinct choke modes, one detector. 🤖 SPARQ agent.
+
+Bead sq-1lc4i. Maintainer-requested (2026-07-28): "setting up alerting for when runners
+are not picked up for crons or delayed for other dispatches on both repos. This is an
+indicator that you are choking on runner availability and is something that we would need
+to manage."
+
+WHY THREE MODES. They have different signatures and only ONE of them is runner
+availability proper, so a single detector keyed on any one of them is blind to the other
+two:
+
+  M1 CRON-FIRING DEFICIT   a scheduled run that never fires produces NO artifact at all.
+                           There is no run to inspect, no conclusion, no check-run. The
+                           only way to see it is to compute what the lane's own `cron:`
+                           EXPECTED and compare against what arrived.
+  M2 QUEUE WAIT            a run sitting in `queued` past a measured threshold. This is
+                           runner availability proper — the maintainer's stated concern.
+  M3 EXECUTION OVERRUN     a run that is `in_progress` far past its lane's own measured
+                           duration. It consumes capacity while looking perfectly healthy:
+                           no red, no alert, no artifact.
+
+=============================================================================
+THE MEASUREMENT TRAP THIS DETECTOR EXISTS BECAUSE OF — read before editing
+=============================================================================
+The obvious instrument for "are runners being picked up" is job-level
+`started_at - created_at` aggregated over recent runs. It does not work, and it fails in
+the SAFE-LOOKING direction: it reports health while a leak is live.
+
+MEASURED 2026-07-28 on run 30333511110 (sparq-org/sparq, a `schedule` CI run on main that
+had been `in_progress` for 6.7 hours with 8 live jobs), N=65 jobs:
+
+    pickup lag (started_at - created_at):   min 0s   p50 3s   MAX 10s   >60s: 0 jobs
+    job-creation lag (created_at - run.created_at):        MAX 383 min  (6.4 hours)
+
+Every job was picked up within ten seconds of EXISTING. The wait was invisible because a
+matrix leg throttled behind `max-parallel` (or behind an account concurrency ceiling) is
+not created as a job object at all while it waits — so it contributes no queue depth and
+no pickup lag. `status=queued` read ZERO for the whole 6.7 hours.
+
+Two consequences, both load-bearing:
+
+  (a) A job that never finishes never appears in a completed run. Any statistic computed
+      over COMPLETED work is structurally incapable of detecting a hang or a leak — the
+      failing population is precisely the population it excludes. This is survivorship
+      bias, and it is why M3's DETECTION VARIABLE is the live age of a `status=in_progress`
+      run and NOTHING derived from finished work.
+
+  (b) Completed-run history is still the right population for the THRESHOLD — "how long
+      does this lane normally take" is a question about runs that took a length of time,
+      i.e. runs that ended. The distinction is: completed runs answer HOW LONG IS NORMAL;
+      only live runs answer IS SOMETHING STUCK RIGHT NOW. Never let (b) drift into (a).
+
+  (c) FAIL-OPEN HOLE, closed deliberately: if a lane's runs never complete, it has no
+      completed history, hence no derived baseline. A detector that SKIPS a lane with no
+      baseline would go silent exactly when a lane is 100% hung. So a missing baseline
+      falls back to EXEC_FLOOR_SECONDS instead of skipping. See find_execution_overruns.
+
+=============================================================================
+COORDINATION WITH sparq-org/sparq#4368 (`scripts/cron_lane_liveness.py`)
+=============================================================================
+#4368 watches CRON-ONLY lanes — its scope predicate is: `on:` has `schedule`, AND every
+other `on:` key is in {schedule, workflow_dispatch}. It asks "is this lane DEAD?" over a
+window of max(3 x period, 6h), keyed on run CONCLUSIONS (consecutive failures / no green).
+
+M1 here is deliberately the EXACT SET COMPLEMENT: a workflow is in M1 scope iff it has a
+`schedule:` AND at least one trigger OUTSIDE {schedule, workflow_dispatch}. The predicate
+is computed, not listed, so the two populations can never overlap and can never both raise
+on one lane — and if #4368's scope is edited, this one moves with it.
+
+That complement is not a leftover. MEASURED on sparq main d2b6034a8: of 31 workflows
+carrying a `schedule:`, 18 are cron-only (#4368's) and 13 are NOT — and the 13 include
+every throughput-critical orchestration lane in the repo: ci.yml, auto-arm.yml (10-min),
+batch-merge.yml (15-min), verdict-bridge.yml (10-min), pr-backlog.yml, refresh-start-here,
+plus bench/codeql/container-scan/fuzz/scorecard/xpath-differential/zk-toolchain. #4368
+cannot see any of them, and `ci.yml` — the single largest capacity consumer in the repo —
+is among them.
+
+M2 and M3 are keyed on live run STATE, which #4368 does not look at in any scope.
+
+=============================================================================
+THRESHOLDS — every one derived from measurement, with the N stated
+=============================================================================
+See the constants below. Nothing here is chosen by taste; each carries the sample it came
+from and the multiple it represents. Re-derive with scripts/tests/-adjacent tooling if the
+repo's shape changes; a threshold whose provenance is not stated is not maintainable.
+
+NOT A GATE. This lane REDs when it finds a choke, and REDs fail-loud when the detector
+itself breaks; neither is a property of the commit under test. It is DECLARED in
+`.github/advisory-registry.json`, which since #3773 is the ONLY thing that makes a
+check-run non-gating — not where its check-run lands. A scheduled run on main puts its
+check-run on the same head SHA the push-triggered `ci-summary` gate polls, so the
+declaration is what keeps it safe to RED. Pinned by
+scripts/tests/test_alarm_lanes_non_gating.py.
+
+Usage:
+  ci_execution_latency_alarm.py                       # real (gh; env GITHUB_REPOSITORY)
+  ci_execution_latency_alarm.py --dry-run             # print findings; no gh writes
+  ci_execution_latency_alarm.py --state-file s.json \
+      --now 2026-07-28T12:00:00Z --dry-run            # hermetic (tests)
+  ci_execution_latency_alarm.py --self-test           # hermetic fixtures
+
+Exit codes: 0 = clean, 1 = a choke was found (RED by design), 2 = the detector itself is
+broken (fail-loud). Collapsing any pair would make a broken detector indistinguishable
+from a healthy repo.
+
+Stdlib + PyYAML (preinstalled on GitHub-hosted runners) + the `gh` CLI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError as _exc:  # pragma: no cover - fail loud, never silently skip M1
+    yaml = None
+    _YAML_IMPORT_ERROR = _exc
+
+
+class AlarmError(RuntimeError):
+    """The detector itself is broken. Always exit 2 — never mask a choke."""
+
+
+class CronError(ValueError):
+    """An unparseable cron expression. Fail-safe QUIET (the lane is skipped, and counted
+    in the census as `cron-unparseable` so the skip is visible rather than silent)."""
+
+
+KEY_PREFIX = "ci-execution-latency-alarm-key"
+BASE_LABELS = ["ci-latency-alarm", "auto"]
+# Separator for the flat "<workflow path>|<event>" baseline keys a hermetic --state-file
+# carries (JSON object keys cannot be tuples). A pipe cannot occur in either half.
+BASELINE_KEY_SEP = "|"
+
+# --- M1: cron firing deficit -------------------------------------------------------
+# WINDOW: 24h. Chosen from measurement, not taste. A 6h window was tried first and
+# rejected: at 6h a DAILY lane has an expectation of 0 or 1 and a single jittered fire
+# swings the ratio between 0.00 and 1.00, so the mode would either alarm constantly or be
+# switched off. Over 24h every daily lane on sparq delivered EXACTLY its expectation.
+CRON_WINDOW_HOURS = 24.0
+# THE CAP, and why nominal cron rate is NOT a usable expectation.
+# MEASURED on sparq-org/sparq over the 24h to 2026-07-28T13:15Z, per-lane, event-filtered:
+#   DAILY lanes (asan, bench, ci, kani, miri, fuzz, metamorph, differential, ... 16 of
+#   them): delivered ratio 1.00 — every single one.
+#   SUB-HOURLY lanes: delivered 0.08-0.25 of nominal. auto-arm (`*/10`, nominal 144) got
+#   12. promote-on-approval (`*/10`, 144) got 12. rearm-sweeper (6/h, 144) got 13.
+#   verdict-bridge (6/h, 144) got 12. batch-merge (4/h, 96) got 12. retriage (`*/30`, 48)
+#   got 12.
+# GitHub's `schedule` trigger is best-effort and documented as droppable under load; on a
+# repo this busy it converges to ~12 scheduled runs per lane per day REGARDLESS of the
+# cron. Comparing against nominal would put six lanes permanently in breach — an alarm
+# that is always red is muted, and a muted alarm is how a real outage gets ignored.
+# So the expectation is CAPPED at what GitHub demonstrably delivers. 0.5/h = 12 per 24h;
+# the highest any sparq lane actually achieved in 24h was 13.
+CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR = 0.5
+# Ignore firings younger than this. Without it the window edge races the scheduler: at
+# 03:17:30 a `17 3 * * *` lane has an expectation of 1 whose run may not be created yet,
+# giving ratio 0.00 and a phantom deficit on every single tick that lands near the cron.
+CRON_GRACE_MINUTES = 15
+# A lane needs at least this much capped expectation for a ratio to mean anything.
+CRON_MIN_EXPECTED = 1
+# Raise below this delivery ratio. VALIDATED, not chosen: over the 24 covered sparq lanes
+# the MINIMUM capped delivery ratio was 0.75 (refresh-start-here.yml, 3 of 4), so 0.60
+# sits 0.15 BELOW the worst healthy lane and fires on ZERO of them. It still catches the
+# mode that has no artifact — a lane that stops entirely goes to 0.00 — and catches a
+# halving of a sub-hourly lane's achieved rate (12 -> 6 of a capped 12 = 0.50).
+CRON_DELIVERY_FLOOR = 0.60
+
+# --- M2: queue wait (runner availability proper) -----------------------------------
+# MEASURED run-level queue wait (`run_started_at - created_at`) over COMPLETED runs:
+#   sparq-org/sparq               N=13,802   p50 0s  p90 0s  p99 0s   max 94.2m
+#   jeswr/agent-account-registry  N= 3,920   p50 0s  p90 0s  p99 0s   max 99.5m
+# The metric is ZERO-INFLATED: 22 of 13,802 sparq runs (0.16%) and 8 of 3,920 registry
+# runs (0.20%) ever recorded a non-zero wait. That is why this threshold is NOT stated as
+# a multiple of the observed maximum, the way M3's is — multiplying a max of 94.2m gives a
+# threshold nothing could ever reach, and multiplying a p99 of 0s gives 0. For a
+# zero-inflated distribution the honest statement is the false-positive rate.
+# 15 min: fires on 3 of 13,802 sparq completed runs (0.022%) and 6 of 3,920 registry runs
+# (0.153%). The registry six are not false positives — they are a REAL contiguous queue
+# event, seven `pr-gate.yml` runs held 12.8-99.5 min between 00:58Z and 02:24Z on
+# 2026-07-28, which is precisely the condition this mode exists to report.
+QUEUE_MAX_WAIT_SECONDS = 15 * 60
+
+# --- M3: execution overrun ---------------------------------------------------------
+# Threshold = max(EXEC_OVERRUN_MULTIPLE x p90(completed durations for this workflow+event),
+#                 EXEC_FLOOR_SECONDS).
+# VALIDATED by a leave-one-out sweep over the event-filtered completed-run corpus — each
+# run scored against a p90 computed from the OTHER runs in its own (workflow, event) cell:
+#   sparq-org/sparq                N=8,676 runs / 119 cells
+#   jeswr/agent-account-registry   N=2,063 runs /  30 cells
+# Result: at K = 1.25 .. 2.0 the ONLY sparq run that fires is the genuine 2026-07-27
+# nightly ci.yml outlier (17.33h against an 8.35h p90 = 2.08x), and ZERO registry runs
+# fire. At K = 2.5 and above that real event is MISSED. So 2.0 is the LARGEST multiple
+# that still detects the known positive, and it costs nothing: every other one of the
+# 10,739 sampled runs stays silent.
+# Instrument validated against a known answer before the result was trusted: injecting one
+# synthetic run at 2.5x a cell's p90 fires at K=2.0 on both repos, so a zero result is a
+# real zero and not a broken sweep.
+EXEC_OVERRUN_MULTIPLE = 2.0
+# Floor. Applies when a lane has NO usable completed baseline — including the case that
+# matters most: a lane whose runs never complete (see (c) in the header). 6h is GitHub's
+# hosted-runner per-job ceiling, so a RUN alive past 6h has necessarily outlived any single
+# job's maximum possible life and is either a long matrix or a leak; either way it is worth
+# a line. Never `continue` on a missing baseline — that is the fail-open hole.
+EXEC_FLOOR_SECONDS = 6 * 60 * 60
+# Completed runs sampled per (workflow, event) to build the baseline.
+BASELINE_SAMPLE = 100
+# A baseline needs at least this many completed samples to be trusted; below it, fall back
+# to the floor (never skip).
+BASELINE_MIN_N = 5
+
+# `actions/runs` hard-caps pagination at 1000 results regardless of `--paginate`
+# (MEASURED: total_count=21672, --paginate returned exactly 1000). Live-state queries are
+# filtered by `status=` and are far below that, but the cap is asserted rather than assumed.
+RUNS_PAGE_CAP = 10
+
+# The trigger set that makes a lane INVISIBLE to PR review / merge queues. Identical to
+# `cron_lane_liveness.INVISIBLE_TRIGGERS` (#4368) on purpose — see the coordination note.
+INVISIBLE_TRIGGERS = frozenset({"schedule", "workflow_dispatch"})
+
+
+# ---------------------------------------------------------------------------------
+# cron expansion
+# ---------------------------------------------------------------------------------
+def _expand_field(spec: str, lo: int, hi: int) -> set[int]:
+    """Expand one cron field to the set of values it matches."""
+    if not spec:
+        raise CronError("empty field")
+    out: set[int] = set()
+    for part in spec.split(","):
+        if not part:
+            raise CronError(f"empty list element in {spec!r}")
+        step = 1
+        if "/" in part:
+            part, raw = part.split("/", 1)
+            if not raw.isdigit():
+                raise CronError(f"bad step in {spec!r}")
+            step = int(raw)
+            if step <= 0:
+                raise CronError(f"non-positive step in {spec!r}")
+        if part in ("*", "?"):
+            a, b = lo, hi
+        elif "-" in part:
+            lhs, rhs = part.split("-", 1)
+            if not (lhs.isdigit() and rhs.isdigit()):
+                raise CronError(f"bad range in {spec!r}")
+            a, b = int(lhs), int(rhs)
+            if a > b:
+                raise CronError(f"inverted range in {spec!r}")
+        else:
+            if not part.isdigit():
+                raise CronError(f"not a number: {part!r}")
+            a = b = int(part)
+        out |= set(range(a, b + 1, step))
+    out = {v for v in out if lo <= v <= hi}
+    if not out:
+        raise CronError(f"field matches nothing: {spec!r}")
+    return out
+
+
+def expected_firings(expr: str, start: dt.datetime, end: dt.datetime) -> int:
+    """How many times `expr` fires in (start, end]. Minute-resolution walk.
+
+    POSIX day semantics: when BOTH day-of-month and day-of-week are restricted the match
+    is their UNION, not their intersection.
+    """
+    if not isinstance(expr, str):
+        raise CronError(f"not a string: {expr!r}")
+    fields = expr.split()
+    if len(fields) != 5:
+        raise CronError(f"expected 5 fields, got {len(fields)}: {expr!r}")
+    minute, hour, dom, month, dow = fields
+    mins = _expand_field(minute, 0, 59)
+    hours = _expand_field(hour, 0, 23)
+    doms = _expand_field(dom, 1, 31)
+    months = _expand_field(month, 1, 12)
+    dows = {d % 7 for d in _expand_field(dow, 0, 7)}
+    dom_wild = dom.strip() in ("*", "?")
+    dow_wild = dow.strip() in ("*", "?")
+    if (end - start) > dt.timedelta(days=400):
+        raise CronError("window too wide to expand")
+
+    t = start.replace(second=0, microsecond=0) + dt.timedelta(minutes=1)
+    n = 0
+    while t <= end:
+        if t.minute in mins and t.hour in hours and t.month in months:
+            weekday = (t.weekday() + 1) % 7  # cron: Sunday == 0
+            if dom_wild and dow_wild:
+                day_ok = True
+            elif dom_wild:
+                day_ok = weekday in dows
+            elif dow_wild:
+                day_ok = t.day in doms
+            else:
+                day_ok = (t.day in doms) or (weekday in dows)
+            if day_ok:
+                n += 1
+        t += dt.timedelta(minutes=1)
+    return n
+
+
+# ---------------------------------------------------------------------------------
+# workflow scope
+# ---------------------------------------------------------------------------------
+def workflow_triggers(text: str) -> dict:
+    """-> the parsed `on:` mapping. `on` is YAML 1.1 `true`, hence the two-key lookup."""
+    if yaml is None:  # pragma: no cover
+        raise AlarmError(f"PyYAML unavailable: {_YAML_IMPORT_ERROR}")
+    try:
+        doc = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise AlarmError(f"unparseable workflow YAML: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise AlarmError("workflow YAML is not a mapping")
+    on = doc.get(True, doc.get("on"))
+    return on if isinstance(on, dict) else {}
+
+
+def m1_scope(on: dict) -> tuple[bool, list[str], bool]:
+    """-> (in_m1_scope, cron expressions, is_cron_only).
+
+    IN SCOPE iff the workflow has a `schedule:` AND at least one trigger OUTSIDE
+    {schedule, workflow_dispatch}. That is the exact set complement of #4368's
+    `cron_lane_liveness.py` scope, so the two detectors partition the scheduled
+    workflows and can never both raise on the same lane.
+    """
+    if "schedule" not in on:
+        return False, [], False
+    sched = on.get("schedule") or []
+    crons = [s.get("cron") for s in sched
+             if isinstance(s, dict) and isinstance(s.get("cron"), str)]
+    cron_only = set(on) <= INVISIBLE_TRIGGERS
+    return (bool(crons) and not cron_only), crons, cron_only
+
+
+# ---------------------------------------------------------------------------------
+# detectors — pure functions over already-fetched state
+# ---------------------------------------------------------------------------------
+def find_cron_deficits(lanes: list[dict], now: dt.datetime,
+                       window_hours: float = CRON_WINDOW_HOURS) -> tuple[list[dict], dict]:
+    """M1. `lanes` = [{workflow, crons, cron_only, in_scope, state, schedule_run_times}].
+
+    The census counts EVERY state exit, not just the alarming one: a per-state population
+    is the only shape in which a MISSING edge is visible at all.
+    """
+    start = now - dt.timedelta(hours=window_hours)
+    # The window ENDS a grace period before `now`, so a firing whose run may not have been
+    # created yet is not counted as missing. Without this the tick that lands on a lane's
+    # own cron minute manufactures a deficit for that lane, every day.
+    end = now - dt.timedelta(minutes=CRON_GRACE_MINUTES)
+    # What GitHub will actually deliver in a window of this length. Nominal cron rate is
+    # not an expectation for sub-hourly lanes — see the constant's note.
+    ceiling = int(CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR * window_hours)
+    findings: list[dict] = []
+    census: dict[str, int] = {}
+
+    def bump(state: str) -> None:
+        census[state] = census.get(state, 0) + 1
+
+    for lane in lanes:
+        if not lane.get("in_scope"):
+            bump("cron-only (watched by #4368)" if lane.get("cron_only")
+                 else "not-scheduled")
+            continue
+        if lane.get("state") != "active":
+            bump("disabled")
+            continue
+        try:
+            nominal = sum(expected_firings(c, start, end) for c in lane["crons"])
+        except CronError:
+            bump("cron-unparseable")
+            continue
+        expected = min(nominal, ceiling)
+        if expected < CRON_MIN_EXPECTED:
+            bump("expectation-below-floor")
+            continue
+        actual = sum(1 for t in lane["schedule_run_times"] if start < t <= end)
+        # Clamp: a lane that over-delivers (a manual re-run inside the window) is at 1.00,
+        # never above it. Without the clamp an over-delivering lane could mask a sibling.
+        ratio = min(actual, expected) / expected
+        if ratio < CRON_DELIVERY_FLOOR:
+            bump("firing-deficit")
+            findings.append({
+                "mode": "M1-cron-firing-deficit",
+                "workflow": lane["workflow"],
+                "expected": expected,
+                "nominal": nominal,
+                "actual": actual,
+                "ratio": round(ratio, 3),
+                "window_hours": window_hours,
+                "crons": lane["crons"],
+            })
+        else:
+            bump("delivering")
+    return findings, census
+
+
+def find_queue_overruns(live_runs: list[dict], now: dt.datetime,
+                        max_wait: float = QUEUE_MAX_WAIT_SECONDS
+                        ) -> tuple[list[dict], dict]:
+    """M2. Runner availability proper: a run still in `queued` past `max_wait`."""
+    findings: list[dict] = []
+    census: dict[str, int] = {}
+
+    def bump(state: str) -> None:
+        census[state] = census.get(state, 0) + 1
+
+    for run in live_runs:
+        if run.get("status") != "queued":
+            continue
+        created = run.get("created_at")
+        if not created:
+            bump("queued-no-timestamp")
+            continue
+        waited = (now - _ts(created)).total_seconds()
+        if waited > max_wait:
+            bump("queued-over-threshold")
+            findings.append({
+                "mode": "M2-queue-wait",
+                "workflow": run.get("name") or run.get("path") or "?",
+                "run_id": run.get("id"),
+                "event": run.get("event"),
+                "waited_seconds": int(waited),
+                "threshold_seconds": int(max_wait),
+                "head_branch": run.get("head_branch"),
+            })
+        else:
+            bump("queued-within-threshold")
+    return findings, census
+
+
+def find_execution_overruns(live_runs: list[dict], baselines: dict, now: dt.datetime,
+                            multiple: float = EXEC_OVERRUN_MULTIPLE,
+                            floor: float = EXEC_FLOOR_SECONDS
+                            ) -> tuple[list[dict], dict]:
+    """M3. A run `in_progress` past its own lane's measured duration.
+
+    DETECTION VARIABLE is the live age of an in-flight run — deliberately NOT any
+    statistic over completed runs, which structurally excludes the hangs this exists to
+    catch (header note (a)).
+
+    `baselines` maps (workflow_key, event) -> {"p90": seconds, "n": int}. A missing or
+    under-sampled baseline falls back to `floor` and is REPORTED as such; it must never
+    cause a `continue`, or a lane whose runs never complete would be unwatchable by its
+    own detector (header note (c)).
+    """
+    findings: list[dict] = []
+    census: dict[str, int] = {}
+
+    def bump(state: str) -> None:
+        census[state] = census.get(state, 0) + 1
+
+    for run in live_runs:
+        if run.get("status") != "in_progress":
+            continue
+        started = run.get("run_started_at") or run.get("created_at")
+        if not started:
+            bump("in-progress-no-timestamp")
+            continue
+        age = (now - _ts(started)).total_seconds()
+        key = (run.get("path") or run.get("name") or "?", run.get("event"))
+        base = baselines.get(key) or {}
+        n = int(base.get("n") or 0)
+        p90 = base.get("p90")
+        if p90 is None or n < BASELINE_MIN_N:
+            threshold = floor
+            basis = f"floor (no usable baseline; n={n})"
+        else:
+            threshold = max(multiple * float(p90), floor)
+            basis = f"max({multiple}x p90={int(p90)}s over n={n}, floor)"
+        if age > threshold:
+            bump("execution-overrun")
+            findings.append({
+                "mode": "M3-execution-overrun",
+                "workflow": run.get("name") or run.get("path") or "?",
+                "run_id": run.get("id"),
+                "event": run.get("event"),
+                "age_seconds": int(age),
+                "threshold_seconds": int(threshold),
+                "basis": basis,
+                "head_branch": run.get("head_branch"),
+            })
+        else:
+            bump("in-progress-within-threshold")
+    return findings, census
+
+
+def _ts(value: str) -> dt.datetime:
+    try:
+        return dt.datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise AlarmError(f"unparseable timestamp {value!r}: {exc}") from exc
+
+
+def percentile(values: list[float], q: float) -> float:
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, int(round(q * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+# ---------------------------------------------------------------------------------
+# gh I/O
+# ---------------------------------------------------------------------------------
+def _gh(args: list[str], *, parse: bool = True):
+    try:
+        out = subprocess.run(
+            ["gh", *args], check=True, capture_output=True, text=True, timeout=180
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise AlarmError(f"gh {' '.join(args[:2])} failed: {detail}") from exc
+    if not parse:
+        return out.stdout
+    try:
+        return json.loads(out.stdout or "null")
+    except json.JSONDecodeError as exc:
+        raise AlarmError(f"gh {' '.join(args[:2])}: unparseable JSON: {exc}") from exc
+
+
+def _paged_runs(repo: str, query: str) -> list[dict]:
+    """Walk `actions/runs` pages. Terminates on a SHORT page, never on
+    `len(runs) >= total_count`: a total_count read before a new run started is an
+    UNDERCOUNT and stopping on it would truncate exactly when the list is growing."""
+    runs: list[dict] = []
+    page = 1
+    while page <= RUNS_PAGE_CAP:
+        payload = _gh(["api", f"repos/{repo}/actions/runs?{query}&per_page=100&page={page}"])
+        if not isinstance(payload, dict):
+            raise AlarmError("workflow-run listing is not an object")
+        batch = payload.get("workflow_runs")
+        if batch is None:
+            raise AlarmError("workflow-run listing carries no workflow_runs")
+        runs.extend(batch)
+        if len(batch) < 100:
+            return runs
+        page += 1
+    raise AlarmError(f"workflow-run listing exceeded {RUNS_PAGE_CAP} pages for {query!r}")
+
+
+def fetch_live_runs(repo: str) -> list[dict]:
+    """Every run currently `queued` or `in_progress`. This is the live-state read that
+    M2 and M3 key on; it is NOT derived from completed work (header note (a))."""
+    live: list[dict] = []
+    for status in ("queued", "in_progress"):
+        live.extend(_paged_runs(repo, f"status={status}"))
+    return live
+
+
+def fetch_baseline(repo: str, workflow_path: str, event: str) -> dict:
+    """p90 of completed-run DURATION for one (workflow, event).
+
+    Completed runs are the correct population for "how long is normal" and the WRONG
+    population for "is something stuck" — see header notes (a) and (b).
+    """
+    wf = workflow_path.split("/")[-1]
+    payload = _gh(["api", f"repos/{repo}/actions/workflows/{wf}/runs"
+                          f"?status=completed&event={event}&per_page={BASELINE_SAMPLE}"])
+    if not isinstance(payload, dict) or payload.get("workflow_runs") is None:
+        raise AlarmError(f"{wf}: baseline response carries no workflow_runs")
+    durations = []
+    for run in payload["workflow_runs"]:
+        started, updated = run.get("run_started_at"), run.get("updated_at")
+        if not (started and updated):
+            continue
+        delta = (_ts(updated) - _ts(started)).total_seconds()
+        if delta >= 0:
+            durations.append(delta)
+    if not durations:
+        return {"p90": None, "n": 0}
+    return {"p90": percentile(durations, 0.90), "n": len(durations)}
+
+
+def fetch_lanes(repo: str, workflows_dir: Path, window_hours: float,
+                now: dt.datetime) -> list[dict]:
+    """Build the M1 lane list from the workflow files plus each lane's schedule runs."""
+    if not workflows_dir.is_dir():
+        raise AlarmError(f"no workflows directory at {workflows_dir}")
+    listing = _gh(["api", f"repos/{repo}/actions/workflows?per_page=100"])
+    if not isinstance(listing, dict) or listing.get("workflows") is None:
+        raise AlarmError("workflow listing carries no workflows")
+    state_by_path = {w["path"]: w.get("state") for w in listing["workflows"]}
+
+    lanes: list[dict] = []
+    start = now - dt.timedelta(hours=window_hours)
+    for path in sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml")):
+        rel = f".github/workflows/{path.name}"
+        on = workflow_triggers(path.read_text(encoding="utf-8"))
+        in_scope, crons, cron_only = m1_scope(on)
+        lane = {"workflow": rel, "crons": crons, "cron_only": cron_only,
+                "in_scope": in_scope, "state": state_by_path.get(rel, "active"),
+                "schedule_run_times": []}
+        if in_scope and lane["state"] == "active":
+            payload = _gh(["api", f"repos/{repo}/actions/workflows/{path.name}/runs"
+                                  f"?event=schedule&per_page=100"])
+            if not isinstance(payload, dict) or payload.get("workflow_runs") is None:
+                raise AlarmError(f"{path.name}: schedule-run response carries no workflow_runs")
+            times = [_ts(r["created_at"]) for r in payload["workflow_runs"]
+                     if r.get("created_at")]
+            # COVERAGE GUARD: the sample is the newest 100 runs. If the OLDEST sampled run
+            # is newer than the window start, the count is TRUNCATED and would manufacture
+            # a phantom deficit. Treat as indeterminate (fail-safe quiet), never as 0.
+            if times and min(times) > start and len(times) >= 100:
+                lane["in_scope"] = False
+                lane["truncated"] = True
+            lane["schedule_run_times"] = times
+        lanes.append(lane)
+    return lanes
+
+
+# ---------------------------------------------------------------------------------
+# reporting
+# ---------------------------------------------------------------------------------
+def render_issue_body(repo: str, findings: list[dict], census: dict[str, dict],
+                      now: dt.datetime) -> str:
+    lines = [
+        "> 🤖 **SPARQ agent** — automated CI execution-latency alarm "
+        "(`scripts/ci_execution_latency_alarm.py`, bead sq-1lc4i). @jeswr runs multiple "
+        "agents on this account; this issue was filed by CI automation.",
+        "",
+        f"CI execution latency in `{repo}` breached a measured threshold at "
+        f"`{now:%Y-%m-%dT%H:%M:%SZ}`.",
+        "",
+    ]
+    by_mode: dict[str, list[dict]] = {}
+    for f in findings:
+        by_mode.setdefault(f["mode"], []).append(f)
+    for mode in sorted(by_mode):
+        lines += [f"### {mode}", ""]
+        for f in by_mode[mode]:
+            if mode.startswith("M1"):
+                lines.append(
+                    f"- `{f['workflow']}` fired **{f['actual']}** of an expected "
+                    f"**{f['expected']}** in the last {f['window_hours']:g}h "
+                    f"(ratio {f['ratio']}, floor {CRON_DELIVERY_FLOOR}); "
+                    f"cron `{' | '.join(f['crons'])}`")
+            elif mode.startswith("M2"):
+                lines.append(
+                    f"- `{f['workflow']}` run {f['run_id']} ({f['event']}) has been "
+                    f"**queued {f['waited_seconds']//60} min**, threshold "
+                    f"{f['threshold_seconds']//60} min")
+            else:
+                lines.append(
+                    f"- `{f['workflow']}` run {f['run_id']} ({f['event']}) has been "
+                    f"**in progress {f['age_seconds']//60} min**, threshold "
+                    f"{f['threshold_seconds']//60} min — basis: {f['basis']}")
+        lines.append("")
+    lines += ["**Census of every state exit** (emitted on every run, including the "
+              "all-clear — a silent alarm is indistinguishable from a healthy system):", ""]
+    for mode in sorted(census):
+        lines += [f"`{mode}`", "", "```"]
+        lines += [f"{k}: {v}" for k, v in sorted(census[mode].items())]
+        lines += ["```", ""]
+    lines.append(f"<!-- {KEY_PREFIX}: {repo} -->")
+    return "\n".join(lines)
+
+
+def file_issue(repo: str, body: str, count: int) -> None:
+    """One open issue, keyed by the body marker. Exact-match the marker rather than
+    using `--search`: a key containing punctuation tokenises unreliably, which could MISS
+    an existing issue and mint a duplicate."""
+    marker = f"<!-- {KEY_PREFIX}: {repo} -->"
+    existing = _gh(["api", "--paginate", "--slurp",
+                    f"repos/{repo}/issues?state=open&labels={BASE_LABELS[0]}&per_page=100"])
+    if not isinstance(existing, list):
+        raise AlarmError("issue listing is not a list")
+    for page in existing:
+        for issue in page if isinstance(page, list) else []:
+            if isinstance(issue, dict) and marker in str(issue.get("body") or ""):
+                _gh(["api", "-X", "PATCH", f"repos/{repo}/issues/{issue['number']}",
+                     "-f", f"body={body}"])
+                print(f"::notice::updated existing ci-latency-alarm issue "
+                      f"#{issue['number']}")
+                return
+    title = f"ci-latency-alarm: {count} CI execution-latency breach(es) in {repo}"
+    _gh(["api", "-X", "POST", f"repos/{repo}/issues",
+         "-f", f"title={title}", "-f", f"body={body}",
+         *[arg for label in BASE_LABELS for arg in ("-f", f"labels[]={label}")]])
+    print("::notice::filed a new ci-latency-alarm issue")
+
+
+# ---------------------------------------------------------------------------------
+# orchestration
+# ---------------------------------------------------------------------------------
+def run(args: argparse.Namespace) -> int:
+    now = _ts(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
+
+    if args.state_file:
+        state = json.loads(Path(args.state_file).read_text(encoding="utf-8"))
+        repo = state.get("repo") or args.repo or "hermetic/fixture"
+        lanes = state.get("lanes", [])
+        for lane in lanes:
+            lane["schedule_run_times"] = [_ts(t) for t in lane.get("schedule_run_times", [])]
+        live = state.get("live_runs", [])
+        baselines = {tuple(k.split(BASELINE_KEY_SEP, 1)): v
+                     for k, v in (state.get("baselines") or {}).items()}
+    else:
+        repo = args.repo or os.environ.get("GITHUB_REPOSITORY") or ""
+        if "/" not in repo:
+            raise AlarmError(f"no usable repo slug: {repo!r}")
+        root = Path(__file__).resolve().parents[1]
+        lanes = fetch_lanes(repo, root / ".github" / "workflows",
+                            args.window_hours, now)
+        live = fetch_live_runs(repo)
+        baselines = {}
+        for r in live:
+            if r.get("status") != "in_progress":
+                continue
+            key = (r.get("path") or r.get("name") or "?", r.get("event"))
+            if key not in baselines and r.get("path"):
+                baselines[key] = fetch_baseline(repo, r["path"], r.get("event") or "push")
+
+    # EMPTY SCAN SET IS FAIL-LOUD. A detector watching nothing is not a healthy repo; it
+    # is a broken detector, and the two must never look alike. This is the 100% question
+    # applied to M1: if every workflow were cron-only, M1's population would be empty and
+    # a `return 0` here would report health while watching zero lanes.
+    if not lanes:
+        raise AlarmError("empty scan set: no workflows discovered")
+    if not any(lane.get("in_scope") for lane in lanes):
+        raise AlarmError(
+            "empty M1 scan set: no workflow has a `schedule:` plus a trigger outside "
+            f"{sorted(INVISIBLE_TRIGGERS)} — either the repo changed shape or the scope "
+            "predicate broke. Refusing to report health over an empty population.")
+
+    m1, c1 = find_cron_deficits(lanes, now, args.window_hours)
+    m2, c2 = find_queue_overruns(live, now)
+    m3, c3 = find_execution_overruns(live, baselines, now)
+    findings = m1 + m2 + m3
+    census = {"M1-cron-firing-deficit": c1, "M2-queue-wait": c2,
+              "M3-execution-overrun": c3}
+
+    print(f"ci-latency census for {repo} at {now:%Y-%m-%dT%H:%M:%SZ} "
+          f"({len(lanes)} workflows, {len(live)} live runs):")
+    for mode in sorted(census):
+        print(f"  {mode}:")
+        for state, count in sorted(census[mode].items()):
+            print(f"    {state}: {count}")
+    for f in findings:
+        print(f"  BREACH {f['mode']} {f['workflow']}")
+
+    if not findings:
+        print("::notice::CI execution latency is within every measured threshold")
+        return 0
+
+    body = render_issue_body(repo, findings, census, now)
+    if args.dry_run:
+        print(body)
+    else:
+        file_issue(repo, body, len(findings))
+    print(f"::error::{len(findings)} CI execution-latency breach(es) in {repo} — "
+          "runner pickup, cron delivery, or execution time is outside its measured band")
+    return 1
+
+
+# ---------------------------------------------------------------------------------
+# hermetic self-test — runs as the FIRST step of every alarm run, so a broken detector
+# reds before it is trusted to watch anything.
+# ---------------------------------------------------------------------------------
+def capped_expectation(window_hours: float = CRON_WINDOW_HOURS) -> int:
+    """The most a lane can be expected to deliver in a window — exposed so tests assert
+    against the DERIVED value rather than re-hard-coding it (a test that pins 12 would go
+    green-but-wrong if the cap changed)."""
+    return int(CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR * window_hours)
+
+
+def _lane(workflow="a.yml", crons=("*/10 * * * *",), cron_only=False,
+          in_scope=True, state="active", fires=0, now=None, spacing_min=30):
+    """`fires` runs, all placed strictly INSIDE the counted window (older than the grace
+    cut-off, newer than the window start), so a fixture's count is exactly its `fires`."""
+    now = now or dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
+    first = now - dt.timedelta(minutes=CRON_GRACE_MINUTES + 1)
+    times = [first - dt.timedelta(minutes=spacing_min * i) for i in range(fires)]
+    return {"workflow": workflow, "crons": list(crons), "cron_only": cron_only,
+            "in_scope": in_scope, "state": state, "schedule_run_times": times}
+
+
+def _run_obj(status="in_progress", event="schedule", path=".github/workflows/a.yml",
+             age_min=10, now=None, name="A"):
+    now = now or dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
+    stamp = (now - dt.timedelta(minutes=age_min)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return {"id": 1, "name": name, "path": path, "event": event, "status": status,
+            "created_at": stamp, "run_started_at": stamp, "head_branch": "main"}
+
+
+def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads best flat
+    failures: list[str] = []
+
+    def check(name: str, condition: bool) -> None:
+        if not condition:
+            failures.append(name)
+
+    NOW = dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
+    H6 = NOW - dt.timedelta(hours=6)
+
+    # --- cron expansion, canary-validated against hand-computed answers ---
+    check("cron */10 over 6h == 36", expected_firings("*/10 * * * *", H6, NOW) == 36)
+    check("cron */10 over 24h == 144",
+          expected_firings("*/10 * * * *", NOW - dt.timedelta(hours=24), NOW) == 144)
+    check("cron nightly over 24h == 1",
+          expected_firings("17 3 * * *", NOW - dt.timedelta(hours=24), NOW) == 1)
+    check("cron explicit-minute list over 6h == 36",
+          expected_firings("4,14,24,34,44,54 * * * *", H6, NOW) == 36)
+    check("cron 4-hourly over 24h == 6",
+          expected_firings("0 */4 * * *", NOW - dt.timedelta(hours=24), NOW) == 6)
+    check("cron weekly Monday absent from a Tuesday 24h window",
+          expected_firings("0 6 * * 1", NOW - dt.timedelta(hours=24), NOW) == 0)
+    check("cron weekly Monday present in a 48h window",
+          expected_firings("0 6 * * 1", NOW - dt.timedelta(hours=48), NOW) == 1)
+    # POSIX day-field UNION semantics (dom AND dow both restricted -> OR, not AND).
+    check("cron dom+dow both restricted is a UNION",
+          expected_firings("0 0 1 * 3", dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc),
+                           dt.datetime(2026, 7, 31, tzinfo=dt.timezone.utc)) > 1)
+    for bad in ("", "* * * *", "* * * * * *", "60 * * * *", "*/0 * * * *", "5-1 * * * *"):
+        try:
+            expected_firings(bad, H6, NOW)
+            check(f"cron {bad!r} must raise CronError", False)
+        except CronError:
+            pass
+        except Exception:
+            check(f"cron {bad!r} raised the wrong error", False)
+
+    # --- M1 scope is the exact complement of #4368 ---
+    sched_only = {"schedule": [{"cron": "*/10 * * * *"}], "workflow_dispatch": None}
+    mixed = dict(sched_only, pull_request=None)
+    check("M1 excludes a cron-ONLY lane (#4368 owns it)", m1_scope(sched_only)[0] is False)
+    check("M1 marks a cron-only lane as such", m1_scope(sched_only)[2] is True)
+    check("M1 includes a schedule+other-trigger lane", m1_scope(mixed)[0] is True)
+    check("M1 excludes an unscheduled workflow", m1_scope({"push": None})[0] is False)
+
+    # --- M1 detection ---
+    CAP = capped_expectation()
+    f, c = find_cron_deficits([_lane(fires=CAP, now=NOW)], NOW)
+    check("M1 quiet when the lane delivers its capped expectation",
+          not f and c.get("delivering") == 1)
+    f, c = find_cron_deficits([_lane(fires=1, now=NOW)], NOW)
+    check("M1 raises on a firing deficit", len(f) == 1 and c.get("firing-deficit") == 1)
+    check("M1 finding carries the CAPPED expectation and the nominal rate",
+          f and f[0]["expected"] == CAP and f[0]["actual"] == 1
+          and f[0]["nominal"] > CAP)
+    f, _ = find_cron_deficits([_lane(fires=0, now=NOW)], NOW)
+    check("M1 raises when a cron fired ZERO times (the no-artifact mode)", len(f) == 1)
+    # The cap is what stops a `*/10` lane alarming forever: nominal 144/day, GitHub
+    # delivers ~12, and 12 of a capped 12 is healthy.
+    f, _ = find_cron_deficits([_lane(crons=("*/10 * * * *",), fires=CAP, now=NOW)], NOW)
+    check("M1 does not alarm on a sub-hourly lane delivering GitHub's real ceiling", not f)
+    # A firing NEWER than the grace cut-off must not be counted as missing.
+    edge = _lane(fires=0, now=NOW)
+    edge["schedule_run_times"] = [NOW - dt.timedelta(minutes=1)] * CAP
+    f, _ = find_cron_deficits([edge], NOW)
+    check("M1 ignores firings inside the grace window (they are not yet due)", len(f) == 1)
+    f, c = find_cron_deficits([_lane(cron_only=True, in_scope=False, fires=0)], NOW)
+    check("M1 never raises on a cron-only lane",
+          not f and c.get("cron-only (watched by #4368)") == 1)
+    f, c = find_cron_deficits([_lane(state="disabled_manually", fires=0, now=NOW)], NOW)
+    check("M1 quiet on a disabled lane", not f and c.get("disabled") == 1)
+    f, c = find_cron_deficits([_lane(crons=("not a cron",), fires=0, now=NOW)], NOW)
+    check("M1 quiet + counted on an unparseable cron",
+          not f and c.get("cron-unparseable") == 1)
+    # A weekly lane has a capped expectation of 0 inside a 24h window -> below the floor.
+    f, c = find_cron_deficits([_lane(crons=("0 6 * * 1",), fires=0, now=NOW)], NOW)
+    check("M1 quiet when the expectation is below the floor",
+          not f and c.get("expectation-below-floor") == 1)
+    # Boundary direction: at/above the delivery floor must NOT raise; just below must.
+    import math  # noqa: PLC0415
+    at_floor = math.ceil(CAP * CRON_DELIVERY_FLOOR)
+    f, _ = find_cron_deficits([_lane(fires=at_floor, now=NOW)], NOW)
+    check("M1 does not raise AT the delivery floor", not f)
+    f, _ = find_cron_deficits([_lane(fires=at_floor - 1, now=NOW)], NOW)
+    check("M1 does raise just BELOW the delivery floor", len(f) == 1)
+    # Over-delivery clamps to 1.00 rather than exceeding it.
+    f, _ = find_cron_deficits([_lane(fires=CAP * 3, now=NOW)], NOW)
+    check("M1 clamps an over-delivering lane to healthy", not f)
+
+    # --- M2 ---
+    late = _run_obj(status="queued", age_min=int(QUEUE_MAX_WAIT_SECONDS / 60) + 5, now=NOW)
+    early = _run_obj(status="queued", age_min=1, now=NOW)
+    f, c = find_queue_overruns([late], NOW)
+    check("M2 raises past the queue threshold",
+          len(f) == 1 and c.get("queued-over-threshold") == 1)
+    f, c = find_queue_overruns([early], NOW)
+    check("M2 quiet within the queue threshold",
+          not f and c.get("queued-within-threshold") == 1)
+    f, _ = find_queue_overruns([_run_obj(status="in_progress", age_min=999, now=NOW)], NOW)
+    check("M2 ignores in_progress runs (that is M3's job)", not f)
+
+    # --- M3: detection variable is LIVE in_progress age ---
+    base = {(".github/workflows/a.yml", "schedule"): {"p90": 3600.0, "n": 50}}
+    f, c = find_execution_overruns([_run_obj(age_min=30, now=NOW)], base, NOW)
+    check("M3 quiet inside the band", not f and c.get("in-progress-within-threshold") == 1)
+    f, c = find_execution_overruns([_run_obj(age_min=8 * 60, now=NOW)], base, NOW)
+    check("M3 raises past the band", len(f) == 1 and c.get("execution-overrun") == 1)
+    f, _ = find_execution_overruns([_run_obj(status="queued", age_min=999, now=NOW)],
+                                   base, NOW)
+    check("M3 ignores queued runs (that is M2's job)", not f)
+    # THE FAIL-OPEN HOLE: a lane whose runs never complete has no baseline. It must still
+    # be watchable, or the detector goes silent exactly when a lane is 100% hung.
+    f, _ = find_execution_overruns([_run_obj(age_min=7 * 60, now=NOW)], {}, NOW)
+    check("M3 still raises with NO baseline at all (fail-open hole closed)", len(f) == 1)
+    check("M3 names the floor as the basis when there is no baseline",
+          f and "floor" in f[0]["basis"])
+    thin = {(".github/workflows/a.yml", "schedule"): {"p90": 60.0, "n": 1}}
+    f, _ = find_execution_overruns([_run_obj(age_min=7 * 60, now=NOW)], thin, NOW)
+    check("M3 falls back to the floor on an under-sampled baseline", len(f) == 1)
+    check("M3 does NOT use a 1-sample p90 as the threshold",
+          f and f[0]["threshold_seconds"] == int(EXEC_FLOOR_SECONDS))
+    # A big baseline must RAISE the threshold above the floor, not be ignored.
+    big = {(".github/workflows/a.yml", "schedule"): {"p90": 8 * 3600.0, "n": 40}}
+    f, _ = find_execution_overruns([_run_obj(age_min=7 * 60, now=NOW)], big, NOW)
+    check("M3 respects a baseline WIDER than the floor", not f)
+    f, _ = find_execution_overruns([_run_obj(age_min=17 * 60, now=NOW)], big, NOW)
+    check("M3 raises on the measured 2026-07-27 17.3h-vs-8.3h shape", len(f) == 1)
+
+    # --- census is emitted even on the all-clear ---
+    _, c1 = find_cron_deficits([_lane(fires=36, now=NOW)], NOW)
+    _, c2 = find_queue_overruns([early], NOW)
+    _, c3 = find_execution_overruns([_run_obj(age_min=1, now=NOW)], base, NOW)
+    check("a clean run still emits a non-empty census for every mode",
+          bool(c1) and bool(c2) and bool(c3))
+
+    # --- issue body carries the dedupe marker ---
+    body = render_issue_body("o/r", [{"mode": "M2-queue-wait", "workflow": "a.yml",
+                                      "run_id": 1, "event": "push", "waited_seconds": 99,
+                                      "threshold_seconds": 60, "head_branch": "main"}],
+                             {"M2-queue-wait": {"queued-over-threshold": 1}}, NOW)
+    check("issue body ends with the dedupe marker",
+          body.rstrip().endswith(f"<!-- {KEY_PREFIX}: o/r -->"))
+    check("issue body self-identifies as a SPARQ agent", body.startswith("> 🤖"))
+    check("issue body prints the census", "Census of every state exit" in body)
+
+    # --- exit codes are distinct ---
+    check("a bad repo slug is fail-loud exit 2",
+          main(["--repo", "not-a-slug", "--dry-run"]) == 2)
+
+    if failures:
+        for name in failures:
+            print(f"FAIL: {name}")
+        print(f"::error::ci_execution_latency_alarm self-test: {len(failures)} failure(s)")
+        return 1
+    print("ci_execution_latency_alarm self-test: all checks passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CI execution-latency alarm")
+    parser.add_argument("--repo", default="")
+    parser.add_argument("--now", default="")
+    parser.add_argument("--state-file", default="")
+    parser.add_argument("--window-hours", type=float, default=CRON_WINDOW_HOURS)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    try:
+        return run(args)
+    except AlarmError as exc:
+        print(f"::error::ci execution-latency alarm infrastructure failure: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_execution_latency_alarm.py
+++ b/scripts/ci_execution_latency_alarm.py
@@ -196,11 +196,24 @@ CRON_DELIVERY_FLOOR = 0.60
 # queue event. Both figures were produced by the contaminated estimator above, and the
 # "real event" was those seven `run_attempt: 2` re-runs. That evidence is retracted.
 #
-# RE-DERIVED 2026-07-28 with the decontaminated estimator, over the completed-run corpus
-# restricted to `run_attempt == 1` (so no re-run can enter it) and with every re-run's
-# TRUE wait resolved against its own `/attempts/{n}` record:
-#   sparq-org/sparq               N=CORPUS_SPARQ_N   over 15 min: CORPUS_SPARQ_OVER
-#   jeswr/agent-account-registry  N=CORPUS_REG_N   over 15 min: CORPUS_REG_OVER
+# RE-DERIVED 2026-07-28 with the decontaminated estimator, over a per-workflow scan (the
+# repo-wide `actions/runs` listing hard-caps at 1000), splitting on `run_attempt` and
+# resolving every re-run's TRUE wait against its own `/attempts/{n}` record:
+#
+#                                          sparq-org/sparq   jeswr/agent-account-registry
+#   completed runs scanned                          35,128                          9,062
+#   contaminated estimator, over 15 min                  7                              6
+#     ... of which are RE-RUNS                     7 (ALL)                        6 (ALL)
+#   DECONTAMINATED (run_attempt == 1)               35,070                          9,053
+#     over 15 min                                        0                              0
+#     with ANY non-zero wait at all                      0                              0
+#     maximum observed wait                           0.0s                           0.0s
+#   re-runs resolved per-attempt                        58                              9
+#     over 15 min                                        0                              0
+#     true maximum wait                              -1.0s                          -1.0s
+#
+# Every single row the old estimator flagged, on BOTH repos, was a re-run artefact. Across
+# 44,190 completed runs there is not ONE attempt whose own queue wait was even non-zero.
 #
 # SO M2 HAS NO VALIDATED KNOWN POSITIVE. There is no run in either observed corpus that
 # this mode would have fired on. That is stated plainly rather than papered over, and it

--- a/scripts/ci_execution_latency_alarm.py
+++ b/scripts/ci_execution_latency_alarm.py
@@ -382,9 +382,11 @@ def find_cron_deficits(lanes: list[dict], now: dt.datetime,
             bump("expectation-below-floor")
             continue
         actual = sum(1 for t in lane["schedule_run_times"] if start < t <= end)
-        # Clamp: a lane that over-delivers (a manual re-run inside the window) is at 1.00,
-        # never above it. Without the clamp an over-delivering lane could mask a sibling.
-        ratio = min(actual, expected) / expected
+        # No clamp on `actual`: an over-delivering lane gives a ratio above 1.0, which is
+        # >= the floor and therefore healthy either way. A `min(actual, expected)` here
+        # was removed after its own mutant SURVIVED — it changed no observable output, so
+        # it was dead code, and an untestable guard is worse than no guard.
+        ratio = actual / expected
         if ratio < CRON_DELIVERY_FLOOR:
             bump("firing-deficit")
             findings.append({

--- a/scripts/ci_execution_latency_alarm.py
+++ b/scripts/ci_execution_latency_alarm.py
@@ -241,11 +241,28 @@ CRON_DELIVERY_FLOOR = 0.60
 # of each lane's configured concurrency and per-leg duration, and there is no observed
 # positive to validate such a model against. That is a research task, not a threshold.
 #
-# WHAT WOULD CHANGE THIS. A run observed with `status=queued` and a genuine per-attempt
-# wait — i.e. `/attempts/{n}` showing `run_started_at - created_at` materially above zero.
-# If one appears, the estimator to use is the per-attempt one (point 1), NOT the run-level
-# field. Until then an alarm here would answer "would we know if we were starved?" with a
-# confident yes that the measurements above do not support.
+# 4. AND THE STRONGEST REASON, FOUND LAST: THE FIELDS CANNOT EXPRESS THE QUANTITY.
+#    This is not "no positive was observed" — the data source does not carry enqueue time
+#    at all, so no threshold on it could ever have worked.
+#      attempt-1 runs, `run_started_at - created_at`: EXACTLY 0.0 on all 44,123 of them
+#        (35,070 sparq + 9,053 registry). Not approximately zero -- identically zero.
+#      re-run attempts, `run_started_at - attempt.created_at`, N=67 (58 sparq + 9 registry):
+#        NEGATIVE on every single one -- sparq {-1: 41, -2: 15, -4: 1, -5: 1},
+#        registry {-1: 7, -2: 2}. A queue wait cannot be negative.
+#    A negative value means the attempt record's `created_at` is stamped at or AFTER the
+#    run starts, not when it is enqueued; and an exactly-zero run-level difference across
+#    44,123 runs is what you see when the two fields are set together rather than
+#    measuring an interval between two events. So BOTH the run-level pair and the
+#    per-attempt pair are unable to express "how long did this wait to be picked up".
+#    The all-zero corpus in point 2 is therefore not evidence that no queueing happened;
+#    it is evidence that these fields do not report queueing.
+#
+# WHAT WOULD CHANGE THIS -- and it is NOT a better threshold. Do not re-derive a detector
+# from `created_at`/`run_started_at` on either the run or the attempt: point 4 shows they
+# cannot carry the signal at any threshold. It would take a DIFFERENT data source that
+# actually timestamps enqueue -- a webhook capturing `workflow_job` `queued` -> `in_progress`
+# transitions, or self-reported timing from inside the job -- plus at least one observed
+# positive from it before a threshold means anything.
 
 # --- M3: execution overrun ---------------------------------------------------------
 # Threshold = max(EXEC_OVERRUN_MULTIPLE x p90(completed durations for this workflow+event),

--- a/scripts/ci_execution_latency_alarm.py
+++ b/scripts/ci_execution_latency_alarm.py
@@ -174,19 +174,60 @@ CRON_MIN_EXPECTED = 1
 CRON_DELIVERY_FLOOR = 0.60
 
 # --- M2: queue wait (runner availability proper) -----------------------------------
-# MEASURED run-level queue wait (`run_started_at - created_at`) over COMPLETED runs:
-#   sparq-org/sparq               N=13,802   p50 0s  p90 0s  p99 0s   max 94.2m
-#   jeswr/agent-account-registry  N= 3,920   p50 0s  p90 0s  p99 0s   max 99.5m
-# The metric is ZERO-INFLATED: 22 of 13,802 sparq runs (0.16%) and 8 of 3,920 registry
-# runs (0.20%) ever recorded a non-zero wait. That is why this threshold is NOT stated as
-# a multiple of the observed maximum, the way M3's is — multiplying a max of 94.2m gives a
-# threshold nothing could ever reach, and multiplying a p99 of 0s gives 0. For a
-# zero-inflated distribution the honest statement is the false-positive rate.
-# 15 min: fires on 3 of 13,802 sparq completed runs (0.022%) and 6 of 3,920 registry runs
-# (0.153%). The registry six are not false positives — they are a REAL contiguous queue
-# event, seven `pr-gate.yml` runs held 12.8-99.5 min between 00:58Z and 02:24Z on
-# 2026-07-28, which is precisely the condition this mode exists to report.
+#
+# THE RE-RUN TRAP — read before touching anything in this mode.
+# `created_at` on the RUN-level object is the creation time of ATTEMPT 1 and does NOT
+# reset when a run is re-run, while `run_attempt` and `run_started_at` DO track the live
+# attempt. MEASURED 2026-07-28 on jeswr/agent-account-registry run 30318886362:
+#     run-level    run_attempt=2  created_at=00:58:13Z  run_started_at=02:37:40Z
+#     /attempts/1                 created_at=00:58:13Z  run_started_at=00:58:13Z   0s
+#     /attempts/2                 created_at=02:37:41Z  run_started_at=02:37:40Z   0s
+# Neither attempt ever queued. The 99-minute "wait" is the IDLE GAP between attempt 1
+# failing at 01:00Z and a re-run being pressed at 02:37Z.
+# Executed on that exact payload, `now - run["created_at"]` reports waited_seconds=5967
+# for an attempt picked up in under a second — so the naive form fires on EVERY re-run
+# older than the threshold, which is the normal case, and a permanently-red alarm is a
+# muted alarm. `attempt_created_at()` below is the fix. Do not reintroduce a bare
+# `run.get("created_at")` here.
+#
+# THRESHOLD — and an HONEST statement of what does and does not support it.
+# WITHDRAWN: an earlier revision of this file claimed "fires on 3 of 13,802 sparq runs
+# (0.022%) and 6 of 3,920 registry runs (0.153%)", and cited the registry six as a real
+# queue event. Both figures were produced by the contaminated estimator above, and the
+# "real event" was those seven `run_attempt: 2` re-runs. That evidence is retracted.
+#
+# RE-DERIVED 2026-07-28 with the decontaminated estimator, over the completed-run corpus
+# restricted to `run_attempt == 1` (so no re-run can enter it) and with every re-run's
+# TRUE wait resolved against its own `/attempts/{n}` record:
+#   sparq-org/sparq               N=CORPUS_SPARQ_N   over 15 min: CORPUS_SPARQ_OVER
+#   jeswr/agent-account-registry  N=CORPUS_REG_N   over 15 min: CORPUS_REG_OVER
+#
+# SO M2 HAS NO VALIDATED KNOWN POSITIVE. There is no run in either observed corpus that
+# this mode would have fired on. That is stated plainly rather than papered over, and it
+# has two consequences that must not be lost:
+#
+#   (i)  The threshold CANNOT be derived from the observed distribution, because after
+#        decontamination the distribution is not merely zero-inflated, it is essentially
+#        ALL ZERO. There is no percentile, multiple, or maximum to anchor to. The corpus
+#        constrains this constant from BELOW only (any value above the observed max has a
+#        measured false-positive rate of zero); it says nothing about where in that
+#        half-line to sit. 15 min is therefore a JUDGMENT about how long a human should
+#        wait before being told, not a measurement, and is labelled as such.
+#   (ii) The corpus proxy is itself weak. `run_started_at - created_at` is a RUN-level
+#        statistic, and the measurement trap in the header is precisely that a run whose
+#        jobs are throttled behind `max-parallel` reads `status=queued` ZERO for hours.
+#        So a zero here is consistent with "no queueing happened" AND with "the API does
+#        not express the queueing that happened". It cannot distinguish them.
+#
+# M2 therefore ships as an UNVALIDATED detector for the maintainer's stated concern, with
+# a measured false-positive rate of 0 over N and no demonstrated true positive. It is
+# cheap (it reads live state already fetched for M3) and it is the only watcher on
+# `status=queued` at all. It is not evidence that queue waits are being caught.
 QUEUE_MAX_WAIT_SECONDS = 15 * 60
+# Key the fetch layer writes onto a queued run whose live attempt is NOT attempt 1: the
+# `created_at` of that attempt's own `/attempts/{n}` record. Absent on attempt-1 runs by
+# design — for those the run-level field is the attempt's field.
+ATTEMPT_CREATED_KEY = "_attempt_created_at"
 
 # --- M3: execution overrun ---------------------------------------------------------
 # Threshold = max(EXEC_OVERRUN_MULTIPLE x p90(completed durations for this workflow+event),
@@ -372,6 +413,29 @@ def find_cron_deficits(lanes: list[dict], now: dt.datetime,
         if lane.get("state") != "active":
             bump("disabled")
             continue
+        # NEW-LANE WINDOW. A lane that did not EXIST for the whole window looks identical
+        # to a lane that stopped firing: out of run times alone the detector cannot tell
+        # "did not fire" from "did not exist yet", so a `*/10` lane added two hours ago
+        # reads ratio 0.08 and alarms for the next ~14 hours. The workflow's own
+        # `created_at` (carried on the `actions/workflows` listing) is the signal that
+        # resolves it.
+        # PRORATING THE EXPECTATION WAS TRIED AND REJECTED: scaling the cap by the lane's
+        # observed lifetime gives a young lane an expectation of ~2, and at a floor of
+        # 0.60 a single undelivered firing (1 of 2) still alarms. A prorated expectation
+        # is not a smaller measurement, it is noise — the cap it derives from is itself a
+        # RATE measured over a full 24h, and GitHub's delivery is bursty at short scales.
+        # (MEASURED: the prorated form still alarmed on a 2h-old lane at the registry's
+        # cap of 30, and was quiet at sparq's 12, which is a threshold that depends on
+        # which repo it is deployed to — not a property of the lane.)
+        # So a lane younger than the window is COUNTED and skipped, never guessed at; it
+        # becomes watchable one window after it appears. The gap is deliberate, bounded,
+        # and visible in the census rather than silent.
+        created = lane.get("created_at")
+        if created:
+            born = created if isinstance(created, dt.datetime) else _ts(created)
+            if born > start:
+                bump("lane-too-new-for-an-expectation")
+                continue
         try:
             nominal = sum(expected_firings(c, start, end) for c in lane["crons"])
         except CronError:
@@ -404,6 +468,24 @@ def find_cron_deficits(lanes: list[dict], now: dt.datetime,
     return findings, census
 
 
+def attempt_created_at(run: dict) -> str | None:
+    """The creation time of the run's CURRENTLY-EXECUTING attempt, or None if it cannot
+    be determined.
+
+    This is not `run["created_at"]`. See the RE-RUN TRAP note on QUEUE_MAX_WAIT_SECONDS:
+    the run-level `created_at` is frozen at attempt 1 and does not reset on re-run, so
+    reading it for a re-run charges the idle gap before the re-run press as queue wait.
+
+    Attempt 1 -> the run-level field IS the attempt's field (MEASURED equal on every
+    sampled run). Attempt N>1 -> the value the fetch layer resolved from
+    `/actions/runs/{id}/attempts/{n}`; None when that resolution was unavailable, which
+    the caller must treat as INDETERMINATE and count, never as the run-level value.
+    """
+    if int(run.get("run_attempt") or 1) > 1:
+        return run.get(ATTEMPT_CREATED_KEY) or None
+    return run.get("created_at") or None
+
+
 def find_queue_overruns(live_runs: list[dict], now: dt.datetime,
                         max_wait: float = QUEUE_MAX_WAIT_SECONDS
                         ) -> tuple[list[dict], dict]:
@@ -417,9 +499,14 @@ def find_queue_overruns(live_runs: list[dict], now: dt.datetime,
     for run in live_runs:
         if run.get("status") != "queued":
             continue
-        created = run.get("created_at")
+        created = attempt_created_at(run)
         if not created:
-            bump("queued-no-timestamp")
+            # A re-run whose own attempt record could not be resolved is INDETERMINATE.
+            # Fail-safe QUIET but COUNTED: the run-level `created_at` is available and
+            # known-wrong here, and firing a known-false alarm is worse than a visible
+            # gap. Two distinct census states so the two causes stay separable.
+            bump("queued-rerun-attempt-unresolved"
+                 if int(run.get("run_attempt") or 1) > 1 else "queued-no-timestamp")
             continue
         waited = (now - _ts(created)).total_seconds()
         if waited > max_wait:
@@ -431,6 +518,7 @@ def find_queue_overruns(live_runs: list[dict], now: dt.datetime,
                 "event": run.get("event"),
                 "waited_seconds": int(waited),
                 "threshold_seconds": int(max_wait),
+                "run_attempt": int(run.get("run_attempt") or 1),
                 "head_branch": run.get("head_branch"),
             })
         else:
@@ -546,13 +634,45 @@ def _paged_runs(repo: str, query: str) -> list[dict]:
     raise AlarmError(f"workflow-run listing exceeded {RUNS_PAGE_CAP} pages for {query!r}")
 
 
+def resolve_attempt_created(repo: str, runs: list[dict]) -> list[dict]:
+    """Enrich every QUEUED run whose live attempt is not attempt 1 with that attempt's own
+    `created_at`, under ATTEMPT_CREATED_KEY.
+
+    WITHOUT THIS CALL M2 IS A FALSE-POSITIVE GENERATOR — see the RE-RUN TRAP note. It is
+    a separate pass rather than logic inside `find_queue_overruns` so the detectors stay
+    pure functions over already-fetched state and remain hermetically testable.
+
+    REQUEST COST is zero in the common case: the pass touches only `queued` runs at
+    attempt > 1. MEASURED over the newest 1000 completed runs per repo on 2026-07-28,
+    re-runs were 2/1000 on sparq and 0/1000 on the registry, and the `queued` population
+    is normally empty. A failed lookup leaves the key absent, which the detector counts as
+    `queued-rerun-attempt-unresolved` rather than falling back to the known-wrong value.
+    """
+    for run in runs:
+        if run.get("status") != "queued":
+            continue
+        attempt = int(run.get("run_attempt") or 1)
+        if attempt <= 1 or not run.get("id"):
+            continue
+        try:
+            payload = _gh(["api", f"repos/{repo}/actions/runs/{run['id']}"
+                                  f"/attempts/{attempt}"])
+        except AlarmError:
+            # Quiet + counted downstream. One unresolvable attempt record must not abort
+            # the whole tick and take M1 and M3 down with it.
+            continue
+        if isinstance(payload, dict) and payload.get("created_at"):
+            run[ATTEMPT_CREATED_KEY] = payload["created_at"]
+    return runs
+
+
 def fetch_live_runs(repo: str) -> list[dict]:
     """Every run currently `queued` or `in_progress`. This is the live-state read that
     M2 and M3 key on; it is NOT derived from completed work (header note (a))."""
     live: list[dict] = []
     for status in ("queued", "in_progress"):
         live.extend(_paged_runs(repo, f"status={status}"))
-    return live
+    return resolve_attempt_created(repo, live)
 
 
 def fetch_baseline(repo: str, workflow_path: str, event: str) -> dict:
@@ -588,6 +708,9 @@ def fetch_lanes(repo: str, workflows_dir: Path, window_hours: float,
     if not isinstance(listing, dict) or listing.get("workflows") is None:
         raise AlarmError("workflow listing carries no workflows")
     state_by_path = {w["path"]: w.get("state") for w in listing["workflows"]}
+    # The lane's own birth date, which is the ONLY thing that separates "did not fire"
+    # from "did not exist yet" — see the NEW-LANE WINDOW note in find_cron_deficits.
+    created_by_path = {w["path"]: w.get("created_at") for w in listing["workflows"]}
 
     lanes: list[dict] = []
     start = now - dt.timedelta(hours=window_hours)
@@ -597,6 +720,7 @@ def fetch_lanes(repo: str, workflows_dir: Path, window_hours: float,
         in_scope, crons, cron_only = m1_scope(on)
         lane = {"workflow": rel, "crons": crons, "cron_only": cron_only,
                 "in_scope": in_scope, "state": state_by_path.get(rel, "active"),
+                "created_at": created_by_path.get(rel),
                 "schedule_run_times": []}
         if in_scope and lane["state"] == "active":
             payload = _gh(["api", f"repos/{repo}/actions/workflows/{path.name}/runs"
@@ -772,22 +896,59 @@ def capped_expectation(window_hours: float = CRON_WINDOW_HOURS) -> int:
 
 
 def _lane(workflow="a.yml", crons=("*/10 * * * *",), cron_only=False,
-          in_scope=True, state="active", fires=0, now=None, spacing_min=30):
+          in_scope=True, state="active", fires=0, now=None, spacing_min=30,
+          created_hours_ago=None):
     """`fires` runs, all placed strictly INSIDE the counted window (older than the grace
-    cut-off, newer than the window start), so a fixture's count is exactly its `fires`."""
+    cut-off, newer than the window start), so a fixture's count is exactly its `fires`.
+
+    `created_hours_ago` gives the lane a birth date, for the NEW-LANE WINDOW. `None`
+    means an established lane (no `created_at`), which must behave exactly as before.
+    """
     now = now or dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
     first = now - dt.timedelta(minutes=CRON_GRACE_MINUTES + 1)
     times = [first - dt.timedelta(minutes=spacing_min * i) for i in range(fires)]
-    return {"workflow": workflow, "crons": list(crons), "cron_only": cron_only,
+    lane = {"workflow": workflow, "crons": list(crons), "cron_only": cron_only,
             "in_scope": in_scope, "state": state, "schedule_run_times": times}
+    if created_hours_ago is not None:
+        lane["created_at"] = (now - dt.timedelta(hours=created_hours_ago)
+                              ).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return lane
 
 
 def _run_obj(status="in_progress", event="schedule", path=".github/workflows/a.yml",
-             age_min=10, now=None, name="A"):
+             age_min=10, now=None, name="A", attempt=1, created_age_min=None,
+             attempt_created_age_min=None):
+    """The REAL shape of an `actions/runs` element, not a minimal hand-built dict.
+
+    A narrow fixture is a vacuity generator. `started = run.get("updated_at") or
+    run_started_at` SURVIVED the first mutation battery for exactly one reason: no fixture
+    carried `updated_at`, while EVERY live run does — and on a live run `updated_at` is
+    bumped continuously, so that mutant collapses M3's age to ~0 and the mode never fires
+    again. The keys and their relationships below are taken from a real payload
+    (jeswr/agent-account-registry run 30318886362).
+
+    `created_age_min` exists to reproduce the RE-RUN shape, where the run-level
+    `created_at` is FROZEN at attempt 1 while `run_started_at` tracks the live attempt.
+    """
     now = now or dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
-    stamp = (now - dt.timedelta(minutes=age_min)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    return {"id": 1, "name": name, "path": path, "event": event, "status": status,
-            "created_at": stamp, "run_started_at": stamp, "head_branch": "main"}
+
+    def stamp(minutes: float) -> str:
+        return (now - dt.timedelta(minutes=minutes)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    obj = {
+        "id": 1, "name": name, "path": path, "event": event, "status": status,
+        "conclusion": None, "run_attempt": attempt, "workflow_id": 99, "run_number": 7,
+        "display_title": name, "head_branch": "main", "head_sha": "0" * 40,
+        "created_at": stamp(created_age_min if created_age_min is not None else age_min),
+        "run_started_at": stamp(age_min),
+        # A LIVE run's `updated_at` tracks the PRESENT moment, which is what makes it a
+        # catastrophic substitute for `run_started_at` in M3.
+        "updated_at": stamp(0) if status != "completed" else stamp(age_min),
+        "html_url": "https://example.invalid/run/1",
+    }
+    if attempt_created_age_min is not None:
+        obj[ATTEMPT_CREATED_KEY] = stamp(attempt_created_age_min)
+    return obj
 
 
 def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads best flat
@@ -799,6 +960,26 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
 
     NOW = dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
     H6 = NOW - dt.timedelta(hours=6)
+
+    # --- THE CONSTANTS, pinned against LITERALS that do not derive from them ----------
+    # Every threshold in this file was previously exercised only through fixtures
+    # COMPUTED FROM the constant, so the fixture rescaled with the mutant and the mutant
+    # survived. MEASURED instance: `CRON_DELIVERY_FLOOR 0.60 -> 0.05` survived the entire
+    # suite in the sibling deployment because `at_floor = ceil(CAP * FLOOR)` moved with
+    # it. A constant is only pinned by a value that is written down independently.
+    check("CRON_WINDOW_HOURS is 24h — the value the rejected 6h trial was replaced by",
+          CRON_WINDOW_HOURS == 24.0)
+    check("CRON_DELIVERY_FLOOR is inside its validated band (worst healthy lane 0.75)",
+          0.50 <= CRON_DELIVERY_FLOOR <= 0.70)
+    check("CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR matches the measured sparq ceiling",
+          CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR == 0.5)
+    check("CRON_GRACE_MINUTES is 15", CRON_GRACE_MINUTES == 15)
+    check("QUEUE_MAX_WAIT_SECONDS is 15 minutes", QUEUE_MAX_WAIT_SECONDS == 15 * 60)
+    check("EXEC_OVERRUN_MULTIPLE is inside the band that still catches the 2.08x outlier",
+          1.25 <= EXEC_OVERRUN_MULTIPLE <= 2.0)
+    check("EXEC_FLOOR_SECONDS is GitHub's 6h hosted-runner job ceiling",
+          EXEC_FLOOR_SECONDS == 6 * 60 * 60)
+    check("BASELINE_MIN_N is 5", BASELINE_MIN_N == 5)
 
     # --- cron expansion, canary-validated against hand-computed answers ---
     check("cron */10 over 6h == 36", expected_firings("*/10 * * * *", H6, NOW) == 36)
@@ -875,9 +1056,52 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
     check("M1 does not raise AT the delivery floor", not f)
     f, _ = find_cron_deficits([_lane(fires=at_floor - 1, now=NOW)], NOW)
     check("M1 does raise just BELOW the delivery floor", len(f) == 1)
-    # Over-delivery clamps to 1.00 rather than exceeding it.
+    # Over-delivery is healthy (the ratio simply exceeds 1.0; there is no clamp).
     f, _ = find_cron_deficits([_lane(fires=CAP * 3, now=NOW)], NOW)
-    check("M1 clamps an over-delivering lane to healthy", not f)
+    check("M1 treats an over-delivering lane as healthy", not f)
+
+    # --- M1 threshold pins against LITERALS ------------------------------------------
+    # `0 */4 * * *` has a 24h nominal of 5, which is BELOW the cap, so `expected` is 5
+    # regardless of CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR. Nothing in these three fixtures
+    # is computed from CRON_DELIVERY_FLOOR or from the cap, so neither can rescale them.
+    FOUR_HOURLY = ("0 */4 * * *",)
+    f, _ = find_cron_deficits([_lane(crons=FOUR_HOURLY, fires=2, now=NOW)], NOW)
+    check("M1 raises at 2 of a literal 5 (ratio 0.40) — pins the floor from BELOW",
+          len(f) == 1 and f[0]["expected"] == 5 and f[0]["ratio"] == 0.4)
+    f, _ = find_cron_deficits([_lane(crons=FOUR_HOURLY, fires=3, now=NOW)], NOW)
+    check("M1 is quiet at 3 of a literal 5 (ratio 0.60) — pins the floor from ABOVE",
+          not f)
+    f, _ = find_cron_deficits([_lane(crons=FOUR_HOURLY, fires=2, now=NOW)], NOW)
+    check("M1's DEFAULT window makes a 4-hourly lane's expectation exactly 5 "
+          "(it is 1 at the rejected 6h window)", len(f) == 1 and f[0]["expected"] == 5)
+
+    # --- M1 new-lane window: 'did not fire' vs 'did not exist yet' --------------------
+    # A `*/10` lane added two hours ago has delivered ~1 run. Against a full-window
+    # expectation of 12 that is ratio 0.08, and it alarms for the next ~14 hours.
+    young = _lane(fires=1, now=NOW, created_hours_ago=2)
+    f, c = find_cron_deficits([young], NOW)
+    check("M1 does not alarm on a lane that did not EXIST for most of the window",
+          not f)
+    check("M1 counts a too-young lane as its own census state",
+          c.get("lane-too-new-for-an-expectation") == 1)
+    # ANTI-VACUITY: the identical fixture WITHOUT a birth date must still alarm, or the
+    # new-lane exit is just an unconditional mute.
+    f, _ = find_cron_deficits([_lane(fires=1, now=NOW)], NOW)
+    check("M1 still alarms on the same delivery from an ESTABLISHED lane", len(f) == 1)
+    # And a lane old enough to have earned an expectation is judged on delivery, not age.
+    f, _ = find_cron_deficits([_lane(fires=1, now=NOW, created_hours_ago=48)], NOW)
+    check("M1 judges a lane older than the window on delivery alone", len(f) == 1)
+    f, _ = find_cron_deficits([_lane(fires=CAP, now=NOW, created_hours_ago=48)], NOW)
+    check("M1 birth-date check does not change an established lane's verdict", not f)
+    # THE BOUNDARY, pinned from both sides against the 24h window: a lane born just
+    # INSIDE the window is skipped, one born just OUTSIDE it is judged. Without both
+    # directions, `if born > start` and `if born > start - 100 years` are the same test.
+    f, c = find_cron_deficits([_lane(fires=1, now=NOW, created_hours_ago=23)], NOW)
+    check("M1 skips a lane born 23h ago (inside the 24h window)",
+          not f and c.get("lane-too-new-for-an-expectation") == 1)
+    f, c = find_cron_deficits([_lane(fires=1, now=NOW, created_hours_ago=25)], NOW)
+    check("M1 judges a lane born 25h ago (outside the 24h window)",
+          len(f) == 1 and c.get("firing-deficit") == 1)
 
     # --- M2 ---
     late = _run_obj(status="queued", age_min=int(QUEUE_MAX_WAIT_SECONDS / 60) + 5, now=NOW)
@@ -890,6 +1114,90 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
           not f and c.get("queued-within-threshold") == 1)
     f, _ = find_queue_overruns([_run_obj(status="in_progress", age_min=999, now=NOW)], NOW)
     check("M2 ignores in_progress runs (that is M3's job)", not f)
+    # ABSOLUTE fixtures. The two above derive their age FROM QUEUE_MAX_WAIT_SECONDS and
+    # rescale with it, so a mutant that multiplied the constant by 10**6 survived them.
+    f, _ = find_queue_overruns([_run_obj(status="queued", age_min=60, now=NOW)], NOW)
+    check("an hour in `queued` raises under the SHIPPED threshold", len(f) == 1)
+    f, _ = find_queue_overruns([_run_obj(status="queued", age_min=2, now=NOW)], NOW)
+    check("two minutes in `queued` stays quiet under the SHIPPED threshold", not f)
+
+    # --- M2 RE-RUN TRAP: the reason the shipped detector is not `now - created_at` -----
+    # The exact shape of jeswr/agent-account-registry run 30318886362: attempt 2, whose
+    # own creation was 1 minute ago, on a run-level object still reporting attempt 1's
+    # creation 99 minutes ago. The naive form reports a 99-minute queue wait for a
+    # pickup that took under a second.
+    rerun = _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99,
+                     attempt_created_age_min=1, now=NOW)
+    check("the re-run fixture reproduces the FROZEN run-level created_at",
+          (now_minus := (NOW - _ts(rerun["created_at"])).total_seconds()) > 90 * 60
+          and (NOW - _ts(rerun[ATTEMPT_CREATED_KEY])).total_seconds() < 5 * 60)
+    check("the naive `now - created_at` WOULD have fired on it (fixture is not vacuous)",
+          now_minus > QUEUE_MAX_WAIT_SECONDS)
+    f, c = find_queue_overruns([rerun], NOW)
+    check("M2 does NOT charge a re-run's idle gap as queue wait", not f)
+    check("M2 counts the re-run as within threshold, not as a skip",
+          c.get("queued-within-threshold") == 1)
+    # A re-run whose attempt record could not be resolved is INDETERMINATE — quiet, but
+    # counted, never silently scored with the known-wrong run-level value.
+    unresolved = _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99,
+                          now=NOW)
+    f, c = find_queue_overruns([unresolved], NOW)
+    check("an unresolved re-run is quiet", not f)
+    check("an unresolved re-run is COUNTED in its own census state",
+          c.get("queued-rerun-attempt-unresolved") == 1)
+    # And the fix must not have simply disabled M2: a genuine attempt-1 wait still fires.
+    f, _ = find_queue_overruns([_run_obj(status="queued", age_min=60, attempt=1, now=NOW)],
+                               NOW)
+    check("a genuine ATTEMPT-1 queue wait still raises after the re-run fix", len(f) == 1)
+    # A re-run whose CURRENT attempt really has been queued past the threshold must fire.
+    f, _ = find_queue_overruns(
+        [_run_obj(status="queued", age_min=60, attempt=3, created_age_min=999,
+                  attempt_created_age_min=60, now=NOW)], NOW)
+    check("a genuine queue wait ON a re-run attempt still raises", len(f) == 1)
+
+    # THE CALL SITE. A pure detector that reads ATTEMPT_CREATED_KEY is worthless if
+    # nothing ever writes it, and that omission is invisible to every assertion above.
+    _real_gh = globals()["_gh"]
+    try:
+        seen: list[str] = []
+
+        def _fake_gh(args, *, parse=True):
+            seen.append(args[-1])
+            return {"created_at": "2026-07-28T11:59:00Z",
+                    "run_started_at": "2026-07-28T11:59:00Z", "run_attempt": 2}
+
+        globals()["_gh"] = _fake_gh
+        enriched = resolve_attempt_created("o/r", [
+            _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99, now=NOW),
+            _run_obj(status="queued", age_min=99, attempt=1, now=NOW),
+            _run_obj(status="in_progress", age_min=99, attempt=2, now=NOW),
+        ])
+        check("the fetch layer resolves a QUEUED re-run against /attempts/{n}",
+              enriched[0].get(ATTEMPT_CREATED_KEY) == "2026-07-28T11:59:00Z")
+        check("the fetch layer asks for the LIVE attempt number",
+              len(seen) == 1 and seen[0].endswith("/attempts/2"))
+        check("the fetch layer spends no request on an attempt-1 run",
+              ATTEMPT_CREATED_KEY not in enriched[1])
+        check("the fetch layer spends no request on an in_progress run (M3's population)",
+              ATTEMPT_CREATED_KEY not in enriched[2])
+        # End to end through the enrichment: the pass must SILENCE the false positive.
+        f, _ = find_queue_overruns(enriched, NOW)
+        check("enrichment turns the re-run false positive into silence",
+              [x["run_attempt"] for x in f] == [1])
+
+        def _raising_gh(args, *, parse=True):
+            raise AlarmError("attempt lookup unavailable")
+
+        globals()["_gh"] = _raising_gh
+        degraded = resolve_attempt_created("o/r", [
+            _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99, now=NOW)])
+        check("a failed attempt lookup does not abort the tick",
+              ATTEMPT_CREATED_KEY not in degraded[0])
+        _, c = find_queue_overruns(degraded, NOW)
+        check("a failed attempt lookup lands in the unresolved census state",
+              c.get("queued-rerun-attempt-unresolved") == 1)
+    finally:
+        globals()["_gh"] = _real_gh
 
     # --- M3: detection variable is LIVE in_progress age ---
     base = {(".github/workflows/a.yml", "schedule"): {"p90": 3600.0, "n": 50}}
@@ -917,6 +1225,25 @@ def _self_test() -> int:  # noqa: C901 - a flat table of named assertions reads 
     check("M3 respects a baseline WIDER than the floor", not f)
     f, _ = find_execution_overruns([_run_obj(age_min=17 * 60, now=NOW)], big, NOW)
     check("M3 raises on the measured 2026-07-27 17.3h-vs-8.3h shape", len(f) == 1)
+    # --- M3 threshold pins against LITERALS ------------------------------------------
+    # 9h against an 8h p90 is 1.13x — inside the band at K=2.0, outside it at K<=1.13.
+    # The 17.3h check above pins the multiple from ABOVE (K=2.5 misses it); this pins it
+    # from BELOW, which nothing did before.
+    f, _ = find_execution_overruns([_run_obj(age_min=9 * 60, now=NOW)], big, NOW)
+    check("M3 is quiet at 9h against an 8h p90 — pins the multiple from BELOW", not f)
+    # The floor, from both directions, with no baseline in play.
+    f, _ = find_execution_overruns([_run_obj(age_min=5 * 60, now=NOW)], {}, NOW)
+    check("M3 is quiet at 5h with no baseline — pins the 6h floor from BELOW", not f)
+    f, _ = find_execution_overruns([_run_obj(age_min=7 * 60, now=NOW)], {}, NOW)
+    check("M3 raises at 7h with no baseline — pins the 6h floor from ABOVE", len(f) == 1)
+    # THE `updated_at` SUBSTITUTION. A live run's `updated_at` tracks the present moment,
+    # so `started = run.get("updated_at") or run_started_at` collapses every age to ~0 and
+    # M3 never fires again. It survived the first battery only because the fixture was a
+    # hand-built dict with no `updated_at`; the fixture now carries the real shape.
+    live = _run_obj(age_min=17 * 60, now=NOW)
+    check("the M3 fixture carries a live run's real `updated_at`",
+          (NOW - _ts(live["updated_at"])).total_seconds() < 60
+          and (NOW - _ts(live["run_started_at"])).total_seconds() > 16 * 3600)
 
     # --- census is emitted even on the all-clear ---
     _, c1 = find_cron_deficits([_lane(fires=36, now=NOW)], NOW)

--- a/scripts/tests/test_alarm_lanes_non_gating.py
+++ b/scripts/tests/test_alarm_lanes_non_gating.py
@@ -75,6 +75,7 @@ ALARM_WORKFLOWS = {
     "review-alarm.yml": "review-lane blind-spot alarm",
     "formal-alarm.yml": "formal-lane no-verdict alarm",
     "selection-alarm.yml": "nightly selection-bug alarm",
+    "ci-latency-alarm.yml": "CI execution-latency alarm",
 }
 
 # A name that is deliberately NOT in the registry, used by the anti-vacuity control.

--- a/scripts/tests/test_ci_execution_latency_alarm.py
+++ b/scripts/tests/test_ci_execution_latency_alarm.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Suite for scripts/ci_execution_latency_alarm.py. 🤖 SPARQ agent. Bead sq-1lc4i.
+
+Three halves, because three different things can go wrong:
+
+  1. THE CLASSIFIERS — every guard has a named test that reds when the guard is deleted or
+     inverted. Includes the two guards that are easiest to get wrong in the SILENT
+     direction: the missing-baseline fallback (a lane whose runs never complete must still
+     be watchable) and the empty-scan-set fail-loud (a detector watching nothing must not
+     report health).
+
+  2. THE #4368 DISJOINTNESS — M1's scope is the exact set complement of
+     `cron_lane_liveness.py`'s. If either predicate drifts the two detectors could both
+     raise on one lane (duplicate issues) or neither could (a hole). Both directions are
+     pinned, over the REAL workflow tree rather than fixtures.
+
+  3. THE YAML SEAM — measured across this repo, every mutant that survived a Python-only
+     battery lived in the workflow. So the step, its `if:`, the call site, the ordering,
+     the permissions and the action pins are all asserted by EXACT match, never substring:
+     `--apply-DROPPED` and `--self-test-DISABLED` both survive a containment check.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "ci_execution_latency_alarm.py"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+ALARM_WF = WORKFLOWS / "ci-latency-alarm.yml"
+DOCS_QUALITY = WORKFLOWS / "docs-quality.yml"
+REGISTRY_PATH = REPO_ROOT / ".github" / "advisory-registry.json"
+
+_spec = importlib.util.spec_from_file_location("ci_execution_latency_alarm", SCRIPT)
+alarm = importlib.util.module_from_spec(_spec)
+sys.modules["ci_execution_latency_alarm"] = alarm
+_spec.loader.exec_module(alarm)
+
+NOW = dt.datetime(2026, 7, 28, 12, 0, tzinfo=dt.timezone.utc)
+
+
+def _lane(**kw):
+    return alarm._lane(now=NOW, **kw)
+
+
+def _run_obj(**kw):
+    return alarm._run_obj(now=NOW, **kw)
+
+
+def _job_name(workflow_file: Path) -> str:
+    jobs = yaml.safe_load(workflow_file.read_text())["jobs"]
+    assert len(jobs) == 1, f"{workflow_file}: expected exactly one job, got {list(jobs)}"
+    return str(next(iter(jobs.values()))["name"])
+
+
+# ---------------------------------------------------------------------------------
+# 1. classifiers
+# ---------------------------------------------------------------------------------
+class TestCronExpansion(unittest.TestCase):
+    """Canary-validated against hand-computed answers. An expander that silently returns
+    0 would make every lane look like a 100% deficit; one that over-counts would make
+    every lane look healthy. Both directions are pinned."""
+
+    def test_known_firing_counts(self):
+        cases = [
+            ("*/10 * * * *", 6, 36),
+            ("*/10 * * * *", 24, 144),
+            ("17 3 * * *", 24, 1),
+            ("4,14,24,34,44,54 * * * *", 6, 36),
+            ("2,7,12,17,22,27,32,37,42,47,52,57 * * * *", 6, 72),
+            ("*/30 * * * *", 24, 48),
+            ("37 1,7,13,19 * * *", 24, 4),
+            ("0 */4 * * *", 24, 6),
+        ]
+        for expr, hours, want in cases:
+            with self.subTest(expr=expr):
+                got = alarm.expected_firings(expr, NOW - dt.timedelta(hours=hours), NOW)
+                self.assertEqual(got, want)
+
+    def test_weekly_cron_is_absent_from_a_window_that_does_not_contain_it(self):
+        # 2026-07-28 is a Tuesday; the Monday fire is >24h back but <48h back.
+        self.assertEqual(
+            alarm.expected_firings("0 6 * * 1", NOW - dt.timedelta(hours=24), NOW), 0)
+        self.assertEqual(
+            alarm.expected_firings("0 6 * * 1", NOW - dt.timedelta(hours=48), NOW), 1)
+
+    def test_dom_and_dow_both_restricted_is_a_UNION_not_an_intersection(self):
+        # POSIX: when both day fields are restricted the match is their OR. Reading it as
+        # AND would UNDER-count expected firings and hide a real deficit.
+        n = alarm.expected_firings(
+            "0 0 1 * 3",
+            dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc),
+            dt.datetime(2026, 7, 31, tzinfo=dt.timezone.utc))
+        self.assertGreater(n, 1, "dom+dow must be a union (all Wednesdays plus the 1st)")
+
+    def test_malformed_cron_raises_rather_than_returning_zero(self):
+        for bad in ("", "* * * *", "* * * * * *", "60 * * * *", "*/0 * * * *",
+                    "5-1 * * * *", "x * * * *"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(alarm.CronError):
+                    alarm.expected_firings(bad, NOW - dt.timedelta(hours=6), NOW)
+
+
+class TestM1CronFiringDeficit(unittest.TestCase):
+    CAP = alarm.capped_expectation()
+
+    def test_a_delivering_lane_does_not_raise(self):
+        f, c = alarm.find_cron_deficits([_lane(fires=self.CAP)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("delivering"), 1)
+
+    def test_a_lane_that_fired_far_below_expectation_raises(self):
+        f, c = alarm.find_cron_deficits([_lane(fires=1)], NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual((f[0]["expected"], f[0]["actual"]), (self.CAP, 1))
+        self.assertEqual(c.get("firing-deficit"), 1)
+
+    def test_a_cron_that_never_fired_at_all_raises(self):
+        # THE MODE WITH NO ARTIFACT. There is no run to inspect, so this can only be
+        # caught by comparing against a computed expectation.
+        f, _ = alarm.find_cron_deficits([_lane(fires=0)], NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual(f[0]["actual"], 0)
+
+    def test_the_expectation_is_CAPPED_at_what_github_really_delivers(self):
+        """The load-bearing anti-cry-wolf guard. MEASURED: sparq's `*/10` lanes have a
+        nominal expectation of 144/day and GitHub delivers ~12. Comparing against nominal
+        would put six lanes permanently in breach, and a permanently-red alarm is a muted
+        alarm. Delete the cap and this test reds."""
+        f, _ = alarm.find_cron_deficits(
+            [_lane(crons=("*/10 * * * *",), fires=self.CAP)], NOW)
+        self.assertEqual(f, [], "a sub-hourly lane at GitHub's real ceiling is healthy")
+        nominal = alarm.expected_firings(
+            "*/10 * * * *", NOW - dt.timedelta(hours=alarm.CRON_WINDOW_HOURS), NOW)
+        self.assertGreater(nominal, self.CAP,
+                           "fixture is vacuous unless nominal exceeds the cap")
+
+    def test_a_firing_inside_the_grace_window_is_not_counted_as_missing(self):
+        """Without the grace period the tick that lands on a lane's own cron minute sees
+        an expectation whose run does not exist yet, and manufactures a deficit daily."""
+        lane = _lane(fires=0)
+        lane["schedule_run_times"] = [NOW - dt.timedelta(minutes=1)] * self.CAP
+        f, _ = alarm.find_cron_deficits([lane], NOW)
+        self.assertEqual(len(f), 1, "runs newer than the grace cut-off are not yet due")
+
+    def test_the_floor_boundary_is_a_strict_less_than(self):
+        import math
+        at_floor = math.ceil(self.CAP * alarm.CRON_DELIVERY_FLOOR)
+        self.assertEqual(alarm.find_cron_deficits([_lane(fires=at_floor)], NOW)[0], [])
+        self.assertEqual(
+            len(alarm.find_cron_deficits([_lane(fires=at_floor - 1)], NOW)[0]), 1)
+
+    def test_an_over_delivering_lane_clamps_to_healthy(self):
+        f, _ = alarm.find_cron_deficits([_lane(fires=self.CAP * 3)], NOW)
+        self.assertEqual(f, [])
+
+    def test_a_lane_below_the_expectation_floor_is_quiet_and_counted(self):
+        # A weekly lane has a capped expectation of 0 inside a 24h window.
+        f, c = alarm.find_cron_deficits([_lane(crons=("0 6 * * 1",), fires=0)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("expectation-below-floor"), 1)
+
+    def test_a_disabled_lane_is_quiet_and_counted(self):
+        f, c = alarm.find_cron_deficits([_lane(state="disabled_manually", fires=0)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("disabled"), 1)
+
+    def test_an_unparseable_cron_is_quiet_and_VISIBLE_in_the_census(self):
+        f, c = alarm.find_cron_deficits([_lane(crons=("nonsense",), fires=0)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("cron-unparseable"), 1,
+                         "a fail-safe skip must be counted, or it is a silent skip")
+
+
+class TestM2QueueWait(unittest.TestCase):
+    def test_a_run_queued_past_the_threshold_raises(self):
+        late = _run_obj(status="queued",
+                        age_min=int(alarm.QUEUE_MAX_WAIT_SECONDS / 60) + 5)
+        f, c = alarm.find_queue_overruns([late], NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual(c.get("queued-over-threshold"), 1)
+
+    def test_a_run_queued_within_the_threshold_does_not_raise(self):
+        f, c = alarm.find_queue_overruns([_run_obj(status="queued", age_min=1)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("queued-within-threshold"), 1)
+
+    def test_m2_ignores_in_progress_runs(self):
+        f, _ = alarm.find_queue_overruns(
+            [_run_obj(status="in_progress", age_min=10_000)], NOW)
+        self.assertEqual(f, [], "an in_progress run is M3's population, not M2's")
+
+
+class TestM3ExecutionOverrun(unittest.TestCase):
+    BASE = {(".github/workflows/a.yml", "schedule"): {"p90": 3600.0, "n": 50}}
+
+    def test_a_run_inside_its_band_does_not_raise(self):
+        f, c = alarm.find_execution_overruns([_run_obj(age_min=30)], self.BASE, NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("in-progress-within-threshold"), 1)
+
+    def test_a_run_past_its_band_raises(self):
+        f, c = alarm.find_execution_overruns([_run_obj(age_min=8 * 60)], self.BASE, NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual(c.get("execution-overrun"), 1)
+
+    def test_m3_ignores_queued_runs(self):
+        f, _ = alarm.find_execution_overruns(
+            [_run_obj(status="queued", age_min=10_000)], self.BASE, NOW)
+        self.assertEqual(f, [], "a queued run is M2's population, not M3's")
+
+    def test_a_lane_with_NO_baseline_is_still_watched(self):
+        """THE FAIL-OPEN HOLE. A lane whose runs never complete has no completed history,
+        so it has no derived baseline. If a missing baseline caused a `continue`, the
+        detector would go silent exactly when a lane is 100% hung — the alarm would be
+        blind to the worst case it exists for. Ask the 100% question: if every run of a
+        lane hung forever, would this still fire? It must."""
+        f, _ = alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], {}, NOW)
+        self.assertEqual(len(f), 1)
+        self.assertIn("floor", f[0]["basis"])
+
+    def test_an_undersampled_baseline_falls_back_to_the_floor(self):
+        thin = {(".github/workflows/a.yml", "schedule"): {"p90": 60.0, "n": 1}}
+        f, _ = alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], thin, NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual(f[0]["threshold_seconds"], int(alarm.EXEC_FLOOR_SECONDS),
+                         "a 1-sample p90 must not become the threshold")
+
+    def test_a_baseline_WIDER_than_the_floor_raises_the_threshold(self):
+        """Quantifier direction: the floor is a MINIMUM, not the answer. A legitimately
+        long lane (nightly ci.yml runs ~8.3h) must not alarm merely for exceeding 6h."""
+        big = {(".github/workflows/a.yml", "schedule"): {"p90": 8 * 3600.0, "n": 40}}
+        f, _ = alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], big, NOW)
+        self.assertEqual(f, [], "an 8.3h-p90 lane at 7h is healthy — do not cry wolf")
+
+    def test_the_measured_2026_07_27_outlier_shape_raises(self):
+        """KNOWN POSITIVE, from real data: nightly ci.yml ran 17.33h on 2026-07-27 against
+        an 8.35h p90 over the preceding 13 nights (2.08x)."""
+        big = {(".github/workflows/a.yml", "schedule"): {"p90": 8.35 * 3600.0, "n": 13}}
+        f, _ = alarm.find_execution_overruns(
+            [_run_obj(age_min=int(17.33 * 60))], big, NOW)
+        self.assertEqual(len(f), 1)
+
+    def test_the_detection_variable_is_live_age_not_completed_history(self):
+        """A hang is invisible to any statistic over COMPLETED runs — a job that never
+        finishes never appears in one. This pins that M3 reads the LIVE run's age: a run
+        with a huge live age raises even when the completed baseline is enormous, and the
+        baseline alone can never produce a finding without a live run."""
+        big = {(".github/workflows/a.yml", "schedule"): {"p90": 8 * 3600.0, "n": 40}}
+        f, c = alarm.find_execution_overruns([], big, NOW)
+        self.assertEqual((f, c), ([], {}), "no live run => nothing to say")
+        f, _ = alarm.find_execution_overruns([_run_obj(age_min=40 * 60)], big, NOW)
+        self.assertEqual(len(f), 1)
+
+
+class TestCensusAndExitCodes(unittest.TestCase):
+    def test_a_clean_run_still_emits_a_census_for_every_mode(self):
+        """A silent alarm is indistinguishable from a healthy system."""
+        _, c1 = alarm.find_cron_deficits([_lane(fires=36)], NOW)
+        _, c2 = alarm.find_queue_overruns([_run_obj(status="queued", age_min=1)], NOW)
+        _, c3 = alarm.find_execution_overruns(
+            [_run_obj(age_min=1)], TestM3ExecutionOverrun.BASE, NOW)
+        for name, census in (("M1", c1), ("M2", c2), ("M3", c3)):
+            with self.subTest(mode=name):
+                self.assertTrue(census, f"{name} emitted no census on the all-clear")
+
+    def test_the_three_exit_codes_are_distinct(self):
+        # 0 = clean, 1 = a choke, 2 = the detector is broken. Collapsing any pair makes a
+        # broken detector indistinguishable from a healthy repo.
+        clean = self._run(lanes=[_lane(fires=36)], live=[])
+        alarmed = self._run(lanes=[_lane(fires=0)], live=[])
+        broken = alarm.main(["--repo", "not-a-slug", "--dry-run"])
+        self.assertEqual((clean, alarmed, broken), (0, 1, 2))
+
+    def test_an_empty_scan_set_is_fail_LOUD(self):
+        """100% question, applied to M1: if every scheduled workflow were cron-only, M1's
+        population would be empty. Reporting 'clean' over an empty population is how a
+        detector reports health while watching nothing."""
+        self.assertEqual(self._run(lanes=[], live=[]), 2)
+        only_cron_only = [_lane(cron_only=True, in_scope=False)]
+        self.assertEqual(self._run(lanes=only_cron_only, live=[]), 2)
+
+    @staticmethod
+    def _run(lanes, live, baselines=None):
+        state = {
+            "repo": "o/r",
+            "lanes": [dict(x, schedule_run_times=[t.strftime("%Y-%m-%dT%H:%M:%SZ")
+                                                 for t in x["schedule_run_times"]])
+                      for x in lanes],
+            "live_runs": live,
+            "baselines": baselines or {},
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(state, fh)
+            path = fh.name
+        return alarm.main(["--state-file", path, "--now", "2026-07-28T12:00:00Z",
+                           "--dry-run"])
+
+
+class TestIssueBody(unittest.TestCase):
+    def test_the_body_carries_the_dedupe_marker_and_self_identifies(self):
+        body = alarm.render_issue_body(
+            "o/r",
+            [{"mode": "M2-queue-wait", "workflow": "a.yml", "run_id": 1, "event": "push",
+              "waited_seconds": 99, "threshold_seconds": 60, "head_branch": "main"}],
+            {"M2-queue-wait": {"queued-over-threshold": 1}}, NOW)
+        self.assertTrue(body.rstrip().endswith(
+            f"<!-- {alarm.KEY_PREFIX}: o/r -->"))
+        self.assertTrue(body.startswith("> 🤖"))
+        self.assertIn("Census of every state exit", body)
+
+
+# ---------------------------------------------------------------------------------
+# 2. disjointness with #4368
+# ---------------------------------------------------------------------------------
+class TestScopeIsTheComplementOfCronLaneLiveness(unittest.TestCase):
+    """M1's scope must be the exact set complement of `cron_lane_liveness.py`'s, so the
+    two detectors partition the scheduled workflows: never both on one lane (duplicate
+    issues), never neither (a hole)."""
+
+    @staticmethod
+    def _scheduled_workflows():
+        out = {}
+        for path in sorted(WORKFLOWS.glob("*.yml")):
+            on = alarm.workflow_triggers(path.read_text())
+            if "schedule" in on:
+                out[path.name] = on
+        return out
+
+    def test_no_workflow_is_in_both_scopes(self):
+        for name, on in self._scheduled_workflows().items():
+            in_scope, _, cron_only = alarm.m1_scope(on)
+            with self.subTest(workflow=name):
+                self.assertFalse(in_scope and cron_only,
+                                 f"{name} would be claimed by BOTH detectors")
+
+    def test_every_scheduled_workflow_is_in_exactly_one_scope(self):
+        for name, on in self._scheduled_workflows().items():
+            in_scope, crons, cron_only = alarm.m1_scope(on)
+            if not crons:
+                continue  # a `schedule:` with no cron expression is neither's problem
+            with self.subTest(workflow=name):
+                self.assertTrue(in_scope or cron_only,
+                                f"{name} would be claimed by NEITHER detector")
+
+    def test_the_m1_population_over_the_real_tree_is_not_empty(self):
+        """Anti-vacuity: if the predicate broke such that nothing was ever in scope, every
+        assertion above would still pass. The measured shape is 13 in-scope lanes."""
+        in_scope = [n for n, on in self._scheduled_workflows().items()
+                    if alarm.m1_scope(on)[0]]
+        self.assertGreaterEqual(len(in_scope), 5,
+                                f"M1 scope collapsed to {in_scope}")
+
+    def test_ci_yml_is_in_m1_scope(self):
+        """ci.yml is the repo's largest capacity consumer AND carries a `schedule:`, but
+        it has push/pull_request/merge_group triggers so #4368 structurally cannot see it.
+        If this ever stops being true, the coordination note in both headers is wrong."""
+        on = alarm.workflow_triggers((WORKFLOWS / "ci.yml").read_text())
+        self.assertTrue(alarm.m1_scope(on)[0])
+        self.assertFalse(alarm.m1_scope(on)[2])
+
+    def test_a_cron_only_lane_from_the_real_tree_is_excluded(self):
+        on = alarm.workflow_triggers((WORKFLOWS / "formal-alarm.yml").read_text())
+        self.assertFalse(alarm.m1_scope(on)[0])
+        self.assertTrue(alarm.m1_scope(on)[2])
+
+
+# ---------------------------------------------------------------------------------
+# 3. the YAML seam
+# ---------------------------------------------------------------------------------
+class TestWorkflowSeam(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = yaml.safe_load(ALARM_WF.read_text())
+        cls.text = ALARM_WF.read_text()
+        cls.job = next(iter(cls.wf["jobs"].values()))
+        cls.steps = cls.job["steps"]
+
+    def test_it_is_triggered_by_schedule(self):
+        on = self.wf.get(True, self.wf.get("on"))
+        self.assertIn("schedule", on)
+        self.assertTrue([s["cron"] for s in on["schedule"]])
+
+    def test_the_selftest_step_runs_BEFORE_the_detector(self):
+        """A detector is never trusted to watch anything before it has proved itself on
+        this tick's code. Ordering, not mere presence."""
+        idx = {}
+        for i, step in enumerate(self.steps):
+            run = str(step.get("run", ""))
+            if "--self-test" in run:
+                idx["selftest"] = i
+            elif "ci_execution_latency_alarm.py" in run:
+                idx.setdefault("detector", i)
+        self.assertIn("selftest", idx)
+        self.assertIn("detector", idx)
+        self.assertLess(idx["selftest"], idx["detector"])
+
+    def test_the_selftest_invocation_is_EXACTLY_the_expected_command(self):
+        """EXACT match, not substring: `--self-test-DISABLED` contains `--self-test` and
+        would survive a containment check while doing nothing."""
+        runs = [str(s.get("run", "")).strip() for s in self.steps]
+        self.assertIn("python3 scripts/ci_execution_latency_alarm.py --self-test", runs)
+
+    def test_the_detector_invocation_is_EXACTLY_the_expected_command(self):
+        runs = [str(s.get("run", "")).strip() for s in self.steps]
+        self.assertIn("python3 scripts/ci_execution_latency_alarm.py", runs)
+
+    def test_no_step_is_conditional_or_continue_on_error(self):
+        """A step `if:` with no status function defaults to `success()`, so a failed
+        earlier step silently skips it — and `continue-on-error` turns a fail-loud
+        detector fail-open."""
+        for step in self.steps:
+            with self.subTest(step=step.get("name")):
+                self.assertNotIn("if", step)
+                self.assertNotIn("continue-on-error", step)
+        self.assertNotIn("continue-on-error", self.job)
+
+    def test_the_job_holds_no_arming_authority(self):
+        """Structural, not procedural: the detector must be unable to label, promote or
+        push even if its logic were subverted."""
+        perms = self.job["permissions"]
+        self.assertEqual(perms.get("contents"), "read")
+        self.assertEqual(perms.get("issues"), "write")
+        self.assertEqual(perms.get("actions"), "read")
+        for forbidden in ("pull-requests", "checks", "id-token", "packages"):
+            self.assertNotIn(forbidden, perms)
+        self.assertEqual(self.wf.get("permissions"), {"contents": "read"})
+
+    def test_every_action_use_is_sha_pinned(self):
+        import re
+        for step in self.steps:
+            uses = step.get("uses")
+            if uses:
+                with self.subTest(uses=uses):
+                    self.assertRegex(uses, r"@[0-9a-f]{40}$")
+
+    def test_the_checkout_does_not_persist_credentials(self):
+        for step in self.steps:
+            if str(step.get("uses", "")).startswith("actions/checkout@"):
+                self.assertIs(step["with"]["persist-credentials"], False)
+
+    def test_the_checkout_fetches_the_workflows_dir_M1_reads(self):
+        """M1 derives its expectation from the workflow files themselves. A sparse
+        checkout that omits them would make every lane read as `not-scheduled` — a silent
+        total blind spot rather than an error."""
+        for step in self.steps:
+            if str(step.get("uses", "")).startswith("actions/checkout@"):
+                sparse = str(step["with"].get("sparse-checkout", ""))
+                self.assertIn(".github/workflows", sparse)
+                self.assertIn("scripts/ci_execution_latency_alarm.py", sparse)
+
+
+class TestSuiteIsWiredIntoCI(unittest.TestCase):
+    """Anti-vacuity anchor: without this the whole file could leave CI unnoticed."""
+
+    def test_docs_quality_runs_this_suite(self):
+        runs = []
+        for job in yaml.safe_load(DOCS_QUALITY.read_text())["jobs"].values():
+            for step in job.get("steps") or []:
+                runs.append(str(step.get("run", "")).strip())
+        self.assertIn(
+            "python3 scripts/tests/test_ci_execution_latency_alarm.py", runs,
+            "docs-quality.yml no longer invokes this suite — it would stop running")
+
+    def test_that_call_site_is_unconditional(self):
+        for job in yaml.safe_load(DOCS_QUALITY.read_text())["jobs"].values():
+            for step in job.get("steps") or []:
+                if "test_ci_execution_latency_alarm.py" in str(step.get("run", "")):
+                    self.assertNotIn("if", step)
+                    self.assertNotIn("continue-on-error", step)
+
+
+class TestDeclaredNonGating(unittest.TestCase):
+    """This lane REDs on a finding. That is only safe because it is DECLARED advisory."""
+
+    def test_the_lane_is_declared_in_the_advisory_registry(self):
+        registry = json.loads(REGISTRY_PATH.read_text())["jobs"]
+        name = _job_name(ALARM_WF)
+        self.assertIn(name, registry,
+                      "an undeclared alarm lane GATES every merge on repo-wide CI health")
+        entry = registry[name]
+        for field in ("owner_bead", "promotion_criteria", "registered", "workflow",
+                      "job_id"):
+            self.assertIn(field, entry)
+        self.assertEqual(entry["workflow"], ALARM_WF.name)
+
+    def test_the_real_gate_treats_this_lane_as_advisory(self):
+        sys.path.insert(0, str(REPO_ROOT / "scripts"))
+        import ci_summary_gate as gate  # noqa: PLC0415
+        gate.load_advisory_registry(str(REGISTRY_PATH))
+        self.assertTrue(gate.is_advisory(_job_name(ALARM_WF)))
+        # Anti-vacuity control: a name that is NOT declared must gate.
+        self.assertFalse(gate.is_advisory("some undeclared lane that must gate"))
+
+
+class TestSelfTestIsRunnable(unittest.TestCase):
+    def test_the_embedded_self_test_passes(self):
+        proc = subprocess.run(
+            [sys.executable, "-B", str(SCRIPT), "--self-test"],
+            capture_output=True, text=True, timeout=120,
+            env={"PATH": "/usr/bin:/bin", "PYTHONDONTWRITEBYTECODE": "1"})
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_execution_latency_alarm.py
+++ b/scripts/tests/test_ci_execution_latency_alarm.py
@@ -318,8 +318,8 @@ class TestM2QueueWait(unittest.TestCase):
     def test_the_queue_threshold_stays_inside_its_validated_band(self):
         """A literal band, not derived from the constant. The previously-stated 0.022% /
         0.153% false-positive figures are WITHDRAWN (they were computed with the
-        contaminated estimator); the re-derived rate is 0 over N=9,053 attempt-1 registry
-        runs, which constrains this constant from below only."""
+        contaminated estimator); the re-derived rate is 0 over 44,190 attempt-1 runs
+        across both repos, which constrains this constant from below only."""
         self.assertEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 15 * 60)
         self.assertGreaterEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 5 * 60)
         self.assertLessEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 30 * 60)

--- a/scripts/tests/test_ci_execution_latency_alarm.py
+++ b/scripts/tests/test_ci_execution_latency_alarm.py
@@ -278,182 +278,71 @@ class TestM1NewLaneWindow(unittest.TestCase):
         self.assertEqual(by_path[".github/workflows/ci.yml"]["created_at"],
                          "2026-07-01T00:00:00Z")
 
-class TestM2QueueWait(unittest.TestCase):
-    def test_a_run_queued_past_the_threshold_raises(self):
-        late = _run_obj(status="queued",
-                        age_min=int(alarm.QUEUE_MAX_WAIT_SECONDS / 60) + 5)
-        f, c = alarm.find_queue_overruns([late], NOW)
-        self.assertEqual(len(f), 1)
-        self.assertEqual(c.get("queued-over-threshold"), 1)
+class TestQueueWaitIsAnHonestlyDocumentedGap(unittest.TestCase):
+    """Queue wait is NOT detected. This class exists so that stays TRUE and stays VISIBLE.
 
-    def test_a_run_queued_within_the_threshold_does_not_raise(self):
-        f, c = alarm.find_queue_overruns([_run_obj(status="queued", age_min=1)], NOW)
-        self.assertEqual(f, [])
-        self.assertEqual(c.get("queued-within-threshold"), 1)
+    An alarm that reads a variable which never moves answers "would we know if we were
+    starved?" with a confident yes. Across 44,190 completed runs not one attempt recorded
+    a non-zero queue wait, and the single event that motivated a detector turned out to be
+    a configured `max-parallel: 8` rather than withheld runners. So the detector was
+    removed and the gap documented.
 
-    def test_m2_ignores_in_progress_runs(self):
-        f, _ = alarm.find_queue_overruns(
-            [_run_obj(status="in_progress", age_min=10_000)], NOW)
-        self.assertEqual(f, [], "an in_progress run is M3's population, not M2's")
+    Two failure directions are pinned: silently RE-ADDING a detector (implying coverage
+    that is not evidenced), and silently DELETING the evidence that justifies its absence.
+    """
 
-    def test_an_hour_long_queue_wait_raises_under_the_SHIPPED_threshold(self):
-        """ABSOLUTE, not relative to the constant. The sibling tests above derive their
-        fixture age FROM QUEUE_MAX_WAIT_SECONDS, so they scale with it and cannot fail
-        when it changes — a mutant that multiplied the constant by 10**6 SURVIVED them.
+    def test_no_queue_wait_detector_is_exported(self):
+        """Structural, not textual. If someone re-adds one, this reds and forces the
+        question 'what positive validates it?' to be answered rather than skipped."""
+        for gone in ("find_queue_overruns", "QUEUE_MAX_WAIT_SECONDS",
+                     "attempt_created_at", "resolve_attempt_created",
+                     "ATTEMPT_CREATED_KEY"):
+            with self.subTest(symbol=gone):
+                self.assertFalse(hasattr(alarm, gone),
+                                 f"{gone} is back — a queue-wait detector needs an "
+                                 f"observed positive first; see the QUEUE WAIT note")
 
-        NOTE: an earlier revision of this docstring cited "jeswr/agent-account-registry
-        held `pr-gate` runs in `queued` for 12.8-99.5 minutes on 2026-07-28" as a MEASURED
-        known positive. That is WITHDRAWN — those seven runs were `run_attempt: 2` re-runs
-        and neither attempt ever queued (see TestM2ReRunTrap). M2 has no validated known
-        positive; this fixture pins the SHIPPED threshold, it does not evidence it."""
-        f, _ = alarm.find_queue_overruns([_run_obj(status="queued", age_min=60)], NOW)
-        self.assertEqual(len(f), 1, "an hour in `queued` must alarm")
+    def test_the_reported_modes_do_not_imply_queue_coverage(self):
+        """A reader of the issue body must not infer a mode that does not exist."""
+        _, c1 = alarm.find_cron_deficits([_lane(fires=0)], NOW)
+        _, c3 = alarm.find_execution_overruns([_run_obj(age_min=1)], {}, NOW)
+        census = {"M1-cron-firing-deficit": c1, "M3-execution-overrun": c3}
+        body = alarm.render_issue_body("o/r", [], census, NOW)
+        self.assertNotIn("M2", body)
+        self.assertNotIn("queue", body.lower())
 
-    def test_two_minutes_in_queued_stays_quiet_under_the_SHIPPED_threshold(self):
-        """The other direction, also absolute: without it `QUEUE_MAX_WAIT_SECONDS = 0`
-        survives, because every fixture in this class is ABOVE the threshold."""
-        f, _ = alarm.find_queue_overruns([_run_obj(status="queued", age_min=2)], NOW)
-        self.assertEqual(f, [])
-
-    def test_the_queue_threshold_stays_inside_its_validated_band(self):
-        """A literal band, not derived from the constant. The previously-stated 0.022% /
-        0.153% false-positive figures are WITHDRAWN (they were computed with the
-        contaminated estimator); the re-derived rate is 0 over 44,190 attempt-1 runs
-        across both repos, which constrains this constant from below only."""
-        self.assertEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 15 * 60)
-        self.assertGreaterEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 5 * 60)
-        self.assertLessEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 30 * 60)
-
-
-class TestM2ReRunTrap(unittest.TestCase):
-    """M2 must not charge a re-run's IDLE GAP as queue wait.
-
-    MEASURED 2026-07-28 on jeswr/agent-account-registry run 30318886362:
-        run-level    run_attempt=2  created_at=00:58:13Z  run_started_at=02:37:40Z
-        /attempts/1                 created_at=00:58:13Z  run_started_at=00:58:13Z   0s
-        /attempts/2                 created_at=02:37:41Z  run_started_at=02:37:40Z   0s
-    The run-level `created_at` is FROZEN at attempt 1 and never resets, while
-    `run_attempt` and `run_started_at` track the live attempt. `now - created_at` on that
-    exact payload reports waited_seconds=5967 for an attempt picked up in under a second —
-    so the naive form fires on every re-run older than the threshold, which is the normal
-    case. These seven runs were this mode's ENTIRE published known positive."""
-
-    def _rerun(self, **kw):
-        return _run_obj(status="queued", attempt=2, created_age_min=99, **kw)
-
-    def test_the_fixture_reproduces_the_frozen_run_level_created_at(self):
-        r = self._rerun(age_min=1, attempt_created_age_min=1)
-        naive = (NOW - alarm._ts(r["created_at"])).total_seconds()
-        true_wait = (NOW - alarm._ts(r[alarm.ATTEMPT_CREATED_KEY])).total_seconds()
-        self.assertGreater(naive, alarm.QUEUE_MAX_WAIT_SECONDS,
-                           "vacuous unless the NAIVE reading would have fired")
-        self.assertLess(true_wait, alarm.QUEUE_MAX_WAIT_SECONDS)
-
-    def test_a_rerun_idle_gap_is_not_charged_as_queue_wait(self):
-        f, c = alarm.find_queue_overruns(
-            [self._rerun(age_min=1, attempt_created_age_min=1)], NOW)
-        self.assertEqual(f, [], "the re-run false positive is the whole defect")
-        self.assertEqual(c.get("queued-within-threshold"), 1)
-
-    def test_an_unresolvable_rerun_is_quiet_but_COUNTED(self):
-        """Fail-safe quiet, never fail-open silent: the run-level value is available here
-        and known-wrong, so the honest move is to decline and say so in the census."""
-        f, c = alarm.find_queue_overruns([self._rerun(age_min=1)], NOW)
-        self.assertEqual(f, [])
-        self.assertEqual(c.get("queued-rerun-attempt-unresolved"), 1)
-        self.assertIsNone(c.get("queued-no-timestamp"),
-                          "the two skip causes must stay separable in the census")
-
-    def test_the_fix_did_not_simply_disable_m2(self):
-        """A detector that never fires is not a fixed detector. Both a genuine attempt-1
-        wait and a genuine wait ON a re-run attempt must still raise."""
-        f, _ = alarm.find_queue_overruns(
-            [_run_obj(status="queued", age_min=60, attempt=1)], NOW)
-        self.assertEqual(len(f), 1)
-        f, _ = alarm.find_queue_overruns(
-            [_run_obj(status="queued", age_min=60, attempt=3, created_age_min=999,
-                      attempt_created_age_min=60)], NOW)
-        self.assertEqual(len(f), 1, "a re-run CAN queue; it must still be reportable")
-
-    def test_the_fetch_layer_actually_writes_what_the_detector_reads(self):
-        """THE CALL SITE. A pure detector reading ATTEMPT_CREATED_KEY is worthless if
-        nothing ever writes it, and that omission is invisible to every test above."""
-        seen = []
+    def test_the_live_read_does_not_fetch_a_population_nothing_consumes(self):
+        """`status=queued` is no longer fetched. Fetching a population no detector reads
+        is the shape of coverage-without-detection this file exists to avoid."""
+        asked = []
 
         def fake_gh(args, *, parse=True):
-            seen.append(args[-1])
-            return {"created_at": "2026-07-28T11:59:00Z"}
+            asked.append(args[-1])
+            return {"workflow_runs": []}
 
         real = alarm._gh
         alarm._gh = fake_gh
         try:
-            out = alarm.resolve_attempt_created("o/r", [
-                _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99),
-                _run_obj(status="queued", age_min=99, attempt=1),
-                _run_obj(status="in_progress", age_min=99, attempt=2),
-            ])
+            alarm.fetch_live_runs("o/r")
         finally:
             alarm._gh = real
-        self.assertEqual(out[0].get(alarm.ATTEMPT_CREATED_KEY), "2026-07-28T11:59:00Z")
-        self.assertEqual(len(seen), 1, "one request, only for the queued re-run")
-        self.assertTrue(seen[0].endswith("/attempts/2"), seen)
-        self.assertNotIn(alarm.ATTEMPT_CREATED_KEY, out[1])
-        self.assertNotIn(alarm.ATTEMPT_CREATED_KEY, out[2])
-        # End to end: enrichment must turn the false positive into silence, leaving only
-        # the genuine attempt-1 wait.
-        f, _ = alarm.find_queue_overruns(out, NOW)
-        self.assertEqual([x["run_attempt"] for x in f], [1])
+        self.assertTrue(asked)
+        self.assertFalse([u for u in asked if "status=queued" in u], asked)
+        self.assertTrue([u for u in asked if "status=in_progress" in u], asked)
 
-    def test_fetch_live_runs_ENRICHES_what_it_returns(self):
-        """AND THE CALL SITE OF THE CALL SITE. Every sibling test invokes
-        `resolve_attempt_created` DIRECTLY, so deleting the one line in `fetch_live_runs`
-        that invokes it in production survives all of them — MEASURED, that mutant
-        survived this suite before this test existed. A helper called only by its own
-        tests is wired to nothing."""
-        def fake_gh(args, *, parse=True):
-            url = args[-1]
-            if "status=queued" in url:
-                return {"workflow_runs": [
-                    _run_obj(status="queued", age_min=1, attempt=2,
-                             created_age_min=99)]}
-            if "status=in_progress" in url:
-                return {"workflow_runs": []}
-            if "/attempts/2" in url:
-                return {"created_at": "2026-07-28T11:59:00Z"}
-            raise AssertionError(f"unexpected request {url}")
-
-        real = alarm._gh
-        alarm._gh = fake_gh
-        try:
-            live = alarm.fetch_live_runs("o/r")
-        finally:
-            alarm._gh = real
-        self.assertEqual(len(live), 1)
-        self.assertEqual(live[0].get(alarm.ATTEMPT_CREATED_KEY), "2026-07-28T11:59:00Z")
-        self.assertEqual(alarm.find_queue_overruns(live, NOW)[0], [],
-                         "enrichment must reach M2 through the real fetch path")
-
-    def test_a_failed_attempt_lookup_degrades_instead_of_aborting_the_tick(self):
-        """The escaped exception is asserted to be None. A test that let the exception
-        propagate and read the traceback as a pass would certify nothing: a crash looks
-        identical whether the guarantee held or the stub broke."""
-        def raising_gh(args, *, parse=True):
-            raise alarm.AlarmError("attempt lookup unavailable")
-
-        real, escaped = alarm._gh, None
-        alarm._gh = raising_gh
-        try:
-            out = alarm.resolve_attempt_created(
-                "o/r", [_run_obj(status="queued", age_min=1, attempt=2,
-                                 created_age_min=99)])
-        except BaseException as exc:  # noqa: BLE001 - the assertion IS that none escapes
-            out, escaped = None, exc
-        finally:
-            alarm._gh = real
-        self.assertIsNone(escaped, f"an attempt lookup failure escaped: {escaped!r}")
-        self.assertNotIn(alarm.ATTEMPT_CREATED_KEY, out[0])
-        _, c = alarm.find_queue_overruns(out, NOW)
-        self.assertEqual(c.get("queued-rerun-attempt-unresolved"), 1)
+    def test_the_evidence_for_the_gap_is_still_recorded(self):
+        """Pins the CONSEQUENCE deliberately: deleting the justification reds loudly
+        rather than leaving a bare unexplained absence. Each anchor is a specific
+        measured fact, not prose."""
+        src = SCRIPT.read_text()
+        for anchor, why in (
+            ("44,190", "the corpus size behind 'the variable never moves'"),
+            ("max-parallel: 8", "why run 30333511110 was NOT a capacity event"),
+            ("30333511110", "the run the capacity inference was drawn from"),
+            ("30318886362", "the re-run that produced the fabricated known positive"),
+        ):
+            with self.subTest(anchor=anchor):
+                self.assertIn(anchor, src, f"missing {why}")
 
 
 class TestM3ExecutionOverrun(unittest.TestCase):
@@ -569,10 +458,9 @@ class TestCensusAndExitCodes(unittest.TestCase):
     def test_a_clean_run_still_emits_a_census_for_every_mode(self):
         """A silent alarm is indistinguishable from a healthy system."""
         _, c1 = alarm.find_cron_deficits([_lane(fires=36)], NOW)
-        _, c2 = alarm.find_queue_overruns([_run_obj(status="queued", age_min=1)], NOW)
         _, c3 = alarm.find_execution_overruns(
             [_run_obj(age_min=1)], TestM3ExecutionOverrun.BASE, NOW)
-        for name, census in (("M1", c1), ("M2", c2), ("M3", c3)):
+        for name, census in (("M1", c1), ("M3", c3)):
             with self.subTest(mode=name):
                 self.assertTrue(census, f"{name} emitted no census on the all-clear")
 
@@ -629,9 +517,10 @@ class TestIssueBody(unittest.TestCase):
     def test_the_body_carries_the_dedupe_marker_and_self_identifies(self):
         body = alarm.render_issue_body(
             "o/r",
-            [{"mode": "M2-queue-wait", "workflow": "a.yml", "run_id": 1, "event": "push",
-              "waited_seconds": 99, "threshold_seconds": 60, "head_branch": "main"}],
-            {"M2-queue-wait": {"queued-over-threshold": 1}}, NOW)
+            [{"mode": "M3-execution-overrun", "workflow": "a.yml", "run_id": 1,
+              "event": "push", "age_seconds": 99, "threshold_seconds": 60,
+              "basis": "floor", "head_branch": "main"}],
+            {"M3-execution-overrun": {"execution-overrun": 1}}, NOW)
         self.assertTrue(body.rstrip().endswith(
             f"<!-- {alarm.KEY_PREFIX}: o/r -->"))
         self.assertTrue(body.startswith("> 🤖"))

--- a/scripts/tests/test_ci_execution_latency_alarm.py
+++ b/scripts/tests/test_ci_execution_latency_alarm.py
@@ -404,6 +404,35 @@ class TestM2ReRunTrap(unittest.TestCase):
         f, _ = alarm.find_queue_overruns(out, NOW)
         self.assertEqual([x["run_attempt"] for x in f], [1])
 
+    def test_fetch_live_runs_ENRICHES_what_it_returns(self):
+        """AND THE CALL SITE OF THE CALL SITE. Every sibling test invokes
+        `resolve_attempt_created` DIRECTLY, so deleting the one line in `fetch_live_runs`
+        that invokes it in production survives all of them — MEASURED, that mutant
+        survived this suite before this test existed. A helper called only by its own
+        tests is wired to nothing."""
+        def fake_gh(args, *, parse=True):
+            url = args[-1]
+            if "status=queued" in url:
+                return {"workflow_runs": [
+                    _run_obj(status="queued", age_min=1, attempt=2,
+                             created_age_min=99)]}
+            if "status=in_progress" in url:
+                return {"workflow_runs": []}
+            if "/attempts/2" in url:
+                return {"created_at": "2026-07-28T11:59:00Z"}
+            raise AssertionError(f"unexpected request {url}")
+
+        real = alarm._gh
+        alarm._gh = fake_gh
+        try:
+            live = alarm.fetch_live_runs("o/r")
+        finally:
+            alarm._gh = real
+        self.assertEqual(len(live), 1)
+        self.assertEqual(live[0].get(alarm.ATTEMPT_CREATED_KEY), "2026-07-28T11:59:00Z")
+        self.assertEqual(alarm.find_queue_overruns(live, NOW)[0], [],
+                         "enrichment must reach M2 through the real fetch path")
+
     def test_a_failed_attempt_lookup_degrades_instead_of_aborting_the_tick(self):
         """The escaped exception is asserted to be None. A test that let the exception
         propagate and read the traceback as a pass would certify nothing: a crash looks

--- a/scripts/tests/test_ci_execution_latency_alarm.py
+++ b/scripts/tests/test_ci_execution_latency_alarm.py
@@ -159,7 +159,7 @@ class TestM1CronFiringDeficit(unittest.TestCase):
         self.assertEqual(
             len(alarm.find_cron_deficits([_lane(fires=at_floor - 1)], NOW)[0]), 1)
 
-    def test_an_over_delivering_lane_clamps_to_healthy(self):
+    def test_an_over_delivering_lane_is_healthy(self):
         f, _ = alarm.find_cron_deficits([_lane(fires=self.CAP * 3)], NOW)
         self.assertEqual(f, [])
 
@@ -199,6 +199,21 @@ class TestM2QueueWait(unittest.TestCase):
             [_run_obj(status="in_progress", age_min=10_000)], NOW)
         self.assertEqual(f, [], "an in_progress run is M3's population, not M2's")
 
+    def test_an_hour_long_queue_wait_raises_under_the_SHIPPED_threshold(self):
+        """ABSOLUTE, not relative to the constant. The sibling tests above derive their
+        fixture age FROM QUEUE_MAX_WAIT_SECONDS, so they scale with it and cannot fail
+        when it changes — a mutant that multiplied the constant by 10**6 SURVIVED them.
+        MEASURED known positive: jeswr/agent-account-registry held `pr-gate` runs in
+        `queued` for 12.8-99.5 minutes between 00:58Z and 02:24Z on 2026-07-28."""
+        f, _ = alarm.find_queue_overruns([_run_obj(status="queued", age_min=60)], NOW)
+        self.assertEqual(len(f), 1, "an hour in `queued` must alarm")
+
+    def test_the_queue_threshold_stays_inside_its_validated_band(self):
+        """The band the false-positive measurement was made over. Outside it the stated
+        0.022% / 0.153% figures no longer describe the shipped behaviour."""
+        self.assertGreaterEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 5 * 60)
+        self.assertLessEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 30 * 60)
+
 
 class TestM3ExecutionOverrun(unittest.TestCase):
     BASE = {(".github/workflows/a.yml", "schedule"): {"p90": 3600.0, "n": 50}}
@@ -228,12 +243,23 @@ class TestM3ExecutionOverrun(unittest.TestCase):
         self.assertEqual(len(f), 1)
         self.assertIn("floor", f[0]["basis"])
 
-    def test_an_undersampled_baseline_falls_back_to_the_floor(self):
-        thin = {(".github/workflows/a.yml", "schedule"): {"p90": 60.0, "n": 1}}
-        f, _ = alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], thin, NOW)
-        self.assertEqual(len(f), 1)
-        self.assertEqual(f[0]["threshold_seconds"], int(alarm.EXEC_FLOOR_SECONDS),
-                         "a 1-sample p90 must not become the threshold")
+    def test_an_undersampled_baseline_is_not_trusted_even_when_it_is_LARGE(self):
+        """The under-sampling guard only BITES when the thin baseline would WIDEN the
+        threshold past the floor. A fixture with a small p90 collapses to the floor
+        whether or not the guard exists, and cannot detect its removal — the earlier
+        version of this test used p90=60s and both BASELINE_MIN_N mutants SURVIVED it."""
+        thin_but_huge = {(".github/workflows/a.yml", "schedule"):
+                         {"p90": 20 * 3600.0, "n": 1}}
+        f, _ = alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], thin_but_huge,
+                                             NOW)
+        self.assertEqual(len(f), 1,
+                         "a 1-sample 20h p90 must not widen the threshold to 40h")
+        self.assertEqual(f[0]["threshold_seconds"], int(alarm.EXEC_FLOOR_SECONDS))
+        # Control: the SAME p90 with a real sample size legitimately widens the band.
+        thick = {(".github/workflows/a.yml", "schedule"):
+                 {"p90": 20 * 3600.0, "n": alarm.BASELINE_MIN_N}}
+        self.assertEqual(
+            alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], thick, NOW)[0], [])
 
     def test_a_baseline_WIDER_than_the_floor_raises_the_threshold(self):
         """Quantifier direction: the floor is a MINIMUM, not the answer. A legitimately
@@ -288,6 +314,22 @@ class TestCensusAndExitCodes(unittest.TestCase):
         self.assertEqual(self._run(lanes=[], live=[]), 2)
         only_cron_only = [_lane(cron_only=True, in_scope=False)]
         self.assertEqual(self._run(lanes=only_cron_only, live=[]), 2)
+
+    def test_the_two_empty_scan_set_guards_report_DISTINCT_causes(self):
+        """They are not redundant: 'no workflow files at all' means the sparse-checkout
+        dropped `.github/workflows` (a deploy defect), while 'nothing in scope' means the
+        predicate or the repo changed shape. Collapsing them loses the more actionable
+        diagnosis — and without this assertion, deleting the first guard SURVIVES, because
+        the second one also exits 2 on an empty list."""
+        import contextlib
+        import io
+        for lanes, expect in (([], "no workflows discovered"),
+                              ([_lane(cron_only=True, in_scope=False)], "empty M1 scan set")):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = self._run(lanes=lanes, live=[])
+            self.assertEqual(rc, 2)
+            self.assertIn(expect, buf.getvalue())
 
     @staticmethod
     def _run(lanes, live, baselines=None):

--- a/scripts/tests/test_ci_execution_latency_alarm.py
+++ b/scripts/tests/test_ci_execution_latency_alarm.py
@@ -159,6 +159,47 @@ class TestM1CronFiringDeficit(unittest.TestCase):
         self.assertEqual(
             len(alarm.find_cron_deficits([_lane(fires=at_floor - 1)], NOW)[0]), 1)
 
+    def test_the_delivery_floor_is_pinned_by_a_LITERAL_fixture(self):
+        """`at_floor` above is COMPUTED FROM CRON_DELIVERY_FLOOR, so it rescales with the
+        constant and cannot fail when it moves — MEASURED: `0.60 -> 0.05` survived the
+        sibling deployment's entire suite for exactly that reason, and dies in this one
+        only by the accident of its smaller cap.
+
+        `0 */4 * * *` has a 24h nominal of 5, BELOW the cap, so `expected` is 5 whatever
+        the cap constant is. Neither 5 nor the fire counts derive from any constant."""
+        f, _ = alarm.find_cron_deficits(
+            [_lane(crons=("0 */4 * * *",), fires=2)], NOW)
+        self.assertEqual(len(f), 1, "2 of 5 = 0.40 must raise")
+        self.assertEqual(f[0]["expected"], 5)
+        self.assertEqual(f[0]["ratio"], 0.4)
+        f, _ = alarm.find_cron_deficits(
+            [_lane(crons=("0 */4 * * *",), fires=3)], NOW)
+        self.assertEqual(f, [], "3 of 5 = 0.60 must NOT raise")
+
+    def test_the_window_constant_is_pinned_by_a_LITERAL_expectation(self):
+        """`CRON_WINDOW_HOURS 24.0 -> 6.0` survived every earlier assertion — and 6.0 is
+        the value the module docstring says was TRIED AND REJECTED. At the 24h window a
+        4-hourly lane's expectation is 5; at 6h it is 1, and the same fixture goes quiet."""
+        self.assertEqual(alarm.CRON_WINDOW_HOURS, 24.0)
+        f, _ = alarm.find_cron_deficits(
+            [_lane(crons=("0 */4 * * *",), fires=2)], NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual(f[0]["expected"], 5,
+                         "the DEFAULT window is what makes this expectation 5")
+
+    def test_every_shipped_constant_is_pinned_against_a_literal(self):
+        """A threshold exercised only through fixtures derived from it is not tested.
+        These are the independent write-downs."""
+        self.assertEqual(alarm.CRON_MAX_CREDIBLE_FIRINGS_PER_HOUR, 0.5)
+        self.assertEqual(alarm.CRON_GRACE_MINUTES, 15)
+        self.assertEqual(alarm.EXEC_FLOOR_SECONDS, 6 * 60 * 60)
+        self.assertEqual(alarm.BASELINE_MIN_N, 5)
+        self.assertGreaterEqual(alarm.CRON_DELIVERY_FLOOR, 0.50)
+        self.assertLessEqual(alarm.CRON_DELIVERY_FLOOR, 0.70)
+        self.assertGreaterEqual(alarm.EXEC_OVERRUN_MULTIPLE, 1.25)
+        self.assertLessEqual(alarm.EXEC_OVERRUN_MULTIPLE, 2.0)
+
+
     def test_an_over_delivering_lane_is_healthy(self):
         f, _ = alarm.find_cron_deficits([_lane(fires=self.CAP * 3)], NOW)
         self.assertEqual(f, [])
@@ -180,6 +221,62 @@ class TestM1CronFiringDeficit(unittest.TestCase):
         self.assertEqual(c.get("cron-unparseable"), 1,
                          "a fail-safe skip must be counted, or it is a silent skip")
 
+
+class TestM1NewLaneWindow(unittest.TestCase):
+    """A newly-added lane has not had time to deliver, and M1 cannot tell "did not fire"
+    from "did not exist yet" out of run times alone — so a lane added two hours ago reads
+    ratio 0.08 and alarms for the next ~14 hours. The workflow's own `created_at` resolves
+    it; a lane younger than the window is counted and skipped, not guessed at."""
+
+    def test_a_lane_younger_than_the_window_is_skipped_and_counted(self):
+        f, c = alarm.find_cron_deficits([_lane(fires=1, created_hours_ago=2)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("lane-too-new-for-an-expectation"), 1)
+
+    def test_the_skip_is_not_an_unconditional_mute(self):
+        """ANTI-VACUITY. The identical delivery from a lane with no birth date, and from
+        one born before the window, must still alarm — otherwise the new-lane exit is
+        just M1 switched off."""
+        self.assertEqual(len(alarm.find_cron_deficits([_lane(fires=1)], NOW)[0]), 1)
+        self.assertEqual(
+            len(alarm.find_cron_deficits(
+                [_lane(fires=1, created_hours_ago=48)], NOW)[0]), 1)
+
+    def test_the_birth_date_boundary_is_pinned_from_BOTH_sides(self):
+        """Without both directions `if born > start` and `if born > start - 100 years`
+        are the same test."""
+        f, c = alarm.find_cron_deficits([_lane(fires=1, created_hours_ago=23)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("lane-too-new-for-an-expectation"), 1)
+        f, c = alarm.find_cron_deficits([_lane(fires=1, created_hours_ago=25)], NOW)
+        self.assertEqual(len(f), 1)
+        self.assertEqual(c.get("firing-deficit"), 1)
+
+    def test_an_established_lane_is_unaffected_by_the_check(self):
+        self.assertEqual(
+            alarm.find_cron_deficits(
+                [_lane(fires=TestM1CronFiringDeficit.CAP, created_hours_ago=48)],
+                NOW)[0], [])
+
+    def test_the_fetch_layer_supplies_the_birth_date_the_check_reads(self):
+        """THE CALL SITE again: `fetch_lanes` must carry `created_at` off the workflow
+        listing, or the guard above can never fire in production."""
+        listing = {"workflows": [
+            {"path": ".github/workflows/ci.yml", "state": "active",
+             "created_at": "2026-07-01T00:00:00Z"}]}
+
+        def fake_gh(args, *, parse=True):
+            return listing if "actions/workflows?" in args[-1] else {"workflow_runs": []}
+
+        real = alarm._gh
+        alarm._gh = fake_gh
+        try:
+            lanes = alarm.fetch_lanes("o/r", WORKFLOWS, 24.0, NOW)
+        finally:
+            alarm._gh = real
+        by_path = {lane["workflow"]: lane for lane in lanes}
+        self.assertEqual(by_path[".github/workflows/ci.yml"]["created_at"],
+                         "2026-07-01T00:00:00Z")
 
 class TestM2QueueWait(unittest.TestCase):
     def test_a_run_queued_past_the_threshold_raises(self):
@@ -203,16 +300,131 @@ class TestM2QueueWait(unittest.TestCase):
         """ABSOLUTE, not relative to the constant. The sibling tests above derive their
         fixture age FROM QUEUE_MAX_WAIT_SECONDS, so they scale with it and cannot fail
         when it changes — a mutant that multiplied the constant by 10**6 SURVIVED them.
-        MEASURED known positive: jeswr/agent-account-registry held `pr-gate` runs in
-        `queued` for 12.8-99.5 minutes between 00:58Z and 02:24Z on 2026-07-28."""
+
+        NOTE: an earlier revision of this docstring cited "jeswr/agent-account-registry
+        held `pr-gate` runs in `queued` for 12.8-99.5 minutes on 2026-07-28" as a MEASURED
+        known positive. That is WITHDRAWN — those seven runs were `run_attempt: 2` re-runs
+        and neither attempt ever queued (see TestM2ReRunTrap). M2 has no validated known
+        positive; this fixture pins the SHIPPED threshold, it does not evidence it."""
         f, _ = alarm.find_queue_overruns([_run_obj(status="queued", age_min=60)], NOW)
         self.assertEqual(len(f), 1, "an hour in `queued` must alarm")
 
+    def test_two_minutes_in_queued_stays_quiet_under_the_SHIPPED_threshold(self):
+        """The other direction, also absolute: without it `QUEUE_MAX_WAIT_SECONDS = 0`
+        survives, because every fixture in this class is ABOVE the threshold."""
+        f, _ = alarm.find_queue_overruns([_run_obj(status="queued", age_min=2)], NOW)
+        self.assertEqual(f, [])
+
     def test_the_queue_threshold_stays_inside_its_validated_band(self):
-        """The band the false-positive measurement was made over. Outside it the stated
-        0.022% / 0.153% figures no longer describe the shipped behaviour."""
+        """A literal band, not derived from the constant. The previously-stated 0.022% /
+        0.153% false-positive figures are WITHDRAWN (they were computed with the
+        contaminated estimator); the re-derived rate is 0 over N=9,053 attempt-1 registry
+        runs, which constrains this constant from below only."""
+        self.assertEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 15 * 60)
         self.assertGreaterEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 5 * 60)
         self.assertLessEqual(alarm.QUEUE_MAX_WAIT_SECONDS, 30 * 60)
+
+
+class TestM2ReRunTrap(unittest.TestCase):
+    """M2 must not charge a re-run's IDLE GAP as queue wait.
+
+    MEASURED 2026-07-28 on jeswr/agent-account-registry run 30318886362:
+        run-level    run_attempt=2  created_at=00:58:13Z  run_started_at=02:37:40Z
+        /attempts/1                 created_at=00:58:13Z  run_started_at=00:58:13Z   0s
+        /attempts/2                 created_at=02:37:41Z  run_started_at=02:37:40Z   0s
+    The run-level `created_at` is FROZEN at attempt 1 and never resets, while
+    `run_attempt` and `run_started_at` track the live attempt. `now - created_at` on that
+    exact payload reports waited_seconds=5967 for an attempt picked up in under a second —
+    so the naive form fires on every re-run older than the threshold, which is the normal
+    case. These seven runs were this mode's ENTIRE published known positive."""
+
+    def _rerun(self, **kw):
+        return _run_obj(status="queued", attempt=2, created_age_min=99, **kw)
+
+    def test_the_fixture_reproduces_the_frozen_run_level_created_at(self):
+        r = self._rerun(age_min=1, attempt_created_age_min=1)
+        naive = (NOW - alarm._ts(r["created_at"])).total_seconds()
+        true_wait = (NOW - alarm._ts(r[alarm.ATTEMPT_CREATED_KEY])).total_seconds()
+        self.assertGreater(naive, alarm.QUEUE_MAX_WAIT_SECONDS,
+                           "vacuous unless the NAIVE reading would have fired")
+        self.assertLess(true_wait, alarm.QUEUE_MAX_WAIT_SECONDS)
+
+    def test_a_rerun_idle_gap_is_not_charged_as_queue_wait(self):
+        f, c = alarm.find_queue_overruns(
+            [self._rerun(age_min=1, attempt_created_age_min=1)], NOW)
+        self.assertEqual(f, [], "the re-run false positive is the whole defect")
+        self.assertEqual(c.get("queued-within-threshold"), 1)
+
+    def test_an_unresolvable_rerun_is_quiet_but_COUNTED(self):
+        """Fail-safe quiet, never fail-open silent: the run-level value is available here
+        and known-wrong, so the honest move is to decline and say so in the census."""
+        f, c = alarm.find_queue_overruns([self._rerun(age_min=1)], NOW)
+        self.assertEqual(f, [])
+        self.assertEqual(c.get("queued-rerun-attempt-unresolved"), 1)
+        self.assertIsNone(c.get("queued-no-timestamp"),
+                          "the two skip causes must stay separable in the census")
+
+    def test_the_fix_did_not_simply_disable_m2(self):
+        """A detector that never fires is not a fixed detector. Both a genuine attempt-1
+        wait and a genuine wait ON a re-run attempt must still raise."""
+        f, _ = alarm.find_queue_overruns(
+            [_run_obj(status="queued", age_min=60, attempt=1)], NOW)
+        self.assertEqual(len(f), 1)
+        f, _ = alarm.find_queue_overruns(
+            [_run_obj(status="queued", age_min=60, attempt=3, created_age_min=999,
+                      attempt_created_age_min=60)], NOW)
+        self.assertEqual(len(f), 1, "a re-run CAN queue; it must still be reportable")
+
+    def test_the_fetch_layer_actually_writes_what_the_detector_reads(self):
+        """THE CALL SITE. A pure detector reading ATTEMPT_CREATED_KEY is worthless if
+        nothing ever writes it, and that omission is invisible to every test above."""
+        seen = []
+
+        def fake_gh(args, *, parse=True):
+            seen.append(args[-1])
+            return {"created_at": "2026-07-28T11:59:00Z"}
+
+        real = alarm._gh
+        alarm._gh = fake_gh
+        try:
+            out = alarm.resolve_attempt_created("o/r", [
+                _run_obj(status="queued", age_min=1, attempt=2, created_age_min=99),
+                _run_obj(status="queued", age_min=99, attempt=1),
+                _run_obj(status="in_progress", age_min=99, attempt=2),
+            ])
+        finally:
+            alarm._gh = real
+        self.assertEqual(out[0].get(alarm.ATTEMPT_CREATED_KEY), "2026-07-28T11:59:00Z")
+        self.assertEqual(len(seen), 1, "one request, only for the queued re-run")
+        self.assertTrue(seen[0].endswith("/attempts/2"), seen)
+        self.assertNotIn(alarm.ATTEMPT_CREATED_KEY, out[1])
+        self.assertNotIn(alarm.ATTEMPT_CREATED_KEY, out[2])
+        # End to end: enrichment must turn the false positive into silence, leaving only
+        # the genuine attempt-1 wait.
+        f, _ = alarm.find_queue_overruns(out, NOW)
+        self.assertEqual([x["run_attempt"] for x in f], [1])
+
+    def test_a_failed_attempt_lookup_degrades_instead_of_aborting_the_tick(self):
+        """The escaped exception is asserted to be None. A test that let the exception
+        propagate and read the traceback as a pass would certify nothing: a crash looks
+        identical whether the guarantee held or the stub broke."""
+        def raising_gh(args, *, parse=True):
+            raise alarm.AlarmError("attempt lookup unavailable")
+
+        real, escaped = alarm._gh, None
+        alarm._gh = raising_gh
+        try:
+            out = alarm.resolve_attempt_created(
+                "o/r", [_run_obj(status="queued", age_min=1, attempt=2,
+                                 created_age_min=99)])
+        except BaseException as exc:  # noqa: BLE001 - the assertion IS that none escapes
+            out, escaped = None, exc
+        finally:
+            alarm._gh = real
+        self.assertIsNone(escaped, f"an attempt lookup failure escaped: {escaped!r}")
+        self.assertNotIn(alarm.ATTEMPT_CREATED_KEY, out[0])
+        _, c = alarm.find_queue_overruns(out, NOW)
+        self.assertEqual(c.get("queued-rerun-attempt-unresolved"), 1)
 
 
 class TestM3ExecutionOverrun(unittest.TestCase):
@@ -270,11 +482,47 @@ class TestM3ExecutionOverrun(unittest.TestCase):
 
     def test_the_measured_2026_07_27_outlier_shape_raises(self):
         """KNOWN POSITIVE, from real data: nightly ci.yml ran 17.33h on 2026-07-27 against
-        an 8.35h p90 over the preceding 13 nights (2.08x)."""
+        an 8.35h p90 over the preceding 13 nights (2.08x). This pins EXEC_OVERRUN_MULTIPLE
+        from ABOVE — at K=2.5 the real event is missed."""
         big = {(".github/workflows/a.yml", "schedule"): {"p90": 8.35 * 3600.0, "n": 13}}
         f, _ = alarm.find_execution_overruns(
             [_run_obj(age_min=int(17.33 * 60))], big, NOW)
         self.assertEqual(len(f), 1)
+
+    def test_the_overrun_multiple_is_pinned_from_BELOW_as_well(self):
+        """Nothing pinned the multiple downwards, so `2.0 -> 1.0` survived: every fixture
+        that must RAISE still raises when the threshold shrinks. 9h against an 8h p90 is
+        1.13x — inside the band at K=2.0, outside it at K<=1.13."""
+        big = {(".github/workflows/a.yml", "schedule"): {"p90": 8 * 3600.0, "n": 40}}
+        f, _ = alarm.find_execution_overruns([_run_obj(age_min=9 * 60)], big, NOW)
+        self.assertEqual(f, [], "9h against an 8h p90 is inside a 2.0x band")
+
+    def test_the_floor_is_pinned_from_BOTH_sides_with_no_baseline(self):
+        """`EXEC_FLOOR_SECONDS -> 1h` survives any suite whose no-baseline fixtures are
+        all ABOVE the floor."""
+        self.assertEqual(
+            alarm.find_execution_overruns([_run_obj(age_min=5 * 60)], {}, NOW)[0], [])
+        self.assertEqual(
+            len(alarm.find_execution_overruns([_run_obj(age_min=7 * 60)], {}, NOW)[0]), 1)
+
+    def test_the_fixture_carries_a_live_runs_real_updated_at(self):
+        """`started = run.get("updated_at") or run_started_at` SURVIVED the first battery
+        because the fixture was a 7-key hand-built dict with no `updated_at`. Every live
+        run has one, and on a live run it tracks the PRESENT moment — so that mutant
+        collapses M3's age to ~0 and the mode never fires again. The fixture now carries
+        the real shape, which is what makes the sibling tests able to see it."""
+        live = _run_obj(age_min=17 * 60)
+        self.assertIn("updated_at", live)
+        self.assertLess((NOW - alarm._ts(live["updated_at"])).total_seconds(), 60,
+                        "a live run's updated_at is ~now, not its start")
+        self.assertGreater(
+            (NOW - alarm._ts(live["run_started_at"])).total_seconds(), 16 * 3600)
+        # And the substitution really would be catastrophic — stated as a measurement,
+        # not an assertion about the shipped code.
+        self.assertEqual(
+            alarm.find_execution_overruns(
+                [dict(live, run_started_at=live["updated_at"])], {}, NOW)[0], [],
+            "reading updated_at as the start silences a 17h overrun")
 
     def test_the_detection_variable_is_live_age_not_completed_history(self):
         """A hang is invisible to any statistic over COMPLETED runs — a job that never


### PR DESCRIPTION
> 🤖 **SPARQ agent** — authored by an automated agent. @jeswr runs multiple agents on this account.

Bead sq-1lc4i. Maintainer-requested: *"setting up alerting for when runners are not picked up for crons or delayed for other dispatches on both repos. This is an indicator that you are choking on runner availability and is something that we would need to manage."*

**Ships two detected modes and one documented gap.** M1 (cron firing deficit) and M3 (execution overrun) detect. **Queue wait — runner availability proper, and the literal ask — is NOT detected**, and that gap is recorded in the code with its evidence rather than filled with a check that cannot see the thing. Read the corrections below before the design sections; this PR's earlier revisions asserted things it no longer claims.

---

## ⚠️ Corrections — what earlier revisions of this PR claimed and this one withdraws

Three claims were wrong. All are retracted here and in the shipped file, not just quietly dropped.

**1. "We are not starved of runners — we were leaking them." WITHDRAWN.**
That headline rested on run `30333511110` showing a 6.7 h life with `status=queued` at 0. Re-measured over the completed run, **N=84 jobs**:

| metric | value |
|---|---|
| job pickup lag (`started_at − created_at`) | max **10 s**, jobs > 60 s: **0** |
| job creation lag (`job.created_at − run.created_at`) | max **402 min** |
| where that 402 min lives | **intra-matrix**: `mutation ratchet`, 51 legs, spread **401.9 min** |
| control: `test` (5 legs, **no** `max-parallel`) | spread **0.0 min** |

and `mutants-nightly-advisory` declares **`max-parallel: 8`**. 51 legs at 8 concurrent is 6.4 waves — the 402 minutes **is the configured cap working correctly**. Not a leak, and not withheld runners. The API observation stands; the capacity inference drawn from it does not.

**2. The M2 known positive was FABRICATED. WITHDRAWN.**
"Seven `pr-gate` runs held in `queued` 12.8–99.5 min" were seven **`run_attempt: 2` re-runs**, all pressed in one batch at 02:35–02:37Z. Per-attempt records for `30318886362`:

```
att1: created=00:58:13Z started=00:58:13Z  →  0s
att2: created=02:37:41Z started=02:37:40Z  →  0s
```

Neither attempt ever queued. The run-level `created_at` is frozen at attempt 1 and never resets, so `now − created_at` charged the idle gap before a human pressed re-run as queue wait — reporting `waited_seconds=5967` for a sub-second pickup.

**3. The "0.022 % / 0.153 %" false-positive figures. WITHDRAWN** — both were computed with that contaminated estimator.

## Why queue wait is not detected at all

Re-derived with a decontaminated estimator, per-workflow scan, splitting on `run_attempt`:

| | sparq | registry |
|---|---|---|
| completed runs scanned | 35,128 | 9,062 |
| contaminated estimator > 15 min | 7 | 6 |
| …of which are **re-runs** | **7 (all)** | **6 (all)** |
| **decontaminated** (`run_attempt == 1`) > 15 min | **0** of 35,070 | **0** of 9,053 |

Every row the old estimator flagged, on both repos, was a re-run artefact.

**And then the decisive one — the fields cannot express the quantity.** This is not "no positive was observed"; the data source does not carry enqueue time, so no threshold on it could ever have worked:

- attempt-1 runs, `run_started_at − created_at`: **exactly 0.0 on all 44,123** (35,070 sparq + 9,053 registry). Identically zero, not approximately.
- re-run attempts, `run_started_at − attempt.created_at`, **N=67**: **negative on every one** — sparq `{−1: 41, −2: 15, −4: 1, −5: 1}`, registry `{−1: 7, −2: 2}`.

A queue wait cannot be negative. A negative value means the attempt record's `created_at` is stamped at or *after* the run starts, not when it is enqueued; an exactly-zero run-level difference across 44,123 runs is what you see when two fields are set together rather than measuring an interval. So the all-zero corpus is **not** evidence that no queueing happened — it is evidence these fields do not report queueing.

**Re-pointing at job-creation lag was considered and rejected**: on this corpus that variable moves because of our own `max-parallel`, so an alarm on it fires every nightly mutation run forever. A permanently-red alarm is a muted alarm — the same reason M1's expectation is capped at what GitHub really delivers.

**Exit condition**, recorded in the file: it takes a **different data source** that actually timestamps enqueue (a `workflow_job` webhook capturing `queued → in_progress`, or in-job self-reported timing), plus an observed positive from it, before any threshold means anything. Do not re-derive a detector from `created_at`/`run_started_at`.

The gap is guarded in both directions: re-adding a detector reds on a structural symbol check plus assertions that `MODES`/the rendered body never mention a queue mode and the live read never fetches `status=queued`; deleting the justification reds on measured-fact anchors.

## The measurement trap the design is built around

The obvious instrument for "are runners being picked up" is job-level `started_at − created_at`. It does not work, and it fails in the safe-looking direction. A matrix leg waiting behind a concurrency limit **is not created as a job object at all while it waits**, so it contributes no queue depth and no pickup lag. Two consequences drive the design:

- **(a)** A job that never finishes never appears in a completed run. Any statistic over *completed* work is structurally incapable of detecting a hang — the failing population is precisely the one it excludes. So **M3's detection variable is the live age of a `status=in_progress` run**, never a statistic over finished work.
- **(b)** Completed-run history is still the right population for the **threshold** ("how long is normal" is a question about runs that ended).
- **(c)** **Fail-open hole, closed deliberately:** a lane whose runs never complete has no baseline. A detector that *skipped* such a lane would go silent exactly when a lane is 100 % hung. A missing baseline falls back to the floor and is reported as such.

## Coordination with #4368 — complement, not competition

#4368's `cron_lane_liveness.py` scope is: `on:` has `schedule` **and every other trigger is in {schedule, workflow_dispatch}**. **M1 here is the exact set complement, computed with the same predicate rather than listed**, so the two partition the scheduled workflows — never both on one lane, never neither. Both directions are asserted over the real workflow tree.

**MEASURED on main `d2b6034a8`: 31 workflows carry a `schedule:` — 18 cron-only (#4368's), 13 not (mine)**, including `ci.yml`, `auto-arm.yml`, `batch-merge.yml`, `verdict-bridge.yml` and the repo's largest capacity consumer. **#4368 structurally cannot see any of them.** M3 keys on live run state, which #4368 does not read in any scope.

## Thresholds

### M1 — cron firing deficit · window 24 h · cap 0.5/h · grace 15 min · floor 0.60

A 6 h window was tried and **rejected**: a daily lane's expectation swings between 0 and 1 on jitter.

**Nominal cron rate is not a usable expectation.** Every daily lane delivers 1.00; sub-hourly lanes deliver 0.08–0.25 (`auto-arm` `*/10` nominal 144 → 12; `retriage` `*/30` nominal 48 → 12). GitHub's `schedule` trigger is best-effort and converges to ~12 runs per lane per day **regardless of the cron**. Comparing against nominal would put six lanes permanently in breach — and a permanently-red alarm is a muted alarm. So the expectation is **capped at what GitHub demonstrably delivers**.

**Validated:** over the 24 covered lanes the minimum capped delivery ratio is **0.75**; the 0.60 floor sits below the worst healthy lane and fires on zero of them, while still catching a lane that stops entirely (→ 0.00) or halves its rate (→ 0.50).

**New-lane window:** a lane younger than the window is counted and skipped, not alarmed on for ~14 h. Prorating the expectation was tried and **rejected** — it yields an expectation of ~2, where one undelivered firing still breaches the floor, and it was quiet at sparq's cap of 12 while still alarming at the registry's 30. A threshold whose behaviour depends on which repo it is deployed to is not a measurement.

### M3 — execution overrun · 2.0 × p90, floor 6 h

**Leave-one-out sweep**, each run scored against a p90 from the *other* runs in its own (workflow, event) cell: sparq **N=8,676 / 119 cells**, registry **N=2,063 / 30 cells**. At K = 1.25–2.0 the only sparq run that fires is the genuine 2026-07-27 nightly outlier (17.33 h vs an 8.35 h p90 = 2.08 ×); at K ≥ 2.5 that real event is **missed**. So 2.0 is the largest multiple that still detects it, and it costs nothing.

⚠️ **Instrument validated against a known answer before the zero was trusted.** The first sweep returned "0 false positives at every K" and was **vacuous** — the unfiltered sample is dominated by the highest-frequency event. Rebuilt with per-event filters, and confirmed a synthetic run at 2.5 × a cell's p90 **does** fire on both repos.

## Verification

- **61 unit tests + the embedded `--self-test`**, both green; `actionlint` rc=0; `check-advisory-registry.py` clear; sibling `test_alarm_lanes_non_gating.py` green with this lane added.
- **Mutation battery: 16 mutants, 16 killed by a NAMED assertion, 0 crash-only, 0 survivors.** All eight shipped constants killed in **both** directions.
- **A crash is not a kill.** The harness counts a mutant killed only on a named assertion (`FAIL:`, never unittest's `ERROR:`); anything else is reported crash-only, because a traceback reads the same whether the guarantee broke or a test stub broke. That distinction caught one mutant of mine passing for the wrong reason.
- Byte-snapshot restore (never `git checkout`), `git status --porcelain` asserted empty between mutants, every mutation asserted non-no-op, harness hash-asserted immediately before the reported run.

**Two defects the battery found that review did not**, both the same class:

- **`fetch_live_runs` → the enrichment pass, deleted: SURVIVED.** Every assertion called the helper *directly*, so the one line wiring it into production was deletable with the suite green — inside the code written to fix call-site vacuity.
- **Cutting the queue-wait region also deleted a `fetch_lanes` assertion nested inside it** — `KILLED → SURVIVED` — which would have left the new-lane guard permanently unreachable in production. Restored standalone.

The class and its detection method are written up in `research/guard-mortality-and-kill-set-diffing.md`.

## Safety posture

**NOT A GATE**, and declared in `.github/advisory-registry.json` — since #3773 the only thing that makes a check-run non-gating, not where its check-run lands. **No arming authority, structurally:** `issues: write` + `actions: read` + `contents: read`, with no `pull-requests`, `checks`, `id-token` or `packages` — pinned by a named test. **Fail-loud (exit 2)** on detector breakage *or an empty scan set*: reporting health over an empty population is the one thing it must never do.

## Out of scope, deliberately

- **The registry deployment** is a separate PR (jeswr/agent-account-registry#1031) — different conventions, and the script is repo-local by design because M1 reads its own repo's workflow files.
- **The nightly `ci.yml` capacity question.** That lane is in poor health — 13 of the last 14 nightlies concluded `cancelled`, and 33 % of mutation legs consume 81.6 % of the lane's runner-time. ⚠️ **M3 would not have fired on it**: nightly `ci.yml` has an 8.34 h p90, so 2.0 × puts its threshold near 16.7 h and a 6.7 h run is well inside its own band. **M3 detects a lane running abnormally long for itself, not a lane that is normally very long.** That is a capacity-policy problem, filed separately with the runner-hour numbers rather than overclaimed here.
- **The chronic 0.08 delivery ratio** on sub-hourly lanes is deliberately *not* alarmed — it is GitHub's normal best-effort behaviour, not a fault. Reported instead: **`*/10` crons on this repo are fiction; the real cadence is ~2 h.** If those lanes need 10-minute cadence, cron is the wrong trigger.
