### PR TITLE
fix(ci): ring the merge-group watchdog from queue events, not only cron

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -215,6 +215,13 @@
    "owner_bead": "registry jeswr/agent-account-registry#563 item 3 (durable fix for registry#556)",
    "promotion_criteria": "permanently advisory BY DESIGN: this job runs on pull_request_target [dequeued] (write-only, no PR-head checkout) AFTER a gate verdict exists on the head SHA, and its writes (disable-auto + review:changes swap + comment) are orchestration feedback, not a merge-worthiness verdict — a feedback hiccup must never red a later gate evaluation on the same SHA. Promote never; delete this entry only if the workflow is removed",
    "registered": "2026-07-24"
+  },
+  "merge-group doorbell (advisory)": {
+   "workflow": "merge-group-doorbell.yml",
+   "job_id": "doorbell",
+   "owner_bead": "sparq-org/sparq#4652 follow-up — event-driven entry point for the zero-dispatch merge-group watchdog",
+   "promotion_criteria": "permanently advisory BY DESIGN, for the same reason as `merge-queue dequeued feedback (advisory)`: it runs on pull_request_target [enqueued, dequeued], i.e. AFTER a gate verdict already exists on the head SHA (a PR cannot be enqueued before it is green), it never checks out or executes anything, and its single action is one `gh workflow run` that rings the merge-group watchdog. Ringing a queue watchdog is not a statement about the commit's merge-worthiness, so a doorbell hiccup must never red a later gate evaluation on that same SHA. No gate_script_waiver: the job invokes no script at all. Promote never; delete this entry only if the workflow is removed",
+   "registered": "2026-07-28"
   }
  }
 }

--- a/.github/workflows/merge-group-doorbell.yml
+++ b/.github/workflows/merge-group-doorbell.yml
@@ -1,0 +1,136 @@
+# [OPUS-5] sparq-org/sparq — the EVENT-DRIVEN entry point for the zero-dispatch
+# merge-group watchdog. 🤖 SPARQ agent.
+#
+# WHY THIS EXISTS: `.github/workflows/merge-group-watchdog.yml` already detects a dead
+# merge-group ref correctly. Its only problem was WHEN it runs. It was `schedule` +
+# `workflow_dispatch` only, and GitHub's cron is best-effort: MEASURED on this repo
+# 2026-07-28, the watchdog's 5-minutely cron produced THREE scheduled fires between
+# 13:19:03Z and 17:07:52Z against ~45 expected — a 93% loss, with a 140-minute gap.
+# The consequence is the outage this file fixes: PR #4810's group ref `38a9d875` was
+# created 15:58:00Z with zero check-suites, and the NEXT cron fire was 17:07:52Z —
+# 69.9 minutes later, i.e. after the ruleset's 60-minute CI_TIMEOUT would already have
+# reaped it. The queue was head-of-line blocked for 46m33s and a human cleared it.
+#
+# ── WHY THE PRODUCER IS *NOT* `merge_group` ──────────────────────────────────────
+# The obvious doorbell (fire from the event that builds the group) is DISQUALIFIED
+# TWICE OVER, and both halves were verified against live data rather than assumed:
+#
+#   (a) SUBSCRIBING WOULD MASK THE DETECTOR. On this repo a check-SUITE is created
+#       1:1 per dispatched workflow RUN — measured on group head `6b291b28`: 8
+#       `merge_group` workflow runs (ci, ci-summary, docs-quality, feature-matrix,
+#       flow-on-gates, pr-area-label, routing-self-tests, vectorized-feature-off) and
+#       exactly 8 check-suites, and the same 8/8 on `37aac5a4`, `e5a9d403`, `bef48bee`.
+#       A tenth `merge_group` subscriber would therefore put a NINTH suite on every
+#       group head, and the watchdog's whole predicate is `total_count == 0`. The
+#       masking would be TOTAL, not partial: the detector could never fire again.
+#
+#   (b) IT WOULD NOT FIRE ON THE FAILING POPULATION ANYWAY. All nine `merge_group`
+#       subscribers here carry a BARE trigger (no `types`, `paths` or `branches`), so
+#       no filter configuration can suppress some-but-not-all. MEASURED over the 42
+#       distinct group refs retained in the activity feed, the per-head `merge_group`
+#       run count is perfectly bimodal — {0 runs: 3 heads, 8 runs: 39 heads}, with no
+#       intermediate value. Zero therefore means the event reached NO workflow, i.e.
+#       Actions never dispatched it. A `merge_group`-triggered watchdog is dispatched
+#       by exactly the delivery that failed, so it would be absent precisely when
+#       needed.
+#
+# ── THE PRODUCER ACTUALLY CHOSEN, AND WHY IT IS COMPLETE ─────────────────────────
+# A merge-group ref is built when an entry enters the queue's build window. That has
+# exactly two causes: the entry is ADDED to the queue, or an entry AHEAD of it LEAVES
+# (merged or removed) and the rest rebuild. Those are the `enqueued` and `dequeued`
+# activity types of `pull_request_target` — both documented, and `dequeued` is already
+# proven in this repo by merge-queue-feedback.yml. So the pair is a COMPLETE cover of
+# "a new group ref was created", with one deliberate exception: a direct push to `main`
+# that bypasses the queue also rebases the queue. That case is left to the retained
+# cron, because a `push` leg would put a check-suite on a commit that is also a former
+# merge-group head and muddy the invariant in (a) for no measured benefit.
+#
+# MEASURED against all three dead refs of 2026-07-28 — the enqueue-to-dead-group delay:
+#     #4810  enqueued 15:58:00Z -> group 38a9d875 built 15:58:00Z    0 s
+#     #4773  enqueued 09:58:54Z -> group 76153a84 built 09:59:10Z   16 s
+#     #4709  enqueued 05:15:07Z -> group 98204656 built 05:15:09Z    2 s
+# Every dead group was built within 16 s of its own PR's `enqueued` event. Delivery
+# latency for this trigger class, measured live here on the `dequeued` half (n=8,
+# merge-queue-feedback.yml against the queue's own removal events): 3-6 s.
+#
+# ── WHY THIS WORKFLOW ITSELF CANNOT MASK ANYTHING ───────────────────────────────
+# `pull_request_target` runs attach their check-run to the PULL REQUEST'S head SHA,
+# never to the `gh-readonly-queue/...` group commit the watchdog inspects. Verified
+# empirically: PR #4810's head `fef71f12` carries `merge-queue dequeued feedback
+# (advisory)` among its 204 check-runs, while the four healthy group heads sampled above
+# carry exactly the 8 `merge_group` suites and nothing else. This workflow adds no
+# suite to any group head, so constraint (a) is satisfied by construction.
+#
+# ── GATE INTEGRATION ────────────────────────────────────────────────────────────
+# A `pull_request_target` leg DOES create a check-run on the PR head, and since #3773
+# the ci-summary gate no longer infers advisory status from job NAMES — the ONLY thing
+# that makes a check-run non-gating is an entry in `.github/advisory-registry.json`.
+# This job is registered there. It is permanently advisory BY DESIGN: it fires AFTER a
+# gate verdict already exists on the head SHA (a PR cannot be enqueued before it is
+# green), and ringing a queue watchdog is not a statement about the commit's
+# merge-worthiness. A doorbell hiccup must never red a later gate evaluation.
+#
+# ── SECURITY (pull_request_target) ──────────────────────────────────────────────
+# The classic `pull_request_target` pitfall is executing untrusted PR-head code with
+# the base repo's write token. This job does NOTHING of the sort, and the bar is lower
+# here than in merge-queue-feedback.yml:
+#   * it NEVER checks out anything — `actions/checkout` does not appear at all;
+#   * it runs no repository script, so no PR-contributed file is executed;
+#   * no `github.event` field is interpolated into any executable line. The dispatch is
+#     keyed only on `github.repository` and the repository's own default branch.
+# Its token holds `actions: write` and NOTHING else — enough to dispatch a workflow,
+# insufficient to write code, labels, comments or contents.
+#
+# The dispatched watchdog is pinned to the DEFAULT BRANCH, so the policy that actually
+# decides a dequeue is always the reviewed copy on `main`, never a PR's version of it.
+#
+# NOT A NEW DECISION. This file changes only the TIMING of an existing sweep. It carries
+# no predicate, no threshold and no dequeue: `merge-group-watchdog.py` still decides,
+# and still recovers only an entry it has POSITIVELY established has zero check-suites.
+name: merge-group doorbell
+
+on:
+  pull_request_target:
+    types: [enqueued, dequeued]
+  # Kept so the doorbell hand-off can be exercised on demand without waiting for a
+  # queue transition (this is how the hand-off was verified before merge).
+  workflow_dispatch:
+
+# Least privilege: dispatching a workflow needs `actions: write` and nothing else.
+# In particular NO `contents`, `pull-requests` or `checks` — this job must not be able
+# to touch code, labels or the queue itself. All of that stays in the watchdog, behind
+# its own predicate.
+permissions:
+  actions: write
+
+# Per-PR, and NOT cancel-in-progress: each queue transition must ring. The runs are
+# seconds long and the sweep they trigger is idempotent, so serialising a PR's own
+# enqueue/dequeue pair costs nothing and losing a ring to a cancellation would.
+concurrency:
+  group: merge-group-doorbell-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  doorbell:
+    # The `(advisory)` token is required by check-advisory-registry.py C2/C4 to match
+    # the registry key EXACTLY. Renaming this job without updating
+    # .github/advisory-registry.json makes it GATE (fail-closed) and reds C4.
+    name: merge-group doorbell (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # ONE API write. This is the whole job: the sweep, its permissions and its
+      # decision table all live in the watchdog, which runs unassociated with any PR.
+      # `workflow_dispatch` is a DOCUMENTED exception to the rule that GITHUB_TOKEN
+      # cannot trigger workflows ("workflow_dispatch and repository_dispatch events
+      # always create workflow runs"), so no PAT or App token is needed here.
+      - name: Ring the zero-dispatch watchdog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          # The reviewed policy on main — never a PR's copy of the watchdog.
+          WATCHDOG_REF: ${{ github.event.repository.default_branch }}
+        run: >-
+          gh workflow run merge-group-watchdog.yml
+          --repo "$REPO"
+          --ref "$WATCHDOG_REF"

--- a/.github/workflows/merge-group-watchdog.yml
+++ b/.github/workflows/merge-group-watchdog.yml
@@ -140,12 +140,27 @@ jobs:
           # 120 s grace at T+139 s and is recovered by the sweep at ~T+150 s.
           RESWEEPS: "4"
           RESWEEP_INTERVAL_SECONDS: "60"
+          # BLAST RADIUS, stated as it actually is. `--max-recoveries-per-run` is
+          # PROCESS-local, so looping five sweeps in one job silently multiplied the
+          # script's own "one tick may never churn the whole queue" bound by 5 (2 -> 10).
+          # Tightening the per-sweep budget to 1 puts the per-FIRE worst case at 5.
+          #
+          # That is still ABOVE the pre-loop 2, and it is a disclosed residual rather
+          # than a fix: restoring exactly 2 needs a budget shared ACROSS sweeps, which
+          # lives in the script's CAP path — decision logic this change deliberately does
+          # not touch. The residual is bounded and, on the measured base rate (3 dead
+          # refs in a DAY), reaching it needs 5 DISTINCT zero-suite entries inside 4
+          # minutes, which is a repo-wide dispatch outage in which recovering them is the
+          # correct action. Per-PR cap (2 per 6 h) and same-head idempotence are
+          # unaffected and still prevent the same entry being churned twice.
+          MAX_RECOVERIES_PER_SWEEP: "1"
         run: |
           set -euo pipefail
           # Built as an array so the optional flag is passed as ONE argv element and
           # never word-split (shellcheck SC2086 — the folded one-liner this replaced
           # relied on unquoted splitting).
-          sweep_args=(sweep --repo "$REPO" --branch "$DEFAULT_BRANCH")
+          sweep_args=(sweep --repo "$REPO" --branch "$DEFAULT_BRANCH"
+                      --max-recoveries-per-run "$MAX_RECOVERIES_PER_SWEEP")
           if [ -n "$DRY_RUN" ]; then
             sweep_args+=("$DRY_RUN")
           fi

--- a/.github/workflows/merge-group-watchdog.yml
+++ b/.github/workflows/merge-group-watchdog.yml
@@ -14,6 +14,23 @@
 # re-enqueue of an entry it has POSITIVELY established has zero check-suites. Every
 # ambiguous reading is a refusal, not an action (see the script header).
 #
+# ── [OPUS-5] THE CRON IS NOW THE BACKSTOP, NOT THE PRIMARY PATH ──────────────────
+# `.github/workflows/merge-group-doorbell.yml` rings this workflow via
+# `workflow_dispatch` on every `pull_request_target` [enqueued, dequeued] — the two
+# events that between them cause every merge-group ref to be built. Read that file for
+# the measurement showing why `merge_group` itself CANNOT be the producer (it would put
+# a 9th check-suite on every group head and mask the `total_count == 0` predicate
+# outright, and it is dispatched by exactly the delivery that failed).
+#
+# The cron below is DELIBERATELY RETAINED as the independent second path. It is not
+# redundant and it is not the primary: MEASURED 2026-07-28 on this workflow, the
+# 5-minutely schedule produced 3 fires between 13:19:03Z and 17:07:52Z against ~45
+# expected (93% loss, largest gap 140 min). The dead ref `38a9d875` was built at
+# 15:58:00Z and the next scheduled fire was 17:07:52Z — 69.9 min later, past the
+# ruleset's own 60-minute CI_TIMEOUT. Two independent paths is the whole point: the
+# doorbell covers queue transitions, the cron covers everything else (notably a direct
+# push to `main` that rebases the queue without any PR-level queue event).
+#
 # Cadence is every 5 minutes — the GitHub scheduler minimum — against a 120 s grace, so
 # worst-case detection is ~10 min and typical is ~5, against the 60-minute ruleset
 # timeout it replaces. The grace is 30x the MEASURED maximum create->first-suite latency
@@ -56,7 +73,10 @@ jobs:
   watch:
     name: recover zero-dispatch merge groups
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Raised from 10 for the resweep loop: 4 x 60 s of sleep plus five sweeps plus the
+    # checkout and self-test. Still a hard ceiling — the job cannot sit on the shared
+    # `merge-group-watchdog` concurrency slot indefinitely.
+    timeout-minutes: 15
     env:
       # Secrets are not readable from step `if:` expressions — mirror the id into env
       # so the mint step can be skipped fail-soft when the App is not configured.
@@ -88,14 +108,57 @@ jobs:
           python3 scripts/gh_retry.py --self-test
           python3 scripts/merge-group-watchdog.py --self-test
 
+      # ── WHY THIS IS A LOOP AND NOT A SINGLE SWEEP ────────────────────────────
+      # One fire must outlive the grace period, because the event that STARTS this run
+      # precedes the thing it has to observe. On the doorbell path the ordering is:
+      # queue transition at T -> group ref built at T+0..19 s (MEASURED over the three
+      # dead refs of 2026-07-28 and five live rebuilds) -> the group only becomes
+      # actionable at T+build+120 s of grace. A run that swept once at start would
+      # decide WAIT on the very group it was rung for and exit, and the next look would
+      # be whenever the unreliable cron next fires.
+      #
+      # The loop is UNCONDITIONAL — no `if:`, no per-trigger branching, no input that
+      # selects between "sweep once" and "sweep repeatedly". That is deliberate: a
+      # conditional here would be a YAML seam, and on this estate a seam is where an
+      # inert-but-innocent-looking mutation survives. The cron path simply gets the same
+      # coverage, which is strictly better than the single sweep it did before.
+      #
+      # STICKY EXIT CODE. A failed recovery in sweep 1 followed by clean sweeps 2-5 must
+      # still FAIL the run: `rc` is only ever raised, never reset, and the step exits on
+      # it after the loop. This repo has shipped the opposite defect three times in one
+      # day (a later transient discarding an earned hard failure), so the interleaved
+      # fail-then-succeed sequence is asserted by executing this very block in
+      # scripts/tests/test_merge_group_watchdog.py, not by reading it.
       - name: Sweep the merge queue for zero-dispatch groups
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           REPO: ${{ github.repository }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           DRY_RUN: ${{ inputs.dry_run && '--dry-run' || '' }}
-        run: >-
-          python3 scripts/merge-group-watchdog.py sweep
-          --repo "$REPO"
-          --branch "$DEFAULT_BRANCH"
-          $DRY_RUN
+          # 5 sweeps 60 s apart => ~4 min of cover per fire. Against a doorbell ring at
+          # T that puts the first sweep at ~T+30 s, a group built at T+19 s clears its
+          # 120 s grace at T+139 s and is recovered by the sweep at ~T+150 s.
+          RESWEEPS: "4"
+          RESWEEP_INTERVAL_SECONDS: "60"
+        run: |
+          set -euo pipefail
+          # Built as an array so the optional flag is passed as ONE argv element and
+          # never word-split (shellcheck SC2086 — the folded one-liner this replaced
+          # relied on unquoted splitting).
+          sweep_args=(sweep --repo "$REPO" --branch "$DEFAULT_BRANCH")
+          if [ -n "$DRY_RUN" ]; then
+            sweep_args+=("$DRY_RUN")
+          fi
+          rc=0
+          for i in $(seq 0 "$RESWEEPS"); do
+            if [ "$i" -gt 0 ]; then
+              sleep "$RESWEEP_INTERVAL_SECONDS"
+            fi
+            echo "::group::sweep $((i + 1))/$((RESWEEPS + 1))"
+            if ! python3 scripts/merge-group-watchdog.py "${sweep_args[@]}"; then
+              rc=1
+              echo "::warning title=merge-group-watchdog::sweep $((i + 1)) exited non-zero; the loop continues but this run will fail"
+            fi
+            echo "::endgroup::"
+          done
+          exit "$rc"

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -2542,6 +2542,94 @@ class TestDoorbellWiring(unittest.TestCase):
         self.assertIs(self.wf["concurrency"]["cancel-in-progress"], False)
 
 
+class TestTheYamlSeamCannotGoInert(unittest.TestCase):
+    """THE SEAM. Measured on this estate: structure-preserving mutations at the YAML
+    seam — `if:`, `continue-on-error`, a changed call-site argument — are where every
+    uncaught mutant lives, because the step, its name and its `run:` body all survive
+    intact and every behavioural test keeps passing while the mechanism is dead.
+
+    Eight such mutants survived the first revision of this suite, including `if: false`
+    on either job and on either step. These assertions are deliberately EXACT-MATCH and
+    whole-mapping, not substring or containment.
+    """
+
+    #: The ONLY guard either workflow is allowed to carry, pinned whole. It is the
+    #: fail-soft App-token mint: without the App configured the step must skip and the
+    #: sweep falls back to `github.token`. Any OTHER `if:` is a way to make the
+    #: mechanism inert while it still reads as wired.
+    ALLOWED_STEP_GUARD = "env.ORCHESTRATOR_APP_ID != ''"
+    ALLOWED_GUARD_STEP = "Mint the sparq-orchestrator App token"
+
+    def _assert_no_inert_seam(self, path, job_id):
+        wf = _yaml(path)
+        job = wf["jobs"][job_id]
+        self.assertNotIn("if", job, f"{path.name}: job `{job_id}` carries an `if:`. "
+                         "`if: false` there makes the entire mechanism inert with every "
+                         "step, name and call site intact.")
+        self.assertNotIn("continue-on-error", job, f"{path.name}: job `{job_id}`")
+        for step in job["steps"]:
+            label = step.get("name") or step.get("uses") or "<unnamed>"
+            guard = step.get("if")
+            if guard is not None:
+                self.assertIn(self.ALLOWED_GUARD_STEP, label,
+                              f"{path.name}: unexpected `if:` on step {label!r}")
+                self.assertEqual(guard, self.ALLOWED_STEP_GUARD,
+                                 f"{path.name}: the one permitted guard drifted")
+            self.assertNotIn("continue-on-error", step, f"{path.name}: step {label!r}")
+
+    def test_the_watchdog_sweep_cannot_be_switched_off_at_the_seam(self):
+        self._assert_no_inert_seam(WATCHDOG_YML, "watch")
+
+    def test_the_doorbell_ring_cannot_be_switched_off_at_the_seam(self):
+        self._assert_no_inert_seam(DOORBELL_YML, "doorbell")
+
+    def test_the_doorbell_carries_no_guard_at_all(self):
+        # Stronger than the shared helper: the doorbell has no App-token step, so it has
+        # no legitimate `if:` anywhere. Stated separately so the shared allowance can
+        # never silently license one here.
+        wf = _yaml(DOORBELL_YML)
+        self.assertNotIn("if", wf["jobs"]["doorbell"])
+        for step in wf["jobs"]["doorbell"]["steps"]:
+            self.assertNotIn("if", step, step.get("name"))
+
+    def test_no_guard_anywhere_carries_a_constant_operand(self):
+        # The conditionally-inert class in general: a literal true/false operand makes a
+        # step unconditionally on or off while still reading as a guard.
+        for path in (WATCHDOG_YML, DOORBELL_YML):
+            wf = _yaml(path)
+            for job_id, job in wf["jobs"].items():
+                for guard in [job.get("if")] + [s.get("if") for s in job["steps"]]:
+                    if not guard:
+                        continue
+                    residue = re.sub(r"[=!]=\s*(?:true|false)\b", "", str(guard))
+                    self.assertIsNone(re.search(r"\b(?:true|false)\b", residue),
+                                      f"{path.name}:{job_id}: {guard!r}")
+
+    def test_the_ring_targets_THIS_repository(self):
+        # `--ref` was pinned exactly while `--repo` was not asserted at all, so swapping
+        # in a foreign repository left every other assertion green while the doorbell
+        # rang somebody else's watchdog and this queue was never swept.
+        wf = _yaml(DOORBELL_YML)
+        step = wf["jobs"]["doorbell"]["steps"][0]
+        self.assertIn('--repo "$REPO"', step["run"])
+        self.assertEqual(step["env"]["REPO"], "${{ github.repository }}")
+        # No literal owner/name may appear in the executable line.
+        self.assertNotRegex(step["run"], r"[\w.-]+/[\w.-]+\.yml\s+.*\b\w+/\w+\b(?!\")")
+
+    def test_the_sweep_call_site_arguments_are_all_pinned(self):
+        # Same class on the other side: every argument the sweep depends on is asserted,
+        # so dropping or retargeting one cannot pass.
+        wf = _yaml(WATCHDOG_YML)
+        step = _step(wf, "watch", "Sweep the merge queue")
+        run = step["run"]
+        for fragment in ('--repo "$REPO"', '--branch "$DEFAULT_BRANCH"',
+                         'scripts/merge-group-watchdog.py'):
+            self.assertIn(fragment, run, fragment)
+        self.assertEqual(step["env"]["REPO"], "${{ github.repository }}")
+        self.assertEqual(step["env"]["DEFAULT_BRANCH"],
+                         "${{ github.event.repository.default_branch }}")
+
+
 class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
     """The loop is the timing fix, so it is verified by RUNNING it.
 
@@ -2568,9 +2656,11 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
                 f'codes=({codes})\n'
                 f'log="{tmp}/calls.log"\n'
                 'n=$(wc -l < "$log")\n'
-                # argv COUNT is logged alongside the text: an extra EMPTY element is
-                # invisible in "$*" but is exactly what unquoted `$DRY_RUN` produces
-                # when the flag is unset, and argparse rejects it — killing every sweep.
+                # argv COUNT is logged alongside the text because an extra EMPTY element
+                # is invisible in "$*". It is NOT something the pre-loop call site could
+                # produce — see test_the_dry_run_flag_is_passed_as_one_argument_when_set
+                # for the measurement — but it IS what a plausible edit to the array
+                # form produces, so the count is asserted rather than the joined text.
                 'printf "%s|%s\\n" "$#" "$*" >> "$log"\n'
                 'code=${codes[$n]:-0}\n'
                 'exit "$code"\n',
@@ -2585,6 +2675,7 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
                     "DEFAULT_BRANCH": "main",
                     "DRY_RUN": "",
                     "RESWEEPS": "4",
+                    "MAX_RECOVERIES_PER_SWEEP": "1",
                     # the real 60 s would make this suite unrunnable; the interval is
                     # not what is under test, the sequencing and the exit code are.
                     "RESWEEP_INTERVAL_SECONDS": "0",
@@ -2608,11 +2699,15 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
             self.assertIn("--repo sparq-org/sparq", text)
             self.assertIn("--branch main", text)
             self.assertNotIn("--dry-run", text)
-            # EXACT argc: script + sweep + --repo + val + --branch + val == 6. An extra
-            # EMPTY seventh element is what unquoted `$DRY_RUN` yields when the flag is
-            # unset; it is invisible in the joined text and argparse rejects it, so
-            # every sweep would fail in the DEFAULT (non-dry-run) configuration.
-            self.assertEqual(argc, "6", call)
+            # EXACT argc: script + sweep + --repo + val + --branch + val
+            # + --max-recoveries-per-run + val == 8, i.e. NO
+            # empty seventh element. The hazard belongs to the ARRAY form this replaced
+            # the folded one-liner with: `sweep_args+=("$DRY_RUN")` applied
+            # UNCONDITIONALLY appends an empty element when the flag is unset, and
+            # argparse rejects it (`error: unrecognized arguments:`, exit 2) — which
+            # would fail every sweep in the DEFAULT non-dry-run configuration. Hence the
+            # `if [ -n "$DRY_RUN" ]` guard, which this count is what pins.
+            self.assertEqual(argc, "8", call)
 
     def test_a_failure_on_the_FIRST_sweep_survives_four_later_successes(self):
         """THE STICKY-STATE ASSERTION. This estate shipped the opposite defect three
@@ -2658,6 +2753,7 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
                     "DEFAULT_BRANCH": "main",
                     "DRY_RUN": "--dry-run",
                     "RESWEEPS": "0",
+                    "MAX_RECOVERIES_PER_SWEEP": "1",
                     "RESWEEP_INTERVAL_SECONDS": "0",
                 },
                 capture_output=True,
@@ -2665,10 +2761,20 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
             )
             lines = (tmp / "calls.log").read_text(encoding="utf-8").splitlines()
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        # script + sweep + --repo + val + --branch + val + --dry-run == 7 argv elements.
-        # The COUNT is the assertion: `--dry-run` must arrive as ONE element, which is
-        # exactly what the pre-fix unquoted `$DRY_RUN` splitting could not guarantee.
-        self.assertEqual(lines[0], "7", lines)
+        # script + sweep + --repo + val + --branch + val
+        # + --max-recoveries-per-run + val + --dry-run == 9 argv elements.
+        # The COUNT is the assertion: `--dry-run` must arrive as exactly ONE element.
+        #
+        # HISTORICAL CORRECTION, recorded because the wrong version was published: the
+        # folded one-liner this replaced used an UNQUOTED `$DRY_RUN`, and an unquoted
+        # expansion of an empty variable yields ZERO words, so the merge-base call site
+        # produced a clean argc=6 and was NOT buggy. Injecting an empty element requires
+        # a QUOTED expansion. Measured under GitHub's default
+        # `bash --noprofile --norc -eo pipefail` on the MERGE-BASE body: unquoted +
+        # empty => argc=6 (no empty word); quoted + empty => argc=7 with a trailing ``. The array rewrite is a
+        # shellcheck-cleanliness change, NOT a bug fix, and the hazard it introduces is
+        # its own (an unconditional `+=("$DRY_RUN")`), which is what these counts pin.
+        self.assertEqual(lines[0], "9", lines)
         self.assertIn("--dry-run", lines[1])
 
     def test_the_loop_actually_repeats(self):
@@ -2679,6 +2785,32 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
         self.assertGreaterEqual(declared, 3)
         _, calls = self._execute([0] * (declared + 1))
         self.assertEqual(len(calls), declared + 1)
+
+    #: The per-FIRE recovery ceiling this workflow is allowed to reach. Pinned so that
+    #: raising RESWEEPS or the per-sweep budget cannot silently widen the blast radius
+    #: again — the loop already multiplied the script's process-local bound once.
+    MAX_RECOVERIES_PER_FIRE = 5
+
+    def test_the_per_fire_blast_radius_is_bounded(self):
+        step = _step(_yaml(WATCHDOG_YML), "watch", "Sweep the merge queue")
+        per_sweep = int(step["env"]["MAX_RECOVERIES_PER_SWEEP"])
+        sweeps = int(step["env"]["RESWEEPS"]) + 1
+        self.assertLessEqual(
+            per_sweep * sweeps, self.MAX_RECOVERIES_PER_FIRE,
+            "`--max-recoveries-per-run` is PROCESS-local, so the per-fire ceiling is "
+            "sweeps x per-sweep budget. Raising either without raising this constant "
+            "widens what a single fire may dequeue.",
+        )
+        self.assertLessEqual(per_sweep, mgw.DEFAULT_MAX_RECOVERIES_PER_RUN,
+                             "the per-sweep budget may only ever TIGHTEN the script "
+                             "default, never widen it")
+
+    def test_the_budget_flag_actually_reaches_the_sweep(self):
+        # The env value is inert unless it is on the command line — the call-site half
+        # of the bound above.
+        _, calls = self._execute([0, 0, 0, 0, 0])
+        for call in calls:
+            self.assertIn("--max-recoveries-per-run 1", call.partition("|")[2], call)
 
     def test_the_loop_covers_the_grace_period(self):
         # The whole reason the loop exists: one fire must outlive
@@ -2696,10 +2828,27 @@ class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
         # i.e. would silently turn every test in this class vacuous.
         self.assertNotIn("${{", self._run_block())
 
-    def test_no_failure_swallowing_idiom(self):
-        body = self._run_block()
-        self.assertNotIn("|| true", body)
-        self.assertNotIn("continue-on-error", body)
+    def test_no_failure_swallowing_idiom_in_the_shell(self):
+        self.assertNotIn("|| true", self._run_block())
+
+    def test_no_failure_swallowing_at_the_YAML_SEAM(self):
+        """`continue-on-error` is a YAML KEY, so looking for it in the `run:` STRING can
+        never fail for the defect it names — the string is a shell body and the key is a
+        sibling mapping entry. That vacuous shape shipped in the first revision of this
+        file and is why the assertion now reads the PARSED step and job.
+
+        `continue-on-error: true` on this step makes the whole sticky-`rc` design inert:
+        the step still runs all five sweeps and still exits non-zero, and the JOB still
+        reports success. Every behavioural test in this class passes on that mutant."""
+        wf = _yaml(WATCHDOG_YML)
+        job = wf["jobs"]["watch"]
+        step = _step(wf, "watch", "Sweep the merge queue")
+        self.assertNotIn("continue-on-error", step, "the sweep step may not swallow its "
+                         "own failure — the sticky exit code would become decorative")
+        self.assertNotIn("continue-on-error", job)
+        for other in _steps(wf, "watch"):
+            self.assertNotIn("continue-on-error", other,
+                             other.get("name") or other.get("uses"))
 
 
 class TestSuiteIsWiredIntoCI(unittest.TestCase):

--- a/scripts/tests/test_merge_group_watchdog.py
+++ b/scripts/tests/test_merge_group_watchdog.py
@@ -35,6 +35,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 SCRIPTS = REPO_ROOT / "scripts"
 FEEDBACK_YML = REPO_ROOT / ".github" / "workflows" / "merge-queue-feedback.yml"
 WATCHDOG_YML = REPO_ROOT / ".github" / "workflows" / "merge-group-watchdog.yml"
+DOORBELL_YML = REPO_ROOT / ".github" / "workflows" / "merge-group-doorbell.yml"
 DOCS_QUALITY_YML = REPO_ROOT / ".github" / "workflows" / "docs-quality.yml"
 
 
@@ -2351,6 +2352,354 @@ class TestWatchdogWorkflowWiring(unittest.TestCase):
         # and require an advisory-registry entry; this job is neither.
         name = self.wf["jobs"]["watch"]["name"]
         self.assertIsNone(re.search(r"\b(advisory|informational)\b", name), name)
+
+
+class TestDoorbellIsNotSubscribedToTheEventItInspects(unittest.TestCase):
+    """THE HEADLINE GUARD. The watchdog's entire predicate is `zero check-suites on the
+    group head`. On this repo a check-suite is created 1:1 per dispatched `merge_group`
+    workflow RUN (MEASURED: group head 6b291b28 -> 8 runs / 8 suites; same 8/8 on
+    37aac5a4, e5a9d403, bef48bee). So ANY workflow that participates in the zero-dispatch
+    sweep and ALSO carries a `merge_group:` trigger would put an extra suite on every
+    group head and make `total_count == 0` unsatisfiable — the detector would be masked
+    completely, silently, and forever.
+
+    This is asserted over the whole workflow directory rather than over the two files
+    this PR happens to add, because the failure mode is someone LATER adding
+    `merge_group:` to the doorbell "so it fires on the group too" — which reads like an
+    improvement and is the exact thing that destroys the signal."""
+
+    #: A step PARTICIPATES in the live sweep if it either performs it or rings it.
+    #  Deliberately narrow. Two neighbours must NOT be swept up:
+    #    * docs-quality.yml runs `merge-group-watchdog.py --self-test`, a hermetic
+    #      decision-table test that touches no queue and reads no group head; and
+    #    * merge-queue-feedback.yml runs `classify-dequeue`, which reads a suite count
+    #      for an already-recorded SHA on the PR-dequeue path.
+    #  Both are fine on a `merge_group` trigger, because their suite exists only when
+    #  dispatch WORKED — that is the baseline the predicate measures against, not
+    #  interference with it. The masking bug is specific to the DETECTOR being
+    #  dispatched by the very event whose non-delivery it detects.
+    SCRIPT_RE = re.compile(r"(?<![\w-])merge-group-watchdog\.py(?![\w.-])")
+    SUBCOMMAND_RE = re.compile(r"(?<![\w-])sweep(?![\w-])")
+    RINGS_RE = re.compile(r"gh\s+workflow\s+run\s+merge-group-watchdog\.yml")
+
+    @classmethod
+    def _performs(cls, body: str) -> bool:
+        """The script AND the `sweep` subcommand, anywhere in the SAME step body.
+
+        Not a lookahead: the real call site builds `sweep_args=(sweep --repo ...)`
+        BEFORE invoking the script, so a forward-only match would silently classify the
+        live sweep as a non-participant — the vacuity this class exists to prevent.
+        """
+        return bool(cls.SCRIPT_RE.search(body) and cls.SUBCOMMAND_RE.search(body))
+
+    def _participants(self):
+        found = {}
+        for path in sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml")):
+            wf = yaml.safe_load(path.read_text(encoding="utf-8"))
+            if not isinstance(wf, dict):
+                continue
+            # Per STEP, never per file: joining a whole workflow's steps would let an
+            # unrelated step contribute the word `sweep` to a self-test invocation.
+            # Only an EXECUTABLE reference counts, so a workflow that merely names the
+            # watchdog in a comment is not a participant.
+            for job in (wf.get("jobs") or {}).values():
+                if not isinstance(job, dict):
+                    continue
+                for step in (job.get("steps") or []):
+                    if not isinstance(step, dict):
+                        continue
+                    body = str(step.get("run", ""))
+                    if self._performs(body) or self.RINGS_RE.search(body):
+                        found[path.name] = wf
+        return found
+
+    def test_the_participant_set_is_the_one_we_think_it_is(self):
+        # Guards the guard: if this set silently empties or narrows, every assertion
+        # below passes vacuously. An instrument that can only report "nothing to see"
+        # is no instrument — so the population is pinned exactly.
+        self.assertEqual(
+            set(self._participants()),
+            {"merge-group-watchdog.yml", "merge-group-doorbell.yml"},
+        )
+
+    def test_the_matcher_separates_a_live_sweep_from_a_hermetic_self_test(self):
+        # Validates the instrument against a KNOWN POSITIVE and a KNOWN NEGATIVE, so a
+        # regex that silently stopped matching anything cannot look like a clean run.
+        self.assertTrue(self._performs(
+            'sweep_args=(sweep --repo "$REPO")\n'
+            'python3 scripts/merge-group-watchdog.py "${sweep_args[@]}"'))
+        self.assertFalse(self._performs(
+            "python3 scripts/merge-group-watchdog.py --self-test"))
+        self.assertFalse(self._performs(
+            "python3 scripts/tests/test_merge_group_watchdog.py"))
+        # ...and the ORDER-INDEPENDENCE that the first lookahead attempt got wrong.
+        self.assertTrue(self._performs(
+            'python3 scripts/merge-group-watchdog.py sweep --repo "$REPO"'))
+        self.assertTrue(self.RINGS_RE.search(
+            'gh workflow run merge-group-watchdog.yml --repo "$REPO"'))
+
+    def test_no_sweep_participant_subscribes_to_merge_group(self):
+        for name, wf in self._participants().items():
+            self.assertNotIn(
+                "merge_group", _on_block(wf),
+                f"{name} subscribes to `merge_group`. A workflow that takes part in the "
+                f"zero-dispatch sweep must never create a check-suite on the group head "
+                f"it inspects — doing so masks the `total_count == 0` predicate on EVERY "
+                f"group, not just its own.",
+            )
+
+    def test_the_doorbell_producer_is_the_pr_level_queue_transition_pair(self):
+        # EXACT list, not a containment check: adding `merge_group` here is the masking
+        # bug, and adding `labeled` (223 events in 4 measured hours, versus 19 queue
+        # transitions) is the cost bug. Either must fail.
+        on = _on_block(_yaml(DOORBELL_YML))
+        self.assertEqual(on["pull_request_target"]["types"], ["enqueued", "dequeued"])
+
+    def test_the_doorbell_creates_no_check_suite_on_a_group_head(self):
+        # The structural reason constraint (a) holds: every trigger this workflow
+        # carries attaches its check-run to a PR head or to nothing at all. `push` is
+        # included in the ban because a merged group head BECOMES the main head.
+        on = _on_block(_yaml(DOORBELL_YML))
+        self.assertEqual(set(on), {"pull_request_target", "workflow_dispatch"})
+
+    def test_the_watchdog_itself_still_has_no_pr_or_group_trigger(self):
+        # The two-stage split exists so the sweep keeps running unassociated with any
+        # PR. Collapsing the doorbell INTO the watchdog would give the sweep a PR-head
+        # check-run and make a 4-minute queue watchdog visible on every enqueue.
+        on = _on_block(_yaml(WATCHDOG_YML))
+        self.assertEqual(set(on), {"schedule", "workflow_dispatch"})
+
+
+class TestDoorbellWiring(unittest.TestCase):
+    def setUp(self):
+        self.wf = _yaml(DOORBELL_YML)
+        self.job = self.wf["jobs"]["doorbell"]
+        self.steps = self.job["steps"]
+
+    def test_the_cron_backstop_is_retained(self):
+        # Two independent paths is the point. A future edit that deletes the schedule
+        # "because the doorbell covers it" removes the only cover for a queue rebase
+        # that produces no PR-level queue event (a direct push to main).
+        on = _on_block(_yaml(WATCHDOG_YML))
+        self.assertIn("schedule", on)
+        minutes = on["schedule"][0]["cron"].split()[0]
+        self.assertEqual(len(minutes.split(",")), 12)
+
+    def test_the_ring_step_dispatches_the_watchdog_on_the_default_branch(self):
+        self.assertEqual(len(self.steps), 1, "the doorbell must stay a one-step job")
+        step = self.steps[0]
+        run = step["run"]
+        self.assertIn("gh workflow run merge-group-watchdog.yml", run)
+        self.assertIn('--ref "$WATCHDOG_REF"', run)
+        self.assertEqual(
+            step["env"]["WATCHDOG_REF"],
+            "${{ github.event.repository.default_branch }}",
+            "the dispatched policy must be the reviewed copy on the default branch, "
+            "never a PR's version of the watchdog",
+        )
+
+    def test_the_watchdog_is_actually_dispatchable(self):
+        # Cross-file contract: `gh workflow run` fails outright unless the target
+        # declares workflow_dispatch. Deleting it there would break the doorbell here.
+        self.assertIn("workflow_dispatch", _on_block(_yaml(WATCHDOG_YML)))
+
+    def test_no_checkout_and_no_repository_script_is_executed(self):
+        # pull_request_target runs with the base repo's token. The mitigation is not
+        # "check out carefully" — it is checking out nothing at all.
+        for step in self.steps:
+            self.assertNotIn("checkout", str(step.get("uses", "")).lower())
+            self.assertNotRegex(str(step.get("run", "")), r"\bpython3?\b|\bbash\b|scripts/")
+
+    def test_no_event_field_is_interpolated_into_an_executable_line(self):
+        for step in self.steps:
+            self.assertNotIn("${{", str(step.get("run", "")))
+
+    def test_permissions_are_exactly_actions_write(self):
+        # Not a superset check. `contents`/`pull-requests`/`checks` would let the
+        # doorbell mutate the very things it exists only to ring about.
+        self.assertEqual(self.wf["permissions"], {"actions": "write"})
+        self.assertNotIn("permissions", self.job)
+
+    def test_the_job_is_declared_advisory_in_the_registry(self):
+        # Since #3773 the registry is the ONLY thing that makes a check-run non-gating,
+        # and this leg lands on a PR head. Undeclared, a doorbell hiccup would red the
+        # gate on a commit whose merge-worthiness it says nothing about.
+        name = self.job["name"]
+        self.assertRegex(name, r"\b(advisory|informational)\b")
+        registry = json.loads(
+            (REPO_ROOT / ".github" / "advisory-registry.json").read_text(encoding="utf-8")
+        )
+        self.assertIn(name, registry["jobs"])
+        entry = registry["jobs"][name]
+        self.assertEqual(entry["workflow"], "merge-group-doorbell.yml")
+        self.assertEqual(entry["job_id"], "doorbell")
+
+    def test_the_job_is_bounded(self):
+        self.assertLessEqual(self.job["timeout-minutes"], 5)
+
+    def test_every_ring_fires(self):
+        # cancel-in-progress would let a burst of queue transitions drop rings.
+        self.assertIs(self.wf["concurrency"]["cancel-in-progress"], False)
+
+
+class TestTheResweepLoopIsExecutedNotJustRead(unittest.TestCase):
+    """The loop is the timing fix, so it is verified by RUNNING it.
+
+    Every assertion here survives a purely structural inspection of the YAML: a mutant
+    that changes `rc=1` to `rc=0`, moves `exit "$rc"` inside the loop, appends
+    `|| true`, or drops the loop to a single sweep leaves the step present, named,
+    and still containing `sweep --repo --branch`. Only execution separates them.
+    """
+
+    def _run_block(self) -> str:
+        return _step(_yaml(WATCHDOG_YML), "watch", "Sweep the merge queue")["run"]
+
+    def _execute(self, exit_codes: list[int]):
+        """Run the real step body with `python3` stubbed to a scripted exit sequence."""
+        import subprocess
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "calls.log").write_text("", encoding="utf-8")
+            codes = " ".join(str(c) for c in exit_codes)
+            (tmp / "python3").write_text(
+                "#!/usr/bin/env bash\n"
+                f'codes=({codes})\n'
+                f'log="{tmp}/calls.log"\n'
+                'n=$(wc -l < "$log")\n'
+                # argv COUNT is logged alongside the text: an extra EMPTY element is
+                # invisible in "$*" but is exactly what unquoted `$DRY_RUN` produces
+                # when the flag is unset, and argparse rejects it — killing every sweep.
+                'printf "%s|%s\\n" "$#" "$*" >> "$log"\n'
+                'code=${codes[$n]:-0}\n'
+                'exit "$code"\n',
+                encoding="utf-8",
+            )
+            (tmp / "python3").chmod(0o755)
+            proc = subprocess.run(
+                ["bash", "-c", self._run_block()],
+                env={
+                    "PATH": f"{tmp}:/usr/bin:/bin",
+                    "REPO": "sparq-org/sparq",
+                    "DEFAULT_BRANCH": "main",
+                    "DRY_RUN": "",
+                    "RESWEEPS": "4",
+                    # the real 60 s would make this suite unrunnable; the interval is
+                    # not what is under test, the sequencing and the exit code are.
+                    "RESWEEP_INTERVAL_SECONDS": "0",
+                },
+                capture_output=True,
+                text=True,
+            )
+            calls = [
+                line for line in (tmp / "calls.log").read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            return proc, calls
+
+    def test_a_clean_run_sweeps_reswept_plus_one_times_and_exits_zero(self):
+        proc, calls = self._execute([0, 0, 0, 0, 0])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(len(calls), 5, calls)
+        for call in calls:
+            argc, _, text = call.partition("|")
+            self.assertIn("scripts/merge-group-watchdog.py sweep", text)
+            self.assertIn("--repo sparq-org/sparq", text)
+            self.assertIn("--branch main", text)
+            self.assertNotIn("--dry-run", text)
+            # EXACT argc: script + sweep + --repo + val + --branch + val == 6. An extra
+            # EMPTY seventh element is what unquoted `$DRY_RUN` yields when the flag is
+            # unset; it is invisible in the joined text and argparse rejects it, so
+            # every sweep would fail in the DEFAULT (non-dry-run) configuration.
+            self.assertEqual(argc, "6", call)
+
+    def test_a_failure_on_the_FIRST_sweep_survives_four_later_successes(self):
+        """THE STICKY-STATE ASSERTION. This estate shipped the opposite defect three
+        times in one day: a later transient discarding an earned hard failure. The
+        interleaved sequence is the only one that can tell `rc` from a plain
+        last-command exit status."""
+        proc, calls = self._execute([1, 0, 0, 0, 0])
+        self.assertEqual(len(calls), 5, "a failed sweep must not abort the loop")
+        self.assertNotEqual(
+            proc.returncode, 0,
+            "sweep 1 failed and sweeps 2-5 succeeded; the run reported success, so the "
+            "failure was discarded by a later success",
+        )
+
+    def test_a_failure_on_the_LAST_sweep_also_fails_the_run(self):
+        proc, _ = self._execute([0, 0, 0, 0, 1])
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_a_middle_failure_fails_the_run(self):
+        proc, calls = self._execute([0, 0, 1, 0, 0])
+        self.assertEqual(len(calls), 5)
+        self.assertNotEqual(proc.returncode, 0)
+
+    def test_the_dry_run_flag_is_passed_as_one_argument_when_set(self):
+        import subprocess
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "calls.log").write_text("", encoding="utf-8")
+            (tmp / "python3").write_text(
+                "#!/usr/bin/env bash\n"
+                f'printf "%s\\n" "$#" >> "{tmp}/calls.log"\n'
+                f'printf "%s\\n" "$*" >> "{tmp}/calls.log"\n',
+                encoding="utf-8",
+            )
+            (tmp / "python3").chmod(0o755)
+            proc = subprocess.run(
+                ["bash", "-c", self._run_block()],
+                env={
+                    "PATH": f"{tmp}:/usr/bin:/bin",
+                    "REPO": "sparq-org/sparq",
+                    "DEFAULT_BRANCH": "main",
+                    "DRY_RUN": "--dry-run",
+                    "RESWEEPS": "0",
+                    "RESWEEP_INTERVAL_SECONDS": "0",
+                },
+                capture_output=True,
+                text=True,
+            )
+            lines = (tmp / "calls.log").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        # script + sweep + --repo + val + --branch + val + --dry-run == 7 argv elements.
+        # The COUNT is the assertion: `--dry-run` must arrive as ONE element, which is
+        # exactly what the pre-fix unquoted `$DRY_RUN` splitting could not guarantee.
+        self.assertEqual(lines[0], "7", lines)
+        self.assertIn("--dry-run", lines[1])
+
+    def test_the_loop_actually_repeats(self):
+        # Pins the resweep COUNT to the env declaration rather than to a literal, so a
+        # silent drop to a single sweep (the pre-fix behaviour) is caught.
+        step = _step(_yaml(WATCHDOG_YML), "watch", "Sweep the merge queue")
+        declared = int(step["env"]["RESWEEPS"])
+        self.assertGreaterEqual(declared, 3)
+        _, calls = self._execute([0] * (declared + 1))
+        self.assertEqual(len(calls), declared + 1)
+
+    def test_the_loop_covers_the_grace_period(self):
+        # The whole reason the loop exists: one fire must outlive
+        # (group build latency + grace) or the doorbell ring is wasted.
+        step = _step(_yaml(WATCHDOG_YML), "watch", "Sweep the merge queue")
+        span = int(step["env"]["RESWEEPS"]) * int(step["env"]["RESWEEP_INTERVAL_SECONDS"])
+        self.assertGreater(
+            span, mgw.DEFAULT_GRACE_SECONDS,
+            "the resweep window must outlast the grace period, or every sweep in the "
+            "run decides WAIT on the group it was rung for",
+        )
+
+    def test_the_step_body_is_pure_shell(self):
+        # An `${{ }}` expression inside the run block would make it unexecutable here —
+        # i.e. would silently turn every test in this class vacuous.
+        self.assertNotIn("${{", self._run_block())
+
+    def test_no_failure_swallowing_idiom(self):
+        body = self._run_block()
+        self.assertNotIn("|| true", body)
+        self.assertNotIn("continue-on-error", body)
 
 
 class TestSuiteIsWiredIntoCI(unittest.TestCase):


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/infra lane, running as **Opus 5**. I am the AUTHOR of this
> change, so there is deliberately no `VERDICT:` line here and I have not armed it.

## What broke, measured

sparq's merge queue was head-of-line blocked for **46m33s** today. Position 1 (#4810,
group head `38a9d875`) had **zero check-suites**; positions 2 and 3 had 8 suites each and
could not land behind it. A human cleared it with `dequeuePullRequest`.

`.github/workflows/merge-group-watchdog.yml` **already detects exactly this** and already
holds `checks: read` for the load-bearing predicate. Nothing was wrong with its decision.
The defect was purely **when it runs** — `schedule` + `workflow_dispatch` only:

| | measured |
|---|---|
| watchdog cron fires, 13:19:03Z → 17:07:52Z | **3** (of ~45 expected — 93% loss) |
| largest gap | **140 min** |
| dead ref `38a9d875` built | 15:58:00Z |
| next scheduled fire after it | 17:07:52Z — **+69.9 min**, past the ruleset's own 60-min `CI_TIMEOUT` |

This is GitHub best-effort scheduler behaviour, not a misconfiguration. Recurrence today
was 3 dead refs in ~11 h, so it would have happened again unattended.

## The masking hypothesis — VERIFIED, not assumed

The obvious doorbell is the `merge_group` event. It is disqualified **twice over**, and I
checked both halves against live API data rather than reasoning about them.

**(a) Subscribing would mask the detector — CONFIRMED.** A check-suite is created **1:1 per
dispatched workflow run**. On group head `6b291b28` there are exactly 8 `merge_group`
workflow runs (`ci`, `ci-summary`, `docs-quality`, `feature-matrix`, `flow-on-gates`,
`pr-area-label`, `routing-self-tests`, `vectorized-feature-off`) and exactly 8 check-suites;
same 8/8 on `37aac5a4`, `e5a9d403`, `bef48bee`. A tenth subscriber therefore puts a **ninth
suite on every group head**, and the predicate is `total_count == 0`. The masking would be
**total, not partial** — the detector could never fire again, on any group.

**(b) The zero-suite case is one where the event was never delivered — CONFIRMED.** All nine
`merge_group` subscribers here carry a **bare** trigger (no `types`/`paths`/`branches`), so
no filter configuration can suppress some-but-not-all. Over the **42 distinct group refs**
retained in the activity feed the per-head `merge_group` run count is perfectly bimodal:

```
{0 runs: 3 heads, 8 runs: 39 heads}   — no intermediate value, ever
```

Zero therefore means the event reached **no** workflow. A `merge_group`-triggered watchdog is
dispatched by precisely the delivery that failed, so it would be absent exactly when needed.

*(One honest caveat: the script header's separate claim that "a `paths`-filtered workflow
matching nothing still creates a check-suite" is **not** verified by this data — no
`merge_group` subscriber here carries a `paths` filter, so the case does not arise. I have
left the predicate untouched; it is correct for this configuration either way.)*

## The producer chosen, and why it is complete

`pull_request_target: types: [enqueued, dequeued]`.

**`enqueued` does exist** — the brief's premise that it does not is refuted. It is a
documented `pull_request`/`pull_request_target` activity type, listed alongside `dequeued`.

A merge-group ref is built when an entry enters the build window, which has exactly two
causes: the entry is **added** to the queue, or an entry **ahead of it leaves** (merged or
removed) and the rest rebuild. That is `enqueued` + `dequeued` — a **complete cover**, with
one deliberate exception: a direct push to `main` that rebases the queue without any
PR-level queue event. **The retained cron covers that**, which is a reason to keep it rather
than a gap.

Measured, enqueue → dead-group-build delay for all three of today's dead refs:

| PR | enqueued | dead group built | delay |
|---|---|---|---|
| #4810 | 15:58:00Z | `38a9d875` 15:58:00Z | **0 s** |
| #4773 | 09:58:54Z | `76153a84` 09:59:10Z | **16 s** |
| #4709 | 05:15:07Z | `98204656` 05:15:09Z | **2 s** |

Delivery latency for this trigger class is **already proven live in this repo**: the
`dequeued` half is what `merge-queue-feedback.yml` runs on, and against the queue's own
removal events it fires in **3–6 s (n=8, all 8 matched)**.

### Why I did *not* piggyback on `auto-arm.yml`

It was the brief's first-listed candidate and it is measurably worse. `labeled` fired **223
times in the same 4 h** against **19 queue transitions** — 12× the cost for a signal that
does not cause a group build at all, only correlates with one. Counterfactually it would
have detected `38a9d875` at 16:15:44Z (**+17.7 min**) versus **~2.5 min** for the doorbell.
It is a clock, not a producer, and the enqueued+dequeued pair being *complete* makes a noisy
clock unnecessary.

I also rejected `push: branches: [main]`: a merged group head **becomes** the main head, so a
`push` leg would put a check-suite on a commit that is also a former merge-group head. It
muddies the constraint-1 invariant for no measured benefit, and it goes silent exactly during
a block (nothing is merging), which is the anti-correlation that makes queue-progress events
a bad clock.

## Constraint compliance

1. **Does not mask its own condition.** `pull_request_target` runs attach their check-run to
   the **PR's head SHA**, never to the `gh-readonly-queue/...` group commit. Verified
   empirically: PR #4810's head `fef71f12` carries `merge-queue dequeued feedback (advisory)`
   among its 204 check-runs, while the four healthy group heads carry exactly the 8
   `merge_group` suites and nothing else. The doorbell adds **no suite to any group head**.
   A repo-wide test enforces this going forward.
2. **Cron retained** — unchanged, and its header now says explicitly that it is the
   independent backstop and why. A test fails if the schedule is deleted.
3. **Decision untouched.** The doorbell carries no predicate, no threshold and no dequeue.
   Grace, caps, marker trust-list, `ACTIONABLE_STATES` and the recover/refuse table are all
   byte-identical. **Only timing changed.**
4. **Cost bounded.** The doorbell is a **one-step, one-API-write** job (`timeout-minutes: 5`),
   ~19 fires per 4 h. It is not on any workflow's critical path — it is its own workflow.

## What changed

- **`.github/workflows/merge-group-doorbell.yml`** (new) — the trigger. No checkout at all,
  no repository script executed, no `github.event` field interpolated into any executable
  line; token holds **`actions: write` and nothing else**. It dispatches the watchdog pinned
  to the **default branch**, so the policy that decides a dequeue is always the reviewed copy
  on `main`.
- **`.github/workflows/merge-group-watchdog.yml`** — the single sweep becomes an
  **unconditional** 5-sweep / 60 s loop, so one fire outlives the 120 s grace (a ring lands
  0–19 s *before* the group exists). Unconditional on purpose: a per-trigger `if:` would be a
  YAML seam, which is where mutants survive on this estate. `timeout-minutes` 10 → 15.
- **`.github/advisory-registry.json`** — registers the doorbell job. **Correction worth
  flagging:** since #3773 the gate no longer infers advisory status from job *names*; the
  registry is the only mechanism. Undeclared, this leg would have **silently gated** every
  enqueue.
- **`scripts/tests/test_merge_group_watchdog.py`** — +36 tests.

**⚠️ RETRACTED — an earlier revision of this PR claimed the merge-base call site had a
pre-existing bug. It does not.** I claimed unquoted `$DRY_RUN` injected an empty argv element
when unset, "killing every sweep in the default configuration". That is **false**, and it was
relayed onward before it was checked. Disproven twice:

- The **verbatim merge-base body** under GitHub's default shell
  (`bash --noprofile --norc -eo pipefail`) with `DRY_RUN` empty gives **`argc=6`, no empty
  element** — an *unquoted* empty expansion yields **zero words**. Control, same body with
  `"$DRY_RUN"` quoted: `argc=7` with a trailing `<>`. Injecting an empty element **requires**
  quoting.
- The three scheduled runs this PR cites as cron-loss evidence (`30362912573`,
  `30374414899`, `30381492560`) all have the sweep step at **`conclusion: success`** on that
  same tree.

My original "verification" typed a **quoted** `""` at a shell prompt and attributed the
result to an **unquoted** expansion — the opposite case. The array rewrite is a
**shellcheck-cleanliness change, not a bug fix**. The hazard is real but belongs to the
**new** shape: an unconditional `sweep_args+=("$DRY_RUN")` *does* inject the empty element,
which is why the `if [ -n "$DRY_RUN" ]` guard and the exact-`argc` assertions stay.

## Verification

`actionlint` clean on both files (including that pre-existing SC2086).
`check-advisory-registry.py` C2+C3+C4 all clear. **198 tests green.**

**Live reproduction** of the exact subcommand the lane runs, against the real queue:

```
$ python3 scripts/merge-group-watchdog.py sweep --repo sparq-org/sparq --branch main --dry-run
[merge-group-watchdog] pos=1 pr=#4757 state=AWAITING_CHECKS ref=…pr-4757-e5a9d403… head=cc70bea7
    suites=8 stacked=0 stacked_green=0 decision=HOLD — 8 check-suite(s) present …
[merge-group-watchdog] sweep complete: entries=1 HOLD=1 errors=0
```

### Mutation testing — 20/20 killed by NAMED assertions

Baseline green first (an instrument that reds on a clean tree proves nothing). Each mutant is
applied to a **copy of the live tree**, the real suite runs against it, and a kill counts only
if it is a `FAIL:` (named assertion) — a crash/`ERROR:` is reported separately and does not
count. Per the brief, several mutants **preserve the structure the assertions inspect while
breaking the behaviour they claim**: they leave the step, its name, its call site, the loop,
the env block and `exit "$rc"` all intact, so no structural assertion can see them.

| mutant | killed by |
|---|---|
| `rc=1` → `rc=0` | `test_a_failure_on_the_FIRST_sweep_survives_four_later_successes` |
| `exit "$rc"` → `exit 0` | same + `..._LAST_sweep...`, `..._middle_failure...` |
| reset `rc` each iteration | `..._FIRST_sweep...`, `..._middle_failure...` |
| `\|\| true` on the sweep | `test_no_failure_swallowing_idiom` + 2 |
| loop collapses to one sweep | `test_the_loop_actually_repeats` |
| resweep window < grace | `test_the_loop_covers_the_grace_period` |
| **doorbell subscribes to `merge_group`** | `test_no_sweep_participant_subscribes_to_merge_group` |
| doorbell fires on `merge_group` instead | + `test_the_doorbell_creates_no_check_suite_on_a_group_head` |
| producer widened to `labeled` | `test_the_doorbell_producer_is_the_pr_level_queue_transition_pair` |
| cron deleted | `test_the_cron_backstop_is_retained` |
| grace 120 → 0 | `test_grace_is_bounded_by_the_measured_dispatch_latency` |
| `pull_request_target` checks out PR head | `test_no_checkout_and_no_repository_script_is_executed` |
| permissions escalated | `test_permissions_are_exactly_actions_write` |
| `(advisory)` token dropped | `test_the_job_is_declared_advisory_in_the_registry` |
| dispatch retargeted at PR branch | `test_the_ring_step_dispatches_the_watchdog_on_the_default_branch` |
| watchdog gains a PR-head trigger | `test_the_watchdog_itself_still_has_no_pr_or_group_trigger` |
| **my own matcher blinded** (×2) | `test_the_matcher_separates_a_live_sweep_from_a_hermetic_self_test` |

The last pair is the vacuity check on the instrument itself: the participant-set assertion
pins the population **exactly** (`{watchdog, doorbell}`), so a matcher that silently stops
matching cannot look like a clean run — the failure mode where an instrument fails toward
"nothing to report".

**Second review round — the seam.** The review found **8 of 8 structure-preserving seam
mutants surviving**: `if: false` on job `doorbell`, job `watch`, or either step made the
mechanism fully inert with names and call sites intact; `continue-on-error` was "guarded" by a
YAML **key** searched for inside a shell **string**, so it could never fail; and `--repo` was
asserted nowhere, so the ring could be retargeted at a foreign repository. All are now killed
by named assertions in `TestTheYamlSeamCannotGoInert` and
`test_no_failure_swallowing_at_the_YAML_SEAM`:

| seam mutant | killed by |
|---|---|
| `if: false` on job `doorbell` / the ring step | `test_the_doorbell_carries_no_guard_at_all` |
| `if: false` on job `watch` / the sweep step | `test_the_watchdog_sweep_cannot_be_switched_off_at_the_seam` |
| `continue-on-error` on the step or the job | `test_no_failure_swallowing_at_the_YAML_SEAM` |
| ring retargeted at a foreign repo | `test_the_ring_targets_THIS_repository` |
| `--repo` dropped from the sweep call site | `test_sweep_call_site_invokes_the_sweep_subcommand` |
| guard made constant-true | `test_no_guard_anywhere_carries_a_constant_operand` |
| blast radius widened back to 10/fire | `test_the_per_fire_blast_radius_is_bounded` |
| budget flag dropped from the call site | `test_the_budget_flag_actually_reaches_the_sweep` |

**Total: 31/31 killed by named assertions, no survivors**, baseline green.

### Blast radius — a 5× widening I introduced, now bounded

`--max-recoveries-per-run` is **process-local** (`merge-group-watchdog.py:1079`), so looping
five sweeps in one job silently multiplied the script's own "one tick may never churn the
whole queue" bound by 5, from 2 to **10**. The per-sweep budget is now passed as **1**, putting
the per-fire ceiling at **5**, pinned by `test_the_per_fire_blast_radius_is_bounded` so raising
`RESWEEPS` cannot widen it again. **That is still above the pre-loop 2 and is a disclosed
residual, not a fix**: closing it exactly needs a budget shared *across* sweeps, which lives in
the CAP path this change deliberately does not touch. Per-PR cap (2 per 6 h) and same-head
idempotence are unaffected, so the same entry still cannot be churned twice.

## Honest limits

- **The `pull_request_target` trigger cannot fire before this merges** — GitHub resolves
  `pull_request_target` workflows from the **base** branch. So the trigger itself is
  documented-untested-until-merge. What that leaves unverified is narrow, and I did not want
  to claim otherwise: the `dequeued` half of the producer pair is *already running live in
  this repo* at 3–6 s (n=8), and `gh workflow run` from a workflow token is a **documented
  exception** to the GITHUB_TOKEN no-recursion rule ("`workflow_dispatch` and
  `repository_dispatch` events always create workflow runs").
- I could **not** safely construct a dead-ref condition: manufacturing one means denying a
  real `merge_group` dispatch, and clearing it means dequeuing a live entry — explicitly out
  of bounds. The evidence is the three real dead refs above plus the counterfactual latency
  table, not a synthetic reproduction.
- Detection latency below is **derived** from measured components (ring 3–6 s + run start +
  the 120 s grace the predicate requires), not from an observed recovery.

<!-- LIVE-FIRE-RESULTS -->

## Live fire — the new code path actually ran, pre-merge

A staged rollout that never leaves stage zero is the failure mode this repo keeps hitting
(#4803), so the resweep loop was **executed in real GitHub Actions against the live queue**
before this PR was opened, not merely configured. Dispatched on this branch with
`dry_run=true` so no queue entry could be touched:

**[run 30383251472](https://github.com/sparq-org/sparq/actions/runs/30383251472)** —
`success`, 17:31:14Z → 17:35:33Z. Runtime output (the `##[group]` markers and the census
rows, *not* the echoed script source):

```
17:31:24.55  ##[group]sweep 1/5   -> sweep complete: entries=1 HOLD=1 errors=0
17:32:27.20  ##[group]sweep 2/5   -> sweep complete: entries=1 HOLD=1 errors=0
17:33:27.90  ##[group]sweep 3/5   -> sweep complete: entries=1 HOLD=1 errors=0
17:34:28.58  ##[group]sweep 4/5   -> sweep complete: entries=1 HOLD=1 errors=0
17:35:29.21  ##[group]sweep 5/5   -> sweep complete: entries=1 HOLD=1 errors=0
```

| measured | value |
|---|---|
| sweeps per fire | **5/5**, intervals 60.6–62.6 s |
| dispatch → first sweep | **12 s** |
| cover from ONE fire | **4 m 06 s** (vs a single instantaneous sweep before) |
| decision on a healthy queue | `HOLD` every time — **no mutation**, the control arm |

### Detection latency, composed from measured parts

| component | measured |
|---|---|
| queue transition → doorbell run | 3–6 s (n=8, live `dequeued` legs in this repo) |
| dispatch → first sweep | 12 s (run above) |
| producer event → group ref built | 0–19 s (all three dead refs + 5 live rebuilds) |
| grace before a zero-suite group is actionable | 120 s (unchanged) |

⇒ **~2.3–3.3 min** to recovery, against **46 m 33 s** actually endured today and **69.9 min**
until the next cron fire would have looked. Detection stays tick-quantised, so the honest
statement is a *bound*, not a point estimate.

**And it is the IDLE best case, not the general case.** `cancel-in-progress: false` on the
doorbell makes every ring *start*, but the serialisation point is the **watchdog's own**
`merge-group-watchdog` concurrency group, which the loop now occupies for ~4 min at a time.
A ring arriving mid-loop waits for the slot (GitHub keeps at most one pending run per group,
so bursts collapse). The running sweep is queue-wide and re-sweeps every 60 s, so a waiting
ring is covered by the loop already executing rather than lost — but the ~2.3–3.3 min figure
assumes no watcher was already running, and I should not have presented it without that.

### Fires observed on the new trigger: ZERO — and why that is not hidden

The `pull_request_target` leg **cannot fire before this merges**: GitHub resolves
`pull_request_target` workflows from the base branch. I confirmed the same limit blocks even a
manual dispatch — `gh workflow run merge-group-doorbell.yml --ref <this branch>` returns
`HTTP 404: workflow merge-group-doorbell.yml not found on the default branch`. So the count of
real doorbell fires today is **0**, and that number will stay 0 until merge. What is verified
instead, and is not nothing:

- the **exact command** the doorbell's only step runs — `gh workflow run
  merge-group-watchdog.yml --repo … --ref …` — is what created run 30383251472 above;
- the **trigger class** is live in this repo now at 3–6 s (n=8);
- `enqueued` is real on **three independent sources**: the GitHub docs activity-type list,
  `actionlint`'s own event schema (it rejects `not_a_real_type` on this exact file while
  accepting `[enqueued, dequeued]`), and the sibling `dequeued` already in production here.

**The first real check is the first enqueue after merge.** If the doorbell is live and no
`merge-group-watchdog` run appears within ~30 s of an `added_to_merge_queue` event, it is not
working and should be reverted rather than left to look configured.
