### PR TITLE
fix(ci): bound selection-alarm's suspect-PR render and NAME what it omits (#4984)

### DIFF
--- a/scripts/ci_selection_alarm.py
+++ b/scripts/ci_selection_alarm.py
@@ -96,6 +96,30 @@ KEY_PREFIX = "selection-alarm-key"
 # Job conclusions that count as a "failed" nightly job.
 FAILED_CONCLUSIONS = {"failure", "timed_out"}
 
+# How many suspect PRs a rendered issue body LISTS. [OPUS-5] sparq-org/sparq#4984.
+#
+# WHY A CAP AT ALL. The suspect set is every PR that selection-skipped the crate in
+# the window (last green nightly, HEAD] — so it grows with the AGE OF THE BACKSTOP,
+# not with the size of the bug. MEASURED 2026-07-28 against real nightly
+# 30333511110: 644 / 579 / 554 suspects per finding in 18,064 / 16,329 / 15,755-char
+# bodies, because the last GREEN nightly was 2026-07-01. Unbounded that reaches
+# GitHub's 65,536-char issue-body limit at roughly 2,300 suspects, where
+# `gh issue create` 422s and create_issue()'s AlarmError escapes main()'s try.
+#
+# WHAT THE CAP IS NOT. It is not a fix for the stale backstop and it does not narrow
+# the correlation: `correlate` still computes the FULL suspect set, dedupe still keys
+# on the same marker, and the omitted COUNT is always stated in the body. A 644-entry
+# list is a TRUE statement about a 28-day gap; the defect is that it is unreadable.
+# Silent truncation would turn a true-but-unreadable body into a false one.
+#
+# WHY 20. It is a page a human actually reads. Past ~20 candidates the response to a
+# suspect list stops being "read it" and becomes "bisect", and the body says so.
+MAX_RENDERED_SUSPECTS = 20
+
+# Stable token marking the truncation disclosure. Present IFF suspects were omitted,
+# so its ABSENCE is the machine-checkable form of "this list is complete".
+SUSPECT_OMISSION_MARKER = "more suspect PR(s) not listed"
+
 # RUN-level conclusions for which an EMPTY genuinely-failed-job set is ANOMALOUS
 # (fail-loud, invariant 1). [OPUS-5] sparq-org/sparq#4965.
 #
@@ -284,6 +308,62 @@ def key_marker(key: str) -> str:
     return f"<!-- {KEY_PREFIX}: {key} -->"
 
 
+def _suspect_row(wc: WindowCommit, kind: str) -> str:
+    row = f"- {_pr_ref(wc)} (`{wc.sha[:12]}`)"
+    if kind == "triage":
+        # Triage cannot name the failing crate from the job, so each suspect's
+        # skip-set is what a human narrows from. Bounded by the WORKSPACE size, not
+        # by the window, so it is not the dimension #4984 caps.
+        row += f" — skipped: {', '.join(sorted(wc.skipped))}"
+    return row
+
+
+def render_suspects(
+    suspects: list[WindowCommit], kind: str, cap: int = MAX_RENDERED_SUSPECTS
+) -> str:
+    """The suspect-PR block, BOUNDED at `cap` rows, disclosing any omission by COUNT.
+
+    ORDERING — landing recency, NEWEST FIRST. This is the INPUT order, not a re-sort:
+    `window_commits` reads `git log <base>..<head>`, which is reverse-chronological;
+    `build_window` appends in that order; and `correlate` appends into
+    `skip_to_prs[crate]` (and filters `window` for triage) in that order too. So
+    `Finding.suspect_prs` arrives newest-landed first. `WindowCommit` carries no
+    timestamp, so the render cannot re-derive this — it is an invariant of the
+    pipeline above, pinned by TestSuspectOrderIsLandingRecency.
+
+    WHY newest-first is the defensible end to keep. Every PR that landed AFTER a
+    given suspect and that AFFECTED the failing crate re-ran that crate's lanes on a
+    tree already containing the suspect. So the older a suspect is, the more
+    independent chances its breakage has already had to surface elsewhere, and the
+    newest suspects are the ones with the least intervening coverage. That is a
+    PRIOR, not an exoneration — per-PR selected lanes are narrower than the nightly
+    full matrix, so an older suspect is not cleared — which is exactly why the
+    omitted count is STATED rather than dropped.
+    """
+    cap = max(cap, 0)
+    total = len(suspects)
+    shown = suspects[:cap]
+    lines = [_suspect_row(wc, kind) for wc in shown]
+    omitted = total - len(shown)
+    if omitted:
+        # Never a silent truncation: the count, the total, the cap, and the ordering
+        # basis all appear, so the reader can tell what was dropped and why.
+        lines.append(
+            f"\n> ⚠️ **{omitted} {SUSPECT_OMISSION_MARKER}.** {total} landed PR(s) "
+            f"are in this finding's suspect set; the {len(shown)} above are the most "
+            f"recently landed, capped at {cap} for legibility.\n"
+            f"> **Ordering is landing recency, newest first.** A suspect that landed "
+            f"earlier has had more subsequent PRs re-run this crate's lanes on top of "
+            f"it, so it is the less likely culprit — a prior, not an exoneration. Past "
+            f"~{cap} candidates, bisect the window rather than read the list.\n"
+            f"> A suspect list this long means the last GREEN nightly is far behind "
+            f"HEAD — the window, not the bug, is what is large. The full set is "
+            f"unchanged in the correlation and reproducible with "
+            f"`scripts/ci_selection_alarm.py --run-id <id> --head-sha <sha> --dry-run`."
+        )
+    return "\n".join(lines)
+
+
 def render_issue(f: Finding, run_id: str, head_sha: str, repo: str | None) -> tuple[str, str]:
     """Return (title, body) for a finding."""
     run_url = (
@@ -317,16 +397,13 @@ def render_issue(f: Finding, run_id: str, head_sha: str, repo: str | None) -> tu
             "then check whether it was among the skipped crates listed."
         )
 
-    prs = "\n".join(
-        f"- {_pr_ref(wc)} (`{wc.sha[:12]}`)"
-        + (f" — skipped: {', '.join(sorted(wc.skipped))}" if f.kind == "triage" else "")
-        for wc in f.suspect_prs
-    )
+    prs = render_suspects(f.suspect_prs, f.kind)
     jobs = "\n".join(f"- `{j}`" for j in f.failed_jobs)
     body = (
         f"{lead}\n\n"
         f"**Failed nightly job(s):**\n{jobs}\n\n"
-        f"**Suspect landed PR(s)** (selection-skipped since last green nightly):\n"
+        f"**Suspect landed PR(s)** — {len(f.suspect_prs)} total, selection-skipped "
+        f"since the last green nightly, newest-landed first:\n"
         f"{prs}\n\n"
         f"**Nightly run:** {run_url} (head `{head_sha[:12]}`)\n\n"
         f"This is a DETECTOR signal, not a proof: a nightly failure can also be a "

--- a/scripts/tests/test_ci_selection_alarm.py
+++ b/scripts/tests/test_ci_selection_alarm.py
@@ -202,6 +202,223 @@ class TestRenderIssue(unittest.TestCase):
         self.assertIn("sparq-vectors", body)  # skipped set shown for triage
 
 
+# --------------------------------------------------------------------------- #
+# #4984 — THE RENDERED SUSPECT LIST
+# --------------------------------------------------------------------------- #
+
+# MEASURED 2026-07-28 by driving real nightly run 30333511110 through the real
+# script (`--dry-run`, real gh + git replay + cargo metadata): the `crate:` findings
+# carried 644 / 579 / 554 suspect PRs in 18,064 / 16,329 / 15,755-char bodies. The
+# suspect set tracks the AGE OF THE BACKSTOP (last green nightly 2026-07-01), not the
+# size of the bug, and dedupe is per-key — so the FIRST render of a key is the ONLY
+# render, and whatever body lands is what persists.
+MEASURED_SUSPECT_COUNT = 644
+
+# GitHub's hard issue-body limit. Past it `gh issue create` 422s.
+GITHUB_ISSUE_BODY_LIMIT = 65_536
+
+SUSPECT_SECTION_HEADER = "**Suspect landed PR(s)**"
+SUSPECT_SECTION_END = "**Nightly run:**"
+
+# The disclosed count, read back out of the rendered body.
+_OMITTED_RE = re.compile(r"\*\*(\d+) more suspect PR\(s\) not listed\.\*\*")
+
+
+def _suspect_rows(body: str) -> list[str]:
+    """The list rows of the rendered suspect section.
+
+    Sliced between two FULL, distinctive anchor strings rather than split on a bare
+    token — a substring that also occurs inside another word would silently truncate
+    what this examines, and a row-count instrument that under-counts fails toward
+    'the cap is working'. Both anchors are looked up with `.index`, so a rename REDs
+    here instead of returning a plausible empty list. Validated against a known
+    answer in test_short_list_renders_in_full_with_no_omission_notice (3 suspects in
+    => exactly 3 rows out)."""
+    start = body.index(SUSPECT_SECTION_HEADER)
+    end = body.index(SUSPECT_SECTION_END, start)
+    return [ln for ln in body[start:end].splitlines() if ln.startswith("- ")]
+
+
+def _suspects(count: int, skipped: set[str], newest_pr: int = 20_000):
+    """`count` suspects in WINDOW order — newest-landed first, as `git log` and
+    `correlate` produce them. PR numbers DESCEND from `newest_pr` so the test can
+    tell which end of the list survived the cap."""
+    return [
+        _wc(sha=f"{i:040x}", pr=newest_pr - i, skipped=skipped) for i in range(count)
+    ]
+
+
+def _crate_finding(suspects) -> "A.Finding":
+    return A.Finding(
+        kind="crate", key="crate:sparq-fedplan", crate="sparq-fedplan",
+        failed_jobs=["mutation ratchet (cargo-mutants, advisory) (sparq-fedplan)"],
+        suspect_prs=suspects,
+    )
+
+
+class TestSuspectOrderIsLandingRecency(unittest.TestCase):
+    """The render truncates from ONE end and tells the reader that end is 'newest
+    landed'. `WindowCommit` carries no timestamp, so that claim is not re-derivable
+    at the render — it rests on `correlate` PRESERVING the order `git log` produced.
+    These pin that invariant, so the ordering the body advertises cannot quietly
+    become an arbitrary slice of an unordered set."""
+
+    # `git log` emits reverse-chronological; `window_commits` does not re-sort. So a
+    # window is newest-landed FIRST, and here PR numbers descend to encode that.
+    WINDOW_PRS = [1006, 1005, 1004, 1003, 1002, 1001]
+
+    def _window(self, skipped: set[str]):
+        return [_wc(f"{pr:040d}", pr, skipped) for pr in self.WINDOW_PRS]
+
+    def test_crate_finding_preserves_window_order(self):
+        window = self._window({"sparq-geo"})
+        findings = A.correlate(["opt-in sparq-geo (geosparql)"], window, MEMBERS)
+        self.assertEqual(
+            [wc.pr for wc in findings[0].suspect_prs], self.WINDOW_PRS,
+            "correlate reordered the suspects; the rendered list claims "
+            "'newest-landed first' and would then be lying",
+        )
+
+    def test_triage_finding_preserves_window_order(self):
+        window = self._window({"sparq-geo"})
+        findings = A.correlate(["test (load-aware shard bulk 1/3)"], window, MEMBERS)
+        self.assertEqual(
+            [wc.pr for wc in findings[0].suspect_prs], self.WINDOW_PRS,
+            "the triage suspect list must also stay in landing order",
+        )
+
+    def test_the_cap_keeps_the_NEWEST_suspects_not_an_arbitrary_slice(self):
+        """CRITERION 3. Which END survives is the whole ordering claim. Keeping the
+        oldest — or any middle slice — would still 'render within a bound' and still
+        state an omitted count, and would still be wrong."""
+        suspects = _suspects(MEASURED_SUSPECT_COUNT, {"sparq-fedplan"}, newest_pr=20_000)
+        self.assertEqual(suspects[0].pr, 20_000, "fixture must be newest-first")
+        _title, body = A.render_issue(_crate_finding(suspects), "1", "a" * 40, None)
+        rows = _suspect_rows(body)
+        # The 20 newest landed are PRs 20000, 19999, … 19981 — descending, in order.
+        self.assertEqual(
+            [int(re.match(r"- #(\d+) ", r).group(1)) for r in rows],
+            list(range(20_000, 19_980, -1)),
+            "the cap must keep the 20 most recently landed suspects, in that order",
+        )
+
+
+class TestSuspectListBound(unittest.TestCase):
+    """CRITERION 1 + 2. A stale-backstop suspect list must render BOUNDED and NAME
+    what it omitted; a short list must render IN FULL. The pair is load-bearing —
+    criterion 1 alone is satisfiable by always truncating, which would make every
+    complete list look incomplete."""
+
+    def test_644_suspects_render_bounded_and_name_the_omitted_count(self):
+        """CRITERION 1, at the measured size. Delete the cap and every assertion here
+        REDs: 644 rows rendered, no disclosure regex match, body back over 18 KB."""
+        suspects = _suspects(MEASURED_SUSPECT_COUNT, {"sparq-fedplan"})
+        _title, body = A.render_issue(
+            _crate_finding(suspects), "30333511110", "6" * 40, "sparq-org/sparq"
+        )
+        rows = _suspect_rows(body)
+        # The stated bound: 20 rows. A literal, not a read-back of the constant —
+        # changing MAX_RENDERED_SUSPECTS must force the bound to be re-stated here.
+        self.assertEqual(len(rows), 20, f"suspect list not capped at 20 rows: {len(rows)}")
+
+        m = _OMITTED_RE.search(body)
+        self.assertIsNotNone(m, f"644 suspects rendered as 20 rows with NO omission "
+                                f"notice — that is silent truncation:\n{body}")
+        # 644 suspects - 20 rendered = 624 omitted. Arithmetic done here, not copied
+        # from the implementation.
+        self.assertEqual(int(m.group(1)), 624)
+        # …and the disclosure must match what was ACTUALLY rendered, so a body cannot
+        # state a bound it did not honour.
+        self.assertEqual(int(m.group(1)), MEASURED_SUSPECT_COUNT - len(rows))
+        # The total is stated too, so the reader never has to add the two numbers.
+        self.assertIn("644 total", body)
+
+    def test_body_size_no_longer_tracks_the_window(self):
+        """The actual defect: body length was a function of BACKSTOP AGE. After the
+        cap, growing the window 3.6x must not grow the body — only the digits of the
+        printed total change. Measured pre-fix: 644 suspects => 18,064 chars."""
+        small = A.render_issue(
+            _crate_finding(_suspects(644, {"sparq-fedplan"})), "1", "a" * 40, None)[1]
+        # 2,300 is where an UNCAPPED body crosses GitHub's 65,536-char limit.
+        huge = A.render_issue(
+            _crate_finding(_suspects(2_300, {"sparq-fedplan"})), "1", "a" * 40, None)[1]
+        self.assertLess(
+            abs(len(huge) - len(small)), 50,
+            f"body still grows with the window: {len(small)} -> {len(huge)} chars",
+        )
+        self.assertLess(len(huge), 4_000, "crate-finding body exceeded its stated bound")
+        self.assertLess(len(huge), GITHUB_ISSUE_BODY_LIMIT)
+
+    def test_triage_body_is_bounded_too(self):
+        """Triage rows also carry each suspect's whole skip-set, so they are the
+        widest rows the alarm renders. That width is O(workspace), not O(window) —
+        but the ROW COUNT is the window-dependent term and must be capped here too."""
+        members = {f"sparq-{i:02d}" for i in range(37)}  # real workspace order of size
+        suspects = _suspects(MEASURED_SUSPECT_COUNT, members)
+        f = A.Finding(kind="triage", key="triage:test (load-aware shard bulk 1/3)",
+                      crate=None, failed_jobs=["test (load-aware shard bulk 1/3)"],
+                      suspect_prs=suspects)
+        _title, body = A.render_issue(f, "1", "a" * 40, None)
+        self.assertEqual(len(_suspect_rows(body)), 20)
+        self.assertIn("624 " + A.SUSPECT_OMISSION_MARKER, body)
+        self.assertLess(len(body), 20_000, "triage body exceeded its stated bound")
+        # …and the per-row skip-set survives the cap — it is what triage narrows from.
+        self.assertIn("— skipped: sparq-00", body)
+
+    def test_short_list_renders_in_full_with_no_omission_notice(self):
+        """CRITERION 2, the PAIRED property. Without it, `suspects[:0]` — truncate
+        everything, always — passes criterion 1. Also the KNOWN-ANSWER validation of
+        the `_suspect_rows` instrument: 3 suspects in, exactly 3 rows out."""
+        suspects = _suspects(3, {"sparq-fedplan"}, newest_pr=100)
+        _title, body = A.render_issue(_crate_finding(suspects), "1", "a" * 40, None)
+        rows = _suspect_rows(body)
+        self.assertEqual(len(rows), 3, f"a 3-suspect list must render in full:\n{body}")
+        for pr in (100, 99, 98):
+            self.assertIn(f"#{pr}", body, "every suspect of a short list must appear")
+        self.assertNotIn(
+            A.SUSPECT_OMISSION_MARKER, body,
+            "a COMPLETE list must carry no omission notice — otherwise the notice "
+            "means nothing and 'omitted' stops being readable as a signal",
+        )
+        self.assertIsNone(_OMITTED_RE.search(body))
+        self.assertIn("3 total", body)
+
+    def test_exactly_at_the_cap_renders_in_full(self):
+        """OFF-BY-ONE, complete side. 20 suspects is not an omission; a `<` where
+        `<=` belongs would claim '0 more not listed' on a complete list."""
+        _title, body = A.render_issue(
+            _crate_finding(_suspects(20, {"sparq-fedplan"})), "1", "a" * 40, None)
+        self.assertEqual(len(_suspect_rows(body)), 20)
+        self.assertNotIn(A.SUSPECT_OMISSION_MARKER, body)
+
+    def test_one_over_the_cap_discloses_exactly_one_omission(self):
+        """OFF-BY-ONE, truncated side. 21 suspects, 20 rendered => exactly 1 omitted."""
+        _title, body = A.render_issue(
+            _crate_finding(_suspects(21, {"sparq-fedplan"})), "1", "a" * 40, None)
+        rows = _suspect_rows(body)
+        self.assertEqual(len(rows), 20)
+        m = _OMITTED_RE.search(body)
+        self.assertIsNotNone(m, f"21 suspects capped at 20 must disclose:\n{body}")
+        self.assertEqual(int(m.group(1)), 1)
+
+    def test_the_notice_states_the_ordering_basis_and_the_real_cause(self):
+        """CRITERION 3 + the anti-suppression rule. A bounded list that does not say
+        HOW it was ordered is an arbitrary first-N wearing a judgement's clothes; and
+        the body must point at the stale backstop rather than imply the alarm is
+        noisy."""
+        _title, body = A.render_issue(
+            _crate_finding(_suspects(644, {"sparq-fedplan"})), "1", "a" * 40, None)
+        self.assertIn("Ordering is landing recency, newest first", body)
+        self.assertIn("last GREEN nightly is far behind HEAD", body)
+        self.assertIn("--dry-run", body)  # the full set stays reproducible
+
+    def test_render_suspects_never_drops_rows_on_a_nonsense_cap(self):
+        """A negative cap must not silently become a from-the-end slice
+        (`suspects[:-1]` quietly drops the OLDEST suspect and discloses nothing)."""
+        out = A.render_suspects(_suspects(5, {"x"}), "crate", cap=-1)
+        self.assertIn("5 " + A.SUSPECT_OMISSION_MARKER, out)
+
+
 class TestCliFailLoud(unittest.TestCase):
     """The CLI must exit NON-ZERO on any infra gap (fail-loud), never mask."""
 


### PR DESCRIPTION
> 🤖 SPARQ agent

Fixes #4984

**Head SHA:** `69e1721ca9e75e20619efcda1ba277ad369d03fd`

## Why this is time-boxed to tonight

`selection-alarm` was **inert** until PR #4982 merged at **05:01Z today**: its job `if:`
admitted only `conclusion == 'failure'`, while a fail-fast nightly concludes `cancelled`
(35 `cancelled` / 7 `success` / 3 `failure` all-time; 266 of 267 alarm runs job-SKIPPED;
last action 2026-07-19). #4982 moved admission into the script over the real jobs API, so
**it will fire again at the next nightly** (`17 3 * * *` on `ci.yml`).

Its backstop is **28 days stale** — last green nightly 2026-07-01 — so the first real
firing renders **644 / 579 / 554** suspect PRs in **18,064 / 16,329 / 15,755-char** bodies
(MEASURED against real nightly `30333511110`).

**Dedupe is per-key, so the first render of a key is the only render.** Whatever body
lands persists; a later cap will not rewrite it.

Verified against the authoritative source — `open_issue_exists()` lists `--state open`
only, so I enumerated the live body markers rather than titles or an all-states listing
(my first pass used `--state all` and got this wrong):

| dedupe key | measured suspects | open issue? | next nightly |
|---|---|---|---|
| `crate:sparq-fedplan` | **644** (18,064 chars) | none | **mints fresh** |
| `crate:sparq-reason` | **554** (15,755 chars) | #3614 **CLOSED** 2026-07-28 | **mints fresh** |
| `crate:sparq-mpc` | 579 (16,329 chars) | #3613 open | deduped, skipped |
| `crate:sparq-core` | — | #3612 open | deduped, skipped |

So **two** of the three measured findings render for the first and only time at the next
nightly, not one. A closed issue does not suppress its key.

## What this changes

The suspect set tracks the **age of the backstop**, not the size of the bug. 644 entries
is a *true* statement about a 28-day gap — the defect is that it is unreadable, not that
it is wrong. So this caps the **render only**:

- `correlate` still computes the **full** suspect set. The window is unchanged, the alarm
  is not suppressed, and dedupe keys are untouched.
- At most `MAX_RENDERED_SUSPECTS` (**20**) rows. The **omitted count**, the **total**, the
  **cap**, and the **ordering basis** are all stated in the body. Never a silent
  truncation.
- A list **at or under** the cap renders **in full with no omission notice**, so the cap
  cannot be satisfied by always truncating.

### Ordering basis

**Landing recency, newest first** — and it is the *input* order, not a re-sort: `git log`
is reverse-chronological, `window_commits` and `build_window` append in that order, and
`correlate` preserves it into `skip_to_prs[crate]` (and into the triage filter).

It is defensible rather than an arbitrary first-N: **every PR that landed after a given
suspect and that *affected* the failing crate re-ran that crate's lanes on a tree already
containing the suspect**, so the older a suspect is, the more independent chances its
breakage has already had to surface. The newest suspects have the least intervening
coverage.

That is a **prior, not an exoneration** — per-PR selected lanes are narrower than the
nightly full matrix, so an older suspect is not cleared. Which is exactly why the omitted
count is *stated* rather than dropped. `WindowCommit` carries no timestamp, so the render
cannot re-derive this ordering; `TestSuspectOrderIsLandingRecency` pins the invariant it
rests on.

### Measured result

| finding | before | after |
|---|---|---|
| `crate:` @ 644 suspects | 18,064 chars | **2,512** |
| `crate:` @ 2,300 suspects | > 65,536 (422) | **2,515** |
| `triage:` @ 644 suspects, 37-member workspace | — | **14,070** |

Body length **no longer tracks the window at all**: 644 vs 2,300 suspects differ by 3
chars — the digits of the printed total. The ~2,300-suspect hard failure against GitHub's
65,536-char limit is now unreachable.

## Verification

- **Control GREEN first**: 40 tests OK on the unmutated tree, *before* any mutation count
  was trusted. Sibling `test_alarm_lanes_non_gating.py` 9 OK; `test_banned_terminology.py`
  23 OK; `typos` rc=0.
- **Known positive**: the real **pre-fix** script (`git show origin/main:...`) dropped into
  the tree REDs **9** of the new tests. An instrument that cannot detect the actual,
  live defect cannot certify the fix.
- **15/15 mutants killed**, on **whole-tree** copies (the suite reads
  `.github/workflows/*`; a `scripts/`-only copy yields phantom kills). The harness refuses
  to score a mutant whose `sed` matched nothing, so a no-op cannot be counted as a kill.

| mutant | killed by |
|---|---|
| `no-cap-at-all` | 7 tests |
| `silent-truncation` (drop the notice) | 5 |
| `always-claim-omitted` | 2 — incl. the short-list pair |
| `keep-oldest-not-newest` | `..._keeps_the_NEWEST_suspects_not_an_arbitrary_slice` |
| `off-by-one-rows` | 6 |
| `wrong-omitted-count` | 6 |
| `hardcoded-tiny-cap` (`[:3]`) | 6 |
| `drop-negative-guard` | `..._never_drops_rows_on_a_nonsense_cap` |
| `drop-ordering-basis` / `drop-stale-backstop` / `drop-repro-hint` | `..._states_the_ordering_basis_and_the_real_cause` |
| `drop-total-in-header` | 2 |
| `correlate-resorts` / `triage-resorts` | the two order-preservation tests |
| `triage-drops-skipset` | 2 |

On expected values: the 644-suspect test asserts the literal **624** omitted (arithmetic
done in the test, not copied from the implementation) **and** that the disclosed count
equals `644 − rows actually rendered in the body`, so a body cannot state a bound it did
not honour. The row-counting extractor slices between two full, distinctive anchors via
`.index` (a rename REDs rather than returning a plausible empty list) and is
**validated against a known answer** — 3 suspects in, exactly 3 rows out — because a
row-count instrument that under-counts fails toward "the cap is working".

## What this does NOT fix

- **The 28-day-stale backstop.** Out of scope by design; filed as **#5025** with the
  measurement and the likely cause (fail-fast cancellation may make a run-level `success`
  structurally unreachable, so `last_green_nightly_sha()` is the last place still trusting
  the lossy aggregate #4982 moved off). This PR does **not** widen the lookback window and
  does **not** suppress the alarm — both would make it lie.
- **Triage-row width.** A `triage:` row still carries that suspect's whole skip-set, so a
  37-member workspace gives ~14 KB bodies. That width is `O(workspace)`, not `O(window)` —
  it is not the unbounded dimension, and capping it would add a second truncation site and
  a second disclosure for no bound improvement.
- **`failed_jobs` is uncapped.** Bounded by one run's job count (~84), not by the window.
- **`open_issue_exists()` still lists with `--limit 100`.** Same silent-truncation class as
  the render defect — if the open `selection-alarm` set ever exceeds 100, dedupe would
  quietly start minting duplicates. Not currently reachable (2 open) and out of scope here;
  noting it because it is the same failure mode, one layer over.
- It does not change which PRs are suspects, the dedupe keys, the fail-loud invariants, or
  the admission seam from #4982.

## Reviewer notes

Diff is **+300 / −6** across 2 files, no workflow change. The load-bearing questions:
1. Is **newest-first** the right end to keep, and is the intervening-coverage argument
   sound as a *prior*?
2. Is **20** the right bound?
3. `TestSuspectOrderIsLandingRecency` is the only thing standing between the body's
   "newest-landed first" claim and it becoming an arbitrary slice — is it pinned at the
   right layer?

Verified against `origin/main` via `git show origin/main:<path>`, not the local checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
