### PR TITLE
fix(ci): a missing REGISTRY_RING_TOKEN must fail LOUD, not suppress ~130 rings into green runs (#4966)

### DIFF
--- a/.github/advisory-registry.json
+++ b/.github/advisory-registry.json
@@ -209,6 +209,13 @@
    "promotion_criteria": "not promotable to a gate: the ring runs post-hoc via workflow_run (on ci-summary completion), never on a PR/merge_group head commit, so it produces no gating check-run by design (sparq-org/sparq#3474 moved it here so the REGISTRY_RING_TOKEN doorbell is unreachable from PR-head content); it only notifies the registry doorbell after a gating-leg failure and must never gate a PR",
    "registered": "2026-07-18"
   },
+  "ring registry dispatcher": {
+   "workflow": "batch-merge.yml",
+   "job_id": "ring",
+   "owner_bead": "sq-4966",
+   "promotion_criteria": "NEVER promotable. This job is a fire-and-forget cross-repo DOORBELL: it dispatches jeswr/agent-account-registry so a freed merge-queue slot is picked up now rather than on the registry's next ~10-min cron. Whether that dispatch succeeds is a property of an EXTERNAL repository's endpoint and of a credential's presence — never a property of the commit under test — so gating on it would block sparq merges on another repo's availability. Same shape and same rationale as `merge-group doorbell (advisory)`. DECLARED as part of #4966, which made a MISSING REGISTRY_RING_TOKEN fail LOUD (exit 1) instead of fail-soft to a green run: the job runs on `push: branches: [main]`, so its check-run lands on the main head SHA that the push-triggered `ci-summary / gate` polls (the sq-huwr8 refutation — MEASURED present on main head 2cbf37359). Undeclared, that new hard failure would have redded `ci-summary / gate` on EVERY push to main (50-103 push runs/day), which AGENTS.md treats as a stop-the-line condition — a manufactured outage rather than an alarm. This declaration is what keeps the failure LOUD (the run reds, named and countable) without letting it gate. No gate_script_waiver: the job invokes no script at all, only an inline `gh workflow run`. Delete this entry only if the job is removed.",
+   "registered": "2026-07-29"
+  },
   "release-plz / Release-PR (advisory)": {
    "workflow": "release-plz.yml",
    "job_id": "release-plz-pr",

--- a/.github/workflows/batch-merge.yml
+++ b/.github/workflows/batch-merge.yml
@@ -129,8 +129,22 @@ jobs:
           python3 scripts/batch-merge.py "${args[@]}"
 
   # Merged-PR pickup ring: a merge into main frees merge-queue/worker capacity — poke the
-  # registry dispatcher immediately instead of waiting for its cron. Fail-soft: without
-  # the secret this skips with a notice (the registry cron is the backstop).
+  # registry dispatcher immediately instead of waiting for its cron.
+  #
+  # FAIL-LOUD on a missing credential (#4966), was `::notice::` + exit 0. This job has
+  # never once rung: REGISTRY_RING_TOKEN does not exist at repo or org level, so every
+  # push-triggered run took the fail-soft branch and reported SUCCESS. 12 of 12 sampled
+  # push runs, 0 rings. Reporting success while doing nothing is what kept it invisible.
+  #
+  # DECLARED ADVISORY (.github/advisory-registry.json, "ring registry dispatcher") in
+  # the same change, and that declaration is what makes this hard failure SAFE. This
+  # job runs on `push: branches: [main]`, so its check-run lands on the main head SHA —
+  # MEASURED present on main head 2cbf37359 — which is exactly the SHA the
+  # push-triggered `ci-summary / gate` polls (the sq-huwr8 refutation). Undeclared, a
+  # red here would have gated `ci-summary / gate` on EVERY push to main, and AGENTS.md
+  # treats a red main as a stop-the-line condition: that is a manufactured outage, not
+  # an alarm. Declared, the run itself reds (visible, countable, named) and the gate
+  # stays green. Pinned by scripts/tests/test_ring_credential_loud.py.
   ring:
     name: ring registry dispatcher
     if: github.event_name == 'push'
@@ -144,7 +158,13 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${REGISTRY_RING_TOKEN}" ]; then
-            echo "::notice::REGISTRY_RING_TOKEN not configured — skipping the registry ring (the registry's own cron is the backstop)."
-            exit 0
+            echo "::error title=registry ring suppressed::REGISTRY_RING_TOKEN is not configured, so the merged-PR pickup ring was NOT sent. Freed merge-queue/worker capacity will not be picked up until the registry's own ~10-min cron tick. Provision the secret — or delete this job if the ring is no longer wanted."
+            {
+              echo "### registry ring SUPPRESSED — REGISTRY_RING_TOKEN unset"
+              echo
+              echo "A merge landed on \`main\` but the pickup ring could not be sent."
+              echo "Effect: capacity pickup waits for the next ~10-min registry cron."
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            exit 1
           fi
           GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -963,6 +963,19 @@ jobs:
         run: python3 scripts/check-fast-fix-ring-guard.py --self-test
       - name: "Enforce the fast-fix ring fail-closed cross-repo guard (#3475) — GATING"
         run: python3 scripts/check-fast-fix-ring-guard.py
+      # [OPUS-5] #4966: the SAME two doorbells, from the opposite direction — a MISSING
+      # REGISTRY_RING_TOKEN must fail LOUD instead of suppressing ~130 rings into green
+      # runs. Extracts each ring job's real `run:` script from the live YAML and
+      # EXECUTES it under bash with a stubbed `gh`, asserting the exit code and the
+      # emitted annotations in BOTH credential states (empty => non-zero + `::error::`
+      # + no dispatch; present => exit 0 + the dispatch actually attempted, so the fix
+      # cannot be "always fail"). Also drives the REAL ci_summary_gate.render_verdict()
+      # to prove the new hard failure cannot red `ci-summary / gate` — both check-runs
+      # land on the main head SHA that the push-triggered gate polls (sq-huwr8), so the
+      # advisory-registry declaration is what keeps them non-gating. Needs PyYAML,
+      # installed once in the shared setup above.
+      - name: Self-test the ring doorbells fail LOUD on a missing credential (#4966)
+        run: python3 scripts/tests/test_ring_credential_loud.py
       # [OPUS-5] The VERDICT-comment -> review:pass bridge (scripts/verdict-bridge.py,
       # .github/workflows/verdict-bridge.yml). It is the ONLY automated writer of the
       # label the whole arming chain admits on, so a regression in it either strands

--- a/.github/workflows/fast-fix-ring.yml
+++ b/.github/workflows/fast-fix-ring.yml
@@ -214,8 +214,39 @@ jobs:
             # derives ci-fix admission from the PR's gate STATE and treats
             # needs:* PR labels as human-owned holds that EXCLUDE the PR from
             # the repair enumeration — a label here would suppress the fix.
-            echo "::notice::REGISTRY_RING_TOKEN unavailable (secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
-            exit 0
+            #
+            # FAIL LOUD (#4966), was `::notice::` + exit 0. REGISTRY_RING_TOKEN has
+            # never existed at repo or org level — MEASURED from a runtime env dump
+            # (`GH_TOKEN: ***` masked-and-present vs `REGISTRY_RING_TOKEN:` empty) —
+            # so this branch has taken EVERY ring this workflow ever computed: ~130
+            # suppressed across 1969 runs, each reporting SUCCESS. A control that is
+            # disabled by missing configuration and green about it is indistinguishable
+            # from one that works, which is exactly how this stayed invisible.
+            #
+            # This is the LAST guard, after every eligibility check above has already
+            # passed, so a non-zero exit here means precisely "a ring was warranted and
+            # could not be sent" — a true positive every time, never a false alarm on an
+            # ineligible PR.
+            #
+            # BLAST RADIUS (why a hard failure is safe here). This job is DECLARED in
+            # .github/advisory-registry.json ("fast-fix ring (advisory)"), the only
+            # thing that makes a check-run non-gating since #3773, so it cannot red
+            # `ci-summary / gate`. And `workflow_run` runs execute on the DEFAULT
+            # BRANCH: this run's check-run lands on the main head SHA, never on a PR or
+            # merge_group head — MEASURED on main head 2cbf37359, where both this lane
+            # and `ring registry dispatcher` are present. So no PR is redded by this.
+            # Pinned by scripts/tests/test_ring_credential_loud.py.
+            echo "::error title=fast-fix ring suppressed::REGISTRY_RING_TOKEN is not configured, so the cross-repo doorbell for PR #${PR_NUMBER} could NOT be sent. This job's ONE write capability is unavailable; the registry cron (~10 min) is the only remaining backstop. Provision the secret (or switch this lane to the ORCHESTRATOR_APP_* credentials already present in this repo) — or delete this job if the ring is no longer wanted."
+            {
+              echo "### fast-fix ring SUPPRESSED — REGISTRY_RING_TOKEN unset"
+              echo
+              echo "| field | value |"
+              echo "| --- | --- |"
+              echo "| PR | #${PR_NUMBER} |"
+              echo "| failing run head | \`${HEAD_SHA}\` |"
+              echo "| effect | repair sweep waits for the next ~10-min registry cron |"
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            exit 1
           fi
           GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry
           echo "rang jeswr/agent-account-registry dispatch for PR #${PR_NUMBER} — the repair sweep runs now instead of on the next cron tick."

--- a/scripts/tests/fast-fix-ring.golden.yml
+++ b/scripts/tests/fast-fix-ring.golden.yml
@@ -214,8 +214,39 @@ jobs:
             # derives ci-fix admission from the PR's gate STATE and treats
             # needs:* PR labels as human-owned holds that EXCLUDE the PR from
             # the repair enumeration — a label here would suppress the fix.
-            echo "::notice::REGISTRY_RING_TOKEN unavailable (secret unconfigured) — cannot ring; the registry cron (every ~10 min) is the backstop."
-            exit 0
+            #
+            # FAIL LOUD (#4966), was `::notice::` + exit 0. REGISTRY_RING_TOKEN has
+            # never existed at repo or org level — MEASURED from a runtime env dump
+            # (`GH_TOKEN: ***` masked-and-present vs `REGISTRY_RING_TOKEN:` empty) —
+            # so this branch has taken EVERY ring this workflow ever computed: ~130
+            # suppressed across 1969 runs, each reporting SUCCESS. A control that is
+            # disabled by missing configuration and green about it is indistinguishable
+            # from one that works, which is exactly how this stayed invisible.
+            #
+            # This is the LAST guard, after every eligibility check above has already
+            # passed, so a non-zero exit here means precisely "a ring was warranted and
+            # could not be sent" — a true positive every time, never a false alarm on an
+            # ineligible PR.
+            #
+            # BLAST RADIUS (why a hard failure is safe here). This job is DECLARED in
+            # .github/advisory-registry.json ("fast-fix ring (advisory)"), the only
+            # thing that makes a check-run non-gating since #3773, so it cannot red
+            # `ci-summary / gate`. And `workflow_run` runs execute on the DEFAULT
+            # BRANCH: this run's check-run lands on the main head SHA, never on a PR or
+            # merge_group head — MEASURED on main head 2cbf37359, where both this lane
+            # and `ring registry dispatcher` are present. So no PR is redded by this.
+            # Pinned by scripts/tests/test_ring_credential_loud.py.
+            echo "::error title=fast-fix ring suppressed::REGISTRY_RING_TOKEN is not configured, so the cross-repo doorbell for PR #${PR_NUMBER} could NOT be sent. This job's ONE write capability is unavailable; the registry cron (~10 min) is the only remaining backstop. Provision the secret (or switch this lane to the ORCHESTRATOR_APP_* credentials already present in this repo) — or delete this job if the ring is no longer wanted."
+            {
+              echo "### fast-fix ring SUPPRESSED — REGISTRY_RING_TOKEN unset"
+              echo
+              echo "| field | value |"
+              echo "| --- | --- |"
+              echo "| PR | #${PR_NUMBER} |"
+              echo "| failing run head | \`${HEAD_SHA}\` |"
+              echo "| effect | repair sweep waits for the next ~10-min registry cron |"
+            } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+            exit 1
           fi
           GH_TOKEN="${REGISTRY_RING_TOKEN}" gh workflow run dispatch.yml -R jeswr/agent-account-registry
           echo "rang jeswr/agent-account-registry dispatch for PR #${PR_NUMBER} — the repair sweep runs now instead of on the next cron tick."

--- a/scripts/tests/test_ring_credential_loud.py
+++ b/scripts/tests/test_ring_credential_loud.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+# [OPUS-5] sparq-org/sparq#4966 — a MISSING CREDENTIAL must fail LOUD, not suppress
+# silently into a green run. 🤖 SPARQ agent.
+#
+# THE DEFECT THIS PINS. Both cross-repo doorbells end in one privileged call gated on
+# `secrets.REGISTRY_RING_TOKEN`. That secret does not exist — MEASURED from a runtime
+# env dump of run 30411348407, where `GH_TOKEN: ***` renders masked-and-present while
+# `REGISTRY_RING_TOKEN:` renders empty (and that log carries ZERO `ESC[36;1m` lines, so
+# these are runtime values, not echoed script source). Both guards therefore took the
+# fail-soft branch on every single invocation:
+#
+#     fast-fix-ring   1969 runs, 355 executed, ~130 rings suppressed, 0 sent
+#     batch-merge ring  12/12 sampled push runs reached the guard,       0 sent
+#
+# …and every one of those runs reported SUCCESS. The difference between "the ring
+# fired" and "the ring CANNOT fire and never could" was not visible in any field a
+# monitor queries. A control that is disabled by missing configuration and green about
+# it is indistinguishable from one that works.
+#
+# HOW THIS SUITE IS BUILT TO FAIL.
+#   * It does not re-implement the guard, and it does not grep for it. It EXTRACTS the
+#     real `run:` script out of the real workflow YAML (structurally, via PyYAML — so a
+#     comment mentioning the guard cannot satisfy it) and EXECUTES it under bash with a
+#     stubbed `gh` on PATH. The assertions are on the process exit code, the emitted
+#     workflow commands, and whether the privileged dispatch was actually attempted.
+#     Reverting either guard to `::notice::` + `exit 0` REDs this file by name.
+#   * Both credential states are pinned. Without the credential-PRESENT half, "always
+#     exit 1" would satisfy the missing-credential half — the fix could be a brick.
+#   * TestTheNewFailureCannotGate drives the REAL ci_summary_gate.render_verdict() to
+#     prove the new hard failure cannot red `ci-summary / gate`, and carries an
+#     anti-vacuity CONTROL (an UNDECLARED lane failing MUST still red it). Without the
+#     control, a render_verdict() that returned 0 unconditionally would satisfy it.
+#
+# WHY LOUD IS SAFE HERE, given the repo's own stop-the-line doctrine. Neither job's
+# check-run can land on a PR or merge_group head: `fast-fix-ring` is a `workflow_run`
+# workflow (GitHub runs those from the DEFAULT BRANCH) and `batch-merge`'s ring is
+# `push: branches: [main]`. Both land on the MAIN head SHA — MEASURED, both names are
+# present in the check-run set of main head 2cbf37359 — which the push-triggered
+# `ci-summary / gate` polls. Both are therefore DECLARED in
+# .github/advisory-registry.json, the only thing that makes a check-run non-gating
+# since #3773. That declaration is load-bearing, so it is asserted below rather than
+# assumed.
+#
+# Run:  python3 scripts/tests/test_ring_credential_loud.py
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+REGISTRY_PATH = REPO_ROOT / ".github" / "advisory-registry.json"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+import ci_summary_gate as gate  # noqa: E402
+
+SECRET = "REGISTRY_RING_TOKEN"
+
+# job name -> (workflow file, job id). Both are the doorbell shape #4966 covers.
+RING_JOBS = {
+    "fast-fix ring (advisory)": ("fast-fix-ring.yml", "ring"),
+    "ring registry dispatcher": ("batch-merge.yml", "ring"),
+}
+
+# A name deliberately NOT in the registry, for the anti-vacuity control.
+UNDECLARED_LANE = "some undeclared lane that must gate"
+
+
+def _ring_step(workflow_file: str, job_id: str) -> dict:
+    """The single `run:` step of a ring job, read STRUCTURALLY from the live YAML."""
+    doc = yaml.safe_load((WORKFLOWS / workflow_file).read_text())
+    steps = [s for s in doc["jobs"][job_id]["steps"] if "run" in s]
+    assert len(steps) == 1, f"{workflow_file}:{job_id} expected one run-step, got {len(steps)}"
+    return steps[0]
+
+
+class _Harness:
+    """Executes an extracted `run:` script with a stubbed `gh` on PATH."""
+
+    def __init__(self, tmp: Path):
+        self.tmp = tmp
+        self.dispatch_log = tmp / "dispatch.log"
+        self.summary = tmp / "step-summary.md"
+        self.summary.touch()
+        bindir = tmp / "bin"
+        bindir.mkdir()
+        # The stub answers the two `gh` shapes these scripts use: an `api` read of the
+        # PR's live state, and the privileged `workflow run` dispatch (recorded, so the
+        # tests can assert the doorbell was — or was not — actually pressed).
+        pr_state = json.dumps({
+            "draft": False, "armed": True,
+            "head_repo": "o/r", "head_sha": "f" * 40,
+            "labels": ["review:pass"],
+        })
+        (bindir / "gh").write_text(
+            "#!/usr/bin/env bash\n"
+            'if [ "$1" = "api" ]; then\n'
+            f"  echo '{pr_state}'\n"
+            "  exit 0\n"
+            "fi\n"
+            'if [ "$1" = "workflow" ]; then\n'
+            f'  echo "$@" >> "{self.dispatch_log}"\n'
+            "  exit 0\n"
+            "fi\n"
+            'echo "unstubbed gh invocation: $*" >&2\n'
+            "exit 97\n"
+        )
+        (bindir / "gh").chmod(
+            (bindir / "gh").stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        )
+        self.bindir = bindir
+
+    def run(self, script: str, token: str) -> subprocess.CompletedProcess:
+        env = dict(os.environ)
+        env.update({
+            "PATH": f"{self.bindir}:{env['PATH']}",
+            SECRET: token,
+            "GH_TOKEN": "stub-workflow-token",
+            "REPO": "o/r",
+            "HEAD_SHA": "f" * 40,
+            "RUN_PR_NUMBER": "123",
+            "GITHUB_STEP_SUMMARY": str(self.summary),
+        })
+        return subprocess.run(
+            ["bash", "-c", script], env=env, capture_output=True, text=True, timeout=60
+        )
+
+    @property
+    def rang(self) -> bool:
+        return self.dispatch_log.exists() and "dispatch.yml" in self.dispatch_log.read_text()
+
+
+class TestMissingCredentialIsLoud(unittest.TestCase):
+    """CRITERION 3. An empty credential must produce a VISIBLE NON-SUCCESS."""
+
+    def test_empty_credential_exits_non_zero_and_annotates(self):
+        for job_name, (wf, job_id) in RING_JOBS.items():
+            with self.subTest(job=job_name):
+                step = _ring_step(wf, job_id)
+                with tempfile.TemporaryDirectory() as d:
+                    h = _Harness(Path(d))
+                    proc = h.run(step["run"], token="")
+                    self.assertNotEqual(
+                        proc.returncode, 0,
+                        f"{wf}:{job_id} exited 0 with {SECRET} EMPTY — the ring was "
+                        f"suppressed and the run still reported success. That is the "
+                        f"#4966 defect: ~130 rings vanished into green runs.\n"
+                        f"stdout:\n{proc.stdout}",
+                    )
+                    self.assertIn(
+                        "::error", proc.stdout,
+                        f"{wf}:{job_id} produced no ::error:: annotation — a "
+                        f"`::notice::` is not a visible non-success",
+                    )
+                    self.assertIn(
+                        SECRET, proc.stdout,
+                        "the annotation must NAME the missing secret, or the reader "
+                        "cannot act on it",
+                    )
+                    self.assertFalse(
+                        h.rang,
+                        "no dispatch may be attempted without the credential",
+                    )
+                    self.assertIn(
+                        "SUPPRESSED", h.summary.read_text(),
+                        f"{wf}:{job_id} wrote no step-summary row — the suppression "
+                        f"must be countable on the run page, not only in the log",
+                    )
+
+    def test_the_annotation_is_not_merely_a_notice(self):
+        """`::notice::` is what made this invisible for ~130 rings; its return must red
+        this test even if an `::error::` were added alongside it."""
+        for job_name, (wf, job_id) in RING_JOBS.items():
+            with self.subTest(job=job_name):
+                script = _ring_step(wf, job_id)["run"]
+                guard = script.split(f'if [ -z "${{{SECRET}}}" ]; then', 1)
+                self.assertEqual(len(guard), 2, f"{wf}: the {SECRET} guard moved")
+                body = guard[1].split("fi", 1)[0]
+                self.assertNotIn(
+                    "::notice::", body,
+                    f"{wf}:{job_id} still reports the missing credential as a NOTICE — "
+                    f"a notice on a green run is precisely the silent suppression "
+                    f"#4966 exists to remove",
+                )
+
+
+class TestCredentialPresentStillWorks(unittest.TestCase):
+    """CRITERION 4. The fix must not be 'always fail' — with the credential present the
+    doorbell must still be pressed and the job must still succeed."""
+
+    def test_present_credential_rings_and_exits_zero(self):
+        for job_name, (wf, job_id) in RING_JOBS.items():
+            with self.subTest(job=job_name):
+                step = _ring_step(wf, job_id)
+                with tempfile.TemporaryDirectory() as d:
+                    h = _Harness(Path(d))
+                    proc = h.run(step["run"], token="ghp_a_real_looking_token")
+                    self.assertEqual(
+                        proc.returncode, 0,
+                        f"{wf}:{job_id} failed WITH a credential present — the fix "
+                        f"became an unconditional failure.\nstdout:\n{proc.stdout}\n"
+                        f"stderr:\n{proc.stderr}",
+                    )
+                    self.assertTrue(
+                        h.rang,
+                        f"{wf}:{job_id} did not dispatch jeswr/agent-account-registry "
+                        f"even with the credential present — the control is a no-op "
+                        f"in BOTH states, which is worse than the bug",
+                    )
+                    self.assertNotIn("::error", proc.stdout)
+
+
+class TestTheNewFailureCannotGate(unittest.TestCase):
+    """The declaration that makes the new hard failure SAFE, asserted rather than
+    assumed. Both check-runs land on the MAIN head SHA that the push-triggered
+    `ci-summary / gate` polls (sq-huwr8), so only the advisory registry keeps them from
+    blocking merges."""
+
+    def setUp(self) -> None:
+        gate.load_advisory_registry(str(REGISTRY_PATH))
+
+    def test_both_ring_jobs_are_declared_advisory(self):
+        for job_name in RING_JOBS:
+            with self.subTest(job=job_name):
+                self.assertTrue(
+                    gate.is_advisory(job_name),
+                    f"{job_name!r} is NOT declared in .github/advisory-registry.json, "
+                    f"so ci_summary_gate.py GATES on it (#3773). Since #4966 this job "
+                    f"REDs whenever {SECRET} is unset, and its check-run lands on the "
+                    f"main head SHA the push-triggered gate polls — undeclared, that "
+                    f"reds `ci-summary / gate` on every push to main.",
+                )
+
+    def test_registry_key_matches_the_live_yaml_job_name(self):
+        """A rename must not silently re-arm either doorbell as a merge blocker."""
+        registry = json.loads(REGISTRY_PATH.read_text())["jobs"]
+        for job_name, (wf, job_id) in RING_JOBS.items():
+            with self.subTest(job=job_name):
+                self.assertIn(job_name, registry)
+                entry = registry[job_name]
+                self.assertEqual((entry["workflow"], entry["job_id"]), (wf, job_id))
+                doc = yaml.safe_load((WORKFLOWS / wf).read_text())
+                self.assertEqual(doc["jobs"][job_id]["name"], job_name)
+
+    def test_a_failing_ring_leaves_the_gate_green(self):
+        """BEHAVIOUR, via the REAL render_verdict(): the exact new failure mode must
+        not red the gate."""
+        healthy = [
+            {"name": "changed-file test selection", "status": "completed",
+             "conclusion": "success", "id": 1, "_workflow_id": 1},
+            {"name": "build", "status": "completed", "conclusion": "success",
+             "id": 2, "_workflow_id": 1},
+        ]
+        for job_name in RING_JOBS:
+            with self.subTest(job=job_name):
+                runs = healthy + [{"name": job_name, "status": "completed",
+                                   "conclusion": "failure", "id": 3, "_workflow_id": 2}]
+                self.assertEqual(
+                    gate.render_verdict(runs), 0,
+                    f"a suppressed-ring failure from {job_name!r} red the gate",
+                )
+
+    def test_control_undeclared_lane_failure_does_red_the_gate(self):
+        """ANTI-VACUITY CONTROL. Same fixture shape, undeclared lane. This MUST red — if
+        it ever passes green, every assertion in this class is measuring nothing."""
+        healthy = [
+            {"name": "changed-file test selection", "status": "completed",
+             "conclusion": "success", "id": 1, "_workflow_id": 1},
+            {"name": "build", "status": "completed", "conclusion": "success",
+             "id": 2, "_workflow_id": 1},
+        ]
+        self.assertFalse(gate.is_advisory(UNDECLARED_LANE))
+        runs = healthy + [{"name": UNDECLARED_LANE, "status": "completed",
+                           "conclusion": "failure", "id": 3, "_workflow_id": 2}]
+        self.assertEqual(
+            gate.render_verdict(runs), 1,
+            "CONTROL FAILED: an UNDECLARED lane concluding `failure` did not red the "
+            "gate, so the non-gating assertions above are vacuous.",
+        )
+
+    def test_declaring_the_rings_does_not_forgive_a_real_gating_failure(self):
+        """QUANTIFIER DIRECTION. The declarations must make the DOORBELLS non-gating,
+        not buy green by weakening the gate for the commit's own legs."""
+        runs = [
+            {"name": "changed-file test selection", "status": "completed",
+             "conclusion": "success", "id": 1, "_workflow_id": 1},
+            {"name": "ring registry dispatcher", "status": "completed",
+             "conclusion": "failure", "id": 2, "_workflow_id": 2},
+            {"name": "build", "status": "completed", "conclusion": "failure",
+             "id": 3, "_workflow_id": 1},
+        ]
+        self.assertFalse(gate.is_advisory("build"))
+        self.assertEqual(
+            gate.render_verdict(runs), 1,
+            "a real gating leg's failure was forgiven — the gate was weakened",
+        )
+
+
+class TestSuiteIsWiredIntoCI(unittest.TestCase):
+    """Anti-vacuity anchor: without this the file could leave CI's reachable set."""
+
+    def test_docs_quality_runs_this_suite(self):
+        text = (WORKFLOWS / "docs-quality.yml").read_text()
+        self.assertIn("scripts/tests/test_ring_credential_loud.py", text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes #4966. Head SHA `c2fcb8b346205141de824fe7b85de6f4e83e4d25`.

## The defect

Both cross-repo doorbells end in one privileged call gated on `secrets.REGISTRY_RING_TOKEN`. That secret does not exist — MEASURED from the runtime env dump of run `30411348407` (`GH_TOKEN: ***` masked-and-present vs `REGISTRY_RING_TOKEN:` empty; that log carries **zero** `ESC[36;1m` lines, so these are runtime values, not echoed script source). Both guards took the fail-soft branch every time and **reported SUCCESS**:

| control | runs | reached the guard | rings sent |
|---|---|---|---|
| `fast-fix-ring` | 1969 (355 executed) | ~130 | **0** |
| `batch-merge` `ring` | 12/12 sampled push runs | all | **0** |

A control that is disabled by missing configuration and green about it is indistinguishable from one that works. That is exactly how this stayed invisible.

## Fix shape, and why this one

**Both guards now emit an `::error::` annotation naming the secret, write a `$GITHUB_STEP_SUMMARY` row, and `exit 1`.** I chose a hard, named non-success over an annotation-only signal because the blast radius is genuinely contained — and I verified that rather than assuming it.

**Why a hard failure is safe.** Neither check-run can land on a PR or merge_group head: `fast-fix-ring` is a `workflow_run` workflow (GitHub executes those from the **default branch**, so the run's own head SHA is main's), and `batch-merge`'s ring is `push: branches: [main]`. MEASURED: both `fast-fix ring (advisory)` and `ring registry dispatcher` are present in the check-run set of main head `2cbf37359`. That is the SHA the **push-triggered** `ci-summary / gate` polls (the sq-huwr8 refutation), so the advisory-registry declaration — not the trigger type — is what keeps them non-gating.

**`fast-fix ring (advisory)` was already declared. `ring registry dispatcher` was NOT** — it was silently gating. Undeclared, a hard failure there would have redded `ci-summary / gate` on **every push to main** (50–103 push runs/day), and AGENTS.md treats a red main as a stop-the-line condition. That is a manufactured outage, not an alarm. **This PR declares it**, so the run reds — visible, named, countable — while the gate stays green.

**Every red is a true positive.** In `fast-fix-ring` the credential guard is the *last* one, after every eligibility check (draft / human-hold / armed-or-in-review / same-repo / same-SHA), so `exit 1` means precisely "a ring was warranted and could not be sent" — never a false alarm on an ineligible PR. This is why the ~25–60/day rate is a correctly-sized alarm rather than noise: the volume *is* the damage.

## Acceptance criteria

| # | criterion | result |
|---|---|---|
| 3 | empty credential → visible non-success | **PASS** — `TestMissingCredentialIsLoud`: non-zero exit, `::error::` naming the secret, step-summary row, no dispatch attempted |
| 4 | still works when the credential is present | **PASS** — `TestCredentialPresentStillWorks`: exit 0 **and** the dispatch actually recorded, so the fix cannot be "always fail" |
| 5 | control suite GREEN before trusting mutations | **PASS** — baseline green, re-verified GREEN on each copied tree |

### Mutation results — 7/7 killed

| mutant | killed by |
|---|---|
| R1 `fast-fix-ring` back to notice + `exit 0` | `test_empty_credential_exits_non_zero_and_annotates` |
| R2 `batch-merge` ring back to notice + `exit 0` | same, + `test_the_annotation_is_not_merely_a_notice` |
| R3 "always fail" brick (dispatch removed) | `test_present_credential_rings_and_exits_zero` |
| R4 non-zero but downgraded to `::notice::` | `test_empty_credential_exits_non_zero_and_annotates` |
| R5 drop the `ring registry dispatcher` declaration | `test_a_failing_ring_leaves_the_gate_green` + `test_both_ring_jobs_are_declared_advisory` |
| R6 drop the step-summary counter | `test_empty_credential_exits_non_zero_and_annotates` |
| R7 **instrument sabotage** (`gh` stub always reports a dispatch) | `test_empty_credential_exits_non_zero_and_annotates` |

## The test does not grep — it executes

`scripts/tests/test_ring_credential_loud.py` **extracts each ring job's real `run:` script structurally from the live YAML** (via PyYAML, so a comment cannot satisfy it) and **executes it under bash** with a stubbed `gh` on PATH, asserting the process exit code, the emitted workflow commands, and whether the privileged dispatch was actually attempted — in **both** credential states. It also drives the real `ci_summary_gate.render_verdict()` to prove the new failure cannot gate, with an **anti-vacuity control** (an undeclared lane failing MUST still red the gate) and a **quantifier-direction test** (declaring the doorbells must not forgive a real gating leg).

`scripts/tests/fast-fix-ring.golden.yml` is regenerated: the #3475 whole-file byte-pin correctly went RED on my edit first, and `--self-test`'s 17 negative fixtures still pass.

## What this does **not** fix

- **It does not provision the secret.** That is the maintainer's, and I have not attempted to work around it. This PR only makes the absence impossible to miss. **`REGISTRY_RING_TOKEN` is still absent, so on merge both lanes begin failing immediately** — that is the intended signal, and the two exits are: provision the secret (or switch to the `ORCHESTRATOR_APP_*` credentials already in this repo, which also addresses the long-lived-cross-repo-PAT concern in the `fast-fix-ring` header re #3474), **or delete both jobs** if the ring is no longer wanted. Both annotations say so.
- **It does not make the failure rate-limited or deduped.** Expect ~25–60/day from `fast-fix-ring` and 50–103/day from `batch-merge`'s ring until one of those two decisions is taken. A rolling deduped issue would be quieter, but it needs `issues: write` on a deliberately minimal-privilege privileged workflow (#3474), which I judged the wrong trade to make unreviewed.
- **It slightly narrows the gating set**: `ring registry dispatcher` was gating (always green) and is now advisory. Justified because its success is a property of an *external* repo's dispatch endpoint, never of the commit under test — the same rationale as the existing `merge-group doorbell (advisory)` entry. `test_declaring_the_rings_does_not_forgive_a_real_gating_failure` pins that this did not weaken the gate for the commit's own legs.
- **`.github/workflows/pr-backlog.yml:96` `EXCLUDE_PR: "2431"`** (dead config noted in the issue) is untouched — unrelated to the credential.

---
Not armed — for independent review.
