### PR TITLE
fix(ci): selection-alarm must admit runs whose JOBS failed, not runs GitHub called 'failure' (#4965)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -809,11 +809,14 @@ jobs:
         run: python3 scripts/tests/test_ci_select_wiring.py
       # [OPUS-4.8] sq-va7at: the nightly selection-bug ALARM
       # (scripts/ci_selection_alarm.py, .github/workflows/selection-alarm.yml,
-      # design §6.1). Hermetic stdlib-unittest suite (NO gh, NO git, NO cargo,
-      # NO network): the pure correlation core (precise per-crate hit, fail-safe
-      # triage for narrowed shards, the non-spam empty-skip-set property), the
-      # TRIAGE_LANE_RE pin against the real ci.yml shard job name, and the
-      # fail-loud exits (replay error / total blocker => non-zero).
+      # design §6.1). Hermetic unittest suite (NO gh, NO git, NO cargo, NO network;
+      # stdlib + PyYAML, installed once in the shared setup above): the pure
+      # correlation core (precise per-crate hit, fail-safe triage for narrowed
+      # shards, the non-spam empty-skip-set property), the TRIAGE_LANE_RE pin
+      # against the real ci.yml shard job name, the fail-loud exits (replay error /
+      # total blocker => non-zero), and — since #4965 — the ADMISSION SEAM: the live
+      # workflow `if:` evaluated against the real known-positive event payload, with
+      # the evaluator validated against the pre-fix expression as a known answer.
       - name: Self-test the nightly selection-bug alarm (correlation + fail-loud — sq-va7at)
         run: python3 scripts/tests/test_ci_selection_alarm.py
       # [OPUS-5] The review-lane BLIND-SPOT alarm (scripts/review_lane_alarm.py,

--- a/.github/workflows/selection-alarm.yml
+++ b/.github/workflows/selection-alarm.yml
@@ -2,7 +2,9 @@
 # epic sq-fmx4u). [OPUS-4.8] Design: research/change-based-test-selection.md §6.1.
 #
 # WHAT: when the nightly FULL-matrix backstop (CI workflow, `schedule` =>
-# mode=full) FAILS, correlate each failed job's crate with the crates that
+# mode=full) has any GENUINELY-FAILED JOB — regardless of the run's aggregate
+# conclusion, which fail-fast cancellation makes lossy (#4965) — correlate each
+# failed job's crate with the crates that
 # change-based selection (scripts/ci_select.py) SKIPPED in the PRs landed since
 # the last green nightly. Any intersection is prima-facie a selection soundness
 # bug (design §2) — scripts/ci_selection_alarm.py files a self-identified SPARQ
@@ -36,8 +38,9 @@
 name: selection-alarm
 
 on:
-  # Fire after a CI run on MAIN completes; the job `if:` narrows to a FAILED
-  # nightly (schedule / manual dispatch). The `branches: [main]` filter keys on the
+  # Fire after a CI run on MAIN completes; the job `if:` narrows to a
+  # nightly (schedule / manual dispatch) and the SCRIPT decides, from the real job
+  # list, whether anything genuinely failed (#4965). The `branches: [main]` filter keys on the
   # TRIGGERING run's head branch, so a PR's CI completion (head branch = the PR
   # branch) never fires this workflow — that guarantees selection-alarm produces
   # NO check-run on any PR head commit and so can never interact with the
@@ -67,14 +70,37 @@ concurrency:
 jobs:
   alarm:
     name: nightly selection-bug alarm
-    # workflow_dispatch: always run (operator asked). workflow_run: only a FAILED
+    # workflow_dispatch: always run (operator asked). workflow_run: every
     # scheduled/dispatched nightly on main (a PR/push/merge_group run carries a diff
     # => selection may narrow legitimately; only the full-matrix backstop is the
     # oracle here).
+    #
+    # [OPUS-5] #4965 — THERE IS DELIBERATELY NO `conclusion` TEST HERE, and adding
+    # one back re-breaks the alarm. This `if:` used to read
+    # `github.event.workflow_run.conclusion == 'failure' && …`, and that single
+    # clause is where the alarm died: MEASURED over all 45 nightlies — 35
+    # `cancelled`, 7 `success`, 3 `failure`, the last `failure` on 2026-07-19, the
+    # exact day the alarm last acted. 266 of 267 alarm runs were job-SKIPPED, and a
+    # SKIPPED JOB IS NEVER RED, so nine days of silence looked exactly like a healthy
+    # no-op. Known positive: nightly run 30333511110 concluded `cancelled` while
+    # carrying FOUR genuinely `failure` jobs (sparq-mpc / sparq-fedplan /
+    # sparq-reason ×2) — because ONE dying leg fail-fast-CANCELS the other 30 and
+    # GitHub aggregates that to `cancelled`.
+    #
+    # The run-level conclusion cannot express "some job failed", and a job `if:`
+    # cannot see the job list at all, so no expression here can make this admission
+    # precise. It is made in scripts/ci_selection_alarm.py instead, over the real
+    # jobs API, by the SAME `FAILED_CONCLUSIONS` predicate the analysis already uses:
+    # zero genuinely-failed jobs => a quiet exit 0 (the common `cancelled` case, so
+    # the alarm cannot cry wolf and get muted); a `failure`/`timed_out`-concluded run
+    # with zero failed jobs => still RED, fail-loud (STRICT_EMPTY_CONCLUSIONS).
+    # Widening to every conclusion costs ~1 extra short run per night (the nightly is
+    # the only schedule/dispatch CI run on main) and leaves NO conclusion literal here
+    # that can silently drift away from the script. Pinned by
+    # scripts/tests/test_ci_selection_alarm.py::TestWorkflowAdmissionSeam.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'failure' &&
-       (github.event.workflow_run.event == 'schedule' ||
+      ((github.event.workflow_run.event == 'schedule' ||
         github.event.workflow_run.event == 'workflow_dispatch') &&
        github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
@@ -112,9 +138,15 @@ jobs:
           CARGO_NET_RETRY: "10"
           RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
+          # NOT an admission filter (#4965) — the script uses it only to decide
+          # whether an EMPTY genuinely-failed-job set is anomalous (fail-loud) or the
+          # ordinary `cancelled`-with-nothing-really-broken case (quiet exit 0).
+          # Empty on the workflow_dispatch path; the script looks it up then.
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         run: |
           set -euo pipefail
           python3 scripts/ci_selection_alarm.py \
             --run-id "$RUN_ID" \
             --head-sha "$HEAD_SHA" \
+            --run-conclusion "$RUN_CONCLUSION" \
             --repo "$GITHUB_REPOSITORY"

--- a/scripts/ci_selection_alarm.py
+++ b/scripts/ci_selection_alarm.py
@@ -21,6 +21,13 @@
 #   `workflow_run` trigger, see .github/workflows/selection-alarm.yml), files
 #   issues, and never blocks a merge (design §6.1: "fail-open").
 #
+#   [OPUS-5] #4965 — WHAT COUNTS AS A NIGHTLY WORTH CORRELATING. A "failed nightly"
+#   means "a nightly with genuinely-failed JOBS", never "a nightly GitHub concluded
+#   `failure`". Those are different populations: fail-fast cancels the surviving
+#   matrix legs, so the RUN concludes `cancelled` and the run-level conclusion is a
+#   lossy aggregate. Admission is therefore made HERE, over the job list, by the same
+#   FAILED_CONCLUSIONS predicate the analysis uses — see STRICT_EMPTY_CONCLUSIONS.
+#
 # TWO DESIGN INVARIANTS (both load-bearing):
 #   1. FAIL-SAFE / FAIL-LOUD (opposite of ci_select.py's fail-CLOSED). An
 #      alarm-INFRASTRUCTURE error (cannot list the failed jobs, cannot load cargo
@@ -88,6 +95,33 @@ KEY_PREFIX = "selection-alarm-key"
 
 # Job conclusions that count as a "failed" nightly job.
 FAILED_CONCLUSIONS = {"failure", "timed_out"}
+
+# RUN-level conclusions for which an EMPTY genuinely-failed-job set is ANOMALOUS
+# (fail-loud, invariant 1). [OPUS-5] sparq-org/sparq#4965.
+#
+# WHY THIS EXISTS. The workflow used to admit ONLY `conclusion == 'failure'` runs,
+# so "the run fired => at least one job failed" was a safe premise and an empty
+# failed-job set could only be an API-shape surprise. That premise cost the alarm
+# its whole population: on a fail-fast matrix ONE dying job CANCELS the other 30,
+# and GitHub then concludes the RUN `cancelled`, not `failure`. MEASURED over all
+# 45 nightlies: 35 `cancelled`, 7 `success`, 3 `failure` (last 2026-07-19) — 266 of
+# 267 alarm runs job-SKIPPED, and a skipped job is never red, so the alarm went
+# inert in silence. Known positive: run 30333511110 concluded `cancelled` while
+# carrying FOUR genuinely `failure` jobs (sparq-mpc / sparq-fedplan / sparq-reason).
+#
+# The run conclusion is therefore a LOSSY aggregate and is no longer the admission
+# filter (see .github/workflows/selection-alarm.yml). What survives of the old
+# premise is exactly this: a run GitHub concluded `failure` or `timed_out` MUST
+# contain a job in FAILED_CONCLUSIONS, so an empty set there is still anomalous and
+# must never be swallowed into a silent exit 0. Every OTHER conclusion — above all
+# `cancelled`, which is the COMMON case here — can legitimately carry zero genuine
+# job failures, and for those an empty set is a correct, quiet no-op. That split is
+# what keeps a nightly alarm from crying wolf 35 times a window; an alarm that cries
+# wolf gets muted, which is the same inertness by a slower route.
+#
+# "" (conclusion unknown / unresolvable) is STRICT on purpose: fail loud on
+# ignorance rather than assume the quiet branch.
+STRICT_EMPTY_CONCLUSIONS = {"failure", "timed_out", ""}
 
 # --- triage lanes (design §5.2 + the erratum) --------------------------------
 # The change-based selector skips two lane CLASSES per PR:
@@ -323,9 +357,24 @@ def _run(cmd: list[str], cwd: str | None = None, check: bool = True) -> str:
     return proc.stdout
 
 
-def gather_failed_jobs(run_id: str, repo: str) -> list[str]:
-    """Names of the nightly run's jobs whose conclusion is a failure (design: the
-    failed-job set to correlate). Uses `gh api --paginate` over the run's jobs."""
+def fetch_run_conclusion(run_id: str, repo: str) -> str:
+    """The RUN-level conclusion of `run_id`, for the paths where the caller does not
+    already have it (the alarm's own workflow_dispatch). Fail-loud: an unreadable
+    run conclusion leaves us unable to tell an anomaly from a quiet no-op."""
+    out = _run(
+        ["gh", "api", f"repos/{repo}/actions/runs/{run_id}", "--jq", ".conclusion // \"\""]
+    )
+    return out.strip()
+
+
+def gather_failed_jobs(run_id: str, repo: str, run_conclusion: str = "") -> list[str]:
+    """Names of the nightly run's jobs whose conclusion is a GENUINE failure (design:
+    the failed-job set to correlate). Uses `gh api --paginate` over the run's jobs.
+
+    `run_conclusion` is the RUN-level aggregate, used ONLY to decide whether an empty
+    result is anomalous — see STRICT_EMPTY_CONCLUSIONS. The per-JOB filter is
+    unchanged: cancelled siblings of a fail-fast matrix are not failures and never
+    enter the correlation."""
     out = _run(
         [
             "gh", "api", "--paginate",
@@ -340,13 +389,15 @@ def gather_failed_jobs(run_id: str, repo: str) -> list[str]:
         name, _, conclusion = line.partition("\t")
         if conclusion.strip() in FAILED_CONCLUSIONS:
             failed.append(name)
-    # The workflow only fires on a failure-concluded run, so an empty failed-job
-    # set is always anomalous (jobs-API filter=latest re-run race, shape surprise,
-    # etc.).  Distinguish this from "no correlation found" to prevent silent exit 0
-    # masking a real failure.
-    if not failed:
+    # A run GitHub concluded `failure`/`timed_out` MUST contain a failed job, so an
+    # empty set there is anomalous (jobs-API filter=latest re-run race, shape
+    # surprise) and must be distinguished from "no correlation found" to prevent a
+    # silent exit 0 masking a real failure. A `cancelled` (or `success`) run may
+    # legitimately have none — that is the quiet no-op, handled by the caller.
+    if not failed and run_conclusion.strip() in STRICT_EMPTY_CONCLUSIONS:
         raise AlarmError(
-            "gather_failed_jobs: empty failed-job set on a failure-concluded run "
+            "gather_failed_jobs: empty failed-job set on a "
+            f"{run_conclusion.strip() or 'conclusion-unknown'}-concluded run "
             f"(run_id={run_id}); jobs-API shape surprise or filter=latest re-run "
             "race — cannot correlate, refusing to exit 0"
         )
@@ -508,6 +559,12 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     p.add_argument("--run-id", required=True, help="the failed nightly CI run id")
     p.add_argument("--head-sha", required=True, help="the nightly run's head SHA")
+    p.add_argument("--run-conclusion", default="",
+                   help="the nightly run's RUN-level conclusion. NOT an admission "
+                        "filter (#4965) — it only decides whether an EMPTY "
+                        "genuinely-failed-job set is anomalous (STRICT_EMPTY_"
+                        "CONCLUSIONS) or a quiet no-op. Empty => looked up via gh on "
+                        "the non-hermetic path, and STRICT on the hermetic one.")
     p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"),
                    help="owner/name (default $GITHUB_REPOSITORY)")
     p.add_argument("--event", default="schedule",
@@ -540,6 +597,14 @@ def run_alarm(args: argparse.Namespace) -> tuple[list[Finding], list[str], str]:
     repo = args.repo or ""
     repo_root = _resolve_repo_root(args.repo_root)
 
+    # The RUN-level aggregate. It is NOT the admission filter (#4965: it is lossy —
+    # one fail-fast cancellation turns a run full of real failures into `cancelled`).
+    # It decides ONE thing: whether an EMPTY genuinely-failed-job set is anomalous.
+    run_conclusion = (args.run_conclusion or "").strip()
+    if not run_conclusion and not args.failed_jobs_file and repo:
+        # The alarm's own workflow_dispatch path has no event payload to read it from.
+        run_conclusion = fetch_run_conclusion(args.run_id, repo)
+
     # Failed jobs — hermetic file or gh.
     if args.failed_jobs_file:
         failed_jobs = [
@@ -549,17 +614,31 @@ def run_alarm(args: argparse.Namespace) -> tuple[list[Finding], list[str], str]:
     else:
         if not repo:
             raise AlarmError("--repo (or $GITHUB_REPOSITORY) required for the gh path")
-        failed_jobs = gather_failed_jobs(args.run_id, repo)
-    # The workflow only fires on a failure-concluded run, so an empty failed-job
-    # set (from either the file path or the gh path) is always anomalous — an
-    # empty correlation must be distinguishable from anomalous-empty to prevent a
-    # silent exit 0 masking a real failure.
+        failed_jobs = gather_failed_jobs(args.run_id, repo, run_conclusion)
     if not failed_jobs:
-        raise AlarmError(
-            "run_alarm: empty failed-jobs set; workflow fires on failure-concluded "
-            "runs only, so this is anomalous (jobs-API shape surprise, re-run race, "
-            "or empty --failed-jobs-file). Refusing to exit 0."
+        # THE PRECISE ADMISSION (#4965). Analysis and admission now agree: a job is
+        # a failure iff its conclusion is in FAILED_CONCLUSIONS, at BOTH ends.
+        if run_conclusion in STRICT_EMPTY_CONCLUSIONS:
+            # A failure/timed_out-concluded run with no failed job is anomalous —
+            # an empty correlation must stay distinguishable from anomalous-empty
+            # so a silent exit 0 can never mask a real failure.
+            raise AlarmError(
+                "run_alarm: empty failed-jobs set on a "
+                f"{run_conclusion or 'conclusion-unknown'}-concluded run — anomalous "
+                "(jobs-API shape surprise, re-run race, or empty --failed-jobs-file). "
+                "Refusing to exit 0."
+            )
+        # The NOISE half: a `cancelled` run whose jobs contain no genuine failure is
+        # the COMMON case (fail-fast cancels the matrix). Nothing failed, so there is
+        # no correlation input and no finding to make — exit quiet, not loud and not
+        # green-with-a-fake-finding. Returning here also skips the cargo-metadata load
+        # and the per-commit git replay, which have nothing to work on.
+        print(
+            f"selection-alarm: run {args.run_id} concluded '{run_conclusion}' and no "
+            f"job concluded {sorted(FAILED_CONCLUSIONS)} — nothing genuinely failed, "
+            "so there is no correlation input. No alarm."
         )
+        return [], [], repo
 
     # cargo metadata (member set + reverse closure for the replay).
     meta = ci_select.load_metadata(args.metadata_file, repo_root)

--- a/scripts/tests/test_ci_selection_alarm.py
+++ b/scripts/tests/test_ci_selection_alarm.py
@@ -13,26 +13,54 @@
 #   * fail-loud: replay errors AND a total blocker both exit NON-ZERO.
 #   * idempotency-key stability + the dry-run path (no gh calls).
 #
-# Fully hermetic: no gh, no git, no cargo, no network. Correlation is a pure
-# function; the CLI is exercised via --failed-jobs-file + --metadata-file +
-# --dry-run and a monkeypatched git-log/diff.
+# [OPUS-5] sparq-org/sparq#4965 — THE ADMISSION SEAM. The alarm's analysis was always
+# correct and its workflow `if:` was where it died: the job admitted only
+# `github.event.workflow_run.conclusion == 'failure'`, and fail-fast cancellation
+# means a nightly with real failures concludes `cancelled`. 266 of 267 alarm runs were
+# job-SKIPPED, and a skipped job is never red. Three new classes pin the fix, and each
+# one can go RED:
+#   * TestKnownPositiveRun30333511110 — the REAL job census of the real cancelled
+#     nightly that carried four real failures. Asserts the alarm fires and names
+#     EXACTLY sparq-mpc / sparq-fedplan / sparq-reason. The fixture is its own
+#     negative control: sparq-core and sparq-geo sit in the SAME job family with
+#     `cancelled` conclusions, so an admission that let cancelled jobs through would
+#     name them too and this test would red.
+#   * TestQuietOnACleanCancelledRun — the NOISE half. A cancelled run with nothing
+#     genuinely failed must exit 0 SILENTLY (no finding, no red). Without this,
+#     "admit everything" satisfies the positive test and buys a nightly alarm that
+#     cries wolf 35 times a window — muted is inert by a slower route.
+#   * TestWorkflowAdmissionSeam — evaluates the LIVE `if:` from
+#     .github/workflows/selection-alarm.yml against real event payloads, with the
+#     evaluator itself validated against a KNOWN ANSWER: the verbatim OLD expression
+#     must reject the known positive and admit the 2026-07-19 `failure` run, exactly
+#     as GitHub was observed to behave. An instrument that cannot reproduce the bug
+#     cannot certify the fix.
 #
-# Run:  python3 scripts/tests/test_ci_selection_alarm.py   (stdlib only)
+# Fully hermetic: no gh, no git, no cargo, no network. Correlation is a pure
+# function; the CLI is exercised via --failed-jobs-file / a stubbed `_run` +
+# --metadata-file + --dry-run and a monkeypatched git-log/diff.
+#
+# Run:  python3 scripts/tests/test_ci_selection_alarm.py   (stdlib + PyYAML, which the
+#       docs-quality quick-gates job installs once in its shared setup)
 
 from __future__ import annotations
 
 import importlib.util
 import io
 import json
+import re
 import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 ALARM = REPO_ROOT / "scripts" / "ci_selection_alarm.py"
 CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+ALARM_YML = REPO_ROOT / ".github" / "workflows" / "selection-alarm.yml"
 
 
 def _load_module():
@@ -273,6 +301,458 @@ class TestCliFailLoud(unittest.TestCase):
             self.assertIn("[dry-run] WOULD file", out)
             self.assertIn("crate:sparq-core", out)
             self.assertIn("#55", out)
+
+
+# --------------------------------------------------------------------------- #
+# #4965 — THE ADMISSION SEAM
+# --------------------------------------------------------------------------- #
+
+# The REAL job census of nightly CI run 30333511110 (sparq-org/sparq, 2026-07-28,
+# event=schedule, head_branch=main). Fetched from
+# `repos/sparq-org/sparq/actions/runs/30333511110/jobs` with `gh api --paginate`
+# (--limit would have truncated silently): 84 jobs — 43 success, 31 cancelled,
+# 6 skipped, 4 FAILURE. GitHub concluded the RUN `cancelled`.
+#
+# The four failures are reproduced VERBATIM. The cancelled/success/skipped rows are a
+# faithful sample of the real names, chosen to preserve the property that matters: the
+# cancelled rows are SIBLINGS of the failed ones in the very same job family, naming
+# crates that were ALSO selection-skipped. So "admit any non-success job" and
+# "admit the run, then correlate every job" both name extra crates and red the test.
+KNOWN_POSITIVE_RUN_ID = "30333511110"
+KNOWN_POSITIVE_HEAD_SHA = "63dfb7a0b0a8c92c8b478929a09b650843ce0a87"
+KNOWN_POSITIVE_RUN_CONCLUSION = "cancelled"
+KNOWN_POSITIVE_JOBS: list[tuple[str, str]] = [
+    # (job name, conclusion) — the four GENUINE failures:
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-mpc)", "failure"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-fedplan)", "failure"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-reason, 1/3)", "failure"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-reason, 2/3)", "failure"),
+    # …fail-fast cancelled siblings, same family, crates also in the skipped set:
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-core)", "cancelled"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-geo)", "cancelled"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-shacl)", "cancelled"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-solid)", "cancelled"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-server)", "cancelled"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-vectors)", "cancelled"),
+    ("mutation ratchet (cargo-mutants, advisory) (sparq-engine, 1/24, 360)", "cancelled"),
+    # …and green/skipped rows.
+    ("unsafe-register (count ratchet)", "success"),
+    ("detect rust changes", "success"),
+    ("nightly-gate", "success"),
+    ("coverage (nightly, full incl. heavy vectors)", "skipped"),
+]
+
+# The crates the four REAL failures name. Anything else appearing is over-admission.
+KNOWN_POSITIVE_CRATES = {"sparq-mpc", "sparq-fedplan", "sparq-reason"}
+
+
+def _jobs_tsv(jobs: list[tuple[str, str]]) -> str:
+    """The exact `gh api --jq '.jobs[] | [.name, (.conclusion // "")] | @tsv'` shape."""
+    return "".join(f"{name}\t{conclusion}\n" for name, conclusion in jobs)
+
+
+class _StubRun:
+    """Stands in for ci_selection_alarm._run so the REAL gh/git call sites execute.
+
+    Dispatches on the actual argv the script builds, so a change to those call sites
+    surfaces here as an unstubbed-command error rather than a silent pass."""
+
+    def __init__(self, jobs: list[tuple[str, str]], base_sha: str | None,
+                 commits: list[tuple[str, int | None]],
+                 diffs: dict[str, list[str]], run_conclusion: str = ""):
+        self.jobs, self.base_sha = jobs, base_sha
+        self.commits, self.diffs = commits, diffs
+        self.run_conclusion = run_conclusion
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, cwd=None, check=True):  # noqa: ANN001 — mirrors _run
+        self.calls.append(list(cmd))
+        joined = " ".join(cmd)
+        if cmd[0] == "gh" and "/jobs" in joined:
+            return _jobs_tsv(self.jobs)
+        if cmd[0] == "gh" and any(re.search(r"actions/runs/\d+$", c) for c in cmd):
+            return self.run_conclusion + "\n"
+        if cmd[0] == "gh" and "status=success" in joined:
+            return (self.base_sha or "") + "\n"
+        if cmd[:2] == ["git", "log"]:
+            return "".join(f"{sha}\x00subject (#{pr})\n" for sha, pr in self.commits)
+        if cmd[:2] == ["git", "diff"]:
+            return "".join(f"{p}\n" for p in self.diffs.get(cmd[-1], []))
+        raise AssertionError(f"unstubbed command: {cmd}")
+
+
+def _metadata_with(members: list[str], deps: dict[str, list[str]] | None = None) -> dict:
+    """Minimal cargo-metadata-shaped dict (see ci_select.parse_workspace)."""
+    deps = deps or {}
+    root = "/repo"
+    pkgs = [
+        {
+            "id": f"{m} 0", "name": m, "source": None,
+            "manifest_path": f"{root}/crates/{m}/Cargo.toml",
+            "dependencies": [{"name": d} for d in deps.get(m, [])],
+        }
+        for m in members
+    ]
+    return {"workspace_root": root, "packages": pkgs,
+            "workspace_members": [f"{m} 0" for m in members]}
+
+
+class TestKnownPositiveRun30333511110(unittest.TestCase):
+    """CRITERION 1. The real cancelled nightly that carried four real failures must
+    make the alarm ACT, and name exactly the crates those four failures name."""
+
+    MEMBERS = ["sparq-core", "sparq-geo", "sparq-mpc", "sparq-fedplan", "sparq-reason",
+               "sparq-shacl", "sparq-solid", "sparq-server", "sparq-vectors",
+               "sparq-engine"]
+
+    def test_gather_failed_jobs_admits_only_the_four_genuine_failures(self):
+        """The analysis half, driven through the REAL gather_failed_jobs over the real
+        job census — cancelled siblings must not enter the failed set."""
+        mod = _load_module()
+        mod._run = _StubRun(KNOWN_POSITIVE_JOBS, None, [], {})
+        failed = mod.gather_failed_jobs(
+            KNOWN_POSITIVE_RUN_ID, "sparq-org/sparq", KNOWN_POSITIVE_RUN_CONCLUSION
+        )
+        self.assertEqual(
+            len(failed), 4,
+            f"expected the 4 genuinely-failed jobs of run {KNOWN_POSITIVE_RUN_ID}, "
+            f"got {failed}",
+        )
+        crates: set[str] = set()
+        for job in failed:
+            crates |= mod.job_crate_tokens(job, set(self.MEMBERS))
+        self.assertEqual(
+            crates, KNOWN_POSITIVE_CRATES,
+            "the failed jobs must map onto exactly the crates the four real failures "
+            "name; extra crates mean cancelled siblings leaked into the failed set",
+        )
+
+    def test_end_to_end_alarm_fires_and_names_the_crates(self):
+        """CRITERION 1, end to end through main(): the real cancelled run, the real job
+        census, a landed PR that selection-skipped those crates => findings filed.
+
+        Before the #4965 fix this run never reached the script at all — the workflow
+        `if:` skipped the job (266 of 267 runs). Pinning it at the script level is only
+        half the guard; TestWorkflowAdmissionSeam pins the other half."""
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            # sparq-geo is the only crate the landed commit touches and nothing depends
+            # on it, so ci_select selects {sparq-geo} and SKIPS every other member —
+            # including the four failures' crates AND their cancelled siblings.
+            meta_f.write_text(json.dumps(_metadata_with(self.MEMBERS)))
+            landed_sha = "a" * 40
+            mod._run = _StubRun(
+                jobs=KNOWN_POSITIVE_JOBS,
+                base_sha="9" * 40,
+                commits=[(landed_sha, 4321)],
+                diffs={landed_sha: ["crates/sparq-geo/src/lib.rs"]},
+            )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = mod.main([
+                    "--run-id", KNOWN_POSITIVE_RUN_ID,
+                    "--head-sha", KNOWN_POSITIVE_HEAD_SHA,
+                    "--run-conclusion", KNOWN_POSITIVE_RUN_CONCLUSION,
+                    "--repo", "sparq-org/sparq", "--repo-root", d,
+                    "--metadata-file", str(meta_f), "--dry-run",
+                ])
+            out = buf.getvalue()
+            self.assertEqual(rc, 0, f"alarm exited {rc} on the known positive:\n{out}")
+            self.assertIn("[dry-run] WOULD file", out,
+                          "the alarm did NOT act on the known positive:\n" + out)
+            for crate in sorted(KNOWN_POSITIVE_CRATES):
+                self.assertIn(f"crate:{crate}", out,
+                              f"finding for {crate} missing:\n{out}")
+            self.assertIn("#4321", out, "the suspect landed PR must be named")
+            # Negative control INSIDE the positive: crates whose jobs were merely
+            # CANCELLED were skipped by the same PR, so they are in the skip set and
+            # would be named the moment admission stopped distinguishing them.
+            for cancelled_crate in ("sparq-core", "sparq-shacl", "sparq-server"):
+                self.assertNotIn(
+                    f"crate:{cancelled_crate}", out,
+                    f"{cancelled_crate} was only CANCELLED, never failed — naming it "
+                    f"means the admission stopped being precise:\n{out}",
+                )
+
+
+class TestQuietOnACleanCancelledRun(unittest.TestCase):
+    """CRITERION 2 — the NOISE half. `cancelled` is the COMMON nightly conclusion (35
+    of 45 all-time). A cancelled run with nothing genuinely failed must produce NO
+    finding and NO red; otherwise the fix trades a silent alarm for a muted one."""
+
+    def test_clean_cancelled_run_is_a_quiet_no_op(self):
+        mod = _load_module()
+        clean = [(name, "cancelled" if c == "failure" else c)
+                 for name, c in KNOWN_POSITIVE_JOBS]
+        self.assertNotIn("failure", {c for _, c in clean},
+                         "fixture must contain NO genuine failure for this control")
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            meta_f.write_text(json.dumps(_metadata_with(["sparq-core", "sparq-geo"])))
+            mod._run = _StubRun(clean, base_sha="9" * 40, commits=[("a" * 40, 1)],
+                                diffs={"a" * 40: ["crates/sparq-geo/src/lib.rs"]})
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = mod.main([
+                    "--run-id", "1", "--head-sha", "b" * 40,
+                    "--run-conclusion", "cancelled",
+                    "--repo", "o/r", "--repo-root", d,
+                    "--metadata-file", str(meta_f), "--dry-run",
+                ])
+            out = buf.getvalue()
+            self.assertEqual(rc, 0, "a clean cancelled run must NOT red the alarm lane")
+            self.assertNotIn("WOULD file", out, "a clean cancelled run must file nothing")
+            self.assertIn("nothing genuinely failed", out,
+                          "the quiet no-op must still say why it did nothing:\n" + out)
+
+    def test_failure_concluded_run_with_no_failed_job_is_still_LOUD(self):
+        """ANTI-REGRESSION on the fail-loud invariant. The quiet branch must be scoped
+        to conclusions that can legitimately carry zero failures. A run GitHub concluded
+        `failure` MUST contain a failed job, so an empty set there is an API-shape
+        anomaly and must still exit NON-ZERO — otherwise #4965's fix would have bought
+        its quiet by deleting the masking guard the alarm was built around."""
+        mod = _load_module()
+        green_only = [(n, "success") for n, _ in KNOWN_POSITIVE_JOBS]
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            meta_f.write_text(json.dumps(_metadata_with(["sparq-core"])))
+            for conclusion in ("failure", "timed_out", ""):
+                with self.subTest(run_conclusion=conclusion or "<unknown>"):
+                    mod._run = _StubRun(green_only, None, [], {},
+                                        run_conclusion=conclusion)
+                    buf = io.StringIO()
+                    with redirect_stdout(buf):
+                        rc = mod.main([
+                            "--run-id", "1", "--head-sha", "b" * 40,
+                            "--run-conclusion", conclusion,
+                            "--repo", "o/r", "--repo-root", d,
+                            "--metadata-file", str(meta_f), "--dry-run",
+                        ])
+                    self.assertEqual(
+                        rc, 1,
+                        f"a {conclusion or 'conclusion-unknown'}-concluded run with no "
+                        f"failed job must fail LOUD, not exit 0",
+                    )
+
+
+# --- the workflow `if:` seam ------------------------------------------------- #
+
+# The expression this job carried until #4965, verbatim from
+# .github/workflows/selection-alarm.yml. It is the KNOWN ANSWER the evaluator below is
+# validated against: it must REJECT the cancelled known positive (which is why the
+# alarm was skipped 266 times) and ADMIT a failure-concluded nightly (which is why it
+# acted once, on 2026-07-19). An evaluator that cannot reproduce the bug cannot
+# certify the fix.
+OLD_BROKEN_IF = (
+    "github.event_name == 'workflow_dispatch' || "
+    "(github.event.workflow_run.conclusion == 'failure' && "
+    "(github.event.workflow_run.event == 'schedule' || "
+    "github.event.workflow_run.event == 'workflow_dispatch') && "
+    "github.event.workflow_run.head_branch == 'main')"
+)
+
+_TOKEN_RE = re.compile(r"\s*(\(|\)|\|\||&&|==|!=|'[^']*'|[A-Za-z_][A-Za-z0-9_.\-]*)")
+
+
+def _tokenize(expr: str) -> list[str]:
+    """Tokenize the SMALL GitHub-expression grammar these `if:`s use. Anything outside
+    it RAISES — the evaluator is fail-closed, so an expression shape it does not
+    understand REDs the suite instead of being silently judged admissible."""
+    toks, pos = [], 0
+    while pos < len(expr):
+        m = _TOKEN_RE.match(expr, pos)
+        if not m:
+            if expr[pos].isspace():
+                pos += 1
+                continue
+            raise ValueError(f"unsupported token at {pos}: {expr[pos:pos + 30]!r}")
+        toks.append(m.group(1))
+        pos = m.end()
+    return toks
+
+
+def _lookup(path: str, ctx: dict):
+    """`github.event.workflow_run.event` -> ctx['github']['event']['workflow_run']
+    ['event']; a missing leg is null, and null == 'literal' is False (GitHub semantics
+    for an absent context property)."""
+    cur = ctx
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def eval_if(expr: str, ctx: dict) -> bool:
+    """Evaluate a `||`/`&&`/`==`/`!=`/parenthesised GitHub `if:` against a context."""
+    toks = _tokenize(expr)
+    pos = 0
+
+    def peek():
+        return toks[pos] if pos < len(toks) else None
+
+    def operand():
+        nonlocal pos
+        t = toks[pos]
+        pos += 1
+        if t.startswith("'"):
+            return t[1:-1]
+        if t in ("true", "false"):
+            return t == "true"
+        return _lookup(t, ctx)
+
+    def primary():
+        nonlocal pos
+        if peek() == "(":
+            pos += 1
+            val = or_expr()
+            if peek() != ")":
+                raise ValueError("unbalanced parentheses")
+            pos += 1
+            return val
+        left = operand()
+        if peek() in ("==", "!="):
+            op = toks[pos]
+            pos += 1
+            right = operand()
+            return (left == right) if op == "==" else (left != right)
+        return bool(left)
+
+    def and_expr():
+        nonlocal pos
+        val = primary()
+        while peek() == "&&":
+            pos += 1
+            val = primary() and val
+        return val
+
+    def or_expr():
+        nonlocal pos
+        val = and_expr()
+        while peek() == "||":
+            pos += 1
+            val = and_expr() or val
+        return val
+
+    result = or_expr()
+    if pos != len(toks):
+        raise ValueError(f"trailing tokens: {toks[pos:]}")
+    return bool(result)
+
+
+def _workflow_run_ctx(conclusion: str, event: str = "schedule",
+                      head_branch: str = "main") -> dict:
+    return {"github": {"event_name": "workflow_run",
+                       "event": {"workflow_run": {"conclusion": conclusion,
+                                                  "event": event,
+                                                  "head_branch": head_branch}}}}
+
+
+class TestWorkflowAdmissionSeam(unittest.TestCase):
+    """CRITERION 1+2 at the seam that actually killed the alarm. Every assertion drives
+    the LIVE `if:` string parsed structurally out of the workflow, so a comment
+    mentioning `conclusion` cannot satisfy or break it."""
+
+    @staticmethod
+    def _live_if() -> str:
+        doc = yaml.safe_load(ALARM_YML.read_text())
+        return " ".join(doc["jobs"]["alarm"]["if"].split())
+
+    # -- instrument validation (run FIRST: a broken evaluator invalidates everything) --
+    def test_evaluator_reproduces_the_old_bug(self):
+        """KNOWN ANSWER. The pre-#4965 expression must SKIP the cancelled known positive
+        and RUN on a failure-concluded nightly — exactly the live behaviour measured
+        over 267 runs (266 skipped; the one action on the 2026-07-19 `failure`). If this
+        ever passes trivially, every other assertion in this class is vacuous."""
+        self.assertFalse(
+            eval_if(OLD_BROKEN_IF, _workflow_run_ctx("cancelled")),
+            "CONTROL FAILED: the evaluator thinks the OLD expression admitted a "
+            "cancelled run. It did not — that is the entire defect of #4965, and an "
+            "instrument that cannot see it cannot certify the fix.",
+        )
+        self.assertTrue(
+            eval_if(OLD_BROKEN_IF, _workflow_run_ctx("failure")),
+            "CONTROL FAILED: the evaluator thinks the OLD expression rejected a "
+            "failure-concluded nightly. It admitted them — that is how the alarm acted "
+            "on 2026-07-19.",
+        )
+
+    def test_evaluator_is_fail_closed_on_an_unknown_shape(self):
+        """An expression using syntax outside the supported grammar must RAISE, never
+        be silently judged admissible."""
+        with self.assertRaises(ValueError):
+            eval_if("contains(github.ref, 'main') ? 1 : 0", _workflow_run_ctx("failure"))
+
+    # -- the fix ---------------------------------------------------------------- #
+    def test_live_if_admits_the_known_positive_cancelled_nightly(self):
+        """CRITERION 1, seam half. Reinstate `conclusion == 'failure'` in the live
+        workflow and this REDs by name."""
+        self.assertTrue(
+            eval_if(self._live_if(), _workflow_run_ctx(KNOWN_POSITIVE_RUN_CONCLUSION)),
+            f"the selection-alarm job `if:` does NOT admit nightly run "
+            f"{KNOWN_POSITIVE_RUN_ID} (conclusion=cancelled, event=schedule, "
+            f"branch=main), which carried FOUR genuinely-failed jobs. A run-level "
+            f"conclusion cannot express 'some job failed' — do not filter on it here; "
+            f"scripts/ci_selection_alarm.py makes that decision over the real job list.",
+        )
+
+    def test_live_if_admits_every_terminal_run_conclusion(self):
+        """The general property behind the known positive: NO run conclusion may be
+        excluded here, because the aggregate is lossy for every one of them."""
+        for conclusion in ("failure", "cancelled", "timed_out", "success",
+                           "startup_failure", "neutral", "action_required", "stale"):
+            with self.subTest(conclusion=conclusion):
+                self.assertTrue(
+                    eval_if(self._live_if(), _workflow_run_ctx(conclusion)),
+                    f"conclusion={conclusion!r} is excluded by the job `if:`",
+                )
+
+    def test_live_if_still_rejects_the_runs_that_are_not_the_oracle(self):
+        """QUANTIFIER DIRECTION. Widening on CONCLUSION must not widen on EVENT or
+        BRANCH: only the full-matrix nightly on main is the selection oracle. A PR's CI
+        completion carries a diff, so selection narrowing there is legitimate and
+        correlating it would manufacture findings. Without this, 'admit everything'
+        passes the two tests above."""
+        for label, ctx in (
+            ("pull_request run on main",
+             _workflow_run_ctx("failure", event="pull_request")),
+            ("push run on main", _workflow_run_ctx("failure", event="push")),
+            ("merge_group run", _workflow_run_ctx("failure", event="merge_group")),
+            ("scheduled run off main",
+             _workflow_run_ctx("failure", head_branch="sparq-agent/x")),
+        ):
+            with self.subTest(case=label):
+                self.assertFalse(
+                    eval_if(self._live_if(), ctx),
+                    f"the alarm must not fire for a {label}",
+                )
+
+    def test_operator_dispatch_always_runs(self):
+        """The manual re-correlation path is unconditional (operator asked)."""
+        self.assertTrue(
+            eval_if(self._live_if(), {"github": {"event_name": "workflow_dispatch"}})
+        )
+
+    def test_the_workflow_passes_the_run_conclusion_to_the_script(self):
+        """The conclusion is still NEEDED — for the fail-loud/quiet split — so it must
+        reach the script. Structural: read the step's env + the run command."""
+        doc = yaml.safe_load(ALARM_YML.read_text())
+        steps = doc["jobs"]["alarm"]["steps"]
+        correlate = [s for s in steps if "ci_selection_alarm.py" in s.get("run", "")]
+        self.assertEqual(len(correlate), 1, "expected exactly one correlate step")
+        step = correlate[0]
+        self.assertIn(
+            "workflow_run.conclusion", str(step.get("env", {})),
+            "the step must receive the run conclusion — without it the script cannot "
+            "tell an anomalous empty failed-job set from an ordinary cancelled run",
+        )
+        self.assertIn("--run-conclusion", step["run"])
+
+    def test_suite_is_wired_into_ci(self):
+        """Anti-vacuity anchor: this file could otherwise leave CI's reachable set."""
+        text = (REPO_ROOT / ".github" / "workflows" / "docs-quality.yml").read_text()
+        self.assertIn("scripts/tests/test_ci_selection_alarm.py", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes #4965. Head SHA `8ab249d9b12e68f8f61e9278d3650a24bddc6110`.

## The defect, and where it actually lived

The alarm's Python was always correct. The job-level `if:` in `.github/workflows/selection-alarm.yml` is where it died — it admitted only `github.event.workflow_run.conclusion == 'failure'`, and **fail-fast cancellation means a nightly carrying real failures concludes `cancelled`**.

MEASURED, `--paginate` over all 45 nightlies: **35 `cancelled`, 7 `success`, 3 `failure`** — last `failure` 2026-07-19, the exact day the alarm last acted. **266 of 267 alarm runs job-SKIPPED**, and a skipped job is never red, so nine days of inertness looked exactly like a healthy no-op.

## Known positive, driven live

Nightly run `30333511110`: run conclusion `cancelled`, **4 genuinely `failure` jobs among 31 cancelled**. Running the *fixed* script against the real run, with real `gh` + real git replay + real `cargo metadata`:

```
[dry-run] WOULD file (kind=crate, key=crate:sparq-fedplan)
[dry-run] WOULD file (kind=crate, key=crate:sparq-mpc)
[dry-run] WOULD file (kind=crate, key=crate:sparq-reason)
exit 0
```

Exactly the three crates the four real failures name. Before this change the job never ran at all.

## The fix shape, and why not just "add `cancelled` to the `if:`"

Adding `cancelled` alone would have been worse than the bug. A `cancelled` run is the *common* case (35 of 45), and the script raises `AlarmError` on an empty failed-job set — so the alarm would have gone RED on most nights for runs where **nothing was actually broken**. A nightly alarm that cries wolf gets muted, which is the same inertness by a slower route.

A run-level conclusion cannot express "some job failed", and a job `if:` cannot see the job list, so **no expression there can be precise**. So:

- the conclusion filter is **removed from the YAML entirely** — there is no longer any conclusion literal that can drift away from the script;
- the admission is made in `scripts/ci_selection_alarm.py`, over the real jobs API, by the **same `FAILED_CONCLUSIONS` predicate the analysis already uses**:
  - ≥1 genuinely-failed job → correlate (behaviour unchanged);
  - 0 failed jobs on a `cancelled`/`success` run → **quiet exit 0** (the noise half);
  - 0 failed jobs on a `failure`/`timed_out`/unknown run → **still RED, fail-loud** (`STRICT_EMPTY_CONCLUSIONS`). The anti-masking invariant is preserved, not traded away to buy the quiet branch.

Cost of widening: ~1 extra short run per night (the nightly is the only schedule/dispatch CI run on main).

## Acceptance criteria

| # | criterion | result |
|---|---|---|
| 1 | acts on the known positive | **PASS** — live run above; and `TestKnownPositiveRun30333511110` pins it hermetically |
| 2 | does **not** fire on a clean cancelled run | **PASS** — `TestQuietOnACleanCancelledRun` |
| 5 | control suite GREEN before trusting mutations | **PASS** — 17/17 at baseline, then 29/29; baseline re-verified GREEN *on each copied tree* |

### Mutation results — 7/7 killed, each naming a row

| mutant | killed by |
|---|---|
| M1 revert `if:` to `conclusion == 'failure'` | `test_live_if_admits_the_known_positive_cancelled_nightly` |
| M2 `FAILED_CONCLUSIONS` += `cancelled` | `test_gather_failed_jobs_admits_only_the_four_genuine_failures` |
| M3 quiet branch deleted | `test_clean_cancelled_run_is_a_quiet_no_op` |
| M4 fail-loud invariant deleted | `test_failure_concluded_run_with_no_failed_job_is_still_LOUD` |
| M5 `if:` widened to `true` | `test_live_if_still_rejects_the_runs_that_are_not_the_oracle` |
| M6 **instrument sabotage** (`eval_if` always True) | `test_evaluator_reproduces_the_old_bug` |
| M7 `gather_failed_jobs` never reports a failure | known-positive tests |

## The instrument is validated against a known answer

`TestWorkflowAdmissionSeam` evaluates the **live** `if:` — parsed structurally out of the YAML, so a comment mentioning `conclusion` can neither satisfy nor break it — against real event payloads. Its evaluator is validated first: the **verbatim pre-fix expression must reject the cancelled known positive and admit a `failure` nightly**, exactly as GitHub was observed to behave across 267 runs. An instrument that cannot reproduce the bug cannot certify the fix (M6 confirms this control is live). The evaluator is fail-closed: an expression shape outside its grammar raises rather than being judged admissible.

The known-positive fixture is its own negative control — `sparq-core`, `sparq-shacl`, `sparq-server` sit in the *same job family* with `cancelled` conclusions and were skipped by the same PR, so any loosening of the admission names them and reds the test.

## What this does **not** fix

- **The nightly backstop itself.** It has not concluded `success` since **2026-07-01, 28 days ago** (7 successes all-time). This PR makes that visible; it does not repair it.
- **The suspect-PR window is unbounded.** Because the window is "since the last green nightly" and that is 28 days back, the first real firing will list **644 / 579 / 554 suspect PRs** (issue bodies 18.1 / 16.3 / 15.8 KB). Under GitHub's 65536-char body limit today, but not actionable, and at ~2300 suspects it would exceed the limit and `create_issue` would raise. **Deliberately not fixed here** — it is analysis-side, and this PR is scoped to the admission seam. Filed separately.
- **Advisory-job failures are still correlated.** All four failures in the known positive are `mutation ratchet (…, advisory)` jobs. The analysis is unchanged by design; whether advisory lanes should feed the alarm is a separate judgment.
- **The per-crate dedupe is unchanged** (one open issue per crate), so this cannot spam beyond one issue per affected crate.

## Blast radius

`nightly selection-bug alarm` is declared in `.github/advisory-registry.json`, so it cannot red `ci-summary / gate` — `test_alarm_lanes_non_gating.py` still passes unchanged. No PR is affected.

---
Not armed — for independent review.
