### PR TITLE
fix(orchestration): the cross-cutting ci/docs partitions route work without occupying it

### DIFF
--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -186,6 +186,78 @@ def keys_conflict(a, b, roots=None):
     """
     pa, pb = partition_path(a, roots), partition_path(b, roots)
     return pa[:len(pb)] == pb or pb[:len(pa)] == pa
+
+
+# ---------------------------------------------------------------------------
+# NON-RESERVING (cross-cutting) PARTITIONS — THE ONE PLACE THIS IS DECLARED.
+#
+# [OPUS-5 2026-07-28] These partitions still ROUTE work and are still valid candidate keys — a
+# candidate declaring `area:ci` is derived, counted and dispatchable exactly as before. They
+# simply do not OCCUPY: an in-flight PR or in-progress issue holding one of them no longer blocks
+# a new worker from being dispatched onto an issue that declares it. See `_reserving_packages`.
+#
+# THE MEASURED BASIS (live sparq snapshot, open non-parked PRs holding each area, counting
+# holder PAIRS that share at least one changed file):
+#
+#     area          holder pairs   sharing >=1 file
+#     area:ci            120          6   ( 5%)   -> exempt
+#     area:docs           66          2   ( 3%)   -> exempt
+#     area:deps            3          3   (100%)  -> NOT exempt (every pair collides on
+#                                                    Cargo.lock; serialising it is correct)
+#     crate areas          -          -   (57.1%) -> NOT exempt
+#                                                    (research/crate-region-parallelism.md §4)
+#
+# So the reservation on `ci`/`docs` was refusing ~99% of a partition-starved frontier to prevent a
+# 3-5% file collision, while `deps` and the crate areas are serialising real overlap and stay.
+# Measured counterfactual on that same snapshot, through this engine: baseline frontier 1;
+# `ci` non-reserving 2; `ci`+`docs` non-reserving 3; adding `deps` would give 4 (not taken).
+#
+# It is also aimed at the right axis only in part, and the comment says so rather than
+# overselling it: `ci`/`docs` reservation never serialised PR-vs-PR contention at all (14 open PRs
+# co-hold `ci` and 10 co-hold `docs` right now, concurrently — a PR enters those partitions by
+# TOUCHING A PATH, with zero admission control). All it ever did was refuse dispatch.
+#
+# FAIL-SAFE DIRECTION: `non_reserving_partitions()` validates this declaration and returns the
+# EMPTY set — i.e. today's fully-reserving behaviour — for anything malformed. Never the reverse.
+NON_RESERVING_PARTITIONS = frozenset({"ci", "docs"})
+
+
+def non_reserving_partitions(declared=None):
+    """`NON_RESERVING_PARTITIONS`, VALIDATED. Anything malformed degrades to RESERVING.
+
+    A wrong answer here is asymmetric: too SMALL a set costs dispatch width (today's behaviour,
+    which the fleet has been running), while too LARGE a set silently un-serialises real work.
+    So the whole declaration is voided by a single bad entry rather than partially honoured, and
+    `GLOBAL` (and any degenerate key, which `partition_path` maps to the `()` root that contains
+    every partition) can NEVER appear in it — exempting the root would exempt everything, which
+    is exactly the "fail toward exempt everything" outcome this must not have.
+    """
+    raw = NON_RESERVING_PARTITIONS if declared is None else declared
+    if isinstance(raw, str) or not isinstance(raw, (set, frozenset, list, tuple)):
+        return frozenset()
+    names = set()
+    for name in raw:
+        if not isinstance(name, str) or not name.strip() or name.strip() == GLOBAL:
+            return frozenset()
+        if partition_path(name.strip()) == ():        # degenerate key -> the containing root
+            return frozenset()
+        names.add(name.strip())
+    return frozenset(names)
+
+
+def reserves_partition(key, exempt=None):
+    """Whether an OCCUPANT declaring `key` reserves it, or merely routes on it.
+
+    Expressed on the PARTITION PATH, not the raw label, so it agrees with `keys_conflict`: every
+    key that resolves INTO the `ci` partition (`ci`, and e.g. the live `ci-fragments`) is exempt
+    together with it. A per-string exemption would leave `ci-fragments` reserving a partition that
+    `ci` itself does not, which reads as a bug to the next person and behaves like one.
+    """
+    path = partition_path(key)
+    if not path:                       # GLOBAL / degenerate: contains everything, never exempt
+        return True
+    exempt = non_reserving_partitions() if exempt is None else exempt
+    return path[0] not in exempt
 # --- open blockers: NATIVE GitHub dependencies UNIONED with the legacy body markers -------------
 # [OPUS-5] Until this landed, BOTH readers of "is this issue blocked" (this file and the registry's
 # dispatch.yml planner step) derived `open_blockers` ONLY by regexing `Blocked-by: #NN` out of the
@@ -305,8 +377,16 @@ def _reserving_packages(labels):
     cross-cutting paths), so 9 open PRs still declare nothing, and making those 9 seize
     `__global__` would reproduce the measured whole-fleet stall. Only the stated reason needed
     correcting; leaving a false premise in place is how a correct rule gets "fixed" back.
+
+    [OPUS-5 2026-07-28] ...and of the areas it declares, only the RESERVING ones — the
+    cross-cutting `NON_RESERVING_PARTITIONS` (`ci`, `docs`) route work without occupying it. That
+    declaration, its measured basis and its fail-safe live in ONE place above; nothing else in
+    this file knows the names. This is the OCCUPANCY half ONLY: `packages_of` (the candidate side)
+    is untouched, so candidacy is unchanged, and a SELECTED candidate still reserves its own areas
+    through `compute_ready`'s `reserve(pkgs, it)` — per-tick width stays one worker per partition,
+    which is why the measured effect is +1 frontier row per exempted partition and not +49.
     """
-    return declared_packages(labels)
+    return {key for key in declared_packages(labels) if reserves_partition(key)}
 
 
 def has_role(labels):
@@ -874,6 +954,57 @@ def _self_test():
     check("flatten pages retains PRs", _flatten_pages(
         [[{"number": 1}, {"number": 2, "pull_request": {}}], [{"number": 3}], "junk", [None]]),
         [{"number": 1}, {"number": 2, "pull_request": {}}, {"number": 3}])
+    # ---------------------------------------------------------------------------------------
+    # [OPUS-5 2026-07-28] NON-RESERVING cross-cutting partitions. END-TO-END through
+    # compute_ready, and run HERE and not only in scripts/tests/ because the registry's
+    # dispatch.yml executes THIS --self-test against every target before it plans anything — so
+    # a tree whose exemption set has been widened to a colliding partition fails at the gate the
+    # fleet actually passes through. `scripts/tests/test_readiness_visibility.py::
+    # TestNonReservingCrossCuttingPartitions` carries the full contract.
+    # ---------------------------------------------------------------------------------------
+    def held_board(area, held_by=None):
+        return [pr(70, [f"area:{held_by or area}"]),
+                iss(20, R + ["priority:P1", f"area:{area}"])]
+
+    def offered(area, held_by=None):
+        return [i["number"] for i in compute_ready(held_board(area, held_by),
+                                                   conflict_log=quiet)]
+
+    check("a PR holding area:ci no longer refuses a ci-only candidate", offered("ci"), [20])
+    check("...same for area:docs", offered("docs"), [20])
+    check("...and for a key that resolves INTO the ci partition", offered("ci", "ci-fragments"),
+          [20])
+    # The SAFETY half. deps: 3 of 3 live holder pairs collide, all on Cargo.lock. Crate areas:
+    # 57.1% (research/crate-region-parallelism.md §4). Widening the set to either is the mutation
+    # this line exists to kill.
+    check("area:deps STILL reserves (every live deps pair collides on Cargo.lock)",
+          offered("deps"), [])
+    check("crate areas STILL reserve", offered("sparq-core"), [])
+    check("sub-crate containment still reserves through the exemption",
+          offered("sparq-core-store", "sparq-core"), [])
+    check("the global partition can never be exempted", offered("sparq-core", GLOBAL), [])
+    # The FAIL-SAFE, both directions: a malformed declaration degrades to TODAY's behaviour, and
+    # a well-formed one is honoured — without the second line a fail-safe that voided everything
+    # would look perfect.
+    _declared = NON_RESERVING_PARTITIONS
+    try:
+        for _broken in (None, "ci", 7, {"ci": True}, {"ci", 7}, ["ci", ""], {GLOBAL}):
+            globals()["NON_RESERVING_PARTITIONS"] = _broken
+            check(f"malformed exemption {_broken!r} falls back to RESERVING", offered("ci"), [])
+        globals()["NON_RESERVING_PARTITIONS"] = frozenset({"ci"})
+        check("...and a well-formed exemption is honoured (fail-safe is not vacuous)",
+              offered("ci"), [20])
+    finally:
+        globals()["NON_RESERVING_PARTITIONS"] = _declared
+    # SCOPE: candidacy untouched, and a SELECTED candidate still reserves — per-tick width stays
+    # one worker per partition, which is why the live frontier moved 1 -> 3 and not 1 -> ~50.
+    check("candidate keying for ci/docs is unchanged", (packages_of({"area:ci"}),
+                                                        packages_of({"area:docs"})),
+          ({"ci"}, {"docs"}))
+    check("a selected ci candidate still reserves ci for the tick",
+          [i["number"] for i in compute_ready(
+              [iss(20, R + ["priority:P0", "area:ci"]), iss(21, R + ["priority:P1", "area:ci"])],
+              conflict_log=quiet)], [20])
     print("ready-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -1389,5 +1389,162 @@ class TestRoutingSelfTestWorkflowWiring(unittest.TestCase):
         self.assertRegex(self.SOURCE, r"(?m)^  merge_group:")
 
 
+class TestNonReservingCrossCuttingPartitions(unittest.TestCase):
+    """`ci` / `docs` ROUTE work but do not OCCUPY it — and everything else still does.
+
+    [OPUS-5 2026-07-28] The dispatch frontier is the binding throughput constraint: three
+    consecutive production PLAN runs read `candidates=379 frontier=1 partition-deferred=378`, i.e.
+    99.7% of attested candidates refused for partition contention. Driving the REAL production
+    predicate (the registry's dispatch.yml `readiness` step, this repo's engine, a live snapshot)
+    reproduced that at `candidates=376 frontier=1`, and made `ci`+`docs` non-reserving takes it to
+    `candidates=376 frontier=3` — the two added rows declaring exactly `area:ci` and `area:docs`.
+
+    The justification is a MEASURED conflict rate, not an argument (see NON_RESERVING_PARTITIONS
+    for the table): 5% of open `area:ci` holder pairs and 3% of `area:docs` pairs share a changed
+    file, against 100% for `area:deps` (all `Cargo.lock`) and 57.1% for crate areas. So the safety
+    half of this contract is as load-bearing as the throughput half, and both are pinned here.
+
+    Every assertion runs END-TO-END through `compute_ready`. An assertion that only inspected
+    `reserves_partition`'s shape would stay green with its call site in `_reserving_packages`
+    deleted, which is the surviving-mutant class this estate keeps measuring.
+    """
+
+    def test_a_ci_only_issue_is_offered_while_an_occupant_holds_ci(self):
+        # THE headline behaviour. Before: the PR held `ci` and #20 was partition-deferred.
+        waiting = iss(20, READY + ["priority:P1", "area:ci"])
+        occupant = pr(70, ["area:ci"])
+        self.assertEqual(
+            numbers(ready.compute_ready([occupant, waiting], conflict_log=quiet)), [20],
+            "a PR holding area:ci must no longer refuse a ci-only candidate")
+
+    def test_a_docs_only_issue_is_offered_while_an_occupant_holds_docs(self):
+        waiting = iss(20, READY + ["priority:P1", "area:docs"])
+        self.assertEqual(
+            numbers(ready.compute_ready([pr(70, ["area:docs"]), waiting], conflict_log=quiet)),
+            [20])
+
+    def test_an_in_progress_issue_holding_ci_also_stops_reserving_it(self):
+        # The issue-occupancy path, not just the PR path — both go through _reserving_packages.
+        board = [iss(72, ["status:in-progress", "area:ci"]),
+                 iss(20, READY + ["priority:P1", "area:ci"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [20])
+
+    def test_the_exempt_partition_is_released_and_nothing_else_is(self):
+        # The measured shape of the change on the live board: reserved keys lost EXACTLY
+        # {ci, docs}. A mutant that widens the set shows up here as an extra released key.
+        rows = [pr(70, ["area:ci", "area:docs", "area:deps", "area:sparq-core"])]
+        held = {key for keys, _ in ready.unit_reservations(rows) for key in keys}
+        self.assertEqual(held, {"deps", "sparq-core"})
+
+    # -- the SAFETY half: what must still reserve ------------------------------------------
+    def test_deps_still_reserves_because_every_deps_pair_collides_on_the_lockfile(self):
+        # MEASURED: 3 of 3 open `area:deps` holder pairs share a changed file, all Cargo.lock.
+        # Serialising deps is CORRECT and this exemption must never grow to include it.
+        waiting = iss(20, READY + ["priority:P1", "area:deps"])
+        self.assertEqual(
+            numbers(ready.compute_ready([pr(70, ["area:deps"]), waiting], conflict_log=quiet)),
+            [], "area:deps must still be occupied by an open PR that declares it")
+
+    def test_crate_areas_still_reserve(self):
+        # 57.1% pairwise file collision (research/crate-region-parallelism.md §4).
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core"])
+        self.assertEqual(
+            numbers(ready.compute_ready([pr(70, ["area:sparq-core"]), waiting],
+                                        conflict_log=quiet)), [])
+
+    def test_sub_crate_containment_still_reserves_through_the_exemption(self):
+        # The exemption is applied on the PARTITION PATH, so it must not have flattened the
+        # containment algebra it shares that path with.
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core-store"])
+        self.assertEqual(
+            numbers(ready.compute_ready([pr(70, ["area:sparq-core"]), waiting],
+                                        conflict_log=quiet)), [])
+
+    def test_the_global_partition_can_never_be_exempted(self):
+        # `partition_path` maps GLOBAL and every degenerate key to `()`, the root that CONTAINS
+        # every partition. Exempting it would be "fail toward exempt everything" exactly.
+        self.assertTrue(ready.reserves_partition(ready.GLOBAL))
+        self.assertTrue(ready.reserves_partition(""))
+        waiting = iss(20, READY + ["priority:P1", "area:sparq-core"])
+        board = [pr(70, [f"area:{ready.GLOBAL}"]), waiting]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [],
+                         "an occupant on the global partition must still serialize everything")
+        for bad in ({ready.GLOBAL}, {"ci", ready.GLOBAL}, {"-"}, {""}):
+            self.assertEqual(ready.non_reserving_partitions(bad), frozenset(), bad)
+
+    # -- the FAIL-SAFE: malformed declaration degrades to TODAY's behaviour -----------------
+    def test_a_malformed_declaration_falls_back_to_reserving(self):
+        waiting = iss(20, READY + ["priority:P1", "area:ci"])
+        board = [pr(70, ["area:ci"]), waiting]
+        for broken in (None, "ci,docs", 7, {"ci": True}, {"ci", 7}, ["ci", ""], ("ci", None),
+                       {"ci", "  "}):
+            with mock.patch.object(ready, "NON_RESERVING_PARTITIONS", broken):
+                self.assertEqual(ready.non_reserving_partitions(), frozenset(), broken)
+                self.assertEqual(
+                    numbers(ready.compute_ready(board, conflict_log=quiet)), [],
+                    f"a {broken!r} declaration must degrade to RESERVING, never to exempt-all")
+
+    def test_an_absent_declaration_falls_back_to_reserving(self):
+        # Deleting the constant entirely is the "unreadable" case: NameError would abort the
+        # whole dispatch tick for every target, so the engine must simply reserve.
+        waiting = iss(20, READY + ["priority:P1", "area:ci"])
+        board = [pr(70, ["area:ci"]), waiting]
+        with mock.patch.object(ready, "NON_RESERVING_PARTITIONS", frozenset()):
+            self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [])
+
+    def test_a_wellformed_declaration_is_honoured_so_the_failsafe_is_not_vacuous(self):
+        # KNOWN-POSITIVE control for the loop above: the same board, a VALID declaration, the
+        # opposite outcome. Without this a fail-safe that rejected everything would look perfect.
+        waiting = iss(20, READY + ["priority:P1", "area:ci"])
+        board = [pr(70, ["area:ci"]), waiting]
+        with mock.patch.object(ready, "NON_RESERVING_PARTITIONS", frozenset({"ci"})):
+            self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [20])
+
+    # -- SCOPE: what this change deliberately does NOT touch --------------------------------
+    def test_candidacy_is_unchanged_a_ci_issue_is_still_counted_and_routed(self):
+        # Measured obligation 5: `candidates=` must not move. The candidate-side key algebra is
+        # untouched, so a ci issue is still a candidate, still keyed on `ci`, still dispatchable.
+        self.assertEqual(ready.packages_of({"area:ci"}), {"ci"})
+        self.assertEqual(ready.packages_of({"area:docs"}), {"docs"})
+        self.assertEqual(ready.declared_packages({"area:ci", "area:docs"}), {"ci", "docs"})
+        board = [pr(70, ["area:ci"]), iss(20, READY + ["priority:P1", "area:ci"]),
+                 iss(21, READY + ["priority:P1", "area:docs"]),
+                 iss(22, READY + ["priority:P1", "area:deps"])]
+        cands = ready.ready_candidates(board, log=quiet)
+        self.assertEqual([(number, sorted(keys)) for _p, number, _row, keys in cands],
+                         [(20, ["ci"]), (21, ["docs"]), (22, ["deps"])],
+                         "candidacy and candidate keying must be byte-identical to before")
+
+    def test_a_selected_ci_candidate_still_reserves_ci_for_the_tick(self):
+        # The exemption is the OCCUPANCY half ONLY. Per-tick dispatch width stays one worker per
+        # partition; this is why the live frontier moved 1 -> 3 and not 1 -> ~50.
+        board = [iss(20, READY + ["priority:P0", "area:ci"]),
+                 iss(21, READY + ["priority:P1", "area:ci"])]
+        self.assertEqual(numbers(ready.compute_ready(board, conflict_log=quiet)), [20])
+
+    def test_ci_fragments_travels_with_the_ci_partition(self):
+        # `ci-fragments` is a LIVE label that resolves into the `ci` partition. Exempting the raw
+        # string only would leave it reserving a partition `ci` itself does not — incoherent with
+        # `keys_conflict`, and a trap for the next reader.
+        self.assertEqual(ready.partition_path("ci-fragments"), ("ci",))
+        self.assertFalse(ready.reserves_partition("ci-fragments"))
+        waiting = iss(20, READY + ["priority:P1", "area:ci"])
+        self.assertEqual(
+            numbers(ready.compute_ready([pr(70, ["area:ci-fragments"]), waiting],
+                                        conflict_log=quiet)), [20])
+
+    def test_the_declaration_records_its_measured_basis(self):
+        # The brief's one durable requirement: the next reader must be able to RE-DERIVE the
+        # decision rather than guess at it. Asserted on the numbers, not on prose.
+        source = (SCRIPTS / "ready-issues.py").read_text(encoding="utf-8")
+        head, _, rest = source.partition("NON_RESERVING_PARTITIONS = ")
+        self.assertTrue(rest, "NON_RESERVING_PARTITIONS is no longer declared")
+        basis = head[head.rindex("# ------"):]
+        for token in ("area:ci", "area:docs", "area:deps", "Cargo.lock",
+                      "5%", "3%", "100%", "57.1%", "crate-region-parallelism.md"):
+            self.assertIn(token, basis,
+                          f"the measured basis for the exemption no longer states {token}")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Declares the cross-cutting partitions `ci` and `docs` **non-reserving for occupancy**. They still
route work, are still valid candidate keys, are still derived and applied exactly as today, and a
*selected* candidate still reserves them for the tick. An in-flight PR or in-progress issue simply
no longer refuses a **new** dispatch onto an issue that declares them.

Head SHA: `f77d872149f74c26f9a7ea3bad8c85095cfe86fe`

## Why — the frontier is the binding constraint

Three consecutive production PLAN runs: `candidates=379 frontier=1 partition-deferred=378`. 99.7%
of attested candidates are refused for partition contention, and 49 of them declare `ci` as their
only area.

The reservation is aimed at the wrong axis. A PR enters the `ci`/`docs` partitions by **touching a
path** (`scripts/pr-area-labels.py` derives the label post-hoc from changed files) with **zero
admission control** — 14 open PRs co-hold `ci` and 10 co-hold `docs` right now, concurrently and
unserialized. The occupancy reservation therefore never prevented PR-vs-PR collision and cannot;
all it ever did was refuse to dispatch a new worker.

### Conflict-rate evidence

Open non-parked PRs holding each area, counting **holder pairs that share at least one changed file**:

| area | holder pairs | sharing ≥1 file | |
|---|---|---|---|
| `area:ci` | 120 | 6 | **5%** → exempt |
| `area:docs` | 66 | 2 | **3%** → exempt |
| `area:deps` | 3 | 3 | **100%** (all `Cargo.lock`) → **NOT** exempt |
| crate areas | — | — | **57.1%** (`research/crate-region-parallelism.md` §4) → **NOT** exempt |

`deps` and the crate areas are serialising real overlap. They stay.

## Measurement — before/after on the same live snapshot

Driven through the **real production predicate**: the registry's `dispatch.yml` `readiness` step
heredoc, exec'd verbatim against a live snapshot written by the real producer and this repo's
engine — not a reimplementation.

**Instrument validation:** the unpatched run reproduces the production census
(`candidates=376 frontier=1 partition-deferred=375` vs the cited `379 / 1 / 378`; the ±3 candidate
delta is snapshot drift, the frontier is identical).

| | candidates | frontier | partition-deferred | reservations (rows / key-pairs / distinct keys) |
|---|---|---|---|---|
| before | 376 | **1** | 375 | 59 / 79 / 44 |
| after | 376 | **3** | 373 | 47 / 55 / 42 |

* **`candidates=` unchanged: 376 → 376.** Candidacy is provably untouched — `packages_of` is not
  on the diff path.
* Released key set is **exactly `{ci, docs}`**; nothing else moved, nothing was gained.
* The two added rows declare exactly `area:ci` (#2606) and `area:docs` (#2725); the baseline row
  (#2706) is retained. The deferred lane is unchanged at frontier 3.
* Matches the counterfactual ladder exactly (baseline 1 → `ci` 2 → `ci`+`docs` 3), which is the
  signature of an **occupancy-side-only** exemption: each exempted partition adds one row, because
  a selected candidate still reserves its own areas.

## Design

One declaration, one consumption point:

* `NON_RESERVING_PARTITIONS = frozenset({"ci", "docs"})` in `scripts/ready-issues.py`, immediately
  after the partition algebra, with the measured table above written into the comment so the
  decision can be re-derived rather than guessed at.
* `reserves_partition(key)` decides on the **partition path**, not the raw string, so it agrees
  with `keys_conflict`: the live `ci-fragments` label travels with the `ci` partition instead of
  reserving a partition `ci` itself does not.
* Consumed in `_reserving_packages` — the function whose docstring already *is* the occupancy rule.
* **`__global__` and every degenerate key can never be exempted** (they map to the `()` root that
  contains every partition).
* **Fail-safe:** `non_reserving_partitions()` validates the declaration and returns the **empty**
  set — today's fully-reserving behaviour — for a non-collection, a bare string, a dict, a
  non-string entry, a blank entry, or `__global__`. One bad entry voids the whole declaration
  rather than being partially honoured. Never the reverse.

## Tests + mutation results

Contract in `scripts/tests/test_readiness_visibility.py::TestNonReservingCrossCuttingPartitions`
(15 tests), plus end-to-end tripwires in `scripts/ready-issues.py --self-test` — that one runs
inside the registry's dispatch tick against every target before it plans anything, so a widened
exemption fails at the gate the fleet actually passes through. Every assertion runs end-to-end
through `compute_ready`.

**Control run GREEN first** (116 → 131 tests, all suites green), then each mutant applied alone to
a fresh copy of the tree, `PYTHONDONTWRITEBYTECODE=1` throughout:

| mutant | result |
|---|---|
| M1 exemption set emptied | KILLED |
| M2 call site deleted in `_reserving_packages` | KILLED |
| M3 `reserves_partition` always True | KILLED |
| M4 **safety:** `deps` added to the exemption set | KILLED |
| M5 **safety:** a crate area added to the exemption set | KILLED |
| M6 **safety:** `reserves_partition` always False (exempt everything) | KILLED |
| M7 **safety:** `__global__`/degenerate path becomes exemptible | KILLED |
| M8 **fail-safe:** validation bypassed (raw declaration returned) | KILLED |
| M9 **fail-safe:** bad entry skipped instead of voiding the declaration | KILLED |
| M10 **scope:** exemption leaks onto the candidate side (`packages_of`) | KILLED |
| M11 **scope:** a selected candidate stops reserving its own areas too | KILLED |
| M12 exemption applied per-string instead of per-partition-path | KILLED |
| M13 the measured basis stripped from the declaration | KILLED |

**13/13, against a green control.** M1–M12 are each killed independently by *both* suites (M13,
comment-only, by the visibility suite). The fail-safe assertions carry an explicit known-positive
control (`test_a_wellformed_declaration_is_honoured_so_the_failsafe_is_not_vacuous`) so a
validator that rejected *everything* could not look perfect.

## What this does **not** fix

* **It does not change PR-vs-PR collision — that was never serialised.** Two PRs both touching
  `ci/` collided before this change and collide after it. The reservation only ever gated
  *dispatch*, and PRs enter these partitions by touching a path with no admission control. The
  5%/3% numbers are why that is acceptable, not evidence that anything was protecting them.
* **It does not touch `deps`.** Every live `deps` holder pair collides on `Cargo.lock`.
  Serialising it is correct. M4 exists to keep it that way.
* **It does not touch crate areas or `package_width`.**
* **It does not address the vocabulary gap** — 17 issue-side `area:` keys the PR deriver
  (`ci/area-labels.toml`) cannot emit, so those issues are keyed on a partition no PR can ever be
  attributed to. Separate defect, unchanged here.
* **`ci` remains the top-contended key** (`ci=54 → 53` in the census). A *selected* `ci` candidate
  still reserves `ci` for the tick, so per-tick dispatch width stays one worker per partition.
  That is deliberate and pinned by M11 — it is why the frontier moved 1→3 rather than 1→~50.
* ⚠️ **It is necessary but very likely NOT sufficient — there is a SECOND occupancy leg, in the
  registry.** `jeswr/agent-account-registry`'s `scripts/dispatch-claim.py::busy_packages_of_pulls`
  independently derives a busy-area union from open worker PRs' `area:*` labels and applies it at
  `filter_busy_area_items` (assemble) **and again** at `revalidate_items_against_live_pulls`
  (claim). It has **no** cross-cutting exemption. On this snapshot **16 open worker PRs contribute
  `ci` and 25 contribute `docs`** to that leg's busy set, and because that leg only ever *unions*
  areas onto a PR's own labels, more complete provenance can only widen it — so `ci`/`docs` stay
  busy there regardless. Unless the registry mirrors this exemption, the two extra rows PLAN now
  offers will be re-deferred one layer down. I could **not** measure that leg's before/after: it
  reads provenance records from the registry's `ledger` branch, which I do not have, and my
  partial reconstruction refuses **all** rows in *both* the baseline and the patched case
  (a `__global__` reservation from an unprovenanced PR) — i.e. it fails to reproduce production
  and its numbers are not reportable. Filed as a follow-up; the correct next step is the mirror
  change in the registry, measured there.

## Scope

`scripts/ready-issues.py` + `scripts/tests/test_readiness_visibility.py` only. Both are already
`paths:` triggers on `routing-self-tests.yml` (both `pull_request` and `push`) and both are already
invoked in its run block, so no workflow change is needed and this diff cannot land without the
gate that tests it running.

## Gate

`python3 scripts/preflight.py` → **PASS**. `routing-validate --self-test`, `route-resolve
--self-test`, `ready-issues --self-test`, `dispatch-plan --self-test`,
`test_readiness_visibility.py` (131 tests) all green. `typos` clean; no added line over 100 chars.

---

I authored this change and must not review it. **Not armed, not merged** — an independent reviewer
owns the verdict.
