### PR TITLE
ci: route implementation to Sol and review to Opus

### DIFF
--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -92,8 +92,9 @@ provider_model = "gpt-5.6-luna"        # Second tier of the unified fix ladder o
 credential_format = "codex-auth-json"
 
 [defaults]
-model_chain = ["opus5", "sol"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-rust-impl"
+escalate = true
 
 # ---------------------------------------------------------------------------------------------------
 # SECURITY-LABEL OVERRIDES (first-match; win over role). Soundness surfaces run on Opus 5 ALONE
@@ -108,24 +109,15 @@ agent = "sparq-reviewer"
 escalate = true                        # consumed by dispatch: on chain-exhaustion, label needs:user
 
 # ---------------------------------------------------------------------------------------------------
-# ROLE ROUTES. Implementation chains LEAD WITH OPUS 5 (maintainer directive 2026-07-26: "Opus5
-# should be prioritised over sol on all tasks for which they are both possible implementors;
-# except for GUI work where sol should remain prioritised").
-#
-# WHY THIS CHANGED, because the mechanism matters more than the edit: these chains led with SOL
-# under the 2026-07-18 "credit abundance" directive, taken during a period of high sol
-# availability. Nothing about sol's dominance was adaptive — the registry's account selector walks
-# `model_chain` IN ORDER and claims the first available account (select-and-claim.choose_account),
-# so a sol-first literal simply won every route, every tick, regardless of how availability had
-# since shifted. Measured 2026-07-26: 11 of the 12 most recent orchestrator PRs were
-# openai/sol-implemented. The stale steer was the chain ORDER itself, not a heuristic, so the fix
-# is the order.
-#
-# Cross-provider review flips automatically: opus5-authored implementation receives codex review,
-# and vice versa — so leading with opus5 also moves the review load onto sol, which is where the
-# spare credit actually is.
+# [GPT-5.6] ROLE ROUTES. The 2026-09-02 maintainer protocol separates responsibilities: GPT-5.6
+# Sol is the primary implementation tier, while Opus 5 remains the review/soundness tier and
+# reviews new Sol-authored PRs through the existing cross-provider inversion. Opus stays behind Sol as a
+# continuity fallback for current Anthropic-authored repairs and total Sol unavailability. Each
+# implementation route declares `escalate = true` so total exhaustion has the existing bounded,
+# machine-owned exit.
 
-# [OPUS-5] `role:impl` IS OPUS5-ONLY SINCE 2026-07-26 — sol was REMOVED, not demoted.
+# HISTORICAL CONTEXT (superseded by the 2026-09-02 protocol above): `role:impl` was Opus5-only
+# beginning 2026-07-26. The measurements below explain that prior state; they are not current policy.
 #
 # MAINTAINER DECISION 2026-07-26, taken on the measurement in registry #738: "Remove sol from impl
 # fallback." This is a deliberate change from PREFERENCE to EXCLUSION and it applies to `role:impl`
@@ -167,37 +159,33 @@ escalate = true                        # consumed by dispatch: on chain-exhausti
 # steady-state projection.
 [[route]]
 role = "impl"
-model_chain = ["opus5"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-rust-impl"
 escalate = true
 
-# [FABLE-5] UI/front-end ownership (maintainer decision 2026-07-17): GPT-5.6 codex (openai; alias
-# `terra`) implemented the original registry dashboard UI (jeswr/agent-account-registry e4098b9)
-# and is responsible for ALL UI/front-end work, so the site chain LEADS with terra; the previous
-# chain follows as fallback. scripts/triage.py derives role:site for UI-surface labels
-# (area:site/area:gui/surface:frontend/dashboard) so surface-labelled work lands here too.
+# Site/front-end implementation follows the Sol-first implementation protocol. scripts/triage.py
+# derives role:site for UI-surface labels, so surface-labelled work lands here too.
 # Deliberately a ROLE route, not match_labels: the review lane's arm-side security classifier
 # unions ALL match_labels keywords, so UI keywords there would human-arm every UI PR.
 [[route]]
 role = "site"
-model_chain = ["opus5", "sol"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-site"
+escalate = true
 
-# [OPUS-5] THE `area:gui` CARVE-OUT (maintainer directive 2026-07-26): "Opus5 should be prioritised
-# over sol on all tasks for which they are both possible implementors; except for GUI work where
-# sol should remain prioritised". Boundary settled by the maintainer the same day: "Let's just go
-# with area:gui work" — so the carve-out is `area:gui` and NOTHING ELSE. The site* surfaces
-# (area:site, area:site-specs, area:site-papers, …) are NOT GUI: they fall under the opus5-first
-# default above, even though "GUI" reads informally as if it covered them.
+# GUI implementation is Sol-first like every other implementation route. The exact `area:gui`
+# selector and legacy preference declaration remain below for PLAN/CLAIM compatibility with older
+# target revisions; on the current Sol-first chain they are deliberately idempotent.
 #
-# This route PRESERVES the existing UI -> codex/sol original-builder steer (task #331) for the
-# desktop GUI; it is a carve-out from a new default, not a reversal of anything.
+# This also preserves the existing UI -> Codex/Sol original-builder steer (task #331) for the
+# desktop GUI while bringing every other implementation surface onto the same default.
 #
-# WHERE THE CARVE-OUT ACTUALLY BINDS. This route alone is NOT sufficient and must not be mistaken
+# HISTORICAL FAILURE MODE / WHERE THE CARVE-OUT ACTUALLY BINDS. This route alone is NOT sufficient
+# and must not be mistaken
 # for the mechanism: role routes are reached only via a `role:` LABEL, `role:gui` did not exist as a
 # repo label until 2026-07-26, and `triage._role()` returns an EXPLICIT `role:*` before it consults
 # any surface label — so all 35 open `area:gui` issues (33 role:impl, 1 role:perf, 1 role:research)
-# resolved `role:impl` and took the opus5-first default, INVERTING the directive for the whole GUI
+# resolved `role:impl` and took the then-opus5-first default, INVERTING the directive for the GUI
 # backlog. The binding rule therefore lives in scripts/route-resolve.py `gui_carve_out()`: it reads
 # the `area:gui` label the issues ALREADY carry, at plan time, and re-orders whatever chain they
 # resolve to. This route is the declarative statement of the same preference for an issue that does
@@ -208,38 +196,32 @@ agent = "sparq-site"
 # human-arm every GUI PR. scripts/triage.py derives role:gui from `area:gui` alone (it used to
 # fold area:gui into role:site).
 #
-# PREFERENCE, NOT EXCLUSION: opus5 remains the fallback, so GUI work stays dispatchable during a
-# sol/OpenAI outage. The chain is cross-provider and therefore cannot be starved by one provider.
+# Opus 5 is retained behind Sol only as the continuity fallback described above.
 [[route]]
 role = "gui"
 model_chain = ["sol", "opus5"]
 agent = "sparq-site"
+escalate = true
 
-# [FABLE-5] STANDING RULE — frontier-tier CI/infrastructure authorship (maintainer decision
-# 2026-07-17; same standing-rule pattern as the UI→codex route above, PR #3416): ALL CI/
-# infrastructure work — .github/workflows, gate aggregators, orchestration/ + dispatch scripts,
-# the self-draining pipeline itself — is authored by a FRONTIER-tier model only: opus5 (Claude
-# Opus 5, the SOLE anthropic tier since 2026-07-26 — fable was deprecated out of this chain) or
-# sol (GPT-5.6 / codex). Cheaper tiers (sonnet/haiku) no longer author infra;
-# cross-provider review is unchanged (whichever provider's frontier writes, the other reviews).
-# The chain is deliberately FRONTIER-ONLY rather than floor-pinned: the routing schema has no
-# floor/pin marker (the fix-floor pin lives in the registry's review loop, not here), and
-# chain-exhaustion at the registry's claim step already DEFERS the item (no eligible account →
-# no claim → retried next tick) instead of degrading below the chain. NOT `escalate = true`:
-# that flips a starved item to needs:user (human); this rule wants defer+retry.
+# [GPT-5.6] CI/infrastructure is implementation and therefore uses the same Sol-first lane. Opus 5
+# reviews the resulting OpenAI-authored PR through the registry-owned review chain.
+# The chain is deliberately frontier-only rather than floor-pinned. `escalate = true` uses the
+# registry's bounded capacity-starvation path: retry first, then a visible machine-owned park.
 # scripts/triage.py derives role:ci for infra-surface labels (area:ci/area:ci-fragments/
 # area:orchestration/area:workflows/area:release) so surface-labelled infra work lands here.
-# Security overlap: the match_labels overrides above still WIN over this route (opus + human
+# Security overlap: the match_labels overrides above still WIN over this route (Opus + human
 # escalation) — where role:ci and a security surface overlap, the security lane is correct.
 [[route]]
 role = "ci"
-model_chain = ["opus5", "sol"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-ci-infra"
+escalate = true
 
 [[route]]
 role = "perf"
-model_chain = ["opus5", "sol"]
+model_chain = ["sol", "opus5"]
 agent = "sparq-perf-engineer"
+escalate = true
 
 # [OPUS-5] research was ["opus5", "fable", "opus"] until 2026-07-26. Deprecating the two tail
 # rungs left a ONE-RUNG chain with no `escalate`, i.e. no exit at all: on an opus5 capacity outage
@@ -282,10 +264,10 @@ agent = "sparq-reviewer"
 escalate = true
 
 # ---------------------------------------------------------------------------------------------------
-# [OPUS-5] CHAIN-ORDER PREFERENCES — THE CARVE-OUT, DECLARED WHERE **BOTH** RESOLVERS CAN READ IT.
-#
-# The route above is not enough on its own, and the reason is that the dispatch decision is made
-# TWICE, in two repositories:
+# [GPT-5.6] LEGACY CHAIN-ORDER PREFERENCE — retained for PLAN/CLAIM compatibility with older
+# target revisions.
+# The current implementation routes are already Sol-first, so this rule is idempotent today. It
+# remains declared as data because the dispatch decision is made twice, in two repositories:
 #
 #   PLAN   the registry's dispatch.yml clones THIS repo and runs THIS repo's scripts/dispatch-plan.py
 #          -> scripts/route-resolve.py -> gui_carve_out().
@@ -293,13 +275,9 @@ escalate = true
 #          scripts/policy-resolve.py, reading THIS FILE from the protected default-branch tip, and
 #          `_route_matches` then demands EXACT equality of model_chain / agent / escalate.
 #
-# So a chain-order rule expressed ONLY in this repo's Python is not a preference that half-applies:
-# CLAIM re-derives a different chain, raises DispatchError, and the item is counted
-# `route-policy-failed` and skipped. That comparison is a pure function of the issue's labels and
-# this table, so it produces the identical skip on every subsequent tick — the affected issues
-# stop dispatching ENTIRELY, and the only symptom is a defer counter. Measured against this
-# branch's own resolver before this block existed: 34 of the 35 open `area:gui` issues (33
-# `role:impl` + 1 `role:perf`) diverged.
+# A chain-order rule expressed only in target Python would make PLAN and CLAIM disagree. Keeping
+# the declaration preserves exact agreement while older revisions or synthetic tests still carry
+# mixed Sol/Opus implementation chains.
 #
 # CLAIM cannot import this repo's resolver — running target-authored CODE in the privileged claim
 # step is the escalation registry #119 closed. But it already trusts this file, fetched from the
@@ -323,18 +301,11 @@ escalate = true
 #             the EXACT roles for which `lead` may be ADDED to a chain that lacks it, rather than
 #             only re-ordered. Absent => none, i.e. the original re-order-only rule.
 #
-# WHY `inject_roles` IS NOW REQUIRED HERE (registry #738, 2026-07-26). Re-ordering was sufficient
-# only while every affected route still HAD sol in its chain. `role:impl` is now `["opus5"]`, and a
-# `["opus5"]` chain does not contain sol — so the both-implementors condition DECLINES and the
-# carve-out goes INERT for all 33 open `area:gui` + `role:impl` issues, resolving them opus5-only.
-# That is the exact inversion of the maintainer's one stated exception that PR #4211 fixed, and it
-# has NO SYMPTOM: both resolvers agree on the wrong answer, so the PLAN/CLAIM agreement harness
-# reports nothing. `inject_roles = ["impl"]` is what keeps `area:gui` sol-first across that edit.
-#
-# The allow-list is deliberately minimal. `role:perf` / `role:site` / `role:ci` / `role:docs` still
-# contain sol, so they take the RE-ORDER path and are absent here. The registry mechanism REFUSES to
-# parse `research` / `review` / `soundness` in this field (chain_preference.INJECT_FORBIDDEN_ROLES),
-# so the escalating single-provider lanes cannot be made cross-provider even by editing this table.
+# `inject_roles = ["impl"]` is retained solely to reproduce the historical mixed-chain behavior
+# when an older target revision is resolved. The current `role:impl = ["sol", "opus5"]` chain
+# already has Sol in front and therefore does not activate injection. The registry parser still
+# refuses research/review/soundness injection, so this compatibility declaration cannot widen
+# those Opus-only lanes.
 #
 # A SECURITY-override route is exempt on both sides: `area:gui` + `area:sparq-zk` is a ZK issue
 # first, and an implementor preference must never re-order OR extend a soundness chain.

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -60,7 +60,8 @@ provider_model = "claude-opus-5"       # Opus 5 — the SOLE anthropic routing t
                                        # rather than retained as tail fallbacks. Chains that used to
                                        # end at fable/opus now either end at opus5 and DEFER on
                                        # exhaustion (retried next tick) or carry `escalate = true`
-                                       # and park to needs:user — never a silent degrade.
+                                       # and take the bounded machine-park path described below —
+                                       # never a silent degrade.
                                        # Probe-verified live 2026-07-26: `claude --model
                                        # claude-opus-5 -p` -> OK, modelUsage reports canonicalModel
                                        # "claude-opus-5" (1M context). ALWAYS pin the full id: the
@@ -99,14 +100,18 @@ escalate = true
 # ---------------------------------------------------------------------------------------------------
 # SECURITY-LABEL OVERRIDES (first-match; win over role). Soundness surfaces run on Opus 5 ALONE
 # (2026-07-26: the opus-4.8 tail fallback was deprecated, so there is no weaker anthropic rung to
-# degrade to) and, on chain-exhaustion, ESCALATE to a human (needs:user) rather than fall to a
-# weaker/cross-provider model. That is the intended fail-closed behaviour, not a dead end: an opus5
-# capacity outage now parks the item for a human instead of quietly serving it from a retired tier.
+# degrade to). [GPT-5.6] CAPACITY-ESCALATION CONTRACT: for capacity exhaustion, `escalate = true`
+# never writes `needs:user`.
+# Registry CLAIM first keeps the item `status:deferred` during the bounded retry grace, then applies
+# the machine-owned `status:parked` soft hold if zero headroom persists; a successful retry after
+# recovery clears that hold.
+# This keeps the route fail-closed without turning provider capacity into a human-owned terminal.
+# The separate post-review trust/soundness arm remains human-gated.
 [[route]]
 match_labels = ["zk", "mpc", "reasoner", "crypto", "auth", "e2ee"]
 model_chain = ["opus5"]
 agent = "sparq-reviewer"
-escalate = true                        # consumed by dispatch: on chain-exhaustion, label needs:user
+escalate = true                        # capacity: bounded defer -> machine status:parked, not needs:user
 
 # ---------------------------------------------------------------------------------------------------
 # [SPARQ agent] ROLE ROUTES. The 2026-09-02 maintainer protocol separates responsibilities: GPT-5.6
@@ -211,8 +216,8 @@ escalate = true
 # defer loop; `status:parked` remains machine-recoverable when capacity returns.
 # scripts/triage.py derives role:ci for infra-surface labels (area:ci/area:ci-fragments/
 # area:orchestration/area:workflows/area:release) so surface-labelled infra work lands here.
-# Security overlap: the match_labels overrides above still WIN over this route (Opus + human
-# escalation) — where role:ci and a security surface overlap, the security lane is correct.
+# Security overlap: the match_labels overrides above still WIN over this route (Opus-only review +
+# a separate human post-review arm) — where role:ci and a security surface overlap, that lane wins.
 [[route]]
 role = "ci"
 model_chain = ["sol", "opus5"]
@@ -229,9 +234,10 @@ escalate = true
 # rungs left a ONE-RUNG chain with no `escalate`, i.e. no exit at all: on an opus5 capacity outage
 # the item could only defer, and defer again, forever — a silent permanent stall with no human
 # ever notified. Deprecating a fallback therefore has to come with an exit, so research now
-# escalates like the other single-rung (review/soundness/security) chains: chain exhaustion parks
-# the issue to needs:user. Deliberately NOT solved by adding `sol`: research authorship stays on
-# the anthropic side, and a cross-provider rung would have hidden the stall rather than surfaced it.
+# escalates like the other single-rung (review/soundness/security) chains: chain exhaustion takes
+# the bounded defer -> machine-owned `status:parked` path documented above. Deliberately NOT solved
+# by adding `sol`: research authorship stays on the anthropic side, and a cross-provider rung would
+# have hidden the stall rather than surfaced it.
 [[route]]
 role = "research"
 model_chain = ["opus5"]
@@ -253,7 +259,7 @@ agent = "sparq-docs"
 escalate = true
 
 # Review / soundness: Opus 5 alone (the opus-4.8 tail fallback was deprecated 2026-07-26);
-# escalate to human on chain-exhaustion (do NOT fall to a weaker model).
+# on chain-exhaustion use the bounded machine-park contract above (do NOT fall to a weaker model).
 [[route]]
 role = "review"
 model_chain = ["opus5"]

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -109,7 +109,7 @@ agent = "sparq-reviewer"
 escalate = true                        # consumed by dispatch: on chain-exhaustion, label needs:user
 
 # ---------------------------------------------------------------------------------------------------
-# [GPT-5.6] ROLE ROUTES. The 2026-09-02 maintainer protocol separates responsibilities: GPT-5.6
+# [SPARQ agent] ROLE ROUTES. The 2026-09-02 maintainer protocol separates responsibilities: GPT-5.6
 # Sol is the primary implementation tier, while Opus 5 remains the review/soundness tier and
 # reviews new Sol-authored PRs through the existing cross-provider inversion. Opus stays behind Sol as a
 # continuity fallback for current Anthropic-authored repairs and total Sol unavailability. Each
@@ -203,7 +203,7 @@ model_chain = ["sol", "opus5"]
 agent = "sparq-site"
 escalate = true
 
-# [GPT-5.6] CI/infrastructure is implementation and therefore uses the same Sol-first lane. Opus 5
+# [SPARQ agent] CI/infrastructure is implementation and therefore uses the same Sol-first lane. Opus 5
 # reviews the resulting OpenAI-authored PR through the registry-owned review chain.
 # The chain is deliberately frontier-only rather than floor-pinned. `escalate = true` uses the
 # registry's bounded capacity-starvation path: retry first, then a visible machine-owned park.
@@ -264,7 +264,7 @@ agent = "sparq-reviewer"
 escalate = true
 
 # ---------------------------------------------------------------------------------------------------
-# [GPT-5.6] LEGACY CHAIN-ORDER PREFERENCE — retained for PLAN/CLAIM compatibility with older
+# [SPARQ agent] LEGACY CHAIN-ORDER PREFERENCE — retained for PLAN/CLAIM compatibility with older
 # target revisions.
 # The current implementation routes are already Sol-first, so this rule is idempotent today. It
 # remains declared as data because the dispatch decision is made twice, in two repositories:

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -105,13 +105,21 @@ escalate = true
 # Registry CLAIM first keeps the item `status:deferred` during the bounded retry grace, then applies
 # the machine-owned `status:parked` soft hold if zero headroom persists; a successful retry after
 # recovery clears that hold.
+# The executable cross-repo contract lives at stable symbols, not copied prose: this repo's
+# `scripts/route-resolve.py::resolve()` propagates the flag into
+# `scripts/dispatch-plan.py::plan_dispatch()`. The registry revalidates it in
+# `jeswr/agent-account-registry/scripts/policy-resolve.py::resolve()`, then
+# `scripts/dispatch-claim.py::escalate_starved()` and `::escalate_persist_decision()` enforce the
+# zero-headroom observation and bounded grace. Its `::_park_source_issue()` delegates the label
+# transition to `scripts/worker-issue.py::set_status(..., "parked")`; the same function's `"retry"`
+# transition clears both `status:deferred` and `status:parked` when capacity recovers.
 # This keeps the route fail-closed without turning provider capacity into a human-owned terminal.
 # The separate post-review trust/soundness arm remains human-gated.
 [[route]]
 match_labels = ["zk", "mpc", "reasoner", "crypto", "auth", "e2ee"]
 model_chain = ["opus5"]
 agent = "sparq-reviewer"
-escalate = true                        # capacity: bounded defer -> machine status:parked, not needs:user
+escalate = true                        # capacity contract above; registry _park_source_issue(), never needs:user
 
 # ---------------------------------------------------------------------------------------------------
 # [SPARQ agent] ROLE ROUTES. The 2026-09-02 maintainer protocol separates responsibilities: GPT-5.6
@@ -211,7 +219,8 @@ escalate = true
 # [SPARQ agent] CI/infrastructure is implementation and therefore uses the same Sol-first lane. Opus 5
 # reviews the resulting OpenAI-authored PR through the registry-owned review chain.
 # The chain is deliberately frontier-only rather than floor-pinned. `escalate = true` uses the
-# registry's bounded capacity-starvation path: retry first, then a visible machine-owned park.
+# registry's `dispatch-claim.py::{escalate_starved, escalate_persist_decision,
+# _park_source_issue}` path: retry first, then a visible machine-owned park, never `needs:user`.
 # This is intentional for CI: exhaustion of both providers must not become an unbounded silent
 # defer loop; `status:parked` remains machine-recoverable when capacity returns.
 # scripts/triage.py derives role:ci for infra-surface labels (area:ci/area:ci-fragments/

--- a/orchestration/routing.toml
+++ b/orchestration/routing.toml
@@ -113,8 +113,8 @@ escalate = true                        # consumed by dispatch: on chain-exhausti
 # Sol is the primary implementation tier, while Opus 5 remains the review/soundness tier and
 # reviews new Sol-authored PRs through the existing cross-provider inversion. Opus stays behind Sol as a
 # continuity fallback for current Anthropic-authored repairs and total Sol unavailability. Each
-# implementation route declares `escalate = true` so total exhaustion has the existing bounded,
-# machine-owned exit.
+# implementation route declares `escalate = true` so capacity exhaustion takes the registry's
+# bounded retry path and then its visible, machine-owned `status:parked` soft hold.
 
 # HISTORICAL CONTEXT (superseded by the 2026-09-02 protocol above): `role:impl` was Opus5-only
 # beginning 2026-07-26. The measurements below explain that prior state; they are not current policy.
@@ -207,6 +207,8 @@ escalate = true
 # reviews the resulting OpenAI-authored PR through the registry-owned review chain.
 # The chain is deliberately frontier-only rather than floor-pinned. `escalate = true` uses the
 # registry's bounded capacity-starvation path: retry first, then a visible machine-owned park.
+# This is intentional for CI: exhaustion of both providers must not become an unbounded silent
+# defer loop; `status:parked` remains machine-recoverable when capacity returns.
 # scripts/triage.py derives role:ci for infra-surface labels (area:ci/area:ci-fragments/
 # area:orchestration/area:workflows/area:release) so surface-labelled infra work lands here.
 # Security overlap: the match_labels overrides above still WIN over this route (Opus + human
@@ -248,6 +250,7 @@ escalate = true
 role = "docs"
 model_chain = ["sol", "terra", "opus5"]
 agent = "sparq-docs"
+escalate = true
 
 # Review / soundness: Opus 5 alone (the opus-4.8 tail fallback was deprecated 2026-07-26);
 # escalate to human on chain-exhaustion (do NOT fall to a weaker model).

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -271,7 +271,7 @@ def _self_test():
 
     R = ["status:ready"]
 
-    # [GPT-5.6] Fixture: impl → Sol-first + Opus continuity fallback + escalate.
+    # [SPARQ agent] Fixture: impl → Sol-first + Opus continuity fallback + escalate.
     # The WHOLE chain is asserted, not only its head: the planner row is what the registry's CLAIM
     # step compares for exact equality. This catches either a lead-order regression or accidental
     # removal of the transition fallback needed to repair existing Opus-authored PRs.

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -271,17 +271,16 @@ def _self_test():
 
     R = ["status:ready"]
 
-    # --- Fixture: an impl issue → OPUS5-ONLY chain + escalate -------------------------------------
-    # [OPUS-5] maintainer decision 2026-07-26 on the registry #738 measurement ("Remove sol from
-    # impl fallback"): sol 18% vs opus5 86% in-cell first-attempt yield, n=74. The WHOLE chain is
-    # asserted, not its head — the planner row is what the registry's CLAIM step compares for EXACT
-    # equality, so a demoted-not-removed sol must red here too.
+    # [GPT-5.6] Fixture: impl → Sol-first + Opus continuity fallback + escalate.
+    # The WHOLE chain is asserted, not only its head: the planner row is what the registry's CLAIM
+    # step compares for exact equality. This catches either a lead-order regression or accidental
+    # removal of the transition fallback needed to repair existing Opus-authored PRs.
     impl = compute_ready([iss(1, R + ["priority:P1", "role:impl", "area:sparq-core"])])
     p_impl = plan_dispatch(impl, doc)
     chk("impl -> single row", len(p_impl), 1)
     row = p_impl[0]
     chk("impl row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
-        ("impl", ["opus5"], "sparq-rust-impl", True))
+        ("impl", ["sol", "opus5"], "sparq-rust-impl", True))
     chk("impl package", row["package"], "sparq-core")
     chk("impl priority", row["priority"], 1)
 
@@ -306,13 +305,11 @@ def _self_test():
     chk("docs -> sparq-docs", row["agent"], "sparq-docs")
 
     # --- Fixture: a ci/infra issue → frontier-only chain (standing rule 2026-07-17) --------------
-    # No sub-frontier model (sonnet/haiku) in the plan row's chain: the registry claim step can
-    # only serve a frontier account or DEFER the item to the next tick — degradation to a cheaper
-    # authoring tier is impossible by construction (see routing-validate's frontier-floor check).
+    # CI is implementation, so the plan row must be Sol-first with the continuity fallback.
     ci = compute_ready([iss(8, R + ["priority:P1", "role:ci", "area:ci"])])
     row = plan_dispatch(ci, doc)[0]
-    chk("ci -> frontier-only row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
-        ("ci", ["opus5", "sol"], "sparq-ci-infra", False))
+    chk("ci -> Sol-first row", (row["role"], row["model_chain"], row["agent"], row["escalate"]),
+        ("ci", ["sol", "opus5"], "sparq-ci-infra", True))
     chk("ci row has no sub-frontier tier", sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
 
     # --- Fixture: package-conflict pair → only the higher-priority one is planned ----------------

--- a/scripts/dispatch-plan.py
+++ b/scripts/dispatch-plan.py
@@ -303,6 +303,7 @@ def _self_test():
     chk("docs row has no cheap anthropic tier",
         sorted(set(row["model_chain"]) & {"sonnet", "haiku"}), [])
     chk("docs -> sparq-docs", row["agent"], "sparq-docs")
+    chk("docs -> bounded exhaustion", row["escalate"], True)
 
     # --- Fixture: a ci/infra issue → frontier-only chain (standing rule 2026-07-17) --------------
     # CI is implementation, so the plan row must be Sol-first with the continuity fallback.

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -280,17 +280,19 @@ def _self_test():
         (["sol", "terra", "opus5"], "sparq-docs", True))
     chk("docs chain has no cheap anthropic tier",
         sorted(set(resolve(["role:docs", "area:x"], doc)[0]) & NOT_A_ROUTING_TARGET), [])
-    chk("site -> Sol-first implementation",
-        resolve(["role:site", "area:site"], doc)[0::2], (["sol", "opus5"], True))
+    site_mc, _site_agent, site_esc = resolve(["role:site", "area:site"], doc)
+    chk("site -> Sol-first implementation", (site_mc, site_esc), (["sol", "opus5"], True))
     # CI is implementation under the same Sol-first protocol.
     mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
     chk("ci -> Sol-first implementation", (mc, ag, esc),
         (["sol", "opus5"], "sparq-ci-infra", True))
     chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
+    default_mc, _default_agent, default_esc = resolve(["area:sparq-core"], doc)
     chk("no role -> Sol-first defaults",
-        resolve(["area:sparq-core"], doc)[0::2], (["sol", "opus5"], True))
+        (default_mc, default_esc), (["sol", "opus5"], True))
+    perf_mc, _perf_agent, perf_esc = resolve(["role:perf", "area:sparq-engine"], doc)
     chk("perf -> Sol-first implementation",
-        resolve(["role:perf", "area:sparq-engine"], doc)[0::2], (["sol", "opus5"], True))
+        (perf_mc, perf_esc), (["sol", "opus5"], True))
 
     # ---------------------------------------------------------------------------------------------
     # [SPARQ agent] SOL IMPLEMENTATION + OPUS REVIEW (maintainer protocol 2026-09-02).

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -35,11 +35,14 @@ NOT_A_ROUTING_TARGET = {"haiku", "sonnet"}
 # docs chain and must not appear anywhere else.
 DOCS_ONLY = {"terra"}
 
-# [OPUS-5] THE `area:gui` CARVE-OUT — THE BINDING MECHANISM (review of PR #4211).
+# [GPT-5.6] LEGACY `area:gui` CARVE-OUT — THE COMPATIBILITY MECHANISM (review of PR #4211).
 #
-# MAINTAINER DIRECTIVE 2026-07-26: "Opus5 should be prioritised over sol on all tasks for which they
-# are both possible implementors; except for GUI work where sol should remain prioritised", boundary
-# settled the same day as "Let's just go with area:gui work".
+# Historical maintainer directive 2026-07-26: "Opus5 should be prioritised over sol on all tasks
+# for which they are both possible implementors; except for GUI work where sol should remain
+# prioritised", boundary settled the same day as "Let's just go with area:gui work".
+# The 2026-09-02 protocol now makes every implementation route Sol-first. This mechanism is
+# idempotent for the current routing table, but remains binding when resolving older target refs and
+# therefore must stay aligned between PLAN and CLAIM during the rollout.
 #
 # The first attempt expressed this as a `role:gui` ROUTE and had scripts/triage.py derive that role
 # from `area:gui`. Review proved it could never fire, for two independent reasons:
@@ -66,8 +69,9 @@ DOCS_ONLY = {"terra"}
 # UNIONS every `match_labels` keyword, so "gui" there would human-arm every GUI PR.
 #
 # THE SELECTOR IS `area:gui` AND NOTHING ELSE. `area:site`, `area:site-specs`, `area:site-papers`,
-# `surface:frontend`, `dashboard` are NOT GUI — they take the opus5-first default. Widening this set
-# over a site* label is the likely future mistake and is asserted against.
+# `surface:frontend`, `dashboard` are NOT GUI. They historically took the Opus-first site/default
+# route and now take the common Sol-first implementation route. Widening this exact legacy selector
+# over a site* label remains a compatibility mistake and is asserted against.
 GUI_CARVE_OUT_LABELS = frozenset({"area:gui"})
 GUI_CARVE_OUT_LEAD = "sol"
 # [OPUS-5] THE ROLES WHERE THE CARVE-OUT MAY *ADD* sol BACK, not merely re-order it (registry #738).
@@ -106,9 +110,9 @@ def gui_carve_out(labels, chain, role=None):
       own qualifier, encoded literally: the chain must contain BOTH sol and opus5, and the result is
       a strict PERMUTATION (re-order only).
     * sol ABSENT -> the result is the chain with sol PREPENDED, but only when `role` is in
-      GUI_CARVE_OUT_INJECT_ROLES. `role=None` never injects. That is what keeps the carve-out alive
-      now that `role:impl` is a single-rung `["opus5"]` chain, without making `role:research`
-      (anthropic-side + escalating) quietly cross-provider.
+      GUI_CARVE_OUT_INJECT_ROLES. `role=None` never injects. This preserves compatibility with
+      historical target refs where `role:impl` was a single-rung `["opus5"]` chain, without making
+      `role:research` (Anthropic-side + escalating) quietly cross-provider.
 
     Idempotent in both modes: applying it to an already-sol-first chain is a no-op.
     """
@@ -229,7 +233,7 @@ def resolve(labels, doc):
     # role is None here BY CONSTRUCTION (a roleless issue), so the defaults branch can never be
     # injected into — passed explicitly rather than left to the parameter default.
     return (gui_carve_out(labels, list(d.get("model_chain", [])), role=None),
-            d.get("agent"), False)
+            d.get("agent"), bool(d.get("escalate")))
 
 
 def _self_test():
@@ -261,76 +265,42 @@ def _self_test():
     # (the opus-4.8 tail fallback was deprecated 2026-07-26), escalate
     mc, ag, esc = resolve(["role:impl", "area:sparq-zk"], doc)
     chk("impl+zk -> opus5/escalate", (mc, ag, esc), (["opus5"], "sparq-reviewer", True))
-    # [OPUS-5] plain impl -> OPUS5-ONLY + escalate (maintainer decision 2026-07-26 on the registry
-    # #738 measurement: "Remove sol from impl fallback"; sol 18% vs opus5 86% in-cell, n=74). The
-    # WHOLE tuple is asserted rather than the chain head, so a future demotion of sol back to a
-    # second rung reds this instead of passing on `mc[0] == "opus5"`.
+    # [GPT-5.6] 2026-09-02 protocol: ordinary implementation is Sol-first, with Opus retained as
+    # the continuity fallback for current Anthropic-authored repairs and total Sol unavailability.
     mc, ag, esc = resolve(["role:impl", "area:sparq-core"], doc)
-    chk("impl -> OPUS5-ONLY, escalating", (mc, ag, esc), (["opus5"], "sparq-rust-impl", True))
-    chk("role:impl names NO openai tier at all (exclusion, not a demotion)",
-        sorted({doc["models"][m]["provider"] for m in mc}), ["anthropic"])
-    chk("role:impl ESCALATES, so a single-rung chain has a machine exit instead of deferring "
-        "forever with nobody notified", esc, True)
+    chk("impl -> SOL-FIRST with Opus continuity fallback", (mc, ag, esc),
+        (["sol", "opus5"], "sparq-rust-impl", True))
+    chk("role:impl preserves both providers for continuity",
+        sorted({doc["models"][m]["provider"] for m in mc}), ["anthropic", "openai"])
+    chk("role:impl has an explicit total-exhaustion exit", esc, True)
     # [OPUS-5] docs -> SOL-led (maintainer 2026-07-26: docs writing off haiku/sonnet onto gpt-5.6
     # sol). terra is sol's same-provider fallback; opus5 the cross-provider tail.
     chk("docs -> sol-led", resolve(["role:docs", "area:x"], doc)[0], ["sol", "terra", "opus5"])
     chk("docs chain has no cheap anthropic tier",
         sorted(set(resolve(["role:docs", "area:x"], doc)[0]) & NOT_A_ROUTING_TARGET), [])
-    # [FABLE-5] UI ownership: site -> sol-led (GPT-5.6 codex, the original dashboard builder)
-    # [OPUS-5] site is NOT the gui carve-out — it takes the opus5-first default (2026-07-26).
-    chk("site -> opus5-led (site is outside the area:gui carve-out)",
-        resolve(["role:site", "area:site"], doc)[0], ["opus5", "sol"])
-    # [FABLE-5] frontier-tier infra authorship (standing rule 2026-07-17): ci -> sol-first, opus5
-    # the SOLE anthropic tier since 2026-07-26. FRONTIER-ONLY chain — no sub-frontier model
-    # (sonnet/haiku) anywhere in it, so exhaustion DEFERS at the registry claim step (retried next
-    # tick) instead of degrading tier.
+    chk("site -> Sol-first implementation",
+        resolve(["role:site", "area:site"], doc)[0::2], (["sol", "opus5"], True))
+    # CI is implementation under the same Sol-first protocol.
     mc, ag, esc = resolve(["role:ci", "area:ci"], doc)
-    chk("ci -> frontier-only opus5-first", (mc, ag, esc), (["opus5", "sol"], "sparq-ci-infra", False))
+    chk("ci -> Sol-first implementation", (mc, ag, esc),
+        (["sol", "opus5"], "sparq-ci-infra", True))
     chk("ci chain has no sub-frontier tier", sorted(set(mc) & {"sonnet", "haiku"}), [])
-    # no role -> defaults (sol-led, 2026-07-18)
-    chk("no role -> defaults", resolve(["area:sparq-core"], doc)[0][0], "opus5")
-    chk("perf -> opus5-led", resolve(["role:perf", "area:sparq-engine"], doc)[0], ["opus5", "sol"])
+    chk("no role -> Sol-first defaults",
+        resolve(["area:sparq-core"], doc)[0::2], (["sol", "opus5"], True))
+    chk("perf -> Sol-first implementation",
+        resolve(["role:perf", "area:sparq-engine"], doc)[0::2], (["sol", "opus5"], True))
 
     # ---------------------------------------------------------------------------------------------
-    # [OPUS-5] OPUS-5-FIRST DEFAULT + THE `area:gui` CARVE-OUT (maintainer 2026-07-26).
+    # [GPT-5.6] SOL IMPLEMENTATION + OPUS REVIEW (maintainer protocol 2026-09-02).
     # ---------------------------------------------------------------------------------------------
-    # Every route where opus5 AND sol are both viable implementors must lead with opus5...
-    # `role:impl` is deliberately EXCLUDED from this loop since 2026-07-26: it is the one
-    # implementor route where sol was REMOVED rather than demoted (asserted separately above).
-    for _role in ("site", "ci", "perf"):
-        mc = resolve([f"role:{_role}"], doc)[0]
-        chk(f"role:{_role} prefers opus5 over sol", mc[0], "opus5")
-        chk(f"role:{_role} keeps sol reachable as a fallback (preference, not exclusion)",
-            "sol" in mc, True)
-    chk("defaults prefer opus5 over sol", resolve(["area:sparq-core"], doc)[0][0], "opus5")
-    # ...and the EXCLUSION is scoped to exactly one role. This is the guard that reds if a future
-    # edit copies the sol removal onto a route the maintainer did not scope it to.
-    chk("role:impl is the ONLY role route with no openai rung besides the escalating lanes",
-        sorted(r for r in ("impl", "site", "gui", "ci", "perf", "docs")
-               if not any(doc["models"][m]["provider"] == "openai"
-                          for m in resolve([f"role:{r}"], doc)[0])),
-        ["impl"])
-    # ...EXCEPT role:gui, which keeps the sol lead (original-builder steer, task #331).
-    gui = resolve(["role:gui", "area:gui"], doc)[0]
-    chk("role:gui KEEPS sol first (the carve-out)", gui[0], "sol")
-    chk("role:gui keeps opus5 reachable (GUI stays dispatchable in a sol outage)",
-        "opus5" in gui, True)
+    for _role in ("impl", "site", "gui", "ci", "perf"):
+        mc, _agent, esc = resolve([f"role:{_role}"], doc)
+        chk(f"role:{_role} is Sol-first with Opus continuity fallback",
+            (mc, esc), (["sol", "opus5"], True))
     chk("role:gui routes to the site agent", resolve(["role:gui"], doc)[1], "sparq-site")
-    # The carve-out is EXACTLY role:gui. role:site must NOT be swept into it — "GUI" reads
-    # informally as covering the site surfaces, which is the likely future widening mistake.
-    chk("role:site is NOT in the sol carve-out", resolve(["role:site"], doc)[0][0], "opus5")
-    # Both directions terminate: neither class can become undispatchable. `role:impl` is now
-    # deliberately single-provider, so its termination guarantee is `escalate = true` (a bounded
-    # starvation ladder ending in a self-clearing machine park) rather than a cross-provider rung —
-    # asserted above and, for the GUI carve-out, immediately below.
-    for _role in ("site", "ci", "perf", "gui"):
-        mc = resolve([f"role:{_role}"], doc)[0]
-        chk(f"role:{_role} chain is cross-provider (cannot be starved by one provider)",
-            sorted({doc["models"][m]["provider"] for m in mc}), ["anthropic", "openai"])
-    chk("role:impl is single-provider, so it MUST escalate (otherwise an opus5 outage is a silent "
-        "permanent stall)",
+    chk("role:impl has an explicit total-exhaustion exit",
         (sorted({doc["models"][m]["provider"] for m in resolve(["role:impl"], doc)[0]}),
-         resolve(["role:impl"], doc)[2]), (["anthropic"], True))
+         resolve(["role:impl"], doc)[2]), (["anthropic", "openai"], True))
     chk("research -> opus5 only", resolve(["role:research"], doc)[0], ["opus5"])
     # review role -> opus5 + escalate
     chk("review -> opus5/escalate", resolve(["role:review"], doc)[1:], ("sparq-reviewer", True))
@@ -350,45 +320,35 @@ def _self_test():
         resolve(["area:gui", "role:impl"], doc)[1], "sparq-rust-impl")
     chk("area:gui with NO role at all -> defaults, SOL-first",
         resolve(["area:gui", "priority:P2"], doc)[0], ["sol", "opus5"])
-    # [OPUS-5] THE COLLISION BETWEEN THE TWO DIRECTIVES, as a test rather than as prose
-    # (registry #738). `role:impl` is now a SINGLE-RUNG `["opus5"]` chain, and the carve-out was a
-    # pure re-ordering — so without the `inject_roles` opt-in these 33 issues resolve opus5-only,
-    # re-inverting the maintainer's one stated exception with no symptom whatsoever (both resolvers
-    # agree on the wrong answer, so the PLAN/CLAIM agreement harness reports nothing). These three
-    # rows are the ones that red if the injection branch, the declaration, or the allow-list is
-    # deleted.
-    chk("the live role:impl route really IS single-rung (so the row above is not passing because "
-        "sol happens to still be in the chain)",
-        [r["model_chain"] for r in doc["route"] if r.get("role") == "impl"], [["opus5"]])
-    chk("a re-order-ONLY carve-out would DISARM on that chain (this is the defect being fixed)",
+    # Compatibility behavior: the current route is already Sol-first, while the retained
+    # declaration still handles an older Opus-only target revision identically on PLAN and CLAIM.
+    chk("the live role:impl route is Sol-first with the continuity fallback",
+        [r["model_chain"] for r in doc["route"] if r.get("role") == "impl"],
+        [["sol", "opus5"]])
+    chk("a re-order-only legacy rule declines an Opus-only chain",
         gui_carve_out({"area:gui", "role:impl"}, ["opus5"], role=None), ["opus5"])
-    chk("...and the injection allow-list is what restores it",
+    chk("...and its legacy injection allow-list restores Sol-first continuity",
         gui_carve_out({"area:gui", "role:impl"}, ["opus5"], role="impl"), ["sol", "opus5"])
     chk("area:gui + role:impl still ESCALATES (it inherits the impl route's exit; sol is a "
         "preference on top, not a replacement for the exit)",
         resolve(["area:gui", "role:impl"], doc)[2], True)
     for _role in ("impl", "site", "ci", "perf", "gui"):
         mc = resolve(["area:gui", f"role:{_role}"], doc)[0]
-        chk(f"area:gui + role:{_role} -> sol-first", mc[0], "sol")
-        chk(f"area:gui + role:{_role} keeps opus5 reachable (preference, not exclusion)",
-            "opus5" in mc, True)
-    # site* is NOT GUI — the exclusion the review confirmed already works; assert it end to end too.
-    # Since 2026-07-26 the correct answer for a NON-gui role:impl issue is the OPUS5-ONLY chain, so
-    # these rows are simultaneously the "site is outside the carve-out" guard and the "injection
-    # does not leak past the exact `area:gui` selector" guard.
+        chk(f"area:gui + role:{_role} -> Sol-first implementation", mc, ["sol", "opus5"])
+    # Non-GUI implementation takes the same Sol-first default.
     for _area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
-        chk(f"{_area} + role:impl -> opus5-ONLY (site is outside the carve-out, and gets no sol)",
-            resolve([_area, "role:impl"], doc)[0], ["opus5"])
-    chk("role:site + area:site -> opus5-first end to end",
-        resolve(["role:site", "area:site"], doc)[0], ["opus5", "sol"])
+        chk(f"{_area} + role:impl -> Sol-first implementation",
+            resolve([_area, "role:impl"], doc)[0], ["sol", "opus5"])
+    chk("role:site + area:site -> Sol-first implementation end to end",
+        resolve(["role:site", "area:site"], doc)[0], ["sol", "opus5"])
     chk("surface:frontend is not in the carve-out",
-        resolve(["surface:frontend", "role:site"], doc)[0][0], "opus5")
+        gui_carve_out({"surface:frontend"}, ["opus5"], role="impl"), ["opus5"])
     # EXACT label: a substring selector would sweep area:guide into the sol carve-out. Now that the
     # carve-out can ADD sol, a false match is no longer merely a re-order — it would hand a
     # deliberately excluded model back to a non-GUI issue, so these rows carry more weight.
     for _near in ("area:guide", "area:guidance", "area:gui-toolkit", "xarea:gui", "gui"):
-        chk(f"{_near} does NOT false-match the carve-out (and is given NO sol rung)",
-            resolve([_near, "role:impl"], doc)[0], ["opus5"])
+        chk(f"{_near} does NOT false-match the carve-out",
+            gui_carve_out({_near}, ["opus5"], role="impl"), ["opus5"])
     # Security still wins, and its chain is returned UNTOUCHED by the preference rule.
     chk("area:gui + a security surface -> soundness lane, unmodified",
         resolve(["area:gui", "area:sparq-zk", "role:impl"], doc),
@@ -409,7 +369,7 @@ def _self_test():
         resolve(["area:gui", "area:sparq-zk", "role:impl"], _xsec)[0], ["opus5", "sol"])
     chk("...while the same table still applies the carve-out on the role branch (so the check "
         "above is an exemption, not a dead fixture)",
-        resolve(["area:gui", "role:impl"], _xsec)[0], ["sol", "opus5"])
+        gui_carve_out({"area:gui"}, ["opus5"], role="impl"), ["sol", "opus5"])
     # "for which they are BOTH possible implementors": a chain without sol is left alone, so the
     # carve-out cannot quietly turn research (anthropic-side + escalate) into a cross-provider route.
     chk("area:gui + role:research is NOT rewritten (sol is not an implementor there)",

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -35,7 +35,7 @@ NOT_A_ROUTING_TARGET = {"haiku", "sonnet"}
 # docs chain and must not appear anywhere else.
 DOCS_ONLY = {"terra"}
 
-# [GPT-5.6] LEGACY `area:gui` CARVE-OUT — THE COMPATIBILITY MECHANISM (review of PR #4211).
+# [SPARQ agent] LEGACY `area:gui` CARVE-OUT — THE COMPATIBILITY MECHANISM (review of PR #4211).
 #
 # Historical maintainer directive 2026-07-26: "Opus5 should be prioritised over sol on all tasks
 # for which they are both possible implementors; except for GUI work where sol should remain
@@ -265,7 +265,7 @@ def _self_test():
     # (the opus-4.8 tail fallback was deprecated 2026-07-26), escalate
     mc, ag, esc = resolve(["role:impl", "area:sparq-zk"], doc)
     chk("impl+zk -> opus5/escalate", (mc, ag, esc), (["opus5"], "sparq-reviewer", True))
-    # [GPT-5.6] 2026-09-02 protocol: ordinary implementation is Sol-first, with Opus retained as
+    # [SPARQ agent] 2026-09-02 protocol: ordinary implementation is Sol-first, with Opus retained as
     # the continuity fallback for current Anthropic-authored repairs and total Sol unavailability.
     mc, ag, esc = resolve(["role:impl", "area:sparq-core"], doc)
     chk("impl -> SOL-FIRST with Opus continuity fallback", (mc, ag, esc),
@@ -291,7 +291,7 @@ def _self_test():
         resolve(["role:perf", "area:sparq-engine"], doc)[0::2], (["sol", "opus5"], True))
 
     # ---------------------------------------------------------------------------------------------
-    # [GPT-5.6] SOL IMPLEMENTATION + OPUS REVIEW (maintainer protocol 2026-09-02).
+    # [SPARQ agent] SOL IMPLEMENTATION + OPUS REVIEW (maintainer protocol 2026-09-02).
     # ---------------------------------------------------------------------------------------------
     for _role in ("impl", "site", "gui", "ci", "perf"):
         mc, _agent, esc = resolve([f"role:{_role}"], doc)

--- a/scripts/route-resolve.py
+++ b/scripts/route-resolve.py
@@ -275,7 +275,9 @@ def _self_test():
     chk("role:impl has an explicit total-exhaustion exit", esc, True)
     # [OPUS-5] docs -> SOL-led (maintainer 2026-07-26: docs writing off haiku/sonnet onto gpt-5.6
     # sol). terra is sol's same-provider fallback; opus5 the cross-provider tail.
-    chk("docs -> sol-led", resolve(["role:docs", "area:x"], doc)[0], ["sol", "terra", "opus5"])
+    chk("docs -> sol-led with bounded exhaustion",
+        resolve(["role:docs", "area:x"], doc),
+        (["sol", "terra", "opus5"], "sparq-docs", True))
     chk("docs chain has no cheap anthropic tier",
         sorted(set(resolve(["role:docs", "area:x"], doc)[0]) & NOT_A_ROUTING_TARGET), [])
     chk("site -> Sol-first implementation",

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -147,7 +147,7 @@ class TestRoutingTable(unittest.TestCase):
 
 
 class TestProviderPreference(unittest.TestCase):
-    """[GPT-5.6] The 2026-09-02 protocol makes model responsibility explicit.
+    """[SPARQ agent] The 2026-09-02 protocol makes model responsibility explicit.
 
     Sol is the primary default implementation tier. Opus 5 is retained behind it for continuity
     with current Anthropic-authored fixes and total Sol unavailability, and is the sole

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -120,6 +120,8 @@ class TestRoutingTable(unittest.TestCase):
         self.assertEqual(len(docs), 1, "exactly one role=docs route expected")
         chain = docs[0]["model_chain"]
         self.assertEqual(chain[0], "sol", "docs writing must lead with sol (gpt-5.6)")
+        self.assertTrue(docs[0].get("escalate"),
+                        "docs writing needs a bounded exit when every provider is unavailable")
         self.assertEqual(sorted(set(chain) & {"haiku", "sonnet"}), [],
                          "docs writing was moved off the cheap anthropic tiers on 2026-07-26")
 

--- a/scripts/tests/test_no_deprecated_models.py
+++ b/scripts/tests/test_no_deprecated_models.py
@@ -147,26 +147,14 @@ class TestRoutingTable(unittest.TestCase):
 
 
 class TestProviderPreference(unittest.TestCase):
-    """[OPUS-5] Opus 5 is preferred over sol EXCEPT on `area:gui` (maintainer 2026-07-26).
+    """[GPT-5.6] The 2026-09-02 protocol makes model responsibility explicit.
 
-    WHY THIS IS A GUARD AND NOT JUST AN EDIT: sol did not win ~every implementation route through
-    any adaptive heuristic. The registry's allocator walks `model_chain` IN ORDER and claims the
-    first available account, so the sol-first literal — set during a 2026-07-18 high-availability
-    window — simply won every route on every tick, and kept winning long after availability
-    shifted. Measured 2026-07-26: 11 of the 12 most recent orchestrator PRs were sol-implemented.
-    A preference expressed purely as chain ORDER decays exactly this way, so the order is pinned.
+    Sol is the primary default implementation tier. Opus 5 is retained behind it for continuity
+    with current Anthropic-authored fixes and total Sol unavailability, and is the sole
+    review/soundness tier. These tests pin whole chains rather than only their first elements.
     """
 
-    # The routes where opus5 and sol are BOTH viable implementors and the preference is expressed
-    # as ORDER. role:docs is excluded: the separate 2026-07-26 docs-writing directive puts sol first
-    # there deliberately. role:impl is excluded because it is no longer a preference at all — see
-    # OPUS5_ONLY_ROLES.
-    OPUS5_FIRST_ROLES = ("site", "ci", "perf")
-    # [OPUS-5] registry #738 (maintainer decision 2026-07-26: "Remove sol from impl fallback"). The
-    # routes where sol is EXCLUDED, not merely outranked. Measured in-cell `role:impl` first-attempt
-    # yield: sol 7/40 = 18% vs opus5 12/14 = 86%, n=74, same route and same brief; 4/4 same-issue
-    # crossovers; budget exhaustion refuted (longest no-diff model step 177s vs a 90-minute timeout).
-    OPUS5_ONLY_ROLES = ("impl",)
+    IMPLEMENTATION_ROLES = ("impl", "site", "gui", "ci", "perf")
     GUI_ROLE = "gui"
 
     @classmethod
@@ -174,61 +162,32 @@ class TestProviderPreference(unittest.TestCase):
         cls.doc = _routing_doc()
         cls.routes = {r["role"]: r for r in cls.doc["route"] if r.get("role")}
 
-    def test_default_prefers_opus5_over_sol(self):
-        """MUTANT: reorder any of these chains back to sol-first => RED."""
-        for role in self.OPUS5_FIRST_ROLES:
-            chain = self.routes[role]["model_chain"]
-            self.assertEqual(chain[0], "opus5",
-                             f"role:{role} must prefer opus5 over sol (maintainer 2026-07-26)")
-            self.assertLess(chain.index("opus5"), chain.index("sol"),
-                            f"role:{role}: opus5 must outrank sol")
+    def test_implementation_routes_are_sol_first(self):
+        """MUTANT: add or substitute any implementation tier => RED."""
+        for role in self.IMPLEMENTATION_ROLES:
+            self.assertEqual(self.routes[role]["model_chain"], ["sol", "opus5"],
+                             f"role:{role} must be Sol-first implementation")
 
-    def test_defaults_chain_prefers_opus5(self):
-        self.assertEqual(self.doc["defaults"]["model_chain"][0], "opus5")
+    def test_defaults_chain_is_sol_first(self):
+        self.assertEqual(self.doc["defaults"]["model_chain"], ["sol", "opus5"])
+        self.assertTrue(self.doc["defaults"].get("escalate"))
 
-    def test_preference_is_not_exclusion(self):
-        """sol must stay REACHABLE on the ORDER-preference routes. MUTANT: drop sol from one of
-        these chains => RED. `role:impl` is deliberately NOT in this set since 2026-07-26."""
-        for role in self.OPUS5_FIRST_ROLES:
-            self.assertIn("sol", self.routes[role]["model_chain"],
-                          f"role:{role}: sol must remain a fallback, not be excluded")
+    def test_review_and_soundness_routes_are_opus5_only(self):
+        for role in ("review", "soundness"):
+            self.assertEqual(self.routes[role]["model_chain"], ["opus5"])
+            self.assertTrue(self.routes[role].get("escalate"))
 
-    def test_impl_route_is_opus5_only(self):
-        """[OPUS-5] registry #738 — the EXCLUSION, asserted as a whole-chain equality rather than a
-        head check so demoting sol back to a second rung reds this too.
+    def test_implementation_routes_preserve_cross_provider_continuity(self):
+        for role in self.IMPLEMENTATION_ROLES:
+            providers = {self.doc["models"][m]["provider"]
+                         for m in self.routes[role]["model_chain"]}
+            self.assertEqual(providers, {"anthropic", "openai"})
 
-        MUTANT: restore ["opus5", "sol"] on role:impl => RED."""
-        for role in self.OPUS5_ONLY_ROLES:
-            chain = self.routes[role]["model_chain"]
-            self.assertEqual(chain, ["opus5"],
-                             f"role:{role} must be opus5-ONLY (maintainer 2026-07-26: remove sol "
-                             f"from impl fallback)")
-            providers = {self.doc["models"][m]["provider"] for m in chain}
-            self.assertEqual(providers, {"anthropic"},
-                             f"role:{role} must name no openai tier at all")
-
-    def test_impl_exclusion_comes_with_an_exit(self):
-        """A single-rung chain with no `escalate` has NO exit: on an opus5 capacity outage the item
-        defers, and defers again, forever, with nobody notified. Deprecating a fallback has to come
-        with an exit — the same shape role:research uses.
-
-        MUTANT: delete `escalate = true` from the role:impl route => RED."""
-        for role in self.OPUS5_ONLY_ROLES:
+    def test_implementation_routes_have_an_explicit_exhaustion_exit(self):
+        """Total implementation-chain exhaustion must park visibly rather than defer forever."""
+        for role in self.IMPLEMENTATION_ROLES:
             self.assertTrue(self.routes[role].get("escalate"),
-                            f"role:{role} is single-provider and single-rung, so it MUST escalate")
-
-    def test_the_exclusion_is_scoped_to_the_roles_the_maintainer_named(self):
-        """The directive removed sol from `role:impl` and nothing else. This is the guard that reds
-        if a future edit copies the exclusion onto another implementor route (or onto docs/gui).
-
-        MUTANT: drop sol from role:site / role:perf / role:ci / role:gui / role:docs => RED."""
-        excluded = sorted(
-            role for role, r in self.routes.items()
-            if role in ("impl", "site", "ci", "perf", "gui", "docs")
-            and not any(self.doc["models"][m]["provider"] == "openai"
-                        for m in r["model_chain"]))
-        self.assertEqual(excluded, sorted(self.OPUS5_ONLY_ROLES),
-                         "exactly the roles in OPUS5_ONLY_ROLES may lack an openai rung")
+                            f"role:{role} needs a bounded exit when both providers are unavailable")
 
     def test_gui_carve_out_keeps_sol_first(self):
         """MUTANT: delete the role:gui route, or flip it to opus5-first => RED."""
@@ -238,20 +197,8 @@ class TestProviderPreference(unittest.TestCase):
         self.assertEqual(chain[0], "sol",
                          "GUI work keeps sol first (original-builder steer, task #331)")
 
-    def test_gui_carve_out_is_preference_not_exclusion(self):
-        """GUI must stay dispatchable during a sol/OpenAI outage."""
-        self.assertIn("opus5", self.routes[self.GUI_ROLE]["model_chain"])
-
-    def test_every_preference_chain_terminates_cross_provider(self):
-        """Both directions must terminate: a chain naming only ONE provider can be starved by that
-        provider's outage with no other rung to fall to. `role:impl` is excluded since 2026-07-26 —
-        it is deliberately single-provider and its termination guarantee is `escalate = true`
-        (test_impl_exclusion_comes_with_an_exit), not a cross-provider rung."""
-        for role in self.OPUS5_FIRST_ROLES + (self.GUI_ROLE,):
-            chain = self.routes[role]["model_chain"]
-            providers = {self.doc["models"][m]["provider"] for m in chain}
-            self.assertEqual(providers, {"anthropic", "openai"},
-                             f"role:{role} chain {chain} is single-provider — it can be starved")
+    def test_gui_route_keeps_the_continuity_fallback(self):
+        self.assertEqual(self.routes[self.GUI_ROLE]["model_chain"], ["sol", "opus5"])
 
     def test_carve_out_selector_is_exactly_area_gui(self):
         """THE ONE THAT MATTERS MOST. "GUI" informally reads as covering the site surfaces, so the
@@ -269,8 +216,8 @@ class TestProviderPreference(unittest.TestCase):
                          "no surface:frontend, no dashboard")
 
     def test_site_surfaces_are_not_in_the_carve_out(self):
-        """The same property from the other side: the generic UI label set (which routes to the
-        opus5-first role:site) must not contain area:gui, and the gui set must not contain any
+        """The same property from the other side: the generic UI label set (which routes to
+        role:site) must not contain area:gui, and the gui set must not contain any
         site* label. MUTANT: move area:gui back into UI_SURFACE_LABELS => RED."""
         triage_src = (REPO_ROOT / "scripts" / "triage.py").read_text(encoding="utf-8")
         ui = re.search(r"(?m)^UI_SURFACE_LABELS = \(([^)]*)\)", triage_src)
@@ -278,7 +225,7 @@ class TestProviderPreference(unittest.TestCase):
         ui_labels = [x.strip().strip("\"'") for x in ui.group(1).split(",") if x.strip()]
         self.assertNotIn("area:gui", ui_labels,
                          "area:gui must derive role:gui, not role:site — otherwise the carve-out "
-                         "is inexpressible and GUI silently takes the opus5-first default")
+                         "is inexpressible on older target refs during the protocol rollout")
         self.assertIn("area:site", ui_labels, "role:site must still cover area:site")
 
 
@@ -325,13 +272,12 @@ class TestLabelsToModelChain(unittest.TestCase):
 
     def test_area_gui_with_no_role_at_all_is_sol_first(self):
         """The fail-open case the write path produced: a GUI issue promoted with NO role label
-        resolves through `[defaults]`, which is opus5-first. The carve-out must bind there too."""
+        resolves through `[defaults]`, which is now Sol-first."""
         self.assertEqual(self.chain(["area:gui", "priority:P2", "area:sparq-gui"])[0], "sol")
 
-    def test_gui_carve_out_is_preference_not_exclusion_end_to_end(self):
-        """GUI work must stay dispatchable during an OpenAI outage."""
+    def test_gui_implementation_is_sol_first_end_to_end(self):
         for role in ("impl", "perf", "site", "ci", "gui"):
-            self.assertIn("opus5", self.chain(["area:gui", f"role:{role}"]))
+            self.assertEqual(self.chain(["area:gui", f"role:{role}"]), ["sol", "opus5"])
 
     def test_gui_carve_out_re_orders_but_never_re_routes(self):
         """The directive speaks only about MODEL priority. The carve-out must not change which
@@ -343,20 +289,19 @@ class TestLabelsToModelChain(unittest.TestCase):
                          self.rr.resolve(["role:perf"], self.doc)[1])
 
     # -- the exclusion that already worked, now asserted at the deciding layer ------------------
-    def test_site_surfaces_are_opus5_first_end_to_end(self):
-        """`site*` is NOT in the carve-out (maintainer: "Let's just go with area:gui work").
-        MUTANT: add any site* label to `GUI_CARVE_OUT_LABELS` => RED."""
+    def test_site_surfaces_are_sol_first_end_to_end(self):
         for area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
-            self.assertEqual(self.chain([area, "role:impl", "priority:P2"])[0], "opus5",
-                             f"{area} must take the opus5-first default")
-            self.assertEqual(self.chain([area, "role:site", "priority:P2"])[0], "opus5")
-        self.assertEqual(self.chain(["surface:frontend", "role:site"])[0], "opus5")
-        self.assertEqual(self.chain(["dashboard", "role:site"])[0], "opus5")
+            self.assertEqual(self.chain([area, "role:impl", "priority:P2"]), ["sol", "opus5"])
+            self.assertEqual(self.chain([area, "role:site", "priority:P2"]), ["sol", "opus5"])
+        self.assertEqual(self.chain(["surface:frontend", "role:site"]), ["sol", "opus5"])
+        self.assertEqual(self.chain(["dashboard", "role:site"]), ["sol", "opus5"])
 
     def test_the_selector_is_an_exact_label_not_a_substring(self):
         """`"gui" in label` would sweep `area:guide` into the sol carve-out."""
-        self.assertEqual(self.chain(["area:guide", "role:impl"])[0], "opus5")
-        self.assertEqual(self.chain(["kind:guidance", "role:impl"])[0], "opus5")
+        self.assertEqual(self.rr.gui_carve_out({"area:guide"}, ["opus5"], role="impl"),
+                         ["opus5"])
+        self.assertEqual(self.rr.gui_carve_out({"kind:guidance"}, ["opus5"], role="impl"),
+                         ["opus5"])
 
     def test_carve_out_label_set_is_exactly_area_gui(self):
         """MUTANT: widen `GUI_CARVE_OUT_LABELS` => RED. Pinned as a set as well as behaviourally,
@@ -400,29 +345,13 @@ class TestLabelsToModelChain(unittest.TestCase):
                    & {"research", "review", "soundness"}), [],
             "no authorship-pinned escalating lane may be in the injection allow-list")
 
-    def test_gui_impl_work_survives_the_single_rung_impl_chain(self):
-        """[OPUS-5] THE HEADLINE GUARD OF registry #738's ROUTING CHANGE.
-
-        `role:impl` is now `["opus5"]`. The `area:gui` carve-out was a pure RE-ORDERING, so on a
-        chain that no longer contains sol its both-implementors condition declines and the carve-out
-        goes INERT — all 33 open `area:gui` + `role:impl` issues would resolve opus5-only, which is
-        the exact inversion of the maintainer's one stated exception that PR #4211 fixed. And it has
-        NO symptom: PLAN and CLAIM agree on the wrong answer, so the cross-resolver agreement
-        harness reports nothing.
-
-        MUTANT (any of these) => RED:
-          * delete `inject_roles` from the `[[chain_preference]]` block in routing.toml
-          * delete the injection branch from `route-resolve.gui_carve_out`
-          * remove "impl" from `GUI_CARVE_OUT_INJECT_ROLES`
-        """
+    def test_gui_impl_work_uses_the_sol_implementation_lane(self):
         impl_route = next(r for r in self.doc["route"] if r.get("role") == "impl")
-        self.assertEqual(impl_route["model_chain"], ["opus5"],
-                         "precondition: this guard is only meaningful on a single-rung impl chain")
+        self.assertEqual(impl_route["model_chain"], ["sol", "opus5"])
         for labels in (["area:gui", "role:impl"],
                        ["area:gui", "role:impl", "priority:P2"],
                        ["area:gui", "role:impl", "area:sparq-gui"]):
-            self.assertEqual(self.chain(labels), ["sol", "opus5"],
-                             f"{labels} must stay SOL-FIRST (maintainer: GUI keeps sol)")
+            self.assertEqual(self.chain(labels), ["sol", "opus5"])
         self.assertEqual(self.rr.resolve(["area:gui", "role:impl"], self.doc)[1],
                          "sparq-rust-impl",
                          "the carve-out re-orders/leads the chain and never re-routes the agent")
@@ -447,14 +376,14 @@ class TestLabelsToModelChain(unittest.TestCase):
                              "typo would make the carve-out silently never fire")
 
     def test_injection_is_scoped_to_the_exact_gui_label(self):
-        """The carve-out can now hand back a model the impl route deliberately excludes, so a
-        false-matching selector is worse than a re-order: it would give sol to non-GUI work.
+        """On an older Opus-only target ref, this compatibility rule may add Sol to impl work.
+        A false-matching selector would therefore alter non-GUI routing during the rollout.
 
         MUTANT: make the selector a substring test => RED (area:guide would gain a sol rung)."""
         for near in ("area:guide", "area:guidance", "area:gui-toolkit", "kind:guidance",
                      "area:site", "surface:frontend", "dashboard"):
-            self.assertEqual(self.chain([near, "role:impl"]), ["opus5"],
-                             f"{near} is not area:gui and must be given NO sol rung")
+            self.assertEqual(self.rr.gui_carve_out({near}, ["opus5"], role="impl"), ["opus5"],
+                             f"{near} is not area:gui and must not gain a sol rung")
 
     def test_a_roleless_gui_issue_is_never_injected_into(self):
         """`role=None` (the `[defaults]` branch) has no role to check against the allow-list, so it
@@ -472,23 +401,15 @@ class TestLabelsToModelChain(unittest.TestCase):
                          (["sol", "terra", "opus5"], "sparq-docs"))
 
     # -- non-GUI work is unaffected ------------------------------------------------------------
-    def test_non_gui_implementation_work_is_opus5_first_end_to_end(self):
-        """The first directive, asserted the same way: labels in, chain out."""
+    def test_non_gui_implementation_work_is_sol_first_end_to_end(self):
         for role in ("impl", "site", "ci", "perf"):
-            self.assertEqual(self.chain([f"role:{role}", "area:sparq-core", "priority:P1"])[0],
-                             "opus5")
-        self.assertEqual(self.chain(["area:sparq-core", "priority:P1"])[0], "opus5")
+            self.assertEqual(self.chain([f"role:{role}", "area:sparq-core", "priority:P1"]),
+                             ["sol", "opus5"])
+        self.assertEqual(self.chain(["area:sparq-core", "priority:P1"]), ["sol", "opus5"])
 
-    def test_non_gui_impl_work_gets_no_sol_rung_end_to_end(self):
-        """[OPUS-5] registry #738, at the deciding layer: a plain `role:impl` issue resolves to the
-        WHOLE opus5-only chain. Asserted as an equality rather than a head check, because the defect
-        this replaces (sol serving the majority of impl work) came from the SECOND rung, not the
-        first — a head-only assertion cannot see it.
-
-        MUTANT: restore sol as a second rung on role:impl => RED."""
+    def test_non_gui_impl_work_keeps_the_opus_continuity_fallback(self):
         for area in ("area:sparq-core", "area:sparq-engine", "area:orchestration"):
-            self.assertEqual(self.chain(["role:impl", area, "priority:P1"]), ["opus5"],
-                             f"role:impl + {area} must resolve to the opus5-only chain")
+            self.assertEqual(self.chain(["role:impl", area, "priority:P1"]), ["sol", "opus5"])
         self.assertTrue(self.rr.resolve(["role:impl", "area:sparq-core"], self.doc)[2],
                         "and it must escalate, so a capacity outage is not a silent stall")
 

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -27,20 +27,21 @@ ROLE_BY_KIND = {"docs": "docs", "design": "research", "research": "research", "p
 ROLE_BY_TYPE = {"feature": "impl", "bug": "impl", "task": "impl", "chore": "ci",
                 "spike": "research", "epic": "impl"}
 SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
-# [FABLE-5] UI/front-end surfaces route role:site (maintainer decision 2026-07-17: GPT-5.6 codex,
-# the original registry-dashboard builder — agent-account-registry e4098b9 — owns ALL UI work; the
-# role:site chain in orchestration/routing.toml leads with terra/codex). EXACT labels, not
-# substrings: a substring set would false-match (e.g. "gui" in "guide") and UI keywords must NOT
-# enter routing match_labels, which the arm-side security classifier unions into its keyword set.
+# [FABLE-5] UI/front-end surfaces route role:site (maintainer decision 2026-07-17: the original
+# registry-dashboard builder — agent-account-registry e4098b9 — owns ALL UI work). [SPARQ agent]
+# The current protocol makes role:site Sol-first. EXACT labels, not substrings: a substring set
+# would false-match (e.g. "gui" in "guide") and UI keywords must NOT enter routing match_labels,
+# which the arm-side security classifier unions into its keyword set.
 UI_SURFACE_LABELS = ("area:site", "surface:frontend", "dashboard")
 # [OPUS-5] `area:gui` gets its OWN role (maintainer directive 2026-07-26). The routing default
-# flipped to opus5-first over sol, "except for GUI work where sol should remain prioritised", and
+# previously flipped to opus5-first over sol, "except for GUI work where sol should remain
+# prioritised", and
 # the maintainer settled the boundary as "just go with area:gui work". area:gui used to sit in
 # UI_SURFACE_LABELS above and therefore derived role:site — which made the carve-out inexpressible,
 # because role:site also covers area:site / surface:frontend / dashboard, and those are NOT in the
-# carve-out. Splitting the label out is what lets orchestration/routing.toml give role:gui a
-# [SPARQ agent] The current protocol makes both role:gui and role:site Sol-first; role:site
-# historically took the Opus-first default.
+# carve-out. Splitting the label out makes role:gui independently routable. [SPARQ agent] The
+# current protocol makes both role:gui and role:site Sol-first; retaining the distinct role keeps
+# that explicit policy boundary available without conflating all site work with area:gui.
 # EXACT label, never a substring: a substring test would match "guide"/"guidance".
 #
 # THIS IS NOT WHERE THE CARVE-OUT BINDS. This rule fires only for an issue with NO explicit role —

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -39,7 +39,7 @@ UI_SURFACE_LABELS = ("area:site", "surface:frontend", "dashboard")
 # UI_SURFACE_LABELS above and therefore derived role:site — which made the carve-out inexpressible,
 # because role:site also covers area:site / surface:frontend / dashboard, and those are NOT in the
 # carve-out. Splitting the label out is what lets orchestration/routing.toml give role:gui a
-# [GPT-5.6] The current protocol makes both role:gui and role:site Sol-first; role:site
+# [SPARQ agent] The current protocol makes both role:gui and role:site Sol-first; role:site
 # historically took the Opus-first default.
 # EXACT label, never a substring: a substring test would match "guide"/"guidance".
 #
@@ -113,7 +113,7 @@ def _role(labels, issue_type):
     # precedence slot otherwise (after security, an explicit role:*, and kind).
     if any(lb in GUI_SURFACE_LABELS for lb in labels):
         return "gui"
-    # [GPT-5.6] UI-surface labels derive role:site (now the common Sol-first implementation
+    # [SPARQ agent] UI-surface labels derive role:site (now the common Sol-first implementation
     # chain) before the
     # generic type map, after kind (so kind:docs about the site stays docs) and after an explicit
     # role:* label. NOTE: area:gui is deliberately NOT here — see GUI_SURFACE_LABELS.

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -27,21 +27,15 @@ ROLE_BY_KIND = {"docs": "docs", "design": "research", "research": "research", "p
 ROLE_BY_TYPE = {"feature": "impl", "bug": "impl", "task": "impl", "chore": "ci",
                 "spike": "research", "epic": "impl"}
 SEC_KEYWORDS = ("zk", "mpc", "reasoner", "crypto", "auth", "e2ee")
-# [FABLE-5] UI/front-end surfaces route role:site (maintainer decision 2026-07-17: the original
-# registry-dashboard builder — agent-account-registry e4098b9 — owns ALL UI work). [SPARQ agent]
-# The current protocol makes role:site Sol-first. EXACT labels, not substrings: a substring set
-# would false-match (e.g. "gui" in "guide") and UI keywords must NOT enter routing match_labels,
-# which the arm-side security classifier unions into its keyword set.
+# [FABLE-5] UI/front-end surfaces route role:site (maintainer decision 2026-07-17). EXACT labels,
+# not substrings: a substring set would false-match (e.g. "gui" in "guide") and UI keywords must
+# NOT enter routing match_labels, which the arm-side security classifier unions into its keyword
+# set. Model preference belongs to orchestration/routing.toml, not this label-to-role classifier.
 UI_SURFACE_LABELS = ("area:site", "surface:frontend", "dashboard")
-# [OPUS-5] `area:gui` gets its OWN role (maintainer directive 2026-07-26). The routing default
-# previously flipped to opus5-first over sol, "except for GUI work where sol should remain
-# prioritised", and
-# the maintainer settled the boundary as "just go with area:gui work". area:gui used to sit in
-# UI_SURFACE_LABELS above and therefore derived role:site — which made the carve-out inexpressible,
-# because role:site also covers area:site / surface:frontend / dashboard, and those are NOT in the
-# carve-out. Splitting the label out makes role:gui independently routable. [SPARQ agent] The
-# current protocol makes both role:gui and role:site Sol-first; retaining the distinct role keeps
-# that explicit policy boundary available without conflating all site work with area:gui.
+# [OPUS-5] `area:gui` gets its OWN role (maintainer directive 2026-07-26). area:gui used to sit in
+# UI_SURFACE_LABELS above and therefore derived role:site, conflating the explicit GUI surface with
+# area:site / surface:frontend / dashboard. Splitting it out makes role:gui independently routable
+# while leaving model selection to orchestration/routing.toml.
 # EXACT label, never a substring: a substring test would match "guide"/"guidance".
 #
 # THIS IS NOT WHERE THE CARVE-OUT BINDS. This rule fires only for an issue with NO explicit role —

--- a/scripts/triage.py
+++ b/scripts/triage.py
@@ -39,13 +39,14 @@ UI_SURFACE_LABELS = ("area:site", "surface:frontend", "dashboard")
 # UI_SURFACE_LABELS above and therefore derived role:site — which made the carve-out inexpressible,
 # because role:site also covers area:site / surface:frontend / dashboard, and those are NOT in the
 # carve-out. Splitting the label out is what lets orchestration/routing.toml give role:gui a
-# sol-first chain while role:site takes the opus5-first default like everything else.
+# [GPT-5.6] The current protocol makes both role:gui and role:site Sol-first; role:site
+# historically took the Opus-first default.
 # EXACT label, never a substring: a substring test would match "guide"/"guidance".
 #
 # THIS IS NOT WHERE THE CARVE-OUT BINDS. This rule fires only for an issue with NO explicit role —
 # the explicit-role branch in _role() returns first — and 35 of 35 open area:gui issues already
 # carry one (33 role:impl, 1 role:perf, 1 role:research), so on its own it reached NONE of the live
-# backlog and GUI work silently took the opus5-first default. The binding rule is
+# backlog and GUI work silently took the then-opus5-first default. The binding rule is
 # scripts/route-resolve.py `gui_carve_out()`, which reads `area:gui` directly at plan time
 # regardless of role. Keep the two label sets in sync — `test_both_gui_selectors_agree`.
 GUI_SURFACE_LABELS = ("area:gui",)
@@ -112,7 +113,8 @@ def _role(labels, issue_type):
     # precedence slot otherwise (after security, an explicit role:*, and kind).
     if any(lb in GUI_SURFACE_LABELS for lb in labels):
         return "gui"
-    # [FABLE-5] UI-surface labels derive role:site (now the opus5-first default chain) before the
+    # [GPT-5.6] UI-surface labels derive role:site (now the common Sol-first implementation
+    # chain) before the
     # generic type map, after kind (so kind:docs about the site stays docs) and after an explicit
     # role:* label. NOTE: area:gui is deliberately NOT here — see GUI_SURFACE_LABELS.
     if any(lb in UI_SURFACE_LABELS for lb in labels):
@@ -212,7 +214,7 @@ def _self_test():
     # role:gui — that is the exact property, asserted independently of which non-gui role each
     # one happens to take (area:site -> site; the narrower area:site-specs / area:site-papers are
     # not exact UI_SURFACE_LABELS and fall through to the type map, which is fine: every one of
-    # those roles is on the opus5-first default).
+    # those roles historically used the opus5-first default).
     for _area in ("area:site", "area:site-specs", "area:site-papers", "area:sitemap"):
         chk(f"{_area} does NOT derive role:gui (not swept into the sol carve-out)",
             triage(["priority:P2", _area], "task")["role"] == "gui", False)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Closes #6236

## What changes

- routes ordinary implementation/default work to `gpt-5.6-sol` first
- keeps `claude-opus-5` as a continuity fallback so current Opus-authored repair chains remain serviceable
- keeps review, soundness, and security overrides Opus-5-only; new Sol-authored PRs therefore take the existing OpenAI → Anthropic review inversion
- gives every implementation route an explicit bounded exhaustion exit
- makes `[defaults].escalate` survive resolution instead of being hard-coded to `false`

The retained `area:gui` preference is now idempotent on the live table, but remains in place so PLAN and CLAIM agree while older target revisions are still observed.

## Evidence

- route resolver, planner, routing validator, deprecation/model-policy, readiness-visibility, and workflow-dispatch-contract suites pass
- all 25 cross-repo PLAN/CLAIM agreement cases pass against this routing table
- line tracing executes the changed default-resolution return path in both repositories
- mutation checks fail when implementation order is inverted, the Opus continuity rung is removed, review is moved off Opus 5, or default escalation is disabled

Security/trust-surface routing remains Opus-only and human-armed.
