### PR TITLE
perf(engine): reuse RHS scans across capped seed blocks

### DIFF
--- a/bench/feature-off-declarations/6477.json
+++ b/bench/feature-off-declarations/6477.json
@@ -1,0 +1,5 @@
+{
+  "pr": 6477,
+  "date": "2026-09-10",
+  "reason": "[GPT-6 Astra] Intentional always-compiled engine changes: bounded query-local capped RHS scan reuse and borrowed join inputs. This is not a byte-neutrality assertion; the separate wasm size ratchet remains unchanged."
+}

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -4128,8 +4128,8 @@ fn in_scope_vars(p: &GraphPattern) -> Vec<Variable> {
 const CAPPED_SEED_BLOCK: usize = 1024;
 /// Second-tier block: one escalation before the remainder is processed whole, so a
 /// first-block miss still avoids the full chain when a solution lives within the
-/// first ~64k seed rows. Exactly two escalations bound the per-step rhs re-scan
-/// overhead of a NO-solution (ASK false) query at 3x the single-pass scans.
+/// first ~64k seed rows. Exactly two escalations bound a NO-solution query to
+/// three blocks; identical non-bind RHS scans are reused when no budget is armed.
 const CAPPED_SEED_BLOCK_2: usize = 65_536;
 
 /// Capped conjunctive (BGP + FILTER) evaluation — the ASK / LIMIT-k first-solutions
@@ -4191,9 +4191,20 @@ fn eval_bgp_binary_capped(
         None,
     );
 
+    #[cfg(test)]
+    capped_rhs_tests::observe(0);
+    // [GPT-6 Astra] Query-local and lazy: never scan an unreached step. Pattern
+    // filters are immutable here; each slot also keys the requested scan order.
+    // Armed budgets retain the old per-step lifetime and polling: their working-set
+    // estimate does not account for multiple retained RHS relations.
+    let reuse_rhs = !budget::active();
+    let mut rhs_cache: Vec<Option<(Option<usize>, Bindings)>> =
+        std::iter::repeat_with(|| None).take(if reuse_rhs { prepared.len() } else { 0 }).collect();
     let mut acc: Option<Bindings> = None;
     let mut start = 0usize;
     while start < seed_all.rows.len() {
+        #[cfg(test)]
+        capped_rhs_tests::observe(1);
         let end = if start == 0 {
             CAPPED_SEED_BLOCK.min(seed_all.rows.len())
         } else if start == CAPPED_SEED_BLOCK {
@@ -4231,28 +4242,36 @@ fn eval_bgp_binary_capped(
                 let jv = &connecting[0];
                 let rk = result.col(jv).unwrap();
                 let pp = prepared[i].var_pos(jv).unwrap();
+                #[cfg(test)]
+                capped_rhs_tests::observe(3);
                 result = bind_join(graph, result, &prepared[i].id_pat, &prepared[i].pos_vars, rk, pp, pfilter(i));
             } else {
                 let filt = pfilter(i);
                 let merge_var = result.sorted_by.clone().filter(|sv| prepared[i].var_pos(sv).is_some());
                 let scan_sort = filt.map(|(c, _)| c).or_else(|| merge_var.as_ref().map(|jv| prepared[i].var_pos(jv).unwrap()));
-                let rhs = scan_to_bindings(
-                    graph,
-                    &prepared[i].id_pat,
-                    &prepared[i].pos_vars,
-                    scan_sort,
-                    filt,
-                    None,
-                    #[cfg(feature = "semijoin-bitmap")]
-                    None,
-                );
+                let mut uncached = None;
+                let slot = if reuse_rhs { &mut rhs_cache[i] } else { &mut uncached };
+                let rhs = capped_rhs(slot, scan_sort, || {
+                    #[cfg(test)]
+                    capped_rhs_tests::observe(2);
+                    scan_to_bindings(
+                        graph,
+                        &prepared[i].id_pat,
+                        &prepared[i].pos_vars,
+                        scan_sort,
+                        filt,
+                        None,
+                        #[cfg(feature = "semijoin-bitmap")]
+                        None,
+                    )
+                });
                 let connected = prepared[i].pos_vars.iter().flatten().any(|v| result.vars.contains(v));
                 if let Some(jv) = merge_var.filter(|jv| rhs.sorted_by.as_ref() == Some(jv)) {
-                    result = merge_join(result, rhs, &jv);
+                    result = merge_join_ref(&result, rhs, &jv);
                 } else if connected {
-                    result = hash_join(result, rhs);
+                    result = hash_join_ref(&result, rhs);
                 } else {
-                    result = cross_product(result, rhs);
+                    result = cross_product_ref(&result, rhs);
                 }
             }
             record_pattern_ndv(graph, &prepared, i, cur_card, &mut var_ndv, &cs_ctx);
@@ -4293,6 +4312,22 @@ fn eval_bgp_binary_capped(
         start = end;
     }
     Ok(Some(acc.unwrap_or_else(|| Bindings::unsorted(collect_vars(patterns), vec![]))))
+}
+
+// [GPT-6 Astra] Reuse only the same requested order of one immutable prepared pattern.
+// Retain the actual sorted_by metadata returned by the scan, including fallback orders.
+fn capped_rhs(
+    slot: &mut Option<(Option<usize>, Bindings)>,
+    sort: Option<usize>,
+    scan: impl FnOnce() -> Bindings,
+) -> &Bindings {
+    if slot
+        .as_ref()
+        .is_none_or(|(cached_sort, _)| *cached_sort != sort)
+    {
+        *slot = Some((sort, scan()));
+    }
+    &slot.as_ref().unwrap().1
 }
 
 /// Distinct (non-repeated) variable positions of a prepared pattern, or `None` if
@@ -8574,6 +8609,11 @@ fn scan_to_bindings(
 }
 
 fn merge_join(left: Bindings, right: Bindings, jv: &Variable) -> Bindings {
+    merge_join_ref(&left, &right, jv)
+}
+
+// [GPT-6 Astra] Borrow rows so the capped caller can reuse its RHS without cloning it.
+fn merge_join_ref(left: &Bindings, right: &Bindings, jv: &Variable) -> Bindings {
     let lk = left.col(jv).unwrap();
     let rk = right.col(jv).unwrap();
     let mut out_vars = left.vars.clone();
@@ -8626,6 +8666,11 @@ use sjoin::{any_unbound, compatible, merge_rows};
 use sjoin::{key_hash, JOIN_PARTS};
 
 fn hash_join(left: Bindings, right: Bindings) -> Bindings {
+    hash_join_ref(&left, &right)
+}
+
+// [GPT-6 Astra] Borrow rows so the capped caller can reuse its RHS without cloning it.
+fn hash_join_ref(left: &Bindings, right: &Bindings) -> Bindings {
     // Build the hash table on the smaller side.
     let (build, probe) = if left.rows.len() <= right.rows.len() {
         (left, right)
@@ -9163,6 +9208,11 @@ mod bind_join_run_grouping {
 }
 
 fn cross_product(left: Bindings, right: Bindings) -> Bindings {
+    cross_product_ref(&left, &right)
+}
+
+// [GPT-6 Astra] Borrow rows so the capped caller can reuse its RHS without cloning it.
+fn cross_product_ref(left: &Bindings, right: &Bindings) -> Bindings {
     let mut out_vars = left.vars.clone();
     out_vars.extend(right.vars.iter().cloned());
     let mut rows = Vec::with_capacity(budget::cap_alloc(left.rows.len().saturating_mul(right.rows.len())));
@@ -21175,6 +21225,196 @@ mod order_bindings_worker_reinstall {
             result.len(),
             n,
             "all {n} rows must survive ORDER BY with custom function on parallel dataset"
+        );
+    }
+}
+
+// [GPT-6 Astra] Actual public-query path and physical RHS-work witness for #3105.
+#[cfg(test)]
+mod capped_rhs_tests {
+    use super::*;
+    use std::cell::Cell;
+
+    thread_local! {
+        static WORK: Cell<[usize; 4]> = const { Cell::new([0; 4]) };
+    }
+
+    pub(super) fn observe(index: usize) {
+        WORK.with(|cell| {
+            let mut counts = cell.get();
+            counts[index] += 1;
+            cell.set(counts);
+        });
+    }
+
+    fn take_work() -> [usize; 4] {
+        WORK.with(|cell| cell.replace([0; 4]))
+    }
+
+    #[test]
+    fn capped_rhs_three_block_miss() {
+        let mut ttl = String::from("@prefix : <http://ex/> .\n");
+        // More than the second block boundary; two shared variables prohibit bind join.
+        for i in 0..70_000 {
+            ttl.push_str(&format!(":s{i} :p {i} ; :q {} .\n", i + 1));
+        }
+        let graph = Graph::load_str(&ttl, "turtle").unwrap();
+        // Arithmetic keeps this filter residual and defeats the count shortcut.
+        let body = "?s :p ?o . ?s :q ?o . FILTER(?o + 0 >= 0)";
+        take_work();
+        assert!(!crate::ask(&graph, &format!("PREFIX : <http://ex/> ASK {{ {body} }}")).unwrap());
+        let ask_work = take_work();
+        assert_eq!(ask_work, [1, 3, 1, 0]);
+        assert!(
+            crate::query(
+                &graph,
+                &format!("PREFIX : <http://ex/> SELECT * WHERE {{ {body} }} LIMIT 1")
+            )
+            .unwrap()
+            .rows
+            .is_empty()
+        );
+        let limit_work = take_work();
+        assert_eq!(limit_work, [1, 3, 1, 0]);
+        println!(
+            "ASK and LIMIT miss: entries/blocks/RHS scans/bind calls = {ask_work:?}, {limit_work:?}"
+        );
+        // The budget permits the old scan. Its presence must disable retention,
+        // independently of whether it actually trips on this query.
+        let generous = crate::QueryBudget {
+            max_rows: Some(100_000),
+            ..Default::default()
+        };
+        assert!(
+            !crate::ask_with_budget(
+                &graph,
+                &format!("PREFIX : <http://ex/> ASK {{ {body} }}"),
+                &generous
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            take_work(),
+            [1, 3, 3, 0],
+            "armed budget must retain original scan behavior"
+        );
+        let row_limited = crate::QueryBudget {
+            max_rows: Some(10),
+            ..Default::default()
+        };
+        // A nonempty intermediate, unlike the all-miss witness, exercises the row ceiling.
+        let expansion =
+            "PREFIX : <http://ex/> ASK { ?s :p ?o . ?s :q ?other . FILTER(?o + 0 >= 0) }";
+        assert!(
+            crate::ask_with_budget(&graph, expansion, &row_limited)
+                .unwrap_err()
+                .contains("max-rows")
+        );
+        take_work();
+        let cancelled = crate::QueryBudget {
+            cancel: Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                true,
+            ))),
+            ..Default::default()
+        };
+        assert!(
+            crate::ask_with_budget(
+                &graph,
+                &format!("PREFIX : <http://ex/> ASK {{ {body} }}"),
+                &cancelled
+            )
+            .unwrap_err()
+            .contains("cancelled")
+        );
+        take_work();
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let expired = crate::QueryBudget {
+                deadline: Some(std::time::Instant::now()),
+                ..Default::default()
+            };
+            assert!(
+                crate::ask_with_budget(
+                    &graph,
+                    &format!("PREFIX : <http://ex/> ASK {{ {body} }}"),
+                    &expired
+                )
+                .is_err()
+            );
+            take_work();
+        }
+    }
+    #[test]
+    fn capped_rhs_keeps_rows_and_actual_order_until_request_changes() {
+        let mut slot = None;
+        let variable = Variable::new("x").unwrap();
+        let first = capped_rhs(&mut slot, Some(0), || Bindings {
+            vars: vec![variable.clone()],
+            rows: vec![Row::from_slice(&[1]), Row::from_slice(&[1])],
+            // Requested and actual order need not agree on restricted permutations.
+            sorted_by: None,
+        });
+        let pointer = first.rows.as_ptr();
+        assert_eq!(first.rows.len(), 2);
+        assert_eq!(first.sorted_by, None);
+        let reused = capped_rhs(&mut slot, Some(0), || panic!("identical scan was repeated"));
+        assert_eq!(
+            reused.rows.as_ptr(),
+            pointer,
+            "reuse must not deep-clone rows"
+        );
+        assert_eq!(
+            reused.rows[0], reused.rows[1],
+            "bag multiplicity is retained"
+        );
+        let changed = capped_rhs(&mut slot, Some(2), || Bindings {
+            vars: vec![variable.clone()],
+            rows: vec![Row::from_slice(&[2])],
+            sorted_by: Some(variable.clone()),
+        });
+        assert_eq!(changed.rows, vec![Row::from_slice(&[2])]);
+        assert_eq!(changed.sorted_by, Some(variable));
+    }
+
+    #[test]
+    fn capped_rhs_public_bags_repeated_variables_and_first_block_hit() {
+        let graph = Graph::load_str(
+            "@prefix : <http://ex/> . :a :p 1, 2 ; :q 1, 2 . :b :p :b ; :q :b . :c :p :b .",
+            "turtle",
+        )
+        .unwrap();
+        let body = "?s :p ?o . ?s :q ?o . FILTER(?o + 0 >= 0)";
+        let full = crate::query(
+            &graph,
+            &format!("PREFIX : <http://ex/> SELECT ?s WHERE {{ {body} }}"),
+        )
+        .unwrap();
+        take_work();
+        let limited = crate::query(
+            &graph,
+            &format!("PREFIX : <http://ex/> SELECT ?s WHERE {{ {body} }} LIMIT 10"),
+        )
+        .unwrap();
+        assert_eq!(take_work(), [1, 1, 1, 0]);
+        assert_eq!(limited.rows, full.rows);
+        assert_eq!(limited.rows.len(), 2);
+        assert_eq!(
+            limited.rows[0], limited.rows[1],
+            "projection preserves multiplicity"
+        );
+        take_work();
+        assert!(crate::ask(&graph, &format!("PREFIX : <http://ex/> ASK {{ {body} }}")).unwrap());
+        assert_eq!(take_work(), [1, 1, 1, 0]);
+        let repeated = "?s :p ?s . ?s :q ?o . FILTER(?s != <http://ex/missing>)";
+        let result = crate::query(
+            &graph,
+            &format!("PREFIX : <http://ex/> SELECT ?s WHERE {{ {repeated} }} LIMIT 10"),
+        )
+        .unwrap();
+        assert_eq!(
+            result.rows.len(),
+            1,
+            "off-diagonal repeated-variable rows must not survive"
         );
     }
 }

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -4244,6 +4244,8 @@ fn eval_bgp_binary_capped(
                 let pp = prepared[i].var_pos(jv).unwrap();
                 #[cfg(test)]
                 capped_rhs_tests::observe(3);
+                #[cfg(test)]
+                capped_rhs_tests::step(start, i, "bind", None, false, None);
                 result = bind_join(graph, result, &prepared[i].id_pat, &prepared[i].pos_vars, rk, pp, pfilter(i));
             } else {
                 let filt = pfilter(i);
@@ -4251,9 +4253,14 @@ fn eval_bgp_binary_capped(
                 let scan_sort = filt.map(|(c, _)| c).or_else(|| merge_var.as_ref().map(|jv| prepared[i].var_pos(jv).unwrap()));
                 let mut uncached = None;
                 let slot = if reuse_rhs { &mut rhs_cache[i] } else { &mut uncached };
+                #[cfg(test)]
+                let mut scanned = false;
                 let rhs = capped_rhs(slot, scan_sort, || {
                     #[cfg(test)]
-                    capped_rhs_tests::observe(2);
+                    {
+                        capped_rhs_tests::observe(2);
+                        scanned = true;
+                    }
                     scan_to_bindings(
                         graph,
                         &prepared[i].id_pat,
@@ -4267,10 +4274,16 @@ fn eval_bgp_binary_capped(
                 });
                 let connected = prepared[i].pos_vars.iter().flatten().any(|v| result.vars.contains(v));
                 if let Some(jv) = merge_var.filter(|jv| rhs.sorted_by.as_ref() == Some(jv)) {
+                    #[cfg(test)]
+                    capped_rhs_tests::step(start, i, "merge", scan_sort, scanned, rhs.sorted_by.as_ref());
                     result = merge_join_ref(&result, rhs, &jv);
                 } else if connected {
+                    #[cfg(test)]
+                    capped_rhs_tests::step(start, i, "hash", scan_sort, scanned, rhs.sorted_by.as_ref());
                     result = hash_join_ref(&result, rhs);
                 } else {
+                    #[cfg(test)]
+                    capped_rhs_tests::step(start, i, "cross", scan_sort, scanned, rhs.sorted_by.as_ref());
                     result = cross_product_ref(&result, rhs);
                 }
             }
@@ -4325,6 +4338,9 @@ fn capped_rhs(
         .as_ref()
         .is_none_or(|(cached_sort, _)| *cached_sort != sort)
     {
+        // [GPT-6 Astra] Release the stale relation before materializing its replacement.
+        // No subsequent step can borrow the old requested order from this slot.
+        *slot = None;
         *slot = Some((sort, scan()));
     }
     &slot.as_ref().unwrap().1
@@ -21233,12 +21249,254 @@ mod order_bindings_worker_reinstall {
 #[cfg(test)]
 mod capped_rhs_tests {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
 
     thread_local! {
         static WORK: Cell<[usize; 4]> = const { Cell::new([0; 4]) };
+        static STEPS: RefCell<Option<Vec<Step>>> = const { RefCell::new(None) };
     }
 
+    // [GPT-6 Astra] Observe the actual branch, scan closure and returned metadata.
+    #[derive(Debug, PartialEq, Eq)]
+    struct Step {
+        start: usize,
+        pattern: usize,
+        kernel: &'static str,
+        requested: Option<usize>,
+        scanned: bool,
+        actual: Option<String>,
+    }
+
+    pub(super) fn step(
+        start: usize,
+        pattern: usize,
+        kernel: &'static str,
+        requested: Option<usize>,
+        scanned: bool,
+        actual: Option<&Variable>,
+    ) {
+        STEPS.with_borrow_mut(|steps| {
+            if let Some(steps) = steps {
+                steps.push(Step {
+                    start,
+                    pattern,
+                    kernel,
+                    requested,
+                    scanned,
+                    actual: actual.map(|v| v.as_str().to_owned()),
+                });
+            }
+        });
+    }
+
+    fn trace<T>(f: impl FnOnce() -> T) -> (T, Vec<Step>) {
+        STEPS.with_borrow_mut(|steps| *steps = Some(Vec::new()));
+        let result = f();
+        let steps = STEPS.with_borrow_mut(|steps| steps.take().unwrap());
+        (result, steps)
+    }
+
+    fn bag(result: &crate::QueryResult) -> std::collections::BTreeMap<Vec<String>, usize> {
+        let mut bag = std::collections::BTreeMap::new();
+        for row in &result.rows {
+            *bag.entry(
+                row.iter()
+                    .map(|v| v.as_ref().unwrap().to_string())
+                    .collect(),
+            )
+            .or_default() += 1;
+        }
+        bag
+    }
+
+    #[test]
+    fn capped_rhs_changing_sort_mixed_kernels_preserves_full_bag() {
+        let mut ttl = String::from("@prefix : <http://ex/> .\n");
+        for i in 0..70_000 {
+            // Projection deliberately collapses pairs, making multiplicity observable.
+            ttl.push_str(&format!(":s{i} :p {} ; :q {i} ; :r {i} .\n", i / 2));
+        }
+        ttl.push_str(":extra1 :q 70001 ; :r 70001 . :extra2 :r 70002 .");
+        let graph = Graph::load_str(&ttl, "turtle").unwrap();
+        let query = "PREFIX : <http://ex/> SELECT ?o WHERE { ?s :p ?o . ?s :q ?x . ?s :r ?x . FILTER(?o + 0 >= 0) }";
+        let full = crate::query(&graph, query).unwrap();
+        let (limited, steps) =
+            trace(|| crate::query(&graph, &format!("{query} LIMIT 70001")).unwrap());
+        println!("changing-sort actual steps: {steps:?}");
+        assert_eq!(limited.rows.len(), 70_000);
+        assert_eq!(bag(&limited), bag(&full));
+        let expected: std::collections::BTreeMap<_, _> = (0..35_000)
+            .map(|i| (vec![oxrdf::Literal::from(i).to_string()], 2))
+            .collect();
+        assert_eq!(bag(&limited), expected);
+        let q: Vec<_> = steps
+            .iter()
+            .filter(|s| s.pattern == 1)
+            .map(|s| {
+                (
+                    s.start,
+                    s.kernel,
+                    s.requested,
+                    s.scanned,
+                    s.actual.as_deref(),
+                )
+            })
+            .collect();
+        let r: Vec<_> = steps
+            .iter()
+            .filter(|s| s.pattern == 2)
+            .map(|s| (s.start, s.requested, s.scanned, s.actual.as_deref()))
+            .collect();
+        if sparq_core::store::BUILT.contains(&sparq_core::store::Perm::Pso) {
+            assert_eq!(
+                q,
+                [
+                    (0, "bind", None, false, None),
+                    (1024, "merge", Some(0), true, Some("s")),
+                    (65536, "bind", None, false, None)
+                ]
+            );
+            assert_eq!(
+                r,
+                [
+                    (0, None, true, Some("s")),
+                    (1024, Some(0), true, Some("s")),
+                    (65536, None, true, Some("s"))
+                ]
+            );
+        } else {
+            // Three permutations return object order: no false subject-order claim,
+            // and the unchanged None request must reuse the actually unsorted-for-s RHS.
+            assert_eq!(
+                q,
+                [
+                    (0, "bind", None, false, None),
+                    (1024, "hash", None, true, Some("x")),
+                    (65536, "bind", None, false, None)
+                ]
+            );
+            assert_eq!(
+                r,
+                [
+                    (0, None, true, Some("x")),
+                    (1024, None, false, Some("x")),
+                    (65536, None, false, Some("x"))
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn capped_rhs_replacement_releases_old_slot_before_scan() {
+        let mut slot = Some((
+            None,
+            Bindings::unsorted(
+                vec![Variable::new("x").unwrap()],
+                vec![Row::from_slice(&[1])],
+            ),
+        ));
+        // A failed replacement leaves the actual slot empty only if old ownership
+        // was released before invoking the scan. This is not a timing/heap estimate.
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            capped_rhs(&mut slot, Some(0), || panic!("replacement scan sentinel"));
+        }));
+        assert!(failed.is_err());
+        assert!(
+            slot.is_none(),
+            "old RHS remained live through replacement scan"
+        );
+        let replacement = capped_rhs(&mut slot, Some(0), || {
+            Bindings::unsorted(
+                vec![Variable::new("x").unwrap()],
+                vec![Row::from_slice(&[2])],
+            )
+        });
+        assert_eq!(replacement.rows, [Row::from_slice(&[2])]);
+    }
+
+    #[test]
+    fn capped_rhs_disconnected_cross_preserves_multiplicity() {
+        let graph = Graph::load_str(
+            "@prefix : <http://ex/> . :a :p 1 . :b :p 2 . :c :q 3, 4, 5 .",
+            "turtle",
+        )
+        .unwrap();
+        let query =
+            "PREFIX : <http://ex/> SELECT ?s WHERE { ?s :p ?o . ?t :q ?x . FILTER(?o + 0 >= 0) }";
+        let (limited, steps) = trace(|| crate::query(&graph, &format!("{query} LIMIT 7")).unwrap());
+        assert_eq!(bag(&limited), bag(&crate::query(&graph, query).unwrap()));
+        assert_eq!(limited.rows.len(), 6);
+        assert_eq!(bag(&limited).values().copied().collect::<Vec<_>>(), [3, 3]);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].kernel, "cross");
+        assert!(steps[0].scanned);
+        println!("disconnected actual steps: {steps:?}");
+    }
+
+    #[test]
+    fn capped_rhs_named_view_overlay_and_residual_exists() {
+        let mut graph = Graph::load_dataset("@prefix : <http://ex/> . :g { :a :p 1, 2 ; :q 1, 2 ; :visible true . :b :p 3 ; :q 3 . }", "trig").unwrap();
+        let query = "PREFIX : <http://ex/> SELECT ?s WHERE { GRAPH :g { SELECT ?s WHERE { ?s :p ?o . ?s :q ?o . FILTER(?o + 0 >= 0 && EXISTS { ?s :visible true }) } LIMIT 10 } }";
+        let (base, steps) = trace(|| crate::query(&graph, query).unwrap());
+        assert_eq!(base.rows.len(), 2);
+        assert_eq!(base.rows[0], base.rows[1]);
+        // EXISTS is deliberately non-conjunctive: prove the existing fallback remains.
+        assert!(
+            steps.is_empty(),
+            "EXISTS must retain the scope-safe fallback"
+        );
+        let eligible = query.replace(" && EXISTS { ?s :visible true }", "");
+        let (eligible_base, eligible_steps) = trace(|| crate::query(&graph, &eligible).unwrap());
+        assert_eq!(eligible_base.rows.len(), 3);
+        assert!(
+            eligible_steps.iter().any(|s| s.scanned),
+            "named subquery must reach capped RHS: {eligible_steps:?}"
+        );
+        let visible = crate::DatasetView {
+            base: &graph,
+            named: std::sync::Arc::new([graph.named[0].0.clone()].into_iter().collect()),
+            default: crate::DefaultGraphMode::Empty,
+        };
+        assert_eq!(
+            bag(&crate::query_view(&visible, query).unwrap()),
+            bag(&base)
+        );
+        let (visible_rows, visible_steps) =
+            trace(|| crate::query_view(&visible, &eligible).unwrap());
+        assert_eq!(bag(&visible_rows), bag(&eligible_base));
+        assert!(visible_steps.iter().any(|s| s.scanned));
+        let hidden = crate::DatasetView {
+            base: &graph,
+            named: std::sync::Arc::new(Default::default()),
+            default: crate::DefaultGraphMode::StoreDefault,
+        };
+        assert!(crate::query_view(&hidden, query).unwrap().rows.is_empty());
+        let (hidden_rows, hidden_steps) = trace(|| crate::query_view(&hidden, &eligible).unwrap());
+        assert!(hidden_rows.rows.is_empty());
+        assert!(
+            hidden_steps.is_empty(),
+            "hidden graph must not enter RHS cache"
+        );
+        let mut fork = graph.named[0].1.fork();
+        fork.apply_delta(
+            &[],
+            &[[
+                oxrdf::NamedNode::new("http://ex/a").unwrap().into(),
+                oxrdf::NamedNode::new("http://ex/q").unwrap().into(),
+                oxrdf::Literal::from(2).into(),
+            ]],
+        )
+        .unwrap();
+        graph.named[0].1 = fork;
+        let (changed, changed_steps) = trace(|| crate::query(&graph, query).unwrap());
+        assert_eq!(changed.rows.len(), 1);
+        assert_eq!(changed.rows[0], base.rows[0]);
+        assert!(changed_steps.is_empty(), "overlay EXISTS retains fallback");
+        let (eligible_overlay, overlay_steps) = trace(|| crate::query(&graph, &eligible).unwrap());
+        assert_eq!(eligible_overlay.rows.len(), 2);
+        assert!(overlay_steps.iter().any(|s| s.scanned));
+        println!("named EXISTS fallback: {steps:?}, {changed_steps:?}; eligible base/overlay: {eligible_steps:?}, {overlay_steps:?}");
+    }
     pub(super) fn observe(index: usize) {
         WORK.with(|cell| {
             let mut counts = cell.get();

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -4129,7 +4129,8 @@ const CAPPED_SEED_BLOCK: usize = 1024;
 /// Second-tier block: one escalation before the remainder is processed whole, so a
 /// first-block miss still avoids the full chain when a solution lives within the
 /// first ~64k seed rows. Exactly two escalations bound a NO-solution query to
-/// three blocks; identical non-bind RHS scans are reused when no budget is armed.
+/// three blocks; identical non-bind RHS scans may be reused within a private storage
+/// allowance when no budget is armed.
 const CAPPED_SEED_BLOCK_2: usize = 65_536;
 
 /// Capped conjunctive (BGP + FILTER) evaluation — the ASK / LIMIT-k first-solutions
@@ -4198,8 +4199,7 @@ fn eval_bgp_binary_capped(
     // Armed budgets retain the old per-step lifetime and polling: their working-set
     // estimate does not account for multiple retained RHS relations.
     let reuse_rhs = !budget::active();
-    let mut rhs_cache: Vec<Option<(Option<usize>, Bindings)>> =
-        std::iter::repeat_with(|| None).take(if reuse_rhs { prepared.len() } else { 0 }).collect();
+    let (mut rhs_cache, mut rhs_remaining) = capped_rhs_cache(prepared.len(), reuse_rhs);
     let mut acc: Option<Bindings> = None;
     let mut start = 0usize;
     while start < seed_all.rows.len() {
@@ -4252,10 +4252,11 @@ fn eval_bgp_binary_capped(
                 let merge_var = result.sorted_by.clone().filter(|sv| prepared[i].var_pos(sv).is_some());
                 let scan_sort = filt.map(|(c, _)| c).or_else(|| merge_var.as_ref().map(|jv| prepared[i].var_pos(jv).unwrap()));
                 let mut uncached = None;
-                let slot = if reuse_rhs { &mut rhs_cache[i] } else { &mut uncached };
+                let mut spare_slot = None;
+                let slot = rhs_cache.get_mut(i).unwrap_or(&mut spare_slot);
                 #[cfg(test)]
                 let mut scanned = false;
-                let rhs = capped_rhs(slot, scan_sort, || {
+                let rhs = capped_rhs(slot, &mut rhs_remaining, &mut uncached, scan_sort, || {
                     #[cfg(test)]
                     {
                         capped_rhs_tests::observe(2);
@@ -4327,21 +4328,91 @@ fn eval_bgp_binary_capped(
     Ok(Some(acc.unwrap_or_else(|| Bindings::unsorted(collect_vars(patterns), vec![]))))
 }
 
-// [GPT-6 Astra] Reuse only the same requested order of one immutable prepared pattern.
-// Retain the actual sorted_by metadata returned by the scan, including fallback orders.
-fn capped_rhs(
-    slot: &mut Option<(Option<usize>, Bindings)>,
+// [GPT-6 Astra] Conservative private allowance for retained scan storage, not a
+// public QueryBudget or a limit on transient join/scan allocations. Keep room below
+// the diagnostic's extra-heap rejection threshold; do not retain one RHS per pattern.
+const CAPPED_RHS_STORAGE: usize = 4 * 1024 * 1024;
+// Requested order, immutable scan relation, and its charged allocated storage.
+type CappedRhs = (Option<usize>, Bindings, usize);
+
+fn capped_rhs_cache(len: usize, enabled: bool) -> (Vec<Option<CappedRhs>>, usize) {
+    let mut slots = Vec::new();
+    if !enabled
+        || len
+            .checked_mul(std::mem::size_of::<Option<CappedRhs>>())
+            .is_none_or(|bytes| bytes > CAPPED_RHS_STORAGE)
+        || slots.try_reserve_exact(len).is_err()
+    {
+        return (slots, 0);
+    }
+    let Some(bytes) = slots
+        .capacity()
+        .checked_mul(std::mem::size_of::<Option<CappedRhs>>())
+        .filter(|&bytes| bytes <= CAPPED_RHS_STORAGE)
+    else {
+        return (Vec::new(), 0);
+    };
+    slots.resize_with(len, || None);
+    (slots, CAPPED_RHS_STORAGE - bytes)
+}
+
+// [GPT-6 Astra] Count capacities, not planner estimates or populated lengths.
+// Scan rows have at most three ids and fit inline; decline an unproved spilled
+// representation. Variable owns a String, whose capacity is exposed by its safe
+// consuming API; move it out and back without cloning or allocating its text.
+fn capped_rhs_storage(rhs: &mut Bindings, allowance: usize) -> Option<usize> {
+    let mut bytes = rhs
+        .rows
+        .capacity()
+        .checked_mul(std::mem::size_of::<Row>())?
+        .checked_add(
+            rhs.vars
+                .capacity()
+                .checked_mul(std::mem::size_of::<Variable>())?,
+        )?;
+    if bytes > allowance || rhs.rows.iter().any(Row::spilled) {
+        return None;
+    }
+    for variable in rhs.vars.iter_mut().chain(rhs.sorted_by.iter_mut()) {
+        let name =
+            std::mem::replace(variable, Variable::new_unchecked(String::new())).into_string();
+        let capacity = name.capacity();
+        *variable = Variable::new_unchecked(name);
+        bytes = bytes.checked_add(capacity)?;
+        if bytes > allowance {
+            return None;
+        }
+    }
+    Some(bytes)
+}
+
+// [GPT-6 Astra] Reuse requires a pure scan of the same immutable prepared pattern,
+// filters and requested order. Actual sorted_by remains the scan's truthful value.
+// Fitting entries live until order replacement/query exit; non-fitting entries live
+// only in the caller's per-step scratch. Allocator metadata is outside this allowance.
+fn capped_rhs<'a>(
+    slot: &'a mut Option<CappedRhs>,
+    remaining: &mut usize,
+    uncached: &'a mut Option<Bindings>,
     sort: Option<usize>,
     scan: impl FnOnce() -> Bindings,
-) -> &Bindings {
+) -> &'a Bindings {
     if slot
         .as_ref()
-        .is_none_or(|(cached_sort, _)| *cached_sort != sort)
+        .is_none_or(|(cached_sort, _, _)| *cached_sort != sort)
     {
-        // [GPT-6 Astra] Release the stale relation before materializing its replacement.
-        // No subsequent step can borrow the old requested order from this slot.
-        *slot = None;
-        *slot = Some((sort, scan()));
+        if let Some(old) = slot.take() {
+            *remaining += old.2;
+            drop(old); // release stale ownership/accounting before its replacement scan
+        }
+        let mut rhs = scan();
+        if let Some(bytes) = capped_rhs_storage(&mut rhs, *remaining) {
+            *remaining -= bytes;
+            *slot = Some((sort, rhs, bytes));
+        } else {
+            *uncached = Some(rhs);
+            return uncached.as_ref().unwrap();
+        }
     }
     &slot.as_ref().unwrap().1
 }
@@ -21388,24 +21459,31 @@ mod capped_rhs_tests {
 
     #[test]
     fn capped_rhs_replacement_releases_old_slot_before_scan() {
-        let mut slot = Some((
-            None,
-            Bindings::unsorted(
-                vec![Variable::new("x").unwrap()],
-                vec![Row::from_slice(&[1])],
-            ),
-        ));
+        let mut initial = Bindings::unsorted(
+            vec![Variable::new("x").unwrap()],
+            vec![Row::from_slice(&[1])],
+        );
+        let bytes = capped_rhs_storage(&mut initial, CAPPED_RHS_STORAGE).unwrap();
+        let mut slot = Some((None, initial, bytes));
+        let mut remaining = CAPPED_RHS_STORAGE - bytes;
+        let mut uncached = None;
         // A failed replacement leaves the actual slot empty only if old ownership
         // was released before invoking the scan. This is not a timing/heap estimate.
         let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            capped_rhs(&mut slot, Some(0), || panic!("replacement scan sentinel"));
+            capped_rhs(&mut slot, &mut remaining, &mut uncached, Some(0), || {
+                panic!("replacement scan sentinel")
+            });
         }));
         assert!(failed.is_err());
+        assert_eq!(
+            remaining, CAPPED_RHS_STORAGE,
+            "stale charge must be refunded before scan"
+        );
         assert!(
             slot.is_none(),
             "old RHS remained live through replacement scan"
         );
-        let replacement = capped_rhs(&mut slot, Some(0), || {
+        let replacement = capped_rhs(&mut slot, &mut remaining, &mut uncached, Some(0), || {
             Bindings::unsorted(
                 vec![Variable::new("x").unwrap()],
                 vec![Row::from_slice(&[2])],
@@ -21497,6 +21575,144 @@ mod capped_rhs_tests {
         assert!(overlay_steps.iter().any(|s| s.scanned));
         println!("named EXISTS fallback: {steps:?}, {changed_steps:?}; eligible base/overlay: {eligible_steps:?}, {overlay_steps:?}");
     }
+
+    // [GPT-6 Astra] Capacity accounting must include spare buffers and variable text.
+    #[test]
+    fn capped_rhs_storage_counts_allocated_capacity() {
+        let mut name = String::with_capacity(4096);
+        name.push('x');
+        let mut order = String::with_capacity(2048);
+        order.push('x');
+        let mut vars = Vec::with_capacity(8);
+        let text_bytes = name.capacity() + order.capacity();
+        vars.push(Variable::new(name).unwrap());
+        let mut rows = Vec::with_capacity(32);
+        rows.push(Row::from_slice(&[1]));
+        let expected = rows.capacity() * std::mem::size_of::<Row>()
+            + vars.capacity() * std::mem::size_of::<Variable>()
+            + text_bytes;
+        let mut rhs = Bindings {
+            vars,
+            rows,
+            sorted_by: Some(Variable::new(order).unwrap()),
+        };
+        assert_eq!(capped_rhs_storage(&mut rhs, expected), Some(expected));
+        assert_eq!(capped_rhs_storage(&mut rhs, expected - 1), None);
+        assert_eq!(rhs.vars[0].as_str(), "x");
+        assert_eq!(rhs.sorted_by.as_ref().unwrap().as_str(), "x");
+        assert_eq!(rhs.rows, [Row::from_slice(&[1])]);
+        assert_eq!(
+            capped_rhs_storage(&mut rhs, expected),
+            Some(expected),
+            "rejected accounting must preserve all capacities"
+        );
+        let (slots, remaining) = capped_rhs_cache(3, true);
+        assert_eq!(
+            remaining + slots.capacity() * std::mem::size_of::<Option<CappedRhs>>(),
+            CAPPED_RHS_STORAGE
+        );
+        let too_many = CAPPED_RHS_STORAGE / std::mem::size_of::<Option<CappedRhs>>() + 1;
+        for (len, enabled) in [(too_many, true), (usize::MAX, true), (3, false)] {
+            let (slots, remaining) = capped_rhs_cache(len, enabled);
+            assert_eq!((slots.len(), slots.capacity(), remaining), (0, 0, 0));
+        }
+    }
+
+    #[test]
+    fn capped_rhs_exact_fit_and_nonfitting_lifetime() {
+        let make = || {
+            Bindings::unsorted(
+                vec![Variable::new("x").unwrap()],
+                vec![Row::from_slice(&[1])],
+            )
+        };
+        let bytes = capped_rhs_storage(&mut make(), CAPPED_RHS_STORAGE).unwrap();
+        let mut slot = None;
+        let mut uncached = None;
+        let mut remaining = bytes;
+        let ptr = capped_rhs(&mut slot, &mut remaining, &mut uncached, None, make)
+            .rows
+            .as_ptr();
+        assert_eq!(remaining, 0);
+        assert!(uncached.is_none());
+        assert_eq!(
+            capped_rhs(&mut slot, &mut remaining, &mut uncached, None, || panic!(
+                "fit was rescanned"
+            ))
+            .rows
+            .as_ptr(),
+            ptr
+        );
+        drop(slot.take());
+        remaining = bytes - 1;
+        for _ in 0..2 {
+            let rhs = capped_rhs(&mut slot, &mut remaining, &mut uncached, None, make);
+            assert_eq!(rhs.rows, [Row::from_slice(&[1])]);
+            assert!(slot.is_none(), "non-fitting scan must not survive its step");
+            assert_eq!(remaining, bytes - 1);
+            drop(uncached.take());
+        }
+        let mut oversized = Bindings::unsorted(
+            vec![],
+            Vec::with_capacity(CAPPED_RHS_STORAGE / std::mem::size_of::<Row>() + 1),
+        );
+        assert_eq!(capped_rhs_storage(&mut oversized, CAPPED_RHS_STORAGE), None);
+        let mut spilled = Row::with_capacity(16);
+        spilled.push(1);
+        assert!(spilled.spilled());
+        let mut rhs = Bindings::unsorted(vec![Variable::new("x").unwrap()], vec![spilled]);
+        assert_eq!(capped_rhs_storage(&mut rhs, CAPPED_RHS_STORAGE), None);
+        assert_eq!(rhs.rows[0].as_slice(), [1]);
+    }
+
+    #[test]
+    fn capped_rhs_many_relations_respect_storage_allowance() {
+        for n in [5usize, 8] {
+            let mut ttl = String::new();
+            for i in 0..70_000 {
+                for j in 0..n {
+                    ttl.push_str(&format!("<urn:s:{i}> <urn:p{j}> {i} .\n"));
+                }
+            }
+            for i in 0..8192 {
+                ttl.push_str(&format!("<urn:d:{i}> <urn:dead> <urn:o> .\n"));
+            }
+            let graph = Graph::load_str(&ttl, "turtle").unwrap();
+            let patterns: String = (0..n).map(|j| format!("?s <urn:p{j}> ?o . ")).collect();
+            let positive =
+                crate::query(&graph, &format!("SELECT ?s ?o WHERE {{ {patterns} }}")).unwrap();
+            assert_eq!(positive.rows.len(), 70_000);
+            for row in &positive.rows {
+                let o = row[1].as_ref().unwrap().to_string();
+                let i = o.split('"').nth(1).unwrap().parse::<usize>().unwrap();
+                assert!(i < 70_000);
+                assert_eq!(row[0].as_ref().unwrap().to_string(), format!("<urn:s:{i}>"));
+            }
+            take_work();
+            let (answer, steps) = trace(|| {
+                crate::ask(&graph, &format!("ASK {{ {patterns} FILTER(?o + 0 < 0) }}")).unwrap()
+            });
+            assert!(!answer);
+            let work = take_work();
+            assert_eq!((work[0], work[1], work[3]), (1, 3, 0));
+            assert!(
+                work[2] > n - 1,
+                "non-fitting RHS must be rescanned, not retained without a bound: {work:?}"
+            );
+            assert!(work[2] < 3 * (n - 1), "fitting RHS must still be reused");
+            assert_eq!(steps.len(), 3 * (n - 1));
+            for start in [0usize, 1024, 65536] {
+                let reached: Vec<_> = steps.iter().filter(|s| s.start == start).collect();
+                assert_eq!(reached.len(), n - 1);
+                assert!(reached.iter().all(|s| s.kernel != "bind"));
+                let ids: std::collections::BTreeSet<_> =
+                    reached.iter().map(|s| s.pattern).collect();
+                assert_eq!(ids.len(), n - 1);
+            }
+            println!("patterns={n} work={work:?} steps={steps:?}");
+        }
+    }
+
     pub(super) fn observe(index: usize) {
         WORK.with(|cell| {
             let mut counts = cell.get();
@@ -21556,6 +21772,26 @@ mod capped_rhs_tests {
             [1, 3, 3, 0],
             "armed budget must retain original scan behavior"
         );
+        // [GPT-6 Astra] Armed but untripped cancellation/deadline must still disable reuse.
+        let live_budgets = [
+            crate::QueryBudget {
+                cancel: Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false))),
+                ..Default::default()
+            },
+            #[cfg(not(target_arch = "wasm32"))]
+            crate::QueryBudget {
+                deadline: Some(std::time::Instant::now() + std::time::Duration::from_secs(300)),
+                ..Default::default()
+            },
+        ];
+        for live in live_budgets {
+            assert!(!crate::ask_with_budget(
+                &graph,
+                &format!("PREFIX : <http://ex/> ASK {{ {body} }}"),
+                &live
+            ).unwrap());
+            assert_eq!(take_work(), [1, 3, 3, 0], "armed but untripped budget must not retain RHS");
+        }
         let row_limited = crate::QueryBudget {
             max_rows: Some(10),
             ..Default::default()
@@ -21605,17 +21841,23 @@ mod capped_rhs_tests {
     #[test]
     fn capped_rhs_keeps_rows_and_actual_order_until_request_changes() {
         let mut slot = None;
+        let mut remaining = CAPPED_RHS_STORAGE;
+        let mut uncached = None;
         let variable = Variable::new("x").unwrap();
-        let first = capped_rhs(&mut slot, Some(0), || Bindings {
-            vars: vec![variable.clone()],
-            rows: vec![Row::from_slice(&[1]), Row::from_slice(&[1])],
-            // Requested and actual order need not agree on restricted permutations.
-            sorted_by: None,
+        let first = capped_rhs(&mut slot, &mut remaining, &mut uncached, Some(0), || {
+            Bindings {
+                vars: vec![variable.clone()],
+                rows: vec![Row::from_slice(&[1]), Row::from_slice(&[1])],
+                // Requested and actual order need not agree on restricted permutations.
+                sorted_by: None,
+            }
         });
         let pointer = first.rows.as_ptr();
         assert_eq!(first.rows.len(), 2);
         assert_eq!(first.sorted_by, None);
-        let reused = capped_rhs(&mut slot, Some(0), || panic!("identical scan was repeated"));
+        let reused = capped_rhs(&mut slot, &mut remaining, &mut uncached, Some(0), || {
+            panic!("identical scan was repeated")
+        });
         assert_eq!(
             reused.rows.as_ptr(),
             pointer,
@@ -21625,10 +21867,12 @@ mod capped_rhs_tests {
             reused.rows[0], reused.rows[1],
             "bag multiplicity is retained"
         );
-        let changed = capped_rhs(&mut slot, Some(2), || Bindings {
-            vars: vec![variable.clone()],
-            rows: vec![Row::from_slice(&[2])],
-            sorted_by: Some(variable.clone()),
+        let changed = capped_rhs(&mut slot, &mut remaining, &mut uncached, Some(2), || {
+            Bindings {
+                vars: vec![variable.clone()],
+                rows: vec![Row::from_slice(&[2])],
+                sorted_by: Some(variable.clone()),
+            }
         });
         assert_eq!(changed.rows, vec![Row::from_slice(&[2])]);
         assert_eq!(changed.sorted_by, Some(variable));


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the sparq-org/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

## Summary

Reuse reached non-bind RHS scans across capped seed blocks when the prepared pattern and requested sort are unchanged. A private 4 MiB allowance per capped BGP invocation bounds retained cache storage, including indexed slots, row/variable buffers and owned variable-name capacities. Scans that do not fit retain their original per-step lifetime. Stale entries are released and refunded before replacement scans; actual sort metadata stays unchanged.

This reduces repeated scan work for ASK and LIMIT queries that continue into later blocks. Armed resource budgets keep the original scan lifetime, and an armed ZK recorder keeps the existing uncapped execution path. Per-block planning, bind decisions and hash-table builds remain unchanged. No public API, dependency or storage-format changes.

Refs #3105 (`sq-7d3dj.30.18`). Planner and hash-build reuse remain open.

## Validation and review

Implementation: actual GPT-6 Astra, extra-high reasoning. Independent review of the bounded correction by actual Claude Opus 5, extra-high reasoning: **approved for CI validation** at `ed66ef0931fa19dd521fac433870c86a78687a30`; the unbounded-retention finding is resolved. The current-head authoritative CI gate is green: [ci-summary / gate](https://github.com/sparq-org/sparq/actions/runs/34431706773/job/102728401318). Protected merge-queue validation remains ahead. Copilot’s additional uncached-RHS lifetime concern was checked against the source: the scratch owner is inside the non-bind branch and drops before `record_pattern_ndv`; no code change is needed.

At `ed66ef0931fa19dd521fac433870c86a78687a30`, ten focused tests pass in each of the default, core compact-index and semijoin-bitmap configurations; engine library/test clippy passes. Tests cover full result bags, join paths, requested/actual sort, named views, overlays, allocation capacities, exact-fit/oversized entries, spilled rows, stale refunds, metadata overflow and armed-but-untripped cancellation/deadline budgets. Three compiled controls fail their intended runtime assertions for excessive retention, length-based undercounting and missing refunds.

All 24 allocation samples and 40 System-allocator timing samples pass their declared local screens. These are advisory measurements on one macOS arm64 host. Full-miss timing improves while first-hit timing has a small cost; this is not a universal latency or memory-neutrality claim. The larger-pattern cases retain some additional memory within the cache allowance. System-allocator timing of the same five/eight-pattern allocation fixtures also improves. I accept this bounded memory-for-latency tradeoff based on the measured cases; broader workloads remain covered by the repository gates.

The allowance bounds requested retained storage per capped BGP invocation, not total query heap, transient scan/join allocations, allocator metadata or process RSS. Aggregate cache storage scales with concurrent or nested invocations. Local preflight still encounters Bash 3's missing `mapfile` in the existing privacy-check script; The authoritative Linux CI run has now completed successfully.

`bench/feature-off-declarations/6477.json` declares intentional changes to always-compiled engine code under the documented V2 process. It does not claim byte neutrality. The separate wasm size ratchet and all other floors remain unchanged.

## Base gate

- [x] Authoritative workspace build and full workspace clippy on the current head.
- [x] Touched code matches surrounding formatting; no workspace reformat.
- [x] Affected-crate tests from current-head CI, in addition to scoped local tests.

## Targeted re-evaluation

- [x] Query execution: conformance ratchet, operator coverage and builtin error cases.
- [x] Wasm builds/tests, dependency guard and bundle-size gate.
- [x] Coverage ratchet and test-presence gate.
- [x] Bounded retention and larger-pattern allocation checks; local timing tradeoff assessed.

## Ratchets and conventions

- [x] No conformance, performance or coverage ratchet lowered.
- [x] No hard-coded benchmark results added to repository Markdown.
- [x] Remaining planner/hash-build work stays tracked in #3105.
