### PR TITLE
fix(orchestration): refuse to partition a tree that is not this workspace [OPUS-5]

### DIFF
--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -31,6 +31,18 @@ on:
       - "scripts/route-resolve.py"
       - "scripts/dispatch-plan.py"
       - "scripts/ready-issues.py"
+      # [OPUS-5] PR #4925 review — THE INPUTS THE PARTITION GUARD READS FROM THE TREE.
+      # `ready-issues.py`'s `workspace_roots()` derives the `area:` partition algebra from the
+      # workspace manifest plus the crate directory listing, and REFUSES to plan when the two
+      # disagree. Neither input was in this filter, so the one file that can turn the guard into
+      # a hard PLAN stop — root `Cargo.toml` — could change with the guard's own tests never
+      # running, merge green, and stop dispatch for BOTH target repositories on the next tick.
+      # `crates/*/Cargo.toml` (not `crates/**`) is deliberate: what matters here is the SET of
+      # crate partition roots, which changes exactly when a crate manifest is added, removed or
+      # renamed. `crates/**` would fire this lane on essentially every Rust PR in a 67-crate
+      # workspace for no additional coverage of that set.
+      - "Cargo.toml"
+      - "crates/*/Cargo.toml"
       # [OPUS-5] the bd->issues migration pair. Their --self-tests were DEAD in this repo's
       # PR CI: bd-to-issues.py's was invoked by no workflow at all, and
       # ci-close-merged-beads.py's ran only POST-merge inside bead-autoclose.yml
@@ -102,6 +114,18 @@ on:
       - "scripts/route-resolve.py"
       - "scripts/dispatch-plan.py"
       - "scripts/ready-issues.py"
+      # [OPUS-5] PR #4925 review — THE INPUTS THE PARTITION GUARD READS FROM THE TREE.
+      # `ready-issues.py`'s `workspace_roots()` derives the `area:` partition algebra from the
+      # workspace manifest plus the crate directory listing, and REFUSES to plan when the two
+      # disagree. Neither input was in this filter, so the one file that can turn the guard into
+      # a hard PLAN stop — root `Cargo.toml` — could change with the guard's own tests never
+      # running, merge green, and stop dispatch for BOTH target repositories on the next tick.
+      # `crates/*/Cargo.toml` (not `crates/**`) is deliberate: what matters here is the SET of
+      # crate partition roots, which changes exactly when a crate manifest is added, removed or
+      # renamed. `crates/**` would fire this lane on essentially every Rust PR in a 67-crate
+      # workspace for no additional coverage of that set.
+      - "Cargo.toml"
+      - "crates/*/Cargo.toml"
       # [OPUS-5] the bd->issues migration pair. Their --self-tests were DEAD in this repo's
       # PR CI: bd-to-issues.py's was invoked by no workflow at all, and
       # ci-close-merged-beads.py's ran only POST-merge inside bead-autoclose.yml

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -30,6 +30,7 @@ import os
 import re
 import subprocess
 import sys
+import tomllib
 
 GATE_LABELS = ("needs:", "trust:untrusted")
 # [OPUS-5] `status:in-progress-review` was MISSING here while the registry's dispatch.yml keeps
@@ -87,10 +88,89 @@ _ROLE = re.compile(r"^role:.+$")
 _SEP = "-"                       # the hierarchy separator inside an `area:` key
 _PARTITION_MEMO = {}             # key -> path, for the default (workspace-derived) root set
 _WORKSPACE_ROOTS = None          # lazily scanned; None = not yet read
+# The manifest that makes the scan CHECKABLE. `crates/<name>` members are an explicit list here
+# (no globs), so the tree can state its own floor and a crate added next month raises it with no
+# code change — see `assert_workspace_tree`.
+WORKSPACE_MANIFEST = "Cargo.toml"
+
+
+class DegeneratePartitionRoots(RuntimeError):
+    """The tree handed to the partition algebra is not this workspace, so it cannot be partitioned.
+
+    [OPUS-5] `workspace_roots()` derives partition semantics from a DIRECTORY LISTING, so the
+    algebra silently changes meaning when the listing is wrong. If `crates/` is absent, no
+    `sparq-*` key resolves through rule 2 and EVERY one of them falls to rule 3's head segment
+    `sparq` — one mega-partition that every sparq crate conflicts on. The frontier then collapses
+    to ~1 and the census line looks completely normal, because `candidates` and `top-contended`
+    are computed from label sets and never mention the collapse.
+
+    MEASURED (2026-07-28, live sparq snapshot, sparq's own engine): with the real tree the ready
+    lane selected 4 rows; with a scripts-only tree — same snapshot, same code, same labels — it
+    selected 2, and 185 of 377 refusals were attributed to a single phantom `sparq-algos` key held
+    by one PR. That was an ACCIDENT in a repro harness, not a hypothetical: nothing in the engine,
+    the workflow, or the census could tell the two runs apart.
+
+    So the scan is asserted instead of trusted, and a violation REFUSES TO PLAN. Returning an
+    empty frontier would have been worse than useless — it prints `frontier=0` and reads as an
+    ordinary fully-contended tick. A raise cannot be mistaken for a plan.
+    """
 
 
 def _repo_root():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def declared_crate_members(repo_root):
+    """The `crates/<name>` directories `Cargo.toml` DECLARES as workspace members.
+
+    The floor for `assert_workspace_tree` is read from the manifest rather than written down, so
+    it tracks the workspace automatically. Returns an empty set when the manifest is missing or
+    unreadable — the caller treats that as its own failure, not as a floor of zero.
+    """
+    path = os.path.join(repo_root, WORKSPACE_MANIFEST)
+    try:
+        with open(path, "rb") as handle:
+            manifest = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return set()
+    members = (manifest.get("workspace") or {}).get("members")
+    if not isinstance(members, list):
+        return set()
+    return {m.split("/", 1)[1] for m in members
+            if isinstance(m, str) and m.startswith("crates/") and "/" in m}
+
+
+def assert_workspace_tree(base, names):
+    """Refuse a scanned root set that cannot be this workspace. Raises DegeneratePartitionRoots.
+
+    Two conditions, both derived FROM THE TREE — there is no magic number here, and adding a crate
+    raises the floor by itself:
+
+      1. `Cargo.toml` must be present and declare `crates/*` workspace members. Its absence means
+         we are not looking at the repository root at all (the exact shape of the accident that
+         motivated this: a target tree containing only `scripts/`).
+      2. EVERY declared member must have been scanned as a root. This is what catches the case
+         condition 1 cannot — a sparse or partial checkout that has the manifest and only some of
+         `crates/`, where the missing crates' keys would each collapse into `sparq` while the
+         present ones resolve correctly. A partly-wrong partition is not safer than a wholly-wrong
+         one; it is harder to notice.
+    """
+    declared = declared_crate_members(base)
+    if not declared:
+        raise DegeneratePartitionRoots(
+            f"refusing to partition: no readable `[workspace] members` in {base}/"
+            f"{WORKSPACE_MANIFEST}. The partition algebra resolves `area:` keys against the "
+            f"directory listing of {base}, and a tree that is not this workspace collapses every "
+            "unrecognised `sparq-*` key onto the single head-segment partition `sparq` — a "
+            "frontier computed from that is wrong in a way no census line reveals.")
+    missing = sorted(declared - set(names))
+    if missing:
+        shown = ", ".join(missing[:8]) + (f" (+{len(missing) - 8} more)" if len(missing) > 8 else "")
+        raise DegeneratePartitionRoots(
+            f"refusing to partition: {len(missing)} of {len(declared)} declared workspace "
+            f"member(s) are absent from the scanned tree at {base}: {shown}. Each missing crate's "
+            "`area:` key would resolve to the head segment `sparq` instead of to itself, silently "
+            "merging unrelated crates into one partition and collapsing the frontier.")
 
 
 def workspace_roots(repo_root=None):
@@ -106,6 +186,12 @@ def workspace_roots(repo_root=None):
 
     The registry's `dispatch.yml` CLONES this repo and runs this script, so the same tree is
     present there; `--dump-partitions` exports the resolved mapping for a parity fixture.
+
+    [OPUS-5] The scan is now ASSERTED against the workspace manifest before it is returned or
+    memoized (`assert_workspace_tree`) — reading semantics off a directory listing means a wrong
+    listing silently changes them, and the resulting frontier is indistinguishable from a healthy
+    one. A caller that passes an explicit `roots` SET to `partition_path`/`keys_conflict` is
+    unaffected: it supplied the roots and owns them (that is how the hermetic fixtures work).
     """
     global _WORKSPACE_ROOTS
     if repo_root is None and _WORKSPACE_ROOTS is not None:
@@ -119,6 +205,7 @@ def workspace_roots(repo_root=None):
             continue
         names.update(e for e in entries
                      if not e.startswith(".") and os.path.isdir(os.path.join(parent, e)))
+    assert_workspace_tree(base, names)     # BEFORE the memo: never cache a degenerate scan
     if repo_root is None:
         _WORKSPACE_ROOTS = names
     return names
@@ -571,6 +658,12 @@ def compute_ready(issues, in_progress_packages=None, conflict_log=None, source_l
     per-row loop, so the registry's existing `compute_ready(ready_input)` call is unaffected and
     the two repositories may merge in either order.
     """
+    # [OPUS-5] EAGER, so the refusal is a property of the TREE and not of the board. `conflict()`
+    # below is the only consumer of the workspace-derived roots, and it is not reached at all when
+    # nothing is held or nothing is a candidate — on those ticks a degenerate tree would plan
+    # silently and the guard would fire only later, on a busier board. Asserting here makes every
+    # call refuse identically. Costs one memoized directory listing per process.
+    workspace_roots()
     blockers = {}
 
     def reserve(pkgs, artifact):
@@ -772,6 +865,99 @@ def _self_test():
     check("degenerate key falls all the way to global", partition_path(""), ())
     check("unrelated crates do not conflict",
           keys_conflict("sparq-core", "sparq-engine"), False)
+
+    # ---------------------------------------------------------------------------------------
+    # [OPUS-5] THE DEGENERATE-TREE GUARD. These build real directories rather than stubbing the
+    # scan, because the defect IS the scan: `workspace_roots()` reads a directory listing and the
+    # algebra silently changes meaning when the listing is wrong. Every row below goes red if
+    # `assert_workspace_tree` is deleted or if either of its two conditions is dropped.
+    # ---------------------------------------------------------------------------------------
+    import shutil
+    import tempfile
+
+    def _tree(members, present=None, manifest=True):
+        """A throwaway repo root. `members` are declared in Cargo.toml; `present` (default: all
+        of them) are the crate directories actually created."""
+        base = tempfile.mkdtemp(prefix="ready-roots-")
+        os.makedirs(os.path.join(base, "scripts"))
+        for name in (members if present is None else present):
+            os.makedirs(os.path.join(base, "crates", name))
+        if manifest:
+            listed = ", ".join(f'"crates/{n}"' for n in members)
+            with open(os.path.join(base, WORKSPACE_MANIFEST), "w", encoding="utf-8") as handle:
+                handle.write(f"[workspace]\nresolver = \"2\"\nmembers = [{listed}]\n")
+        return base
+
+    def _refusal(base):
+        try:
+            workspace_roots(base)
+        except DegeneratePartitionRoots as exc:
+            return str(exc)
+        return ""
+
+    _crates = ["sparq-core", "sparq-engine", "sparq-algos", "sparq-kb"]
+    # (1) THE ACCIDENT, REPRODUCED: a scripts-only tree — no Cargo.toml, no crates/ — is exactly
+    # what the repro harness handed the engine, and it planned a frontier from a phantom
+    # partition with no diagnostic anywhere.
+    _scripts_only = _tree([], manifest=False)
+    _msg = _refusal(_scripts_only)
+    check("[degenerate] a scripts-only tree REFUSES to partition",
+          ("refusing to partition" in _msg, "Cargo.toml" in _msg), (True, True))
+    # ...and the refusal is NON-VACUOUS: on that same tree the algebra really does merge two
+    # unrelated crates into one `sparq` partition. This is the harm the guard exists to stop, so
+    # it is asserted directly — deleting the guard makes the row above green and leaves THIS
+    # collapse in place, which is precisely how the accident went unnoticed.
+    check("[degenerate] ...and that tree really would merge unrelated crates",
+          (partition_path("sparq-core", roots={"scripts"}),
+           partition_path("sparq-algos", roots={"scripts"}),
+           keys_conflict("sparq-core", "sparq-algos", roots={"scripts"})),
+          (("sparq",), ("sparq",), True))
+    # (2) THE HEALTHY PATH IS UNCHANGED: a complete tree returns its roots and does not raise.
+    _full = _tree(_crates)
+    check("[degenerate] a complete workspace tree is accepted",
+          (_refusal(_full),
+           sorted(n for n in workspace_roots(_full) if n not in {"scripts", "crates"})),
+          ("", sorted(_crates)))
+    # ...and on it the same two keys are INDEPENDENT — the guard changes no semantics, it only
+    # refuses trees where the semantics would be wrong.
+    _roots = workspace_roots(_full)
+    check("[degenerate] ...and unrelated crates stay independent there",
+          keys_conflict("sparq-core", "sparq-algos", roots=_roots), False)
+    # (3) THE PARTIAL CHECKOUT — manifest present, only some crates on disk. Condition 1 alone
+    # cannot see this: the missing crates' keys collapse to `sparq` while the present ones
+    # resolve correctly, so the partition is partly right, which is harder to notice than
+    # wholly wrong. Dropping the member-existence half of the guard makes this row red.
+    _partial = _tree(_crates, present=_crates[:2])
+    _msg = _refusal(_partial)
+    check("[degenerate] a PARTIAL checkout (manifest + some crates) also refuses",
+          ("2 of 4 declared workspace member(s) are absent" in _msg,
+           "sparq-algos" in _msg, "sparq-kb" in _msg), (True, True, True))
+    # (4) A manifest with no `crates/*` members is not a floor of zero — it is an unusable
+    # manifest, and admitting it would let an empty `members = []` disable the guard entirely.
+    _empty_members = _tree([], present=["sparq-core"])
+    check("[degenerate] an empty member list is a refusal, never a floor of zero",
+          "refusing to partition" in _refusal(_empty_members), True)
+    # (5) compute_ready REFUSES rather than returning a plausible-looking empty frontier: an
+    # empty result prints `frontier=0` and reads as an ordinary fully-contended tick.
+    _saved_roots, _saved_memo = _WORKSPACE_ROOTS, dict(_PARTITION_MEMO)
+    globals()["_WORKSPACE_ROOTS"] = None
+    globals()["_PARTITION_MEMO"] = {}
+    _saved_repo_root = globals()["_repo_root"]
+    globals()["_repo_root"] = lambda: _scripts_only
+    try:
+        _planned = compute_ready([iss(90, R + ["priority:P1", "area:sparq-core"])],
+                                 conflict_log=quiet)
+        _outcome = f"PLANNED {[i['number'] for i in _planned]}"
+    except DegeneratePartitionRoots:
+        _outcome = "REFUSED"
+    finally:
+        globals()["_repo_root"] = _saved_repo_root
+        globals()["_WORKSPACE_ROOTS"] = _saved_roots
+        globals()["_PARTITION_MEMO"] = _saved_memo
+    check("[degenerate] compute_ready REFUSES on a degenerate tree (never a quiet empty plan)",
+          _outcome, "REFUSED")
+    for _path in (_scripts_only, _full, _partial, _empty_members):
+        shutil.rmtree(_path, ignore_errors=True)
     check("sibling regions of one crate conflict",
           keys_conflict("sparq-core-store", "sparq-core-nt-dict"), True)
     check("parent+child enter the frontier together? (must not)",

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -92,6 +92,9 @@ _WORKSPACE_ROOTS = None          # lazily scanned; None = not yet read
 # (no globs), so the tree can state its own floor and a crate added next month raises it with no
 # code change — see `assert_workspace_tree`.
 WORKSPACE_MANIFEST = "Cargo.toml"
+# The one directory the workspace keeps its crates in. Mirrors `pr-area-labels.py`'s CRATES_DIR,
+# whose `workspace_members()` parses the same manifest field for the PR-side deriver.
+CRATES_DIR = "crates"
 
 
 class DegeneratePartitionRoots(RuntimeError):
@@ -120,49 +123,122 @@ def _repo_root():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-def declared_crate_members(repo_root):
-    """The `crates/<name>` directories `Cargo.toml` DECLARES as workspace members.
+_GLOB_CHARS = "*?["             # cargo expands `members` with the `glob` crate
+
+
+def _crate_member_root(member):
+    """(partition root, is_glob) for one `[workspace] members` entry, or (None, False).
+
+    Only `crates/...` entries matter — a member elsewhere in the tree (sparq declares none, but
+    `exclude` names `gui/src-tauri` and `vendor/spargebra`) names no `crates/` partition root.
+
+    THE FORMS CARGO ACCEPTS, all of which this must survive (PR #4925 review — every one of them
+    refused a complete, valid tree):
+      * `crates/sparq-core`        -> ("sparq-core", False)   the plain form sparq uses today
+      * `crates/sparq-core/`       -> ("sparq-core", False)   a trailing slash is legal
+      * `crates/sparq-core/derive` -> ("sparq-core", False)   a NESTED member (the proc-macro
+        pattern) is a member, but it is NOT a partition root: it lives INSIDE `sparq-core` and
+        `workspace_roots` never scans that deep, so the root it must be checked against is its
+        first segment under `crates/`.
+      * `crates/*`                 -> (None, True)            a glob delegates the member list to
+        the tree itself, so it names no specific root and cannot be checked against one.
+    """
+    if not isinstance(member, str):
+        return None, False
+    # `.strip()` handles whitespace padding; the empty-segment filter below already absorbs a
+    # trailing slash and a doubled separator, so there is deliberately no `.strip("/")` here — it
+    # was measured to change NO input (a mutation probe could not kill it), and an unkillable
+    # guard reads as protection while providing none.
+    parts = [p for p in member.strip().split("/") if p]
+    if len(parts) < 2 or parts[0] != CRATES_DIR:
+        return None, False
+    if any(c in parts[1] for c in _GLOB_CHARS):
+        return None, True
+    return parts[1], False
+
+
+def declared_crate_roots(repo_root):
+    """`(explicit roots, globbed)` — the `crates/` partition roots `Cargo.toml` names.
 
     The floor for `assert_workspace_tree` is read from the manifest rather than written down, so
-    it tracks the workspace automatically. Returns an empty set when the manifest is missing or
-    unreadable — the caller treats that as its own failure, not as a floor of zero.
+    it tracks the workspace automatically. `globbed` is True when any member delegates to a glob;
+    the caller must then fall back to a structural floor, because a glob states no root to check.
+    Returns `(set(), False)` when the manifest is missing or unreadable — the caller treats that
+    as its own failure, not as a floor of zero.
     """
     path = os.path.join(repo_root, WORKSPACE_MANIFEST)
     try:
         with open(path, "rb") as handle:
             manifest = tomllib.load(handle)
     except (OSError, tomllib.TOMLDecodeError):
-        return set()
+        return set(), False
     members = (manifest.get("workspace") or {}).get("members")
     if not isinstance(members, list):
-        return set()
-    return {m.split("/", 1)[1] for m in members
-            if isinstance(m, str) and m.startswith("crates/") and "/" in m}
+        return set(), False
+    roots, globbed = set(), False
+    for member in members:
+        root, is_glob = _crate_member_root(member)
+        if root is not None:
+            roots.add(root)
+        globbed = globbed or is_glob
+    return roots, globbed
+
+
+def _crates_dir_is_populated(base):
+    """Does `base/crates` exist and hold at least one directory? The floor a GLOB delegates to."""
+    try:
+        entries = os.listdir(os.path.join(base, CRATES_DIR))
+    except OSError:
+        return False
+    return any(not e.startswith(".") and os.path.isdir(os.path.join(base, CRATES_DIR, e))
+               for e in entries)
 
 
 def assert_workspace_tree(base, names):
     """Refuse a scanned root set that cannot be this workspace. Raises DegeneratePartitionRoots.
 
-    Two conditions, both derived FROM THE TREE — there is no magic number here, and adding a crate
-    raises the floor by itself:
+    THREE conditions, all derived FROM THE TREE — there is no magic number here, and adding a
+    crate raises the floor by itself:
 
-      1. `Cargo.toml` must be present and declare `crates/*` workspace members. Its absence means
-         we are not looking at the repository root at all (the exact shape of the accident that
-         motivated this: a target tree containing only `scripts/`).
-      2. EVERY declared member must have been scanned as a root. This is what catches the case
+      1. `Cargo.toml` must be present and name `crates/` workspace members, explicitly or by
+         glob. Its absence means we are not looking at the repository root at all (the exact
+         shape of the accident that motivated this: a target tree containing only `scripts/`).
+      2. EVERY explicitly declared member must have been scanned as a root. This catches what
          condition 1 cannot — a sparse or partial checkout that has the manifest and only some of
-         `crates/`, where the missing crates' keys would each collapse into `sparq` while the
-         present ones resolve correctly. A partly-wrong partition is not safer than a wholly-wrong
-         one; it is harder to notice.
+         `crates/`, where the missing crates' keys each collapse into `sparq` while the present
+         ones resolve correctly. A partly-wrong partition is not safer than a wholly-wrong one;
+         it is harder to notice.
+      3. If any member is a GLOB, `crates/` must exist and hold at least one crate directory.
+
+    WHY CONDITION 3 EXISTS, and why the obvious fix without it is worse than no fix (PR #4925
+    review round 2). Normalising globs so `members = ["crates/*"]` stops being a false positive
+    leaves `declared` EMPTY, which makes condition 2 vacuous and condition 1 satisfied — the
+    guard becomes a COMPLETE NO-OP for exactly that manifest. MEASURED against a model of the
+    normalise-only fix: a glob manifest with `crates/` MISSING, and one with `crates/` EMPTY,
+    were both ACCEPTED. Those are the original defect, restored, under the one manifest edit
+    (`members = ["crates/*"]`) most likely to be made routinely. A glob states no root to check,
+    so it delegates the floor to the tree, and this is that floor.
+
+    ONE LIMITATION, STATED RATHER THAN PAPERED OVER: under a glob a PARTIAL checkout (some crates
+    present, others not) is undetectable here, because the manifest has delegated the member list
+    to the very tree we are trying to check and there is no independent count to compare against.
+    Conditions 1 and 3 still hold; condition 2 has nothing to work with. sparq declares its 67
+    members explicitly today, so all three conditions are live on the real tree.
     """
-    declared = declared_crate_members(base)
-    if not declared:
+    declared, globbed = declared_crate_roots(base)
+    if not declared and not globbed:
         raise DegeneratePartitionRoots(
-            f"refusing to partition: no readable `[workspace] members` in {base}/"
-            f"{WORKSPACE_MANIFEST}. The partition algebra resolves `area:` keys against the "
-            f"directory listing of {base}, and a tree that is not this workspace collapses every "
-            "unrecognised `sparq-*` key onto the single head-segment partition `sparq` — a "
+            f"refusing to partition: no readable `[workspace] members` naming `{CRATES_DIR}/` in "
+            f"{base}/{WORKSPACE_MANIFEST}. The partition algebra resolves `area:` keys against "
+            f"the directory listing of {base}, and a tree that is not this workspace collapses "
+            "every unrecognised `sparq-*` key onto the single head-segment partition `sparq` — a "
             "frontier computed from that is wrong in a way no census line reveals.")
+    if globbed and not _crates_dir_is_populated(base):
+        raise DegeneratePartitionRoots(
+            f"refusing to partition: {base}/{WORKSPACE_MANIFEST} declares its workspace members "
+            f"by glob, which delegates the member list to the tree, but {base}/{CRATES_DIR} is "
+            "missing or holds no crate directory. There is nothing to partition, and every "
+            "`sparq-*` key would collapse onto the head-segment partition `sparq`.")
     missing = sorted(declared - set(names))
     if missing:
         shown = ", ".join(missing[:8]) + (f" (+{len(missing) - 8} more)" if len(missing) > 8 else "")
@@ -198,7 +274,7 @@ def workspace_roots(repo_root=None):
         return _WORKSPACE_ROOTS
     base = repo_root if repo_root is not None else _repo_root()
     names = set()
-    for parent in (base, os.path.join(base, "crates")):
+    for parent in (base, os.path.join(base, CRATES_DIR)):
         try:
             entries = os.listdir(parent)
         except OSError:
@@ -875,17 +951,24 @@ def _self_test():
     import shutil
     import tempfile
 
-    def _tree(members, present=None, manifest=True):
-        """A throwaway repo root. `members` are declared in Cargo.toml; `present` (default: all
-        of them) are the crate directories actually created."""
+    _made = []
+
+    def _tree(members, present=None, manifest=True, raw=None, body=None):
+        """A throwaway repo root. `members` are declared in Cargo.toml as `crates/<name>`;
+        `present` (default: all of them) are the crate directories actually created. `raw`
+        replaces the member list with VERBATIM strings (globs, nested members, trailing
+        slashes); `body` replaces the whole manifest text (malformed-TOML cases)."""
         base = tempfile.mkdtemp(prefix="ready-roots-")
+        _made.append(base)
         os.makedirs(os.path.join(base, "scripts"))
         for name in (members if present is None else present):
-            os.makedirs(os.path.join(base, "crates", name))
+            os.makedirs(os.path.join(base, CRATES_DIR, name), exist_ok=True)
         if manifest:
-            listed = ", ".join(f'"crates/{n}"' for n in members)
+            listed = ", ".join(f'"{m}"' for m in
+                               (raw if raw is not None else [f"crates/{n}" for n in members]))
             with open(os.path.join(base, WORKSPACE_MANIFEST), "w", encoding="utf-8") as handle:
-                handle.write(f"[workspace]\nresolver = \"2\"\nmembers = [{listed}]\n")
+                handle.write(body if body is not None
+                             else f"[workspace]\nresolver = \"2\"\nmembers = [{listed}]\n")
         return base
 
     def _refusal(base):
@@ -956,7 +1039,78 @@ def _self_test():
         globals()["_PARTITION_MEMO"] = _saved_memo
     check("[degenerate] compute_ready REFUSES on a degenerate tree (never a quiet empty plan)",
           _outcome, "REFUSED")
-    for _path in (_scripts_only, _full, _partial, _empty_members):
+    # -------------------------------------------------------------------------------------
+    # [OPUS-5] PR #4925 REVIEW, VERDICT: fail — THE FALSE-POSITIVE SURFACE.
+    # The first cut of this guard parsed `members` with `m.split("/", 1)[1]`, which is correct
+    # for exactly ONE of the forms cargo accepts. Every other legal form refused a COMPLETE,
+    # VALID tree, and `members = ["crates/*"]` — a routine edit — would have hard-stopped PLAN
+    # for BOTH target repositories on the next tick, having merged green because
+    # routing-self-tests.yml's `paths:` filter covered neither `Cargo.toml` nor `crates/**`.
+    #
+    # `declared_crate_roots` had NO direct coverage, which is why a normalisation fix could pass
+    # with no test edits at all. It has some now: each shape below is a NAMED row that goes red
+    # if the normalisation is removed.
+    # -------------------------------------------------------------------------------------
+    check("[members] the plain form sparq uses today",
+          declared_crate_roots(_tree(["a", "b"])), ({"a", "b"}, False))
+    check("[members] a TRAILING SLASH is legal cargo and names the same root",
+          declared_crate_roots(_tree(["a", "b"], raw=["crates/a/", "crates/b"])),
+          ({"a", "b"}, False))
+    check("[members] a NESTED sub-crate member resolves to its CONTAINING crate root",
+          declared_crate_roots(_tree(["a"], raw=["crates/a", "crates/a/derive"])),
+          ({"a"}, False))
+    check("[members] a GLOB names no root and reports itself as a glob",
+          declared_crate_roots(_tree(["a"], raw=["crates/*"])), (set(), True))
+    check("[members] a glob+explicit MIX keeps the explicit root and the glob flag",
+          declared_crate_roots(_tree(["a"], raw=["crates/*", "crates/a"])), ({"a"}, True))
+    check("[members] `?` and `[` are glob metacharacters too",
+          (declared_crate_roots(_tree(["a"], raw=["crates/sparq-?"]))[1],
+           declared_crate_roots(_tree(["a"], raw=["crates/[ab]"]))[1]), (True, True))
+    # Whitespace padding and a doubled separator. This row exists because a mutation probe found
+    # the original `.strip("/")` UNKILLABLE (the empty-segment filter already absorbed every
+    # trailing slash), while `.strip()` — the part that is load-bearing — had no coverage at all.
+    # The dead call is gone; this pins the live one.
+    check("[members] whitespace padding and a doubled separator normalise to the same root",
+          (declared_crate_roots(_tree(["a"], raw=[" crates/a "])),
+           declared_crate_roots(_tree(["a"], raw=["crates//a"]))),
+          (({"a"}, False), ({"a"}, False)))
+    check("[members] members OUTSIDE crates/ name no crate root",
+          declared_crate_roots(_tree(["a"], raw=["gui/src-tauri", "vendor/spargebra"])),
+          (set(), False))
+    check("[members] a missing or malformed manifest yields no roots and no glob",
+          (declared_crate_roots(_tree([], manifest=False)),
+           declared_crate_roots(_tree([], body="[workspace\nmembers = ")),
+           declared_crate_roots(_tree([], body="[workspace]\nmembers = 3\n"))),
+          ((set(), False), (set(), False), (set(), False)))
+
+    # THE FOUR FALSE POSITIVES, END-TO-END: each is a COMPLETE tree and must be ACCEPTED.
+    # Each row goes red if `_crate_member_root`'s normalisation is reverted to `split("/", 1)`.
+    for _label, _raw in (("glob only `crates/*`", ["crates/*"]),
+                         ("glob + explicit mix", ["crates/*", "crates/a"]),
+                         ("nested sub-crate member", ["crates/a", "crates/a/derive"]),
+                         ("trailing slash", ["crates/a/", "crates/b"])):
+        check(f"[members] a COMPLETE tree declaring {_label} is ACCEPTED",
+              _refusal(_tree(["a", "b"], raw=_raw)), "")
+
+    # ...AND THE HOLE THAT NORMALISATION ALONE OPENS. With globs normalised away, `declared` is
+    # empty for a glob-only manifest, so condition 2 is vacuous and condition 1 is satisfied —
+    # the guard silently becomes a NO-OP under precisely the edit most likely to be made. A glob
+    # delegates the member list to the tree, so the tree must carry the floor. Both rows below
+    # are ACCEPTED by a normalise-only fix (measured) and are the reason condition 3 exists.
+    check("[members] a glob manifest with NO crates/ dir still REFUSES",
+          ("declares its workspace members by glob" in _refusal(_tree([], raw=["crates/*"])),
+           "missing or holds no crate directory" in _refusal(_tree([], raw=["crates/*"]))),
+          (True, True))
+    _empty_crates = _tree([], raw=["crates/*"])
+    os.makedirs(os.path.join(_empty_crates, CRATES_DIR), exist_ok=True)
+    check("[members] ...and a glob manifest whose crates/ is EMPTY refuses too",
+          "refusing to partition" in _refusal(_empty_crates), True)
+    # the guard is still LIVE under a glob: a populated crates/ passes, so condition 3 is a
+    # floor and not a blanket refusal of globs.
+    check("[members] a glob manifest with a populated crates/ is accepted",
+          _refusal(_tree(["a"], raw=["crates/*"])), "")
+
+    for _path in (_scripts_only, _full, _partial, _empty_members, *_made):
         shutil.rmtree(_path, ignore_errors=True)
     check("sibling regions of one crate conflict",
           keys_conflict("sparq-core-store", "sparq-core-nt-dict"), True)

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -313,6 +313,14 @@ class TestWorkspaceDerivedRoots(unittest.TestCase):
             (base / "crates" / "sparq-brandnew").mkdir(parents=True)
             (base / "crates" / "sparq-brandnew-region").mkdir(parents=True)
             (base / "site").mkdir()
+            # The fixture must now declare its members: `workspace_roots` asserts the scanned tree
+            # against the manifest (`assert_workspace_tree`). This is a FIXTURE change only — the
+            # property under test is unchanged, and the two crates below are still recognised with
+            # no code change, which is the whole point of the test.
+            (base / "Cargo.toml").write_text(
+                '[workspace]\nresolver = "2"\n'
+                'members = ["crates/sparq-brandnew", "crates/sparq-brandnew-region"]\n',
+                encoding="utf-8")
             roots = ready.workspace_roots(str(base))
             self.assertEqual(roots, {"crates", "site", "sparq-brandnew", "sparq-brandnew-region"})
             # present in the tree -> its own partition; absent -> collapses into its parent
@@ -323,14 +331,43 @@ class TestWorkspaceDerivedRoots(unittest.TestCase):
             self.assertFalse(ready.keys_conflict("sparq-brandnew", "sparq-brandnew-region", roots))
             self.assertTrue(ready.keys_conflict("sparq-brandnew", "sparq-brandnew-unlisted", roots))
 
-    def test_an_unreadable_tree_over_reserves_rather_than_under_reserves(self):
-        # If the scan finds nothing, every key falls back to its head segment. That collapses all
-        # `sparq-*` keys onto `sparq` — a fleet-wide slowdown, never a double dispatch.
-        roots = ready.workspace_roots("/nonexistent/sparq-checkout")
-        self.assertEqual(roots, set())
+    def test_an_empty_root_set_over_reserves_rather_than_under_reserves(self):
+        # UNCHANGED PROPERTY, kept because it is the reason the collapse is not a CORRECTNESS bug:
+        # given an empty root set, every key falls back to its head segment, so all `sparq-*` keys
+        # land on `sparq` and unrelated crates OVER-reserve. Over-serialisation costs delay;
+        # under-serialisation double-dispatches. That direction still holds and is still tested —
+        # here against an EXPLICIT root set, which is the caller-supplies-the-roots path and is
+        # deliberately not guarded.
+        roots = set()
         self.assertEqual(ready.partition_path("sparq-core", roots), ("sparq",))
         self.assertTrue(ready.keys_conflict("sparq-core", "sparq-engine", roots),
-                        "with no tree to read, unrelated crates must OVER-reserve")
+                        "with no roots, unrelated crates must OVER-reserve")
+
+    def test_an_unreadable_tree_now_refuses_instead_of_collapsing_silently(self):
+        """[OPUS-5] A DOCUMENTED TRADE, DELIBERATELY REVISITED — see the PR body.
+
+        This test used to assert that an unreadable tree returns `set()` and lets every key
+        collapse onto `sparq`, on the stated grounds that this is "a fleet-wide slowdown, never a
+        double dispatch". The SAFETY half of that claim is correct and is still tested directly
+        above; it is not what changed.
+
+        What changed is the measured cost of the silence. MEASURED 2026-07-28 against a live sparq
+        snapshot with sparq's own engine: the same board, same labels and same code planned a ready
+        frontier of 4 on the real tree and 2 on a scripts-only tree, with 185 of 377 refusals
+        attributed to a single phantom `sparq-algos` partition — and NOTHING distinguished the two
+        runs. `candidates` and `top-contended` are computed from label sets, so the census line
+        reads exactly the same either way. "A fleet-wide slowdown" that no instrument can see is
+        indistinguishable from a busy board, which is how it survived a whole investigation before
+        being caught by accident.
+
+        So the unattributable case is now LOUD rather than silent. The engine refuses to partition
+        a tree it cannot verify instead of emitting a frontier whose meaning it cannot vouch for.
+        """
+        with self.assertRaises(ready.DegeneratePartitionRoots) as caught:
+            ready.workspace_roots("/nonexistent/sparq-checkout")
+        self.assertIn("refusing to partition", str(caught.exception))
+        # ...and it names the tree it scanned, so the operator can see WHICH checkout was wrong.
+        self.assertIn("/nonexistent/sparq-checkout", str(caught.exception))
 
     def test_dump_partitions_exports_the_mapping_for_the_registry_parity_fixture(self):
         # The registry's dispatch.yml mirrors this key space in `busy_packages_of_pulls`; the two

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -1403,6 +1403,37 @@ class TestRoutingSelfTestWorkflowWiring(unittest.TestCase):
                 "BOTH pull_request and push — it could change without re-running the gate that "
                 "reads it")
 
+    def test_the_partition_guards_tree_inputs_are_path_triggers(self):
+        """[OPUS-5] PR #4925 review — the inputs `workspace_roots()` READS FROM THE TREE.
+
+        The `_declared_data_inputs` derivation above is scoped to `orchestration/*.toml|json`, so
+        it cannot see these: the partition guard's inputs are the root workspace manifest and the
+        crate directory listing. Neither was a path trigger, and root `Cargo.toml` is the one file
+        that can turn the guard into a hard PLAN stop — a routine edit to
+        `members = ["crates/*"]` would have merged green with the guard's own tests never running,
+        then stopped dispatch for BOTH target repositories on the next tick.
+
+        `crates/*/Cargo.toml` rather than `crates/**`: what this gate needs to re-run for is a
+        change to the SET of crate partition roots, which happens exactly when a crate manifest is
+        added, removed or renamed. `crates/**` would fire the lane on essentially every Rust PR in
+        a 67-crate workspace and cover no additional change to that set.
+        """
+        paths_section = self._paths_section()
+        for path in ("Cargo.toml", "crates/*/Cargo.toml"):
+            self.assertEqual(
+                paths_section.count(f'"{path}"'), 2,
+                f"{path} is read by ready-issues.py's partition guard but is not a path trigger "
+                "on BOTH pull_request and push — it could change without re-running the gate "
+                "that reads it, and this one can hard-stop PLAN")
+
+    def test_the_partition_guard_reads_the_manifest_it_claims_to(self):
+        # Non-vacuity pairing for the row above: assert the guard really does open root
+        # Cargo.toml, so the trigger cannot be pinned for a file nothing reads.
+        source = (SCRIPTS / "ready-issues.py").read_text(encoding="utf-8")
+        self.assertIn('WORKSPACE_MANIFEST = "Cargo.toml"', source)
+        self.assertIn('CRATES_DIR = "crates"', source)
+        self.assertIn("os.path.join(repo_root, WORKSPACE_MANIFEST)", source)
+
     def test_gate_is_not_declared_advisory(self):
         # [OPUS-5] Guards the rule that is LIVE. ci-summary's discovery changed on
         # 2026-07-25 (#3773): a check is non-gating iff it is EXPLICITLY DECLARED in


### PR DESCRIPTION
> 🤖 SPARQ agent

Head SHA: `588a7bd8fad323e3b5912f82b3ac50b9885633ff` (base `origin/main` @ `ca4061ba1`)

## The defect

`workspace_roots()` derives the partition algebra from a **directory listing**, so a wrong listing silently changes what `area:` keys mean. `partition_path()` rule 2 resolves a key against recognised workspace roots; rule 3 falls back to the key's head segment. With `crates/` absent, **no `sparq-*` key resolves through rule 2 and every one of them falls to `sparq`** — a single mega-partition that every sparq crate conflicts on.

The frontier collapses, and **the census line looks completely normal**: `candidates` and `top-contended` are computed from label sets and never mention the collapse.

## Before / after frontier measurement

Driven through the registry's real readiness step (`dispatch.yml` `id: readiness`, heredoc extracted verbatim), against a live `sparq-org/sparq` snapshot written by the real producer (`plan-snapshot.py`), using sparq's own engine.

| target tree | census |
|---|---|
| full `origin/main` tree | `candidates=379 frontier=4 partition-deferred=375` |
| scripts-only tree (the accident) | `candidates=379 frontier=2 partition-deferred=377` |

Same snapshot, same labels, same code. **185 of 377 refusals** in the degenerate run were attributed to a single phantom `sparq-algos` partition held by one PR. Nothing in the engine, the workflow, or the census distinguished the two runs — I only caught it because the conflict log and the census disagreed about which areas were contended.

This was an accident in a repro harness, not a hypothesis.

**After this change**, the degenerate tree refuses:

```
DegeneratePartitionRoots: refusing to partition: no readable `[workspace] members` in
/tmp/degen/Cargo.toml. The partition algebra resolves `area:` keys against the directory
listing of /tmp/degen, and a tree that is not this workspace collapses every unrecognised
`sparq-*` key onto the single head-segment partition `sparq` — a frontier computed from
that is wrong in a way no census line reveals.
```

**Healthy path is unchanged — proven, not asserted.** Same snapshot, both trees, full census diffed:

```
diff census(origin/main) census(this branch)  ->  BYTE-IDENTICAL
partition census sparq-org/sparq: candidates=376 frontier=1 partition-deferred=375 top-contended: ci=54, ...
```

## What it does

Two conditions, both **read from the tree** — no magic number, and adding a crate raises the floor by itself:

1. `Cargo.toml` must be present and declare `crates/*` workspace members. Its absence means we are not at the repository root at all — the exact accident above.
2. **Every** declared member must have been scanned as a root. This catches what (1) cannot: a sparse/partial checkout where the missing crates' keys collapse to `sparq` while the present ones resolve correctly. A partly-wrong partition is harder to notice than a wholly-wrong one.

Asserted **before the memo**, so a degenerate scan is never cached, and called **eagerly** from `compute_ready` so the refusal is a property of the tree rather than of the board (`conflict()` is not reached at all when nothing is held or nothing is a candidate, so a lazy guard would fire only on busier ticks).

## Why refuse rather than return an empty frontier

An empty frontier prints `frontier=0` and reads as an ordinary fully-contended tick. A raise cannot be mistaken for a plan.

**Reviewer, please push back on this if you disagree:** the coordinator asked for the refusal to surface *in the census line*. The census is printed by the registry's `dispatch.yml`, not by this repo, so a sparq-side change cannot write to it without cross-repo plumbing. Raising makes the readiness step fail loudly instead — no census line at all, no dispatch. I judged that closer to the intent ("a wrong frontier that looks normal is worse than no frontier") than the alternatives, but it is a deviation and it is the reviewer's call.

Blast radius, stated plainly: the readiness step plans **all** targets in one process, so a raise fails the tick for the registry target too. That matches the existing convention at this seam (`raise SystemExit("target issue fields are malformed")` does the same), and the condition should never occur in production, where the clone is a full `git clone --depth 1`.

One interaction worth knowing: the registry's `pr_row_aware` / `inert_aware` probes catch `Exception`, so on a degenerate tree they report "probe raised DegeneratePartitionRoots" and PLAN drops PR occupancy *before* the real `compute_ready(ready_input)` raises. The step still dies — the refusal lands — but that warning appears first and is misleading.

## A documented decision, deliberately revisited

`test_an_unreadable_tree_over_reserves_rather_than_under_reserves` asserted the old behaviour on the stated grounds that the collapse is *"a fleet-wide slowdown, never a double dispatch"*.

**The safety half of that claim is correct, and I have kept it tested** — `test_an_empty_root_set_over_reserves_rather_than_under_reserves` still pins the over-reserve direction against an explicit root set (the caller-supplies-the-roots path, deliberately unguarded). This change does not make anything under-serialise.

What changed is the measured cost of the *silence*: a 2× frontier loss that no instrument can see is indistinguishable from a busy board. I am not overturning the safety judgement; I am making the unattributable case loud, which is what this repo's doctrine asks for everywhere else.

## Verification

- `scripts/ready-issues.py --self-test` — PASSED (7 new rows)
- `scripts/dispatch-plan.py --self-test` — PASSED
- `scripts/tests/test_readiness_visibility.py` — 102 tests OK
- `ruff check` — clean
- `--dump-partitions` — unchanged output

**Mutation-tested** (the tests are not vacuous). Four independent mutants, each killed:

| mutant | self-test FAIL rows | unittest failures |
|---|---|---|
| baseline | 0 | 0 |
| M1 delete the `assert_workspace_tree` call | 4 | 1 |
| M2 drop condition 1 (`if not declared`) | 3 | 1 |
| M3 drop condition 2 (`missing = []`) | 1 | 0 |
| M4 remove the eager call in `compute_ready` | 1 | 0 |

The self-test also pins the **harm**, not just the guard: on a scripts-only root set it asserts `partition_path("sparq-core") == ("sparq",) == partition_path("sparq-algos")` and `keys_conflict(...) is True`. Deleting the guard leaves that collapse in place — which is exactly how it went unnoticed.

## What this does NOT fix

- **It does not widen the frontier.** Production clones a full tree, so this is worth **+0** today. It is a durable guard against a silent 2× loss, not a throughput lever.
- It does not address the real binding constraint on sparq dispatch — in-flight **issue** occupancy (`status:in-progress-review`), measured as the dominant term.
- It does not detect a tree that is complete but *stale* (e.g. a crate deleted upstream but present locally); condition 2 is one-directional by design.
- It does not change `partition_path`, `keys_conflict`, `conflict()`, or any reservation rule.
