### PR TITLE
ci: preserve reporter grace across cap fetch failures

### DIFF
--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -1793,6 +1793,9 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
     # [GPT-5.6] #6299: `poll_limit` may grow exactly once, and only for an
     # unresolved feature-matrix report after every ordinary sibling is terminal.
     reporter_grace_started = False
+    # [GPT-6-ASTRA] #6437: cached eligibility licenses only re-observation after
+    # a cap fetch failure; it is never evidence for a passing reporter verdict.
+    reporter_grace_eligible = False
     poll_limit = cfg.max_total_polls
 
     attempt = 0
@@ -1821,6 +1824,24 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
                 f"attempt {attempt}: check-run fetch failed ({exc}) — skipping this poll "
                 f"({consec_fetch_failures}/{cfg.max_consec_fetch_failures} consecutive)."
             )
+            # [GPT-6-ASTRA] A failed cap poll cannot evaluate fresh eligibility.
+            # Reuse only the last successfully observed reporter-only state to
+            # arm the SAME fixed tail. Errors consume its polls; the next fresh
+            # observation still faces the ordinary/full-work stop and settle.
+            if (
+                not reporter_grace_started
+                and attempt == cfg.max_total_polls
+                and reporter_grace_eligible
+            ):
+                reporter_grace_started = True
+                poll_limit = cfg.max_total_polls + cfg.reporter_grace_polls
+                print(
+                    "::notice::ci-summary cap fetch recovery: the last observed "
+                    "sibling set was reporter-only eligible. Granting one bounded "
+                    f"reporter-only grace of {cfg.reporter_grace_polls} poll(s) "
+                    "to re-observe it; failed fetches consume the tail, and fresh "
+                    "correlation, ordinary-work and settle checks still apply (#6437)."
+                )
             sleep_fn(
                 cfg.interval
                 if reporter_grace_started
@@ -1902,16 +1923,18 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         # settle window. The current-run external_id correlation remains inside
         # fm_report_status; the tail merely gives that already-required verdict time
         # to appear and settle.
-        if (
-            not reporter_grace_started
-            and attempt == cfg.max_total_polls
-            and (
-                awaiting_report
-                or (report_state == "ok" and stable < cfg.settle_polls)
-            )
+        # [GPT-6-ASTRA] Refresh after EVERY successful observation, including
+        # ineligible states, so an older reporter-only snapshot cannot linger.
+        reporter_grace_eligible = (
+            (awaiting_report or (report_state == "ok" and stable < cfg.settle_polls))
             and not awaiting_full
             and non_reporter_pending == 0
             and cfg.reporter_grace_polls > 0
+        )
+        if (
+            not reporter_grace_started
+            and attempt == cfg.max_total_polls
+            and reporter_grace_eligible
         ):
             reporter_grace_started = True
             poll_limit = cfg.max_total_polls + cfg.reporter_grace_polls

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -456,7 +456,14 @@ class Config:
 
 
 class FetchError(RuntimeError):
-    """A poll's API fetch failed (transient or otherwise)."""
+    """An API fetch failed without a recognized fatal rate-limit refusal."""
+
+
+class RateLimitError(RuntimeError):
+    """[GPT-6-ASTRA] An explicit API rate-limit refusal forbids further requests.
+
+    Deliberately separate from retryable FetchError, including inside a poll.
+    """
 
 
 class SupersededLegsError(RuntimeError):
@@ -469,7 +476,8 @@ class TierContext:
     re-read the PR's live draft state at conclusion time. run_tier is computed from
     the trigger payload (pull_request + draft == true => "draft"; every other
     event/state => "full"). fetch_pr_draft() -> bool (current draft state), raising
-    FetchError on API failure; None when the run has no PR (push/merge_group)."""
+    FetchError on generic API failure or fatal RateLimitError on explicit rate
+    refusal; None when the run has no PR (push/merge_group)."""
 
     run_tier: str = "full"  # "draft" | "full"
     event_name: str = ""
@@ -1465,6 +1473,17 @@ def _emit(line: str, summary_path: str = "") -> None:
             fh.write(line + "\n")
 
 
+def _rate_limit_verdict(exc: RateLimitError, summary_path: str = "") -> int:
+    """[GPT-6-ASTRA] Fail closed without any follow-up quota/probe request."""
+    _emit(
+        "### ci-summary: UNDETERMINED — explicit GitHub rate-limit response; "
+        f"stopping without further API requests ({exc}). No check failure is inferred.",
+        summary_path,
+    )
+    print("::error::ci-summary rate limit reached — no further polling or recovery.")
+    return 1
+
+
 def _bounded_draft_read(
     tier_ctx: TierContext | None,
 ) -> tuple[bool | None, Exception | None]:
@@ -1472,7 +1491,8 @@ def _bounded_draft_read(
     transient FetchError. Returns (state, last_error); state is None when there is no
     fetcher wired or every attempt failed. Shared by the conclusion-time re-check
     (_draft_recheck) and the #3781 unsatisfiable-hold detector so both read the state
-    exactly the same way — the CALLERS decide what an unreadable state means."""
+    exactly the same way — the CALLERS decide what an unreadable state means.
+    Explicit RateLimitError propagates immediately, without bounded retries."""
     still_draft: bool | None = None
     last_err: Exception | None = None
     if tier_ctx is not None and tier_ctx.fetch_pr_draft is not None:
@@ -1497,7 +1517,10 @@ def _draft_recheck(tier_ctx: TierContext | None, summary_path: str = "") -> int:
     violation. Returns 0 (ok to pass) or 1 (fail). Full-tier runs: always 0."""
     if not tier_ctx or tier_ctx.run_tier != "draft":
         return 0
-    still_draft, last_err = _bounded_draft_read(tier_ctx)
+    try:
+        still_draft, last_err = _bounded_draft_read(tier_ctx)
+    except RateLimitError as exc:
+        return _rate_limit_verdict(exc, summary_path)
     if still_draft is None:
         _emit(
             "### ci-summary: FAILED — draft-tier run could not confirm the PR's "
@@ -1803,6 +1826,8 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         attempt += 1
         try:
             raw = fetch_runs()
+        except RateLimitError as exc:
+            return _rate_limit_verdict(exc, cfg.summary_path)
         except SupersededLegsError as exc:
             _emit(
                 f"### ci-summary: FAILED — {exc}. The gate did not treat the "
@@ -2031,7 +2056,10 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
         ):
             unsat_polls += 1
             if unsat_polls >= cfg.unsat_confirm_polls:
-                still_draft, draft_err = _bounded_draft_read(tier_ctx)
+                try:
+                    still_draft, draft_err = _bounded_draft_read(tier_ctx)
+                except RateLimitError as exc:
+                    return _rate_limit_verdict(exc, cfg.summary_path)
                 if still_draft is True:
                     stale = draft_selects_unsuperseded(runs)
                     _emit(
@@ -2110,6 +2138,8 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
             # extension on depth alone (None → saturated = False, conservative branch).
             try:
                 depth = fetch_queue_depth()
+            except RateLimitError as exc:
+                return _rate_limit_verdict(exc, cfg.summary_path)
             except Exception as exc:
                 print(f"  (queue-depth fetch raised {exc!r} — treating depth as unknown)")
                 depth = None
@@ -2243,15 +2273,40 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep,
 # ----------------------------- live (gh-backed) wiring -----------------------------
 
 
+def _raise_if_rate_limited(proc: subprocess.CompletedProcess) -> None:
+    """[GPT-6-ASTRA] Recognize explicit failed-response diagnostics only.
+
+    These gh calls do not expose response headers: no remaining-quota value is
+    inferred, and a generic 401/403/5xx is not evidence of rate exhaustion.
+    """
+    if proc.returncode == 0:
+        return
+    messages = [proc.stderr or ""]
+    try:
+        body = json.loads(proc.stdout)
+    except (TypeError, ValueError):
+        body = None
+    if isinstance(body, dict) and isinstance(body.get("message"), str):
+        messages.append(body["message"])
+    for message in messages:
+        if re.search(
+            r"\brate limit exceeded\b|\bsecondary rate limit\b|\(HTTP 429\)",
+            message,
+            re.IGNORECASE,
+        ):
+            raise RateLimitError("GitHub explicitly refused a rate-limited request")
+
+
 def _gh_json_lines(args: list[str]) -> list[dict]:
     # [SONNET-4.6] Wrap subprocess.run so FileNotFoundError / TimeoutExpired / OSError
     # (e.g. `gh` not on PATH) are converted into FetchError, routing them into the
     # existing bounded-retry / skip-this-poll tolerance in run_gate exactly as a
-    # non-zero exit code does — no raw crash, no false pass.
+    # generic non-zero exit does. Explicit rate-limit refusals instead stop below.
     try:
         proc = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
     except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
         raise FetchError(f"subprocess raised: {exc}") from exc
+    _raise_if_rate_limited(proc)
     if proc.returncode != 0:
         raise FetchError(proc.stderr.strip()[:300] or f"gh api exited {proc.returncode}")
     out = []
@@ -2359,6 +2414,7 @@ def make_redispatch_workflow(repo: str):
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             raise FetchError(f"redispatch subprocess raised: {exc}") from exc
+        _raise_if_rate_limited(proc)
         if proc.returncode != 0:
             raise FetchError(
                 proc.stderr.strip()[:300] or f"redispatch gh api exited {proc.returncode}"
@@ -2382,7 +2438,8 @@ def make_fetch_pr_draft(repo: str, pr_number: str):
     """[FABLE-5] Draft-tier CI: the conclusion-time PR draft-state reader. Returns
     a () -> bool fetcher (True == still a draft) that raises FetchError on any
     API/parse failure — the caller (render_verdict via _draft_recheck) bounded-
-    retries and fail-closes to RED, never to a pass."""
+    retries and fail-closes to RED, never to a pass. Explicit RateLimitError
+    bypasses retries and stops the gate immediately."""
 
     def fetch() -> bool:
         try:
@@ -2393,6 +2450,7 @@ def make_fetch_pr_draft(repo: str, pr_number: str):
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
             raise FetchError(f"subprocess raised: {exc}") from exc
+        _raise_if_rate_limited(proc)
         if proc.returncode != 0:
             raise FetchError(proc.stderr.strip()[:300] or f"gh api exited {proc.returncode}")
         val = proc.stdout.strip().lower()
@@ -2407,8 +2465,9 @@ def make_fetch_pr_draft(repo: str, pr_number: str):
 
 def make_fetch_queue_depth(repo: str):
     """Queued workflow-run count for the repo — the saturation signal. Returns None
-    (unknown) on any failure so a permissions/API blip degrades to progress-only,
-    never crashes the gate. Needs `actions: read` on the workflow token."""
+    (unknown) on a generic failure so a permissions/API blip degrades to progress-only.
+    Explicit RateLimitError instead stops the gate; it cannot license more requests.
+    Needs `actions: read` on the workflow token."""
 
     def fetch():
         proc = subprocess.run(
@@ -2422,6 +2481,7 @@ def make_fetch_queue_depth(repo: str):
             capture_output=True,
             text=True,
         )
+        _raise_if_rate_limited(proc)
         if proc.returncode != 0:
             print(f"  (queue-depth fetch failed: {proc.stderr.strip()[:200]} — treating as unknown)")
             return None

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -2290,7 +2290,7 @@ def _raise_if_rate_limited(proc: subprocess.CompletedProcess) -> None:
         messages.append(body["message"])
     for message in messages:
         if re.search(
-            r"\brate limit exceeded\b|\bsecondary rate limit\b|\(HTTP 429\)",
+            r"\brate limit exceeded\b|\bsecondary rate limit\b|\bHTTP 429\b|\btoo many requests\b",
             message,
             re.IGNORECASE,
         ):

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -2996,6 +2996,122 @@ class TestFeatureMatrixReporterPostCapGrace(unittest.TestCase):
         self.assertNotIn("PASSED", out)
 
 
+    # [GPT-6-ASTRA] #6437: failed cap observations may consume the existing
+    # reporter-only tail, never buy extra ordinary work or assume a verdict.
+    def test_cap_fetch_error_and_neighboring_controls_have_exact_counts(self):
+        cfg = tiny_cfg(reporter_grace_polls=4)
+        waiting = [_grp("222"), GREEN]
+        current = [_grp("222"), _rep("222"), GREEN]
+        cases = (
+            ("healthy", [waiting] * 8 + [current, current]),
+            ("cap error", [waiting] * 7 + [g.FetchError("cap"), current, current]),
+            ("pre-cap error", [waiting] * 6 + [g.FetchError("pre-cap"), waiting, current, current]),
+        )
+        for name, polls in cases:
+            with self.subTest(case=name):
+                code, out, calls = self._drive(cfg, polls)
+                self.assertEqual(code, 0, out)
+                self.assertEqual(calls, 10)
+                self.assertIn("PASSED", out)
+                self.assertEqual(out.count("cap fetch recovery"), int(name == "cap error"))
+
+    def test_cap_fetch_error_requires_last_observed_reporter_only_eligibility(self):
+        waiting = [_grp("222"), GREEN]
+        cases = (
+            ("ordinary work", [*waiting, PENDING], None, 4),
+            ("full-tier hold", [*waiting, R(SELECT_DRAFT)],
+             draft_ctx(lambda: False, run_tier="full"), 4),
+            ("failed report", [*waiting, _rep("222", conclusion="failure")], None, 4),
+            ("grace disabled", waiting, None, 0),
+        )
+        for name, last_observation, tier_ctx, grace in cases:
+            with self.subTest(case=name):
+                cfg = tiny_cfg(reporter_grace_polls=grace)
+                polls = [waiting] * 6 + [last_observation, g.FetchError("cap")]
+                code, out, calls = self._drive(cfg, polls, depth=20, tier_ctx=tier_ctx)
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, 8)
+                self.assertNotIn("cap fetch recovery", out)
+                self.assertNotIn("PASSED", out)
+
+    def test_cap_fetch_error_preserves_normal_successful_observation_settle(self):
+        waiting = [_grp("222"), GREEN]
+        current = [*waiting, _rep("222")]
+        polls = [waiting] * 6 + [current, g.FetchError("cap"), current]
+        code, out, calls = self._drive(tiny_cfg(), polls)
+        self.assertEqual(code, 0, out)
+        self.assertEqual(calls, 9)
+        self.assertIn("all-terminal stable for 2/2", out)
+        self.assertIn("cap fetch recovery", out)
+
+    def test_cap_recovery_keeps_the_consecutive_fetch_failure_limit(self):
+        waiting = [_grp("222"), GREEN]
+        for failure_limit, calls_expected in ((3, 10), (1, 8)):
+            with self.subTest(limit=failure_limit):
+                cfg = tiny_cfg(reporter_grace_polls=4,
+                               max_consec_fetch_failures=failure_limit)
+                code, out, calls = self._drive(
+                    cfg, [waiting] * 7 + [g.FetchError("still down")])
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, calls_expected)
+                self.assertIn(f"{failure_limit} consecutive check-run fetch failures", out)
+                self.assertNotIn("PASSED", out)
+
+    def test_cap_recovery_errors_consume_the_fixed_tail_without_rearming(self):
+        cfg = tiny_cfg(reporter_grace_polls=4)
+        waiting = [_grp("222"), GREEN]
+        polls = [waiting] * 7 + [g.FetchError("cap"), waiting,
+                                g.FetchError("tail"), waiting, g.FetchError("last")]
+        code, out, calls = self._drive(cfg, polls)
+        self.assertEqual(code, 1, out)
+        self.assertEqual(calls, 12)
+        self.assertEqual(out.count("cap fetch recovery"), 1)
+        self.assertIn("bounded reporter-only grace exhausted", out)
+        self.assertNotIn("PASSED", out)
+
+    def test_cap_recovery_fresh_ordinary_work_or_full_hold_stops_immediately(self):
+        waiting = [_grp("222"), GREEN]
+        cases = (
+            ("ordinary work", [*waiting, PENDING], None),
+            ("full-tier hold", [*waiting, R(SELECT_DRAFT)],
+             draft_ctx(lambda: False, run_tier="full")),
+        )
+        for name, fresh, tier_ctx in cases:
+            with self.subTest(case=name):
+                polls = [waiting] * 7 + [g.FetchError("cap"), fresh]
+                code, out, calls = self._drive(tiny_cfg(), polls, tier_ctx=tier_ctx)
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, 9)
+                self.assertIn("reporter-only grace stopped", out)
+                self.assertNotIn("PASSED", out)
+
+    def test_cap_recovery_never_accepts_stale_or_non_success_reporters(self):
+        waiting = [_grp("222"), GREEN]
+        cases = (("stale", _rep("111"), 12),
+                 ("failed", _rep("222", conclusion="failure"), 10),
+                 ("action required", _rep("222", conclusion="action_required"), 10))
+        for name, report, expected_calls in cases:
+            with self.subTest(case=name):
+                polls = [waiting] * 7 + [g.FetchError("cap"), [*waiting, report]]
+                code, out, calls = self._drive(tiny_cfg(reporter_grace_polls=4), polls)
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, expected_calls)
+                self.assertNotIn("PASSED", out)
+
+    def test_cap_recovery_final_success_still_requires_normal_settle(self):
+        waiting = [_grp("222"), GREEN]
+        for grace in (1, 4):
+            with self.subTest(grace=grace):
+                cfg = tiny_cfg(reporter_grace_polls=grace)
+                polls = [waiting] * 7 + [g.FetchError("cap")]
+                polls += [waiting] * (grace - 1) + [[*waiting, _rep("222")]]
+                code, out, calls = self._drive(cfg, polls)
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, 8 + grace)
+                self.assertIn("reached only 1/2 poll(s)", out)
+                self.assertNotIn("PASSED", out)
+
+
 class TestFeatureMatrixReporterCorrelation(unittest.TestCase):
     """[FABLE-5] PR #3511 finding 2 (HIGH): a `feature-matrix report` verdict must
     correlate to the CURRENT feature-matrix run — a stale same-SHA report from an

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1648,14 +1648,6 @@ class TestSelectionSemantics(unittest.TestCase):
         self.assertFalse(g.is_advisory(SELECT_NAME))
 
 
-# [SONNET-4.6] Robustness-hardening tests (sq-90cv4 follow-up: Copilot gaps).
-# Covers:
-#   (a) _gh_json_lines converts subprocess raises (FileNotFoundError, TimeoutExpired)
-#       → FetchError → routed into the existing bounded skip path, not a raw crash.
-#   (b) fetch_queue_depth raising in run_gate → depth treated as None (unknown) →
-#       NO saturation extension granted on depth alone (conservative branch).
-# Mutation check: removing either try/except causes the test to go RED (the
-# underlying exception propagates instead of being caught/re-raised as FetchError).
 class TestRateLimitFailClosed(unittest.TestCase):
     """[GPT-6-ASTRA] Explicit gh refusals stop every API path, without network.
 
@@ -1707,6 +1699,8 @@ class TestRateLimitFailClosed(unittest.TestCase):
             self._limited(),
             self._proc(error="gh: You have exceeded a secondary rate limit. (HTTP 403)\n"),
             self._proc(error="gh: Too Many Requests (HTTP 429)\n"),
+            self._proc(error="HTTP 429: request refused (https://api.github.com/repos/o/r)\n"),
+            self._proc(error="gh: Too Many Requests\n"),
             self._proc(error="gh: Forbidden (HTTP 403)\n",
                        stdout=json.dumps({"message": "API rate limit exceeded for user ID 7."})),
         )
@@ -1717,6 +1711,12 @@ class TestRateLimitFailClosed(unittest.TestCase):
                         g._gh_json_lines(["repos/o/r/commits/head/check-runs"])
                 self.assertIsInstance(raised.exception, g.RateLimitError)
                 self.assertEqual(api.call_count, 1)
+                code, out, calls = self._drive(
+                    [self._proc([_grp("222"), GREEN])] * 7 + [response])
+                self.assertEqual(code, 1, out)
+                self.assertEqual(len(calls), 8)
+                self.assertNotIn("cap fetch recovery", out)
+                self.assertNotIn("PASSED", out)
 
     def test_headerless_generic_failures_and_success_payload_do_not_prove_exhaustion(self):
         from unittest.mock import patch
@@ -1808,6 +1808,14 @@ class TestRateLimitFailClosed(unittest.TestCase):
         self.assertNotIn("Extending the wait", out)
 
 
+# [SONNET-4.6] Robustness-hardening tests (sq-90cv4 follow-up: Copilot gaps).
+# Covers:
+#   (a) _gh_json_lines converts subprocess raises (FileNotFoundError, TimeoutExpired)
+#       → FetchError → routed into the existing bounded skip path, not a raw crash.
+#   (b) fetch_queue_depth raising in run_gate → depth treated as None (unknown) →
+#       NO saturation extension granted on depth alone (conservative branch).
+# Mutation check: removing either try/except causes the test to go RED (the
+# underlying exception propagates instead of being caught/re-raised as FetchError).
 class TestSubprocessRobustness(unittest.TestCase):
     """[SONNET-4.6] subprocess raises in _gh_json_lines / fetch_queue_depth must be
     converted to graceful-degradation paths, never raw crashes."""

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1656,6 +1656,158 @@ class TestSelectionSemantics(unittest.TestCase):
 #       NO saturation extension granted on depth alone (conservative branch).
 # Mutation check: removing either try/except causes the test to go RED (the
 # underlying exception propagates instead of being caught/re-raised as FetchError).
+class TestRateLimitFailClosed(unittest.TestCase):
+    """[GPT-6-ASTRA] Explicit gh refusals stop every API path, without network.
+
+    Counts are gh api invocations, not hidden HTTP requests within --paginate.
+    Fixtures are jq-projected stdout plus realistic gh error diagnostics; no
+    response headers or numerical remaining quota are claimed.
+    """
+
+    @staticmethod
+    def _proc(rows=(), error="", stdout=None):
+        import subprocess
+        return subprocess.CompletedProcess(
+            ["gh", "api"], 1 if error else 0,
+            stdout="\n".join(json.dumps(r) for r in rows) if stdout is None else stdout,
+            stderr=error,
+        )
+
+    @classmethod
+    def _limited(cls):
+        return cls._proc(error="gh: API rate limit exceeded for 192.0.2.1. (HTTP 403)\n")
+
+    @staticmethod
+    def _drive(responses, fetch=None, depth=None, tier_ctx=None):
+        from unittest.mock import patch
+        # Repeat the final response so a weakened stop is an assertion failure,
+        # never mock exhaustion that aborts the remaining test population.
+        seen = []
+        def gh(argv, **_kw):
+            seen.append(argv)
+            return responses[min(len(seen) - 1, len(responses) - 1)]
+        out = io.StringIO()
+        with patch("subprocess.run", side_effect=gh), redirect_stdout(out):
+            try:
+                code = g.run_gate(
+                    tiny_cfg(reporter_grace_polls=4),
+                    fetch or g.make_fetch_check_runs("o/r", "head"),
+                    depth or (lambda: 0), sleep_fn=lambda _s: None, tier_ctx=tier_ctx,
+                )
+            except RuntimeError as exc:
+                # A leaked fatal exception is also a contract failure, asserted
+                # by callers; it must not truncate a calibrated control run.
+                code = None
+                print(f"unexpected escaping runtime error: {exc}")
+        return code, out.getvalue(), seen
+
+    def test_explicit_primary_secondary_429_and_json_error_signals(self):
+        from unittest.mock import patch
+        cases = (
+            self._limited(),
+            self._proc(error="gh: You have exceeded a secondary rate limit. (HTTP 403)\n"),
+            self._proc(error="gh: Too Many Requests (HTTP 429)\n"),
+            self._proc(error="gh: Forbidden (HTTP 403)\n",
+                       stdout=json.dumps({"message": "API rate limit exceeded for user ID 7."})),
+        )
+        for response in cases:
+            with self.subTest(stderr=response.stderr):
+                with patch("subprocess.run", return_value=response) as api:
+                    with self.assertRaises(RuntimeError) as raised:
+                        g._gh_json_lines(["repos/o/r/commits/head/check-runs"])
+                self.assertIsInstance(raised.exception, g.RateLimitError)
+                self.assertEqual(api.call_count, 1)
+
+    def test_headerless_generic_failures_and_success_payload_do_not_prove_exhaustion(self):
+        from unittest.mock import patch
+        for error in ("gh: Bad credentials (HTTP 401)",
+                      "gh: Resource not accessible by integration (HTTP 403)",
+                      "gh: Internal Server Error (HTTP 500)"):
+            with self.subTest(error=error), patch("subprocess.run", return_value=self._proc(error=error)):
+                with self.assertRaises(RuntimeError) as raised:
+                    g._gh_json_lines(["repos/o/r"])
+                self.assertIsInstance(raised.exception, g.FetchError)
+                self.assertNotIsInstance(raised.exception, g.RateLimitError)
+        row = R("API rate limit exceeded")  # successful data is not a refusal
+        with patch("subprocess.run", return_value=self._proc([row])):
+            self.assertEqual(g._gh_json_lines(["repos/o/r"]), [row])
+
+    def test_known_limit_before_at_and_after_cap_stops_at_that_invocation(self):
+        waiting = [_grp("222"), GREEN]
+        current = [*waiting, _rep("222")]
+        for fault_at in (1, 8, 9):
+            with self.subTest(fault_at=fault_at):
+                responses = [self._proc(waiting)] * (fault_at - 1)
+                code, out, calls = self._drive(responses + [self._limited(), self._proc(current)])
+                self.assertEqual(code, 1, out)
+                self.assertEqual(len(calls), fault_at)
+                self.assertIn("no further polling or recovery", out)
+                self.assertNotIn("cap fetch recovery", out)
+                self.assertNotIn("PASSED", out)
+
+    def test_generic_transient_http_error_still_recovers_at_cap(self):
+        waiting = [_grp("222"), GREEN]
+        current = [*waiting, _rep("222")]
+        responses = [self._proc(waiting)] * 7
+        responses += [self._proc(error="gh: Bad Gateway (HTTP 502)"), self._proc(current)]
+        code, out, calls = self._drive(responses)
+        self.assertEqual(code, 0, out)
+        self.assertEqual(len(calls), 10)
+        self.assertIn("cap fetch recovery", out)
+
+    def test_resolver_list_self_and_jobs_refusals_stop_later_calls_in_same_poll(self):
+        own = W(999, 99, name="ci-summary", status="in_progress", conclusion=None)
+        work = [W(101, 7), W(102, 8)]
+        prefix = [self._proc([]), self._proc([own, *work]), self._proc([own])]
+        expected = ["repos/o/r/commits/head/check-runs",
+                    "repos/o/r/actions/runs?head_sha=head&per_page=100",
+                    "repos/o/r/actions/runs/999",
+                    "repos/o/r/actions/runs/101/jobs?filter=latest&per_page=100"]
+        for fault_at in (1, 2, 3, 4):
+            with self.subTest(fault_at=fault_at):
+                code, out, calls = self._drive(
+                    prefix[:fault_at - 1] + [self._limited()],
+                    fetch=g.make_fetch_runs("o/r", "head", "999"),
+                )
+                self.assertEqual(code, 1, out)
+                self.assertEqual([argv[2] for argv in calls], expected[:fault_at])
+                self.assertIn("no further polling or recovery", out)
+
+    def test_redispatch_refusal_prevents_second_post_or_job_fetch(self):
+        own = W(999, 99, name="ci-summary", status="in_progress", conclusion=None)
+        cancelled = [W(101, 7, conclusion="cancelled"), W(102, 8, conclusion="cancelled")]
+        responses = [self._proc([]), self._proc([own, *cancelled]), self._proc([own]), self._limited()]
+        code, out, calls = self._drive(responses, fetch=g.make_fetch_runs("o/r", "head", "999"))
+        self.assertEqual(code, 1, out)
+        self.assertEqual(len(calls), 4)
+        self.assertEqual(calls[-1], ["gh", "api", "--method", "POST", "repos/o/r/actions/runs/101/rerun"])
+        self.assertIn("no further polling or recovery", out)
+
+    def test_draft_finalization_and_full_hold_do_not_retry_known_limit(self):
+        cases = (("draft", [GREEN], 2), ("full", [R(SELECT_DRAFT)], 4))
+        for tier, rows, expected_polls in cases:
+            with self.subTest(tier=tier):
+                fetch = scripted([rows])
+                ctx = g.TierContext(run_tier=tier, event_name="pull_request",
+                                    fetch_pr_draft=g.make_fetch_pr_draft("o/r", "7"))
+                code, out, calls = self._drive([self._limited()], fetch=fetch, tier_ctx=ctx)
+                self.assertEqual(code, 1, out)
+                self.assertEqual(calls, [["gh", "api", "repos/o/r/pulls/7", "--jq", ".draft"]])
+                self.assertEqual(fetch.state["calls"], expected_polls)
+                self.assertIn("no further polling or recovery", out)
+                self.assertNotIn("PASSED", out)
+
+    def test_queue_rate_limit_is_not_swallowed_into_liveness_extension(self):
+        fetch = scripted([[GREEN, IN_PROGRESS]])
+        code, out, calls = self._drive([self._limited()], fetch=fetch,
+                                      depth=g.make_fetch_queue_depth("o/r"))
+        self.assertEqual(code, 1, out)
+        self.assertEqual(fetch.state["calls"], 4)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("no further polling or recovery", out)
+        self.assertNotIn("Extending the wait", out)
+
+
 class TestSubprocessRobustness(unittest.TestCase):
     """[SONNET-4.6] subprocess raises in _gh_json_lines / fetch_queue_depth must be
     converted to graceful-degradation paths, never raw crashes."""


### PR DESCRIPTION
A transient API failure on the aggregate gate’s final ordinary poll could prevent its reporter-only grace period from starting. Preserve that same fixed period using the last successful eligibility observation. Cached eligibility permits re-observation only; passing still requires fresh reporter correlation and the existing work, settle and error bounds.

Recognized GitHub rate-limit refusals now stop the gate immediately, including through workflow resolution, redispatch, queue-depth and draft-state reads. Primary/secondary-limit messages, HTTP 429 and Too Many Requests produce a nonzero UNDETERMINED result without subsequent API invocations. Detection uses failed-response diagnostics, not quota headers; unrecognized wording retains the existing bounded error policy.

Validation: 209 aggregate-gate tests and the script self-test pass. Nine current rate-limit mutation controls are assertion-killed across the complete eight-method suite, with no errors or skips; the restored old HTTP 429 matcher fails two assertions. The reporter recovery also has six calibrated controls from the complete independently reviewed candidate. Counts are gh invocations, not HTTP requests inside gh pagination. Local preflight is limited by host Bash 3 lacking mapfile; required Linux CI remains the merge gate.

Independent review: actual Claude Opus 5 with extra-high reasoning approved the full change at 005b8c62627abac9251c206bf46b57a6323ec808 and the exact follow-up at 54dd9e912195658b89658394a3ee31a68c208a77, both with nonblocking nits and no blockers. The follow-up broadens HTTP 429 recognition and corrects a test header; the rest of the production file is byte-identical to the fully reviewed version. Implementation used GPT-6 Astra with extra-high reasoning.

Closes #6437.
