### PR TITLE
fix(core): serialize predicate statistics in a stable order

### DIFF
--- a/bench/feature-off-declarations/6440.json
+++ b/bench/feature-off-declarations/6440.json
@@ -1,0 +1,75 @@
+{
+  "pr": 6440,
+  "date": "2026-09-07",
+  "reason": "[GPT-6] Canonical predicate-statistics serialization changes only the mmap-gated writer and test code. The added source lines move an unchanged indexing/unwrap statement and its embedded panic locations. An independently reviewed, same-host artifact comparison below identifies exactly two changed data bytes as line 1056 becoming 1065, at unchanged columns 29 and 39. Actual disassembly passes the corresponding records into non-returning bounds-check and Option::unwrap panic paths; every non-data section, including executable code, is byte-identical. This is an artifact-specific manual review of the retained aarch64 build pair, not the generic four-word-pattern heuristic or an automated derivation. The unavailable CI x86_64 binaries are a separate two-byte observation. No claim is made for all toolchains or for identical panic diagnostic line numbers. The byte comparator and wasm_bundle_bytes size ratchet remain unchanged.",
+  "derived": false,
+  "evidence": {
+    "base_source": "f2e8aadd485190a8e82cdc8cd1c0fd0020130cee",
+    "head_source": "42147886f0e25ddc35958e40d04cbf1619e9c133",
+    "toolchain": {
+      "rustc": "1.97.1 (8bab26f4f 2026-07-14)",
+      "cargo": "1.97.1 (c980f4866 2026-06-30)",
+      "host": "aarch64-unknown-linux-gnu",
+      "target": "wasm32-unknown-unknown",
+      "disassembler": "WABT wasm-objdump 1.0.34"
+    },
+    "command": [
+      "cargo", "build", "--locked", "--profile", "release-wasm",
+      "-p", "sparq-wasm", "--target", "wasm32-unknown-unknown"
+    ],
+    "base_artifact": {
+      "bytes": 1560249,
+      "sha256": "379badd83e5a8da56bc4932131f4b94c4b7f2fb9b816faa02bbdf7b8700a46bd",
+      "job_log_sha256": "8f6164b14e2fcfc96fb5a2200b10c6723a6813200fb424cd05850f8b7915f66b"
+    },
+    "head_artifact": {
+      "bytes": 1560249,
+      "sha256": "ea74f386f4a13b4bdd6978bcd59e5cf2200603c94d5c6c4e0894c80719f8d0ff",
+      "job_log_sha256": "94cbc43077ed317ceedde37d26609da4f6e3bd2c469618f0e34c52b5a7e3141f"
+    },
+    "size_delta_bytes": 0,
+    "differing_bytes": 2,
+    "non_data_sections_byte_identical": true,
+    "source_path": "crates/sparq-core/src/store.rs",
+    "source_expression": "let v = pattern[order[k]].unwrap();",
+    "source_occurrence_binding": "Unchanged occurrence mapped through the exact base-to-head Git diff hunks; repeated source text alone was not used as evidence.",
+    "changed_locations": [
+      {
+        "file_offset": 1497240,
+        "record_file_offset": 1497232,
+        "record_memory_address": 1080580,
+        "base_byte": 32,
+        "head_byte": 41,
+        "base_line_u32_le": 1056,
+        "head_line_u32_le": 1065,
+        "unchanged_column": 29,
+        "callsite_review": "Function 1795 passes bounds values 3,3 and record address 1080580 to function 2396, followed by unreachable. Function 2396 formats the decoded index-out-of-bounds message and forwards its third argument unchanged to common panic handler 2384."
+      },
+      {
+        "file_offset": 1497256,
+        "record_file_offset": 1497248,
+        "record_memory_address": 1080596,
+        "base_byte": 32,
+        "head_byte": 41,
+        "base_line_u32_le": 1056,
+        "head_line_u32_le": 1065,
+        "unchanged_column": 39,
+        "callsite_review": "Functions 1795 and 1827 pass record address 1080596 to function 2434, followed by unreachable. Function 2434 supplies the exact 43-byte message called `Option::unwrap()` on a `None` value and forwards this record through function 2365 to common panic handler 2384."
+      }
+    ],
+    "manual_review": "Independent review checked receipt and artifact hashes, exact diff occurrence mapping, decoded location/message memory, function signatures, and disassembled callsite/callee bytes against the retained binary. Pattern matches remained candidate-only until that review.",
+    "manual_evidence_record_sha256": "1319343e37f0def6feb2677323c3ac58676b572d9b3cfd06cfc6312e8bdba9eb",
+    "disassembly_sha256": "ad0ee424e15ba2706156a9861003efc20912e17bdac411fa6795f1bc7ef7f06d",
+    "ci_observation": {
+      "run_id": 34073702442,
+      "job_id": 101595685443,
+      "host": "x86_64-unknown-linux-gnu",
+      "base_bytes": 1560241,
+      "head_bytes": 1560241,
+      "differing_bytes": 2,
+      "raw_binaries_inspected": false,
+      "log_sha256": "7180fc8374d8caf94f7386d850b5e5c313c514d5ee244f3ce7d7fc08445fd94f",
+      "autodeclare_outcome": "neutral-build-failed: blanking the added loop opening left an unexpected closing delimiter; no automated proof was obtained."
+    }
+  }
+}

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -56,6 +56,8 @@ assert_eq!(count, 1);
   point lookups for an id that is ABSENT from the permutation (result-equivalent, never
   serialised; for a PRESENT id the zone map already narrows the candidate window to about one
   block, so there is little left to skip).
+  [GPT-6] Persisted predicate statistics have deterministic record order across builds and
+  re-saves; older unordered statistics files remain readable.
 - **Compressed-seek column codecs (prototype)** — the opt-in `elias-fano` feature adds
   Elias-Fano and Partitioned-Elias-Fano codecs whose `next_geq(target)` answers a successor
   query *directly on the compressed data*, without the whole-block decode the varint block codec

--- a/crates/sparq-core/src/store.rs
+++ b/crates/sparq-core/src/store.rs
@@ -688,15 +688,24 @@ impl TripleStore {
         self.save_pred_stats(dir)
     }
 
-    /// Persists the per-predicate stats so `open` need not RE-SCAN the POS/PSO indexes
+    /// Persists per-predicate statistics in ascending predicate-ID order.
+    ///
+    /// This lets `open` avoid re-scanning the POS/PSO indexes
     /// (a ~2-permutation read — the dominant out-of-core open cost + resident RSS once the
     /// dict is mmap'd). Small: a handful of fields per distinct predicate.
+    ///
+    /// # Errors
+    /// Returns an error if creating, writing, or flushing the statistics file fails.
     #[cfg(feature = "mmap")]
     pub fn save_pred_stats(&self, dir: &std::path::Path) -> std::io::Result<()> {
         use std::io::Write;
         let mut w = std::io::BufWriter::new(std::fs::File::create(dir.join("predstats.bin"))?);
         w.write_all(&(self.pred_stats.len() as u64).to_le_bytes())?;
-        for (&p, s) in self.pred_stats.iter() {
+        // [GPT-6] Hash-map iteration can change after loading/reserving identical stats.
+        // Canonicalize the shared writer so external builds and re-saves agree bytewise.
+        let mut entries: Vec<_> = self.pred_stats.iter().collect();
+        entries.sort_unstable_by_key(|&(&p, _)| p);
+        for (&p, s) in entries {
             w.write_all(&p.to_le_bytes())?;
             w.write_all(&(s.count as u64).to_le_bytes())?;
             w.write_all(&(s.ndv_subj as u64).to_le_bytes())?;
@@ -1747,6 +1756,61 @@ mod tests {
             .expect("persisted predstats.bin must load, not fall back to a POS+PSO re-scan");
         assert_eq!(loaded, *store.pred_stats, "loaded pred stats must equal the saved ones");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// [GPT-6] Persisted bytes depend on statistics, not hash-map layout or reloads.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn pred_stats_serialization_is_canonical_across_map_layouts() {
+        // The same records had different iteration orders after external-build reload.
+        let records: [(Id, PredStat); 4] = [
+            (1, PredStat { count: 400, ndv_subj: 400, ndv_obj: 140 }),
+            (2, PredStat { count: 400, ndv_subj: 400, ndv_obj: 400 }),
+            (182, PredStat { count: 400, ndv_subj: 400, ndv_obj: 400 }),
+            (424, PredStat { count: 400, ndv_subj: 400, ndv_obj: 90 }),
+        ];
+        // Independent format oracle: u64 record count, then u32 ID + three u64 values.
+        let mut expected = 4u64.to_le_bytes().to_vec();
+        for (id, stats) in &records {
+            expected.extend_from_slice(&id.to_le_bytes());
+            for value in [stats.count, stats.ndv_subj, stats.ndv_obj] {
+                expected.extend_from_slice(&(value as u64).to_le_bytes());
+            }
+        }
+        let dir = std::env::temp_dir().join(format!("sparq_predstats_order_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("predstats.bin");
+        for capacity in [0, 4, 64, 1024] {
+            for order in [[0, 1, 2, 3], [3, 2, 1, 0], [2, 0, 3, 1]] {
+                let mut stats = FxHashMap::default();
+                stats.reserve(capacity);
+                for i in order {
+                    stats.insert(records[i].0, records[i].1);
+                }
+                let mut store = TripleStore::from_triples(Vec::new());
+                store.pred_stats = std::sync::Arc::new(stats);
+                store.save_pred_stats(&dir).unwrap();
+                assert_eq!(
+                    std::fs::read(&path).unwrap(),
+                    expected,
+                    "capacity {capacity}, order {order:?}"
+                );
+                let loaded = TripleStore::load_pred_stats(&dir).unwrap();
+                assert_eq!(loaded, *store.pred_stats);
+                store.pred_stats = std::sync::Arc::new(loaded);
+                store.save_pred_stats(&dir).unwrap();
+                assert_eq!(std::fs::read(&path).unwrap(), expected, "reload must preserve exact bytes");
+            }
+        }
+        // Existing files need not already be ordered: read compatibility is unchanged.
+        let mut legacy = expected[..8].to_vec();
+        for record in expected[8..].chunks_exact(28).rev() {
+            legacy.extend_from_slice(record);
+        }
+        std::fs::write(&path, legacy).unwrap();
+        let loaded = TripleStore::load_pred_stats(&dir).unwrap();
+        assert_eq!(loaded, records.into_iter().collect::<FxHashMap<_, _>>());
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     /// The delta-overlay must be INVISIBLE in results: a store with an overlay must answer

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -643,6 +643,8 @@ cargo build -p sparq-cli --features serialize-rdf
   free disk aborts cleanly through the spill pipeline's resource gate, and a spill-built store
   reloads via `Graph::open` (and re-saves raw/compressed) to identical content. External build
   folds N-Quads/TriG named graphs into the default graph (only `load_dataset` preserves them).
+  [GPT-6] All store writers emit `predstats.bin` in ascending predicate-ID order, so equal
+  statistics serialize identically after reload. Older unordered files remain readable.
 - **HDT is opt-in and native-only.** `sparq-hdt` MSRV is **1.87** (the wrapped `hdt` crate),
   above the workspace's 1.85 — in the CLI it is gated behind `--features hdt`. It carries
   zero code into the wasm build. Compression containers are detected by **magic bytes, not


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the sparq-org/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

An external compressed build and a reopened, recompressed store could contain identical predicate statistics but produce different `predstats.bin` bytes because the writer emitted hash-map iteration order. Sort the shared writer's entries by predicate ID. The binary record format and support for existing unordered files remain unchanged.

The regression checks exact bytes across different map capacities and insertion orders, reload/re-save stability, and reading an unordered legacy file. The existing engine differential test remains unchanged and now passes. The sort and temporary borrowed-entry vector apply only while saving statistics.

Validation: focused core statistics regressions, the engine compressed-build differential suite, full workspace tests, full workspace Clippy with warnings denied, all-feature workspace documentation with warnings denied, and Linux preflight passed against implementation commit `42147886f0e25ddc35958e40d04cbf1619e9c133`. Independent code review found no blocking issues.

The declaration-only follow-up records a manual review of paired WebAssembly artifacts: two stored panic line numbers move with the unchanged source statement; code and every other byte remain identical in that checked pair. The declaration distinguishes these inspected artifacts from CI's separate two-byte observation. The existing byte-comparison mechanism and size ratchet are unchanged, and final CI is rerunning.
