### PR TITLE
fix(solid): preserve revocation when an ACP matcher becomes empty

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -38,12 +38,7 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **WAC + ACP** — Web Access Control (`.acl`) and Access Control Policy (`.acr`): inheritance, agent
   classes, groups, `allOf`/`anyOf`/`noneOf`, the ACP `(agent, client, issuer)` principal,
   `acp:CreatorAgent`/`acp:OwnerAgent`, normative deny-overrides.
-  [GPT-6] Empty matchers never match a request context: removing the final supported
-  attribute and rematerializing revokes any grant that requires that matcher.
-  An empty `noneOf` exception cannot block an otherwise satisfied policy; policies
-  require at least one positive `allOf` or `anyOf` condition. See
-  [ACP §6.4](https://solidproject.org/TR/acp#satisfied-policy) and
-  [§6.5](https://solidproject.org/TR/acp#satisfied-matcher).
+  [GPT-6] Empty matchers never match; policies require a positive `allOf` or `anyOf` condition ([ACP §§6.4–6.5](https://solidproject.org/TR/acp#satisfied-policy)).
 - **Trusted caller-asserted channels — creator/owner and verified credentials** — `acp:CreatorAgent`/`acp:OwnerAgent` resolve only against per-resource WebIDs the storage layer supplies through the trusted `AccessProvenance` channel, and `acp:vc <requirement>` (`sq-ysv3u`) only against holdings supplied through the trusted `VerifiedCredentials` channel — **never** graph content (the loader hard-rejects `solidx:` triples, so a writer cannot self-grant). `acp:vc` matches its requirement by exact IRI, conjunctively with `acp:agent`/`acp:client`/`acp:issuer`, and is **fail-closed**: with no credential supplied it accepts nobody (before `sq-ysv3u`, `acp:vc` was an unrecognized attribute, so a credential-gated matcher looked agent-unconstrained and granted everyone, anonymous included).
   Verification never runs in the reasoner — the opt-in `acp-vc` feature adds the [`sparq-vc`](../sparq-vc) **trust-the-issuer** backend that populates the channel (`VcRequirement` + `VerifiedCredentials::admit_data_integrity`: W3C Data Integrity `eddsa-rdfc-2022`, checking issuer, credential type and exact-match claims). Authenticity/integrity only — **no** privacy, unlinkability or selective disclosure, and no revocation or expiry check; a zero-knowledge backend would need the ZK estate, whose external crypto audit is pending (`sq-qhy4`).
 - **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all ordinary

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -38,6 +38,12 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **WAC + ACP** — Web Access Control (`.acl`) and Access Control Policy (`.acr`): inheritance, agent
   classes, groups, `allOf`/`anyOf`/`noneOf`, the ACP `(agent, client, issuer)` principal,
   `acp:CreatorAgent`/`acp:OwnerAgent`, normative deny-overrides.
+  [GPT-6] Empty matchers never match a request context: removing the final supported
+  attribute and rematerializing revokes any grant that requires that matcher.
+  An empty `noneOf` exception cannot block an otherwise satisfied policy; policies
+  require at least one positive `allOf` or `anyOf` condition. See
+  [ACP §6.4](https://solidproject.org/TR/acp#satisfied-policy) and
+  [§6.5](https://solidproject.org/TR/acp#satisfied-matcher).
 - **Trusted caller-asserted channels — creator/owner and verified credentials** — `acp:CreatorAgent`/`acp:OwnerAgent` resolve only against per-resource WebIDs the storage layer supplies through the trusted `AccessProvenance` channel, and `acp:vc <requirement>` (`sq-ysv3u`) only against holdings supplied through the trusted `VerifiedCredentials` channel — **never** graph content (the loader hard-rejects `solidx:` triples, so a writer cannot self-grant). `acp:vc` matches its requirement by exact IRI, conjunctively with `acp:agent`/`acp:client`/`acp:issuer`, and is **fail-closed**: with no credential supplied it accepts nobody (before `sq-ysv3u`, `acp:vc` was an unrecognized attribute, so a credential-gated matcher looked agent-unconstrained and granted everyone, anonymous included).
   Verification never runs in the reasoner — the opt-in `acp-vc` feature adds the [`sparq-vc`](../sparq-vc) **trust-the-issuer** backend that populates the channel (`VcRequirement` + `VerifiedCredentials::admit_data_integrity`: W3C Data Integrity `eddsa-rdfc-2022`, checking issuer, credential type and exact-match claims). Authenticity/integrity only — **no** privacy, unlinkability or selective disclosure, and no revocation or expiry check; a zero-knowledge backend would need the ZK estate, whose external crypto audit is pending (`sq-qhy4`).
 - **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all ordinary

--- a/crates/sparq-solid/rules/acp-a.n3
+++ b/crates/sparq-solid/rules/acp-a.n3
@@ -39,6 +39,14 @@
 { ?pol acp:anyOf ?m . }  => { ?pol solidx:hasMatcher ?m . ?m solidx:isMatcher true . } .
 { ?pol acp:noneOf ?m . } => { ?m solidx:isMatcher true . } .
 
+# [GPT-6] ACP §6.5 requires at least one attribute. Absent dimensions are
+# unconstrained only for a nonempty matcher; rdf:type alone is not an attribute.
+# Keep this guard shared by positive matchers and noneOf exception accept-sets.
+{ ?m solidx:isMatcher true . ?m acp:agent ?v . }  => { ?m solidx:hasAttribute true . } .
+{ ?m solidx:isMatcher true . ?m acp:client ?v . } => { ?m solidx:hasAttribute true . } .
+{ ?m solidx:isMatcher true . ?m acp:issuer ?v . } => { ?m solidx:hasAttribute true . } .
+{ ?m solidx:isMatcher true . ?m acp:vc ?v . }     => { ?m solidx:hasAttribute true . } .
+
 # ── matcher raw values mapped into principal space (drive candidate generation) ───────
 { ?m solidx:isMatcher true . ?m acp:agent ?a . ?a solidx:isWebId true . }
 => { ?m solidx:agentValP ?a . } .
@@ -70,8 +78,8 @@
 # not credential-gate — the second step is the identity, so the auth view is byte-identical
 # to the pre-acp:vc rule set.
 { ?m solidx:agentValP ?a . } => { ?m solidx:rawAgentP ?a . } .
-# no agent attribute at all -> agent-unconstrained -> accepts the top
-{ ?m solidx:isMatcher true . ?UNSCOPED log:notIncludes { ?m acp:agent ?x . } . }
+# A nonempty matcher with no agent attribute is agent-unconstrained.
+{ ?m solidx:hasAttribute true . ?UNSCOPED log:notIncludes { ?m acp:agent ?x . } . }
 => { ?m solidx:rawAgentP auth:Public . } .
 { ?m solidx:rawAgentP auth:Public . }
 => { ?m solidx:rawAgentP auth:Authenticated . } .
@@ -106,14 +114,14 @@
 => { ?m solidx:acceptsAgentP ?a . } .
 
 { ?m solidx:clientValP ?c . } => { ?m solidx:acceptsClientP ?c . } .
-{ ?m solidx:isMatcher true . ?UNSCOPED log:notIncludes { ?m acp:client ?x . } . }
+{ ?m solidx:hasAttribute true . ?UNSCOPED log:notIncludes { ?m acp:client ?x . } . }
 => { ?m solidx:acceptsClientP auth:AnyClient . } .
 { ?m solidx:acceptsClientP auth:AnyClient . ?c solidx:isCandClient true . }
 => { ?m solidx:acceptsClientP ?c . } .
 
 # [OPUS-4.8] sq-3jtd.6: issuer accept-set, the twin of the client one above.
 { ?m solidx:issuerValP ?i . } => { ?m solidx:acceptsIssuerP ?i . } .
-{ ?m solidx:isMatcher true . ?UNSCOPED log:notIncludes { ?m acp:issuer ?x . } . }
+{ ?m solidx:hasAttribute true . ?UNSCOPED log:notIncludes { ?m acp:issuer ?x . } . }
 => { ?m solidx:acceptsIssuerP auth:AnyIssuer . } .
 { ?m solidx:acceptsIssuerP auth:AnyIssuer . ?i solidx:isCandIssuer true . }
 => { ?m solidx:acceptsIssuerP ?i . } .

--- a/crates/sparq-solid/tests/acp_empty_matcher.rs
+++ b/crates/sparq-solid/tests/acp_empty_matcher.rs
@@ -1,0 +1,162 @@
+//! [GPT-6] ACP §6.5: an attribute-free matcher never matches any context.
+
+mod reference;
+
+use reference::{RefDecision, RefMode};
+use sparq_core::Graph;
+use sparq_solid::{Mode, PodStore, Session};
+
+const DOC: &str = "https://pod.example/record";
+const ACR: &str = "https://pod.example/record.acr";
+const RECIPIENT: &str = "https://recipient.example/#me";
+const ACP: &str = "http://www.w3.org/ns/solid/acp#";
+
+fn quad(subject: &str, predicate: &str, object: &str) -> String {
+    format!("<{subject}> <{predicate}> <{object}> <{ACR}> .\n")
+}
+
+fn fixture(conditions: &str, attributes: &str) -> String {
+    format!(
+        r#"<{DOC}#it> <https://example.org/value> "private" <{DOC}> .
+<{ACR}> <{ACP}resource> <{DOC}> <{ACR}> .
+<{ACR}> <{ACP}accessControl> <{ACR}#control> <{ACR}> .
+<{ACR}#control> <{ACP}apply> <{ACR}#policy> <{ACR}> .
+<{ACR}#policy> <{ACP}allow> <http://www.w3.org/ns/auth/acl#Read> <{ACR}> .
+<{ACR}#public> <{ACP}agent> <{ACP}PublicAgent> <{ACR}> .
+<{ACR}#empty> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <{ACP}Matcher> <{ACR}> .
+{conditions}{attributes}"#
+    )
+}
+
+fn materialized(nq: &str) -> PodStore {
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_acp().unwrap();
+    store
+}
+
+fn assert_read(store: &PodStore, agent: Option<&str>, allowed: bool) {
+    let session = Session {
+        agent,
+        ..Session::default()
+    };
+    assert_eq!(
+        store
+            .accessible(&session, Mode::Read)
+            .iter()
+            .any(|g| g.as_str() == DOC),
+        allowed
+    );
+    let query = format!("SELECT ?value WHERE {{ GRAPH <{DOC}> {{ <{DOC}#it> <https://example.org/value> ?value }} }}");
+    assert_eq!(
+        store
+            .query_as(&session, Mode::Read, &query)
+            .unwrap()
+            .rows
+            .len(),
+        usize::from(allowed)
+    );
+}
+
+#[test]
+fn empty_matchers_follow_all_any_and_none_semantics() {
+    for (empty_combinator, public_combinator, expected) in [
+        ("anyOf", None, false),
+        ("allOf", None, false),
+        ("noneOf", None, false),
+        ("allOf", Some("anyOf"), false),
+        ("anyOf", Some("allOf"), false),
+        ("anyOf", Some("anyOf"), true),
+        ("noneOf", Some("anyOf"), true),
+    ] {
+        let mut conditions = quad(
+            &format!("{ACR}#policy"),
+            &format!("{ACP}{empty_combinator}"),
+            &format!("{ACR}#empty"),
+        );
+        if let Some(combinator) = public_combinator {
+            conditions.push_str(&quad(
+                &format!("{ACR}#policy"),
+                &format!("{ACP}{combinator}"),
+                &format!("{ACR}#public"),
+            ));
+        }
+        let nq = fixture(&conditions, "");
+        let store = materialized(&nq);
+        for agent in [Some(RECIPIENT), None] {
+            let reference = reference::acp::decide(
+                &nq,
+                &reference::acp::Request {
+                    agent,
+                    client: None,
+                    mode: RefMode::Read,
+                    resource: DOC,
+                },
+            )
+            .unwrap();
+            assert_eq!(
+                reference,
+                if expected {
+                    RefDecision::Allow
+                } else {
+                    RefDecision::Deny
+                }
+            );
+            assert_read(&store, agent, expected);
+        }
+    }
+}
+
+#[test]
+fn deleting_last_matcher_attribute_revokes_cached_query_access() {
+    let conditions = quad(
+        &format!("{ACR}#policy"),
+        &format!("{ACP}anyOf"),
+        &format!("{ACR}#empty"),
+    );
+    let attribute = quad(&format!("{ACR}#empty"), &format!("{ACP}agent"), RECIPIENT);
+    let mut store = materialized(&fixture(&conditions, &attribute));
+    let body = format!("GRAPH <{ACR}> {{ <{ACR}#empty> <{ACP}agent> <{RECIPIENT}> }}");
+    assert_read(&store, Some(RECIPIENT), true);
+    assert_read(&store, None, false);
+
+    sparq_engine::update_in_place(&mut store.graph, &format!("DELETE DATA {{ {body} }}")).unwrap();
+    store.materialize_acp().unwrap();
+    assert_read(&store, Some(RECIPIENT), false);
+    assert_read(&store, None, false);
+
+    // Rebuild from the stored graph as well: denial must not depend on a warm cache.
+    let mut reopened = PodStore::new(store.graph.fork());
+    reopened.materialize_acp().unwrap();
+    assert_read(&reopened, Some(RECIPIENT), false);
+    assert_read(&reopened, None, false);
+
+    sparq_engine::update_in_place(&mut reopened.graph, &format!("INSERT DATA {{ {body} }}"))
+        .unwrap();
+    reopened.materialize_acp().unwrap();
+    assert_read(&reopened, Some(RECIPIENT), true);
+    assert_read(&reopened, None, false);
+}
+
+#[test]
+fn replacing_acr_with_empty_matcher_revokes_cached_query_access() {
+    let conditions = quad(
+        &format!("{ACR}#policy"),
+        &format!("{ACP}anyOf"),
+        &format!("{ACR}#empty"),
+    );
+    let attribute = quad(&format!("{ACR}#empty"), &format!("{ACP}agent"), RECIPIENT);
+    let mut store = materialized(&fixture(&conditions, &attribute));
+    assert_read(&store, Some(RECIPIENT), true);
+    assert_read(&store, None, false);
+
+    let empty_acr = format!(
+        r#"@prefix acp: <{ACP}> .
+<{ACR}> acp:resource <{DOC}>; acp:accessControl <{ACR}#control> .
+<{ACR}#control> acp:apply <{ACR}#policy> .
+<{ACR}#policy> acp:allow <http://www.w3.org/ns/auth/acl#Read>; acp:anyOf <{ACR}#empty> .
+<{ACR}#empty> a acp:Matcher ."#
+    );
+    store.put_acl_acp(ACR, &empty_acr, "turtle").unwrap();
+    assert_read(&store, Some(RECIPIENT), false);
+    assert_read(&store, None, false);
+}

--- a/crates/sparq-solid/tests/reference/acp.rs
+++ b/crates/sparq-solid/tests/reference/acp.rs
@@ -239,8 +239,13 @@ impl AcpModel {
     }
 
     /// Is `policy` satisfied for `req`? Every `allOf` matcher matches AND (no `anyOf`, or at
-    /// least one `anyOf` matches) AND no `noneOf` matcher matches.
+    /// least one `anyOf` matches) AND no `noneOf` matcher matches. A positive matcher is required.
     fn policy_satisfied(&self, pol: &Policy, req: &Request) -> bool {
+        // [GPT-6] ACP §6.4: noneOf alone cannot satisfy a policy.
+        // https://solidproject.org/TR/acp#satisfied-policy
+        if pol.all_of.is_empty() && pol.any_of.is_empty() {
+            return false;
+        }
         let all_of_ok = pol
             .all_of
             .iter()
@@ -436,5 +441,61 @@ mod tests {
             m.decide(&req(None, None, RefMode::Read, "https://pod.ex/d1")),
             RefDecision::Deny
         );
+    }
+
+    // [GPT-6] Independent fixtures for ACP §6.4's positive-matcher requirement.
+    fn policy_fixture(conditions: &str) -> String {
+        let acr = "https://pod.ex/d1.acr";
+        format!(
+            r#"<{acr}> <{ACP}resource> <https://pod.ex/d1> <{acr}> .
+<{acr}> <{ACP}accessControl> <{acr}#control> <{acr}> .
+<{acr}#control> <{ACP}apply> <{acr}#policy> <{acr}> .
+<{acr}#policy> <{ACP}allow> <{ACL}Read> <{acr}> .
+<{acr}#public> <{ACP}agent> <{PUBLIC_AGENT}> <{acr}> .
+<https://pod.ex/d1#it> <https://ex.dev/ns#prop> "x" <https://pod.ex/d1> .
+{conditions}"#
+        )
+    }
+
+    #[test]
+    fn policies_without_positive_matchers_never_grant() {
+        let acr = "https://pod.ex/d1.acr";
+        let none_of = format!("<{acr}#policy> <{ACP}noneOf> <{acr}#except> <{acr}> .\n");
+        let nonmatching_exception =
+            format!("{none_of}<{acr}#except> <{ACP}agent> <https://alice.ex/#me> <{acr}> .\n");
+        for conditions in ["", &none_of, &nonmatching_exception] {
+            let model = AcpModel::from_nquads(&policy_fixture(conditions)).unwrap();
+            for agent in [None, Some("https://bob.ex/#me")] {
+                assert_eq!(
+                    model.decide(&req(agent, None, RefMode::Read, "https://pod.ex/d1")),
+                    RefDecision::Deny,
+                    "no positive matcher: {conditions}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn positive_matcher_with_empty_exception_is_satisfied() {
+        let acr = "https://pod.ex/d1.acr";
+        for combinator in ["allOf", "anyOf"] {
+            let positive = format!("<{acr}#policy> <{ACP}{combinator}> <{acr}#public> <{acr}> .\n");
+            let empty_exception =
+                format!("{positive}<{acr}#policy> <{ACP}noneOf> <{acr}#except> <{acr}> .\n");
+            let matching_exception = format!(
+                "{empty_exception}<{acr}#except> <{ACP}agent> <{PUBLIC_AGENT}> <{acr}> .\n"
+            );
+            for (conditions, expected) in [
+                (&positive, RefDecision::Allow),
+                (&empty_exception, RefDecision::Allow),
+                (&matching_exception, RefDecision::Deny),
+            ] {
+                let model = AcpModel::from_nquads(&policy_fixture(conditions)).unwrap();
+                assert_eq!(
+                    model.decide(&req(None, None, RefMode::Read, "https://pod.ex/d1")),
+                    expected
+                );
+            }
+        }
     }
 }

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -539,6 +539,13 @@ discovery; neither is itself a conformance-tested HTTP layer.
   **`acp:vc`** — the context agent must hold a verified credential satisfying the named
   requirement, resolved against the TRUSTED holdings supplied via
   `materialize_acp_with_credentials` (above), and fail-closed with none supplied.
+  [GPT-6] A matcher with no supported attribute (`acp:agent`, `acp:client`,
+  `acp:issuer`, or `acp:vc`) is unsatisfied, as required by
+  [ACP §6.5](https://solidproject.org/TR/acp#satisfied-matcher). Removing its final
+  attribute and rematerializing revokes grants requiring that matcher, including
+  cached query access. An empty `noneOf` matcher cannot block an otherwise
+  satisfied policy. A policy still requires a positive `allOf` or `anyOf` matcher
+  ([ACP §6.4](https://solidproject.org/TR/acp#satisfied-policy)).
 - Principal lattice — three independent dimensions (agent, client, issuer):
   `Public ⊒ Authenticated ⊒ concrete-WebID`, `AnyClient ⊒ concrete-client`, and
   ([OPUS-4.8] sq-3jtd.6) `AnyIssuer ⊒ concrete-issuer`. A session expands to the agent


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the sparq-org/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Removing the last attribute from an ACP matcher could make it match every request context, allowing a revoked grant to become public. Require a supported matcher attribute before treating absent agent, client, or issuer dimensions as unconstrained. Attribute-free exceptions also stop blocking otherwise satisfied policies.

The regression tests cover empty matchers under allOf, anyOf, and noneOf, removal and restoration of the last attribute, ACR replacement, and reconstruction of the authorization index. The independent reference evaluator also requires a positive policy matcher. These rules follow [ACP §6.4](https://solidproject.org/TR/acp#satisfied-policy) and [§6.5](https://solidproject.org/TR/acp#satisfied-matcher).

Validation at `e5813c5c75095e38f63be81c1ed20bceec8e64a5`: the focused regression suite, full Solid suite, full-workspace tests and Clippy, all-feature workspace documentation, and release browser build passed on the temporary Linux build host. Rustdoc warnings were denied, and every closed log hash was verified. The exact-source Linux preflight passed. This PR's required CI checks must also pass before merge.

The two ACP patches are unchanged by rebasing onto merged main `543d945983b94cff694583716e2a026c2cc919a9`. The earlier isolated negative control restored the old rule and failed the intended empty-matcher and revocation assertions.
