### PR TITLE
fix(release): bind recovery publications to immutable tags

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -118,6 +118,8 @@ jobs:
           - { tier: win-arm64,        os: windows-latest,   target: aarch64-pc-windows-msvc,   cpu: "",          ext: ".exe" }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - name: Install Rust + target
         shell: bash
         run: |

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -669,6 +669,7 @@ jobs:
           python3 scripts/release_pr_guard.py --self-test
           python3 scripts/release-interval-guard.py --self-test
           python3 scripts/tests/test_release_publish_guard.py
+          python3 scripts/tests/test_release_source.py
       # [OPUS-4.8] sq-ur7o: every SHA-pinned `taiki-e/install-action` step MUST carry an
       # explicit `with: tool:`. install-action picks the tool from its @<tool> git ref; the
       # code-scanning=0 SHA-pin policy DROPS that selector, so without `with: tool:` the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@
 # separately gated by explicit boolean inputs; a tag alone never force-publishes. A Release
 # published directly by a maintainer remains an explicit authorization for the primary npm and
 # PyPI jobs, while the optional npm packages still require their dispatch inputs.
+# [GPT-6] Dispatch at the immutable release tag, never a branch. setup verifies the
+# tag/checkout identity and the versions of every selected registry package first.
 name: publish
 
 on:
@@ -83,6 +85,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  setup:
+    name: verify immutable package source
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify immutable release source
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+          PUBLISH_NPM: ${{ github.event_name == 'release' || inputs.publish_npm }}
+          PUBLISH_SOLID_SERVER: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_solid_server }}
+          PUBLISH_EYEREASONER_COMPAT: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_eyereasoner_compat }}
+        run: python3 scripts/check-release-source.py --tag "$RELEASE_TAG" --publish
+
   # ---- npm: @sparq-org/sparq via OIDC TRUSTED PUBLISHING (no NPM_TOKEN) ----
   # [OPUS-4.8] sq-v286.11 (maintainer #758): switched from a long-lived NPM_TOKEN to npm's
   # OIDC Trusted Publishing (GA 2025-07-31, github.blog/changelog/2025-07-31). The npm CLI
@@ -100,6 +121,7 @@ jobs:
   # and removes the token — every CI publish thereafter is tokenless. See docs/release.md.
   npm:
     name: npm publish (OIDC trusted publishing)
+    needs: setup
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'release' ||
@@ -112,6 +134,8 @@ jobs:
         working-directory: js
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
@@ -142,6 +166,12 @@ jobs:
         run: npm run check:package
       # `prepack` (build:wasm + build:ts + bundle skills) runs automatically on `npm publish`,
       # producing the same tree `npm pack --dry-run` validates in js.yml.
+      - name: Reverify remote release tag immediately before publish
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        run: >-
+          python3 "$GITHUB_WORKSPACE/scripts/check-release-source.py"
+          --repo-root "$GITHUB_WORKSPACE" --tag "$RELEASE_TAG" --remote-tag origin
       - name: Publish to npm (OIDC trusted publishing + provenance)
         # NO `env: NODE_AUTH_TOKEN` — trusted publishing authenticates via the GitHub Actions
         # OIDC token (id-token: write). The npm CLI detects the OIDC environment and exchanges
@@ -195,6 +225,7 @@ jobs:
   # by design — no static token is stored). See docs/release.md.
   npm-eyereasoner-compat:
     name: npm publish @sparq-org/eyereasoner-compat (OIDC trusted publishing)
+    needs: setup
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.publish_eyereasoner_compat
@@ -206,6 +237,8 @@ jobs:
         working-directory: packages/eyereasoner-compat
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
@@ -231,6 +264,12 @@ jobs:
           npm run check:package
       # `prepack` rebuilds the same tree; provenance is emitted by default under trusted
       # publishing (--provenance is belt-and-suspenders). --access public: scoped package.
+      - name: Reverify remote release tag immediately before publish
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        run: >-
+          python3 "$GITHUB_WORKSPACE/scripts/check-release-source.py"
+          --repo-root "$GITHUB_WORKSPACE" --tag "$RELEASE_TAG" --remote-tag origin
       - name: Publish to npm (OIDC trusted publishing + provenance)
         run: npm publish --provenance --access public
       - name: Verify published provenance attestation
@@ -272,6 +311,7 @@ jobs:
   # by design — no static token is stored). See docs/release.md.
   npm-solid-server:
     name: npm publish @sparq-org/solid-server (OIDC trusted publishing)
+    needs: setup
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' && inputs.publish_solid_server
@@ -283,6 +323,8 @@ jobs:
         working-directory: packages/solid-server
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: wasm32-unknown-unknown
@@ -306,6 +348,12 @@ jobs:
       # dependencies are resolved by the consumer at install time and are not bundled, so no npm
       # install is needed for a correct tarball. Provenance is emitted by default under trusted
       # publishing (--provenance is belt-and-suspenders). --access public: scoped package.
+      - name: Reverify remote release tag immediately before publish
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        run: >-
+          python3 "$GITHUB_WORKSPACE/scripts/check-release-source.py"
+          --repo-root "$GITHUB_WORKSPACE" --tag "$RELEASE_TAG" --remote-tag origin
       - name: Publish to npm (OIDC trusted publishing + provenance)
         run: npm publish --provenance --access public
       - name: Verify published provenance attestation
@@ -328,6 +376,7 @@ jobs:
   # before/after publishing. crates.io-native provenance stays an OPEN external sub-gap.
   crates:
     name: attest crate packages
+    needs: setup
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'release' ||
@@ -338,6 +387,8 @@ jobs:
       attestations: write # write the attestation to the repo's attestation store
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - name: Rust (preinstalled stable)
         # [FABLE-5] CI-economy (2026-07-18 directive): the ubuntu runner image
         # ships a rustup stable toolchain; the SHA-pinned action's `rustup
@@ -420,6 +471,7 @@ jobs:
   #   API token is stored). The CI is fully wired; that PyPI account step is the only open item.
   pypi-build:
     name: build sparq-rdf wheels (${{ matrix.platform.target }})
+    needs: setup
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_pypi)
@@ -451,6 +503,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       # maturin-action provisions the Rust toolchain + (on Linux) the manylinux container.
       # `python-release` profile keeps unwinding panics — the plain release profile is
       # panic=abort, which would turn a Rust panic into a hard interpreter abort (pyproject.toml).
@@ -469,6 +523,7 @@ jobs:
 
   pypi-sdist:
     name: build sparq-rdf sdist
+    needs: setup
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.publish_pypi)
@@ -477,6 +532,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - name: Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -500,6 +557,10 @@ jobs:
       contents: read
       id-token: write # OIDC token PyPI Trusted Publishing exchanges + PEP-740 attestation signing
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
       # Collect every wheel + the sdist into one dist/ tree (download-artifact merges patterns).
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -512,6 +573,10 @@ jobs:
       # Publisher, this action mints a short-lived PyPI token via OIDC and (attestations: true,
       # the default) generates + uploads a PEP-740 attestation per file. No static API token.
       # `print-hash` echoes the uploaded digests into the log for audit.
+      - name: Reverify remote release tag immediately before publish
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        run: python3 scripts/check-release-source.py --tag "$RELEASE_TAG" --remote-tag origin
       - name: Publish to PyPI with provenance attestations
         uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,12 +9,15 @@
 # (#789 / sq-v286.3: the version_group over the 37 publishable crates that keeps the
 # locked single-version model):
 #
-#   1. release-pr  — on every push to main, release-plz reads the conventional-commit
+#   1. release-pr  — in normal post-bootstrap operation, on every push to main,
+#                    release-plz reads the conventional-commit
 #                    history (+ cargo-semver-checks API-break detection), computes the
 #                    next single workspace version, and opens/UPDATES one "Release-PR"
 #                    that bumps the version across the version_group + rewrites
 #                    CHANGELOG.md (git-cliff) + updates Cargo.lock. Nothing is released
-#                    yet — a human reviews + merges that PR.
+#                    yet — a human must also align the npm manifests/lock records, then
+#                    reviews + merges that PR. During the first registry bootstrap this
+#                    calculation is skipped entirely; use the manual recovery version PR.
 #
 #   2. release     — when the Release-PR MERGES, its version-bump commit lands on main;
 #                    this push re-runs the workflow and `release-plz release` detects the
@@ -142,7 +145,30 @@ jobs:
           # Do not leave the default GITHUB_TOKEN in the local git config; release-plz uses
           # its own `token:` input for forge operations (release-plz docs recommendation).
           persist-credentials: false
+      # [GPT-6] release-plz update packages a temporary graph even with git_only=true;
+      # before the first registry bootstrap that cannot resolve the unpublished engine.
+      # Keep manual cross-ecosystem version PRs + the independent tag job through the
+      # bootstrap. After the crates.io/OIDC flip, a generated Cargo Release-PR is still
+      # incomplete until its npm manifest + shared-lock records are aligned.
+      - name: Check first-bootstrap mode
+        id: bootstrap
+        run: |
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+          workspace = tomllib.loads(Path("release-plz.toml").read_text())["workspace"]
+          git_only, publish = workspace["git_only"], workspace["publish"]
+          if type(git_only) is not bool or type(publish) is not bool:
+              raise SystemExit("release-plz bootstrap flags must be booleans")
+          bootstrap = git_only and not publish
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"ready={str(not bootstrap).lower()}\n")
+          if bootstrap:
+              print("First registry bootstrap is pending: use a manual version PR; automatic release-pr is skipped.")
+          PY
       - name: Rust (preinstalled stable)
+        if: steps.bootstrap.outputs.ready == 'true'
         # [FABLE-5] CI-economy (2026-07-18 directive): the ubuntu runner image
         # ships a rustup stable toolchain; the SHA-pinned action's `rustup
         # toolchain install stable` re-downloads the whole toolchain whenever
@@ -161,11 +187,13 @@ jobs:
       # behavior is unchanged; only the invocation is now wrapped and captured. The unchanged
       # `release` job below still uses the pinned release-plz/action (no containment needed there).
       - name: Install release-plz + cargo-semver-checks (pinned)
+        if: steps.bootstrap.outputs.ready == 'true'
         uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: release-plz@0.3.160,cargo-semver-checks@0.48
       - name: Run release-plz release-pr (output captured for failure classification)
         id: releasepr
+        if: steps.bootstrap.outputs.ready == 'true'
         # continue-on-error so the containment step below can classify the failure from the
         # captured log: the KNOWN 403 (Actions PR-creation setting disabled) is tolerated with a
         # ::warning; anything else re-fails the job. See the job-level comment.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,29 +19,22 @@
 # events — release.yml has no `pull_request` trigger, so it is invisible to that aggregator).
 #
 # [OPUS-4.8] sq-gl3cf: a `v*` tag push is the canonical release; `workflow_dispatch` is the
-# developer/test path that builds + attaches the SAME assets (GUI bundles, archives, SBOM/VEX,
-# docker image) WITHOUT pushing a real `v*` tag. On dispatch, `github.ref_name` is the BRANCH the
-# dispatch ran on (NOT a version), so every place asset identity / the release tag was derived
-# from `github.ref_name` is now threaded from the `setup` job's single `version` output
-# (`inputs.tag` on dispatch, `github.ref_name` on tag push). Dispatch builds are pre-release by
-# default. There is NO double-build on tag: a single event fires exactly one trigger, and `setup`
-# resolves the version for whichever fired.
+# recovery path, run at the SAME immutable tag as its `tag` input. [GPT-6] setup refuses
+# branch dispatches, source/tag mismatches, and inconsistent manifest versions before any
+# artifact is built or published. Dispatch builds remain pre-release by default.
 name: release
 
 on:
   push:
     tags: ["v*"]
-  # [OPUS-4.8] sq-gl3cf: manual path to build + attach the release assets (incl. the UNSIGNED
-  # Tauri desktop GUI bundles) without cutting a real `v*` tag — for developer/test releases.
+  # Manual recovery must select an existing tag containing this workflow and guard.
   workflow_dispatch:
     inputs:
       tag:
         description: >-
-          Release tag the built assets attach to (e.g. v0.1.0-dev). MUST be a vX.Y.Z release tag —
-          the publish-cadence guard (#2552) refuses anything else, because it cannot tell which tag
-          to exclude from the interval sources. A developer/test dispatch SHOULD use a -dev /
-          pre-release suffix so it is never mistaken for a canonical release.
-          This is the single source of asset naming + the GitHub Release tag on the dispatch path.
+          Existing vX.Y.Z tag to build and attach assets to. Dispatch the workflow at this exact
+          tag (not main); its commit and manifest versions must match. A prerelease tag must
+          also match the prerelease version in the manifests. Never move a public tag to retry.
         required: true
         type: string
       prerelease:
@@ -58,9 +51,8 @@ jobs:
   # ---- 0. resolve the single version string used for asset identity + the release tag ----
   # [OPUS-4.8] sq-gl3cf: ONE source of truth for the version, consumed by EVERY job that names an
   # asset or attaches to a tag. On a `v*` tag push, `inputs.tag` is empty and `github.ref_name` is
-  # the tag (e.g. `v0.1.0`). On `workflow_dispatch`, `inputs.tag` is the developer-supplied release
-  # tag and `github.ref_name` is the BRANCH (wrong for asset identity) — so `${{ inputs.tag ||
-  # github.ref_name }}` picks the dispatch input when present and the tag otherwise. This output is
+  # the tag (e.g. `v0.1.0`). On `workflow_dispatch`, `inputs.tag` must name the same existing
+  # tag as the dispatch ref; setup verifies this before building. This output is
   # threaded into `gui-bundle`, `sbom`, `package` (via build-matrix.yml's `version` input), and
   # `release` (tag_name + body links) so BOTH triggers name assets + tag the Release identically.
   setup:
@@ -73,7 +65,9 @@ jobs:
     steps:
       - name: Resolve version
         id: v
-        run: echo "version=${{ inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: printf 'version=%s\n' "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
       # [OPUS-5] issue #2552 — THE CADENCE GUARD ON THE TAG-PUSH PATH. LOAD-BEARING.
       #
       # Maintainer, verbatim: "We need to make sure that we do not create many many
@@ -98,15 +92,10 @@ jobs:
       # PRECONDITION — on a shallow checkout the tag list is not authoritative and the
       # guard refuses rather than guessing.
       #
-      # WHY UNCONDITIONAL — including `workflow_dispatch`. A dispatch build looks like a
-      # developer/test path (pre-release, `dev-`-prefixed image tags), but the Release it
-      # creates fires `release: published`, and publish.yml's `npm` job runs on ANY
-      # `release` event. So a dispatch reaches a registry too: exempting it would leave the
-      # loophole this guard exists to close. The escape hatch the guard's no-override
-      # design reserves is a maintainer publishing BY HAND, outside CI — not dispatching a
-      # workflow that publishes for them. Consequence, by design: `inputs.tag` must be a
-      # `vX.Y.Z` release tag (a `-dev` suffix is fine); anything else refuses, because the
-      # guard cannot tell which tag to exclude from the cadence sources.
+      # WHY UNCONDITIONAL — including `workflow_dispatch`: dispatch publishes Release
+      # assets and container images too. GITHUB_TOKEN-created Releases do not trigger
+      # publish.yml; registry uploads use a separate explicit dispatch. Both workflows
+      # now require an existing tag whose version and commit match the checkout.
       #
       # DO NOT add an `if:`, do not add `continue-on-error`, do not swap `--enforce` for
       # `--dry-run`, and do not append `|| true`.
@@ -115,8 +104,13 @@ jobs:
       - name: Checkout (full history — the `v*` tag list must be authoritative)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Verify immutable release source
+        env:
+          RELEASE_TAG: ${{ steps.v.outputs.version }}
+        run: python3 scripts/check-release-source.py --tag "$RELEASE_TAG"
       - name: Publish-cadence guard (fail-closed minimum release interval, #2552)
         env:
           # Via env, never string-interpolated into the shell: a tag name is attacker-
@@ -194,9 +188,8 @@ jobs:
       # bytes it uploaded. Deliberately threaded — this job must never recompute them from
       # artifacts, which would drag the build's outputs back inside the trusted builder.
       base64-subjects: ${{ needs.package.outputs.hashes }}
-      # `upload-assets: false`: the generator's own uploader attaches to `github.ref`'s release,
-      # which on a workflow_dispatch is a BRANCH (the same trap sq-gl3cf fixed everywhere else),
-      # and the `release` job below is the single place this pipeline creates the Release. We
+      # `upload-assets: false`: the `release` job below is the single place this pipeline
+      # creates the Release and attaches its complete asset set. We
       # download the provenance artifact there instead, so it lands in SHA256SUMS for free.
       upload-assets: false
       provenance-name: sparq-cli-${{ needs.setup.outputs.version }}.intoto.jsonl
@@ -210,7 +203,7 @@ jobs:
   sbom:
     name: CycloneDX SBOM + VEX
     # [OPUS-4.8] sq-gl3cf: needs the resolved version so the per-release SBOM/VEX filenames carry
-    # the dispatch tag (on dispatch the scripts' GITHUB_REF_NAME fallback is the branch).
+    # the verified release tag on either trigger.
     needs: setup
     runs-on: ubuntu-latest
     permissions:
@@ -219,6 +212,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - name: Rust (preinstalled stable)
         # [FABLE-5] CI-economy (2026-07-18 directive): the ubuntu runner image
         # ships a rustup stable toolchain; the SHA-pinned action's `rustup
@@ -237,8 +232,7 @@ jobs:
         with:
           node-version: 22
       # [OPUS-4.8] sq-gl3cf: pass VERSION explicitly. gen-sbom-vex.sh honors $VERSION (falling
-      # back to GITHUB_REF_NAME), but on a workflow_dispatch GITHUB_REF_NAME is the BRANCH, so the
-      # SBOM/VEX filenames would be mis-stamped — thread the resolved version instead.
+      # back to GITHUB_REF_NAME); thread the verified version explicitly for both triggers.
       - name: Generate per-release SBOM + VEX
         env:
           VERSION: ${{ needs.setup.outputs.version }}
@@ -306,7 +300,7 @@ jobs:
   served-conformance:
     name: served-surface conformance report
     # [OPUS-4.8] sq-ro6if: needs the resolved version so the per-release report filename carries the
-    # release tag (mirrors the SBOM job's VERSION thread; on dispatch GITHUB_REF_NAME is the branch).
+    # release tag (mirrors the SBOM job's VERSION thread).
     needs: setup
     runs-on: ubuntu-latest
     permissions:
@@ -315,6 +309,8 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - name: Rust (preinstalled stable)
         # [FABLE-5] CI-economy (2026-07-18 directive): the ubuntu runner image
         # ships a rustup stable toolchain; the SHA-pinned action's `rustup
@@ -466,6 +462,8 @@ jobs:
           - { os: windows-latest, label: win-x64, soft: true }
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
 
       # The Tauri webview + bundler system libraries are LINUX-ONLY (macOS ships WKWebView,
       # Windows ships WebView2). This is the SAME apt set gui.yml installs to build the GUI
@@ -863,8 +861,7 @@ jobs:
   release:
     name: create GitHub Release
     # [OPUS-4.8] sq-gl3cf: `setup` added so the Release attaches to the resolved tag (tag_name
-    # below) on BOTH triggers — on dispatch, action-gh-release's default tag_name is `github.ref`,
-    # which is the BRANCH, so we must override it explicitly.
+    # below) on BOTH triggers; setup verifies that this is also the workflow's tag ref.
     # [OPUS-5] sq-toze.25: `provenance` is a HARD dependency, not an optional extra. If the
     # isolated trusted builder fails, no Release is cut — a release that shipped without the
     # L3 provenance while the docs claim L3 is precisely the silent overclaim the compliance
@@ -880,6 +877,8 @@ jobs:
       # assets/ dir) — the alias contract check below needs scripts/check-release-aliases.sh and
       # the /download page source it extracts the site-referenced alias set from.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: pkg-*
@@ -969,22 +968,23 @@ jobs:
       # entries (unchanged) PLUS one appended entry per alias (same digest, alias name).
       - name: Generate SHA256SUMS
         run: cd assets && sha256sum -- * > SHA256SUMS
+      - name: Reverify remote release tag immediately before creating the release
+        env:
+          RELEASE_TAG: ${{ needs.setup.outputs.version }}
+        run: python3 scripts/check-release-source.py --tag "$RELEASE_TAG" --remote-tag origin
       - name: Create release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
-          # [OPUS-4.8] sq-gl3cf: attach to the RESOLVED tag. The action defaults tag_name to
-          # `github.ref`, which on a workflow_dispatch is the branch (wrong) — pin it to the
-          # version the rest of the pipeline named assets with so dispatch + tag agree.
+          # Attach to the verified tag used to name every artifact.
           tag_name: ${{ needs.setup.outputs.version }}
-          # [OPUS-4.8] sq-gl3cf: dispatch builds are developer/test releases — mark them
+          # [OPUS-4.8] sq-gl3cf: dispatch builds are marked
           # pre-release by default (the dispatch `prerelease` input; true unless overridden). A
           # tag push has no such input, so `inputs.prerelease` is empty -> not a pre-release.
           prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease }}
           files: assets/*
           generate_release_notes: true
           # CHANGELOG.md is the curated source of truth; point readers at it. Body links use the
-          # resolved version (needs.setup.outputs.version), not github.ref_name, so dispatch
-          # builds (where github.ref_name is the branch) link to the right tag.
+          # resolved version (needs.setup.outputs.version) on both triggers.
           body: |
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ needs.setup.outputs.version }}/CHANGELOG.md) for the curated changelog.
 
@@ -1087,6 +1087,8 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
       # [GPT-5.6] sq-fvzi6: register the arm64 binfmt emulator before Buildx so the final
       # release push can build both target platforms on this native amd64 runner.
       - name: Set up QEMU for arm64
@@ -1188,6 +1190,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "image=ghcr.io/$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')/sparq-server" >> "$GITHUB_OUTPUT"
+      - name: Reverify remote release tag immediately before pushing the image
+        env:
+          RELEASE_TAG: ${{ needs.setup.outputs.version }}
+        run: python3 scripts/check-release-source.py --tag "$RELEASE_TAG" --remote-tag origin
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,11 +4,21 @@ How to cut a sparq release. Everything below is **maintainer-triggered**: the ve
 cuts the tag, while registry uploads require either the one-time bootstrap commands or an
 explicit `publish.yml` dispatch.
 
-## 0. One-time pre-release steps (before the first complete v0.1.1 release)
+## 0. One-time pre-release steps (before the first complete v0.1.2 release)
 
-[GPT-5.6] `v0.1.0` already points at an abandoned release-plz CI commit and cannot be
-reused safely. The first complete release is therefore **v0.1.1**; do not move or delete
-the public `v0.1.0` tag as part of the release.
+[GPT-6] **Recovery snapshot, 2026-09-12:** `v0.1.1` is an incomplete bootstrap.
+Its immutable tag resolves to `1a63aa7c638bd80da55f1811d5fb97e8d014f631`;
+[release run 33723421273](https://github.com/sparq-org/sparq/actions/runs/33723421273)
+failed at workflow startup. There is no GitHub Release, all 37 crates remain unpublished,
+and PyPI `sparq-rdf` remains unpublished. npm `@sparq-org/sparq@0.1.1` and
+`@sparq-org/solid-server@0.1.1` are already published **without `dist.attestations`**.
+Those versions cannot be republished to add provenance. Keep that evidence gap explicit.
+
+The first complete recovery release targets **v0.1.2**. Preserve both public `v0.1.0`
+and `v0.1.1` tags. The SLSA permission and Cargo bootstrap fixes in
+[PR #6488](https://github.com/sparq-org/sparq/pull/6488) landed after `v0.1.1`;
+building main and attaching those different bytes to the old tag is not a recovery.
+Re-check registry state before any irreversible upload; this snapshot is historical evidence.
 
 These are tracked as beads (`bd list -l area:release`); the procedure is documented
 here for the runbook:
@@ -47,8 +57,8 @@ taken name itself.
 | Name | Registry | Required preflight |
 |---|---|---|
 | the 37 names printed by `python3 scripts/release-interval-guard.py --dry-run` | crates.io | available on 2026-08-31; re-check before bootstrap |
-| `@sparq-org/sparq` | npm | available on 2026-08-31; confirm organization rights before bootstrap |
-| `@sparq-org/solid-server` | npm | available on 2026-08-31; confirm organization rights before bootstrap |
+| `@sparq-org/sparq` | npm | 0.1.1 exists without provenance; check new-version availability and Trusted Publisher |
+| `@sparq-org/solid-server` | npm | 0.1.1 exists without provenance; check new-version availability and Trusted Publisher |
 | `@sparq-org/eyereasoner-compat` | npm | already published at 0.1.0; no bootstrap needed |
 | `sparq` | PyPI | **taken** — unrelated `shiventi/sparq` (SJSU degree-planning API client, latest 0.2.6) |
 | `sparq-rdf` | PyPI | chosen distribution name (owner-approved; `pip install sparq-rdf`, `import sparq`) |
@@ -58,7 +68,7 @@ The PyPI **distribution** name `sparq` is taken, so the Python wheel ships as
 **`@sparq-org` for all public packages**; the private `@sparq/client` workspace package is
 an internal build dependency and is not a registry surface.
 
-## 0b. v0.1.1 ships ahead of the external ZK review (issue #2552)
+## 0b. Experimental releases precede the external ZK review (issue #2552)
 
 **Decision (maintainer, issue #2552, 2026-07-26): the first complete release goes out without waiting for the
 external accredited-cryptographer review of the ZK estate (bead `sq-qhy4`), carrying
@@ -95,22 +105,65 @@ published manifests, allowing workspace-only tests without adding a registry edg
 version PR must update the root version, every shipped path-dependency requirement, and
 `Cargo.lock` together; the release guard refuses an incomplete dependency closure.
 
-The first-release PR sets these files explicitly to **0.1.1**. This is deliberately not a
+The recovery version PR must set these files explicitly to **0.1.2**. This is deliberately not a
 release-plz-generated PR: before the first dependency-first crates.io bootstrap,
 `release-plz update` runs `cargo package` while calculating changes and Cargo cannot resolve
-the unpublished inter-crate registry dependencies. `release-plz.toml` therefore keeps
-`git_only = true` only for the tag phase, using the existing `v0.1.0` tag as its baseline.
+the unpublished inter-crate registry dependencies, including in its temporary package graph.
+While `release-plz.toml` has `git_only = true` and `publish = false`, the Release-PR job
+explicitly skips automatic version calculation. The separate tag job remains active and
+creates the new version's tag after the manual version PR merges.
 After all 37 crates exist, flip `git_only = false` only in the same change that enables
-crates.io OIDC publishing; normal release-plz-generated version PRs resume then.
+crates.io OIDC publishing. A generated release-plz PR can resume Cargo versioning then,
+but it is **not merge-ready** until the same PR also aligns every public npm manifest and
+its shared root-lock workspace record. Keep the manual cross-ecosystem version-PR review
+step until that augmentation is automated; the source guard refuses a mismatched tag.
 
-release-plz does not version npm workspaces. The public `@sparq-org/sparq` and
-`@sparq-org/solid-server` manifests are explicitly set to **0.1.1** for this release.
+release-plz does not version npm workspaces. The public `@sparq-org/sparq`,
+`@sparq-org/solid-server`, and `@sparq-org/eyereasoner-compat` manifests and
+their workspace records in the shared root `package-lock.json` must also move to **0.1.2**.
+The compatibility package skips
+0.1.1: its registry release is still 0.1.0, while its source has changed since that publish.
+PyPI's version is derived from the Cargo workspace. Until the separate reviewed version
+PR merges, versions remain at 0.1.1; that version PR is the release-triggering change.
 
 ## 2. Changelog
 
 Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md` (Keep-a-Changelog format:
 Added / Changed / Fixed / Removed). Performance claims go in only with a pointer to the
 measurement (e.g. `bench/qlever-baselines.md`). Add the compare/tag link at the bottom.
+
+### v0.1.2 recovery sequence
+
+1. Merge the source-integrity/recovery changes without changing versions. Prepare the
+   separate manual 0.1.2 version PR, including the new changelog and lockfiles. Before its
+   merge, complete CI and package-file inspection, re-check version availability and the
+   release interval, and confirm registry credentials/Trusted Publishers. **That version
+   PR merge authorizes tag creation and the release workflow's artifact/container uploads.**
+2. Let the new `v0.1.2` tag run `release.yml`, including provenance verification. Keep the
+   tag fixed. If this run needs source changes, fix forward with another version; a
+   dispatch at main with `tag=v0.1.2` is refused. For a transient failure before publication,
+   retry with `gh workflow run release.yml --ref v0.1.2 -f tag=v0.1.2 -f prerelease=false`
+   only after checking no assets/image were already published.
+3. From a clean checkout of `v0.1.2`, bootstrap crates.io in §4's dependency-first order.
+   Run each dry-run immediately before its publish, once its dependencies exist. Do not
+   use main or fill the old 0.1.1 registry gaps with different source.
+4. After bootstrap, explicitly dispatch package publication **at the same immutable tag**:
+
+   ```sh
+   gh workflow run publish.yml --ref v0.1.2 \
+     -f publish_npm=true -f publish_solid_server=true \
+     -f publish_eyereasoner_compat=true \
+     -f publish_pypi=true -f attest_crates=true
+   ```
+
+   `publish.yml` checks source identity and selected package versions before its jobs run.
+   All three public npm manifests must match the tag before this combined dispatch can run.
+   Check which versions/files already exist before retrying any failed publication; never
+   attempt to replace published bytes.
+5. Verify all three npm versions' `dist.attestations`, every PyPI distribution's PEP-740
+   attestation, and the published GitHub assets. Compare attested `.crate` hashes with
+   registry downloads before claiming coverage of the uploaded crate bytes. New-version
+   provenance does not retroactively attest either npm 0.1.1 package.
 
 ## 3. Tag push → what CI does
 
@@ -125,12 +178,20 @@ git push origin vX.Y.Z
 
 Pushing the tag triggers `.github/workflows/release.yml`:
 
-0. **publish-cadence guard** — the `setup` job runs
+0. **source identity and publish-cadence guards** — `setup` first runs
+   `scripts/check-release-source.py`: the workflow must run at the exact existing release
+   tag, the tag must resolve to the workflow/checkout commit, and manifest versions must
+   match. A branch dispatch naming an older tag refuses before any build or publication.
+   Then the job runs
    `scripts/release-interval-guard.py --enforce --released-tag vX.Y.Z` before anything is
    built. If the previous release was less than 24h ago the job fails and **every** job
    below it is blocked (they all depend on `setup`). See §8d — this is the tag-push half
-   of the at-most-one-release-per-day policy. The tag stays pushed; delete it
-   (`git push --delete <remote> vX.Y.Z`) and re-push once the window has passed.
+   of the at-most-one-release-per-day policy. Keep the tag immutable. After the window,
+   retry at that same tag only if it already contains working release logic and nothing
+   was published. A source/workflow fix requires a new version and tag; do not overwrite
+   published assets or reuse registry versions. The npm, PyPI, GitHub Release, and GHCR
+   paths also re-read the remote tag immediately before their irreversible write and refuse
+   if it no longer identifies the workflow commit.
 1. **package** — builds `sparq-cli` for every hardware tier (same matrix as `dist.yml`:
    arm64/x64 darwin, x86-64 baseline/v2/v3/v4 + arm64 Linux, x64/arm64 Windows) and packages
    each as `sparq-cli-vX.Y.Z-<tier>.tar.gz` (`.zip` on Windows) containing the binary,
@@ -200,7 +261,8 @@ Versioned dev-dependencies are shipped and therefore participate in the derived 
 The `sparq-introspect` test-only edge back to `sparq-engine` is deliberately path-only;
 publishing it with a version would create an impossible first-release dependency cycle.
 
-Exact bootstrap commands, from the repo root on the tagged **v0.1.1** commit:
+Exact bootstrap commands, from a clean checkout of the new tagged **v0.1.2** commit,
+after the recovery version PR has merged and the tag's release workflow is green:
 
 ```sh
 cargo publish -p sparq-core
@@ -391,18 +453,13 @@ The primary `npm` job authenticates entirely via OIDC trusted publishing (no `NO
 `npm@^11.5.1` (the trusted-publishing CLI floor — Node 22's bundled npm can be older) and keeps
 `--provenance --access public`.
 
-**needs:user (npmjs.com):** `@sparq-org/sparq` and `@sparq-org/solid-server` must each
-exist before npm allows Trusted Publisher configuration:
+`@sparq-org/sparq` and `@sparq-org/solid-server` already exist at 0.1.1. Their manual
+bootstrap is complete; **do not run it again or try to republish those versions**.
+Before the 0.1.2 release, verify the remaining registry-side configuration:
 
 1. Confirm the `sparq-org` npm organization and the publisher's package-creation rights.
-2. From the tagged v0.1.1 checkout, build/inspect each tarball and perform one bootstrap
-   publish using a short-lived **granular** token:
-   `cd js && NPM_CONFIG_PROVENANCE=false npm publish --access public`, then
-   `cd ../packages/solid-server && NPM_CONFIG_PROVENANCE=false npm publish --access public`.
-   The explicit override is required because provenance can only be generated on a supported
-   hosted CI runner; subsequent trusted-publisher runs generate it automatically.
-3. Delete the granular token.
-4. On each package's **Settings → Trusted Publisher → GitHub Actions**, configure:
+2. Confirm any bootstrap granular token has been removed.
+3. On each package's **Settings → Trusted Publisher → GitHub Actions**, configure:
    - Organization or user: **`sparq-org`**
    - Repository: **`sparq`**
    - Workflow filename: **`publish.yml`** (filename only, with extension — **not** a path)
@@ -410,9 +467,9 @@ exist before npm allows Trusted Publisher configuration:
    - Allowed actions: **`npm publish`**
 
 `@sparq-org/eyereasoner-compat` already exists at 0.1.0, so it only needs its Trusted
-Publisher checked. Every subsequent CI publish is tokenless and provenance-bearing
-(`npm audit signatures`). The bootstrap versions themselves are the unavoidable pre-OIDC
-exception because npm cannot register a publisher for a package that does not yet exist.
+Publisher checked. Subsequent CI publishes use the exact-tag command in §2 and verify
+registry provenance (`npm audit signatures`). The bootstrap versions themselves remain
+unattested; configuring Trusted Publishing now does not add attestations to old versions.
 
 ### 8b. PyPI `sparq-rdf` — WIRED (`publish.yml` `pypi-publish` job)
 
@@ -505,12 +562,12 @@ you flip.
    against the *previous* release. It refuses if handed anything that is not a `vX.Y.Z`
    tag.
 
-   It is **unconditional** — `workflow_dispatch` builds are guarded too. They look like a
-   developer/test path (pre-release, `dev-`-prefixed image tags), but the Release they
-   create fires `release: published`, and `publish.yml`'s `npm` job runs on *any* `release`
-   event, so a dispatch reaches a registry as well. Two consequences: `inputs.tag` on a
-   dispatch **must** be a `vX.Y.Z` tag (a `-dev` suffix is fine), and the unbounded way to
-   exercise the pipeline is a local build, not a dispatch.
+   It is **unconditional** — `workflow_dispatch` builds are guarded too because they
+   publish Release assets and container images. GitHub suppresses the downstream release
+   event when these assets are published with `GITHUB_TOKEN`; registry uploads then need
+   the separate explicit package dispatch. Both workflows require an exact existing tag,
+   matching checkout commit and manifest versions. A `-dev` tag also needs matching
+   prerelease manifest versions; untagged experiments belong in local builds.
    `scripts/tests/test_release_publish_guard.py` pins the step's `run:`, that it carries
    no `if:` and no `continue-on-error`, the `fetch-depth: 0` checkout it depends on, and
    that no job in `release.yml` escapes `setup`.
@@ -529,17 +586,17 @@ python3 scripts/release-interval-guard.py --dry-run
 It prints the publishable crate list, each version, the dependency-first publish order and
 the cadence verdict it *would* return. It only ever runs `git`, never `cargo`.
 
-> [GPT-5.6] **Closure reconciliation complete for v0.1.1:** the guard reports 37
-> publishable crates, all 37 are in the `sparq` version group, and the printed order is the
-> exact bootstrap order in §4. Re-run it on the final Release PR commit; any mismatch blocks
-> the crates.io flip.
+> [GPT-6] **Historical v0.1.1 source closure:** the tagged source contained 37
+> publishable crates in the `sparq` version group, but those crates were not published.
+> Re-run the guard on the final v0.1.2 version PR commit; its printed dependency-first order
+> is the bootstrap order in §4, and any mismatch blocks publication.
 
 ### 8e. release-plz forge token — configured and verified (issue #3273)
 
-For the first complete release, the checked-in v0.1.1 version PR replaces the generated
+For the first complete release, the checked-in v0.1.2 recovery version PR replaces the generated
 Release-PR because `release-plz update` cannot package the unpublished dependency closure.
 The privileged forge token below is still required **before that PR merges**: the
-`release-plz release` job uses it to push `v0.1.1` as a normal actor so the tag starts
+`release-plz release` job uses it to push `v0.1.2` as a normal actor so the tag starts
 `release.yml`. Once the 37-crate bootstrap and post-bootstrap config flip are complete,
 the same token also restores normal generated Release-PRs.
 
@@ -559,10 +616,11 @@ App token (ORCHESTRATOR_APP_ID + ORCHESTRATOR_APP_PRIVATE_KEY)  ← preferred
   || GITHUB_TOKEN          (fallback; cannot open PRs while the setting is disabled)
 ```
 
-**Live verification, 2026-08-31:** `ORCHESTRATOR_APP_ID` and
-`ORCHESTRATOR_APP_PRIVATE_KEY` are present, and run `33434042300` successfully minted the
-App token in both the Release-PR and tag jobs. No PAT or Actions-setting change is needed
-for v0.1.1.
+**Historical verification, 2026-08-31:** `ORCHESTRATOR_APP_ID` and
+`ORCHESTRATOR_APP_PRIVATE_KEY` were present, and run `33434042300` successfully minted the
+App token in both the Release-PR and tag jobs. Reconfirm that the App credentials still mint
+a token before merging the v0.1.2 version PR; no PAT or Actions-setting change is needed
+when that probe succeeds.
 
 **Recovery if that App credential is removed or expires — do exactly one:**
 1. Provision `ORCHESTRATOR_APP_ID` + `ORCHESTRATOR_APP_PRIVATE_KEY` (the App used by

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -104,11 +104,12 @@ git_release_enable = false
 #   `crates` job reverts to attest-only over the .crate bytes — "the point of adoption".
 publish = false
 
-# [GPT-5.6] #3399 / first-release bootstrap: crates.io is still empty, but an abandoned
-# `v0.1.0` tag already exists. Use git tags as the version baseline until the first complete
-# registry publish, so release-plz proposes v0.1.1 without moving/reusing that public tag.
-# The post-bootstrap flip is atomic: `git_only = false` together with `publish = true` and
-# the pre-wired crates.io OIDC step in release-plz.yml.
+# [GPT-6] #3399 / recovery bootstrap: crates.io is still empty, and the existing `v0.1.0`
+# and `v0.1.1` tags are incomplete immutable history. Use git tags as the version baseline
+# until the first complete registry publish; the manual cross-ecosystem version PR targets
+# v0.1.2. The post-bootstrap flip is atomic: `git_only = false` together with `publish = true`
+# and the pre-wired crates.io OIDC step in release-plz.yml. Generated Cargo Release-PRs must
+# still be augmented with matching npm manifest + shared-lock versions before merge.
 git_only = true
 
 # --- The locked version_group: the complete crates.io dependency closure -----

--- a/scripts/check-release-source.py
+++ b/scripts/check-release-source.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""[GPT-6] Refuse a release whose tag, checkout, and package versions disagree."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tomllib
+
+
+class SourceMismatch(ValueError):
+    """The requested release does not identify the checked-out source."""
+
+
+def git(repo: Path, revision: str) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "--verify", revision], cwd=repo, text=True,
+        stderr=subprocess.PIPE,
+    ).strip()
+
+
+def validate_remote_tag(repo: Path, remote: str, tag: str, commit: str) -> None:
+    """Fail if the public tag no longer resolves to the workflow build commit."""
+    if not re.fullmatch(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?", tag):
+        raise SourceMismatch("release tag must be vX.Y.Z (optionally with a prerelease suffix)")
+    if not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", commit):
+        raise SourceMismatch("the workflow build commit is missing or invalid")
+    output = subprocess.check_output(
+        ["git", "ls-remote", remote, f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"],
+        cwd=repo,
+        text=True,
+        stderr=subprocess.PIPE,
+    )
+    refs = dict(line.split("\t", 1)[::-1] for line in output.splitlines() if "\t" in line)
+    # Annotated tags expose a peeled ^{} record; lightweight tags point directly at the commit.
+    tagged = refs.get(f"refs/tags/{tag}^{{}}") or refs.get(f"refs/tags/{tag}")
+    if tagged is None:
+        raise SourceMismatch(f"remote {remote!r} does not contain {tag}")
+    if tagged != commit:
+        raise SourceMismatch(f"remote {tag} no longer identifies the workflow build commit")
+
+
+def validate(repo: Path, tag: str, ref: str, commit: str, npm_manifests: list[str]) -> None:
+    if not re.fullmatch(r"v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?", tag):
+        raise SourceMismatch("release tag must be vX.Y.Z (optionally with a prerelease suffix)")
+    if ref != f"refs/tags/{tag}":
+        raise SourceMismatch(f"run this workflow at the exact tag {tag}, not {ref!r}")
+    if not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", commit):
+        raise SourceMismatch("the workflow build commit is missing or invalid")
+    tagged = git(repo, f"refs/tags/{tag}^{{commit}}")
+    if tagged != commit or git(repo, "HEAD") != commit:
+        raise SourceMismatch("release tag, workflow build commit, and checkout HEAD must match")
+
+    version = tag[1:]
+    workspace = tomllib.loads((repo / "Cargo.toml").read_text(encoding="utf-8"))["workspace"]
+    if workspace["package"]["version"] != version:
+        raise SourceMismatch(f"Cargo workspace version does not match {tag}")
+    for member in workspace["members"]:
+        package = tomllib.loads((repo / member / "Cargo.toml").read_text(encoding="utf-8"))["package"]
+        # Private implementation crates may version independently. sparq-py is
+        # private to Cargo but supplies the version of the published Python wheel.
+        if package.get("publish") in (False, []) and member != "crates/sparq-py":
+            continue
+        declared = package.get("version")
+        if declared != {"workspace": True} and declared != version:
+            raise SourceMismatch(f"{member}/Cargo.toml version does not match {tag}")
+    project = tomllib.loads((repo / "crates/sparq-py/pyproject.toml").read_text(encoding="utf-8"))["project"]
+    if project.get("version") != version and not (
+        "version" not in project and "version" in project.get("dynamic", [])
+    ):
+        raise SourceMismatch(f"PyPI project version does not match {tag}")
+    lock_workspaces = {}
+    if npm_manifests:
+        package_lock = json.loads((repo / "package-lock.json").read_text(encoding="utf-8"))
+        lock_workspaces = package_lock.get("packages")
+        if not isinstance(lock_workspaces, dict):
+            raise SourceMismatch("package-lock.json packages table is missing or invalid")
+    for manifest in npm_manifests:
+        package = json.loads((repo / manifest).read_text(encoding="utf-8"))
+        if package.get("version") != version:
+            raise SourceMismatch(f"{manifest} version does not match {tag}")
+        workspace = Path(manifest).parent.as_posix()
+        locked = lock_workspaces.get(workspace)
+        if not isinstance(locked, dict) or locked.get("version") != version:
+            raise SourceMismatch(
+                f"package-lock.json workspace {workspace} version does not match {tag}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--publish", action="store_true", help="check selected publish.yml npm jobs")
+    parser.add_argument(
+        "--remote-tag",
+        metavar="REMOTE",
+        help="immediately re-check REMOTE's tag before a publication side effect",
+    )
+    args = parser.parse_args()
+    # release.yml emits the primary npm client's SBOM as well as Rust artifacts.
+    # publish.yml validates only selected npm jobs; the optional compatibility
+    # package has its own version and must not block an unrelated publication.
+    manifests = ["js/package.json", "packages/solid-server/package.json"]
+    if args.publish:
+        manifests = []
+        for flag, manifest in (
+            ("PUBLISH_NPM", "js/package.json"),
+            ("PUBLISH_SOLID_SERVER", "packages/solid-server/package.json"),
+            ("PUBLISH_EYEREASONER_COMPAT", "packages/eyereasoner-compat/package.json"),
+        ):
+            value = os.environ.get(flag)
+            if value not in ("true", "false"):
+                parser.error(f"{flag} must be explicitly true or false")
+            if value == "true":
+                manifests.append(manifest)
+    try:
+        if args.remote_tag:
+            validate_remote_tag(args.repo_root, args.remote_tag, args.tag,
+                                os.environ.get("GITHUB_SHA", ""))
+        else:
+            validate(args.repo_root, args.tag, os.environ.get("GITHUB_REF", ""),
+                     os.environ.get("GITHUB_SHA", ""), manifests)
+    except (SourceMismatch, OSError, subprocess.CalledProcessError, ValueError, KeyError, TypeError) as error:
+        print(f"release source refused: {error}", file=sys.stderr)
+        return 1
+    qualifier = f" on {args.remote_tag}" if args.remote_tag else ""
+    print(f"release source verified{qualifier}: {args.tag} at {os.environ['GITHUB_SHA']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_release_source.py
+++ b/scripts/tests/test_release_source.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""[GPT-6] Release source identity and fail-closed workflow wiring regressions."""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/check-release-source.py"
+spec = importlib.util.spec_from_file_location("release_source", SCRIPT)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+
+class TestSourceIdentity(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="sparq-release-source-")
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.write("Cargo.toml", '[workspace]\nmembers = ["crates/sparq-py"]\n'
+                   '[workspace.package]\nversion = "0.1.2"\n')
+        self.write("crates/sparq-py/Cargo.toml", '[package]\nname = "sparq-py"\nversion.workspace = true\n')
+        self.write("crates/sparq-py/pyproject.toml", '[project]\nname = "sparq-rdf"\ndynamic = ["version"]\n')
+        for manifest in ("js/package.json", "packages/solid-server/package.json"):
+            self.write(manifest, json.dumps({"version": "0.1.2"}))
+        self.write("packages/eyereasoner-compat/package.json", '{"version":"0.1.0"}')
+        self.write("package-lock.json", json.dumps({"packages": {
+            "js": {"version": "0.1.2"},
+            "packages/solid-server": {"version": "0.1.2"},
+            "packages/eyereasoner-compat": {"version": "0.1.0"},
+        }}))
+        self.git("init", "-q")
+        self.git("add", ".")
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "commit.gpgsign=false", "commit", "-qm", "fixture")
+        self.sha = self.git("rev-parse", "HEAD")
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "tag.gpgsign=false", "tag", "-a", "v0.1.2", "-m", "fixture")
+
+    def write(self, path, text):
+        path = self.root / path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def git(self, *args):
+        return subprocess.check_output(["git", *args], cwd=self.root, text=True,
+                                       stderr=subprocess.PIPE).strip()
+
+    def validate(self, **overrides):
+        args = dict(repo=self.root, tag="v0.1.2", ref="refs/tags/v0.1.2", commit=self.sha,
+                    npm_manifests=["js/package.json", "packages/solid-server/package.json"])
+        guard.validate(**(args | overrides))
+
+    def test_matching_annotated_tag_passes(self):
+        self.validate()
+
+    def test_branch_dispatch_refuses_even_at_the_tagged_commit(self):
+        with self.assertRaisesRegex(guard.SourceMismatch, "exact tag"):
+            self.validate(ref="refs/heads/main")
+
+    def test_old_tag_with_new_build_commit_refuses(self):
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-qm", "later")
+        with self.assertRaisesRegex(guard.SourceMismatch, "must match"):
+            self.validate(commit=self.git("rev-parse", "HEAD"))
+
+    def test_checkout_must_match_workflow_commit(self):
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-qm", "later")
+        with self.assertRaisesRegex(guard.SourceMismatch, "must match"):
+            self.validate()
+
+    def test_missing_tag_refuses(self):
+        with self.assertRaises(subprocess.CalledProcessError):
+            self.validate(tag="v0.1.3", ref="refs/tags/v0.1.3")
+
+    def test_remote_annotated_tag_must_still_match(self):
+        guard.validate_remote_tag(self.root, ".", "v0.1.2", self.sha)
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-qm", "later")
+        self.git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                 "-c", "tag.gpgsign=false", "tag", "-fam", "moved", "v0.1.2")
+        with self.assertRaisesRegex(guard.SourceMismatch, "no longer identifies"):
+            guard.validate_remote_tag(self.root, ".", "v0.1.2", self.sha)
+
+    def test_missing_remote_tag_refuses(self):
+        with self.assertRaisesRegex(guard.SourceMismatch, "does not contain"):
+            guard.validate_remote_tag(self.root, ".", "v0.1.3", self.sha)
+
+    def test_malformed_identity_refuses(self):
+        for overrides in ({"tag": "v0.1.2\nversion=v9.9.9"}, {"commit": ""}):
+            with self.subTest(overrides=overrides), self.assertRaises(guard.SourceMismatch):
+                self.validate(**overrides)
+
+    def test_each_manifest_version_is_checked(self):
+        for manifest, content in (
+            ("Cargo.toml", '[workspace]\nmembers = []\n[workspace.package]\nversion = "0.1.1"'),
+            ("crates/sparq-py/Cargo.toml", '[package]\nversion = "0.1.1"'),
+            ("crates/sparq-py/pyproject.toml", '[project]\nversion = "0.1.1"'),
+            ("js/package.json", '{"version":"0.1.1"}'),
+            ("packages/solid-server/package.json", '{"version":"0.1.1"}'),
+        ):
+            original = (self.root / manifest).read_text(encoding="utf-8")
+            with self.subTest(manifest=manifest):
+                self.write(manifest, content)
+                with self.assertRaisesRegex(guard.SourceMismatch, "version does not match"):
+                    self.validate()
+                self.write(manifest, original)
+
+    def test_private_implementation_crates_can_version_independently(self):
+        self.write("Cargo.toml", '[workspace]\nmembers = ["crates/sparq-py", "crates/private"]\n'
+                   '[workspace.package]\nversion = "0.1.2"\n')
+        self.write("crates/private/Cargo.toml", '[package]\nname = "private"\n'
+                   'version = "0.0.1"\npublish = false\n')
+        self.validate()
+        self.write("crates/private/Cargo.toml", '[package]\nname = "private"\nversion = "0.0.1"\n')
+        with self.assertRaisesRegex(guard.SourceMismatch, "version does not match"):
+            self.validate()
+
+    def test_each_selected_npm_lock_workspace_version_is_checked(self):
+        lock_path = self.root / "package-lock.json"
+        for workspace in ("js", "packages/solid-server"):
+            original = lock_path.read_text(encoding="utf-8")
+            with self.subTest(workspace=workspace):
+                lock = json.loads(original)
+                lock["packages"][workspace]["version"] = "0.1.1"
+                self.write("package-lock.json", json.dumps(lock))
+                with self.assertRaisesRegex(guard.SourceMismatch, "package-lock.json workspace"):
+                    self.validate()
+                self.write("package-lock.json", original)
+
+    def test_publish_checks_only_selected_npm_packages(self):
+        env = os.environ | {"GITHUB_REF": "refs/tags/v0.1.2", "GITHUB_SHA": self.sha,
+                            "PUBLISH_NPM": "false", "PUBLISH_SOLID_SERVER": "false",
+                            "PUBLISH_EYEREASONER_COMPAT": "false"}
+        command = ["python3", "-B", str(SCRIPT), "--repo-root", str(self.root),
+                   "--tag", "v0.1.2", "--publish"]
+        for flag, manifest in (
+            ("PUBLISH_NPM", "js/package.json"),
+            ("PUBLISH_SOLID_SERVER", "packages/solid-server/package.json"),
+            ("PUBLISH_EYEREASONER_COMPAT", "packages/eyereasoner-compat/package.json"),
+        ):
+            original = (self.root / manifest).read_text(encoding="utf-8")
+            with self.subTest(flag=flag):
+                self.write(manifest, '{"version":"0.1.1"}')
+                unselected = subprocess.run(command, env=env, capture_output=True, text=True,
+                                            timeout=10)
+                self.assertEqual(unselected.returncode, 0, unselected.stderr)
+                selected = subprocess.run(command, env=env | {flag: "true"}, capture_output=True,
+                                          text=True, timeout=10)
+                self.assertEqual(selected.returncode, 1, selected.stderr)
+                self.write(manifest, original)
+
+        invalid = subprocess.run(command, env=env | {"PUBLISH_NPM": ""}, capture_output=True,
+                                 text=True, timeout=10)
+        self.assertEqual(invalid.returncode, 2, invalid.stderr)
+
+    def test_publish_checks_only_selected_npm_lock_workspaces(self):
+        env = os.environ | {"GITHUB_REF": "refs/tags/v0.1.2", "GITHUB_SHA": self.sha,
+                            "PUBLISH_NPM": "false", "PUBLISH_SOLID_SERVER": "false",
+                            "PUBLISH_EYEREASONER_COMPAT": "false"}
+        command = ["python3", "-B", str(SCRIPT), "--repo-root", str(self.root),
+                   "--tag", "v0.1.2", "--publish"]
+        for flag, manifest, workspace in (
+            ("PUBLISH_NPM", "js/package.json", "js"),
+            ("PUBLISH_SOLID_SERVER", "packages/solid-server/package.json", "packages/solid-server"),
+            ("PUBLISH_EYEREASONER_COMPAT", "packages/eyereasoner-compat/package.json",
+             "packages/eyereasoner-compat"),
+        ):
+            manifest_path = self.root / manifest
+            manifest_original = manifest_path.read_text(encoding="utf-8")
+            lock_path = self.root / "package-lock.json"
+            lock_original = lock_path.read_text(encoding="utf-8")
+            with self.subTest(flag=flag):
+                self.write(manifest, '{"version":"0.1.2"}')
+                lock = json.loads(lock_original)
+                lock["packages"][workspace]["version"] = "0.1.1"
+                self.write("package-lock.json", json.dumps(lock))
+                unselected = subprocess.run(command, env=env, capture_output=True, text=True,
+                                            timeout=10)
+                self.assertEqual(unselected.returncode, 0, unselected.stderr)
+                selected = subprocess.run(command, env=env | {flag: "true"}, capture_output=True,
+                                          text=True, timeout=10)
+                self.assertEqual(selected.returncode, 1, selected.stderr)
+                self.write(manifest, manifest_original)
+                self.write("package-lock.json", lock_original)
+
+
+class TestWorkflowWiring(unittest.TestCase):
+    def test_build_checkouts_use_the_workflow_commit(self):
+        for name in ("release", "publish", "build-matrix"):
+            jobs = yaml.safe_load((ROOT / f".github/workflows/{name}.yml").read_text())["jobs"]
+            for job_id, job in jobs.items():
+                for step in job.get("steps", []):
+                    if step.get("uses", "").startswith("actions/checkout@"):
+                        with self.subTest(workflow=name, job=job_id):
+                            self.assertEqual(step.get("with", {}).get("ref"), "${{ github.sha }}")
+
+    def test_release_and_publish_are_guarded_before_work(self):
+        for name in ("release", "publish"):
+            with self.subTest(workflow=name):
+                jobs = yaml.safe_load((ROOT / f".github/workflows/{name}.yml").read_text())["jobs"]
+                setup = jobs["setup"]
+                self.assertNotIn("if", setup)
+                self.assertNotIn("continue-on-error", setup)
+                steps = setup["steps"]
+                matches = [s for s in steps if "scripts/check-release-source.py" in s.get("run", "")]
+                self.assertEqual(len(matches), 1)
+                check = matches[0]
+                self.assertEqual(check["run"], 'python3 scripts/check-release-source.py --tag "$RELEASE_TAG"'
+                                 + (" --publish" if name == "publish" else ""))
+                self.assertNotIn("if", check)
+                self.assertNotIn("continue-on-error", check)
+                checkout = next(s for s in steps if s.get("uses", "").startswith("actions/checkout@"))
+                self.assertEqual(checkout["with"]["fetch-depth"], 0)
+                self.assertLess(steps.index(checkout), steps.index(check))
+                if name == "release":
+                    self.assertEqual(check["env"], {"RELEASE_TAG": "${{ steps.v.outputs.version }}"})
+                    cadence = next(s for s in steps if "scripts/release-interval-guard.py" in s.get("run", ""))
+                    self.assertLess(steps.index(check), steps.index(cadence))
+                else:
+                    self.assertEqual(check["env"], {
+                        "RELEASE_TAG": "${{ github.event.release.tag_name || github.ref_name }}",
+                        "PUBLISH_NPM": "${{ github.event_name == 'release' || inputs.publish_npm }}",
+                        "PUBLISH_SOLID_SERVER": "${{ github.event_name == 'workflow_dispatch' && inputs.publish_solid_server }}",
+                        "PUBLISH_EYEREASONER_COMPAT": "${{ github.event_name == 'workflow_dispatch' && inputs.publish_eyereasoner_compat }}",
+                    })
+
+                def guarded(job_id, seen=frozenset()):
+                    if job_id == "setup":
+                        return True
+                    if job_id in seen:
+                        return False
+                    deps = jobs[job_id].get("needs", [])
+                    if isinstance(deps, str):
+                        deps = [deps]
+                    return any(guarded(dep, seen | {job_id}) for dep in deps)
+
+                for job_id in jobs:
+                    self.assertTrue(guarded(job_id), f"{name}/{job_id} bypasses setup")
+
+    def test_source_regressions_run_in_ci(self):
+        workflow = yaml.safe_load((ROOT / ".github/workflows/docs-quality.yml").read_text())
+        checks = [step for job in workflow["jobs"].values() for step in job.get("steps", [])
+                  if "python3 scripts/tests/test_release_source.py" in step.get("run", "")]
+        self.assertEqual(len(checks), 1)
+        self.assertNotIn("if", checks[0])
+        self.assertNotIn("continue-on-error", checks[0])
+
+    def test_remote_tag_is_rechecked_immediately_before_publication(self):
+        publish = yaml.safe_load((ROOT / ".github/workflows/publish.yml").read_text())["jobs"]
+        release = yaml.safe_load((ROOT / ".github/workflows/release.yml").read_text())["jobs"]
+
+        side_effects = (
+            (publish["npm"], lambda step: "npm publish" in step.get("run", "")),
+            (publish["npm-eyereasoner-compat"],
+             lambda step: "npm publish" in step.get("run", "")),
+            (publish["npm-solid-server"], lambda step: "npm publish" in step.get("run", "")),
+            (publish["pypi-publish"],
+             lambda step: step.get("uses", "").startswith("pypa/gh-action-pypi-publish@")),
+            (release["release"],
+             lambda step: step.get("uses", "").startswith("softprops/action-gh-release@")),
+            (release["docker"],
+             lambda step: step.get("uses", "").startswith("docker/build-push-action@")
+             and step.get("with", {}).get("push") is True),
+        )
+        for job, is_side_effect in side_effects:
+            steps = job["steps"]
+            matches = [index for index, step in enumerate(steps) if is_side_effect(step)]
+            self.assertEqual(len(matches), 1)
+            index = matches[0]
+            self.assertGreater(index, 0)
+            guard_step = steps[index - 1]
+            self.assertIn("scripts/check-release-source.py", guard_step.get("run", ""))
+            self.assertIn("--remote-tag origin", guard_step["run"])
+            self.assertNotIn("continue-on-error", guard_step)
+
+
+class TestBootstrapMode(unittest.TestCase):
+    def test_bootstrap_blocks_update_but_preserves_tag_handoff(self):
+        workflow = yaml.safe_load((ROOT / ".github/workflows/release-plz.yml").read_text())
+        steps = workflow["jobs"]["release-plz-pr"]["steps"]
+        check = next(step for step in steps if step.get("id") == "bootstrap")
+        self.assertNotIn("if", check)
+        self.assertNotIn("continue-on-error", check)
+        update = next(step for step in steps if step.get("id") == "releasepr")
+        self.assertEqual(update["if"], "steps.bootstrap.outputs.ready == 'true'")
+        self.assertLess(steps.index(check), steps.index(update))
+        tag_job = workflow["jobs"]["release-plz-release"]
+        self.assertNotIn("bootstrap", json.dumps(tag_job))
+        self.assertNotIn("needs", tag_job)
+
+        for git_only, publish, expected in (("true", "false", "ready=false"),
+                                            ("false", "true", "ready=true"),
+                                            ('"true"', "false", None)):
+            with self.subTest(git_only=git_only, publish=publish), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                (root / "release-plz.toml").write_text(
+                    f"[workspace]\ngit_only={git_only}\npublish={publish}\n")
+                output = root / "output"
+                result = subprocess.run(["bash", "-e", "-o", "pipefail", "-c", check["run"]],
+                                        cwd=root, env=os.environ | {"GITHUB_OUTPUT": str(output)},
+                                        capture_output=True, text=True, timeout=10)
+                if expected is None:
+                    self.assertNotEqual(result.returncode, 0)
+                else:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(output.read_text().strip(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject release/package workflow dispatches unless the workflow runs at the exact immutable release tag and all selected public package versions match
- contain release-plz automatic version calculation during the first crates.io bootstrap while preserving its independent tag handoff
- document the incomplete v0.1.1 bootstrap and the coherent v0.1.2 recovery for 37 crates, sparq-rdf, and all three public npm packages

## Validation

- python3 scripts/tests/test_release_source.py (13 passed)
- python3 scripts/tests/test_release_publish_guard.py (71 passed)
- existing SLSA workflow regression tests (4 passed)
- git diff --check

## Release impact

This PR changes no versions, tags, registry settings, or published artifacts. It must land before the separate v0.1.2 version PR so that no workflow can attach current-main bytes to the old v0.1.1 tag.