### PR TITLE
ci(guard): refuse a --self-test that can write to a live repo (#5098)

### DIFF
--- a/.github/workflows/routing-self-tests.yml
+++ b/.github/workflows/routing-self-tests.yml
@@ -108,6 +108,14 @@ on:
       - "scripts/tests/test_start_here_render.py"
       - ".github/workflows/refresh-start-here.yml"
       - ".github/workflows/routing-self-tests.yml"
+      # [OPUS-5] sparq#5098 — the SELF-TEST WRITE GUARD's scan surface. It scans
+      # `scripts/**/*.py` for a self-test that can reach a live write (the shape that posted four
+      # real comments to #7/#8 from `--selftest`), so its trigger must be the same DIRECTORY GLOB
+      # rather than an enumeration: the offending file, `retriage-needs-user.py`, did not exist
+      # when this filter was written, and an enumeration cannot name a script that does not exist
+      # yet. That is the same reasoning already applied to `.claude/workflows/*.js` above. This
+      # lane is seconds-cheap and does no build, so widening it to every script is affordable.
+      - "scripts/**/*.py"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
       # and defers EVERY issue, so a drift in the deriver, its declared table, or the
@@ -209,6 +217,14 @@ on:
       - "scripts/tests/test_start_here_render.py"
       - ".github/workflows/refresh-start-here.yml"
       - ".github/workflows/routing-self-tests.yml"
+      # [OPUS-5] sparq#5098 — the SELF-TEST WRITE GUARD's scan surface. It scans
+      # `scripts/**/*.py` for a self-test that can reach a live write (the shape that posted four
+      # real comments to #7/#8 from `--selftest`), so its trigger must be the same DIRECTORY GLOB
+      # rather than an enumeration: the offending file, `retriage-needs-user.py`, did not exist
+      # when this filter was written, and an enumeration cannot name a script that does not exist
+      # yet. That is the same reasoning already applied to `.claude/workflows/*.js` above. This
+      # lane is seconds-cheap and does no build, so widening it to every script is affordable.
+      - "scripts/**/*.py"
       # [OPUS-5] reg#677 — PR `area:` attribution. The scheduler partitions by
       # `area:<name>`; an unlabelled PR takes the serializing `__global__` partition
       # and defers EVERY issue, so a drift in the deriver, its declared table, or the
@@ -267,6 +283,10 @@ jobs:
           # orchestration/start-here.toml (a malformed curated file must fail on ITS PR, not at the
           # next scheduled refresh of the maintainer's front door); the suite pins the drop /
           # fail-closed / truncation rules and refresh-start-here.yml's own wiring.
+          # [OPUS-5] sparq#5098: no `--self-test` anywhere under scripts/ may reach a live
+          # write. Static (AST) — it never imports or runs the files it scans. The suite also
+          # pins its OWN wiring here structurally, so `if: false` on this job or this step reds it.
+          python3 scripts/tests/test_selftest_never_writes.py
           python3 scripts/render-start-here.py --self-test
           python3 scripts/tests/test_start_here_render.py
 

--- a/scripts/selftest_write_guard.py
+++ b/scripts/selftest_write_guard.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# [OPUS-5] 🤖 SPARQ agent — static guard: a self-test must not be able to write to a live repo.
+#
+# WHY THIS EXISTS (sparq-org/sparq#5098)
+# --------------------------------------
+# `scripts/retriage-needs-user.py` (PR #4184) self-tested its "never writes" guard by CALLING the
+# real write function with writes enabled:
+#
+#     apply_one({"n": 7}, "keep", ["needs:user"], [], "r", dry_run=False, log=lambda *_: None)
+#
+# `apply_one`'s `repo` parameter defaulted to the module constant `REPO = "sparq-org/sparq"`, and
+# its body shells out through `_run` -> `subprocess.run(["gh", "issue", ...])`. The ONLY thing
+# standing between `--selftest` and a production mutation was the `if action in ("keep", "skip"):
+# return False` early-out — i.e. the very branch the assertion existed to test. Mutate that branch
+# (which the PR itself advertised as its verification method) and the self-test posts a real comment
+# to a real issue. It did: comments 5084272766 / 5092788561 on #7 and 5098073828 / 5117974900 on #8,
+# both closed dependabot PRs, each rendering the fixture reason string "r".
+#
+# A test whose safety depends on the correctness of the code under test is not a test. This module
+# is the structural repair, expressed as two rules that hold for the whole `scripts/` tree.
+#
+# RULE 1 — NO LIVE DEFAULT TARGET (`live-default-target`)
+#   A function that takes a dry-run-style parameter is a WRITE function. It may not give its
+#   target-repository parameter a default that resolves to a live repository slug, directly or via
+#   a module-level constant. The write target must be named at every call site, so no caller can
+#   inherit production by omission.
+#
+# RULE 2 — NO REACHABLE SUBPROCESS FROM A WRITE-ENABLED SELF-TEST (`selftest-writes-live`)
+#   Inside a self-test, a call that enables writes (`dry_run=False`, `apply=True`, ...) is a
+#   violation when the callee can still reach a real subprocess/network seam. The exemption is
+#   NEUTRALISATION, not intent: the self-test must rebind (`global` + assign) every seam reachable
+#   from the callee's call graph before the call. That is the pattern `scripts/batch-merge.py`
+#   already uses correctly — it swaps `run_git`/`run_gh` for recorders and restores them in a
+#   `finally` — and it is exactly what `retriage-needs-user.py` did not do.
+#
+# The write-enabling keyword set and the live-owner set are DECLARED below rather than inferred, so
+# widening the guard's blast radius is a reviewable diff. The suite
+# `scripts/tests/test_selftest_never_writes.py` validates this detector against known-positive
+# fixtures (including the verbatim #5098 shape) before it is ever run over the tree — an
+# instrument that has only ever been run on a clean tree has not been shown to detect anything.
+#
+# Stdlib only. Pure functions over source text: no import, no execution of the scanned files.
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# A call passing one of these keyword=literal pairs is ENABLING WRITES.
+WRITE_ENABLING = {
+    "dry_run": False,
+    "dryrun": False,
+    "no_dry_run": True,
+    "apply": True,
+    "write": True,
+    "live": True,
+}
+# Parameters that name the repository a write lands in.
+TARGET_PARAM = re.compile(r"^(repo|repository|owner_repo|target_repo|slug)$")
+# Parameter names that make a function a WRITE function for rule 1.
+DRY_RUN_PARAMS = frozenset(WRITE_ENABLING)
+# `owner/name`.
+SLUG = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9._-]+$")
+# Owners whose repositories are LIVE. A fixture slug (`fixture/repo`, `acme/widget`) is fine; these
+# are the ones a stray `gh` invocation actually mutates.
+LIVE_OWNERS = frozenset({"sparq-org", "jeswr"})
+# A function is a self-test entry point when its name matches. `--self-test` / `--selftest` argv
+# dispatch in this tree always lands on one of these.
+SELFTEST_NAME = re.compile(r"^_?(self_?test|selftest)", re.IGNORECASE)
+# Real-world side-effect seams. Reaching one of these from a write-enabled self-test call is the
+# failure; `gh`/`git` in this tree are always spawned through `subprocess`.
+SEAM_ROOTS = frozenset({"subprocess", "urllib", "requests", "socket", "httpx"})
+SEAM_CALLS = frozenset({"os.system", "os.popen", "os.remove", "os.rename"})
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line: int
+    rule: str
+    detail: str
+
+    def __str__(self) -> str:  # pragma: no cover - formatting only
+        return f"{self.path}:{self.line}: [{self.rule}] {self.detail}"
+
+
+def _str_constants(tree: ast.Module) -> dict[str, str]:
+    """Module-level `NAME = "literal"` bindings, so `repo=REPO` resolves to its value."""
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    out[target.id] = node.value.value
+    return out
+
+
+def _resolve_str(node: ast.expr | None, consts: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return consts.get(node.id)
+    return None
+
+
+def is_live_slug(value: str | None) -> bool:
+    return bool(value) and bool(SLUG.match(value)) and value.split("/")[0] in LIVE_OWNERS
+
+
+def _functions(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Module-level function definitions by name (the call-graph nodes we can resolve)."""
+    return {n.name: n for n in tree.body
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))}
+
+
+def _calls_in(fn: ast.AST) -> list[str]:
+    return [ast.unparse(c.func) for c in ast.walk(fn) if isinstance(c, ast.Call)]
+
+
+def _is_seam_call(name: str) -> bool:
+    return name.split(".")[0] in SEAM_ROOTS or name in SEAM_CALLS
+
+
+def direct_seams(tree: ast.Module) -> set[str]:
+    """Module-level functions that themselves touch a side-effect seam."""
+    return {name for name, fn in _functions(tree).items()
+            if any(_is_seam_call(c) for c in _calls_in(fn))}
+
+
+def seams_reachable_from(name: str, tree: ast.Module) -> set[str] | None:
+    """Every seam function reachable from `name` in this module's call graph.
+
+    Returns None when `name` is not a module-level function here — the callee lives in another
+    module and this file-local analysis cannot see its seams. Callers must then fall back to the
+    live-target test (rule 1 guarantees such a callee cannot default to production).
+    """
+    funcs = _functions(tree)
+    if name not in funcs:
+        return None
+    seams = direct_seams(tree)
+    reached: set[str] = set()
+    seen: set[str] = set()
+    stack = [name]
+    while stack:
+        cur = stack.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        if cur in seams:
+            reached.add(cur)
+        for callee in _calls_in(funcs[cur]) if cur in funcs else []:
+            head = callee.split(".")[0]
+            if head in funcs and head not in seen:
+                stack.append(head)
+    return reached
+
+
+def neutralised_in(fn: ast.AST) -> set[str]:
+    """Module globals this function both declares `global` AND assigns — i.e. swaps for a fake."""
+    declared: set[str] = set()
+    assigned: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Global):
+            declared.update(node.names)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                for leaf in ast.walk(target):
+                    if isinstance(leaf, ast.Name):
+                        assigned.add(leaf.id)
+    return declared & assigned
+
+
+def write_enabling_kwargs(call: ast.Call) -> list[str]:
+    """`dry_run=False`-style keyword literals on this call."""
+    return [kw.arg for kw in call.keywords
+            if kw.arg in WRITE_ENABLING
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value is WRITE_ENABLING[kw.arg]]
+
+
+def _param_names(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    args = fn.args
+    return [a.arg for a in args.posonlyargs + args.args]
+
+
+def write_enabling_positional(call: ast.Call, tree: ast.Module) -> list[str]:
+    """A write-enabling literal passed POSITIONALLY — `apply_one(i, a, r, d, x, repo, False)`.
+
+    Without this a caller sidesteps the keyword form, which is the cheapest possible bypass of a
+    keyword-only guard.
+    """
+    if not isinstance(call.func, ast.Name):
+        return []
+    target = _functions(tree).get(call.func.id)
+    if target is None:
+        return []
+    names = _param_names(target)
+    found = []
+    for index, arg in enumerate(call.args):
+        if index >= len(names):
+            break
+        name = names[index]
+        if name in WRITE_ENABLING and isinstance(arg, ast.Constant) \
+                and arg.value is WRITE_ENABLING[name]:
+            found.append(name)
+    return found
+
+
+def _defaults(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> dict[str, ast.expr]:
+    args = fn.args
+    positional = args.posonlyargs + args.args
+    out: dict[str, ast.expr] = {}
+    for arg, default in zip(positional[len(positional) - len(args.defaults):], args.defaults):
+        out[arg.arg] = default
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+        if default is not None:
+            out[arg.arg] = default
+    return out
+
+
+def check_source(source: str, path: str = "<source>") -> list[Violation]:
+    """Both rules over one Python source file. Never imports or executes it."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:  # a file that does not parse is not this guard's business
+        return [Violation(path, exc.lineno or 0, "unparseable", str(exc))]
+    consts = _str_constants(tree)
+    violations: list[Violation] = []
+
+    # --- rule 1: a write function may not default its target to a live repo -------------------
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        args = fn.args
+        names = {a.arg for a in args.posonlyargs + args.args + args.kwonlyargs}
+        if not names & DRY_RUN_PARAMS:
+            continue
+        for param, default in _defaults(fn).items():
+            if not TARGET_PARAM.match(param):
+                continue
+            value = _resolve_str(default, consts)
+            if is_live_slug(value):
+                violations.append(Violation(
+                    path, fn.lineno, "live-default-target",
+                    f"{fn.name}() takes a dry-run parameter, so it is a write function, but its "
+                    f"`{param}` parameter defaults to the live repository {value!r} "
+                    f"(via `{ast.unparse(default)}`). Drop the default so every call site must "
+                    f"name the repository it writes to."))
+
+    # --- rule 2: a write-enabled self-test call may not reach a seam ---------------------------
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not SELFTEST_NAME.match(fn.name):
+            continue
+        neutralised = neutralised_in(fn)
+        for call in ast.walk(fn):
+            if not isinstance(call, ast.Call):
+                continue
+            enabling = write_enabling_kwargs(call) + write_enabling_positional(call, tree)
+            if not enabling:
+                continue
+            callee = ast.unparse(call.func)
+            reachable = seams_reachable_from(callee.split(".")[0], tree)
+            if reachable is None:
+                # Cross-module callee: rule 1 guarantees it cannot default to a live repo, so the
+                # residual risk is a live slug handed over explicitly at this call site.
+                live = [ast.unparse(a) for a in call.args
+                        if is_live_slug(_resolve_str(a, consts))]
+                live += [f"{kw.arg}={ast.unparse(kw.value)}" for kw in call.keywords
+                         if is_live_slug(_resolve_str(kw.value, consts))]
+                if live:
+                    violations.append(Violation(
+                        path, call.lineno, "selftest-writes-live",
+                        f"self-test {fn.name}() calls {callee}() with {', '.join(enabling)} "
+                        f"against the live repository ({', '.join(live)})."))
+                continue
+            exposed = sorted(reachable - neutralised)
+            if exposed:
+                violations.append(Violation(
+                    path, call.lineno, "selftest-writes-live",
+                    f"self-test {fn.name}() calls {callee}() with {', '.join(enabling)} while "
+                    f"{', '.join(exposed)} still reach{'es' if len(exposed) == 1 else ''} a real "
+                    f"subprocess. Either drop the write-enabling argument or rebind "
+                    f"{', '.join(exposed)} (`global` + assign) for the duration of the call, as "
+                    f"scripts/batch-merge.py does for run_git/run_gh."))
+    return violations
+
+
+def check_tree(root: Path) -> list[Violation]:
+    """Every `*.py` under `root`, sorted, so the report is stable."""
+    out: list[Violation] = []
+    for path in sorted(root.rglob("*.py")):
+        out.extend(check_source(path.read_text(encoding="utf-8", errors="replace"),
+                                str(path)))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else None)
+    ap.add_argument("root", nargs="?", default=str(Path(__file__).resolve().parent),
+                    help="directory to scan (default: scripts/)")
+    args = ap.parse_args(argv)
+    violations = check_tree(Path(args.root))
+    for violation in violations:
+        print(violation)
+    print(f"{'FAILED' if violations else 'ok'}: selftest-write-guard "
+          f"({len(violations)} violation(s))")
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_selftest_never_writes.py
+++ b/scripts/tests/test_selftest_never_writes.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# [OPUS-5] 🤖 SPARQ agent — guard suite for scripts/selftest_write_guard.py (sparq-org/sparq#5098).
+#
+# The defect this pins: `scripts/retriage-needs-user.py` (PR #4184) self-tested its "never writes"
+# early-out by CALLING the write function with writes enabled and the target defaulted to
+# `sparq-org/sparq`. Mutating the branch under test — which that PR advertised as its verification
+# method — turned `--selftest` into a production mutation. Four such comments are live on issues #7
+# and #8 (both closed dependabot PRs), each rendering the fixture reason string "r".
+#
+# THE FOUR FAMILIES HERE
+#
+#   1. KNOWN POSITIVES — the detector is run against the VERBATIM #5098 shape and against each
+#      bypass of it (positional literal, partial seam neutralisation, live slug handed to a
+#      cross-module callee). An instrument that has only ever been run on a clean tree has not been
+#      shown to detect anything; these are the "validate against a known answer" rows.
+#   2. KNOWN NEGATIVES — the shapes that MUST stay green: `scripts/batch-merge.py`'s correct
+#      neutralisation pattern, `dry_run=True`, a fixture-owner slug, a target parameter with no
+#      default. A guard that cannot be satisfied gets deleted.
+#   3. THE REAL TREE — `scripts/**/*.py` has no violation, AND the scan is pointed at something
+#      (non-zero self-tests / write functions / seams), so deleting the last real subject cannot
+#      silently turn the tree-scan vacuous.
+#   4. THE YAML SEAM — parsed STRUCTURALLY, never by substring. Measured in this project: every
+#      surviving mutant lived in a workflow `if:` / step / call site, and a wiring pin that greps
+#      text does NOT catch a job-level `if: false` (#5080). So: the `validate` job carries no `if:`,
+#      no run step carries an `if:`, the run block INVOKES this suite, and both `paths:` filters
+#      carry the DIRECTORY GLOB (an enumeration cannot cover a script that does not exist yet —
+#      which is precisely how `retriage-needs-user.py` would have arrived unscanned).
+#
+# Run:  python3 scripts/tests/test_selftest_never_writes.py
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+GUARD = SCRIPTS / "selftest_write_guard.py"
+ROUTING_WF = REPO_ROOT / ".github" / "workflows" / "routing-self-tests.yml"
+SCRIPTS_GLOB = "scripts/**/*.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, path
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load("selftest_write_guard", GUARD)
+
+
+def _yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on_block(wf: dict) -> dict:
+    """Bare `on` is the YAML boolean True, so PyYAML keys it under `True`."""
+    return wf.get("on", wf.get(True, {})) or {}
+
+
+def rules(source: str) -> list[str]:
+    return sorted(v.rule for v in guard.check_source(textwrap.dedent(source), "<fixture>"))
+
+
+# The #5098 defect, reduced to its load-bearing lines and otherwise verbatim.
+THE_DEFECT = '''
+    import subprocess
+    REPO = "sparq-org/sparq"
+
+    def _run(args):
+        return subprocess.run(args, capture_output=True, text=True, check=True)
+
+    def apply_one(issue, action, remove, add, reason, repo=REPO, dry_run=True, log=print):
+        if action in ("keep", "skip"):
+            return False
+        if dry_run:
+            return False
+        _run(["gh", "issue", "edit", str(issue["n"]), "--repo", repo])
+        _run(["gh", "issue", "comment", str(issue["n"]), "--repo", repo, "--body", reason])
+        return True
+
+    def _selftest():
+        assert apply_one({"n": 7}, "keep", ["needs:user"], [], "r",
+                         dry_run=False, log=lambda *_: None) is False
+'''
+
+# What `scripts/batch-merge.py` does, and what the fix for the above looks like.
+THE_SAFE_PATTERN = '''
+    import subprocess
+
+    def run_gh(argv, capture=True):
+        return subprocess.run(argv, capture_output=True, text=True).stdout
+
+    def run_git(argv, check=True):
+        return subprocess.run(argv).returncode
+
+    def execute(actions, state, dry_run=True):
+        if dry_run:
+            return
+        run_git(["merge", "x"])
+        run_gh(["pr", "create"])
+
+    def self_test():
+        calls = []
+        global run_git, run_gh
+        real_git, real_gh = run_git, run_gh
+        run_git, run_gh = lambda a, check=True: calls.append(a) or 0, lambda a, capture=True: ""
+        try:
+            execute([], {}, dry_run=False)
+        finally:
+            run_git, run_gh = real_git, real_gh
+'''
+
+
+class TestKnownPositives(unittest.TestCase):
+    """Each row is a shape the guard MUST refuse. These are the rows that go red on the defect."""
+
+    def test_the_5098_defect_trips_both_rules(self):
+        self.assertEqual(rules(THE_DEFECT),
+                         ["live-default-target", "selftest-writes-live"])
+
+    def test_selftest_calling_a_write_function_with_dry_run_false_is_refused(self):
+        """THE acceptance row for #5098: a `dry_run=False` self-test call reds this test."""
+        found = guard.check_source(textwrap.dedent(THE_DEFECT), "retriage-needs-user.py")
+        writes = [v for v in found if v.rule == "selftest-writes-live"]
+        self.assertEqual(len(writes), 1, found)
+        self.assertIn("dry_run", writes[0].detail)
+        self.assertIn("_run", writes[0].detail)
+
+    def test_positional_write_literal_is_not_a_bypass(self):
+        """`apply_one(i, a, r, d, x, repo, False)` — the cheapest keyword-guard bypass."""
+        self.assertIn("selftest-writes-live", rules('''
+            import subprocess
+            def _run(a):
+                return subprocess.run(a)
+            def apply_one(issue, repo, dry_run=True):
+                if not dry_run:
+                    _run(["gh", "issue", "edit"])
+            def _selftest():
+                apply_one({"n": 7}, "acme/widget", False)
+        '''))
+
+    def test_partial_neutralisation_is_refused(self):
+        """Rebinding ONE of two reachable seams still leaves a live write path."""
+        self.assertIn("selftest-writes-live", rules('''
+            import subprocess
+            def run_gh(a):
+                return subprocess.run(a)
+            def run_git(a):
+                return subprocess.run(a)
+            def execute(dry_run=True):
+                if not dry_run:
+                    run_git(["merge"])
+                    run_gh(["pr", "create"])
+            def self_test():
+                global run_git
+                run_git = lambda a: 0
+                execute(dry_run=False)
+        '''))
+
+    def test_a_bare_global_declaration_is_not_neutralisation(self):
+        """`global _run` with NO assignment leaves the REAL seam bound.
+
+        Declaring the intent to swap a seam is not swapping it. Without this row the guard's
+        `declared & assigned` intersection can be weakened to `declared` and every other test
+        still passes — measured: that mutant survived the first full run of this suite.
+        """
+        self.assertIn("selftest-writes-live", rules('''
+            import subprocess
+            def _run(a):
+                return subprocess.run(a)
+            def apply_one(repo, dry_run=True):
+                if not dry_run:
+                    _run(["gh"])
+            def _selftest():
+                global _run
+                apply_one("acme/widget", dry_run=False)
+        '''))
+
+    def test_transitive_seam_is_reached_through_a_helper(self):
+        """The seam two hops from the callee still counts — `apply_one -> _post -> subprocess`."""
+        self.assertIn("selftest-writes-live", rules('''
+            import subprocess
+            def _post(a):
+                return subprocess.run(a)
+            def _edit(a):
+                return _post(a)
+            def apply_one(repo, dry_run=True):
+                if not dry_run:
+                    _edit(["gh"])
+            def _selftest():
+                apply_one("acme/widget", dry_run=False)
+        '''))
+
+    def test_live_slug_handed_to_a_cross_module_callee_is_refused(self):
+        """Callee defined elsewhere: the guard cannot see its seams, so a LIVE target is
+        the test."""
+        self.assertEqual(rules('''
+            from writer import apply_one
+            def _selftest():
+                apply_one(7, repo="sparq-org/sparq", dry_run=False)
+        '''), ["selftest-writes-live"])
+
+    def test_live_default_target_is_refused_even_with_no_selftest(self):
+        """Rule 1 stands alone: a write function must never inherit production by omission."""
+        self.assertEqual(rules('''
+            REPO = "jeswr/agent-account-registry"
+            def apply_one(issue, repo=REPO, dry_run=True):
+                return None
+        '''), ["live-default-target"])
+
+    def test_inline_live_default_is_refused(self):
+        self.assertEqual(rules('''
+            def apply_one(issue, repo="sparq-org/sparq", dry_run=True):
+                return None
+        '''), ["live-default-target"])
+
+
+class TestKnownNegatives(unittest.TestCase):
+    """Shapes that MUST stay green — a guard nobody can satisfy is a guard that gets deleted."""
+
+    def test_the_batch_merge_neutralisation_pattern_is_accepted(self):
+        self.assertEqual(rules(THE_SAFE_PATTERN), [])
+
+    def test_the_5098_defect_repaired_is_accepted(self):
+        """The fix: drop the live default, inject a recorder, keep the write-enabling call."""
+        self.assertEqual(rules('''
+            import subprocess
+            REPO = "sparq-org/sparq"
+
+            def _run(args):
+                return subprocess.run(args, check=True)
+
+            def apply_one(issue, action, repo, dry_run=True, log=print):
+                if action in ("keep", "skip"):
+                    return False
+                if dry_run:
+                    return False
+                _run(["gh", "issue", "edit", str(issue["n"]), "--repo", repo])
+                return True
+
+            def _selftest():
+                global _run
+                real = _run
+                _run = lambda args: None
+                try:
+                    apply_one({"n": 7}, "keep", "fixture/repo", dry_run=False)
+                finally:
+                    _run = real
+        '''), [])
+
+    def test_dry_run_true_in_a_selftest_is_fine(self):
+        self.assertEqual(rules(THE_DEFECT.replace("dry_run=False", "dry_run=True")
+                               .replace("repo=REPO", "repo")), [])
+
+    def test_a_fixture_owner_default_is_not_a_live_repo(self):
+        self.assertEqual(rules('''
+            def apply_one(issue, repo="fixture/repo", dry_run=True):
+                return None
+        '''), [])
+
+    def test_a_target_parameter_with_no_default_is_fine(self):
+        self.assertEqual(rules('''
+            def apply_one(issue, repo, dry_run=True):
+                return None
+        '''), [])
+
+    def test_a_non_write_function_may_default_to_the_live_repo(self):
+        """Read paths legitimately default to production — only WRITE functions are constrained."""
+        self.assertEqual(rules('''
+            REPO = "sparq-org/sparq"
+            def fetch_needs_user(repo=REPO):
+                return []
+        '''), [])
+
+    def test_a_selftest_with_no_reachable_seam_is_fine(self):
+        self.assertEqual(rules('''
+            def plan(state, dry_run=True):
+                return []
+            def _selftest():
+                plan({}, dry_run=False)
+        '''), [])
+
+
+class TestTheRealTree(unittest.TestCase):
+    """Family 3: the tree is clean AND the scan is pointed at something."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.violations = guard.check_tree(SCRIPTS)
+
+    def test_no_script_lets_a_selftest_write_to_a_live_repo(self):
+        self.assertEqual([str(v) for v in self.violations], [])
+
+    def test_the_scan_is_not_vacuous(self):
+        """A clean report is only meaningful if the scan actually reached self-tests, write
+        functions and subprocess seams. Without this row, deleting every subject would read as a
+        pass."""
+        import ast
+        selftests = writers = seams = 0
+        files = 0
+        for path in sorted(SCRIPTS.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+            except SyntaxError:
+                continue
+            files += 1
+            seams += len(guard.direct_seams(tree))
+            for fn in ast.walk(tree):
+                if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if guard.SELFTEST_NAME.match(fn.name):
+                    selftests += 1
+                args = fn.args
+                if {a.arg for a in args.posonlyargs + args.args + args.kwonlyargs} \
+                        & guard.DRY_RUN_PARAMS:
+                    writers += 1
+        self.assertGreater(files, 100, "the scan is not reaching scripts/")
+        self.assertGreater(selftests, 10, "no self-tests scanned — rule 2 has no population")
+        self.assertGreater(writers, 5, "no write functions scanned — rule 1 has no population")
+        self.assertGreater(seams, 10, "no subprocess seams found — the seam analysis is blind")
+
+
+class TestWorkflowWiring(unittest.TestCase):
+    """Family 4: the YAML seam. Substring assertions do NOT catch `if: false` — parse it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.wf = _yaml(ROUTING_WF)
+        cls.job = cls.wf["jobs"]["validate"]
+
+    def _run_block(self) -> str:
+        return " ".join(" ".join(s["run"] for s in self.job["steps"] if "run" in s).split())
+
+    def test_the_validate_job_has_no_if_guard(self):
+        """MUTANT: `if: false` on the job => RED (a text grep survives this — #5080)."""
+        self.assertNotIn("if", self.job)
+
+    def test_no_run_step_carries_an_if_guard(self):
+        """MUTANT: `if: false` on the step that invokes this suite => RED."""
+        for step in self.job["steps"]:
+            if "run" in step:
+                self.assertNotIn("if", step,
+                                 f"run step {step.get('name')!r} is conditionally skipped")
+
+    def test_routing_self_tests_invokes_this_suite(self):
+        """MUTANT: delete the call site => RED. A suite nobody runs cannot go red."""
+        self.assertIn("python3 scripts/tests/test_selftest_never_writes.py", self._run_block())
+
+    def test_both_paths_filters_carry_the_scripts_glob(self):
+        """MUTANT: drop the glob => RED.
+
+        A DIRECTORY GLOB, not an enumeration: the guard scans `scripts/**/*.py`, so a script that
+        does not exist yet must still trigger the lane. `retriage-needs-user.py` was exactly such a
+        file — an enumeration written today could not have named it.
+        """
+        on = _on_block(self.wf)
+        for event in ("pull_request", "push"):
+            paths = set(on[event].get("paths") or [])
+            self.assertIn(SCRIPTS_GLOB, paths,
+                          f"{event}.paths does not watch {SCRIPTS_GLOB} — a new script could add "
+                          f"a writing self-test without this lane ever running")
+
+    def test_the_workflow_watches_itself(self):
+        on = _on_block(self.wf)
+        for event in ("pull_request", "push"):
+            self.assertIn(".github/workflows/routing-self-tests.yml",
+                          set(on[event].get("paths") or []))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Opus 5, 1M context) — @jeswr runs several agents on this account.

Closes #5098 — the blocking half only. **This PR does not touch #4184**; see *Split* below.

## The defect, re-derived

`scripts/retriage-needs-user.py` (PR #4184, head `e0195dd8`) self-tests its "never writes" early-out
by calling the real write function **with writes enabled**:

```python
chk("keep never writes", apply_one({"n": 7}, "keep", ["needs:user"], [], "r",
                                   dry_run=False, log=lambda *_: None), False)
```

`apply_one`'s `repo` parameter defaults to `REPO = "sparq-org/sparq"`, and its body shells out via
`_run` → `subprocess.run(["gh", "issue", …])`. The only thing standing between `--selftest` and a
production mutation is `if action in ("keep", "skip"): return False` — **the very branch the
assertion exists to test**. Mutate it (which the PR advertises as its verification method) and the
self-test writes to production. It did, four times: `5084272766` / `5092788561` on #7 and
`5098073828` / `5117974900` on #8 — both **closed dependabot PRs**, each rendering the fixture
reason string `"r"`. The most recent landed **2026-07-29T12:50:15Z**, so the path is still live.

A test whose safety depends on the correctness of the code under test is not a test.

## The repair — two rules over `scripts/**/*.py`

Static, AST-only: `scripts/selftest_write_guard.py` never imports or executes what it scans.

| rule | what it refuses |
|---|---|
| `live-default-target` | A function taking a dry-run-style parameter **is** a write function, so it may not default its target-repository parameter to a live slug — directly or via a module constant. The write target must be named at every call site, so no caller inherits production by omission. |
| `selftest-writes-live` | Inside a self-test, a write-enabling literal (`dry_run=False`, `apply=True`, …) is refused while the callee can still reach a subprocess/network seam. The exemption is **neutralisation, not intent**: every seam reachable through the callee's call graph must be rebound (`global` + assign) first. |

The exemption is the pattern `scripts/batch-merge.py` **already uses correctly** — it swaps
`run_git`/`run_gh` for recorders and restores them in a `finally`, so its three `dry_run=False`
self-test calls stay green. That is deliberate: a guard nobody can satisfy is a guard that gets
deleted. Rule 2 also resolves **positional** write literals against the callee's signature, because
`apply_one(i, a, r, d, x, repo, False)` is the cheapest bypass of a keyword-only check.

The write-enabling keyword set and the live-owner set are **declared, not inferred**, so widening the
guard's blast radius is a reviewable diff.

## Shown red on the real defect, not just on fixtures

Run unmodified over PR #4184's head file:

```
retriage-needs-user.py:148: [live-default-target] apply_one() takes a dry-run parameter, so it is a
  write function, but its `repo` parameter defaults to the live repository 'sparq-org/sparq' (via
  `REPO`). Drop the default so every call site must name the repository it writes to.
retriage-needs-user.py:231: [selftest-writes-live] self-test _selftest() calls apply_one() with
  dry_run while _run still reaches a real subprocess. Either drop the write-enabling argument or
  rebind _run (`global` + assign) for the duration of the call, as scripts/batch-merge.py does for
  run_git/run_gh.
FAILED: selftest-write-guard (2 violation(s))
```

An instrument that has only ever been run on a clean tree has not been shown to detect anything, so
the suite carries the known-positive fixtures too — the verbatim #5098 shape, the positional bypass,
a two-hop transitive seam, partial neutralisation, and a bare `global` with no assignment.

## Mutation evidence — 13/13, whole set re-run after every change

| # | mutant | named row that goes red |
|---|---|---|
| M1 | drop the `live-default-target` emission | `test_the_5098_defect_trips_both_rules` (+2) |
| M2 | drop the `selftest-writes-live` emission | `test_selftest_calling_a_write_function_with_dry_run_false_is_refused` (+4) |
| M3 | disable positional write-literal detection | `test_positional_write_literal_is_not_a_bypass` |
| M4 | truncate seam reachability to direct calls | `test_transitive_seam_is_reached_through_a_helper` (+4) |
| M5 | accept a bare `global` as neutralisation | `test_a_bare_global_declaration_is_not_neutralisation` |
| M6 | empty `LIVE_OWNERS` | `test_live_slug_handed_to_a_cross_module_callee_is_refused` (+3) |
| M7 | stop recognising subprocess seams | `test_the_scan_is_not_vacuous` (+5) |
| M8 | inject the verbatim #5098 shape into a real script | `test_no_script_lets_a_selftest_write_to_a_live_repo` |
| M9 | `if: false` on the `validate` job | `test_the_validate_job_has_no_if_guard` |
| M10 | `if: false` on the invoking step | `test_no_run_step_carries_an_if_guard` |
| M11 | delete the call site from the run block | `test_routing_self_tests_invokes_this_suite` |
| M12 | drop the glob from `pull_request.paths` | `test_both_paths_filters_carry_the_scripts_glob` |
| M13 | drop the glob from `push.paths` | `test_both_paths_filters_carry_the_scripts_glob` |

M5 **survived the first full run** — the partial-neutralisation fixture also assigned, so nothing
could discriminate `declared & assigned` from `declared`. The row was added and the whole set re-run.

The seam trigger is a **directory glob** (`scripts/**/*.py`), not an enumeration: the guard scans
every script, and an enumeration cannot name a file that does not exist yet — which is precisely how
`retriage-needs-user.py` would have arrived unscanned. `test_the_scan_is_not_vacuous` asserts the
scan actually reaches self-tests, write functions and seams, so deleting the last real subject
cannot read as a pass.

## Split recommendation for #4184 — **not a reject**

I have **not pushed to #4184**. Its `bd-to-issues.py` half (`_NEVER_RECONCILE = {"needs:user"}`) is
correct, CI-wired and independently valuable. Recommended:

1. **Land that half on its own** — it needs none of the new script.
2. Re-open the re-triage script separately with `apply_one`'s `repo` default dropped and `_run`
   injected/rebound in the self-test. `test_the_5098_defect_repaired_is_accepted` in this suite is
   exactly that shape, green, so the target is unambiguous.

Once this merges, #4184 at its current head goes red on `routing-self-tests` — that is the intended
signal, not collateral damage.

## Not in this PR

The **99 existing marker comments** (97 items) are a separate, reported decision — no comment is
edited here. Nothing is armed, merged, closed or bulk-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
