### PR TITLE
fix(readiness): make the ready-engine and CLAIM agree on review:parked — re-export the inertness contract from the module the registry loads (#4819)

### DIFF
--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -20,6 +20,13 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "orchestration/routing.toml"
+      # [OPUS-5] sparq#4819 — the names jeswr/agent-account-registry reads off
+      # dispatch-plan.py. `dispatch-plan.py --self-test` asserts this file against the
+      # loaded module, so a PR that edits ONLY the contract (adding a name, changing a
+      # wire value) must run that assertion. Without this entry the contract file would be
+      # the one input to the gate that can change without the gate running — which is the
+      # silent-invisibility class it exists to close.
+      - "orchestration/registry-contract.toml"
       - "scripts/routing-validate.py"
       - "scripts/route-resolve.py"
       - "scripts/dispatch-plan.py"
@@ -84,6 +91,13 @@ on:
     branches: [main]
     paths:
       - "orchestration/routing.toml"
+      # [OPUS-5] sparq#4819 — the names jeswr/agent-account-registry reads off
+      # dispatch-plan.py. `dispatch-plan.py --self-test` asserts this file against the
+      # loaded module, so a PR that edits ONLY the contract (adding a name, changing a
+      # wire value) must run that assertion. Without this entry the contract file would be
+      # the one input to the gate that can change without the gate running — which is the
+      # silent-invisibility class it exists to close.
+      - "orchestration/registry-contract.toml"
       - "scripts/routing-validate.py"
       - "scripts/route-resolve.py"
       - "scripts/dispatch-plan.py"

--- a/orchestration/registry-contract.toml
+++ b/orchestration/registry-contract.toml
@@ -1,0 +1,46 @@
+# [OPUS-5] sparq#4819 — THE NAMES jeswr/agent-account-registry READS OFF `scripts/dispatch-plan.py`.
+#
+# WHY THIS FILE EXISTS. The registry's `dispatch.yml` (step `id: readiness`) does
+# `load_dispatch(<target>/scripts/dispatch-plan.py)` and then reads named attributes off THAT
+# module with `getattr(planner, "<name>", None)`. When an attribute it wants is absent the
+# registry does not fail — it DEGRADES, prints a reason, and plans this repository as if the
+# feature did not exist. That is the correct behaviour for a hostile-target planner, and it means
+# a missing export here is invisible from inside sparq: every sparq self-test can be green while
+# the orchestrator has silently stopped consuming the thing those tests prove.
+#
+# It has happened twice. `roleless_ready` went unreported for every tick until it was re-exported;
+# `INERT_FIELD`/`MACHINE_PARK_PR_LABEL` (sparq#4819) were defined only in `scripts/ready-issues.py`
+# and shipped as a MEASURED no-op — ready-issues.py's own suite was 9/9 green throughout, because
+# it pins the ENGINE and the registry reads the MODULE.
+#
+# HOW IT IS ENFORCED. `scripts/dispatch-plan.py --self-test` reads this file and asserts every
+# `required_attributes` name is present on the module as loaded EXACTLY the way `load_dispatch`
+# loads it, and that the pinned `values` still match. Adding a name here without exporting it is
+# red; renaming an export without changing this file is red. It is deliberately DATA and not a
+# Python constant so that a rename sweep over `scripts/` cannot carry the expectation along with
+# the thing it is supposed to be checking.
+#
+# THESE NAMES ARE NOT SPARQ'S TO RENAME. They are hard-coded string literals in the registry's
+# workflow. Changing one here without a matching registry PR does not break a test in CI — it
+# silently returns the pipeline to the degraded path.
+
+[planner_exports]
+# The two-repo interlock that releases a machine-parked (`review:parked`) PR's `area:` keys, but
+# ONLY against the registry's own per-row inertness proof (sparq#4819). The registry's
+# `inert_aware` probe refuses to stamp anything unless BOTH names resolve to strings AND
+# `compute_ready` demonstrably honours them in both directions.
+required_attributes = [
+    "compute_ready",
+    "roleless_ready",
+    "ready_candidates",
+    "INERT_FIELD",
+    "MACHINE_PARK_PR_LABEL",
+]
+
+[planner_exports.values]
+# WIRE VALUES, not just names. `INERT_FIELD` is the key the registry WRITES onto each occupancy
+# row (`row[field] = inert_map.get(pr_number, False)`), and `MACHINE_PARK_PR_LABEL` is a real
+# GitHub label on this repository — so both are observable outside sparq and neither is a free
+# local choice.
+INERT_FIELD = "inert"
+MACHINE_PARK_PR_LABEL = "review:parked"

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -56,8 +56,25 @@ GLOBAL = _ready.GLOBAL
 # `<target>/scripts/dispatch-plan.py`, never `ready-issues.py`. Defining them only in the readiness
 # engine left both attributes `None` here, so the probe returned "planner declares no inertness
 # contract", the field was never stamped onto any occupancy row, and the whole carve-out was a
-# no-op that printed `NOT STAMPED` in a plain (unannotated) line. MEASURED on the live snapshot
-# (2026-07-28, 1721 issue rows / 91 open PRs): frontier 0 without these two names, 7 with them.
+# no-op that printed `NOT STAMPED` in a plain (unannotated) line.
+#
+# WHAT THAT IS WORTH — stated as the two things that are actually DURABLE, because an earlier
+# revision of this comment hard-coded a frontier delta and the number did not survive the week.
+#   1. WITHOUT these names the effect is CATEGORICAL, not statistical: `inert_aware` refuses,
+#      nothing is ever stamped onto an occupancy row, and the carve-out cannot fire on any board.
+#   2. WITH them, what is guaranteed is the RELEASE, not a frontier gain: an `area:` key held only
+#      by attested machine parks is released, and a key retaining any holder that is not itself an
+#      attested machine park is NOT.
+# The frontier delta is neither of those. It is a PER-TICK YIELD — a released key moves the
+# frontier only if some candidate happened to be waiting on exactly that key — so it is a property
+# of the board on the day, not of this code. Three verbatim replays of the registry's readiness
+# step over the same week disagreed on it (+7, +2, +3) while agreeing on the release semantics
+# every time; that spread IS the finding, and it is why no number is pinned here.
+# For a CURRENT figure, read the registry's own per-tick census rather than trusting this comment:
+#   `parked-release census <repo>: stamped|NOT STAMPED (...); N of M open PR(s) attested inert;
+#    K machine-parked row(s) release their areas: ...`
+#   `partition census <repo>: candidates= frontier= partition-deferred= ...`
+#
 # Bound to the engine's own objects, never re-declared: a second literal here could drift from the
 # value `occupies_area` actually consults, which is the two-legs-disagree defect in miniature.
 INERT_FIELD = _ready.INERT_FIELD

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -159,6 +159,22 @@ def _routing_doc():
         return tomllib.load(fh)
 
 
+def _registry_contract():
+    """[OPUS-5] sparq#4819 — the names jeswr/agent-account-registry reads off THIS module.
+
+    Deliberately DATA (`orchestration/registry-contract.toml`) rather than a constant in this
+    file: the registry DEGRADES silently on a missing attribute, so the only thing that can catch
+    a rename is an expectation a rename sweep over `scripts/` does not reach. Opened unguarded —
+    an unreadable or malformed contract file must abort `--self-test`, never be skipped, because
+    "the contract could not be read" and "the contract is satisfied" are the two states this whole
+    mechanism exists to keep apart.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    toml = os.path.join(os.path.dirname(here), "orchestration", "registry-contract.toml")
+    with open(toml, "rb") as fh:
+        return tomllib.load(fh)
+
+
 def _self_test():
     doc = _routing_doc()
     ok = True
@@ -271,12 +287,17 @@ def _self_test():
     # what must hold is the behaviour of the other repo's code against this file, and an
     # approximation of it can agree with us while the real one refuses.
     #
-    # THE NAMES ARE STRING LITERALS ON PURPOSE. They are the REGISTRY's wire names, not ours to
-    # rename: dispatch.yml hard-codes "INERT_FIELD"/"MACHINE_PARK_PR_LABEL", so renaming the
-    # Python constant here — however consistently across sparq's own prod and tests — silently
-    # returns the pipeline to NOT STAMPED. Reading them through `getattr(module, "<literal>")` is
-    # what makes such a rename RED here instead of green-and-dead in production.
-    _WIRE_NAMES = ("INERT_FIELD", "MACHINE_PARK_PR_LABEL")
+    # THE NAMES COME FROM DATA, NOT FROM THIS FILE. They are the REGISTRY's wire names, not ours
+    # to rename: dispatch.yml hard-codes "INERT_FIELD"/"MACHINE_PARK_PR_LABEL", so renaming the
+    # Python constant — however consistently across sparq's own prod and tests — silently returns
+    # the pipeline to NOT STAMPED. Holding the expectation in `orchestration/registry-contract.toml`
+    # is what makes such a rename RED here instead of green-and-dead in production: a rename sweep
+    # over `scripts/` cannot carry the expectation along with the thing it is checking. MEASURED:
+    # renaming the identifier in prod AND every sparq test leaves ready-issues.py 9/9 green and
+    # reds three rows here; a blind textual rename that ALSO rewrote the literals in this file was
+    # green until the expectation moved out of it.
+    _contract = _registry_contract()["planner_exports"]
+    _WIRE_NAMES = tuple(_contract["required_attributes"])
 
     def _as_registry_loads_it():
         """This file, loaded byte-for-byte the way `load_dispatch` loads it — not `globals()`.
@@ -318,18 +339,18 @@ def _self_test():
                        "unattested one")
 
     _mod = _as_registry_loads_it()
-    # (a) THE NAME. Renaming either constant — in prod, or in prod AND every sparq test together —
-    # makes this red, because the expectation is the registry's literal, which no sparq-side
-    # rename reaches.
-    chk("[sparq#4819] dispatch-plan exports the registry's two wire names, as strings",
-        sorted(name for name in _WIRE_NAMES
-               if isinstance(getattr(_mod, name, None), str)), sorted(_WIRE_NAMES))
+    # (a) THE NAMES. Every attribute the registry reads off this module must be PRESENT on it, as
+    # loaded. `roleless_ready`/`ready_candidates` ride along because they degrade the same silent
+    # way and had no module-level assertion either.
+    chk("[sparq#4819] dispatch-plan exports every name registry-contract.toml declares",
+        sorted(name for name in _WIRE_NAMES if not hasattr(_mod, name)), [])
     # (b) THE VALUES. `MACHINE_PARK_PR_LABEL` is a real GitHub label and `INERT_FIELD` is the key
-    # the registry writes onto the occupancy row (`row[field] = ...`); both are wire values, so a
-    # "tidy-up" of either detaches this engine from the attestations it is sent.
+    # the registry WRITES onto the occupancy row (`row[field] = ...`); both are wire values, so a
+    # "tidy-up" of either detaches this engine from the attestations it is sent. Compared as a
+    # whole mapping so a name dropped from the contract file is as red as a value changed.
     chk("[sparq#4819] ...bound to the wire VALUES the registry writes",
-        (getattr(_mod, "INERT_FIELD", None), getattr(_mod, "MACHINE_PARK_PR_LABEL", None)),
-        ("inert", "review:parked"))
+        {name: getattr(_mod, name, None) for name in _contract["values"]},
+        dict(_contract["values"]))
     # (c) THE BEHAVIOUR, through THIS module's compute_ready. Asserted on the full (field, why)
     # pair, not on truthiness: every refusal path returns (None, <reason>), and the reason names
     # which half broke — so this row reports the registry's own diagnosis rather than "not ok".

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -50,6 +50,19 @@ resolve = _route.resolve
 roleless_ready = _ready.roleless_ready
 ready_candidates = _ready.ready_candidates
 GLOBAL = _ready.GLOBAL
+# [OPUS-5] sparq#4819 — THE SAME SILENT-INVISIBILITY CLASS AS `roleless_ready`, THREE LINES UP.
+# The registry's `inert_aware` probe reads `getattr(planner, "INERT_FIELD")` and
+# `getattr(planner, "MACHINE_PARK_PR_LABEL")` off THIS module — it loads
+# `<target>/scripts/dispatch-plan.py`, never `ready-issues.py`. Defining them only in the readiness
+# engine left both attributes `None` here, so the probe returned "planner declares no inertness
+# contract", the field was never stamped onto any occupancy row, and the whole carve-out was a
+# no-op that printed `NOT STAMPED` in a plain (unannotated) line. MEASURED on the live snapshot
+# (2026-07-28, 1721 issue rows / 91 open PRs): frontier 0 without these two names, 7 with them.
+# Bound to the engine's own objects, never re-declared: a second literal here could drift from the
+# value `occupies_area` actually consults, which is the two-legs-disagree defect in miniature.
+INERT_FIELD = _ready.INERT_FIELD
+MACHINE_PARK_PR_LABEL = _ready.MACHINE_PARK_PR_LABEL
+is_provably_inert = _ready.is_provably_inert
 
 try:
     import tomllib
@@ -243,6 +256,94 @@ def _self_test():
                  for r in plan]
     chk("no planned row names a deprecated alias",
         sorted({m for r in _all_rows for m in r["model_chain"]} & _dep), [])
+
+    # --- [OPUS-5] sparq#4819 THE CROSS-REPO INTERLOCK, REPLAYED AGAINST THIS FILE ----------------
+    # WHY THIS EXISTS, AND WHY IT IS HERE AND NOT IN ready-issues.py. The registry's dispatch.yml
+    # `readiness` step does `load_dispatch(<target>/scripts/dispatch-plan.py)` and then probes THE
+    # LOADED MODULE. ready-issues.py's own suite proved the ENGINE honours the carve-out and was
+    # 9/9 green while this module exported neither name, so the registry read
+    # `getattr(planner, "INERT_FIELD", None) is None`, printed "planner declares no inertness
+    # contract", and stamped nothing — the whole two-PR change was a measured no-op. A guard on
+    # the wrong module is not a guard.
+    #
+    # `_probe` below is the registry's `inert_aware` VERBATIM (jeswr/agent-account-registry
+    # .github/workflows/dispatch.yml, step `id: readiness`), reproduced rather than approximated:
+    # what must hold is the behaviour of the other repo's code against this file, and an
+    # approximation of it can agree with us while the real one refuses.
+    #
+    # THE NAMES ARE STRING LITERALS ON PURPOSE. They are the REGISTRY's wire names, not ours to
+    # rename: dispatch.yml hard-codes "INERT_FIELD"/"MACHINE_PARK_PR_LABEL", so renaming the
+    # Python constant here — however consistently across sparq's own prod and tests — silently
+    # returns the pipeline to NOT STAMPED. Reading them through `getattr(module, "<literal>")` is
+    # what makes such a rename RED here instead of green-and-dead in production.
+    _WIRE_NAMES = ("INERT_FIELD", "MACHINE_PARK_PR_LABEL")
+
+    def _as_registry_loads_it():
+        """This file, loaded byte-for-byte the way `load_dispatch` loads it — not `globals()`.
+
+        A `globals()` read would pass on a module that only defines the name at self-test time;
+        the registry gets whatever `exec_module` leaves on the module object, so that is what is
+        probed."""
+        here = os.path.dirname(os.path.abspath(__file__))
+        spec = importlib.util.spec_from_file_location(
+            "target_dispatch_plan", os.path.join(here, "dispatch-plan.py"))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def _probe(planner):
+        """VERBATIM `inert_aware` from the registry's readiness step. Returns (field, why)."""
+        field = getattr(planner, "INERT_FIELD", None)
+        label = getattr(planner, "MACHINE_PARK_PR_LABEL", None)
+        if not isinstance(field, str) or not isinstance(label, str):
+            return None, "planner declares no inertness contract"
+        area = "area:__inert_probe__"
+        rival = {"number": 999000012, "state": "OPEN", "open_blockers": 0,
+                 "labels": ["status:ready", "priority:P0", "role:impl", area]}
+        holder = {"number": 999000011, "state": "OPEN", "open_blockers": 0,
+                  "pull_request": {}, "labels": [area, label]}
+        try:
+            held = [row.get("number") for row in planner.compute_ready(
+                [dict(holder), dict(rival)])]
+            freed = [row.get("number") for row in planner.compute_ready(
+                [dict(holder, **{field: True}), dict(rival)])]
+        except Exception as exc:                              # noqa: BLE001 — mirrors the registry
+            return None, f"probe raised {type(exc).__name__}"
+        if held:
+            return None, ("planner RELEASES a machine-parked area with no attestation "
+                          "— refusing to feed it attestations")
+        if freed != [999000012]:
+            return None, "planner ignores the inertness attestation"
+        return field, (f"releases an attested machine park via `{field}` and holds an "
+                       "unattested one")
+
+    _mod = _as_registry_loads_it()
+    # (a) THE NAME. Renaming either constant — in prod, or in prod AND every sparq test together —
+    # makes this red, because the expectation is the registry's literal, which no sparq-side
+    # rename reaches.
+    chk("[sparq#4819] dispatch-plan exports the registry's two wire names, as strings",
+        sorted(name for name in _WIRE_NAMES
+               if isinstance(getattr(_mod, name, None), str)), sorted(_WIRE_NAMES))
+    # (b) THE VALUES. `MACHINE_PARK_PR_LABEL` is a real GitHub label and `INERT_FIELD` is the key
+    # the registry writes onto the occupancy row (`row[field] = ...`); both are wire values, so a
+    # "tidy-up" of either detaches this engine from the attestations it is sent.
+    chk("[sparq#4819] ...bound to the wire VALUES the registry writes",
+        (getattr(_mod, "INERT_FIELD", None), getattr(_mod, "MACHINE_PARK_PR_LABEL", None)),
+        ("inert", "review:parked"))
+    # (c) THE BEHAVIOUR, through THIS module's compute_ready. Asserted on the full (field, why)
+    # pair, not on truthiness: every refusal path returns (None, <reason>), and the reason names
+    # which half broke — so this row reports the registry's own diagnosis rather than "not ok".
+    chk("[sparq#4819] the registry's inert_aware probe STAMPS against this module",
+        _probe(_mod),
+        ("inert", "releases an attested machine park via `inert` and holds an unattested one"))
+    # (d) ...and the refusal direction is reachable, so (c) cannot be passing because `_probe`
+    # returns its happy value unconditionally. A planner missing the names must be REFUSED with
+    # the registry's exact wording — this is the state sparq was in when the pair was measured a
+    # no-op, reproduced here as a fixture so it can never be the silent state again.
+    class _NoContract:
+        compute_ready = staticmethod(_mod.compute_ready)
+    chk("[sparq#4819] ...and refuses a planner without the names, by the registry's own reason",
+        _probe(_NoContract), (None, "planner declares no inertness contract"))
 
     print("dispatch-plan self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -340,6 +340,25 @@ def is_provably_inert(artifact):
     not proved anything, and a truthiness test would read all three as proof. Absent ⇒ False, so an
     engine invoked WITHOUT the widened occupancy input (sparq's own `--self-test`, any standalone
     run, a registry that has not shipped the producer yet) behaves EXACTLY as before this change.
+
+    WHAT THE PROOF IS WORTH, MEASURED — do not read "provably inert" as "will never land".
+    Over the 120 sparq PRs that ever carried `review:parked` (census, 2026-07-14..28; the label
+    itself is only ~5 days old, so long parks are structurally unobservable and every rate below
+    is a FLOOR):
+      * 120/120 were DRAFT at their first park, so the draft conjunct discriminates NOTHING on
+        this cohort — 33 of 33 currently-parked open PRs satisfy the whole predicate;
+      * 75% were un-parked again (80–88% among parks old enough to have resumed), median 6.2 h
+        (N=130 park→unpark pairs, p90 17.3 h);
+      * 34% (41/120) went on to MERGE, median 12.4 h after the park, 13 of them past 24 h;
+      * 30/120 had auto-merge enabled STRICTLY AFTER the park and 24 of those merged — the latch
+        bit is a snapshot, re-read each tick, never a durable property of the PR.
+    So this releases a partition a re-admitted PR can return to. That trade is accepted
+    deliberately (sparq#4819): the release is confined to crates where the parked PR is the ONLY
+    open holder — a union over holders means one un-parked PR keeps the key — so the exposure is
+    1 open PR becoming 2 on ~14 low-traffic crates, never a deepening of the 25-to-30-deep
+    `docs`/`ci` buckets, which stay held. A dwell-threshold narrowing was measured and REJECTED,
+    not skipped: gating on ≥12 h idle leaves the live frontier at 1 (i.e. buys nothing), because
+    the crates with a waiting candidate are held by RECENT parks.
     """
     return artifact.get(INERT_FIELD) is True
 

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -46,6 +46,19 @@ IN_FLIGHT_STATUS = {"status:in-progress", "status:in-progress-review"}
 # advance autonomously, so they must not reserve an area indefinitely. Removing the label in a
 # later snapshot restores occupancy immediately; there is no remembered park state.
 PARKED_AREA_LABELS = {"needs:user", "review:needs-user", "status:blocked"}
+# [OPUS-5] sparq#4819. The MACHINE park — set by the registry's park policy when the review loop
+# runs out of rounds — is DELIBERATELY not in PARKED_AREA_LABELS. Unlike the three human-owned
+# labels above, a machine park can be lifted by the machine on any tick, so "cannot advance
+# autonomously" is not true of it by definition and its area must NOT be released on the label
+# alone. It is released only against a POSITIVE, per-row proof of inertness (`INERT_FIELD`), which
+# the two partition legs must agree on; see `is_provably_inert`.
+MACHINE_PARK_PR_LABEL = "review:parked"
+# The field on an occupancy row that carries that proof. It is NOT derived here: the registry's
+# `_pull_inactivity_decision` (scripts/dispatch-claim.py) is the ONE implementation of "is this PR
+# provably inert", and this engine CONSUMES its answer rather than minting a second one — two
+# partition legs disagreeing about the same PR is the whole defect sparq#4819 describes. Absent,
+# non-boolean, or False ⇒ the row keeps holding its areas (fail closed).
+INERT_FIELD = "inert"
 # [OPUS-4.8] an epic is a tracking umbrella (its children are the work) — never dispatchable, even
 # with a full ready label-set + zero blockers. Excluded here so a worker never "implements" an epic.
 NON_DISPATCHABLE = "kind:epic"
@@ -312,9 +325,48 @@ def is_parked(labels):
     return bool(labels & PARKED_AREA_LABELS)
 
 
+def is_provably_inert(artifact):
+    """Whether the SNAPSHOT PRODUCER attested that this PR row cannot advance or land.
+
+    [OPUS-5] sparq#4819. STRICTLY a consumer of the registry's `_pull_inactivity_decision`, whose
+    answer arrives on the row as `INERT_FIELD`. That predicate proves one thing and only one
+    thing — a DRAFT with no latched auto-merge, coherent across the listing/detail split-snapshot
+    read — and it fails closed on every malformed, latched, non-draft, or head-mismatched shape.
+    Nothing about that proof is re-derived here, because a second implementation of it is exactly
+    the drift that let sparq's PLAN leg reserve crates the registry's CLAIM leg was freeing in the
+    same tick.
+
+    `is True` and not truthiness, deliberately: a producer that stamps a string, a dict, or 1 has
+    not proved anything, and a truthiness test would read all three as proof. Absent ⇒ False, so an
+    engine invoked WITHOUT the widened occupancy input (sparq's own `--self-test`, any standalone
+    run, a registry that has not shipped the producer yet) behaves EXACTLY as before this change.
+    """
+    return artifact.get(INERT_FIELD) is True
+
+
 def occupies_area(artifact):
-    """Whether an otherwise in-flight PR/issue occupies its areas in this snapshot."""
-    return not is_parked(labels_of(artifact))
+    """Whether an otherwise in-flight PR/issue occupies its areas in this snapshot.
+
+    [OPUS-5] sparq#4819 adds the SECOND, conditional release. The asymmetry between the two is the
+    point, not an inconsistency:
+
+    * `PARKED_AREA_LABELS` (human park) releases on the LABEL ALONE. Nobody can say when a human
+      will act, so the option the hold buys has unbounded price.
+    * `MACHINE_PARK_PR_LABEL` releases only against a per-row PROOF that the PR is a defused draft
+      with no latch. The machine can un-park on any tick, so on the label alone this would free a
+      crate a re-admitted PR resumes into.
+
+    PR ROWS ONLY. The proof is about `draft` + `auto_merge`, which no issue has; an issue carrying
+    the label keeps its areas. That is the conservative direction and it keeps this carve-out
+    exactly co-extensive with the registry leg's own (`busy_packages_of_pulls`, PR-scoped).
+    """
+    labels = labels_of(artifact)
+    if is_parked(labels):
+        return False
+    if (MACHINE_PARK_PR_LABEL in labels and "pull_request" in artifact
+            and is_provably_inert(artifact)):
+        return False
+    return True
 
 
 def _artifact_name(artifact):
@@ -611,6 +663,60 @@ def _self_test():
     unparked = {**parked, "labels": ["area:sparq-store"]}
     check("park-label removal restores snapshot occupancy",
           compute_ready([unparked, waiting], conflict_log=quiet), [])
+
+    # ---------------------------------------------------------------------------------------
+    # [OPUS-5] sparq#4819 MACHINE-PARK tripwires. EVERY row runs END-TO-END through
+    # compute_ready: an assertion that only inspects `is_provably_inert`'s shape would stay green
+    # while the call site in `occupies_area` was deleted, which is the surviving-mutant class this
+    # estate keeps measuring. The four mutants each row is written to kill are named inline, and
+    # three of them PRESERVE the structure (`is_provably_inert` still exists, still takes a row,
+    # is still called from `occupies_area`) while breaking the behaviour claimed for it.
+    # ---------------------------------------------------------------------------------------
+    def park_pr(n, extra=(), **fields):
+        row = pr(n, ["area:sparq-store", MACHINE_PARK_PR_LABEL] + list(extra))
+        row.update(fields)
+        return row
+
+    def frontier(*rows):
+        return [i["number"] for i in compute_ready(list(rows) + [waiting], conflict_log=quiet)]
+
+    # THE HEADLINE CLAIM: an ATTESTED-inert machine-parked PR releases its crate.
+    check("attested-inert review:parked PR frees its area",
+          frontier(park_pr(74, **{INERT_FIELD: True})), [20])
+    # MUTANT 1 — "just add review:parked to PARKED_AREA_LABELS" (the fix the issue forbids) and
+    # MUTANT 2 — free on the `draft` bit instead of the attestation. Both make these red: an
+    # UNATTESTED parked draft is exactly the shape both mutants would free.
+    check("review:parked with NO inertness attestation keeps holding",
+          frontier(park_pr(75)), [])
+    check("review:parked attested NOT inert keeps holding",
+          frontier(park_pr(76, **{INERT_FIELD: False})), [])
+    # MUTANT 3 — `is True` weakened to truthiness (`bool(...)`, `if artifact.get(INERT_FIELD):`).
+    # Structure-preserving: the helper, its name, and its call site all survive. A producer that
+    # stamps a string or an int has proved NOTHING and must not free a crate.
+    check("truthy-but-not-True attestations prove nothing",
+          [frontier(park_pr(77, **{INERT_FIELD: value}))
+           for value in ("yes", 1, ["proof"], {"inert": True})], [[], [], [], []])
+    # MUTANT 4 — the `and` linking label to proof turned into `or`, or the label test dropped.
+    # Structure-preserving. An inert-attested PR that is NOT machine-parked is an ordinary
+    # in-flight draft and must keep its crate.
+    check("inertness alone (no review:parked) frees nothing",
+          frontier(pr(78, ["area:sparq-store"]) | {INERT_FIELD: True}), [])
+    # MUTANT 5 — the `"pull_request" in artifact` clause dropped. An ISSUE has no draft/latch
+    # surface for the registry predicate to have proved anything about, so a stamped issue row
+    # must be ignored. In-progress so it is an occupant at all.
+    check("a machine-parked ISSUE row is never freed by an attestation",
+          frontier({**iss(79, ["status:in-progress", "area:sparq-store",
+                               MACHINE_PARK_PR_LABEL]), INERT_FIELD: True}), [])
+    # The carve-out must not have widened CANDIDATE enumeration (sparq#4819 constraint: 386
+    # candidates is correct). `review:parked` is deliberately absent from PARKED_AREA_LABELS, so
+    # it is not an exclusion reason — adding it there to "simplify" reds this AND the four rows
+    # above that depend on the unconditional-free behaviour it would introduce.
+    check("review:parked is not a candidate-exclusion reason",
+          exclusion_reason(set(R + ["priority:P1", MACHINE_PARK_PR_LABEL])), None)
+    parked_logs = []
+    compute_ready([park_pr(80), waiting], conflict_log=parked_logs.append)
+    check("an unattested park still names itself in the conflict log",
+          parked_logs, ["conflict #20: area sparq-store held by pr#80"])
 
     active = pr(71, ["area:sparq-store", "review:changes"])
     active_logs = []

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -1322,6 +1322,50 @@ class TestRoutingSelfTestWorkflowWiring(unittest.TestCase):
             self.assertEqual(paths_section.count(f'"{script}"'), 2,
                              f"{script} must be a path trigger on BOTH pull_request and push")
 
+    # [OPUS-5] sparq#4819 review, S8. The rule above covers the SCRIPTS the gate runs. It says
+    # nothing about the DATA those scripts assert against, and `dispatch-plan.py --self-test` now
+    # asserts the shipped `orchestration/registry-contract.toml` (the names the registry reads off
+    # that module). Dropping that file from both `paths:` filters survived the entire suite —
+    # including every test in this class — because a data file is not an invoked script. That is
+    # the same silent-invisibility class the contract file exists to close, one layer out, in the
+    # half whose whole thesis is "pin the wiring".
+    #
+    # DERIVED, not listed. A hard-coded tuple here would be one more written statement that has to
+    # be remembered; scanning the invoked scripts for the orchestration data they actually open
+    # means a NEW data input demands its own trigger with no edit to this file. The derivation is
+    # asserted non-empty and asserted to have found the known inputs, because a regex that silently
+    # matches nothing is the way this kind of check fails — quietly, toward "nothing to report".
+    _DATA_REF = re.compile(r'orchestration/([A-Za-z0-9._-]+\.(?:toml|json))'
+                           r'|"orchestration",\s*"([A-Za-z0-9._-]+\.(?:toml|json))"')
+
+    def _declared_data_inputs(self):
+        found = {}
+        for script in self.INVOKED:
+            text = (REPO_ROOT / script).read_text(encoding="utf-8")
+            for match in self._DATA_REF.finditer(text):
+                name = match.group(1) or match.group(2)
+                found.setdefault(f"orchestration/{name}", set()).add(script)
+        return found
+
+    def test_the_data_input_derivation_is_not_vacuous(self):
+        found = self._declared_data_inputs()
+        # A KNOWN-POSITIVE control: these two are read by the gate's own scripts today, so a
+        # derivation that cannot see them cannot see a third one either.
+        self.assertLessEqual({"orchestration/routing.toml",
+                              "orchestration/registry-contract.toml"}, set(found), found)
+        for path in found:
+            self.assertTrue((REPO_ROOT / path).is_file(),
+                            f"{path} is referenced by a gated script but does not exist")
+
+    def test_every_orchestration_data_input_is_a_path_trigger(self):
+        paths_section = self._paths_section()
+        for path, readers in sorted(self._declared_data_inputs().items()):
+            self.assertEqual(
+                paths_section.count(f'"{path}"'), 2,
+                f"{path} is asserted against by {sorted(readers)} but is not a path trigger on "
+                "BOTH pull_request and push — it could change without re-running the gate that "
+                "reads it")
+
     def test_gate_is_not_declared_advisory(self):
         # [OPUS-5] Guards the rule that is LIVE. ci-summary's discovery changed on
         # 2026-07-25 (#3773): a check is non-gating iff it is EXPLICITLY DECLARED in


### PR DESCRIPTION
> 🤖 **SPARQ agent** — Opus 5. Closes the sparq half of #4819. **Author, not reviewer — no `VERDICT:` on my own work.** Not armed.

---

## ⚠️ CORRECTION (round 2) — the round-1 pair did nothing, and this body said otherwise

An independent review failed round 1 as a **provable no-op**, and the correction matters more than the fix.

**The defect.** The registry's readiness step loads `<target>/scripts/dispatch-plan.py` and probes *that module* for `INERT_FIELD` / `MACHINE_PARK_PR_LABEL`. Round 1 defined both only in `scripts/ready-issues.py` and never re-exported them — three lines below the `roleless_ready` re-export whose own comment documents this exact silent-invisibility class. So `inert_aware` returned *"planner declares no inertness contract"*, nothing was stamped on any occupancy row, and the carve-out could not fire. `ready-issues.py --self-test` was 9/9 green throughout, because it pins the **engine** and the registry reads the **module**.

**The false claim.** The table below used to read *"frontier 1 → 9, reproduced by replaying `dispatch.yml`'s readiness step verbatim"*. That was a replay of the **lever** — this consumer against a planner that already honoured the field — **not** of the state either PR shipped. A verbatim replay of the merged trees printed `NOT STAMPED`. I am replacing the figure rather than deleting it, because it was repeated onward as the fix's effect.

**What round 2 adds:** the two-line re-export on `dispatch-plan.py`, plus a guard that replays the registry's `inert_aware` probe **verbatim** against this file loaded the way `load_dispatch` loads it, with the expected wire names held in `orchestration/registry-contract.toml` (data, so a rename sweep over `scripts/` cannot carry the expectation along with the thing it checks).

---

## What this changes

`scripts/ready-issues.py` gains a **second, conditional** partition release. A `review:parked` PR row releases its `area:` keys **iff** the snapshot producer stamped a positive inertness attestation on the row.

```
occupies_area(artifact):
  human park (PARKED_AREA_LABELS)              -> release on the LABEL ALONE   (unchanged)
  review:parked AND pull_request AND inert is True -> release                  (NEW)
  otherwise                                    -> hold
```

`review:parked` is **deliberately NOT added to `PARKED_AREA_LABELS`** — that is the unconditional fix #4819 rules out, and mutant M6 below reds on it. `ready_candidates` / `compute_ready` admission is untouched — **candidates identical before and after** (385 on the 2026-07-28 board; the count itself moves with the board, the *equality* is the invariant).

## The prerequisite, and how it is handled

`occupancy_input` carries `{number, state, labels, open_blockers, pull_request}` — no `draft`, no `auto_merge` — so the inertness predicate could not be evaluated where the decision is made. **The predicate is not duplicated here.** This engine consumes a boolean produced by the registry's own `_pull_inactivity_decision` (registry PR, linked below). Absent / non-boolean / `False` ⇒ the row holds its areas, so **this PR alone is a no-op**: with no producer, behaviour is byte-identical to today. Safe to merge in either order.

Round 1 shipped that no-op property *unconditionally* — see the correction above. The re-export is what makes the non-no-op case reachable at all.

## Measured — re-run in round 2, live sparq snapshot 2026-07-28 (1721 issue rows / 91 open PRs / 33 `review:parked`)

Replaying the registry's `id: readiness` heredoc **verbatim** against both trees, with the registry's own `inertness_attestation` as producer:

| tree | census line | candidates | ready-lane frontier | plan rows |
|---|---|---|---|---|
| **round 1 as shipped** | `NOT STAMPED (planner declares no inertness contract)` | 385 | **0** | 2 |
| **round 2 (this head)** | `stamped (releases an attested machine park via `inert`…)` | 385 | **2** | 4 |

Candidate enumeration is unchanged, as #4819 requires.

**That `2` is a per-tick yield, not a property of this code.** Releasing a key only moves the frontier when some candidate was waiting on *exactly* that key, so it swings with the board and a repeat run will differ. The stable, mechanism-level measurement is the release itself: **33/33 parked PRs attested inert; PR-held `area:` keys 40 → 25, with 15 fully released and no key losing a holder that is not itself an attested machine park.** `docs` 34 → 25 and `ci` 30 → 27 stay held.

## The conflict risk, stated rather than implied

A census of the 120 sparq PRs that ever carried `review:parked` (2026-07-14..28; the label is ~5 days old, so every rate is a **floor**):

- **120/120 were draft at their first park** — the draft conjunct discriminates *nothing* on this cohort; 33/33 currently-parked open PRs satisfy the whole predicate. The predicate is a formality here, not a filter, and it is written that way in the docstring.
- 75% were un-parked again (80–88% among parks old enough to have resumed), **median 6.2 h** (N=130 pairs, p90 17.3 h).
- **34% (41/120) went on to MERGE**, median 12.4 h after the park, 13 of them past 24 h.
- 30/120 had auto-merge enabled *strictly after* the park; 24 of those merged. The latch bit is a snapshot re-read each tick, not a durable property.

**So this releases partitions that resuming PRs can return to. That trade is accepted deliberately**, on three grounds:

1. **Bounded by union semantics.** Occupancy is a union over holders, so a key is released only when **no holder that is not itself an attested machine park** remains. Re-measured on the 2026-07-28 board: PR-held `area:` keys **40 → 25**, **15 fully released**, **0 retaining a holder**. `docs` (34 → 25 holders) and `ci` (30 → 27) stay held. Exposure is 1 open PR becoming 2 on low-traffic keys — never a deepening of the crowded buckets. The reviewer independently confirmed this on their own board and called it the strongest part of the work.
2. **CLAIM already frees these crates** and logs it (142 events / 57 crates in one tick), and re-validates every item against the live pull listing before launch. This makes an existing decision reachable rather than inventing one.
3. **The narrower alternative was measured and does not exist.** A dwell threshold derived from the resumption distribution is a cliff, not a dial:

| min idle | parked PRs released | crates released | frontier |
|---|---|---|---|
| none | 33/33 | 14 | **9** |
| >6 h | 22/33 | 6 | 2 |
| >12 h | 19/33 | 5 | **1** |
| >18 h (p90) | 15/33 | 3 | **1** |
| >36 h | 12/33 | 2 | **1** |

At ≥12 h it buys **nothing** — the crates with a waiting candidate are held by *recent* parks. So "narrow it with a measured threshold" is refuted by measurement, not skipped.

**Scope of that table, stated honestly.** It was produced by the round-1 sweep, i.e. by the same replay that turned out to be measuring the **lever**. For *this* question that is the right instrument — every row carries the attestation and only the dwell threshold varies, so the row-to-row comparison is valid. But the **absolute** frontier column is a snapshot of that board, not of this one, and **I did not re-run the sweep in round 2.** Treat the comparison as the finding and the absolute numbers as stale.

## Vacuity check — 9/9 in round 1, **and that was the problem**

Applied to a copy of the tree; dead ⇔ `ready-issues.py --self-test` exits non-zero. Recorded **unedited**: every one of these nine is genuinely dead, and the review confirmed the battery is not vacuous — yet all nine were green on a pair that did nothing, because every one of them mutates the **engine** and the registry reads the **module**. 9/9 on the seam you chose to mutate says nothing about the seam you did not.

| mutant | result |
|---|---|
| M0 delete the carve-out | DEAD |
| M1 invert it | DEAD |
| **M2 `is True` → truthiness** (helper, name, call site all intact) | DEAD |
| **M3 `and` → `or` between label and proof** | DEAD |
| **M4 drop the PR-only clause** | DEAD |
| **M5 free on the `draft` bit instead of the attestation** | DEAD |
| **M6 the forbidden fix: `review:parked` joins `PARKED_AREA_LABELS`** | DEAD |
| **M7 drop the label test, keep the proof** | DEAD |
| **M8 read the attestation from the wrong key** | DEAD |

M2–M8 all leave `is_provably_inert` present, named, and called from `occupies_area` while breaking what it claims. Every assertion runs **end-to-end through `compute_ready`** — none inspects a structure without executing it. The YAML seam is already pinned by `TestRoutingSelfTestWorkflowWiring`.

### Round 2 — the mutant that mattered, and the module the guard was on

The battery above is real, and it is why the review's mutant **S1 mattered**: it was on the *other* module. Re-run with `-B` / `PYTHONDONTWRITEBYTECODE=1`, byte-snapshot restore, `git status --porcelain` empty between mutants, every mutation asserted non-no-op.

| mutant | `ready-issues.py` | `dispatch-plan.py` — killed by |
|---|---|---|
| **S1a** rename `INERT_FIELD` → `INERT_KEY` in prod **and** every sparq test (identifiers; wire-name literals untouched) | **PASSED — 9/9 green** | `dispatch-plan exports every name registry-contract.toml declares` · `…bound to the wire VALUES the registry writes` · `the registry's inert_aware probe STAMPS against this module` |
| **S1b** *blind* global text rename, rewriting the wire-name literals too | crashes | same first two rows (the expectation lives in the TOML, not in the renamed file) |
| **S2** delete the two re-export lines — *the as-shipped round-1 state, restored* | — | all three rows above |
| **S3** re-declare `INERT_FIELD` locally with a drifted value | — | `…bound to the wire VALUES` · `…probe STAMPS against this module` |
| **S4** delete the `occupies_area` call site (helper survives, unused) | — | `…probe STAMPS against this module` |
| **S5** `is True` → truthiness | **`truthy-but-not-True attestations prove nothing`** | survives here — correctly: the predicate lives in `ready-issues.py`, and `routing-self-tests.yml` runs **both** suites |

S1a is the load-bearing row: it is the review's own mutant, and it shows the failure mode directly — the engine's suite stays perfectly green while the module the registry actually reads has lost the contract.

**S1b was green until the expectation moved out of the file under test.** That is why `orchestration/registry-contract.toml` exists rather than a `_WIRE_NAMES` tuple in `dispatch-plan.py`: an expectation that travels with the thing it checks is not an expectation. It is also added to both `paths:` filters of `routing-self-tests.yml`, so a PR editing only the contract still runs the assertion that reads it.

## Honest limits

- **The production-census proof is still not in hand.** #4819 asks for `frontier=` rising in consecutive ticks of the `Build ready + deferred issue rows` step. That requires the registry producer to be live, and I am not armed or merging. The numbers above are a faithful replay of that step against the live snapshot, **not** a reading of the production log — and explicitly not the `--self-test` fixture line (`partition census o/t: candidates=5 frontier=2`). Round 1 is the reason to weight that gap heavily: a replay that is *nearly* the shipped state is exactly how a no-op passed for a 9× improvement.
- **`frontier` is a per-tick yield.** 0 → 2 on this board is not a number to carry forward; the mechanism-level claim (33/33 attested, 40 → 25 keys, 15 released, 0 retaining a holder) is.
- **Conversion is unverified.** `frontier` rising ≠ dispatches rising (~55% historically). Adjacent defect **#4821** zeroes the CLAIM lane whenever an unprovenanced worker PR holds `__global__` (68 of 89 open PRs have worker heads). Raising dispatch rate ~5× raises the rate of provenance-lag windows proportionally, so **#4821 should land first or alongside**; a flat dispatch count after this merges should be checked against a `__global__` holder before being read as a failure here.

