### PR TITLE
ci: bind cancelled-gate receipts to GitHub Bot identity

### DIFF
--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -1063,11 +1063,13 @@ RERUN_PHASE = "gate-rerun-claim"
 RERUN_MARKER = "> 🤖 [GPT-6 Astra] SPARQ agent — cancelled gate recovery (#6438)"
 RERUN_RECEIPT_OPEN = "<!-- gate-rerun-claim:"
 RERUN_RECEIPT_CLOSE = ":gate-rerun-claim -->"
+# [GPT-6 Astra] Actor exposes no id; request the stable identity on concrete Bot.
+# Other actor types remain readable but cannot satisfy authenticated claim binding.
 RERUN_HISTORY_QUERY = """query($owner:String!,$name:String!,$number:Int!){
   viewer{login}
   repository(owner:$owner,name:$name){pullRequest(number:$number){
     comments(last:100){totalCount pageInfo{hasPreviousPage}
-      nodes{databaseId body author{id login __typename}}}
+      nodes{databaseId body author{login __typename ... on Bot{id}}}}
   }}
 }"""
 

--- a/scripts/rearm-sweeper.py
+++ b/scripts/rearm-sweeper.py
@@ -1877,6 +1877,10 @@ class StuckArmSweeper:
         if (not isinstance(bot, dict) or bot.get("type") != "Bot"
                 or bot.get("login") != viewer["login"] or not bot.get("node_id")):
             raise GhError("rerun refused: authenticated account is not a verified bot")
+        # [GPT-6 Astra] GitHub's REST account includes [bot], while the same
+        # GraphQL Bot node omits it. Normalize only this already-verified account;
+        # the author must still match its stable node id, canonical login and type.
+        actor_login = bot["login"].removesuffix("[bot]")
         found = []
         for comment in comments:
             if not isinstance(comment, dict) or not isinstance(comment.get("body"), str):
@@ -1889,7 +1893,7 @@ class StuckArmSweeper:
             parsed = parse_rerun_claim(body)
             author = comment.get("author") or {}
             if (parsed is None or body != self.rerun_claim_body(parsed)
-                    or author.get("id") != bot["node_id"] or author.get("login") != viewer["login"]
+                    or author.get("id") != bot["node_id"] or author.get("login") != actor_login
                     or author.get("__typename") != "Bot"
                     or set(parsed) != set(claim) or parsed.get("v") != RECEIPT_VERSION
                     or parsed.get("program") != PROGRAM or parsed.get("phase") != RERUN_PHASE

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -1477,7 +1477,9 @@ class ActionsRerunFixture:
         self.m = module
         self.clock = module._iso_epoch("2026-09-06T12:00:00Z")
         self.viewer = {"login": "sparq-orchestrator[bot]"}
-        self.actor = dict(id="BOT_4300853", login=self.viewer["login"], __typename="Bot")
+        # [GPT-6 Astra] Verified live: these APIs share a node id, not login spelling.
+        self.actor = dict(id="BOT_4300853", login="sparq-orchestrator", __typename="Bot")
+        self.rest_actor = dict(login=self.viewer["login"], node_id=self.actor["id"], type="Bot")
         self.raw = module.live_pr(6360, labels=("review:pass",), head="a" * 40)
         self.check = dict(module.check_run("gate", "cancelled", ident=101),
             head_sha="a" * 40, app={"slug": "github-actions"},
@@ -1567,7 +1569,7 @@ class ActionsRerunFixture:
             raise AssertionError(f"unexpected mutation: {argv}")
         path = argv[-1]
         if path == f"users/{self.viewer['login']}":
-            return json.dumps(dict(login=self.actor["login"],node_id=self.actor["id"],type="Bot"))
+            return json.dumps(self.rest_actor)
         if "/commits/" in path:
             return json.dumps(self.m.check_pages([self.check]))
         if "/actions/workflows/ci-summary.yml/runs?" in path:
@@ -1627,6 +1629,21 @@ class TestCancelledActionsRecovery(unittest.TestCase):
         with patch.object(self.m, "RERUN_HISTORY_QUERY", bad):
             self.denied()
         self.assertEqual(self.f.posts(), [])
+
+    def test_real_bot_login_forms_bind_to_the_same_authenticated_node(self):
+        self.assertEqual(self.f.viewer["login"], "sparq-orchestrator[bot]")
+        self.assertEqual(self.f.actor["login"], "sparq-orchestrator")
+        self.assertEqual(self.f.rest_actor["node_id"], self.f.actor["id"])
+        self.f.drive()
+        self.assertEqual(len(self.f.reruns()), 1)
+
+    def test_unverified_rest_identity_is_refused_before_claiming(self):
+        for field, value in (("login", "someone[bot]"), ("node_id", ""), ("type", "User")):
+            with self.subTest(field=field):
+                self.f = ActionsRerunFixture(self.m)
+                self.f.rest_actor[field] = value
+                self.denied()
+                self.assertEqual(self.f.posts(), [])
 
     def test_unrequested_bot_id_cannot_authenticate_posted_claim(self):
         missing_id = self.m.RERUN_HISTORY_QUERY.replace("... on Bot{id}", "")

--- a/scripts/tests/test_arm_capability_wiring.py
+++ b/scripts/tests/test_arm_capability_wiring.py
@@ -1507,6 +1507,38 @@ class ActionsRerunFixture:
         return self.m.StuckArmSweeper("sparq-org/sparq", "main", gh=self,
             log=self.logs.append, now=lambda: self.clock)
 
+    def history_comments(self, query):
+        # [GPT-6 Astra] #6462: model the field-only Actor/Bot selection used here,
+        # not a general GraphQL parser. These fields were checked by live schema
+        # introspection; fixtures must not return an unrequested authenticated id.
+        actor_fields = {"avatarUrl", "login", "resourcePath", "url", "__typename"}
+        bot_fields = actor_fields | {"createdAt", "databaseId", "id", "updatedAt"}
+        start = query.index("{", query.index("author")) + 1
+        depth, end = 1, start
+        while depth:
+            char = query[end]
+            depth += (char == "{") - (char == "}")
+            end += 1
+        selection = query[start:end - 1]
+        fragment = r"\.\.\.\s+on\s+(\w+)\s*\{([^{}]*)\}"
+        fragments = re.findall(fragment, selection)
+        common = set(re.sub(fragment, "", selection).split())
+        if common - actor_fields:
+            raise self.m.GhError("Field does not exist on type Actor")
+        for kind, fields in fragments:
+            if kind != "Bot" or set(fields.split()) - bot_fields:
+                raise self.m.GhError("Unsupported concrete actor selection")
+        comments = copy.deepcopy(self.comments)
+        for comment in comments:
+            author = comment.get("author")
+            if isinstance(author, dict):
+                selected = common.copy()
+                for kind, fields in fragments:
+                    if author.get("__typename") == kind:
+                        selected.update(fields.split())
+                comment["author"] = {key: value for key, value in author.items() if key in selected}
+        return comments
+
     def __call__(self, argv):
         self.calls.append(list(argv))
         if argv[:2] == ["pr", "list"]:
@@ -1518,7 +1550,8 @@ class ActionsRerunFixture:
             if "viewer{" in query:
                 return json.dumps({"data": {"viewer": self.viewer, "repository": {"pullRequest": {
                     "comments": {"totalCount": len(self.comments) + self.history_extra,
-                        "pageInfo": {"hasPreviousPage": self.history_truncated}, "nodes": self.comments}}}}})
+                        "pageInfo": {"hasPreviousPage": self.history_truncated},
+                        "nodes": self.history_comments(query)}}}}})
             return json.dumps({"data": {"repository": {"pullRequest": self.raw}}})
         if argv[:3] == ["api", "-X", "POST"]:
             if argv[3].endswith("/comments"):
@@ -1586,6 +1619,21 @@ class TestCancelledActionsRecovery(unittest.TestCase):
         claim = self.m.parse_rerun_claim(self.f.comments[0]["body"])
         self.assertEqual((claim["check"], claim["job"], claim["run"], claim["attempt"]), (101, 202, 303, 1))
         self.assertFalse(any("/rerequest" in arg for call in self.f.calls for arg in call))
+
+    def test_actor_id_selection_is_rejected_before_any_mutation(self):
+        # Keep an invalid direct selection realistic even when its field is last.
+        bad = self.m.RERUN_HISTORY_QUERY.replace("... on Bot{id}", "id")
+        self.assertNotEqual(bad, self.m.RERUN_HISTORY_QUERY)
+        with patch.object(self.m, "RERUN_HISTORY_QUERY", bad):
+            self.denied()
+        self.assertEqual(self.f.posts(), [])
+
+    def test_unrequested_bot_id_cannot_authenticate_posted_claim(self):
+        missing_id = self.m.RERUN_HISTORY_QUERY.replace("... on Bot{id}", "")
+        self.assertNotEqual(missing_id, self.m.RERUN_HISTORY_QUERY)
+        with patch.object(self.m, "RERUN_HISTORY_QUERY", missing_id):
+            self.denied()
+        self.assertEqual(len(self.f.posts()), 1)  # Claim only; no Actions rerun.
 
     def test_fallback_identity_is_refused_before_any_claim_or_rerun(self):
         # [GPT-6 Astra] Opus B1: valid bot metadata cannot grant the explicitly


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Cancelled-gate recovery could not authenticate its durable rerun receipt: its query requested `id` on the `Actor` interface, and its consumer expected GraphQL's bot login to include REST's `[bot]` suffix. Select the ID on concrete `Bot` and derive the canonical author login from the already verified REST account. The authenticated viewer, stable node ID, bot type, exact run-attempt claim, current-head/queue/review guards and #6049 hold stay enforced.

The fixture now models GitHub's actual field projection and the two login spellings. Read-only GitHub checks accepted the exact production query and confirmed that the orchestrator's REST and GraphQL identities share a node ID. No production claim, rerun or dispatch was used for validation.

Validation: 80 arm-capability tests and the rearm self-test pass. Two calibrated controls independently restore the invalid query and the old login comparison; each makes the same positive recovery test fail with one assertion failure, zero errors and zero skips. Preflight's other checks pass; the existing macOS Bash 3 `mapfile` limitation in privacy-claims remains, so Linux CI is still required.

Independent review used actual Claude Opus 5 with extra-high reasoning. The complete change at `ed9689d5be5be28ccbc3300c1d90b250319f2c7c` and the focused identity correction at final head `5640d06b669f4a6cd52029d6b0dcc9ee48b6e692` both received `approve_with_nits`, with no blockers. The fixture intentionally supports the fixed Actor/Bot selection used here, rather than being a general GraphQL validator. Review packet SHA-256 values: `ebc73847ffc5c568f78fcda1bcffe3045c69ecb370985ee809753636e00b81c6` and `cbbed101eb48afd78a04ed9ae18e72294f9a3010417c7730ced407b7e96edf9f`.

Closes #6462.
