### PR TITLE
ci: recover cancelled Actions gates with verified job identity

### DIFF
--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -36,6 +36,9 @@ on:
 # remediation with a 403 — visible, but useless. `contents: write` already present above
 # also covers the `PUT /pulls/{n}/update-branch` the CONFLICTING class attempts.
 permissions:
+  # [GPT-6 Astra] #6438: cancelled Actions recovery uses the preferred App's
+  # actions:write, not this legacy checks grant. Grants remain unchanged here;
+  # fallback GITHUB_TOKEN has no actions:write and rerun denial stays fail-closed.
   contents: write
   pull-requests: write
   checks: write

--- a/.github/workflows/rearm-sweeper.yml
+++ b/.github/workflows/rearm-sweeper.yml
@@ -29,16 +29,15 @@ on:
 # so a merge it triggers is attributed to the App rather than github-actions[bot]); the
 # workflow token is the fallback and, with write, is sufficient to arm.
 #
-# [OPUS-5] #4548 — the stuck-arm phase adds two more scopes. `checks: write` is the ONLY
-# thing that can re-request a cancelled check run, and `issues: write` is what labelling a
-# pull request actually consumes (`gh pr edit --add-label` posts to the ISSUES labels
-# endpoint). Without them the stuck-arm phase would classify correctly and then fail every
-# remediation with a 403 — visible, but useless. `contents: write` already present above
-# also covers the `PUT /pulls/{n}/update-branch` the CONFLICTING class attempts.
+# [OPUS-5] #4548 added checks/issue write scopes for the original stuck-arm phase.
+# [GPT-6 Astra] #6438 replaces that Checks rerequest with an Actions job rerun under
+# the preferred App. The legacy checks grant is retained pending separate review.
+# `issues: write` covers labels and recovery comments; `contents: write` also covers
+# `PUT /pulls/{n}/update-branch` for the CONFLICTING class.
 permissions:
   # [GPT-6 Astra] #6438: cancelled Actions recovery uses the preferred App's
   # actions:write, not this legacy checks grant. Grants remain unchanged here;
-  # fallback GITHUB_TOKEN has no actions:write and rerun denial stays fail-closed.
+  # fallback GITHUB_TOKEN has no actions:write and is refused before any claim POST.
   contents: write
   pull-requests: write
   checks: write

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -32,7 +32,7 @@ import re
 import subprocess
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
@@ -945,10 +945,9 @@ class RearmSweeper:
 #   every indeterminate reading maps to a NO-ACTION class that is still COUNTED.
 #
 #   EVERY ACTION MUST LEAVE THE POPULATION. The mutating classes all end in a disarm, a
-#   branch update, or a check-run re-request — each of which either drops the PR out of
-#   the armed set or bumps its activity back under the grace window. That is what keeps a
-#   ten-minute cron from commenting on the same PR 144 times a day; there is no marker
-#   comment to latch on, because the state transition IS the latch.
+#   branch update, or rerun. [GPT-6 Astra] #6438 adds a durable BEFORE-POST receipt
+#   specifically for cancelled Actions gates: a rejected/uncertain rerun may not move
+#   server state, so the activity clock alone cannot prevent repeated requests.
 # ======================================================================================
 
 # The tier-correct required-check names. sparq's ci-summary.yml publishes `gate` on a
@@ -1055,6 +1054,18 @@ OPEN_PR_COUNT_QUERY = """query($owner:String!,$name:String!){
 }"""
 
 STUCK_MARKER = "> 🤖 SPARQ agent"
+
+# [GPT-6 Astra] #6438: an operator approval hold is not a cancelled-run remedy.
+# Removing this hold requires the maintainer's separate approval, not a sweep tick.
+RERUN_HELD_PRS = frozenset({6049})
+RERUN_PHASE = "gate-rerun-claim"
+RERUN_HISTORY_QUERY = """query($owner:String!,$name:String!,$number:Int!){
+  viewer{login}
+  repository(owner:$owner,name:$name){pullRequest(number:$number){
+    comments(last:100){totalCount pageInfo{hasPreviousPage}
+      nodes{databaseId body author{id login __typename}}}
+  }}
+}"""
 
 
 @dataclass(frozen=True)
@@ -1630,7 +1641,7 @@ class StuckArmSweeper:
             )
         return [item for item in raw if isinstance(item, dict) and item.get("autoMergeRequest")]
 
-    def live_pull(self, number: int) -> ArmedPull | None:
+    def live_pull(self, number: int, *, strict: bool = False) -> ArmedPull | None:
         response = self._read_json(
             [
                 "api", "graphql",
@@ -1649,6 +1660,24 @@ class StuckArmSweeper:
         labels = raw.get("labels") or {}
         threads = raw.get("reviewThreads") or {}
         nodes = threads.get("nodes")
+        # [GPT-6 Astra] #6438: reruns need positive, complete current-state evidence.
+        if strict and (
+            raw.get("number") != number or raw.get("state") != "OPEN"
+            or type(raw.get("isDraft")) is not bool
+            or not isinstance(raw.get("autoMergeRequest"), dict)
+            or not isinstance(labels.get("nodes"), list)
+            or any(not isinstance(n, dict) or not isinstance(n.get("name"), str)
+                   for n in labels.get("nodes", []))
+            or (labels.get("pageInfo") or {}).get("hasNextPage") is not False
+            or not isinstance(nodes, list)
+            or type(threads.get("totalCount")) is not int
+            or threads.get("totalCount") != len(nodes)
+            or (threads.get("pageInfo") or {}).get("hasNextPage") is not False
+            or "mergeQueueEntry" not in raw
+            or any(not isinstance(n, dict) or type(n.get("isResolved")) is not bool
+                   for n in nodes)
+        ):
+            raise GhError("rerun refused: incomplete or no longer armed PR state")
         unresolved = 0
         if isinstance(nodes, list):
             unresolved = sum(
@@ -1677,7 +1706,7 @@ class StuckArmSweeper:
         )
 
     def gate_state(self, pull: ArmedPull) -> tuple[str, int | None]:
-        """`resolve_gate` over a PAGINATED read, plus the newest gate run's id for re-trigger."""
+        """`resolve_gate` over a complete read, plus its CHECK id (not an Actions id)."""
         if not pull.head_oid:
             return GATE_UNKNOWN, None
         pages = self._read_json(
@@ -1721,8 +1750,155 @@ class StuckArmSweeper:
             ]
         )
 
-    def rerequest(self, run_id: int) -> None:
-        self.gh(["api", "-X", "POST", f"repos/{self.repo}/check-runs/{run_id}/rerequest"])
+    # [GPT-6 Astra] #6438: the Checks rerequest endpoint cannot rerun another App's
+    # Actions job. Keep the server's check/job/run identities separate throughout.
+    def rerun_target(self, pull: ArmedPull, check_id: int) -> dict:
+        if type(check_id) is not int or check_id <= 0:
+            raise GhError("rerun refused: invalid check id")
+        def get(path):
+            value = self._read_json(["api", f"repos/{self.repo}/{path}"])
+            if not isinstance(value, dict):
+                raise GhError("rerun refused: malformed Actions metadata")
+            return value
+
+        check = get(f"check-runs/{check_id}")
+        match = re.fullmatch(
+            rf"https://github\.com/{re.escape(self.repo)}/actions/runs/([1-9][0-9]*)/job/([1-9][0-9]*)",
+            str(check.get("details_url") or ""),
+        )
+        if (not match or check.get("id") != check_id
+                or (check.get("app") or {}).get("slug") != "github-actions"
+                or check.get("head_sha") != pull.head_oid
+                or check.get("name") != GATE_CHECK_NAME
+                or check.get("status") != "completed" or check.get("conclusion") != "cancelled"):
+            raise GhError("rerun refused: check is not the cancelled Actions PR gate")
+        run_id, job_id = map(int, match.groups())
+        run = get(f"actions/runs/{run_id}")
+        pages = self._read_json(["api", "--paginate", "--slurp",
+            f"repos/{self.repo}/actions/workflows/ci-summary.yml/runs?head_sha={pull.head_oid}&per_page=100"])
+        runs = self.rerun_inventory(pages, "workflow_runs")
+        if any(type(r.get("id")) is not int for r in runs) or not runs:
+            raise GhError("rerun refused: incomplete workflow identity")
+        latest = max(runs, key=lambda r: r["id"])
+        prs = run.get("pull_requests")
+        if (run.get("id") != run_id or latest.get("id") != run_id
+                or run.get("path") != ".github/workflows/ci-summary.yml"
+                or latest.get("workflow_id") != run.get("workflow_id")
+                or type(run.get("workflow_id")) is not int
+                or run.get("event") != "pull_request" or latest.get("event") != "pull_request"
+                or run.get("head_sha") != pull.head_oid or latest.get("head_sha") != pull.head_oid
+                or (run.get("repository") or {}).get("full_name") != self.repo
+                or not isinstance(prs, list)
+                or not any(isinstance(pr, dict) and pr.get("number") == pull.number
+                           and (pr.get("head") or {}).get("sha") == pull.head_oid for pr in prs)
+                or type(run.get("run_attempt")) is not int or run.get("run_attempt") != 1
+                or type(latest.get("run_attempt")) is not int or latest.get("run_attempt") != 1
+                or any(r.get("status") != "completed" or r.get("conclusion") != "cancelled"
+                       for r in (run, latest))):
+            raise GhError("rerun refused: not the latest cancelled first PR attempt")
+        # Attempt-scoped server inventory proves job membership; check id != job id.
+        jobs = self.rerun_inventory(self._read_json(["api", "--paginate", "--slurp",
+            f"repos/{self.repo}/actions/runs/{run_id}/attempts/1/jobs?per_page=100"]), "jobs")
+        matches = [j for j in jobs if j.get("id") == job_id]
+        if len(matches) != 1:
+            raise GhError("rerun refused: job absent from current attempt")
+        job = matches[0]
+        if (job.get("run_id") != run_id or job.get("head_sha") != pull.head_oid
+                or job.get("check_run_url") != f"https://api.github.com/repos/{self.repo}/check-runs/{check_id}"
+                or job.get("name") != GATE_CHECK_NAME or job.get("status") != "completed"
+                or job.get("conclusion") != "cancelled"):
+            raise GhError("rerun refused: Actions job/check/run mismatch")
+        return {"v": RECEIPT_VERSION, "program": PROGRAM, "phase": RERUN_PHASE,
+                "repo": self.repo, "pr": pull.number, "head": pull.head_oid,
+                "run": run_id, "attempt": 1, "job": job_id, "check": check_id}
+
+    @staticmethod
+    def rerun_inventory(pages: object, key: str) -> list[dict]:
+        if not isinstance(pages, list) or not pages:
+            raise GhError("rerun refused: missing paginated inventory")
+        rows = []
+        for page in pages:
+            if (not isinstance(page, dict) or type(page.get("total_count")) is not int
+                    or not isinstance(page.get(key), list)
+                    or any(not isinstance(row, dict) for row in page[key])):
+                raise GhError("rerun refused: malformed paginated inventory")
+            rows.extend(page[key])
+        if any(page["total_count"] != len(rows) for page in pages):
+            raise GhError("rerun refused: truncated or changing inventory")
+        return rows
+
+    def rerun_history(self, claim: dict, claimed_id: int | None = None) -> None:
+        response = self._read_json(["api", "graphql", "-f", f"query={RERUN_HISTORY_QUERY}",
+            "-f", f"owner={self.owner}", "-f", f"name={self.name}", "-F", f"number={claim['pr']}"])
+        try:
+            viewer = response["data"]["viewer"]
+            history = response["data"]["repository"]["pullRequest"]["comments"]
+            comments = history["nodes"]
+            valid = (not response.get("errors")
+                and viewer["login"] in ("sparq-orchestrator[bot]", "github-actions[bot]")
+                and history["pageInfo"]["hasPreviousPage"] is False
+                and type(history["totalCount"]) is int and history["totalCount"] == len(comments))
+        except (KeyError, TypeError):
+            valid = False
+        if not valid or not isinstance(comments, list):
+            raise GhError("rerun refused: incomplete receipt history or unknown authenticated bot")
+        # GraphQL viewer has schema type User even for installation authentication.
+        # Resolve its authenticated login to the public Bot node, then bind authors
+        # by both server node id and login; an author-controlled body supplies neither.
+        bot = self._read_json(["api", f"users/{viewer['login']}"])
+        if (not isinstance(bot, dict) or bot.get("type") != "Bot"
+                or bot.get("login") != viewer["login"] or not bot.get("node_id")):
+            raise GhError("rerun refused: authenticated account is not a verified bot")
+        found = []
+        for comment in comments:
+            if not isinstance(comment, dict) or not isinstance(comment.get("body"), str):
+                raise GhError("rerun refused: malformed receipt history")
+            body = comment["body"]
+            if RERUN_PHASE not in body:
+                continue
+            parsed = parse_stuck_receipt(body)
+            author = comment.get("author") or {}
+            if (parsed is None or body != self.rerun_claim_body(parsed)
+                    or author.get("id") != bot["node_id"] or author.get("login") != viewer["login"]
+                    or author.get("__typename") != "Bot"
+                    or set(parsed) != set(claim) or parsed.get("v") != RECEIPT_VERSION
+                    or parsed.get("program") != PROGRAM or parsed.get("phase") != RERUN_PHASE
+                    or parsed.get("repo") != self.repo or parsed.get("pr") != claim["pr"]
+                    or not isinstance(parsed.get("head"), str)
+                    or not re.fullmatch(r"[0-9a-f]{40}", parsed["head"])
+                    or any(type(parsed.get(k)) is not int or parsed[k] <= 0
+                           for k in ("run", "attempt", "job", "check"))):
+                raise GhError("rerun refused: malformed, copied or foreign receipt needs review")
+            # Dedupe by the attempt, even if its job/check inventory changes.
+            if all(parsed[k] == claim[k] for k in ("repo", "pr", "head", "run", "attempt")):
+                if claimed_id is not None and parsed != claim:
+                    raise GhError("rerun refused: recorded claim changed; separate recovery required")
+                found.append(comment.get("databaseId"))
+        if found != ([] if claimed_id is None else [claimed_id]):
+            raise GhError("rerun refused: attempt already claimed or claim not visible; separate recovery required")
+
+    @staticmethod
+    def rerun_claim_body(claim: dict) -> str:
+        return (f"{STUCK_MARKER} — [GPT-6 Astra] cancelled gate recovery (#6438)\n\n"
+                "This claim permits one Actions rerun request after fresh verification. "
+                "A rejected or uncertain request stays claimed; recovery requires separate review.\n\n"
+                + render_receipt(claim))
+
+    def fresh_rerun_pull(self, original: ArmedPull, *, claimed: bool = False) -> ArmedPull:
+        current = self.live_pull(original.number, strict=True)
+        if current is None:
+            raise GhError("rerun refused: PR no longer exists")
+        # Posting our own receipt bumps updatedAt. Only that clock is discounted;
+        # every other observed PR property must remain identical after the claim.
+        comparable = replace(current, updated_at=original.updated_at) if claimed else current
+        if (comparable != original or current.number in RERUN_HELD_PRS
+                or current.is_draft or current.base_ref != self.default_branch
+                or not re.fullmatch(r"[0-9a-f]{40}", current.head_oid)
+                or "review:pass" not in current.labels or current.unresolved_threads != 0
+                or current.mergeable != "MERGEABLE" or current.armed_at <= 0
+                or classify(comparable, GATE_CANCELLED, self.now(), self.limits) != "gate-cancelled"):
+            raise GhError("rerun refused: PR changed, held, queued or not reviewed/settled")
+        return current
 
     # ---- the per-class exits ----------------------------------------------------------
 
@@ -1761,10 +1937,27 @@ class StuckArmSweeper:
                 "re-requestable run id"
             )
             return
-        self.rerequest(run_id)
+        self.fresh_rerun_pull(pull)
+        claim = self.rerun_target(pull, run_id)
+        self.rerun_history(claim)
+        self.fresh_rerun_pull(pull)
+        # Serial workflow concurrency + a BEFORE-POST claim survives both API failure
+        # and process death. Never retry the mutation, even if its result is uncertain.
+        try:
+            posted = json.loads(self.gh(["api", "-X", "POST",
+                f"repos/{self.repo}/issues/{pull.number}/comments", "-f", f"body={self.rerun_claim_body(claim)}"]))
+        except json.JSONDecodeError as error:
+            raise GhError("rerun refused: claim response unreadable; separate recovery required") from error
+        if not isinstance(posted, dict) or type(posted.get("id")) is not int:
+            raise GhError("rerun refused: claim response unreadable; separate recovery required")
+        self.rerun_history(claim, posted["id"])
+        if self.gate_state(pull) != (GATE_CANCELLED, run_id) or self.rerun_target(pull, run_id) != claim:
+            raise GhError("rerun refused: latest gate/run/attempt changed after claim")
+        self.fresh_rerun_pull(pull, claimed=True)
+        self.gh(["api", "-X", "POST", f"repos/{self.repo}/actions/jobs/{claim['job']}/rerun"])
         self.log(
-            f"[{PROGRAM}] stuck-arm PR #{pull.number}: RETRIGGER — re-requested the "
-            f"cancelled gate run {run_id} ({detail})"
+            f"[{PROGRAM}] stuck-arm PR #{pull.number}: RETRIGGER — requested Actions "
+            f"job {claim['job']} in run {claim['run']} attempt {claim['attempt']} ({detail})"
         )
 
     def apply(
@@ -2463,7 +2656,8 @@ def stuck_self_test() -> None:
     assert "review:changes" in fake.mutations("pr", "edit")[0]
     assert "branch update refused" in fake.mutations("pr", "comment")[0][-1]
 
-    # gate-cancelled -> re-request the NEWEST gate run, bounded; nothing is disarmed.
+    # [GPT-6 Astra] #6438: a bare check id is not Actions provenance. The focused
+    # wiring suite supplies the complete server inventory and exercises the rerun.
     fake, messages, errors, sweeper = sweep(
         {13: live_pr(13, updated=old, armed=old)},
         [check_run("gate", "success", started="2026-07-20T00:00:00Z", ident=7),
@@ -2472,9 +2666,7 @@ def stuck_self_test() -> None:
     )
     assert sweeper.counts == {"gate-cancelled": 1}, sweeper.counts
     rerun = [c for c in fake.calls if c[:3] == ["api", "-X", "POST"]]
-    assert rerun and "/check-runs/8/rerequest" in rerun[0][3], (
-        f"must re-request the NEWEST cancelled run, got {rerun}"
-    )
+    assert errors == 1 and not rerun, (errors, rerun)
     assert not fake.mutations("pr", "merge"), "a cancelled gate is not a failed gate"
 
     # A DRAFT armed PR resolves its own tier. With only `gate, draft-tier` present a

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -1059,6 +1059,10 @@ STUCK_MARKER = "> 🤖 SPARQ agent"
 # Removing this hold requires the maintainer's separate approval, not a sweep tick.
 RERUN_HELD_PRS = frozenset({6049})
 RERUN_PHASE = "gate-rerun-claim"
+# Keep both the human marker and machine delimiters outside the park protocol.
+RERUN_MARKER = "> 🤖 [GPT-6 Astra] SPARQ agent — cancelled gate recovery (#6438)"
+RERUN_RECEIPT_OPEN = "<!-- gate-rerun-claim:"
+RERUN_RECEIPT_CLOSE = ":gate-rerun-claim -->"
 RERUN_HISTORY_QUERY = """query($owner:String!,$name:String!,$number:Int!){
   viewer{login}
   repository(owner:$owner,name:$name){pullRequest(number:$number){
@@ -1399,12 +1403,14 @@ def stuck_receipt(pull: ArmedPull, klass: str, gate: str, now: int) -> dict:
     }
 
 
-def render_receipt(receipt: dict) -> str:
+def render_receipt(
+    receipt: dict, *, opening: str = RECEIPT_OPEN, closing: str = RECEIPT_CLOSE
+) -> str:
     """One line, HTML-comment-wrapped so it renders as nothing and greps as everything."""
     return (
-        f"{RECEIPT_OPEN} "
+        f"{opening} "
         f"{json.dumps(receipt, sort_keys=True, separators=(',', ':'), ensure_ascii=False)} "
-        f"{RECEIPT_CLOSE}"
+        f"{closing}"
     )
 
 
@@ -1417,14 +1423,24 @@ def parse_stuck_receipt(body: object) -> dict | None:
     cannot read the receipt must behave as if the park were opaque, never as if it were
     satisfied.
     """
-    if not isinstance(body, str) or RECEIPT_OPEN not in body:
+    return _parse_receipt(body, RECEIPT_OPEN, RECEIPT_CLOSE)
+
+
+def parse_rerun_claim(body: object) -> dict | None:
+    """Parse only the rerun protocol; park receipts cannot claim a rerun attempt."""
+    return _parse_receipt(body, RERUN_RECEIPT_OPEN, RERUN_RECEIPT_CLOSE)
+
+
+def _parse_receipt(body: object, opening: str, closing: str) -> dict | None:
+    # [GPT-6 Astra] #6438: share the existing parser without sharing its sentinels.
+    if not isinstance(body, str) or opening not in body:
         return None
-    start = body.rfind(RECEIPT_OPEN)
-    end = body.find(RECEIPT_CLOSE, start + len(RECEIPT_OPEN))
+    start = body.rfind(opening)
+    end = body.find(closing, start + len(opening))
     if end < 0:
         return None
     try:
-        parsed = json.loads(body[start + len(RECEIPT_OPEN):end].strip())
+        parsed = json.loads(body[start + len(opening):end].strip())
     except (ValueError, TypeError):
         return None
     if not isinstance(parsed, dict):
@@ -1717,13 +1733,13 @@ class StuckArmSweeper:
         )
         state = resolve_gate(pages, is_draft=pull.is_draft)
         runs, _declared = collect_check_runs(pages)
-        run_id = None
+        check_id = None
         if runs:
             rows = [r for r in runs if r.get("name") == gate_check_name(pull.is_draft)]
             if rows:
                 ident = max(rows, key=_run_order).get("id")
-                run_id = ident if isinstance(ident, int) else None
-        return state, run_id
+                check_id = ident if isinstance(ident, int) else None
+        return state, check_id
 
     # ---- mutations. One-shot, never through the retrying read runner. -----------------
 
@@ -1771,7 +1787,10 @@ class StuckArmSweeper:
                 or check.get("head_sha") != pull.head_oid
                 or check.get("name") != GATE_CHECK_NAME
                 or check.get("status") != "completed" or check.get("conclusion") != "cancelled"):
-            raise GhError("rerun refused: check is not the cancelled Actions PR gate")
+            raise GhError(
+                "rerun refused: check is not the cancelled Actions PR gate; "
+                f"details_url={check.get('details_url')!r}"
+            )
         run_id, job_id = map(int, match.groups())
         run = get(f"actions/runs/{run_id}")
         pages = self._read_json(["api", "--paginate", "--slurp",
@@ -1832,16 +1851,23 @@ class StuckArmSweeper:
             "-f", f"owner={self.owner}", "-f", f"name={self.name}", "-F", f"number={claim['pr']}"])
         try:
             viewer = response["data"]["viewer"]
+            login = viewer["login"]
             history = response["data"]["repository"]["pullRequest"]["comments"]
             comments = history["nodes"]
             valid = (not response.get("errors")
-                and viewer["login"] in ("sparq-orchestrator[bot]", "github-actions[bot]")
                 and history["pageInfo"]["hasPreviousPage"] is False
                 and type(history["totalCount"]) is int and history["totalCount"] == len(comments))
         except (KeyError, TypeError):
             valid = False
         if not valid or not isinstance(comments, list):
-            raise GhError("rerun refused: incomplete receipt history or unknown authenticated bot")
+            raise GhError("rerun refused: incomplete receipt history or authenticated identity")
+        # The explicitly scoped workflow fallback has no actions:write. Reject it
+        # BEFORE claiming anything; a known denial must not strand an attempt.
+        if login != "sparq-orchestrator[bot]":
+            raise GhError(
+                f"rerun refused: authenticated login {login!r}; requires sparq-orchestrator[bot] "
+                "(the workflow fallback has no actions:write)"
+            )
         # GraphQL viewer has schema type User even for installation authentication.
         # Resolve its authenticated login to the public Bot node, then bind authors
         # by both server node id and login; an author-controlled body supplies neither.
@@ -1853,10 +1879,12 @@ class StuckArmSweeper:
         for comment in comments:
             if not isinstance(comment, dict) or not isinstance(comment.get("body"), str):
                 raise GhError("rerun refused: malformed receipt history")
-            body = comment["body"]
+            # GitHub may return CRLF line endings. Preserve every other byte so
+            # quotes, added prose and malformed/foreign receipts still refuse.
+            body = comment["body"].replace("\r\n", "\n")
             if RERUN_PHASE not in body:
                 continue
-            parsed = parse_stuck_receipt(body)
+            parsed = parse_rerun_claim(body)
             author = comment.get("author") or {}
             if (parsed is None or body != self.rerun_claim_body(parsed)
                     or author.get("id") != bot["node_id"] or author.get("login") != viewer["login"]
@@ -1879,10 +1907,10 @@ class StuckArmSweeper:
 
     @staticmethod
     def rerun_claim_body(claim: dict) -> str:
-        return (f"{STUCK_MARKER} — [GPT-6 Astra] cancelled gate recovery (#6438)\n\n"
+        return (f"{RERUN_MARKER}\n\n"
                 "This claim permits one Actions rerun request after fresh verification. "
                 "A rejected or uncertain request stays claimed; recovery requires separate review.\n\n"
-                + render_receipt(claim))
+                + render_receipt(claim, opening=RERUN_RECEIPT_OPEN, closing=RERUN_RECEIPT_CLOSE))
 
     def fresh_rerun_pull(self, original: ArmedPull, *, claimed: bool = False) -> ArmedPull:
         current = self.live_pull(original.number, strict=True)
@@ -1930,15 +1958,15 @@ class StuckArmSweeper:
             return
         self.log(f"[{PROGRAM}] stuck-arm PR #{pull.number}: REBASE — branch update requested")
 
-    def retrigger(self, pull: ArmedPull, run_id: int | None, detail: str) -> None:
-        if run_id is None:
+    def retrigger(self, pull: ArmedPull, check_id: int | None, detail: str) -> None:
+        if check_id is None:
             self.log(
                 f"[{PROGRAM}] stuck-arm PR #{pull.number}: SKIP — cancelled gate has no "
-                "re-requestable run id"
+                "check id to verify"
             )
             return
         self.fresh_rerun_pull(pull)
-        claim = self.rerun_target(pull, run_id)
+        claim = self.rerun_target(pull, check_id)
         self.rerun_history(claim)
         self.fresh_rerun_pull(pull)
         # Serial workflow concurrency + a BEFORE-POST claim survives both API failure
@@ -1951,7 +1979,7 @@ class StuckArmSweeper:
         if not isinstance(posted, dict) or type(posted.get("id")) is not int:
             raise GhError("rerun refused: claim response unreadable; separate recovery required")
         self.rerun_history(claim, posted["id"])
-        if self.gate_state(pull) != (GATE_CANCELLED, run_id) or self.rerun_target(pull, run_id) != claim:
+        if self.gate_state(pull) != (GATE_CANCELLED, check_id) or self.rerun_target(pull, check_id) != claim:
             raise GhError("rerun refused: latest gate/run/attempt changed after claim")
         self.fresh_rerun_pull(pull, claimed=True)
         self.gh(["api", "-X", "POST", f"repos/{self.repo}/actions/jobs/{claim['job']}/rerun"])
@@ -1961,7 +1989,7 @@ class StuckArmSweeper:
         )
 
     def apply(
-        self, pull: ArmedPull, klass: str, gate: str, run_id: int | None, detail: str
+        self, pull: ArmedPull, klass: str, gate: str, check_id: int | None, detail: str
     ) -> None:
         action = CLASS_ACTIONS[klass]
         if self.dry_run:
@@ -1976,7 +2004,7 @@ class StuckArmSweeper:
         elif action == ACTION_REBASE:
             self.rebase(pull, gate, detail)
         elif action == ACTION_RETRIGGER:
-            self.retrigger(pull, run_id, detail)
+            self.retrigger(pull, check_id, detail)
 
     # ---- the sweep --------------------------------------------------------------------
 
@@ -2006,7 +2034,7 @@ class StuckArmSweeper:
                     # Not our lane; still counted so the totals stay closed.
                     self.counts["progressing"] = self.counts.get("progressing", 0) + 1
                     continue
-                gate, run_id = self.gate_state(pull)
+                gate, check_id = self.gate_state(pull)
             except (GhError, json.JSONDecodeError) as error:
                 self.log(f"[{PROGRAM}] stuck-arm PR #{number}: SKIP — read failed ({error})")
                 self.counts["gate-indeterminate"] = (
@@ -2043,7 +2071,7 @@ class StuckArmSweeper:
                 continue
             self.actions += 1
             try:
-                self.apply(pull, klass, gate, run_id, detail)
+                self.apply(pull, klass, gate, check_id, detail)
                 self.log(
                     f"[{PROGRAM}] stuck-arm PR #{number}: {klass} -> "
                     f"{CLASS_ACTIONS[klass]} ({detail})"
@@ -2760,14 +2788,14 @@ def stuck_self_test() -> None:
         "the budget must have been spent on the ACTIONABLE PR, not on a queued one"
     )
 
-    # A cancelled gate with NO re-requestable run id must SKIP, not call the API with None.
+    # A cancelled gate with NO check id must SKIP, not call the API with None.
     fake, messages, errors, sweeper = sweep(
         {73: live_pr(73, updated=old, armed=old)},
         [check_run("gate", "cancelled", ident=None)], now_=clock,
     )
     assert sweeper.counts == {"gate-cancelled": 1}, sweeper.counts
     assert not [c for c in fake.calls if c[:3] == ["api", "-X", "POST"]], fake.calls
-    assert any("no re-requestable run id" in line for line in messages), messages
+    assert any("no check id to verify" in line for line in messages), messages
     assert errors == 0, messages
 
     # A SHORT ENUMERATION is flagged, not silently reported as a full census.

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -44,13 +44,16 @@ from __future__ import annotations
 import ast
 import copy
 import importlib.util
+import json
 import re
 import shutil
 import subprocess
+import socket
 import sys
 import tempfile
 import textwrap
 import unittest
+from unittest.mock import patch
 from pathlib import Path
 from types import ModuleType
 from typing import NamedTuple
@@ -1152,8 +1155,9 @@ class TestStuckArmWiring(unittest.TestCase):
     def test_the_scopes_its_mutations_need_are_granted(self) -> None:
         """Classify-then-403 is the failure mode this pin exists for.
 
-        `checks: write` is the only scope that can re-request a cancelled run, and
-        labelling a pull request consumes the ISSUES scope.
+        [GPT-6 Astra] #6438 keeps existing workflow grants. The preferred App's
+        Actions grant governs reruns; the fallback has no Actions write and fails
+        closed. These declarations never elevate the minted installation token.
         """
         permissions = self.document.get("permissions") or {}
         for scope in ("contents", "pull-requests", "checks", "issues"):
@@ -1464,6 +1468,286 @@ class TestStuckArmScriptContract(unittest.TestCase):
             set(),
         )
 
+
+
+# [GPT-6 Astra] #6438: exercise the production rerun path with distinct server IDs.
+# The existing workflow runs THIS suite; these are not an uncalled fixture appendix.
+class ActionsRerunFixture:
+    def __init__(self, module):
+        self.m = module
+        self.clock = module._iso_epoch("2026-09-06T12:00:00Z")
+        self.viewer = {"login": "sparq-orchestrator[bot]"}
+        self.actor = dict(id="BOT_4300853", login=self.viewer["login"], __typename="Bot")
+        self.raw = module.live_pr(6360, labels=("review:pass",), head="a" * 40)
+        self.check = dict(module.check_run("gate", "cancelled", ident=101),
+            head_sha="a" * 40, app={"slug": "github-actions"},
+            details_url="https://github.com/sparq-org/sparq/actions/runs/303/job/202")
+        self.run = dict(id=303, workflow_id=404, run_attempt=1, event="pull_request",
+            path=".github/workflows/ci-summary.yml", status="completed", conclusion="cancelled",
+            head_sha="a" * 40, repository={"full_name": "sparq-org/sparq"},
+            pull_requests=[{"number": 6360, "head": {"sha": "a" * 40}}])
+        self.job = dict(id=202, run_id=303, head_sha="a" * 40, name="gate",
+            status="completed", conclusion="cancelled",
+            check_run_url="https://api.github.com/repos/sparq-org/sparq/check-runs/101")
+        self.comments = []
+        self.calls = []
+        self.after_claim = lambda: None
+        self.claim_reply = None
+        self.post_error = False
+        self.history_extra = 0
+        self.history_truncated = False
+        self.latest_extra = []
+        self.jobs_extra = 0
+        self.logs = []
+        self.sweeper = self.new_sweeper()
+        self.original = self.sweeper.live_pull(6360)
+        self.calls.clear()
+
+    def new_sweeper(self):
+        return self.m.StuckArmSweeper("sparq-org/sparq", "main", gh=self,
+            log=self.logs.append, now=lambda: self.clock)
+
+    def __call__(self, argv):
+        self.calls.append(list(argv))
+        if argv[:2] == ["pr", "list"]:
+            return json.dumps([self.raw])
+        if argv[:2] == ["api", "graphql"]:
+            query = next(x for x in argv if x.startswith("query="))
+            if "pullRequests(states:OPEN)" in query:
+                return json.dumps({"data": {"repository": {"pullRequests": {"totalCount": 1}}}})
+            if "viewer{" in query:
+                return json.dumps({"data": {"viewer": self.viewer, "repository": {"pullRequest": {
+                    "comments": {"totalCount": len(self.comments) + self.history_extra,
+                        "pageInfo": {"hasPreviousPage": self.history_truncated}, "nodes": self.comments}}}}})
+            return json.dumps({"data": {"repository": {"pullRequest": self.raw}}})
+        if argv[:3] == ["api", "-X", "POST"]:
+            if argv[3].endswith("/comments"):
+                body = next(x.removeprefix("body=") for x in argv if x.startswith("body="))
+                self.comments.append(dict(databaseId=505, body=body, author=copy.deepcopy(self.actor)))
+                self.raw["updatedAt"] = "2026-09-06T12:00:00Z"
+                self.after_claim()
+                return self.claim_reply if self.claim_reply is not None else json.dumps({"id": 505})
+            if argv[3] == "repos/sparq-org/sparq/actions/jobs/202/rerun":
+                if self.post_error:
+                    raise self.m.GhError("Resource not accessible by integration (HTTP 403)")
+                return "{}"
+            raise AssertionError(f"unexpected mutation: {argv}")
+        path = argv[-1]
+        if path == "users/sparq-orchestrator[bot]":
+            return json.dumps(dict(login=self.actor["login"],node_id=self.actor["id"],type="Bot"))
+        if "/commits/" in path:
+            return json.dumps(self.m.check_pages([self.check]))
+        if "/actions/workflows/ci-summary.yml/runs?" in path:
+            rows = [self.run] + self.latest_extra
+            return json.dumps([{"total_count": len(rows), "workflow_runs": rows}])
+        if "/attempts/1/jobs?" in path:
+            return json.dumps([{"total_count": 1 + self.jobs_extra, "jobs": [self.job]}])
+        if path == "repos/sparq-org/sparq/check-runs/101":
+            return json.dumps(self.check)
+        if path == "repos/sparq-org/sparq/actions/runs/303":
+            return json.dumps(self.run)
+        raise AssertionError(f"unexpected read: {argv}")
+
+    def posts(self):
+        return [c for c in self.calls if c[:3] == ["api", "-X", "POST"]]
+
+    def reruns(self):
+        return [c for c in self.posts() if c[3].endswith("/rerun")]
+
+    def drive(self):
+        self.sweeper.retrigger(self.original, 101, "fixture")
+
+
+class TestCancelledActionsRecovery(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.m = load_module(REARM_PY, "rerun_rearm")
+
+    def setUp(self):
+        def poison(*args, **kwargs):
+            raise AssertionError("unexpected process/network access in rerun fixture")
+        for target, name in ((subprocess, "run"), (subprocess, "Popen"),
+                             (socket, "create_connection"), (socket.socket, "connect")):
+            patcher = patch.object(target, name, poison)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        self.f = ActionsRerunFixture(self.m)
+
+    def denied(self):
+        with self.assertRaises(self.m.GhError):
+            self.f.drive()
+        self.assertEqual(self.f.reruns(), [])
+
+    def test_distinct_check_job_and_run_ids_reach_actions_only(self):
+        self.assertEqual(self.f.sweeper.run(), 0)
+        self.assertEqual([c[3] for c in self.f.posts()], [
+            "repos/sparq-org/sparq/issues/6360/comments",
+            "repos/sparq-org/sparq/actions/jobs/202/rerun"])
+        claim = self.m.parse_stuck_receipt(self.f.comments[0]["body"])
+        self.assertEqual((claim["check"], claim["job"], claim["run"], claim["attempt"]), (101, 202, 303, 1))
+        self.assertFalse(any("/rerequest" in arg for call in self.f.calls for arg in call))
+
+    def test_changed_head_draft_review_hold_queue_and_grace_never_claim(self):
+        changes = [dict(headRefOid="b" * 40), dict(isDraft=True), dict(state="CLOSED"),
+            dict(autoMergeRequest=None), dict(baseRefName="other"), dict(mergeable="UNKNOWN"),
+            dict(mergeQueueEntry={"id": "queued"}), dict(updatedAt="2026-09-06T12:00:00Z"),
+            dict(labels={"nodes": [], "pageInfo": {"hasNextPage": False}}),
+            dict(labels={"nodes": [{"name": "review:pass"}, {"name": "needs:user"}], "pageInfo": {"hasNextPage": False}}),
+            dict(reviewThreads={"totalCount": 1,"nodes": [{"isResolved": False}], "pageInfo": {"hasNextPage": False}}),
+            dict(labels={"nodes": [{"name":"review:pass"}], "pageInfo":{"hasNextPage":True}}),
+            dict(reviewThreads={"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":True}})]
+        for change in changes:
+            with self.subTest(change=change):
+                self.f = ActionsRerunFixture(self.m)
+                self.f.raw.update(change)
+                self.denied()
+                self.assertEqual(self.f.posts(), [])
+
+    def test_explicit_6049_hold_survives_even_cancelled_metadata(self):
+        self.f.raw["number"] = 6049
+        self.f.original = self.m.replace(self.f.original, number=6049)
+        self.f.run["pull_requests"][0]["number"] = 6049
+        self.denied()
+        self.assertEqual(self.f.posts(), [])
+
+    def test_live_waiting_requested_and_action_required_are_not_cancelled(self):
+        for target in ("check", "job", "run"):
+            for status, conclusion in (("queued",None), ("in_progress",None), ("waiting",None),
+                    ("requested",None), ("completed","action_required"), ("completed","success"),
+                    ("completed","failure"), ("completed","stale")):
+                with self.subTest(target=target, status=status, conclusion=conclusion):
+                    self.f = ActionsRerunFixture(self.m)
+                    getattr(self.f,target).update(status=status,conclusion=conclusion)
+                    self.denied()
+                    self.assertEqual(self.f.posts(), [])
+
+    def test_wrong_app_url_job_run_head_workflow_event_or_attempt(self):
+        cases = [("check", "app", {"slug":"other"}),
+            ("check","details_url","https://github.com/other/repo/actions/runs/303/job/202"),
+            ("check","head_sha","b"*40), ("check","name","gate, draft-tier"),
+            ("job","check_run_url","https://api.github.com/repos/sparq-org/sparq/check-runs/999"),
+            ("job","id",999), ("job","run_id",999), ("job","head_sha","b"*40),
+            ("job","name","other"), ("run","head_sha","b"*40),
+            ("run","path",".github/workflows/other.yml"),
+            ("run","repository",{"full_name":"other/repo"}), ("run","pull_requests",[]),
+            ("run","event","merge_group"), ("run","event","schedule"), ("run","event","workflow_dispatch"),
+            ("run","run_attempt",2), ("run","run_attempt",True)]
+        for target,key,value in cases:
+            with self.subTest(target=target,key=key,value=value):
+                self.f = ActionsRerunFixture(self.m)
+                getattr(self.f,target)[key] = value
+                self.denied()
+                self.assertEqual(self.f.posts(), [])
+
+    def test_latest_workflow_supersedes_cancelled_check_and_short_attempt_denies(self):
+        for status,conclusion in (("waiting",None),("completed","cancelled")):
+            self.f = ActionsRerunFixture(self.m)
+            self.f.latest_extra = [dict(self.f.run,id=304,status=status,conclusion=conclusion)]
+            self.denied()
+            self.assertEqual(self.f.posts(), [])
+        self.f = ActionsRerunFixture(self.m)
+        self.f.jobs_extra = 1
+        self.denied()
+        self.assertEqual(self.f.posts(), [])
+
+    def test_stale_metadata_after_claim_prevents_rerun(self):
+        for target,key,value in (("raw","headRefOid","b"*40), ("raw","mergeQueueEntry",{"id":"q"}),
+                ("run","run_attempt",2), ("run","status","waiting"), ("job","status","in_progress"),
+                ("check","conclusion","success"),
+                ("raw","labels",{"nodes":[{"name":"review:needs"}],"pageInfo":{"hasNextPage":False}})):
+            with self.subTest(target=target,key=key):
+                self.f = ActionsRerunFixture(self.m)
+                self.f.after_claim = lambda: getattr(self.f,target).__setitem__(key,value)
+                self.denied()
+                self.assertEqual(len(self.f.posts()), 1)
+
+    def test_claim_blocks_repeat_within_and_across_ticks_after_rejection(self):
+        self.f.post_error = True
+        self.assertEqual(self.f.sweeper.run(), 1)
+        self.assertEqual(len(self.f.reruns()), 1)
+        self.f.clock += 1800  # beyond the comment's grace, same server attempt
+        self.assertEqual(self.f.sweeper.run(), 2)  # same instance retains sticky errors
+        self.assertEqual(self.f.new_sweeper().run(), 1)
+        self.assertEqual(len(self.f.reruns()), 1)
+        self.assertEqual(len(self.f.comments), 1)
+
+    def test_successful_but_not_yet_visible_attempt_stays_claimed(self):
+        self.f.drive()
+        self.f.clock += 1800
+        self.assertEqual(self.f.new_sweeper().run(), 1)
+        self.assertEqual(len(self.f.reruns()), 1)
+
+    def test_receipts_must_be_complete_unquoted_and_authenticated(self):
+        claim = self.f.sweeper.rerun_target(self.f.original,101)
+        valid_body = self.m.StuckArmSweeper.rerun_claim_body(claim)
+        old_body = self.m.StuckArmSweeper.rerun_claim_body(dict(claim,head="b"*40))
+        for body, author in ((valid_body,dict(self.f.actor,id="OTHER")),
+                (valid_body,dict(self.f.actor,login="someone")),
+                (old_body,dict(self.f.actor,id="OTHER")),
+                (old_body,dict(self.f.actor,login="someone")),
+                (old_body,dict(self.f.actor,__typename="User")),
+                ("> " + valid_body,self.f.actor), ("```\n"+valid_body+"\n```",self.f.actor),
+                (old_body.replace('"head":"'+'b'*40+'"','"head":"invalid"'),self.f.actor),
+                (valid_body.replace('"attempt":1','"attempt":"bad"'),self.f.actor),
+                (valid_body.replace('"repo":"sparq-org/sparq"','"repo":"other/repo"'),self.f.actor),
+                (valid_body.replace("-->",""),self.f.actor),
+                (valid_body,self.f.actor)):
+            with self.subTest(body=body,author=author):
+                self.f = ActionsRerunFixture(self.m)
+                self.f.comments=[dict(databaseId=501,body=body,author=author)]
+                self.denied()
+                self.assertEqual(self.f.posts(), [])
+
+    def test_authenticated_receipt_on_an_old_head_does_not_claim_new_head(self):
+        claim = self.f.sweeper.rerun_target(self.f.original,101)
+        self.f.comments = [dict(databaseId=501,author=self.f.actor,
+            body=self.m.StuckArmSweeper.rerun_claim_body(dict(claim,head="b"*40)))]
+        self.f.drive()
+        self.assertEqual(len(self.f.reruns()),1)
+
+    def test_same_attempt_is_claimed_even_if_job_or_check_id_changes(self):
+        claim = self.f.sweeper.rerun_target(self.f.original,101)
+        self.f.comments = [dict(databaseId=501,author=self.f.actor,
+            body=self.m.StuckArmSweeper.rerun_claim_body(dict(claim,job=999,check=998)))]
+        self.denied()
+        self.assertEqual(self.f.posts(),[])
+
+    def test_claim_is_not_review_evidence_or_a_verdict_bridge_trigger(self):
+        claim = self.f.sweeper.rerun_target(self.f.original,101)
+        body = self.m.StuckArmSweeper.rerun_claim_body(claim)
+        bridge_tests = load_module(REPO_ROOT / "scripts/tests/test_verdict_bridge.py", "claim_bridge_tests")
+        condition = load(WORKFLOWS / "verdict-bridge.yml")["jobs"]["bridge"]["if"]
+        event = bridge_tests.payload("issue_comment", issue={"number":6360,"pull_request":{}}, comment={"body":body})
+        self.assertFalse(bridge_tests.evaluate_if(condition,event))
+        self.assertIsNone(bridge_tests.vb.trailing_verdict(body))
+        # Positive control: the same production condition admits a real verdict.
+        event["github"]["event"]["comment"]["body"] = "VERDICT: pass"
+        self.assertTrue(bridge_tests.evaluate_if(condition,event))
+
+    def test_truncated_history_or_nonbot_authentication_never_claims(self):
+        for attr,value in (("history_truncated",True),("history_extra",1),
+                ("viewer",{"id":"HUMAN","login":"jeswr","__typename":"User"})):
+            self.f = ActionsRerunFixture(self.m)
+            setattr(self.f,attr,value)
+            self.denied()
+            self.assertEqual(self.f.posts(), [])
+
+    def test_claim_response_or_readback_uncertainty_never_posts_rerun(self):
+        for reply in ("bad-json", "{}", '{"id":"505"}', '{"id":999}'):
+            self.f = ActionsRerunFixture(self.m)
+            self.f.claim_reply=reply
+            self.denied()
+            self.assertEqual(len(self.f.posts()),1)
+
+    def test_per_tick_cap_and_dry_run_preserve_zero_posts(self):
+        self.f.sweeper.limits=self.m.StuckLimits(max_actions=0)
+        self.assertEqual(self.f.sweeper.run(),0)
+        self.assertEqual(self.f.sweeper.deferred,1)
+        self.assertEqual(self.f.posts(),[])
+        self.f.sweeper=self.f.new_sweeper()
+        self.f.sweeper.dry_run=True
+        self.assertEqual(self.f.sweeper.run(),0)
+        self.assertEqual(self.f.posts(),[])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -1533,7 +1533,7 @@ class ActionsRerunFixture:
                 return "{}"
             raise AssertionError(f"unexpected mutation: {argv}")
         path = argv[-1]
-        if path == "users/sparq-orchestrator[bot]":
+        if path == f"users/{self.viewer['login']}":
             return json.dumps(dict(login=self.actor["login"],node_id=self.actor["id"],type="Bot"))
         if "/commits/" in path:
             return json.dumps(self.m.check_pages([self.check]))
@@ -1583,9 +1583,70 @@ class TestCancelledActionsRecovery(unittest.TestCase):
         self.assertEqual([c[3] for c in self.f.posts()], [
             "repos/sparq-org/sparq/issues/6360/comments",
             "repos/sparq-org/sparq/actions/jobs/202/rerun"])
-        claim = self.m.parse_stuck_receipt(self.f.comments[0]["body"])
+        claim = self.m.parse_rerun_claim(self.f.comments[0]["body"])
         self.assertEqual((claim["check"], claim["job"], claim["run"], claim["attempt"]), (101, 202, 303, 1))
         self.assertFalse(any("/rerequest" in arg for call in self.f.calls for arg in call))
+
+    def test_fallback_identity_is_refused_before_any_claim_or_rerun(self):
+        # [GPT-6 Astra] Opus B1: valid bot metadata cannot grant the explicitly
+        # unprivileged fallback a claim. Keep the real App happy path above.
+        self.f.viewer = {"login": "github-actions[bot]"}
+        self.f.actor = dict(id="BOT_ACTIONS", login="github-actions[bot]", __typename="Bot")
+        self.f.post_error = True  # model the fallback's known Actions denial
+        self.assertEqual(self.f.sweeper.run(), 1)
+        self.assertEqual(self.f.posts(), [])
+        self.assertEqual(self.f.comments, [])
+        self.assertTrue(any("github-actions[bot]" in line and "no actions:write" in line
+                            for line in self.f.logs), self.f.logs)
+
+    def test_rerun_claim_cannot_shadow_or_satisfy_a_park_receipt(self):
+        # [GPT-6 Astra] Opus B2: exercise the actual park parser/evaluator, with
+        # a new claim appearing AFTER the park in a complete comment history.
+        park = self.m.stuck_comment(self.f.original, "gate-failed", self.m.GATE_FAILURE,
+                                   "fixture park", self.f.clock)
+        self.f.comments = [dict(databaseId=501, body=park, author=self.f.actor)]
+        self.f.drive()
+        claim_body = self.f.comments[-1]["body"]
+        self.assertEqual(len(self.f.reruns()), 1)
+        self.assertNotIn(self.m.STUCK_MARKER, claim_body)
+        self.assertNotIn(self.m.RECEIPT_OPEN, claim_body)
+        self.assertIsNone(self.m.parse_stuck_receipt(claim_body))
+        self.assertIsNone(self.m.parse_rerun_claim(park))
+        expected_park = self.m.parse_stuck_receipt(park)
+        for history in (park + "\n\n" + claim_body, claim_body + "\n\n" + park):
+            selected = self.m.parse_stuck_receipt(history)
+            self.assertEqual(selected, expected_park)
+            self.assertTrue(self.m.unpark_satisfied(selected, self.f.original, self.m.GATE_SUCCESS))
+            self.assertFalse(self.m.unpark_satisfied(selected, self.f.original, self.m.GATE_FAILURE))
+        claim = self.m.parse_rerun_claim(claim_body)
+        self.assertFalse(self.m.unpark_satisfied(claim, self.f.original, self.m.GATE_SUCCESS))
+
+    def test_claim_history_cannot_change_the_existing_rearm_path(self):
+        self.f.drive()
+        claim_history = copy.deepcopy(self.f.comments)
+        for held in (False, True):
+            with self.subTest(held=held):
+                labels = ("review:pass", "needs:user") if held else ("review:pass",)
+                dropped = self.m.fixture(6360, labels=labels, armed=False)
+                dropped["comments"] = {"nodes": claim_history}
+                fake, _messages, outcome = self.m.exercise(dropped)
+                self.assertEqual(outcome.exit_code, 0)
+                self.assertEqual(len(self.m.arm_calls(fake)), 0 if held else 1)
+                # There is no production comment fetch/selector in re-arm; the
+                # separate unpark evaluator remains a human-only tool today.
+                queries = [arg for call in fake.calls for arg in call if arg.startswith("query=")]
+                self.assertFalse(any("comments(" in query for query in queries))
+
+    def test_crlf_claim_readback_preserves_integrity_and_attempt_dedupe(self):
+        def normalize_server_body():
+            self.f.comments[-1]["body"] = self.f.comments[-1]["body"].replace("\n", "\r\n")
+        self.f.after_claim = normalize_server_body
+        self.assertEqual(self.f.sweeper.run(), 0)
+        self.assertEqual(len(self.f.reruns()), 1)
+        self.f.clock += 1800
+        self.assertEqual(self.f.new_sweeper().run(), 1)
+        self.assertEqual(len(self.f.reruns()), 1)
+        self.assertEqual(len(self.f.comments), 1)
 
     def test_changed_head_draft_review_hold_queue_and_grace_never_claim(self):
         changes = [dict(headRefOid="b" * 40), dict(isDraft=True), dict(state="CLOSED"),
@@ -1687,6 +1748,7 @@ class TestCancelledActionsRecovery(unittest.TestCase):
                 (old_body,dict(self.f.actor,login="someone")),
                 (old_body,dict(self.f.actor,__typename="User")),
                 ("> " + valid_body,self.f.actor), ("```\n"+valid_body+"\n```",self.f.actor),
+                (valid_body + "\n",self.f.actor), (valid_body.replace("\n", "\r"),self.f.actor),
                 (old_body.replace('"head":"'+'b'*40+'"','"head":"invalid"'),self.f.actor),
                 (valid_body.replace('"attempt":1','"attempt":"bad"'),self.f.actor),
                 (valid_body.replace('"repo":"sparq-org/sparq"','"repo":"other/repo"'),self.f.actor),


### PR DESCRIPTION
> 🤖 SPARQ agent — [GPT-6 Astra]

The re-arm sweeper tried to recover a cancelled GitHub Actions gate through the Checks rerequest endpoint, which returned 403 under the preferred orchestrator App. Recover it through the Actions job endpoint after verifying the server's distinct check, job, workflow run and attempt identities.

Require the current reviewed, armed, non-draft PR and latest completed/cancelled first PR attempt, with fresh head, queue, hold and review-thread checks before requesting a rerun. Write and authenticate a durable attempt claim before the one-shot POST so rejection or an uncertain outcome cannot cause repeated requests across ticks. Reject the unprivileged workflow fallback before any claim. Rerun claims use separate human and machine sentinels, cannot shadow park receipts, and do not enter verdict-bridge review evidence. Existing workflow permissions and the explicit PR6049 approval hold remain intact.

Validation: the complete arm-capability/wiring suite passes 76 tests; 20 calibrated mutants each run the same 76 tests and are killed by assertions, with zero harness errors. The sweeper self-test and actionlint pass. Author preflight reports only the existing Bash 3.2/mapfile incompatibility in privacy-claims; that shell check still needs a supported environment before admission.

The coordinator verified installation 146840030 for sparq-orchestrator (App 4300853) through the organization installation API: it is not suspended and has actions:write and checks:read. This verifies the installed grant rather than only the App's requested permissions. The selected-repository list was unavailable to the current OAuth scope; no scope or permission was changed. No live rerun was attempted. A rejected or uncertain request intentionally remains claimed and requires separately reviewed recovery. More than 100 comments, malformed or foreign claim history, or an already-rerun attempt stop automatic recovery. The existing serialized workflow is required for deduplication; fresh reads cannot provide an atomic server-side state lock.

The production PR6049 hold can be removed only with separate explicit maintainer authorization and review. Automatic approval review rejected the attempted removal because it would weaken the specific approval boundary; the edit was not applied or retried.

Actual Claude Opus 5 at extra-high reasoning approved corrected head `8ca8026bf2b3942759d7615198ffbd5e98c3d875` with nits and no blocking findings; both earlier blockers are resolved. Supported-shell CI and normal protected merge checks remain required.

Closes #6438
