### PR TITLE
fix(ci): identify unknown area labels before triage writes

### DIFF
--- a/scripts/tests/test_triage_area.py
+++ b/scripts/tests/test_triage_area.py
@@ -47,6 +47,7 @@ import re
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 try:  # the parsed-regex API moved in 3.11
     from re import _parser as sre_parser
@@ -171,6 +172,123 @@ TEXT_SCOPED_RULES = frozenset({
 # TestScopeDiscipline.setUp so it can never quietly acquire an area and turn the
 # per-rule property into a tautology.
 NEUTRAL_TITLE = "Recurring chore: worktree disk-hygiene sweep"
+
+
+class TestTriageAreaDiagnostics(unittest.TestCase):
+    """[GPT-6 Astra] #6468: real routing and the global prewrite failure boundary."""
+
+    DIAGNOSTIC = "triage-area aborts the classification pass on missing area:sparq-wrapper-gen label"
+    GENERATOR = "sparq-wrapper-gen: give the SHACL object-model generator an entry point (build script / CLI)"
+
+    @staticmethod
+    def issue(number, title, *labels, body=""):
+        return {"number": number, "title": title, "body": body,
+                "labels": [{"name": name} for name in labels]}
+
+    def run_main(self, issues, known, *args):
+        """Drive the actual CLI, poisoning every unmocked GitHub call."""
+        calls, out, err = [], io.StringIO(), io.StringIO()
+
+        def gh(argv):
+            if argv[:2] != ["issue", "edit"]:
+                raise AssertionError(f"unexpected GitHub call: {argv}")
+            calls.append(list(argv))
+            return ""
+
+        with patch.object(TA, "candidate_issues", return_value=issues), \
+                patch.object(TA, "live_area_labels", return_value=set(known)), \
+                patch.object(TA, "_gh", side_effect=gh), \
+                patch.object(TA, "_sleep") as sleep, \
+                patch.object(sys, "argv", ["triage-area.py", "--apply", *args]), \
+                contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = TA.main()
+        return code, calls, out.getvalue(), err.getvalue(), sleep.call_count
+
+    @staticmethod
+    def records(stderr):
+        return [json.loads(line.removeprefix("UNKNOWN_AREA "))
+                for line in stderr.splitlines() if line.startswith("UNKNOWN_AREA ")]
+
+    def test_captured_titles_and_existing_area(self):
+        self.assertEqual(areas(self.DIAGNOSTIC), ["ci"])
+        self.assertTrue(evidence(self.DIAGNOSTIC).startswith("T1 triage-area:"))
+        for title in ("triage-area.py: identify missing labels", "triage-area"):
+            self.assertEqual(areas(title), ["ci"])
+        self.assertEqual(areas(self.GENERATOR), ["sparq-wrapper-gen"])
+        self.assertEqual(areas("sparq-wrapper: improve generated bindings"), ["sparq-wrapper"])
+        row = TA.plan([self.issue(6468, self.DIAGNOSTIC, "area:ci")], CRATES)[0]
+        self.assertEqual(row[1:], ([], "SKIP already carries an area: label"))
+
+    def test_title_scope_and_t0_priority(self):
+        for title, body in ((NEUTRAL_TITLE, "triage-area: inspect routing"),
+                            ("Investigate triage-area diagnostics", ""),
+                            ("triage-area-other: inspect routing", "")):
+            self.assertEqual(TA.classify(title, body, CRATES), ([], ""))
+        self.assertEqual(TA.classify(self.DIAGNOSTIC, "crate_or_surface: sparq-core", CRATES),
+                         (["sparq-core"], "T0 author-declared crate_or_surface/crates field"))
+
+    def test_unknown_later_row_blocks_all_writes_even_outside_budget(self):
+        issues = [self.issue(5016, self.GENERATOR, TA.PARK_LABEL),
+                  self.issue(1, self.DIAGNOSTIC, TA.PARK_LABEL)]
+        for args in ((), ("--max-writes", "1"), ("--json",)):
+            code, calls, out, err, sleeps = self.run_main(issues, {"area:ci"}, *args)
+            self.assertEqual((code, calls, out, sleeps), (2, [], "", 0))
+            self.assertEqual(self.records(err), [{
+                "number": 5016, "label": "area:sparq-wrapper-gen",
+                "evidence": "T2 bd-to-issues.derive_areas (title scope/crate token)"}])
+            self.assertIn("separately reviewed label provisioning", err)
+            self.assertIn("This classifier never creates labels.", err)
+
+    def test_offenders_keep_row_label_tier_association_and_order(self):
+        issues = [self.issue(5016, self.GENERATOR),
+                  self.issue(19, NEUTRAL_TITLE, body="crates: sparq-core + sparq-engine"),
+                  self.issue(6468, self.DIAGNOSTIC)]
+        result = self.run_main(issues, {"area:ci"})
+        self.assertEqual((result[0], result[1], result[4]), (2, [], 0))
+        self.assertEqual(self.records(result[3]), [
+            {"number": 19, "label": "area:sparq-core",
+             "evidence": "T0 author-declared crate_or_surface/crates field"},
+            {"number": 19, "label": "area:sparq-engine",
+             "evidence": "T0 author-declared crate_or_surface/crates field"},
+            {"number": 5016, "label": "area:sparq-wrapper-gen",
+             "evidence": "T2 bd-to-issues.derive_areas (title scope/crate token)"}])
+        self.assertEqual(result, self.run_main(list(reversed(issues)), {"area:ci"}))
+
+    def test_diagnostic_escapes_records_without_dumping_issue_body(self):
+        # A synthetic plan probes serialization only; the preceding tests exercise
+        # real classification. Never execute these strings as workflow commands.
+        why = 'T2 evidence\n::error::forged\r\t"quoted"'
+        label = 'area:missing\nsecond-line'
+        row = self.issue(7, "unprinted title", body="private fixture body")
+        with patch.object(TA, "plan", return_value=[(row, [label], why)]):
+            code, calls, out, err, sleeps = self.run_main([], set())
+        self.assertEqual((code, calls, out, sleeps), (2, [], "", 0))
+        self.assertEqual(self.records(err), [{"number": 7, "label": label, "evidence": why}])
+        self.assertFalse(any(line.startswith("::") for line in err.splitlines()))
+        self.assertNotIn("private fixture body", err)
+        self.assertNotIn("unprinted title", err)
+
+    def test_supported_label_uses_normal_add_and_unpark_path(self):
+        issues = [self.issue(5016, self.GENERATOR, TA.PARK_LABEL),
+                  self.issue(1, self.DIAGNOSTIC),
+                  self.issue(6468, self.DIAGNOSTIC, "area:ci")]
+        code, calls, _out, err, sleeps = self.run_main(
+            issues, {"area:ci", "area:sparq-wrapper-gen"})
+        self.assertEqual((code, err, sleeps), (0, "", 1))
+        self.assertEqual([c[2] for c in calls], ["1", "5016"])
+        self.assertIn("area:ci", calls[0])
+        self.assertNotIn("--remove-label", calls[0])
+        self.assertEqual(calls[1][-4:], ["--remove-label", TA.PARK_LABEL,
+                                         "--add-label", "area:sparq-wrapper-gen"])
+
+    def test_unrelated_unknown_still_blocks_after_generator_provisioning(self):
+        issues = [self.issue(1, self.GENERATOR),
+                  self.issue(19, NEUTRAL_TITLE, body="crate: sparq-core")]
+        code, calls, out, err, sleeps = self.run_main(issues, {"area:sparq-wrapper-gen"})
+        self.assertEqual((code, calls, out, sleeps), (2, [], "", 0))
+        self.assertEqual(self.records(err), [{
+            "number": 19, "label": "area:sparq-core",
+            "evidence": "T0 author-declared crate_or_surface/crates field"}])
 
 
 class TestFailClosed(unittest.TestCase):
@@ -743,7 +861,7 @@ class TestScopeDiscipline(unittest.TestCase):
     #: dropping a `^` moves a rule OUT of this set, which reds this test and
     #: simultaneously brings the rule under the per-rule assertion below.
     ANCHORED_ONLY = {"difftest-normaliser", "difftest-harness", "kani-harness",
-                     "site-page", "deploy-demo"}
+                     "site-page", "deploy-demo", "triage-area"}
 
     def setUp(self):
         # Anti-tautology: the carrier title must itself classify to nothing, or

--- a/scripts/tests/test_triage_area.py
+++ b/scripts/tests/test_triage_area.py
@@ -185,7 +185,7 @@ class TestTriageAreaDiagnostics(unittest.TestCase):
         return {"number": number, "title": title, "body": body,
                 "labels": [{"name": name} for name in labels]}
 
-    def run_main(self, issues, known, *args):
+    def run_main(self, issues, known, *args, apply=True):
         """Drive the actual CLI, poisoning every unmocked GitHub call."""
         calls, out, err = [], io.StringIO(), io.StringIO()
 
@@ -199,7 +199,7 @@ class TestTriageAreaDiagnostics(unittest.TestCase):
                 patch.object(TA, "live_area_labels", return_value=set(known)), \
                 patch.object(TA, "_gh", side_effect=gh), \
                 patch.object(TA, "_sleep") as sleep, \
-                patch.object(sys, "argv", ["triage-area.py", "--apply", *args]), \
+                patch.object(sys, "argv", ["triage-area.py", *(["--apply"] if apply else []), *args]), \
                 contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
             code = TA.main()
         return code, calls, out.getvalue(), err.getvalue(), sleep.call_count
@@ -227,16 +227,28 @@ class TestTriageAreaDiagnostics(unittest.TestCase):
         self.assertEqual(TA.classify(self.DIAGNOSTIC, "crate_or_surface: sparq-core", CRATES),
                          (["sparq-core"], "T0 author-declared crate_or_surface/crates field"))
 
+    def test_rule_precedes_benchmark_and_website_collisions(self):
+        for title in ("triage-area: benchmark the classification pass",
+                      "triage-area: website routing"):
+            got, why = TA.classify(title, "", CRATES)
+            self.assertEqual(got, ["ci"], title)
+            self.assertTrue(why.startswith("T1 triage-area:"), (title, why))
+
     def test_unknown_later_row_blocks_all_writes_even_outside_budget(self):
         issues = [self.issue(5016, self.GENERATOR, TA.PARK_LABEL),
                   self.issue(1, self.DIAGNOSTIC, TA.PARK_LABEL)]
-        for args in ((), ("--max-writes", "1"), ("--json",)):
-            code, calls, out, err, sleeps = self.run_main(issues, {"area:ci"}, *args)
+        for apply, args in ((True, ()), (True, ("--max-writes", "1")),
+                            (True, ("--json",)), (False, ())):
+            code, calls, out, err, sleeps = self.run_main(issues, {"area:ci"}, *args, apply=apply)
             self.assertEqual((code, calls, out, sleeps), (2, [], "", 0))
             self.assertEqual(self.records(err), [{
                 "number": 5016, "label": "area:sparq-wrapper-gen",
                 "evidence": "T2 bd-to-issues.derive_areas (title scope/crate token)"}])
-            self.assertIn("separately reviewed label provisioning", err)
+            self.assertIn("absent from the fetched area-label set (1 area labels", err)
+            self.assertIn("the fetch may be incomplete", err)
+            self.assertIn("Do not create a label based on this failure.", err)
+            self.assertIn("GET /repos/{owner}/{repo}/labels/{url-encoded-name}", err)
+            self.assertIn("a separate reviewed maintenance action", err)
             self.assertIn("This classifier never creates labels.", err)
 
     def test_offenders_keep_row_label_tier_association_and_order(self):
@@ -263,8 +275,11 @@ class TestTriageAreaDiagnostics(unittest.TestCase):
         with patch.object(TA, "plan", return_value=[(row, [label], why)]):
             code, calls, out, err, sleeps = self.run_main([], set())
         self.assertEqual((code, calls, out, sleeps), (2, [], "", 0))
-        self.assertEqual(self.records(err), [{"number": 7, "label": label, "evidence": why}])
+        # Assert line behavior BEFORE decoding: a newline can split a record and
+        # inject a workflow command without adding another UNKNOWN_AREA prefix.
         self.assertFalse(any(line.startswith("::") for line in err.splitlines()))
+        self.assertEqual(sum(line.startswith("UNKNOWN_AREA ") for line in err.splitlines()), 1)
+        self.assertEqual(self.records(err), [{"number": 7, "label": label, "evidence": why}])
         self.assertNotIn("private fixture body", err)
         self.assertNotIn("unprinted title", err)
 

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -150,6 +150,9 @@ _sleep = time.sleep
 RULES = [
     # -- workflow lanes that merely *mention* another surface ---------------------
     # These must precede the surface rules they name, else the named surface wins.
+    # [GPT-6 Astra] #6468: a classifier diagnostic can name the crate it misroutes.
+    ("triage-area", "title", r"^triage-area(?:\.py)?(?:\s|:|$)",
+     ["ci"], "scripts/triage-area.py and its workflow"),
     ("zk-toolchain-lane", "title", r"into the zk-toolchain\.yml lane",
      ["ci"], "adds a step to .github/workflows/zk-toolchain.yml"),
 
@@ -741,8 +744,19 @@ def main():
 
     unknown = sorted({lb for _, add, _ in rows for lb in add} - known)
     if unknown:
-        print(f"ERROR: rule table produced labels that do not exist: {unknown}", file=sys.stderr)
-        print("Fix the rule table — do NOT create the label.", file=sys.stderr)
+        print(f"ERROR: classification produced labels that do not exist: {unknown}",
+              file=sys.stderr)
+        # [GPT-6 Astra] Bind each missing label to its row and classification tier.
+        # JSON escapes newlines/control characters; no issue body is logged. Keep
+        # this whole-plan check before the write budget and every apply/unpark.
+        for it, add, why in rows:
+            for label in sorted(set(add).intersection(unknown)):
+                print("UNKNOWN_AREA " + json.dumps(
+                    {"number": it["number"], "label": label, "evidence": why},
+                    sort_keys=True), file=sys.stderr)
+        print("Review the row's routing evidence. A wrong mapping needs a classifier fix; "
+              "a verified existing crate may need separately reviewed label provisioning. "
+              "This classifier never creates labels.", file=sys.stderr)
         return 2
 
     classified = [r for r in rows if r[1]]

--- a/scripts/triage-area.py
+++ b/scripts/triage-area.py
@@ -744,7 +744,8 @@ def main():
 
     unknown = sorted({lb for _, add, _ in rows for lb in add} - known)
     if unknown:
-        print(f"ERROR: classification produced labels that do not exist: {unknown}",
+        print(f"ERROR: classification produced labels absent from the fetched area-label set "
+              f"({len(known)} area labels; the fetch may be incomplete): {unknown}",
               file=sys.stderr)
         # [GPT-6 Astra] Bind each missing label to its row and classification tier.
         # JSON escapes newlines/control characters; no issue body is logged. Keep
@@ -754,8 +755,10 @@ def main():
                 print("UNKNOWN_AREA " + json.dumps(
                     {"number": it["number"], "label": label, "evidence": why},
                     sort_keys=True), file=sys.stderr)
-        print("Review the row's routing evidence. A wrong mapping needs a classifier fix; "
-              "a verified existing crate may need separately reviewed label provisioning. "
+        print("Do not create a label based on this failure. First verify each name with "
+              "GET /repos/{owner}/{repo}/labels/{url-encoded-name}. Review incomplete "
+              "enumeration or wrong routing separately; label provisioning for a verified "
+              "existing crate requires a separate reviewed maintenance action. "
               "This classifier never creates labels.", file=sys.stderr)
         return 2
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the sparq-org/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

## Summary

An unknown area label currently aborts triage without identifying the issue that produced it. This adds one JSON-escaped `UNKNOWN_AREA` record per offending issue/label pair, including its classification tier. The error names the fetched label set and possible incomplete enumeration, prohibits creating a label from the failure, and directs exact-label verification before a separate reviewed maintenance action. The global check still exits before every write, unpark, write-budget cut, JSON report or dry-run path.

Titles beginning with `triage-area` or `triage-area.py` now route to `ci` before generic topic rules. Author-declared T0 ownership still wins, and actual generator work such as #5016 continues to route to `sparq-wrapper-gen`.

Addresses #6468. The missing existing-crate label was repaired through separately reviewed maintenance. The first later [ordinary scheduled run](https://github.com/sparq-org/sparq/actions/runs/34395557649) succeeded on existing main and completed its bounded writes; #5016 was correctly classified but deferred by the write budget. That run does not validate this unmerged patch. Issue closure follows merge and recovery verification. Related enumeration issue #6335, older PRs #5457/#6095 and policy documentation issue #5412 remain separate.

## Validation and review

- 45 classifier tests and both embedded self-test suites pass locally. Ten executed negative controls were killed, including global-guard removal, checking only the writable prefix, late rule placement, anchor metadata removal, row/label/tier corruption and newline injection. No compile-only kills or test errors.
- Author preflight passed its other applicable checks. The local privacy checker could not execute under Bash 3.2 (`mapfile`); the existing Linux privacy gate must pass before admission. Linux CI must also execute the classifier suite under its pinned Python 3.12.
- Actual GPT-6 Astra, extra-high reasoning, authored the two-file change. Actual Claude Opus 5, extra-high reasoning, approved the original source and final focused delta for validation, with no blocking findings and `perf_affecting: false`. Test outputs were reviewed as supplied evidence, not independently rerun by Opus. Copilot review, resolved threads and all protected checks remain required.
- Root verified the clean exact head, all frozen evidence hashes and both committed diffs. Tracked-source searches found no consumers of the removed error strings. The frozen #6095 patch passes a read-only applicability check; this is not combined testing or approval of that PR.

Review head: `afa9c6489db0351855acd9297a6aa2c845434106`. Final Opus result SHA256: `58b405c9018ef10c161b37c32517cb2c88de284506b057e69e2342b69c4000d4`.

## Limits and conventions

The fixtures intentionally use real workspace crate discovery; a future wrapper/generator rename requires updating their ownership contract. Complete finite offender records are retained. The classifier does not create labels or log raw issue bodies. No workflow, write budget, pacing, T0 parser, partition policy, protection, conformance/performance/coverage floor or registry dispatch setting changes. Registry Actions remain disabled. No native human review or roborev result is claimed.
