### PR TITLE
fix(deps): clear dependency advisory gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -1929,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4022,7 +4022,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.2",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -271,6 +271,11 @@ version = "0.9.1"
 criteria = "safe-to-deploy"
 notes = "RustCrypto/dalek AEAD+X25519 stack pulled in by the opt-in, publish=false sparq-e2ee-ng crate (XChaCha20-Poly1305 + X25519 wrap); no trusted-import audit available upstream. [SONNET-4.6]"
 
+[[exemptions.chacha20]]
+version = "0.10.2"
+criteria = "safe-to-deploy"
+notes = "Advisory-clearing patch upgrade; the prior 0.10.0 release is covered by the imported ISRG audit. [GPT-5.6]"
+
 [[exemptions.chacha20poly1305]]
 version = "0.10.1"
 criteria = "safe-to-deploy"
@@ -672,7 +677,7 @@ criteria = "safe-to-deploy"
 notes = "RustCrypto-org crate; transitive dep of the OFF-by-default vc-bridge feature (p256 path); no upstream audit covers this exact version [OPUS-4.8]"
 
 [[exemptions.h2]]
-version = "0.4.15"
+version = "0.4.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.h3]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -274,7 +274,7 @@ notes = "RustCrypto/dalek AEAD+X25519 stack pulled in by the opt-in, publish=fal
 [[exemptions.chacha20]]
 version = "0.10.2"
 criteria = "safe-to-deploy"
-notes = "Advisory-clearing patch upgrade; the prior 0.10.0 release is covered by the imported ISRG audit. [GPT-5.6]"
+notes = "Yank-clearing patch upgrade from chacha20 0.10.0; the prior release is covered by the imported ISRG audit. [GPT-5.6]"
 
 [[exemptions.chacha20poly1305]]
 version = "0.10.1"


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Closes #5980.

This is the minimal dependency-lock and cargo-vet configuration remediation for both findings from the dependency-monitoring lane:

- `h2` 0.4.15 → 0.4.16, fixing RUSTSEC-2026-0258
- `chacha20` 0.10.0 → 0.10.2, replacing the yanked release
- the corresponding `h2` and `chacha20` cargo-vet exemptions are aligned to the resolved versions, with the chacha20 rationale explicitly identifying the yank-clearing upgrade

No manifest or unrelated package changed.

Verification:

- `env RUSTC_WRAPPER= cargo deny check advisories` — `advisories ok`
- `env RUSTC_WRAPPER= cargo vet --locked --frozen` — succeeded
- `env RUSTC_WRAPPER= cargo metadata --locked --no-deps --format-version 1`
- `env RUSTC_WRAPPER= cargo check --locked --workspace`
- `git diff --check`
- independent lockfile review: no findings