### PR TITLE
ci: recover reporter races and zero-job review failures

### DIFF
--- a/.github/workflows/verdict-bridge.yml
+++ b/.github/workflows/verdict-bridge.yml
@@ -9,11 +9,11 @@
 # write-path-vs-read-predicate mismatch class.
 #
 # NOT A GATE, and the event triggers do not change that. `ci-summary / gate` decides by
-# POLLING check-runs on the PR HEAD commit; for `issue_comment`, `pull_request_review`
-# and `workflow_run`, GitHub sets GITHUB_SHA to the DEFAULT BRANCH head, not the PR head,
-# so this workflow's check-run never lands on a ref the aggregator inspects. That is the
-# same property batch-merge.yml and pr-backlog.yml already rely on for their `workflow_run`
-# legs. It never runs on a PR head and never executes candidate-PR code. It grants
+# POLLING check-runs on the PR HEAD commit; for `issue_comment` and `workflow_run`, GitHub
+# sets GITHUB_SHA to the DEFAULT BRANCH head, so this workflow's check-run never lands on
+# a ref the aggregator inspects. That is the same property batch-merge.yml and
+# pr-backlog.yml already rely on for their `workflow_run` legs. It never executes
+# candidate-PR code. It grants
 # NO new arming authority: it writes LABELS only. The arm itself is still performed by
 # auto-arm.py with its own expectedHeadOid CAS and its own security-label exclusions, so
 # every existing fail-closed guard still applies.
@@ -23,7 +23,7 @@
 # the last commit. This would seem to be an operation that can just be done statically by
 # CI."). Every input this policy reads — head SHA, comments on that head, review bodies,
 # the `gate` conclusion — is carried by a webhook, so the decision is a pure function of
-# state that is already delivered. Three event triggers are added below and the CRON IS
+# state that is already delivered. Two event triggers are added below and the CRON IS
 # KEPT as the reconciliation backstop for dropped or never-delivered webhooks: removing
 # it would convert a latency bug into a lost-work bug.
 #
@@ -47,8 +47,8 @@
 # green CI and an armed auto-merge release NOTHING. So every minute a mergeable PR sits
 # unlabelled-and-therefore-unarmed is a minute its partition is closed to the frontier.
 #
-# TRUST. issue_comment / pull_request_review / workflow_run all resolve the workflow file
-# from the DEFAULT BRANCH and never check out the PR head, so no candidate-controlled code
+# TRUST. issue_comment / workflow_run both resolve the workflow file from the DEFAULT BRANCH
+# and never check out the PR head, so no candidate-controlled code
 # or workflow definition ever runs. `pull_request` and `pull_request_target` are both
 # still forbidden here (the former takes its workflow file from the candidate ref). The
 # only value taken from the payload is an integer PR number, parsed by
@@ -85,12 +85,11 @@ on:
   issue_comment:
     types: [created, edited]
 
-  # EVENT: the same verdict arriving through a PR REVIEW body. Review bodies are
-  # WITHHOLD-ONLY in the policy, so this can only ever SHRINK the promote-set — but a
-  # retraction must not wait an hour either. `dismissed` carries no body change but does
-  # change which reviews are evidence.
-  pull_request_review:
-    types: [submitted, edited, dismissed]
+  # `pull_request_review` is deliberately NOT a trigger (#6311). Every automatic Copilot review
+  # created an approval-held `action_required` run with zero jobs on the PR head; ci-summary then
+  # correctly failed that head on the run-level verdict. Ten such deterministic false-red runs
+  # accumulated between 2026-08-30 and 2026-09-03. Review bodies are WITHHOLD-ONLY, so the cron
+  # reconciles their edits/dismissals; promotion still arrives immediately through issue_comment.
 
   # EVENT: `gate` concluded on a PR head, which is what makes a PR green + visible (the
   # `flag` / `unflag` population). ci-summary is the workflow that publishes the `gate`
@@ -128,7 +127,6 @@ permissions:
 concurrency:
   group: >-
     verdict-bridge-${{ github.event.issue.number
-    || github.event.pull_request.number
     || github.event.workflow_run.pull_requests[0].number
     || 'sweep' }}
   cancel-in-progress: false
@@ -168,7 +166,6 @@ jobs:
       github.event_name == 'schedule'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, 'VERDICT'))
-      || (github.event_name == 'pull_request_review' && github.event.pull_request.number != null)
       || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests[0].number != null)
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -230,7 +227,6 @@ jobs:
           # rather than degrading to a sweep.
           BRIDGE_PR: >-
             ${{ github.event.issue.number
-            || github.event.pull_request.number
             || github.event.workflow_run.pull_requests[0].number
             || '' }}
           # event: no useful cron backstop on the measured 53-75 minute real cadence, so

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -2061,10 +2061,11 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             and attempt > cfg.max_total_polls
             and (non_reporter_pending > 0 or awaiting_full)
         ):
-            print(
+            _emit(
                 "::notice::ci-summary reporter-only grace stopped because ordinary "
                 "pending work or the full-tier hold appeared; those states do not "
-                "receive post-cap time (#6299)."
+                "receive post-cap time (#6299).",
+                cfg.summary_path,
             )
             break
 

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -407,6 +407,13 @@ UNSAT_HOLD_REMEDY = (
 # sees them). Their presence therefore PROVES the reporter must post
 # `feature-matrix report`; its absence keeps the gate polling (still-settling)
 # until the loop's own timeout, then FAILS CLOSED — never a conclude-by-timing.
+# [GPT-5.6] #6299: `workflow_run` executes on the default branch, so the
+# reporter itself never creates a non-terminal check on the target head; its
+# manually posted summary appears only when reporting finishes. If the final
+# ordinary sibling completes at the absolute poll cap, give only this
+# structurally required reporter one short, bounded post-cap grace. The grace
+# neither infers a verdict nor extends ordinary pending siblings, and expiry
+# still reaches the same fail-closed reporter belt below.
 FM_GROUP_PREFIX = "opt-in group ("
 FM_REPORT_NAME = "feature-matrix report"
 # [FABLE-5] PR #3511 finding 2 (same-SHA stale-report race): an `opt-in group (…)`
@@ -433,6 +440,10 @@ class Config:
     base_polls: int = 110       # base budget: 110 x 20s ~= 37 min (the old hard cap)
     sat_interval: int = 40      # slower poll cadence during the saturation extension
     max_total_polls: int = 155  # absolute cap: 45 extension polls x 40s = +30 min
+    # [GPT-5.6] #6299: one-shot reporter-only tail after the ordinary cap. Fifteen
+    # normal-cadence polls are about five minutes, including room for the normal
+    # two-poll settle, while the job's 80-minute hard timeout remains the outer bound.
+    reporter_grace_polls: int = 15
     sat_queue_min: int = 5      # queued workflow-runs in the repo => saturation
     progress_window: int = 15   # polls over which a completed-count rise = progress
     # [OPUS-5] #3781: consecutive polls the UNSATISFIABLE-HOLD state must persist before
@@ -1779,9 +1790,13 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     ff_suspect: tuple | None = None
     # [OPUS-5] #3781: consecutive polls the UNSATISFIABLE-HOLD state has persisted.
     unsat_polls = 0
+    # [GPT-5.6] #6299: `poll_limit` may grow exactly once, and only for an
+    # unresolved feature-matrix report after every ordinary sibling is terminal.
+    reporter_grace_started = False
+    poll_limit = cfg.max_total_polls
 
     attempt = 0
-    while attempt < cfg.max_total_polls:
+    while attempt < poll_limit:
         attempt += 1
         try:
             raw = fetch_runs()
@@ -1806,7 +1821,11 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 f"attempt {attempt}: check-run fetch failed ({exc}) — skipping this poll "
                 f"({consec_fetch_failures}/{cfg.max_consec_fetch_failures} consecutive)."
             )
-            sleep_fn(cfg.sat_interval if extension_started else cfg.interval)
+            sleep_fn(
+                cfg.interval
+                if reporter_grace_started
+                else (cfg.sat_interval if extension_started else cfg.interval)
+            )
             continue
         consec_fetch_failures = 0
 
@@ -1827,6 +1846,15 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         ]
         total = len(runs)
         pending = sum(1 for r in runs if r.get("status") != "completed")
+        # A present reporter check may itself be non-terminal. It is the only
+        # pending check the reporter-only grace may wait for; every other pending
+        # check remains governed by the ordinary absolute cap.
+        non_reporter_pending = sum(
+            1
+            for r in runs
+            if r.get("status") != "completed"
+            and not is_fm_report(r.get("name", ""))
+        )
         # [FABLE-5] Draft-tier CI: on a FULL-tier pull_request run, a draft-tier-
         # assembled selection with no full-tier successor means the ready_for_review
         # re-run has not registered yet — treat the set as STILL-SETTLING (hold the
@@ -1847,7 +1875,8 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         # draft-tier awaiting_full. A "failed" reporter does NOT hold (it is
         # terminal and must conclude RED). Budget exhaustion while still awaiting
         # FAILS CLOSED via render_verdict's reporter belt — never conclude-by-timing.
-        awaiting_report = fm_report_status(runs) == "pending"
+        report_state = fm_report_status(runs)
+        awaiting_report = report_state == "pending"
         completed_hist.append(total - pending)
         # Settle is a POST-TERMINAL window re-armed ONLY by pending work (sq-ipkku):
         # already-terminal injections must not starve convergence.
@@ -1863,6 +1892,38 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             f"all-terminal stable for {stable}/{cfg.settle_polls} poll(s){changed}{extra}",
             flush=True,
         )
+
+        # [GPT-5.6] #6299: the trusted reporter starts only after feature-matrix
+        # completes, and its workflow_run is attached to the default branch rather
+        # than this head. Therefore an absent target-head report plus zero pending
+        # ordinary checks can still mean a healthy reporter is in flight. At the
+        # ordinary cap, arm one fixed tail only for that exact state. A report that
+        # first lands on the cap also gets the tail solely to complete the normal
+        # settle window. The current-run external_id correlation remains inside
+        # fm_report_status; the tail merely gives that already-required verdict time
+        # to appear and settle.
+        if (
+            not reporter_grace_started
+            and attempt == cfg.max_total_polls
+            and (
+                awaiting_report
+                or (report_state == "ok" and stable < cfg.settle_polls)
+            )
+            and not awaiting_full
+            and non_reporter_pending == 0
+            and cfg.reporter_grace_polls > 0
+        ):
+            reporter_grace_started = True
+            poll_limit = cfg.max_total_polls + cfg.reporter_grace_polls
+            print(
+                "::notice::ci-summary ordinary poll cap reached after every "
+                "non-reporter sibling became terminal, but the structurally required "
+                "current feature-matrix report is unresolved or has not completed "
+                "the normal settle window. Granting one "
+                f"bounded reporter-only grace of {cfg.reporter_grace_polls} poll(s) "
+                f"at the normal {cfg.interval}s cadence (#6299); it cannot re-arm or "
+                "extend an ordinary pending sibling, and expiry remains fail-closed."
+            )
 
         # [FABLE-5] FAIL-FAST (header §FAIL-FAST): a concluded gating failure in
         # the (already forgiveness-filtered) sibling set decides the verdict now
@@ -1992,6 +2053,21 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         else:
             unsat_polls = 0
 
+        # The grace is licensed only by the all-ordinary-terminal state at the
+        # ordinary cap. If an ordinary sibling or the separate full-tier hold
+        # appears afterward, stop immediately rather than lending it this tail.
+        if (
+            reporter_grace_started
+            and attempt > cfg.max_total_polls
+            and (non_reporter_pending > 0 or awaiting_full)
+        ):
+            print(
+                "::notice::ci-summary reporter-only grace stopped because ordinary "
+                "pending work or the full-tier hold appeared; those states do not "
+                "receive post-cap time (#6299)."
+            )
+            break
+
         # Clean convergence: everything terminal, held for the settle, past the floor.
         if attempt >= cfg.min_polls and pending == 0 and stable >= cfg.settle_polls:
             return render_verdict(runs, cfg.summary_path, tier_ctx)
@@ -1999,7 +2075,7 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         # ADAPTIVE SATURATION BUDGET (sq-90cv4): at/after the base budget with work
         # still pending, extend ONLY while the evidence says throughput-starvation
         # (deep queue) or live progress — otherwise it's a genuine hang: RED.
-        if attempt >= cfg.base_polls and pending > 0:
+        if attempt >= cfg.base_polls and pending > 0 and not reporter_grace_started:
             progressing = (
                 len(completed_hist) > cfg.progress_window
                 and completed_hist[-1] > completed_hist[-1 - cfg.progress_window]
@@ -2055,10 +2131,38 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 sleep_fn(cfg.sat_interval)
             continue
 
-        if attempt < cfg.max_total_polls:
+        if attempt < poll_limit:
             sleep_fn(cfg.interval)
 
-    # Absolute budget exhausted.
+    # [GPT-5.6] #6299: reporter grace exhaustion never infers success. A still-
+    # unresolved current report takes the existing reporter failure belt. A report
+    # that first became green on the final grace poll also cannot bypass the normal
+    # settle window merely because the bounded tail ended.
+    if reporter_grace_started and non_reporter_pending == 0 and not awaiting_full:
+        report_state = fm_report_status(runs)
+        if report_state == "pending":
+            print(
+                "::notice::ci-summary bounded reporter-only grace exhausted without "
+                "a terminal verdict for the current feature-matrix run — rendering "
+                "the unchanged fail-closed reporter verdict (#6299)."
+            )
+            return render_verdict(runs, cfg.summary_path, tier_ctx)
+        if report_state == "ok" and stable < cfg.settle_polls:
+            _emit(
+                "### ci-summary: UNDETERMINED (not a test failure) — the current "
+                "feature-matrix reporter concluded successfully at the end of its "
+                "bounded post-cap grace, but the normal all-terminal settle window "
+                f"reached only {stable}/{cfg.settle_polls} poll(s). Fail-closed: a "
+                "reporter verdict never bypasses the normal settle requirement.",
+                cfg.summary_path,
+            )
+            print(
+                "::error::ci-summary UNDETERMINED — reporter grace ended before the "
+                "normal settle window completed (#6299)."
+            )
+            return 1
+
+    # Absolute budget (plus the one-shot reporter tail, when armed) exhausted.
     if pending == 0:
         # The #997 graceful timeout: everything IS terminal, we just never got a
         # full quiet settle — render the real verdict, never a blind RED.

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -106,6 +106,7 @@ def tiny_cfg(**over):
     base budget = 4 polls, absolute cap = 8, settle = 2, floor = 2."""
     base = dict(self_run_id="999", interval=0, min_polls=2, settle_polls=2,
                 base_polls=4, sat_interval=0, max_total_polls=8,
+                reporter_grace_polls=3,
                 sat_queue_min=5, progress_window=2, max_consec_fetch_failures=3,
                 summary_path="")
     base.update(over)
@@ -2855,6 +2856,111 @@ def _grp(run_id, name="opt-in group (sparq-engine 1/2)"):
 def _rep(run_id, conclusion="success", status="completed"):
     return R("feature-matrix report", status=status, conclusion=conclusion,
              external_id=str(run_id))
+
+
+class TestFeatureMatrixReporterPostCapGrace(unittest.TestCase):
+    """[GPT-5.6] #6299: only the correlated reporter gets one bounded tail."""
+
+    @staticmethod
+    def _drive(cfg, polls, depth=0, tier_ctx=None):
+        fetch = scripted(polls)
+        out = io.StringIO()
+        with redirect_stdout(out):
+            code = g.run_gate(
+                cfg,
+                fetch,
+                lambda: depth,
+                sleep_fn=lambda _s: None,
+                tier_ctx=tier_ctx,
+            )
+        return code, out.getvalue(), fetch.state["calls"]
+
+    def test_current_report_lands_after_ordinary_cap_and_settles(self):
+        cfg = tiny_cfg(reporter_grace_polls=4)
+        waiting = [_grp("222"), GREEN]
+        in_progress = [
+            _grp("222"),
+            _rep("222", status="in_progress", conclusion=None),
+            GREEN,
+        ]
+        current = [_grp("222"), _rep("222"), GREEN]
+        # The live #6223 reporter check was absent at the cap; also pin the
+        # equivalent states where it is visible but non-terminal, or first lands
+        # terminal-success on the cap and still needs its second settle poll.
+        cap_cases = (
+            ("absent", waiting, [current, current], cfg.settle_polls),
+            ("in progress", in_progress, [current, current], cfg.settle_polls),
+            ("terminal", current, [current], 1),
+        )
+        for state, cap_state, tail, extra_calls in cap_cases:
+            with self.subTest(report_at_cap=state):
+                polls = [waiting] * (cfg.max_total_polls - 1) + [cap_state, *tail]
+
+                code, out, calls = self._drive(cfg, polls)
+
+                self.assertEqual(code, 0, out)
+                self.assertEqual(calls, cfg.max_total_polls + extra_calls)
+                self.assertIn("bounded reporter-only grace", out)
+                self.assertIn("PASSED", out)
+
+    def test_absent_reporter_exhausts_only_the_bounded_grace_then_reds(self):
+        cfg = tiny_cfg(reporter_grace_polls=3)
+
+        code, out, calls = self._drive(cfg, [[_grp("222"), GREEN]])
+
+        self.assertEqual(code, 1, out)
+        self.assertEqual(
+            calls,
+            cfg.max_total_polls + cfg.reporter_grace_polls,
+            "the reporter-only grace must have a fixed, non-rearming bound",
+        )
+        self.assertIn("bounded reporter-only grace exhausted", out)
+        self.assertIn("reporter verdict never landed", out)
+
+    def test_current_report_failure_during_grace_still_reds(self):
+        cfg = tiny_cfg(reporter_grace_polls=4)
+        waiting = [_grp("222"), GREEN]
+        failed = [_grp("222"), _rep("222", conclusion="failure"), GREEN]
+        polls = [waiting] * cfg.max_total_polls + [failed, failed]
+
+        code, out, calls = self._drive(cfg, polls)
+
+        self.assertEqual(code, 1, out)
+        self.assertEqual(calls, cfg.max_total_polls + cfg.settle_polls)
+        self.assertIn("reporter concluded a NON-SUCCESS verdict", out)
+        self.assertNotIn("PASSED", out)
+
+    def test_ordinary_pending_sibling_or_full_tier_hold_gets_no_reporter_grace(self):
+        cfg = tiny_cfg(reporter_grace_polls=3)
+        cases = (
+            ("ordinary pending", [_grp("222"), GREEN, PENDING], 20, None),
+            (
+                "awaiting full tier",
+                [_grp("222"), GREEN, R(SELECT_DRAFT, started="2026-07-25T07:00:00Z")],
+                0,
+                draft_ctx(lambda: False, run_tier="full"),
+            ),
+        )
+        for name, runs, depth, tier_ctx in cases:
+            with self.subTest(state=name):
+                code, out, calls = self._drive(
+                    cfg, [runs], depth=depth, tier_ctx=tier_ctx
+                )
+
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, cfg.max_total_polls)
+                self.assertNotIn("bounded reporter-only grace", out)
+
+    def test_stale_report_cannot_satisfy_or_outlive_the_bounded_grace(self):
+        cfg = tiny_cfg(reporter_grace_polls=3)
+        stale_only = [_grp("222"), _rep("111"), GREEN]
+
+        code, out, calls = self._drive(cfg, [stale_only])
+
+        self.assertEqual(code, 1, out)
+        self.assertEqual(calls, cfg.max_total_polls + cfg.reporter_grace_polls)
+        self.assertIn("reporter verdict never landed", out)
+        self.assertNotIn("PASSED", out)
 
 
 class TestFeatureMatrixReporterCorrelation(unittest.TestCase):

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -2918,6 +2918,22 @@ class TestFeatureMatrixReporterPostCapGrace(unittest.TestCase):
         self.assertIn("bounded reporter-only grace exhausted", out)
         self.assertIn("reporter verdict never landed", out)
 
+    def test_report_success_on_final_grace_poll_cannot_skip_settle(self):
+        # [GPT-6-ASTRA] A last-poll success has only one terminal observation;
+        # the timeout fallback must not turn it green without the normal settle.
+        cfg = tiny_cfg(reporter_grace_polls=3)
+        waiting = [_grp("222"), GREEN]
+        current = [_grp("222"), _rep("222"), GREEN]
+        polls = [waiting] * (cfg.max_total_polls + cfg.reporter_grace_polls - 1)
+
+        code, out, calls = self._drive(cfg, [*polls, current])
+
+        self.assertEqual(code, 1, out)
+        self.assertEqual(calls, cfg.max_total_polls + cfg.reporter_grace_polls)
+        self.assertIn("reporter grace ended before the normal settle window", out)
+        self.assertIn("reached only 1/2 poll(s)", out)
+        self.assertNotIn("PASSED", out)
+
     def test_current_report_failure_during_grace_still_reds(self):
         cfg = tiny_cfg(reporter_grace_polls=4)
         waiting = [_grp("222"), GREEN]

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -27,6 +27,7 @@ import io
 import json
 import re
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -2950,6 +2951,22 @@ class TestFeatureMatrixReporterPostCapGrace(unittest.TestCase):
                 self.assertEqual(code, 1, out)
                 self.assertEqual(calls, cfg.max_total_polls)
                 self.assertNotIn("bounded reporter-only grace", out)
+
+    def test_post_cap_grace_stop_reason_is_written_to_step_summary(self):
+        waiting = [_grp("222"), GREEN]
+        ordinary_work_appears = [_grp("222"), GREEN, PENDING]
+        with tempfile.TemporaryDirectory() as directory:
+            summary = Path(directory) / "step-summary.md"
+            cfg = tiny_cfg(reporter_grace_polls=3, summary_path=str(summary))
+            polls = [waiting] * cfg.max_total_polls + [ordinary_work_appears]
+
+            code, out, calls = self._drive(cfg, polls)
+
+            self.assertEqual(code, 1, out)
+            self.assertEqual(calls, cfg.max_total_polls + 1)
+            message = "reporter-only grace stopped because ordinary pending work"
+            self.assertIn(message, out)
+            self.assertIn(message, summary.read_text(encoding="utf-8"))
 
     def test_stale_report_cannot_satisfy_or_outlive_the_bounded_grace(self):
         cfg = tiny_cfg(reporter_grace_polls=3)

--- a/scripts/tests/test_verdict_bridge.py
+++ b/scripts/tests/test_verdict_bridge.py
@@ -2232,8 +2232,8 @@ class TestWorkflowWiring(unittest.TestCase):
         with write permissions), plus `pull_request_target`, which additionally hands a
         privileged token to a run about untrusted head code.
 
-        `issue_comment`, `pull_request_review` and `workflow_run` are NOT in this set:
-        GitHub resolves all three from the DEFAULT BRANCH, and the checkout step below is
+        `issue_comment` and `workflow_run` are NOT in this set: GitHub resolves both from the
+        DEFAULT BRANCH, and the checkout step below is
         separately pinned to the default branch, so no candidate code or candidate
         workflow definition can execute here.
         """
@@ -2244,6 +2244,11 @@ class TestWorkflowWiring(unittest.TestCase):
             )
         self.assertIn("schedule", on)
         self.assertIn("workflow_dispatch", on)
+        self.assertNotIn(
+            "pull_request_review", on,
+            "#6311: Copilot reviews create approval-held action_required runs with zero jobs; "
+            "the scheduled reconciliation owns the review-body withholding path",
+        )
 
     def test_the_cron_backstop_survives_the_event_conversion(self):
         """CONSTRAINT: the event trigger is ADDITIVE. Deleting the cron converts a
@@ -2263,10 +2268,6 @@ class TestWorkflowWiring(unittest.TestCase):
             sorted(on["issue_comment"]["types"]),
             ["created", "edited"],
             "an EDITED comment can add or retract a verdict just as a new one can",
-        )
-        self.assertEqual(
-            sorted(on["pull_request_review"]["types"]),
-            ["dismissed", "edited", "submitted"],
         )
         self.assertEqual(on["workflow_run"]["workflows"], ["ci-summary"])
         self.assertEqual(on["workflow_run"]["types"], ["completed"])
@@ -2298,10 +2299,10 @@ class TestWorkflowWiring(unittest.TestCase):
         bridge_pr = " ".join(str(step["env"]["BRIDGE_PR"]).split())
         for source in (
             "github.event.issue.number",
-            "github.event.pull_request.number",
             "github.event.workflow_run.pull_requests[0].number",
         ):
             self.assertIn(source, bridge_pr, f"{source} would never scope its event")
+        self.assertNotIn("github.event.pull_request.number", bridge_pr)
         self.assertTrue(bridge_pr.startswith("${{") and bridge_pr.endswith("}}"))
 
     def test_the_mode_expression_makes_exactly_the_cron_paths_fail_soft(self):
@@ -2315,7 +2316,6 @@ class TestWorkflowWiring(unittest.TestCase):
             ("schedule", "sweep"),
             ("workflow_dispatch", "sweep"),
             ("issue_comment", "event"),
-            ("pull_request_review", "event"),
             ("workflow_run", "event"),
         ):
             with self.subTest(event=event_name):
@@ -2493,9 +2493,11 @@ class TestJobConditionAdmission(unittest.TestCase):
             with self.subTest(body=body):
                 self.assertFalse(self.admits(self.comment_event(body)))
 
-    def test_a_pull_request_review_is_admitted(self):
-        self.assertTrue(
-            self.admits(payload("pull_request_review", pull_request={"number": 4324}))
+    def test_a_pull_request_review_is_refused(self):
+        self.assertFalse(
+            self.admits(payload("pull_request_review", pull_request={"number": 4324})),
+            "#6311: a review event must not re-enter through a stale job condition even though "
+            "the workflow trigger itself is absent",
         )
 
     def ci_event(self, conclusion="success", pulls=({"number": 4324},)):
@@ -2522,7 +2524,8 @@ class TestJobConditionAdmission(unittest.TestCase):
     def test_an_unknown_event_is_refused(self):
         """Adding a trigger without extending this condition must not fall through to an
         unscoped sweep."""
-        for event_name in ("pull_request", "push", "issues", "check_suite"):
+        for event_name in ("pull_request", "pull_request_review", "push", "issues",
+                           "check_suite"):
             with self.subTest(event=event_name):
                 self.assertFalse(self.admits(payload(event_name)))
 
@@ -2554,15 +2557,12 @@ class TestConcurrencyGrouping(unittest.TestCase):
         b = self.group_for(payload("issue_comment", issue={"number": 4325}))
         self.assertNotEqual(a, b)
 
-    def test_events_about_the_SAME_pr_share_a_group_across_channels(self):
+    def test_events_about_the_SAME_pr_share_a_group_across_live_channels(self):
         comment = self.group_for(payload("issue_comment", issue={"number": 4324}))
-        review = self.group_for(
-            payload("pull_request_review", pull_request={"number": 4324})
-        )
         ci = self.group_for(
             payload("workflow_run", workflow_run={"pull_requests": [{"number": 4324}]})
         )
-        self.assertEqual({comment, review, ci}, {comment})
+        self.assertEqual({comment, ci}, {comment})
 
     def test_schedule_and_dispatch_share_the_single_sweep_group(self):
         self.assertEqual(


### PR DESCRIPTION
> 🤖 **SPARQ agent** — direct coordinator for @jeswr's sparq RDF/SPARQL engine.

Fixes #6299. Fixes #6311.

This repairs two causes of false-red CI gates. When the feature-matrix workflow finishes near the ordinary polling cap, its reporter can still be starting. The gate now gives only that reporter one bounded tail after ordinary siblings are terminal, retains current-run correlation and the normal settle window, and fails closed on real failures or exhaustion. Ordinary pending work cannot extend or re-arm the tail.

The verdict bridge also stops subscribing to `pull_request_review`. Copilot reviews were creating approval-held runs with zero jobs, which the aggregate correctly rejected. Issue comments, successful `ci-summary` completion, manual dispatch and scheduled reconciliation retain their existing paths. Review-body withholding or retraction can consequently wait for a retained event or reconciliation; no bound on cron delivery is claimed. This trade-off is accepted for the event-surface fix and was included in the independent review. Reviewer note: a normal PR comment triggers prompt reconciliation; editing only a review body may wait for a later retained event or sweep.

The change prevents future review-trigger holds. It does not approve, erase or forgive existing held runs, including #6049's run `34052150830`, and it does not weaken the aggregate's treatment of genuine `action_required` failures.

## Validation

Current candidate: `beb02d9e4d1f7c9e455f3fe25aa810c0922139d0`.

- 193 gate tests and 163 bridge tests pass: 356 total.
- Focused tracing exposed an untested final-grace settle refusal. Astra added one 16-line regression test; runtime and workflow code are unchanged from `c23dec756`.
- All five checked mutations are rejected with the full 356-test population and no test errors, including deletion and conditional suppression of grace arming, loss of the ordinary-sibling stop, loss of final-poll settling, and restoration of the review trigger.
- Supplemental deterministic probes cover transient fetch cadence during grace, genuine `action_required` failure, and a post-cap full-tier hold.
- Actionlint and diff checks pass. Local preflight is limited by macOS Bash 3 lacking `mapfile` in the privacy-claims helper; supported Linux CI remains required.
- The four changed files have no intervening changes on current main `60e3f84c` since the merge base. This establishes clean source composition, not a fresh combined-head CI result.

Actual Claude Opus 5 at extra-high reasoning reviewed this candidate: **approve with nits, no blocking findings**. The fresh [required gate](https://github.com/sparq-org/sparq/actions/runs/34054633692) passed on this exact head. Combined-head validation against current main remains required through the normal merge queue.

The original implementation predates this takeover and retains its Sol attribution. The current verification and regression-test correction were performed by GPT-6 Astra at extra-high reasoning.

<!-- sparq-impl-provider:openai model:sol -->
