### PR TITLE
fix(orchestration): report realisable frontier HEADROOM, not partition contention [OPUS-5]

### DIFF
--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -49,6 +49,19 @@ resolve = _route.resolve
 # readiness engine so the orchestrator reports a real number for sparq instead of degrading.
 roleless_ready = _ready.roleless_ready
 ready_candidates = _ready.ready_candidates
+# [OPUS-5 2026-07-29] Re-exported for the SAME reason as `roleless_ready` above: the registry's
+# readiness step reads its probes off THIS module, so a measurement that lives only in the
+# readiness engine is one the orchestrator cannot print. `ready_candidates` already rides here and
+# feeds dispatch.yml's partition census — the census that ranks CONTENDED keys, i.e. how many
+# candidates WANT each key. `refusal_attribution` is the missing companion: how many rows the
+# frontier could actually carry, and which of the refusals are in-flight occupancy that widening
+# can never recover. Reading the first as the second is what produced sparq#5119.
+#
+# Deliberately NOT added to `orchestration/registry-contract.toml`: that file records names the
+# registry is KNOWN to read, and declaring an expectation the other side does not yet hold would
+# make this repo's self-test assert a contract nobody is party to. It is exported so the registry
+# CAN adopt it via the same `getattr(planner, ...)` degradation path as every other probe.
+refusal_attribution = _ready.refusal_attribution
 GLOBAL = _ready.GLOBAL
 # [OPUS-5] sparq#4819 — THE SAME SILENT-INVISIBILITY CLASS AS `roleless_ready`, THREE LINES UP.
 # The registry's `inert_aware` probe reads `getattr(planner, "INERT_FIELD")` and

--- a/scripts/ready-issues.py
+++ b/scripts/ready-issues.py
@@ -1337,7 +1337,16 @@ def _self_test():
     finally:
         globals()["NON_RESERVING_PARTITIONS"] = _declared
     # SCOPE: candidacy untouched, and a SELECTED candidate still reserves — per-tick width stays
-    # one worker per partition, which is why the live frontier moved 1 -> 3 and not 1 -> ~50.
+    # one worker per partition, so the carve-out is worth at most +1 ROW PER EXEMPTED PARTITION,
+    # never one row per exempted CANDIDATE.
+    #
+    # [OPUS-5 2026-07-29] The delta this comment used to state (`1 -> 3`) did not survive four
+    # days, exactly as the sibling warning in `dispatch-plan.py` predicts of any pinned frontier
+    # number: re-measured through the production call shape (`compute_ready(ready_input)`, one
+    # positional argument) on the 2026-07-29T19:05:57Z snapshot — 1869 open rows, 365 candidates —
+    # it reads 1 -> 2, because on that board `docs` had no sole-area candidate on a free key and
+    # contributed +0. The DURABLE claim is the bound asserted on the next two lines, not the
+    # delta; for a current figure read `--diagnose`'s realisable-headroom line.
     check("candidate keying for ci/docs is unchanged", (packages_of({"area:ci"}),
                                                         packages_of({"area:docs"})),
           ({"ci"}, {"docs"}))
@@ -1345,6 +1354,41 @@ def _self_test():
           [i["number"] for i in compute_ready(
               [iss(20, R + ["priority:P0", "area:ci"]), iss(21, R + ["priority:P1", "area:ci"])],
               conflict_log=quiet)], [20])
+
+    # --- [OPUS-5 2026-07-29] CONTENTION IS NOT HEADROOM (`refusal_attribution`) ------------------
+    # sparq#5119 argued for a partition change from "`ci` is 61 of 357 candidates". Measured
+    # through the production call shape on the 2026-07-29T19:05:57Z snapshot, the realisable gain
+    # from that same board was ONE ROW, because 306 of the 363 refusals were held by an in-flight
+    # artifact and not by the width rule at all. These rows pin the DISTINCTION, so the next
+    # reader of the census cannot repeat the substitution.
+    _occupied = [pr(70, ["area:sparq-core"]),                     # an in-flight occupant
+                 iss(30, R + ["priority:P1", "area:sparq-core"]),  # occupant-blocked
+                 iss(31, R + ["priority:P2", "area:sparq-core"]),  # occupant-blocked
+                 iss(32, R + ["priority:P0", "area:sparq-hdt"]),   # SELECTED
+                 iss(33, R + ["priority:P1", "area:sparq-hdt"])]   # self-blocked by #32
+    _occ, _self = refusal_attribution(_occupied)
+    check("occupant-blocked candidates are attributed to the OCCUPANT", _occ, [30, 31])
+    check("...and only the width-refused one is headroom, on the key that took it",
+          _self, {"sparq-hdt": 1})
+    # THE IDENTITY. Without it the two buckets could both be wrong by the same amount and still
+    # look consistent; with it, any candidate that falls out of the walk is red.
+    check("frontier + occupant-blocked + self-blocked == candidates",
+          len(compute_ready(_occupied, conflict_log=quiet)) + len(_occ) + sum(_self.values()),
+          len(ready_candidates(_occupied)))
+    # THE OVER-COUNT MUTATION, pinned. A multi-area candidate declares several keys; counting it
+    # once PER KEY inflates the headroom, which is the #5119 error in miniature. Two candidates,
+    # one of them two-area, must total 1 refusal — not 2.
+    _multi = [iss(40, R + ["priority:P0", "area:sparq-hdt"]),
+              iss(41, R + ["priority:P1", "area:sparq-hdt", "area:sparq-geo"])]
+    check("a multi-area self-blocked candidate is counted ONCE, not once per key",
+          sum(refusal_attribution(_multi)[1].values()), 1)
+    # THE HEADLINE CLAIM: a key with MANY candidates and an in-flight holder has ZERO headroom.
+    # This is the exact shape #5119 read as a 61-row prize.
+    _contended = [pr(71, ["area:sparq-core"])] + [
+        iss(50 + i, R + ["priority:P2", "area:sparq-core"]) for i in range(9)]
+    _c_occ, _c_self = refusal_attribution(_contended)
+    check("9 candidates contending one OCCUPIED key are 9 contention and 0 headroom",
+          (len(_c_occ), _c_self), (9, {}))
     print("ready-issues self-test", "PASSED" if ok else "FAILED")
     return 0 if ok else 1
 
@@ -1503,6 +1547,71 @@ def dispatchable_view(issues, linked=()):
             if it.get("number") not in linked or labels_of(it) & IN_FLIGHT_STATUS]
 
 
+def refusal_attribution(issues, source_links=None):
+    """WHY the frontier is narrow, split into the two causes that have OPPOSITE remedies.
+
+    [OPUS-5 2026-07-29] THE NUMBER THIS EXISTS TO REPLACE. The orchestrator's partition census
+    (registry `dispatch.yml`, step `readiness`) ranks the keys that the most REFUSED CANDIDATES
+    declare, and prints e.g. `ci=60`. That is a CONTENTION count, and it has now twice been read
+    as a frontier prize — sparq#5119 proposed a change on the strength of "`ci` is 61 of 357
+    candidates" when the realisable gain from the same board was ONE ROW. Contention counts every
+    candidate that wants a key; headroom counts the rows the frontier could actually carry. They
+    differ here by a factor of ~30, and nothing printed the second one.
+
+    The split, both derived from the same walk so they cannot drift:
+
+    * OCCUPANT-blocked — the candidate collides with a key some IN-FLIGHT artifact (an open PR, an
+      `status:in-progress*` issue) is holding. This is the one-per-area rule doing the job it
+      exists to do: a second worker on that key would be a genuine double-dispatch. It is NOT
+      headroom, and widening the frontier cannot recover it without weakening concurrency safety.
+    * SELF-blocked — the candidate collides ONLY with a key THIS TICK'S OWN SELECTION took. No
+      in-flight artifact holds it; the refusal is the per-tick WIDTH rule (`reserve(pkgs, it)` in
+      `compute_ready`'s selection loop), not occupancy. This is the whole of the relaxable
+      headroom, and it is reported PER KEY because the remedy is per-key too: a width change is
+      only ever defensible on a partition whose concurrent holders are measured not to collide
+      (today, that is `NON_RESERVING_PARTITIONS` and nothing else).
+
+    Returns `(occupant_blocked, self_blocked)` — a sorted list of issue numbers, and a
+    `{partition key: count}` mapping. A candidate refused for BOTH reasons is attributed to the
+    OCCUPANT, because that is the binding one: releasing the width would not free it.
+
+    EACH CANDIDATE IS COUNTED EXACTLY ONCE, against the single key that actually refused it,
+    chosen by `compute_ready`'s OWN tie-break (coarsest partition first, then alphabetical). The
+    first cut of this function incremented every key a multi-area candidate declared, which
+    over-counted the headroom by 3 on the measuring board and — much worse — reproduced in
+    miniature the exact error it was written to prevent: reporting a per-key WANT as if it were a
+    per-key GAIN. `sum(self_blocked.values()) + len(occupant_blocked) + len(frontier)` therefore
+    equals the candidate count exactly, and that identity is asserted in `--self-test`.
+
+    Pure, and deliberately built from `unit_reservations` + `ready_candidates` + `compute_ready`
+    rather than by re-walking `compute_ready`'s selection loop. A second copy of that loop is the
+    two-legs-disagree defect this file has already paid for twice; and parsing `conflict_log`'s
+    prose would couple this to a message format the registry consumes.
+    """
+    held = set()
+    for areas, _artifact in unit_reservations(issues, source_links):
+        held |= areas
+    frontier = compute_ready(issues, conflict_log=lambda _m: None, source_links=source_links)
+    selected = {it.get("number") for it in frontier}
+    # What THIS TICK's own selections took. `packages_of`, not `_reserving_packages`: the
+    # selection loop reserves a selected row's declared areas in full, exemptions included, and
+    # that asymmetry with the occupancy half is precisely what this split makes visible.
+    taken = {key for it in frontier for key in packages_of(labels_of(it))}
+    occupant, self_blocked = [], {}
+    for _priority, number, _it, pkgs in ready_candidates(issues, log=None):
+        if number in selected:
+            continue
+        if any(keys_conflict(key, h) for key in pkgs for h in held):
+            occupant.append(number)
+            continue
+        blocking = [key for key in taken if any(keys_conflict(key, p) for p in pkgs)]
+        if not blocking:                  # refused by neither: not reachable via compute_ready
+            continue
+        key = min(blocking, key=lambda k: (len(partition_path(k)), k))
+        self_blocked[key] = self_blocked.get(key, 0) + 1
+    return sorted(occupant), self_blocked
+
+
 def occupancy_parity(issues, source_links=None):
     """The PR-HALF-STRIPPED occupancy divergence, as a re-runnable measurement.
 
@@ -1654,6 +1763,17 @@ def main():
             print(f"  {n:5d}  {100 * n / total:5.1f}%  {reason}")
         print(f"\ndrainable backlog (ready_candidates): {len(cands)}")
         print(f"concurrency frontier (compute_ready): {len(frontier)}")
+        # [OPUS-5 2026-07-29] The two refusal causes, ALWAYS printed including at zero — the
+        # headroom line is the one the orchestrator's contention census does not carry, and a
+        # figure that appears only when it is interesting cannot be trusted when it is absent.
+        occ_blocked, headroom = refusal_attribution(visible, source_links)
+        print(f"  refused, held by an in-flight artifact: {len(occ_blocked)} "
+              f"(concurrency safety — NOT recoverable by widening the frontier)")
+        print(f"  refused by this tick's own selection:   {sum(headroom.values())} "
+              f"(per-tick WIDTH — the whole of the relaxable headroom)")
+        if headroom:
+            print("    realisable headroom by key: " + ", ".join(
+                f"{key}={n}" for key, n in sorted(headroom.items(), key=lambda kv: (-kv[1], kv[0]))))
         print(f"unit occupancy: {len(units)} unit(s), "
               f"{sum(len(a) for a, _ in units)} reservation(s) over "
               f"{len(set().union(set(), *[a for a, _ in units]))} partition key(s)")

--- a/scripts/tests/test_readiness_visibility.py
+++ b/scripts/tests/test_readiness_visibility.py
@@ -1614,5 +1614,76 @@ class TestNonReservingCrossCuttingPartitions(unittest.TestCase):
                           f"the measured basis for the exemption no longer states {token}")
 
 
+class TestContentionIsNotHeadroom(unittest.TestCase):
+    """`refusal_attribution` — the quantity sparq#5119 substituted for the one it needed.
+
+    The orchestrator's partition census ranks keys by how many REFUSED CANDIDATES declare them.
+    That is contention. The frontier gain available from relaxing a key is headroom. On the
+    2026-07-29T19:05:57Z live snapshot (1869 open rows, 365 candidates, production call shape)
+    they differed by ~30x: `ci` carried 57 refusals but the realisable frontier gain of the
+    shipped carve-out was ONE row, because 306 of the 363 refusals were held by an in-flight
+    artifact and no width change can recover those.
+    """
+
+    # One occupant, two candidates it blocks, and two candidates that contend only with each
+    # other — so contention and headroom are different numbers on the same board.
+    BOARD = [
+        pr(70, ["area:sparq-core"]),
+        iss(30, READY + ["priority:P1", "area:sparq-core"]),
+        iss(31, READY + ["priority:P2", "area:sparq-core"]),
+        iss(32, READY + ["priority:P0", "area:sparq-hdt"]),
+        iss(33, READY + ["priority:P1", "area:sparq-hdt"]),
+    ]
+
+    def test_occupant_blocked_candidates_are_not_headroom(self):
+        occupant, headroom = ready.refusal_attribution(self.BOARD)
+        self.assertEqual(occupant, [30, 31])
+        self.assertNotIn("sparq-core", headroom,
+                         "a key an in-flight PR is holding offers NO width headroom")
+
+    def test_headroom_names_the_key_this_ticks_own_selection_took(self):
+        _occupant, headroom = ready.refusal_attribution(self.BOARD)
+        self.assertEqual(headroom, {"sparq-hdt": 1})
+
+    def test_the_three_buckets_partition_the_candidate_set(self):
+        occupant, headroom = ready.refusal_attribution(self.BOARD)
+        frontier = ready.compute_ready(self.BOARD, conflict_log=quiet)
+        self.assertEqual(len(frontier) + len(occupant) + sum(headroom.values()),
+                         len(ready.ready_candidates(self.BOARD)))
+
+    def test_a_multi_area_candidate_is_counted_once_not_once_per_key(self):
+        # Counting per declared key inflates headroom — the #5119 error in miniature.
+        board = [iss(40, READY + ["priority:P0", "area:sparq-hdt"]),
+                 iss(41, READY + ["priority:P1", "area:sparq-hdt", "area:sparq-geo"])]
+        self.assertEqual(sum(ready.refusal_attribution(board)[1].values()), 1)
+
+    def test_a_heavily_contended_but_occupied_key_reports_zero_headroom(self):
+        # THE HEADLINE SHAPE: nine candidates want one key, an open PR holds it. Contention 9,
+        # headroom 0. Reading the first as the second is what produced sparq#5119.
+        board = [pr(71, ["area:sparq-core"])] + [
+            iss(50 + i, READY + ["priority:P2", "area:sparq-core"]) for i in range(9)]
+        occupant, headroom = ready.refusal_attribution(board)
+        self.assertEqual(len(occupant), 9)
+        self.assertEqual(headroom, {})
+
+    def test_the_carve_out_is_bounded_by_one_row_per_exempted_partition(self):
+        # WHY the carve-out cannot pay out its contention: the selection loop reserves a selected
+        # row's declared areas IN FULL, exemptions included. Ten `ci` candidates, none occupied,
+        # yield one frontier row and nine units of headroom on `ci`.
+        board = [iss(60 + i, READY + ["priority:P2", "area:ci"]) for i in range(10)]
+        frontier = ready.compute_ready(board, conflict_log=quiet)
+        occupant, headroom = ready.refusal_attribution(board)
+        self.assertEqual(len(frontier), 1, "the exemption is occupancy-side only")
+        self.assertEqual((occupant, headroom), ([], {"ci": 9}))
+
+    def test_diagnose_always_prints_both_causes_including_at_zero(self):
+        # A figure that appears only when it is interesting cannot be trusted when it is absent.
+        source = (SCRIPTS / "ready-issues.py").read_text()
+        self.assertIn("held by an in-flight artifact", source)
+        self.assertIn("refused by this tick's own selection", source)
+        self.assertIn("refusal_attribution(visible, source_links)", source,
+                      "--diagnose must consume the attribution, not just define it")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent

Brief: quantify and, if it held up, fix the partition-frontier defect behind #5119. The headline result is that **#5119's fix is already merged** and its premise is a misread number, so this PR ships the instrument that would have caught that, not the change #5119 asked for.

## 1. Reachability, first — the carve-out IS reachable from production

Production call site: `jeswr/agent-account-registry`, `.github/workflows/dispatch.yml:868`

```python
ready = dispatch.compute_ready(ready_input)
```

One positional argument. `compute_ready(issues, in_progress_packages=None, conflict_log=None, source_links=None)` — so **three parameters take defaults in production**, `source_links` among them.

That matters because a partition fix landed earlier today measured frontier 1 → 17 locally and **+0 in production**, since the path it depended on only forms when `source_links` is passed. The `ci`/`docs` carve-out is **not** in that class: it lives in `_reserving_packages` → `_own_reservation` → `unit_reservations`, and `_own_reservation` runs for every row regardless of `source_links`. Verified by executing `compute_ready` in the production positional shape and observing the frontier move. **Reachable.**

## 2. The realised gain — +1 row, and it is already banked

#5119 proposes aligning `_reserving_packages` with the registry carve-out. That is **already merged**, as #4928 (`4c82876`, on `main`). Measured through the production call shape on a single live snapshot, **2026-07-29T19:05:57Z**, 1869 open rows, **denominator 365 candidates**:

| exemption set | frontier |
|---|---|
| `{}` (pre-#4928) | **1** |
| `{ci}` | **2** |
| `{ci, docs}` — current `main` | **2** |

**+1 row. 0.27% → 0.55% of candidates.** `docs` contributes **+0** on this board — it has no sole-area candidate on a free key.

`ci` being 61 of 357 candidates is a **contention** count. The realisable gain from that same board is one row. They differ by ~30×, and nothing in the pipeline printed the second number — which is exactly how #5119 came to be filed.

**Why the gain is capped, precisely:** the carve-out is applied at one of `compute_ready`'s two `reserve()` call sites. The occupancy loop uses `_reserving_packages` (carve-out honoured); the selection loop's `reserve(pkgs, it)` uses `packages_of` (carve-out **not** honoured). So a selected `ci` row re-blocks every other `ci` candidate for the tick, and the carve-out is worth at most **+1 row per exempted partition** — never one per exempted candidate. Measured: frontier = 1 + width, exactly linear, up to 59 unbounded.

That cap is not an oversight. It is pinned by an existing assertion — `check("a selected ci candidate still reserves ci for the tick", ..., [20])`. Relaxing it is a deliberate policy change, not a bug fix.

## 3. Concurrency safety — and why I did **not** relax the selection side

The whole remaining headroom is `ci`: of 13 free candidate keys, only `ci` (55 sole-area candidates) and `sparq-crdt` (1) have any candidate that is not also blocked on a held key. So reaching "meaningfully more than 0.5%" requires **simultaneous `ci` dispatch** and nothing else.

Re-measured independently (GraphQL, 58 PRs, same snapshot), holder pairs sharing ≥1 changed file:

| population | holders | pairs | colliding |
|---|---|---|---|
| `area:ci` | 36 | 630 | 63 (**10.0%**) |
| `area:docs` | 40 | 780 | 34 (**4.4%**) |

Consistent with the 9.2% / 4.8% already recorded in the registry. But the question is whether `ci`/`docs` are genuinely low-collision or merely low-*conflict-labelled*, so splitting by how the holder acquired the key:

| `area:ci` holders | n | pairs | colliding |
|---|---|---|---|
| **dispatched onto** it (source issue carries `area:ci`) | 6 | 15 | 2 (**13.3%**) |
| acquired it incidentally (source issue does not) | 23 | 253 | 18 (7.1%) |

The population that a width relaxation would create is the **first** row, and its point estimate is *higher* than the incidental rate, not lower. n=6 cannot distinguish the two, so there is **no evidence that deliberately co-dispatched `ci` workers are as safe as the incidental co-holders the 10% figure is drawn from**. 84% of `ci` collisions concentrate in three files (`.github/workflows/docs-quality.yml`, `AGENTS.md`, `scripts/tests/feature-matrix-legnames.golden.txt`).

Against that: the conflict-repair lane has acted 2 times, on 1 of 20 PRs, in its lifetime, and **0 times on any sparq PR ever**. A collision we manufacture is empirically one nobody repairs — it lands as a DIRTY PR, which earns no gate run and stalls until a human intervenes.

So the honest answer to "what stops two workers colliding" is: **for the already-shipped occupancy carve-out, nothing needs to — it adds at most one concurrent holder per partition to a board that already carries 36 concurrent `area:ci` holders with zero admission control** (a PR enters that partition by touching a path, long after dispatch). The one-per-area rule never serialised `ci` PR-vs-PR; all it ever did was refuse dispatch. That exposure is real but marginal, and it is the one already authorised.

For the **selection-side** relaxation — the only change that reaches the stated throughput goal — the answer is that nothing stops them, the population most likely to collide is the one it creates, and the repair lane behind it has never once fired on this repo. **That is the broader relaxation already declined pending a working conflict lane, and this PR does not take it.** The conflict lane is the gating dependency for the frontier goal, not a parallel concern.

One further reason to be sceptical the frontier is even the binding constraint: frontier 2/tick × ~2.8 executed ticks/hr = ~5.6 dispatch offers/hr, against an observed 1–2.5 PRs/hr. Offer→PR conversion is 20–45%, so most of the loss is already downstream of dispatch.

## 4. What this PR actually ships

`refusal_attribution()` in `scripts/ready-issues.py` — splits frontier refusals into the two causes that have opposite remedies:

- **occupant-blocked** — collides with a key an in-flight artifact holds. The one-per-area rule doing its job; unrecoverable by widening.
- **self-blocked** — collides *only* with a key this tick's own selection took. The per-tick width rule; the whole of the relaxable headroom, reported **per key** because the remedy is per-key.

Each candidate is counted once, against the key that actually refused it, by `compute_ready`'s own tie-break — so `frontier + occupant + headroom == candidates` exactly, and that identity is asserted. Wired into `--diagnose`, printed on every run including at zero. Re-exported from `dispatch-plan.py` so the registry census can adopt it via the same `getattr` degradation path as every other probe (deliberately **not** added to `registry-contract.toml` — that file records names the registry is known to read, and the registry does not read this one yet).

Live output:

```
drainable backlog (ready_candidates): 368
concurrency frontier (compute_ready): 2
  refused, held by an in-flight artifact: 309 (concurrency safety — NOT recoverable by widening the frontier)
  refused by this tick's own selection:   57 (per-tick WIDTH — the whole of the relaxable headroom)
    realisable headroom by key: ci=57
```

Also corrects a comment pinning the carve-out delta as `1 -> 3`; re-measured it reads `1 -> 2`. The durable claim is the bound, not the delta — the same failure the sibling warning in `dispatch-plan.py` already predicts of any pinned frontier number.

**No behaviour change to the frontier.** Instrumentation plus its contract.

## 5. Red test

The instrument was validated against a known answer before being trusted: `frontier + self-blocked on exempt keys = 59`, matching an independently-computed unbounded-width frontier of 59.

`--self-test` and 7 new suite cases; three mutations, each reverting only the behaviour, all killed:

| mutation | result |
|---|---|
| count once **per key** instead of per candidate | 🔴 `counted ONCE, not once per key: 2 (want 1)` |
| attribute both-blocked candidates to **self** instead of occupant | 🔴 3 rows red |
| report **contention** as headroom (the #5119 error itself) | 🔴 `(0, {'sparq-core': 9})` vs `(9, {})` |

`ready-issues --self-test` PASSED, `dispatch-plan --self-test` PASSED, `test_readiness_visibility.py` 126 passed (was 119).

## 6. Recommendation

**Close #5119 as already-implemented by #4928**, and record that its premise — 61 contended candidates — was a contention count worth one row. Not hand-labelling it; leaving that to a maintainer.

Not armed. Author only; someone else reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
